### PR TITLE
Bump Maven Assembly Plugin Version to 2.4

### DIFF
--- a/artemis-distribution/pom.xml
+++ b/artemis-distribution/pom.xml
@@ -192,7 +192,7 @@
          </plugin>
          <plugin>
             <artifactId>maven-assembly-plugin</artifactId>
-            <version>2.2</version>
+            <version>${maven.assembly.plugin.version}</version>
             <executions>
                <execution>
                   <id>source</id>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
        <!-- base url for site deployment.  See distribution management for full url.  Override this in settings.xml for staging -->
       <staging.siteURL>scp://people.apache.org/x1/www/activemq.apache.org</staging.siteURL>
       <netty.version>4.0.20.Final</netty.version>
+      <maven.assembly.plugin.version>2.4</maven.assembly.plugin.version>
       <activemq.version.versionName>${project.version}</activemq.version.versionName>
       <activemq.version.majorVersion>1</activemq.version.majorVersion>
       <activemq.version.minorVersion>0</activemq.version.minorVersion>


### PR DESCRIPTION
A bug in version 2.2 was causing directory permissions in the assembly file to be ignored.