### PR TITLE
License stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -748,3 +748,5 @@ activemq.log
 */activemq.log
 */*/activemq.log
 */*/*/activemq.log
+
+ratReport.txt

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,7 +12,7 @@ Things to do before issuing a new release:
 
 * Bump the version numbers in example and test poms to the next release version. e.g. 2.0.0
 
-* Build the release locally: mvn clean install -DskipLicenseCheck=false -Prelease
+* Build the release locally: mvn clean install -Prelease
 
 * Test the standalone release (this should be done on windows as well as linux):
 1. Unpack the distribution zip or tar.gz

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.activemq.artemis.cli.commands;
 
 import java.io.ByteArrayInputStream;

--- a/examples/core/embedded-remote/pom.xml
+++ b/examples/core/embedded-remote/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis Core Embedded Remote Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq</groupId>

--- a/examples/core/embedded/pom.xml
+++ b/examples/core/embedded/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis Core Embedded Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq</groupId>

--- a/examples/core/perf/pom.xml
+++ b/examples/core/perf/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis Perf Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq</groupId>

--- a/examples/core/pom.xml
+++ b/examples/core/pom.xml
@@ -34,6 +34,7 @@ under the License.
 
    <properties>
       <udp-address>231.7.7.7</udp-address>
+      <activemq.basedir>${project.basedir}/../..</activemq.basedir>
    </properties>
 
    <profiles>

--- a/examples/core/vertx-connector/pom.xml
+++ b/examples/core/vertx-connector/pom.xml
@@ -32,8 +32,10 @@ under the License.
    <name>ActiveMQ Artemis Vert.x Example</name>
 
    <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
       <vertx.version>2.1.2</vertx.version>
    </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq</groupId>

--- a/examples/core/vertx-connector/src/main/resources/server0/broker.xml
+++ b/examples/core/vertx-connector/src/main/resources/server0/broker.xml
@@ -62,14 +62,14 @@ under the License.
 
       <connector-services>
          <connector-service name="my-incoming-vertx">
-            <factory-class>org.apache.activemq.integration.vertx.VertxIncomingConnectorServiceFactory</factory-class>
+            <factory-class>org.apache.activemq.artemis.integration.vertx.VertxIncomingConnectorServiceFactory</factory-class>
             <param key="queue" value="queue.vertxQueue"/>
             <param key="host" value="localhost"/>
             <param key="port" value="0"/>
             <param key="vertx-address" value="incoming.vertx.address"/>
          </connector-service>
          <connector-service name="my-outgoing-vertx">
-            <factory-class>org.apache.activemq.integration.vertx.VertxOutgoingConnectorServiceFactory</factory-class>
+            <factory-class>org.apache.activemq.artemis.integration.vertx.VertxOutgoingConnectorServiceFactory</factory-class>
             <param key="queue" value="queue.vertxQueue"/>
             <param key="host" value="localhost"/>
             <param key="port" value="0"/>
@@ -77,5 +77,5 @@ under the License.
          </connector-service>
       </connector-services>
    </core>
-   
+
 </configuration>

--- a/examples/jms/aerogear/pom.xml
+++ b/examples/jms/aerogear/pom.xml
@@ -31,6 +31,7 @@ under the License.
       <endpoint />
       <applicationid />
       <mastersecret />
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
    </properties>
 
    <artifactId>artemis-jms-aerogear-example</artifactId>

--- a/examples/jms/application-layer-failover/pom.xml
+++ b/examples/jms/application-layer-failover/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Application Layer Failover Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/artemis-jms-examples-common/pom.xml
+++ b/examples/jms/artemis-jms-examples-common/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis Examples common</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.geronimo.specs</groupId>

--- a/examples/jms/artemis-ra-rar/pom.xml
+++ b/examples/jms/artemis-ra-rar/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>rar</packaging>
    <name>ActiveMQ Artemis JMS RA</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq</groupId>

--- a/examples/jms/bridge/pom.xml
+++ b/examples/jms/bridge/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Bridge Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/browser/pom.xml
+++ b/examples/jms/browser/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Browser Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/client-kickoff/pom.xml
+++ b/examples/jms/client-kickoff/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Kick Off Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/client-side-failoverlistener/pom.xml
+++ b/examples/jms/client-side-failoverlistener/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Client Side Failover listener Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/client-side-load-balancing/pom.xml
+++ b/examples/jms/client-side-load-balancing/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Client Side Load Balancing Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/clustered-durable-subscription/pom.xml
+++ b/examples/jms/clustered-durable-subscription/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Clustered Durable Subscription Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/clustered-grouping/pom.xml
+++ b/examples/jms/clustered-grouping/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS CLustered Grouping Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/clustered-jgroups/pom.xml
+++ b/examples/jms/clustered-jgroups/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Clustered JGroups Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/clustered-queue/pom.xml
+++ b/examples/jms/clustered-queue/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Clustered Queue Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/clustered-standalone/pom.xml
+++ b/examples/jms/clustered-standalone/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Clustered Standalone Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/clustered-static-discovery/pom.xml
+++ b/examples/jms/clustered-static-discovery/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Clustered Static Discovery Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/clustered-static-oneway/pom.xml
+++ b/examples/jms/clustered-static-oneway/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Clustered Static One Way Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/clustered-topic/pom.xml
+++ b/examples/jms/clustered-topic/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Clustered Topic Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/colocated-failover-scale-down/pom.xml
+++ b/examples/jms/colocated-failover-scale-down/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Colocated Failover Recover Only Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/colocated-failover/pom.xml
+++ b/examples/jms/colocated-failover/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Colocated Failover Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/consumer-rate-limit/pom.xml
+++ b/examples/jms/consumer-rate-limit/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Consumer Rate Limit Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/dead-letter/pom.xml
+++ b/examples/jms/dead-letter/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Dead Letter Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/delayed-redelivery/pom.xml
+++ b/examples/jms/delayed-redelivery/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Delayed Redelivery Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/divert/pom.xml
+++ b/examples/jms/divert/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Divert Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/durable-subscription/pom.xml
+++ b/examples/jms/durable-subscription/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Durable Subscription Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/embedded-simple/pom.xml
+++ b/examples/jms/embedded-simple/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Simple Embedded Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/embedded/pom.xml
+++ b/examples/jms/embedded/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Embedded Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/expiry/pom.xml
+++ b/examples/jms/expiry/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Expiry Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/ha-policy-autobackup/pom.xml
+++ b/examples/jms/ha-policy-autobackup/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS HA Policy Auto backup example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/http-transport/pom.xml
+++ b/examples/jms/http-transport/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Http Transport Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/instantiate-connection-factory/pom.xml
+++ b/examples/jms/instantiate-connection-factory/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Instantiate Connection Factory Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/interceptor/pom.xml
+++ b/examples/jms/interceptor/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Interceptor Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/jms-auto-closeable/pom.xml
+++ b/examples/jms/jms-auto-closeable/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Auto Closable Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/jms-bridge/pom.xml
+++ b/examples/jms/jms-bridge/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Bridge Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/jms-completion-listener/pom.xml
+++ b/examples/jms/jms-completion-listener/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Completion Listener Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/jms-context/pom.xml
+++ b/examples/jms/jms-context/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Context Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/jms-shared-consumer/pom.xml
+++ b/examples/jms/jms-shared-consumer/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Shared Consumer Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/jmx/pom.xml
+++ b/examples/jms/jmx/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS "JMX" Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/large-message/pom.xml
+++ b/examples/jms/large-message/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Large Message Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/last-value-queue/pom.xml
+++ b/examples/jms/last-value-queue/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Last Value Queue Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/management-notifications/pom.xml
+++ b/examples/jms/management-notifications/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Management Notifications Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/management/pom.xml
+++ b/examples/jms/management/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Management Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/message-counters/pom.xml
+++ b/examples/jms/message-counters/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Message Counter Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/message-group/pom.xml
+++ b/examples/jms/message-group/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Message Group Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/message-group2/pom.xml
+++ b/examples/jms/message-group2/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Message Group Example 2</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/message-priority/pom.xml
+++ b/examples/jms/message-priority/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS MessagePriorityExample Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/multiple-failover-failback/pom.xml
+++ b/examples/jms/multiple-failover-failback/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Multiple Failover Failback Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/multiple-failover/pom.xml
+++ b/examples/jms/multiple-failover/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Multiple Failover Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/no-consumer-buffering/pom.xml
+++ b/examples/jms/no-consumer-buffering/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS No Consumer Buffering Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/non-transaction-failover/pom.xml
+++ b/examples/jms/non-transaction-failover/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Non Transaction Failover Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/openwire/pom.xml
+++ b/examples/jms/openwire/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Openwire Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <profiles>
       <profile>
          <id>example</id>

--- a/examples/jms/paging/pom.xml
+++ b/examples/jms/paging/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Paging Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/perf/pom.xml
+++ b/examples/jms/perf/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS PerfExample Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq</groupId>

--- a/examples/jms/pom.xml
+++ b/examples/jms/pom.xml
@@ -34,6 +34,7 @@ under the License.
 
    <properties>
       <udp-address>231.7.7.7</udp-address>
+      <activemq.basedir>${project.basedir}/../..</activemq.basedir>
    </properties>
 
    <profiles>

--- a/examples/jms/pre-acknowledge/pom.xml
+++ b/examples/jms/pre-acknowledge/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Pre Acknowledge Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/producer-rate-limit/pom.xml
+++ b/examples/jms/producer-rate-limit/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Producer Rate Limit Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/proton-cpp/pom.xml
+++ b/examples/jms/proton-cpp/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis AMQP CPP Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/proton-j/pom.xml
+++ b/examples/jms/proton-j/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis Proton-J Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/proton-ruby/pom.xml
+++ b/examples/jms/proton-ruby/pom.xml
@@ -29,7 +29,11 @@ under the License.
 
    <artifactId>artemis-jms-proton-ruby-example</artifactId>
    <packaging>jar</packaging>
-   <name>ActiveMQ Artemis Proton Ruby Examplee</name>
+   <name>ActiveMQ Artemis Proton Ruby Example</name>
+
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
 
    <dependencies>
       <dependency>

--- a/examples/jms/queue-message-redistribution/pom.xml
+++ b/examples/jms/queue-message-redistribution/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Queue Message Redistribution Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/queue-requestor/pom.xml
+++ b/examples/jms/queue-requestor/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Queue Requestor Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/queue-selector/pom.xml
+++ b/examples/jms/queue-selector/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Queue Selector Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/queue/pom.xml
+++ b/examples/jms/queue/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Queue Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/reattach-node/pom.xml
+++ b/examples/jms/reattach-node/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Reattach Node Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/replicated-failback-static/pom.xml
+++ b/examples/jms/replicated-failback-static/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Replicated Failback Static Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/replicated-failback/pom.xml
+++ b/examples/jms/replicated-failback/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Replicated Failback Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/replicated-multiple-failover/pom.xml
+++ b/examples/jms/replicated-multiple-failover/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Replicated Multiple Failover Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/replicated-transaction-failover/pom.xml
+++ b/examples/jms/replicated-transaction-failover/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Replicated Transaction Failover Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/request-reply/pom.xml
+++ b/examples/jms/request-reply/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Request Reply Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/rest/dup-send/pom.xml
+++ b/examples/jms/rest/dup-send/pom.xml
@@ -28,6 +28,11 @@ under the License.
    <artifactId>dup-send</artifactId>
    <packaging>war</packaging>
    <name>Duplicate Send Demo</name>
+
+   <properties>
+      <activemq.basedir>${project.basedir}/../../../..</activemq.basedir>
+   </properties>
+
    <repositories>
       <repository>
          <id>jboss</id>

--- a/examples/jms/rest/javascript-chat/pom.xml
+++ b/examples/jms/rest/javascript-chat/pom.xml
@@ -28,6 +28,11 @@ under the License.
    <artifactId>javascript-chat</artifactId>
    <packaging>war</packaging>
    <name>Browser Chat App</name>
+
+   <properties>
+      <activemq.basedir>${project.basedir}/../../../..</activemq.basedir>
+   </properties>
+
    <repositories>
       <repository>
          <id>jboss</id>

--- a/examples/jms/rest/jms-to-rest/pom.xml
+++ b/examples/jms/rest/jms-to-rest/pom.xml
@@ -28,6 +28,11 @@ under the License.
    <artifactId>mixed-jms-rest</artifactId>
    <packaging>war</packaging>
    <name>Mixed JMS and REST Producers/Consumers</name>
+
+   <properties>
+      <activemq.basedir>${project.basedir}/../../../..</activemq.basedir>
+   </properties>
+
    <repositories>
       <repository>
          <id>jboss</id>

--- a/examples/jms/rest/pom.xml
+++ b/examples/jms/rest/pom.xml
@@ -32,6 +32,10 @@ under the License.
    <packaging>pom</packaging>
    <name>ActiveMQ Artemis REST Examples</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <modules>
       <module>javascript-chat</module>
       <module>jms-to-rest</module>

--- a/examples/jms/rest/push/pom.xml
+++ b/examples/jms/rest/push/pom.xml
@@ -28,6 +28,11 @@ under the License.
    <artifactId>push</artifactId>
    <packaging>war</packaging>
    <name>Push Subscriptions</name>
+
+   <properties>
+      <activemq.basedir>${project.basedir}/../../../..</activemq.basedir>
+   </properties>
+
    <repositories>
       <repository>
          <id>jboss</id>

--- a/examples/jms/scale-down/pom.xml
+++ b/examples/jms/scale-down/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Scale Down Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/scheduled-message/pom.xml
+++ b/examples/jms/scheduled-message/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Scheduled Message Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/security/pom.xml
+++ b/examples/jms/security/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Security Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/send-acknowledgements/pom.xml
+++ b/examples/jms/send-acknowledgements/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Send Acknowledgements Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/spring-integration/pom.xml
+++ b/examples/jms/spring-integration/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Spring Integration Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/ssl-enabled/pom.xml
+++ b/examples/jms/ssl-enabled/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS SSL Enabled Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/static-selector-jms/pom.xml
+++ b/examples/jms/static-selector-jms/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Static Selector Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/static-selector/pom.xml
+++ b/examples/jms/static-selector/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis Static Selector Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/stomp-websockets/pom.xml
+++ b/examples/jms/stomp-websockets/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS StompWebSocketExample Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/stomp/pom.xml
+++ b/examples/jms/stomp/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Stomp Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/stomp1.1/pom.xml
+++ b/examples/jms/stomp1.1/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Stomp 1.1 Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/stomp1.2/pom.xml
+++ b/examples/jms/stomp1.2/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Stomp 1.2 Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/stop-server-failover/pom.xml
+++ b/examples/jms/stop-server-failover/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Stop Server Failover Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/symmetric-cluster/pom.xml
+++ b/examples/jms/symmetric-cluster/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Symmetric Cluster Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/temp-queue/pom.xml
+++ b/examples/jms/temp-queue/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Temporary Queue Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/topic-hierarchies/pom.xml
+++ b/examples/jms/topic-hierarchies/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Topic Hierarchies Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/topic-selector-example1/pom.xml
+++ b/examples/jms/topic-selector-example1/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Topic Selector Example 1</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/topic-selector-example2/pom.xml
+++ b/examples/jms/topic-selector-example2/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Topic Selector Example 2</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/topic/pom.xml
+++ b/examples/jms/topic/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Topic Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/transaction-failover/pom.xml
+++ b/examples/jms/transaction-failover/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Transaction Failover Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/transactional/pom.xml
+++ b/examples/jms/transactional/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS Transactional Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/xa-heuristic/pom.xml
+++ b/examples/jms/xa-heuristic/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS XAHeuristicExample Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/xa-receive/pom.xml
+++ b/examples/jms/xa-receive/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS XA Receive Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/jms/xa-send/pom.xml
+++ b/examples/jms/xa-send/pom.xml
@@ -31,6 +31,10 @@ under the License.
    <packaging>jar</packaging>
    <name>ActiveMQ Artemis JMS XA Send Example</name>
 
+   <properties>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
+   </properties>
+
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq.examples.jms</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -35,6 +35,7 @@ under the License.
    <properties>
       <skipLicenseCheck>true</skipLicenseCheck>
       <skipStyleCheck>true</skipStyleCheck>
+      <activemq.basedir>${project.basedir}/..</activemq.basedir>
    </properties>
 
    <repositories>

--- a/examples/soak/normal/pom.xml
+++ b/examples/soak/normal/pom.xml
@@ -41,6 +41,7 @@ under the License.
 
    <properties>
       <server.dir>${basedir}/server0/</server.dir>
+      <activemq.basedir>${project.basedir}/../../..</activemq.basedir>
    </properties>
 
    <build>

--- a/examples/soak/pom.xml
+++ b/examples/soak/pom.xml
@@ -40,6 +40,7 @@ under the License.
       filtered resources, i.e. build is platform dependent!
       -->
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      <activemq.basedir>${project.basedir}/../..</activemq.basedir>
    </properties>
 
    <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
          -Djava.net.preferIPv4Stack=true
       </activemq-surefire-argline>
       <activemq.basedir>${project.basedir}</activemq.basedir>
-      <skipLicenseCheck>true</skipLicenseCheck>
+      <skipLicenseCheck>false</skipLicenseCheck>
       <skipStyleCheck>false</skipStyleCheck>
       <geronimo.jms.2.spec.version>1.0-alpha-1</geronimo.jms.2.spec.version>
    </properties>
@@ -900,11 +900,47 @@
             </configuration>
          </plugin>
          <plugin>
+            <groupId>com.mycila</groupId>
+            <artifactId>license-maven-plugin</artifactId>
+            <version>2.6</version>
+            <configuration>
+               <skip>${skipLicenseCheck}</skip>
+               <basedir>${activemq.basedir}</basedir>
+               <header>etc/license-header.txt</header>
+               <quiet>false</quiet>
+               <failIfMissing>true</failIfMissing>
+               <includes>
+                  <include>**/*.java</include>
+               </includes>
+               <excludes>
+                  <exclude>**/filter/impl/Identifier.java</exclude>
+                  <exclude>**/filter/impl/Operator.java</exclude>
+                  <exclude>**/filter/impl/RegExp.java</exclude>
+                  <exclude>**/utils/UUID*.java</exclude>
+                  <exclude>**/org/apache/activemq/selector/**</exclude>
+                  <exclude>**/org/apache/activemq/utils/json/**</exclude>
+                  <exclude>**/org/apache/activemq/utils/Base64.java</exclude>
+               </excludes>
+               <useDefaultExcludes>true</useDefaultExcludes>
+               <strictCheck>true</strictCheck>
+               <mapping>
+                  <java>JAVADOC_STYLE</java>
+               </mapping>
+            </configuration>
+            <executions>
+               <execution>
+                  <phase>compile</phase>
+                  <goals>
+                     <goal>check</goal>
+                  </goals>
+               </execution>
+            </executions>
+         </plugin>
+         <plugin>
             <groupId>org.apache.rat</groupId>
             <artifactId>apache-rat-plugin</artifactId>
             <version>0.11</version>
             <configuration>
-               <skip>${skipLicenseCheck}</skip>
                <excludes>
                   <exclude>**/*.bin</exclude>
                   <exclude>**/*.log</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -900,72 +900,22 @@
             </configuration>
          </plugin>
          <plugin>
-            <groupId>com.mycila</groupId>
-            <artifactId>license-maven-plugin</artifactId>
-            <version>2.6</version>
-            <configuration>
-               <skip>${skipLicenseCheck}</skip>
-               <basedir>${activemq.basedir}</basedir>
-               <header>etc/license-header.txt</header>
-               <quiet>false</quiet>
-               <failIfMissing>true</failIfMissing>
-               <includes>
-                  <include>**/*.java</include>
-               </includes>
-               <excludes>
-                  <exclude>**/filter/impl/Identifier.java</exclude>
-                  <exclude>**/filter/impl/Operator.java</exclude>
-                  <exclude>**/filter/impl/RegExp.java</exclude>
-                  <exclude>**/utils/UUID*.java</exclude>
-                  <exclude>**/org/apache/activemq/selector/**</exclude>
-                  <exclude>**/org/apache/activemq/utils/json/**</exclude>
-                  <exclude>**/org/apache/activemq/utils/Base64.java</exclude>
-               </excludes>
-               <useDefaultExcludes>true</useDefaultExcludes>
-               <strictCheck>true</strictCheck>
-               <mapping>
-                  <java>JAVADOC_STYLE</java>
-               </mapping>
-            </configuration>
-            <executions>
-               <execution>
-                  <phase>compile</phase>
-                  <goals>
-                     <goal>check</goal>
-                  </goals>
-               </execution>
-            </executions>
-         </plugin>
-         <plugin>
             <groupId>org.apache.rat</groupId>
             <artifactId>apache-rat-plugin</artifactId>
             <version>0.11</version>
             <configuration>
+               <reportFile>${activemq.basedir}/ratReport.txt</reportFile>
                <excludes>
-                  <exclude>**/*.bin</exclude>
-                  <exclude>**/*.log</exclude>
                   <exclude>**/*.txt</exclude>
-                  <exclude>**/src/main/resources/licenses/</exclude>
                   <exclude>**/*.md</exclude>
-                  <exclude>**/banner.txt</exclude>
-                  <exclude>docs/quickstart-guide/target/**/*.log</exclude>
-                  <exclude>docs/user-manual/target/**/*.log</exclude>
-                  <exclude>**/resources/webapps/WebServerComponentTest.txt</exclude>
-                  <exclude>integration/activemq-jboss-as-integration/target/checkstyle-cachefile</exclude>
-                  <exclude>integration/activemq-jboss-as-integration/target/**/*.lst</exclude>
                   <exclude>etc/org.eclipse.*</exclude>
                   <exclude>docs/user-manual/en/*.json</exclude>
                   <exclude>**/target/</exclude>
-                  <exclude>**/data/</exclude>
-                  <exclude>**/*.bindings</exclude>
-                  <exclude>**/*.lock</exclude>
                   <exclude>**/META-INF/services/*</exclude>
                   <exclude>**/*.iml</exclude>
-                  <exclude>**/*.jceks</exclude>
-                  <exclude>**/*.jks</exclude>
                   <exclude>**/org/apache/activemq/artemis/utils/json/**</exclude>
-                  <exclude>**/src/main/resources/META-INF/LICENSE</exclude>
                   <exclude>**/org/apache/activemq/artemis/utils/Base64.java</exclude>
+                  <exclude>ratReport.txt</exclude>
                </excludes>
             </configuration>
             <executions>


### PR DESCRIPTION
All the example poms needed to be updated so they would use the same location from the license report file (i.e. ratReport.txt).  This is necessary so this file can be printed at the end of the Jenkins build so that if the license check fails the developer will know which file caused it.