### PR TITLE
Make Topology non-serializable and also improve constructor

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/Topology.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/Topology.java
@@ -16,7 +16,6 @@
  */
 package org.apache.activemq.artemis.core.client.impl;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -32,14 +31,13 @@ import org.apache.activemq.artemis.api.core.client.ClusterTopologyListener;
 import org.apache.activemq.artemis.core.client.ActiveMQClientLogger;
 import org.apache.activemq.artemis.spi.core.remoting.Connector;
 
-public final class Topology implements Serializable
+public final class Topology
 {
 
-   private static final long serialVersionUID = -9037171688692471371L;
 
    private final Set<ClusterTopologyListener> topologyListeners = new HashSet<ClusterTopologyListener>();
 
-   private transient Executor executor = null;
+   private final Executor executor = null;
 
    /**
     * Used to debug operations.
@@ -58,7 +56,7 @@ public final class Topology implements Serializable
     */
    private final Map<String, TopologyMemberImpl> topology = new ConcurrentHashMap<String, TopologyMemberImpl>();
 
-   private transient Map<String, Long> mapDelete;
+   private Map<String, Long> mapDelete;
 
    public Topology(final Object owner)
    {

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/Topology.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/Topology.java
@@ -258,7 +258,7 @@ public final class Topology
             return true;
          }
          /*
-          * always add the backup, better to try to reconnect to something thats not there then to
+          * always add the backup, better to try to reconnect to something that's not there then to
           * not know about it at all
           */
          if (currentMember.getBackup() == null && memberInput.getBackup() != null)
@@ -322,7 +322,7 @@ public final class Topology
       ArrayList<ClusterTopologyListener> listenersCopy;
       synchronized (topologyListeners)
       {
-         listenersCopy = new ArrayList<ClusterTopologyListener>(topologyListeners);
+         listenersCopy = new ArrayList<>(topologyListeners);
       }
       return listenersCopy;
    }
@@ -454,7 +454,7 @@ public final class Topology
       ArrayList<TopologyMemberImpl> members;
       synchronized (this)
       {
-         members = new ArrayList<TopologyMemberImpl>(topology.values());
+         members = new ArrayList<>(topology.values());
       }
       return members;
    }
@@ -484,11 +484,11 @@ public final class Topology
    private synchronized String describe(final String text)
    {
       StringBuilder desc = new StringBuilder(text + "topology on " + this + ":\n");
-      for (Entry<String, TopologyMemberImpl> entry : new HashMap<String, TopologyMemberImpl>(topology).entrySet())
+      for (Entry<String, TopologyMemberImpl> entry : new HashMap<>(topology).entrySet())
       {
-         desc.append("\t" + entry.getKey() + " => " + entry.getValue() + "\n");
+         desc.append("\t").append(entry.getKey()).append(" => ").append(entry.getValue()).append("\n");
       }
-      desc.append("\t" + "nodes=" + nodes() + "\t" + "members=" + members());
+      desc.append("\t" + "nodes=").append(nodes()).append("\t").append("members=").append(members());
       if (topology.isEmpty())
       {
          desc.append("\tEmpty");
@@ -535,7 +535,7 @@ public final class Topology
    {
       if (mapDelete == null)
       {
-         mapDelete = new ConcurrentHashMap<String, Long>();
+         mapDelete = new ConcurrentHashMap<>();
       }
       return mapDelete;
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/impl/ClusterConnectionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/impl/ClusterConnectionImpl.java
@@ -151,7 +151,7 @@ public final class ClusterConnectionImpl implements ClusterConnection, AfterConn
 
    // Stuff that used to be on the ClusterManager
 
-   private final Topology topology = new Topology(this);
+   private final Topology topology;
 
    private volatile boolean stopping = false;
 
@@ -228,7 +228,7 @@ public final class ClusterConnectionImpl implements ClusterConnection, AfterConn
 
       this.executor = executorFactory.getExecutor();
 
-      this.topology.setExecutor(executor);
+      this.topology = new Topology(this, executor);
 
       this.server = server;
 
@@ -341,7 +341,7 @@ public final class ClusterConnectionImpl implements ClusterConnection, AfterConn
 
       this.executor = executorFactory.getExecutor();
 
-      this.topology.setExecutor(executor);
+      this.topology = new Topology(this, executor);
 
       this.server = server;
 


### PR DESCRIPTION
Topology serialization is already broken at this point, as its `topologyListeners` are not Serializable themselves.

Also, all the `executor` logic was simplified by making it `final`, defined at the constructor.