### PR TITLE
Upgrade to proton 0.9.1 and fix the build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
          ${project.version}(${activemq.version.incrementingVersion})
       </ActiveMQ-Version>
       <resteasy.version>3.0.9.Final</resteasy.version>
+      <proton.version>0.9.1</proton.version>
       <skipUnitTests>true</skipUnitTests>
       <skipJmsTests>true</skipJmsTests>
       <skipExtraTests>true</skipExtraTests>
@@ -334,13 +335,13 @@
          <dependency>
             <groupId>org.apache.qpid</groupId>
             <artifactId>proton-j</artifactId>
-            <version>0.9</version>
+            <version>${proton.version}</version>
             <!-- License: Apache 2.0 -->
          </dependency>
          <dependency>
             <groupId>org.apache.qpid</groupId>
             <artifactId>proton-jms</artifactId>
-            <version>0.8</version>
+            <version>${proton.version}</version>
             <!-- License: Apache 2.0 -->
          </dependency>
          <dependency>


### PR DESCRIPTION
#218 broke the build, needed a couple of fixes to the distribution module to account for the reduced offset.

#217 upgraded the main proton-j dependency to 0.9, but left the other at 0.8. There were some issues in 0.9 that we did a 0.9.1 to get fixes out for, so this upgrades both to that.