### PR TITLE
Fix FileConfigurationTest for Windows

### DIFF
--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
@@ -372,13 +372,13 @@ public class FileConfigurationTest extends ConfigurationImplTest
       {
 
          // copy working configuration to a location where the standard classloader cannot find it
-         final Path workingConfiguration = new File(getClass().getResource(File.separator + fullConfigurationName).toURI()).toPath();
+         final Path workingConfiguration = new File(getClass().getResource("/" + fullConfigurationName).toURI()).toPath();
          final Path targetFile = customConfiguration.toPath();
 
          Files.copy(workingConfiguration, targetFile, StandardCopyOption.REPLACE_EXISTING);
 
          // build a custom classloader knowing the location of the config created above (used as context class loader)
-         final URL customConfigurationDirUrl = new URL("file://" + customConfiguration.getParentFile().getAbsolutePath() + File.separator);
+         final URL customConfigurationDirUrl = customConfiguration.getParentFile().toURI().toURL();
          final ClassLoader testWebappClassLoader = new URLClassLoader(new URL[]{customConfigurationDirUrl});
 
          /*
@@ -388,7 +388,7 @@ public class FileConfigurationTest extends ConfigurationImplTest
 
          final class ThrowableHolder
          {
-            public Exception t = null;
+            volatile Exception t;
          }
 
          final ThrowableHolder holder = new ThrowableHolder();


### PR DESCRIPTION
The test wrongly assumes that Class.getResource(..) needs to specify the
System's line-separator. The contract for the method dictates:

    "If the name begins with a '/' ('\u002f'), then the absolute name of
     the resource is the portion of the name following the '/'."

Also, it manipulates File.getAbsolutePath() in a way that generates wrong
URL for Windows.