### PR TITLE
More test-suite refactoring

### DIFF
--- a/artemis-core-client/src/test/java/org/apache/activemq/artemis/tests/util/SilentTestCase.java
+++ b/artemis-core-client/src/test/java/org/apache/activemq/artemis/tests/util/SilentTestCase.java
@@ -40,7 +40,6 @@ public abstract class SilentTestCase extends Assert
    @Before
    public void setUp() throws Exception
    {
-
       origSysOut = System.out;
       origSysErr = System.err;
       sysOut = new PrintStream(new ByteArrayOutputStream());
@@ -54,6 +53,5 @@ public abstract class SilentTestCase extends Assert
    {
       System.setOut(origSysOut);
       System.setErr(origSysErr);
-
    }
 }

--- a/artemis-core-client/src/test/java/org/apache/activemq/artemis/util/ConcurrentHashSetTest.java
+++ b/artemis-core-client/src/test/java/org/apache/activemq/artemis/util/ConcurrentHashSetTest.java
@@ -15,19 +15,15 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.util;
-import org.junit.Before;
-import org.junit.After;
-
-import org.junit.Test;
-
-import java.util.Iterator;
-
-import org.junit.Assert;
-
 
 import org.apache.activemq.artemis.tests.util.RandomUtil;
 import org.apache.activemq.artemis.utils.ConcurrentHashSet;
 import org.apache.activemq.artemis.utils.ConcurrentSet;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Iterator;
 
 public class ConcurrentHashSetTest extends Assert
 {
@@ -132,20 +128,10 @@ public class ConcurrentHashSetTest extends Assert
    @Before
    public void setUp() throws Exception
    {
-
-
       set = new ConcurrentHashSet<String>();
       element = RandomUtil.randomString();
    }
 
-   @After
-   public void tearDown() throws Exception
-   {
-      set = null;
-      element = null;
-
-
-   }
    // Package protected ---------------------------------------------
 
    // Protected -----------------------------------------------------

--- a/artemis-core-client/src/test/java/org/apache/activemq/artemis/util/TypedPropertiesConversionTest.java
+++ b/artemis-core-client/src/test/java/org/apache/activemq/artemis/util/TypedPropertiesConversionTest.java
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.util;
+
 import org.apache.activemq.artemis.api.core.ActiveMQPropertyConversionException;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
 import org.apache.activemq.artemis.utils.TypedProperties;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -46,19 +46,8 @@ public class TypedPropertiesConversionTest
    @Before
    public void setUp() throws Exception
    {
-
-
       key = RandomUtil.randomSimpleString();
       props = new TypedProperties();
-   }
-
-   @After
-   public void tearDown() throws Exception
-   {
-      key = null;
-      props = null;
-
-
    }
 
    @Test

--- a/artemis-protocols/artemis-proton-plug/src/test/java/org/proton/plug/test/AbstractJMSTest.java
+++ b/artemis-protocols/artemis-proton-plug/src/test/java/org/proton/plug/test/AbstractJMSTest.java
@@ -24,8 +24,6 @@ import javax.jms.Queue;
 
 import java.lang.ref.WeakReference;
 
-//import io.hawtjms.jms.JmsConnectionFactory;
-//import io.hawtjms.jms.JmsQueue;
 import org.apache.qpid.amqp_1_0.jms.impl.ConnectionFactoryImpl;
 import org.apache.qpid.amqp_1_0.jms.impl.QueueImpl;
 import org.proton.plug.test.minimalserver.DumbServer;

--- a/artemis-protocols/artemis-proton-plug/src/test/java/org/proton/plug/test/ProtonTest.java
+++ b/artemis-protocols/artemis-proton-plug/src/test/java/org/proton/plug/test/ProtonTest.java
@@ -84,7 +84,6 @@ public class ProtonTest extends AbstractJMSTest
       AbstractJMSTest.forceGC();
       server.start("127.0.0.1", Constants.PORT, true);
       connection = createConnection();
-
    }
 
    @After

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
@@ -270,6 +270,8 @@ public interface Configuration
 
    Configuration addConnectorConfiguration(final String key, final TransportConfiguration info);
 
+   Configuration clearConnectorConfigurations();
+
    /**
     * Returns the broadcast groups configured for this server.
     */
@@ -323,6 +325,8 @@ public interface Configuration
     * Sets the diverts configured for this server.
     */
    Configuration setDivertConfigurations(final List<DivertConfiguration> configs);
+
+   Configuration addDivertConfiguration(final DivertConfiguration config);
 
    /**
     * Returns the cluster connections configured for this server.
@@ -796,6 +800,8 @@ public interface Configuration
    Configuration setAddressesSettings(Map<String, AddressSettings> addressesSettings);
 
    Configuration addAddressesSetting(String key, AddressSettings addressesSetting);
+
+   Configuration clearAddressesSettings();
 
    /**
     * @param roles a list of roles per matching

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
@@ -377,6 +377,12 @@ public class ConfigurationImpl implements Configuration, Serializable
       return this;
    }
 
+   public ConfigurationImpl clearConnectorConfigurations()
+   {
+      connectorConfigs.clear();
+      return this;
+   }
+
    public GroupingHandlerConfiguration getGroupingHandlerConfiguration()
    {
       return groupingHandlerConfiguration;
@@ -1023,6 +1029,13 @@ public class ConfigurationImpl implements Configuration, Serializable
    public ConfigurationImpl addAddressesSetting(String key, AddressSettings addressesSetting)
    {
       this.addressesSettings.put(key, addressesSetting);
+      return this;
+   }
+
+   @Override
+   public ConfigurationImpl clearAddressesSettings()
+   {
+      this.addressesSettings.clear();
       return this;
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
@@ -146,9 +146,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       return autoCreateJmsQueues != null ? autoCreateJmsQueues : AddressSettings.DEFAULT_AUTO_CREATE_QUEUES;
    }
 
-   public void setAutoCreateJmsQueues(final boolean autoCreateJmsQueues)
+   public AddressSettings setAutoCreateJmsQueues(final boolean autoCreateJmsQueues)
    {
       this.autoCreateJmsQueues = autoCreateJmsQueues;
+      return this;
    }
 
    public boolean isAutoDeleteJmsQueues()
@@ -156,9 +157,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       return autoDeleteJmsQueues != null ? autoDeleteJmsQueues : AddressSettings.DEFAULT_AUTO_DELETE_QUEUES;
    }
 
-   public void setAutoDeleteJmsQueues(final boolean autoDeleteJmsQueues)
+   public AddressSettings setAutoDeleteJmsQueues(final boolean autoDeleteJmsQueues)
    {
       this.autoDeleteJmsQueues = autoDeleteJmsQueues;
+      return this;
    }
 
    public boolean isLastValueQueue()
@@ -166,9 +168,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       return lastValueQueue != null ? lastValueQueue : AddressSettings.DEFAULT_LAST_VALUE_QUEUE;
    }
 
-   public void setLastValueQueue(final boolean lastValueQueue)
+   public AddressSettings setLastValueQueue(final boolean lastValueQueue)
    {
       this.lastValueQueue = lastValueQueue;
+      return this;
    }
 
    public AddressFullMessagePolicy getAddressFullMessagePolicy()
@@ -177,9 +180,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
          : AddressSettings.DEFAULT_ADDRESS_FULL_MESSAGE_POLICY;
    }
 
-   public void setAddressFullMessagePolicy(final AddressFullMessagePolicy addressFullMessagePolicy)
+   public AddressSettings setAddressFullMessagePolicy(final AddressFullMessagePolicy addressFullMessagePolicy)
    {
       this.addressFullMessagePolicy = addressFullMessagePolicy;
+      return this;
    }
 
    public long getPageSizeBytes()
@@ -187,9 +191,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       return pageSizeBytes != null ? pageSizeBytes : AddressSettings.DEFAULT_PAGE_SIZE;
    }
 
-   public void setPageSizeBytes(final long pageSize)
+   public AddressSettings setPageSizeBytes(final long pageSize)
    {
       pageSizeBytes = pageSize;
+      return this;
    }
 
    public int getPageCacheMaxSize()
@@ -197,9 +202,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       return pageMaxCache != null ? pageMaxCache : AddressSettings.DEFAULT_PAGE_MAX_CACHE;
    }
 
-   public void setPageCacheMaxSize(final int pageMaxCache)
+   public AddressSettings setPageCacheMaxSize(final int pageMaxCache)
    {
       this.pageMaxCache = pageMaxCache;
+      return this;
    }
 
    public long getMaxSizeBytes()
@@ -207,9 +213,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       return maxSizeBytes != null ? maxSizeBytes : AddressSettings.DEFAULT_MAX_SIZE_BYTES;
    }
 
-   public void setMaxSizeBytes(final long maxSizeBytes)
+   public AddressSettings setMaxSizeBytes(final long maxSizeBytes)
    {
       this.maxSizeBytes = maxSizeBytes;
+      return this;
    }
 
    public int getMaxDeliveryAttempts()
@@ -217,9 +224,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       return maxDeliveryAttempts != null ? maxDeliveryAttempts : AddressSettings.DEFAULT_MAX_DELIVERY_ATTEMPTS;
    }
 
-   public void setMaxDeliveryAttempts(final int maxDeliveryAttempts)
+   public AddressSettings setMaxDeliveryAttempts(final int maxDeliveryAttempts)
    {
       this.maxDeliveryAttempts = maxDeliveryAttempts;
+      return this;
    }
 
    public int getMessageCounterHistoryDayLimit()
@@ -228,9 +236,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
          : AddressSettings.DEFAULT_MESSAGE_COUNTER_HISTORY_DAY_LIMIT;
    }
 
-   public void setMessageCounterHistoryDayLimit(final int messageCounterHistoryDayLimit)
+   public AddressSettings setMessageCounterHistoryDayLimit(final int messageCounterHistoryDayLimit)
    {
       this.messageCounterHistoryDayLimit = messageCounterHistoryDayLimit;
+      return this;
    }
 
    public long getRedeliveryDelay()
@@ -238,9 +247,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       return redeliveryDelay != null ? redeliveryDelay : AddressSettings.DEFAULT_REDELIVER_DELAY;
    }
 
-   public void setRedeliveryDelay(final long redeliveryDelay)
+   public AddressSettings setRedeliveryDelay(final long redeliveryDelay)
    {
       this.redeliveryDelay = redeliveryDelay;
+      return this;
    }
 
    public double getRedeliveryMultiplier()
@@ -248,9 +258,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       return redeliveryMultiplier != null ? redeliveryMultiplier : AddressSettings.DEFAULT_REDELIVER_MULTIPLIER;
    }
 
-   public void setRedeliveryMultiplier(final double redeliveryMultiplier)
+   public AddressSettings setRedeliveryMultiplier(final double redeliveryMultiplier)
    {
       this.redeliveryMultiplier = redeliveryMultiplier;
+      return this;
    }
 
    public long getMaxRedeliveryDelay()
@@ -260,9 +271,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       return maxRedeliveryDelay != null ? maxRedeliveryDelay : (getRedeliveryDelay() * 10);
    }
 
-   public void setMaxRedeliveryDelay(final long maxRedeliveryDelay)
+   public AddressSettings setMaxRedeliveryDelay(final long maxRedeliveryDelay)
    {
       this.maxRedeliveryDelay = maxRedeliveryDelay;
+      return this;
    }
 
    public SimpleString getDeadLetterAddress()
@@ -270,9 +282,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       return deadLetterAddress;
    }
 
-   public void setDeadLetterAddress(final SimpleString deadLetterAddress)
+   public AddressSettings setDeadLetterAddress(final SimpleString deadLetterAddress)
    {
       this.deadLetterAddress = deadLetterAddress;
+      return this;
    }
 
    public SimpleString getExpiryAddress()
@@ -280,9 +293,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       return expiryAddress;
    }
 
-   public void setExpiryAddress(final SimpleString expiryAddress)
+   public AddressSettings setExpiryAddress(final SimpleString expiryAddress)
    {
       this.expiryAddress = expiryAddress;
+      return this;
    }
 
    public Long getExpiryDelay()
@@ -290,9 +304,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       return expiryDelay;
    }
 
-   public void setExpiryDelay(final Long expiryDelay)
+   public AddressSettings setExpiryDelay(final Long expiryDelay)
    {
       this.expiryDelay = expiryDelay;
+      return this;
    }
 
    public boolean isSendToDLAOnNoRoute()
@@ -300,9 +315,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       return sendToDLAOnNoRoute != null ? sendToDLAOnNoRoute : AddressSettings.DEFAULT_SEND_TO_DLA_ON_NO_ROUTE;
    }
 
-   public void setSendToDLAOnNoRoute(final boolean value)
+   public AddressSettings setSendToDLAOnNoRoute(final boolean value)
    {
       sendToDLAOnNoRoute = value;
+      return this;
    }
 
    public long getRedistributionDelay()
@@ -310,9 +326,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       return redistributionDelay != null ? redistributionDelay : AddressSettings.DEFAULT_REDISTRIBUTION_DELAY;
    }
 
-   public void setRedistributionDelay(final long redistributionDelay)
+   public AddressSettings setRedistributionDelay(final long redistributionDelay)
    {
       this.redistributionDelay = redistributionDelay;
+      return this;
    }
 
    public long getSlowConsumerThreshold()
@@ -320,9 +337,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       return slowConsumerThreshold != null ? slowConsumerThreshold : AddressSettings.DEFAULT_SLOW_CONSUMER_THRESHOLD;
    }
 
-   public void setSlowConsumerThreshold(final long slowConsumerThreshold)
+   public AddressSettings setSlowConsumerThreshold(final long slowConsumerThreshold)
    {
       this.slowConsumerThreshold = slowConsumerThreshold;
+      return this;
    }
 
    public long getSlowConsumerCheckPeriod()
@@ -330,9 +348,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       return slowConsumerCheckPeriod != null ? slowConsumerCheckPeriod : AddressSettings.DEFAULT_SLOW_CONSUMER_CHECK_PERIOD;
    }
 
-   public void setSlowConsumerCheckPeriod(final long slowConsumerCheckPeriod)
+   public AddressSettings setSlowConsumerCheckPeriod(final long slowConsumerCheckPeriod)
    {
       this.slowConsumerCheckPeriod = slowConsumerCheckPeriod;
+      return this;
    }
 
    public SlowConsumerPolicy getSlowConsumerPolicy()
@@ -341,9 +360,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
          : AddressSettings.DEFAULT_SLOW_CONSUMER_POLICY;
    }
 
-   public void setSlowConsumerPolicy(final SlowConsumerPolicy slowConsumerPolicy)
+   public AddressSettings setSlowConsumerPolicy(final SlowConsumerPolicy slowConsumerPolicy)
    {
       this.slowConsumerPolicy = slowConsumerPolicy;
+      return this;
    }
 
    /**

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImplTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImplTest.java
@@ -23,7 +23,7 @@ import org.apache.activemq.artemis.core.config.ha.LiveOnlyPolicyConfiguration;
 import org.apache.activemq.artemis.core.journal.impl.JournalConstants;
 import org.apache.activemq.artemis.core.server.JournalType;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,7 +33,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
-public class ConfigurationImplTest extends ServiceTestBase
+public class ConfigurationImplTest extends ActiveMQTestBase
 {
    protected Configuration conf;
 

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationParserTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationParserTest.java
@@ -20,7 +20,7 @@ import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.FileDeploymentManager;
 import org.apache.activemq.artemis.core.deployers.impl.FileConfigurationParser;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.DefaultSensitiveStringCodec;
 import org.junit.Test;
 
@@ -29,7 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
-public class FileConfigurationParserTest extends ServiceTestBase
+public class FileConfigurationParserTest extends ActiveMQTestBase
 {
    /**
     * These "InvalidConfigurationTest*.xml" files are modified copies of {@value

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/HAPolicyConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/HAPolicyConfigurationTest.java
@@ -34,12 +34,12 @@ import org.apache.activemq.artemis.core.server.impl.SharedNothingBackupActivatio
 import org.apache.activemq.artemis.core.server.impl.SharedNothingLiveActivation;
 import org.apache.activemq.artemis.core.server.impl.SharedStoreBackupActivation;
 import org.apache.activemq.artemis.core.server.impl.SharedStoreLiveActivation;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 
 import java.util.List;
 
-public class HAPolicyConfigurationTest extends ServiceTestBase
+public class HAPolicyConfigurationTest extends ActiveMQTestBase
 {
    @Test
    public void liveOnlyTest() throws Exception

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/WrongRoleFileConfigurationParserTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/WrongRoleFileConfigurationParserTest.java
@@ -18,7 +18,7 @@ package org.apache.activemq.artemis.core.config.impl;
 
 import org.apache.activemq.artemis.core.deployers.impl.FileConfigurationParser;
 import org.apache.activemq.artemis.logs.AssertionLoggerHandler;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -30,7 +30,7 @@ import java.nio.charset.StandardCharsets;
  * When running this test from an IDE add this to the test command line so that the AssertionLoggerHandler works properly:
  * -Djava.util.logging.manager=org.jboss.logmanager.LogManager  -Dlogging.configuration=file:<path_to_source>/tests/config/logging.properties
  */
-public class WrongRoleFileConfigurationParserTest extends ServiceTestBase
+public class WrongRoleFileConfigurationParserTest extends ActiveMQTestBase
 {
    @BeforeClass
    public static void prepareLogger()

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/list/PriorityLinkedListTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/list/PriorityLinkedListTest.java
@@ -15,16 +15,12 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.core.list;
-import org.junit.Before;
-import org.junit.After;
-
-import org.junit.Test;
-
-import org.junit.Assert;
-
 
 import org.apache.activemq.artemis.utils.LinkedListIterator;
 import org.apache.activemq.artemis.utils.PriorityLinkedListImpl;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 public final class PriorityLinkedListTest extends Assert
 {
@@ -120,13 +116,6 @@ public final class PriorityLinkedListTest extends Assert
       x = new Wibble("x");
       y = new Wibble("y");
       z = new Wibble("z");
-   }
-
-   @After
-   public void tearDown() throws Exception
-   {
-      list = null;
-
    }
 
    @Test

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/message/impl/MessagePropertyTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/message/impl/MessagePropertyTest.java
@@ -24,11 +24,11 @@ import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 import org.junit.Test;
 
-public class MessagePropertyTest extends ServiceTestBase
+public class MessagePropertyTest extends ActiveMQTestBase
 {
    private ActiveMQServer server;
    private ServerLocator locator;

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/group/impl/ClusteredResetMockTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/group/impl/ClusteredResetMockTest.java
@@ -48,7 +48,7 @@ import org.apache.activemq.artemis.core.settings.HierarchicalRepository;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.core.transaction.ResourceManager;
 import org.apache.activemq.artemis.spi.core.remoting.Acceptor;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.ConcurrentHashSet;
 import org.apache.activemq.artemis.utils.ReusableLatch;
 import org.junit.Assert;
@@ -65,7 +65,7 @@ import java.util.concurrent.TimeUnit;
  * There is a small window where you could receive notifications wrongly
  * this test will make sure the component would play well with that notification
  */
-public class ClusteredResetMockTest extends ServiceTestBase
+public class ClusteredResetMockTest extends ActiveMQTestBase
 {
 
    public static final SimpleString ANYCLUSTER = SimpleString.toSimpleString("anycluster");

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/settings/AddressSettingsTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/settings/AddressSettingsTest.java
@@ -19,11 +19,11 @@ package org.apache.activemq.artemis.core.settings;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class AddressSettingsTest extends ServiceTestBase
+public class AddressSettingsTest extends ActiveMQTestBase
 {
    @Test
    public void testDefaults()

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/settings/RepositoryTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/settings/RepositoryTest.java
@@ -18,7 +18,7 @@ package org.apache.activemq.artemis.core.settings;
 
 import org.apache.activemq.artemis.core.security.Role;
 import org.apache.activemq.artemis.core.settings.impl.HierarchicalObjectRepository;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class RepositoryTest extends ServiceTestBase
+public class RepositoryTest extends ActiveMQTestBase
 {
    HierarchicalRepository<HashSet<Role>> securityRepository;
 

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/RemoveFolder.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/RemoveFolder.java
@@ -38,6 +38,6 @@ public class RemoveFolder extends ExternalResource
     */
    protected void after()
    {
-      ServiceTestBase.deleteDirectory(new File(folderName));
+      ActiveMQTestBase.deleteDirectory(new File(folderName));
    }
 }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/SimpleStringTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/SimpleStringTest.java
@@ -437,7 +437,7 @@ public class SimpleStringTest extends Assert
             x[i].start();
          }
 
-         ServiceTestBase.waitForLatch(latch);
+         ActiveMQTestBase.waitForLatch(latch);
          start.countDown();
 
          for (T t : x)

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/SingleServerTestBase.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/SingleServerTestBase.java
@@ -16,12 +16,9 @@
  */
 package org.apache.activemq.artemis.tests.util;
 
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.junit.Before;
 
@@ -29,9 +26,8 @@ import org.junit.Before;
  * Any test based on a single server can extend this class.
  * This is useful for quick writing tests with starting a server, locator, factory... etc
  */
-public abstract class SingleServerTestBase extends ServiceTestBase
+public abstract class SingleServerTestBase extends ActiveMQTestBase
 {
-
    protected ActiveMQServer server;
 
    protected ClientSession session;
@@ -47,9 +43,7 @@ public abstract class SingleServerTestBase extends ServiceTestBase
    {
       super.setUp();
 
-      Configuration configuration = createDefaultConfig()
-         .setSecurityEnabled(false);
-      server = createServer(false, configuration);
+      server = createServer(false, createDefaultInVMConfig());
       server.start();
 
       locator = createLocator();
@@ -59,9 +53,6 @@ public abstract class SingleServerTestBase extends ServiceTestBase
 
    protected ServerLocator createLocator()
    {
-      ServerLocator retlocator = ActiveMQClient.createServerLocatorWithoutHA(new TransportConfiguration(INVM_CONNECTOR_FACTORY));
-      addServerLocator(retlocator);
-      return retlocator;
+      return createInVMNonHALocator();
    }
-
 }

--- a/docs/hacking-guide/en/tests.md
+++ b/docs/hacking-guide/en/tests.md
@@ -22,6 +22,48 @@ The broker is comprised of POJOs so it's simple to configure and run a broker in
 Even complex test-cases involving multiple clustered brokers are relatively easy to write. Almost every test in the 
 test-suite follows this pattern - configure broker, start broker, test functionality, stop broker.
 
-The test-suite uses JUnit to manage test execution and life-cycle.  Most tests extend [org.apache.activemq.artemis.tests.util.ServiceTestBase](../../../artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ServiceTestBase.java)
+The test-suite uses JUnit to manage test execution and life-cycle.  Most tests extend [org.apache.activemq.artemis.tests.util.ActiveMQTestBase](../../../artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java)
 which contains JUnit setup and tear-down methods as well as a wealth of utility functions to configure, start, manage,
 and stop brokers as well as perform other common tasks.
+
+Check out [`org.apache.activemq.artemis.tests.integration.SimpleTest`](../../../tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/SimpleTest.java).
+It's a very simple test-case that extends `org.apache.activemq.artemis.tests.util.ActiveMQTestBase` and uses its methods
+to configure a server, run a test, and then `super.tearDown()` cleans it up once the test completes. The test-case 
+includes comments to explain everything. As the name implies, this is a simple test-case that demonstrates the most basic
+functionality of the test-suite. A simple test like this takes less than a second to run on modern hardware.
+
+Although `org.apache.activemq.artemis.tests.integration.SimpleTest` is simple it could be simpler still by extending
+[`org.apache.activemq.artemis.tests.util.SingleServerTestBase`](../../../artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/SingleServerTestBase.java).
+This class does all the setup of a simple server automatically and provides the test-case with a `ServerLocator`, 
+`ClientSessionFactory`, and `ClientSession` instance. [`org.apache.activemq.artemis.tests.integration.SingleServerSimpleTest`](../../../tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/SingleServerSimpleTest.java)
+is an example based on `org.apache.activemq.artemis.tests.integration.SimpleTest` but extends `org.apache.activemq.artemis.tests.util.SingleServerTestBase`
+which eliminates all the setup and class variables which are provided by `SingleServerTestBase` itself.
+
+## Keys for writing good tests
+
+### Avoid leaks
+
+An important task for any test-case is to clean up all the resources it creates when it runs. This includes the server
+instance itself and any resources created to connect to it (e.g. instances of `ServerLocator`, `ClientSessionFactory`,
+`ClientSession`, etc.). This task is typically completed in the test's `tearDown()` method.  However, `ActiveMQTestBase` 
+(and other classes which extend it) simplifies this process. As [`org.apache.activemq.artemis.tests.integration.SimpleTest`](../../../tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/SimpleTest.java)
+demonstrates, there are several methods you can use when creating your test which will ensure proper clean up _automatically_
+when the test is torn down. These include:
+
+- All the overloaded `org.apache.activemq.artemis.tests.util.ActiveMQTestBase.createServer(..)` methods. If you choose
+_not_ to use one of these methods to create your `ActiveMQServer` instance then use the `addServer(ActiveMQServer)` 
+method to add the instance to the test-suite's internal resource ledger.
+- Methods from `org.apache.activemq.artemis.tests.util.ActiveMQTestBase` to create a `ServerLocator` like 
+`createInVMNonHALocator` and `createNettyNonHALocator`. If you choose _not_ to use one of these methods then use 
+`addServerLocator(ServerLocator)` to add the locator to the test-suite's internal resource ledger.
+- `org.apache.activemq.artemis.tests.util.ActiveMQTestBase.createSessionFactory(ServerLocator)` for creating your session
+factory. If you choose _not_ to use this method then use `org.apache.activemq.artemis.tests.util.ActiveMQTestBase.addSessionFactory`
+to add the factory to the test-suite's internal resource ledger.
+
+### Create configurations
+
+There are numerous methods in `org.apache.activemq.artemis.tests.util.ActiveMQTestBase` to create a configuration. These
+methods are named like create&#42;Config(..). Each one creates a slightly different configuration but there is a lot of 
+overlap between them. 
+
+    

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/BMFailoverTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/BMFailoverTest.java
@@ -16,10 +16,6 @@
  */
 package org.apache.activemq.artemis.tests.extras.byteman;
 
-import javax.transaction.xa.XAException;
-import javax.transaction.xa.XAResource;
-import javax.transaction.xa.Xid;
-
 import org.apache.activemq.artemis.api.core.ActiveMQTransactionOutcomeUnknownException;
 import org.apache.activemq.artemis.api.core.ActiveMQTransactionRolledBackException;
 import org.apache.activemq.artemis.api.core.ActiveMQUnBlockedException;
@@ -45,11 +41,14 @@ import org.apache.activemq.artemis.utils.UUIDGenerator;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMRules;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
 
 @RunWith(BMUnitRunner.class)
 public class BMFailoverTest extends FailoverTestBase
@@ -66,13 +65,6 @@ public class BMFailoverTest extends FailoverTestBase
       super.setUp();
       stopped = false;
       locator = getServerLocator();
-   }
-
-   @After
-   @Override
-   public void tearDown() throws Exception
-   {
-      super.tearDown();
    }
 
    private static boolean stopped = false;
@@ -209,8 +201,8 @@ public class BMFailoverTest extends FailoverTestBase
    public void testFailoverOnCommit2() throws Exception
    {
       serverToStop = liveServer;
-      locator = getServerLocator();
-      locator.setFailoverOnInitialConnection(true);
+      locator = getServerLocator()
+              .setFailoverOnInitialConnection(true);
       SimpleString inQueue = new SimpleString("inQueue");
       SimpleString outQueue = new SimpleString("outQueue");
       createSessionFactory();
@@ -312,8 +304,8 @@ public class BMFailoverTest extends FailoverTestBase
    public void testFailoverOnCommit() throws Exception
    {
       serverToStop = liveServer;
-      locator = getServerLocator();
-      locator.setFailoverOnInitialConnection(true);
+      locator = getServerLocator()
+              .setFailoverOnInitialConnection(true);
       createSessionFactory();
       ClientSession session = createSessionAndQueue();
 
@@ -353,8 +345,8 @@ public class BMFailoverTest extends FailoverTestBase
    public void testFailoverOnReceiveCommit() throws Exception
    {
       serverToStop = liveServer;
-      locator = getServerLocator();
-      locator.setFailoverOnInitialConnection(true);
+      locator = getServerLocator()
+              .setFailoverOnInitialConnection(true);
       createSessionFactory();
       ClientSession session = createSessionAndQueue();
 
@@ -433,9 +425,9 @@ public class BMFailoverTest extends FailoverTestBase
 
    private void createSessionFactory() throws Exception
    {
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setReconnectAttempts(-1);
 
       sf = createSessionFactoryAndWaitForTopology(locator, 2);
    }

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/BridgeServerLocatorConfigurationTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/BridgeServerLocatorConfigurationTest.java
@@ -28,14 +28,14 @@ import org.apache.activemq.artemis.core.config.CoreQueueConfiguration;
 import org.apache.activemq.artemis.core.remoting.impl.invm.TransportConstants;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.cluster.impl.BridgeImpl;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(BMUnitRunner.class)
-public class BridgeServerLocatorConfigurationTest extends ServiceTestBase
+public class BridgeServerLocatorConfigurationTest extends ActiveMQTestBase
 {
 
    private static final long BRIDGE_TTL = 1234L;
@@ -130,10 +130,10 @@ public class BridgeServerLocatorConfigurationTest extends ServiceTestBase
          server1.getConfiguration().setQueueConfigurations(queueConfigs1);
 
          server1.start();
-         waitForServer(server1);
+         waitForServerToStart(server1);
 
          serverWithBridge.start();
-         waitForServer(serverWithBridge);
+         waitForServerToStart(serverWithBridge);
 
          long bridgeTTL = getBridgeTTL(serverWithBridge, BRIDGE_NAME);
 

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/ClosingConnectionTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/ClosingConnectionTest.java
@@ -31,7 +31,7 @@ import org.apache.activemq.artemis.core.server.JournalType;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
 import org.apache.activemq.artemis.tests.integration.management.ManagementControlHelper;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMRules;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
@@ -40,7 +40,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(BMUnitRunner.class)
-public class ClosingConnectionTest extends ServiceTestBase
+public class ClosingConnectionTest extends ActiveMQTestBase
 {
    public static final SimpleString ADDRESS = new SimpleString("SimpleAddress");
 
@@ -68,7 +68,7 @@ public class ClosingConnectionTest extends ServiceTestBase
       server.getConfiguration().setJournalType(JournalType.NIO);
       server.getConfiguration().setJMXManagementEnabled(true);
       server.start();
-      waitForServer(server);
+      waitForServerToStart(server);
       locator = createFactory(isNetty());
       readyToKill = false;
    }
@@ -135,9 +135,9 @@ public class ClosingConnectionTest extends ServiceTestBase
       )
    public void testKillConnection() throws Exception
    {
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       ClientSessionFactory sf = createSessionFactory(locator);
       ClientSession session = sf.createSession("guest", null, false, true, true, false, 0);
@@ -182,9 +182,9 @@ public class ClosingConnectionTest extends ServiceTestBase
       ActiveMQServer server = createServer(true, createDefaultConfig(isNetty()));
       server.setMBeanServer(mBeanServer);
 
-      AddressSettings defaultSetting = new AddressSettings();
-      defaultSetting.setPageSizeBytes(10 * 1024);
-      defaultSetting.setMaxSizeBytes(20 * 1024);
+      AddressSettings defaultSetting = new AddressSettings()
+              .setPageSizeBytes(10 * 1024)
+              .setMaxSizeBytes(20 * 1024);
 
       server.getAddressSettingsRepository().addMatch("#", defaultSetting);
 

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/ClusteredGroupingTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/ClusteredGroupingTest.java
@@ -16,14 +16,11 @@
  */
 package org.apache.activemq.artemis.tests.extras.byteman;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 import org.apache.activemq.artemis.api.core.ActiveMQNonExistentQueueException;
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.api.core.management.ManagementHelper;
 import org.apache.activemq.artemis.api.core.management.CoreNotificationType;
+import org.apache.activemq.artemis.api.core.management.ManagementHelper;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.group.impl.GroupingHandlerConfiguration;
 import org.apache.activemq.artemis.core.server.group.impl.Response;
@@ -32,10 +29,11 @@ import org.apache.activemq.artemis.tests.integration.cluster.distribution.Cluste
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMRules;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 @RunWith(BMUnitRunner.class)
 public class ClusteredGroupingTest extends ClusterTestBase
@@ -443,24 +441,6 @@ public class ClusteredGroupingTest extends ClusterTestBase
    public static void restart2()
    {
       latch.countDown();
-   }
-
-
-   @Override
-   @Before
-   public void setUp() throws Exception
-   {
-      super.setUp();
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      closeAllConsumers();
-      closeAllSessionFactories();
-      closeAllServerLocatorsFactories();
-      super.tearDown();
    }
 
    public boolean isNetty()

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/GroupingTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/GroupingTest.java
@@ -16,6 +16,17 @@
  */
 package org.apache.activemq.artemis.tests.extras.byteman;
 
+import org.apache.activemq.artemis.api.core.ActiveMQNotConnectedException;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
+import org.apache.activemq.artemis.tests.util.JMSTestBase;
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.jboss.byteman.contrib.bmunit.BMRules;
+import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
 import javax.jms.JMSException;
@@ -24,18 +35,6 @@ import javax.jms.MessageProducer;
 import javax.jms.Queue;
 import javax.jms.Session;
 import javax.jms.TextMessage;
-
-import org.apache.activemq.artemis.api.core.ActiveMQNotConnectedException;
-import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
-import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
-import org.apache.activemq.artemis.tests.util.JMSTestBase;
-import org.jboss.byteman.contrib.bmunit.BMRule;
-import org.jboss.byteman.contrib.bmunit.BMRules;
-import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 
 /**
  * GroupingTest
@@ -53,13 +52,6 @@ public class GroupingTest extends JMSTestBase
       super.setUp();
 
       queue = createQueue("TestQueue");
-   }
-
-   @After
-   @Override
-   public void tearDown() throws Exception
-   {
-      super.tearDown();
    }
 
    protected ConnectionFactory getCF() throws Exception

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/LatencyTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/LatencyTest.java
@@ -20,7 +20,7 @@ import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMRules;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
@@ -28,7 +28,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(BMUnitRunner.class)
-public class LatencyTest extends ServiceTestBase
+public class LatencyTest extends ActiveMQTestBase
 {
    /*
    * simple test to make sure connect still works with some network latency  built into netty
@@ -58,7 +58,7 @@ public class LatencyTest extends ServiceTestBase
       )
    public void testLatency() throws Exception
    {
-      ActiveMQServer server = createServer(createDefaultConfig(true));
+      ActiveMQServer server = createServer(createDefaultNettyConfig());
       server.start();
       ServerLocator locator = createNettyNonHALocator();
       ClientSessionFactory factory = createSessionFactory(locator);

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/OrphanedConsumerTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/OrphanedConsumerTest.java
@@ -26,7 +26,7 @@ import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.client.impl.ClientSessionFactoryImpl;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.Queue;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMRules;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
@@ -36,7 +36,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(BMUnitRunner.class)
-public class OrphanedConsumerTest extends ServiceTestBase
+public class OrphanedConsumerTest extends ActiveMQTestBase
 {
 
    private static boolean conditionActive = true;
@@ -200,16 +200,16 @@ public class OrphanedConsumerTest extends ServiceTestBase
       server.start();
       staticServer = server;
 
-      locator.setBlockOnNonDurableSend(false);
-      locator.setBlockOnDurableSend(false);
-      locator.setBlockOnAcknowledge(true);
-      locator.setConnectionTTL(1000);
-      locator.setClientFailureCheckPeriod(100);
-      locator.setReconnectAttempts(0);
       // We are not interested on consumer-window-size on this test
       // We want that every message is delivered
       // as we asserting for number of consumers available and round-robin on delivery
-      locator.setConsumerWindowSize(-1);
+      locator.setConsumerWindowSize(-1)
+              .setBlockOnNonDurableSend(false)
+              .setBlockOnDurableSend(false)
+              .setBlockOnAcknowledge(true)
+              .setConnectionTTL(1000)
+              .setClientFailureCheckPeriod(100)
+              .setReconnectAttempts(0);
 
       ClientSessionFactoryImpl sf = (ClientSessionFactoryImpl)createSessionFactory(locator);
 
@@ -258,13 +258,12 @@ public class OrphanedConsumerTest extends ServiceTestBase
 
       setConditionActive(false);
 
-      locator = internalCreateNonHALocator(true);
-
-      locator.setBlockOnNonDurableSend(false);
-      locator.setBlockOnDurableSend(false);
-      locator.setBlockOnAcknowledge(true);
-      locator.setReconnectAttempts(0);
-      locator.setConsumerWindowSize(-1);
+      locator = internalCreateNonHALocator(true)
+              .setBlockOnNonDurableSend(false)
+              .setBlockOnDurableSend(false)
+              .setBlockOnAcknowledge(true)
+              .setReconnectAttempts(0)
+              .setConsumerWindowSize(-1);
 
       sf = (ClientSessionFactoryImpl)locator.createSessionFactory();
       session = sf.createSession(true, true, 0);

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/ReplicationBackupTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/ReplicationBackupTest.java
@@ -20,7 +20,7 @@ import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.tests.util.ReplicatedBackupUtils;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.tests.util.TransportConfigurationUtils;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMRules;
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith;
 import java.util.concurrent.CountDownLatch;
 
 @RunWith(BMUnitRunner.class)
-public class ReplicationBackupTest extends ServiceTestBase
+public class ReplicationBackupTest extends ActiveMQTestBase
 {
    private static final CountDownLatch ruleFired = new CountDownLatch(1);
    private ActiveMQServer backupServer;
@@ -63,15 +63,13 @@ public class ReplicationBackupTest extends ServiceTestBase
       TransportConfiguration backupConnector = TransportConfigurationUtils.getNettyConnector(false, 0);
       TransportConfiguration backupAcceptor = TransportConfigurationUtils.getNettyAcceptor(false, 0);
 
-      final String suffix = "_backup";
+      Configuration backupConfig = createDefaultInVMConfig()
+         .setBindingsDirectory(getBindingsDir(0, true))
+         .setJournalDirectory(getJournalDir(0, true))
+         .setPagingDirectory(getPageDir(0, true))
+         .setLargeMessagesDirectory(getLargeMessagesDir(0, true));
 
-      Configuration backupConfig = createDefaultConfig()
-         .setBindingsDirectory(getBindingsDir() + suffix)
-         .setJournalDirectory(getJournalDir() + suffix)
-         .setPagingDirectory(getPageDir() + suffix)
-         .setLargeMessagesDirectory(getLargeMessagesDir() + suffix);
-
-      Configuration liveConfig = createDefaultConfig();
+      Configuration liveConfig = createDefaultInVMConfig();
 
       ReplicatedBackupUtils.configureReplicationPair(backupConfig, backupConnector, backupAcceptor, liveConfig, liveConnector, liveAcceptor);
 
@@ -99,7 +97,7 @@ public class ReplicationBackupTest extends ServiceTestBase
 
       backupServer = createServer(backupConfig);
       backupServer.start();
-      ServiceTestBase.waitForRemoteBackup(null, 3, true, backupServer);
+      ActiveMQTestBase.waitForRemoteBackup(null, 3, true, backupServer);
    }
 
    public static void breakIt()

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/ScaleDownFailoverTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/ScaleDownFailoverTest.java
@@ -25,7 +25,6 @@ import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.tests.integration.cluster.distribution.ClusterTestBase;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -82,17 +81,6 @@ public class ScaleDownFailoverTest extends ClusterTestBase
    protected boolean isGrouped()
    {
       return false;
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      closeAllConsumers();
-      closeAllSessionFactories();
-      closeAllServerLocatorsFactories();
-      stopServers(0, 1, 2);
-      super.tearDown();
    }
 
 

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/ScaleDownFailureTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/ScaleDownFailureTest.java
@@ -22,7 +22,6 @@ import org.apache.activemq.artemis.core.config.ha.LiveOnlyPolicyConfiguration;
 import org.apache.activemq.artemis.tests.integration.cluster.distribution.ClusterTestBase;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -60,18 +59,6 @@ public class ScaleDownFailureTest extends ClusterTestBase
    protected boolean isGrouped()
    {
       return false;
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      closeAllConsumers();
-      closeAllSessionFactories();
-      closeAllServerLocatorsFactories();
-      ((LiveOnlyPolicyConfiguration) servers[0].getConfiguration().getHAPolicyConfiguration()).setScaleDownConfiguration(null);
-      stopServers(0, 1);
-      super.tearDown();
    }
 
    @Test

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/StompInternalStateTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/StompInternalStateTest.java
@@ -16,10 +16,6 @@
  */
 package org.apache.activemq.artemis.tests.extras.byteman;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
@@ -27,22 +23,24 @@ import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.api.core.management.CoreNotificationType;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.protocol.stomp.StompProtocolManagerFactory;
-import org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptorFactory;
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.management.Notification;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMRules;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
 @RunWith(BMUnitRunner.class)
-public class StompInternalStateTest extends ServiceTestBase
+public class StompInternalStateTest extends ActiveMQTestBase
 {
    private static final String STOMP_QUEUE_NAME = "jms.queue.StompTestQueue";
 
@@ -92,17 +90,15 @@ public class StompInternalStateTest extends ServiceTestBase
    @Override
    protected Configuration createDefaultConfig(final boolean netty) throws Exception
    {
-      Configuration config = super.createDefaultConfig(netty)
-         .setSecurityEnabled(false)
-         .setPersistenceEnabled(false);
-
-      Map<String, Object> params = new HashMap<String, Object>();
+      Map<String, Object> params = new HashMap<>();
       params.put(TransportConstants.PROTOCOLS_PROP_NAME, StompProtocolManagerFactory.STOMP_PROTOCOL_NAME);
       params.put(TransportConstants.PORT_PROP_NAME, TransportConstants.DEFAULT_STOMP_PORT);
       params.put(TransportConstants.STOMP_CONSUMERS_CREDIT, "-1");
       TransportConfiguration stompTransport = new TransportConfiguration(NettyAcceptorFactory.class.getName(), params);
-      config.getAcceptorConfigurations().add(stompTransport);
-      config.getAcceptorConfigurations().add(new TransportConfiguration(InVMAcceptorFactory.class.getName()));
+
+      Configuration config = super.createDefaultConfig(netty)
+              .setPersistenceEnabled(false)
+              .addAcceptorConfiguration(stompTransport);
 
       return config;
    }
@@ -132,15 +128,7 @@ public class StompInternalStateTest extends ServiceTestBase
    public void setUp() throws Exception
    {
       super.setUp();
-      server = createServer(createDefaultConfig(true));
+      server = createServer(createDefaultNettyConfig());
       server.start();
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      server.stop();
-      super.tearDown();
    }
 }

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/jms/bridge/BridgeTestBase.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/jms/bridge/BridgeTestBase.java
@@ -60,12 +60,12 @@ import org.apache.activemq.artemis.jms.server.JMSServerManager;
 import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
 import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 
-public abstract class BridgeTestBase extends ServiceTestBase
+public abstract class BridgeTestBase extends ActiveMQTestBase
 {
    private static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
 
@@ -392,7 +392,7 @@ public abstract class BridgeTestBase extends ServiceTestBase
             if (largeMessage)
             {
                BytesMessage msg = sess.createBytesMessage();
-               ((ActiveMQMessage) msg).setInputStream(ServiceTestBase.createFakeLargeStream(1024L * 1024L));
+               ((ActiveMQMessage) msg).setInputStream(ActiveMQTestBase.createFakeLargeStream(1024L * 1024L));
                msg.setStringProperty("msg", "message" + i);
                prod.send(msg);
             }

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/jms/bridge/ClusteredBridgeTestBase.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/jms/bridge/ClusteredBridgeTestBase.java
@@ -53,7 +53,7 @@ import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.jms.server.JMSServerManager;
 import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
 import org.apache.activemq.artemis.tests.unit.util.InVMContext;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.After;
 import org.junit.Before;
 
@@ -62,7 +62,7 @@ import org.junit.Before;
  * This class serves as a base class for jms bridge tests in
  * clustered scenarios.
  */
-public abstract class ClusteredBridgeTestBase extends ServiceTestBase
+public abstract class ClusteredBridgeTestBase extends ActiveMQTestBase
 {
    private static int index = 0;
 
@@ -170,7 +170,7 @@ public abstract class ClusteredBridgeTestBase extends ServiceTestBase
          liveNode.setRegistry(new JndiBindingRegistry(liveContext));
 
          //backup
-         Configuration conf = createBasicConfig()
+         Configuration config = createBasicConfig()
             .setJournalDirectory(getJournalDir(id, true))
             .setBindingsDirectory(getBindingsDir(id, true))
             .addAcceptorConfiguration(new TransportConfiguration(INVM_ACCEPTOR_FACTORY, params))
@@ -179,7 +179,7 @@ public abstract class ClusteredBridgeTestBase extends ServiceTestBase
             .setHAPolicyConfiguration(new ReplicaPolicyConfiguration())
             .addClusterConfiguration(basicClusterConnectionConfig(backupConnector.getName(), liveConnector.getName()));
 
-         ActiveMQServer backup = addServer(ActiveMQServers.newActiveMQServer(conf, true));
+         ActiveMQServer backup = addServer(ActiveMQServers.newActiveMQServer(config, true));
 
          Context context = new InVMContext();
 
@@ -190,12 +190,12 @@ public abstract class ClusteredBridgeTestBase extends ServiceTestBase
       public void start() throws Exception
       {
          liveNode.start();
-         waitForServer(liveNode.getActiveMQServer());
+         waitForServerToStart(liveNode.getActiveMQServer());
          backupNode.start();
          waitForRemoteBackupSynchronization(backupNode.getActiveMQServer());
 
-         locator = ActiveMQClient.createServerLocatorWithHA(liveConnector);
-         locator.setReconnectAttempts(-1);
+         locator = ActiveMQClient.createServerLocatorWithHA(liveConnector)
+                 .setReconnectAttempts(-1);
          sessionFactory = locator.createSessionFactory();
       }
 

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/protocols/hornetq/HornetQProtocolTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/protocols/hornetq/HornetQProtocolTest.java
@@ -27,11 +27,8 @@ import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.hornetq.api.core.client.HornetQClient;
-
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -41,7 +38,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-public class HornetQProtocolTest extends ServiceTestBase
+public class HornetQProtocolTest extends ActiveMQTestBase
 {
    protected ActiveMQServer server;
 
@@ -50,41 +47,17 @@ public class HornetQProtocolTest extends ServiceTestBase
    @Before
    public void setUp() throws Exception
    {
-      startBroker();
-   }
-
-   @After
-   public void tearDown() throws Exception
-   {
-      stopBroker();
-   }
-
-   public void startBroker() throws Exception
-   {
-      super.setUp();
-      server = createServer(true, true);
-      addHornetQConnector();
-      server.start();
-      waitForServer(server);
-   }
-
-   public void stopBroker() throws Exception
-   {
-      if (server.isStarted())
-      {
-         server.stop();
-         server = null;
-      }
-   }
-
-   protected void addHornetQConnector() throws Exception
-   {
       HashMap<String, Object> params = new HashMap<String, Object>();
       params.put(org.hornetq.core.remoting.impl.netty.TransportConstants.PORT_PROP_NAME, "" + 5445);
       params.put(org.hornetq.core.remoting.impl.netty.TransportConstants.PROTOCOLS_PROP_NAME, "HORNETQ");
       TransportConfiguration transportConfig = new TransportConfiguration(NETTY_ACCEPTOR_FACTORY, params);
+
+      super.setUp();
+      server = createServer(true, true);
       server.getConfiguration().getAcceptorConfigurations().add(transportConfig);
       LOG.info("Added connector {} to broker", "HornetQ");
+      server.start();
+      waitForServerToStart(server);
    }
 
    @Test

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/InterceptorTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/InterceptorTest.java
@@ -42,12 +42,12 @@ import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ServerMessage;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
 import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManagerImpl;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class InterceptorTest extends ServiceTestBase
+public class InterceptorTest extends ActiveMQTestBase
 {
    private ActiveMQServer server;
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/String64KLimitTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/String64KLimitTest.java
@@ -33,7 +33,7 @@ import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 
 /**
  *
@@ -43,7 +43,7 @@ import org.apache.activemq.artemis.tests.util.ServiceTestBase;
  * http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4806007
  * http://jira.jboss.com/jira/browse/JBAS-2641
  */
-public class String64KLimitTest extends ServiceTestBase
+public class String64KLimitTest extends ActiveMQTestBase
 {
    // Constants -----------------------------------------------------
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/aerogear/AeroGearBasicServerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/aerogear/AeroGearBasicServerTest.java
@@ -18,8 +18,6 @@ package org.apache.activemq.artemis.tests.integration.aerogear;
 
 
 import org.apache.activemq.artemis.api.core.Message;
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
@@ -33,7 +31,7 @@ import org.apache.activemq.artemis.core.config.CoreQueueConfiguration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.integration.aerogear.AeroGearConnectorServiceFactory;
 import org.apache.activemq.artemis.integration.aerogear.AeroGearConstants;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.json.JSONArray;
 import org.apache.activemq.artemis.utils.json.JSONException;
 import org.apache.activemq.artemis.utils.json.JSONObject;
@@ -53,7 +51,7 @@ import java.util.HashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-public class AeroGearBasicServerTest extends ServiceTestBase
+public class AeroGearBasicServerTest extends ActiveMQTestBase
 {
 
    private ActiveMQServer server;
@@ -88,7 +86,8 @@ public class AeroGearBasicServerTest extends ServiceTestBase
       params.put(AeroGearConstants.DEVICE_TYPE_NAME, "android,ipad");
       params.put(AeroGearConstants.SOUND_NAME, "sound1");
       params.put(AeroGearConstants.VARIANTS_NAME, "variant1,variant2");
-      Configuration configuration = createDefaultConfig()
+
+      Configuration configuration = createDefaultInVMConfig()
          .addConnectorServiceConfiguration(
             new ConnectorServiceConfiguration()
                .setFactoryClassName(AeroGearConnectorServiceFactory.class.getName())
@@ -97,7 +96,8 @@ public class AeroGearBasicServerTest extends ServiceTestBase
          .addQueueConfiguration(new CoreQueueConfiguration()
                                    .setAddress("testQueue")
                                    .setName("testQueue"));
-      server = createServer(configuration);
+
+      server = addServer(createServer(configuration));
       server.start();
 
    }
@@ -110,14 +110,6 @@ public class AeroGearBasicServerTest extends ServiceTestBase
       {
          jetty.stop();
       }
-      if (locator != null)
-      {
-         locator.close();
-      }
-      if (server != null)
-      {
-         server.stop();
-      }
       super.tearDown();
    }
 
@@ -127,8 +119,7 @@ public class AeroGearBasicServerTest extends ServiceTestBase
       CountDownLatch latch = new CountDownLatch(1);
       AeroGearHandler aeroGearHandler = new AeroGearHandler(latch);
       jetty.addHandler(aeroGearHandler);
-      TransportConfiguration tpconf = new TransportConfiguration(INVM_CONNECTOR_FACTORY);
-      locator = ActiveMQClient.createServerLocatorWithoutHA(tpconf);
+      locator = createInVMNonHALocator();
       ClientSessionFactory sf = createSessionFactory(locator);
       ClientSession session = sf.createSession(false, true, true);
       ClientProducer producer = session.createProducer("testQueue");
@@ -276,8 +267,7 @@ public class AeroGearBasicServerTest extends ServiceTestBase
          }
 
       });
-      TransportConfiguration tpconf = new TransportConfiguration(INVM_CONNECTOR_FACTORY);
-      locator = ActiveMQClient.createServerLocatorWithoutHA(tpconf);
+      locator = createInVMNonHALocator();
       ClientSessionFactory sf = createSessionFactory(locator);
       ClientSession session = sf.createSession(false, true, true);
       ClientProducer producer = session.createProducer("testQueue");
@@ -330,8 +320,7 @@ public class AeroGearBasicServerTest extends ServiceTestBase
          }
 
       });
-      TransportConfiguration tpconf = new TransportConfiguration(INVM_CONNECTOR_FACTORY);
-      locator = ActiveMQClient.createServerLocatorWithoutHA(tpconf);
+      locator = createInVMNonHALocator();
       ClientSessionFactory sf = createSessionFactory(locator);
       ClientSession session = sf.createSession(false, true, true);
       ClientProducer producer = session.createProducer("testQueue");
@@ -368,8 +357,7 @@ public class AeroGearBasicServerTest extends ServiceTestBase
          }
 
       });
-      TransportConfiguration tpconf = new TransportConfiguration(INVM_CONNECTOR_FACTORY);
-      locator = ActiveMQClient.createServerLocatorWithoutHA(tpconf);
+      locator = createInVMNonHALocator();
       ClientSessionFactory sf = createSessionFactory(locator);
       ClientSession session = sf.createSession(false, true, true);
       ClientProducer producer = session.createProducer("testQueue");

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/AckBatchSizeTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/AckBatchSizeTest.java
@@ -23,13 +23,13 @@ import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class AckBatchSizeTest extends ServiceTestBase
+public class AckBatchSizeTest extends ActiveMQTestBase
 {
    public final SimpleString addressA = new SimpleString("addressA");
 
@@ -64,10 +64,10 @@ public class AckBatchSizeTest extends ServiceTestBase
    {
       ActiveMQServer server = createServer(false);
       server.start();
-      ServerLocator locator = createInVMNonHALocator();
       int numMessages = 100;
-      locator.setAckBatchSize(numMessages * getMessageEncodeSize(addressA));
-      locator.setBlockOnAcknowledge(true);
+      ServerLocator locator = createInVMNonHALocator()
+              .setAckBatchSize(numMessages * getMessageEncodeSize(addressA))
+              .setBlockOnAcknowledge(true);
       ClientSessionFactory cf = createSessionFactory(locator);
       ClientSession sendSession = cf.createSession(false, true, true);
 
@@ -106,9 +106,9 @@ public class AckBatchSizeTest extends ServiceTestBase
       ActiveMQServer server = createServer(false);
 
       server.start();
-      ServerLocator locator = createInVMNonHALocator();
-      locator.setAckBatchSize(0);
-      locator.setBlockOnAcknowledge(true);
+      ServerLocator locator = createInVMNonHALocator()
+              .setAckBatchSize(0)
+              .setBlockOnAcknowledge(true);
       ClientSessionFactory cf = createSessionFactory(locator);
       ClientSession sendSession = cf.createSession(false, true, true);
       int numMessages = 100;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/AcknowledgeTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/AcknowledgeTest.java
@@ -34,7 +34,7 @@ import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.MessageHandler;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.client.impl.ClientSessionInternal;
 import org.apache.activemq.artemis.core.protocol.core.impl.ActiveMQConsumerContext;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
@@ -44,7 +44,7 @@ import org.apache.activemq.artemis.utils.UUID;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class AcknowledgeTest extends ServiceTestBase
+public class AcknowledgeTest extends ActiveMQTestBase
 {
    private static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
 
@@ -61,9 +61,9 @@ public class AcknowledgeTest extends ServiceTestBase
    {
       ActiveMQServer server = createServer(false);
       server.start();
-      ServerLocator locator = createInVMNonHALocator();
-      locator.setAckBatchSize(0);
-      locator.setBlockOnAcknowledge(true);
+      ServerLocator locator = createInVMNonHALocator()
+              .setAckBatchSize(0)
+              .setBlockOnAcknowledge(true);
       ClientSessionFactory cf = createSessionFactory(locator);
       ClientSession sendSession = cf.createSession(false, true, true);
       ClientSession session = cf.createSession(false, true, true);
@@ -136,9 +136,9 @@ public class AcknowledgeTest extends ServiceTestBase
    {
       ActiveMQServer server = createServer(false);
       server.start();
-      ServerLocator locator = createInVMNonHALocator();
-      locator.setBlockOnAcknowledge(true);
-      locator.setAckBatchSize(0);
+      ServerLocator locator = createInVMNonHALocator()
+              .setBlockOnAcknowledge(true)
+              .setAckBatchSize(0);
       ClientSessionFactory cf = createSessionFactory(locator);
       ClientSession sendSession = cf.createSession(false, true, true);
       final ClientSession session = cf.createSession(false, true, true);
@@ -193,11 +193,9 @@ public class AcknowledgeTest extends ServiceTestBase
       ActiveMQServer server = createServer(false);
       server.start();
 
-      ServerLocator locator = createInVMNonHALocator();
-
-      locator.setAckBatchSize(0);
-
-      locator.setBlockOnAcknowledge(true);
+      ServerLocator locator = createInVMNonHALocator()
+              .setAckBatchSize(0)
+              .setBlockOnAcknowledge(true);
 
       ClientSessionFactory cf = createSessionFactory(locator);
 
@@ -277,9 +275,9 @@ public class AcknowledgeTest extends ServiceTestBase
    {
       ActiveMQServer server = createServer(false);
       server.start();
-      ServerLocator locator = createInVMNonHALocator();
-      locator.setBlockOnAcknowledge(true);
-      locator.setAckBatchSize(0);
+      ServerLocator locator = createInVMNonHALocator()
+              .setBlockOnAcknowledge(true)
+              .setAckBatchSize(0);
       ClientSessionFactory cf = createSessionFactory(locator);
       ClientSession sendSession = cf.createSession(false, true, true);
       final ClientSession session = cf.createSession(false, true, true);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ActiveMQCrashTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ActiveMQCrashTest.java
@@ -19,7 +19,6 @@ package org.apache.activemq.artemis.tests.integration.client;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.Interceptor;
 import org.apache.activemq.artemis.api.core.Message;
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
@@ -29,12 +28,11 @@ import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.protocol.core.Packet;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
-import org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,7 +42,7 @@ import org.junit.Test;
  * From https://jira.jboss.org/jira/browse/HORNETQ-144
  *
  */
-public class ActiveMQCrashTest extends ServiceTestBase
+public class ActiveMQCrashTest extends ActiveMQTestBase
 {
    private static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
 
@@ -56,19 +54,14 @@ public class ActiveMQCrashTest extends ServiceTestBase
    @Test
    public void testHang() throws Exception
    {
-      Configuration configuration = createDefaultConfig()
-         .setPersistenceEnabled(false)
-         .setSecurityEnabled(false)
-         .addAcceptorConfiguration(new TransportConfiguration(InVMAcceptorFactory.class.getName()));
+      Configuration configuration = createDefaultInVMConfig()
+         .setPersistenceEnabled(false);
 
       server = addServer(ActiveMQServers.newActiveMQServer(configuration));
 
       server.start();
 
       server.getRemotingService().addIncomingInterceptor(new AckInterceptor(server));
-
-
-
 
       // Force an ack at once - this means the send call will block
       locator.setConfirmationWindowSize(1);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/AddressSettingsTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/AddressSettingsTest.java
@@ -26,11 +26,11 @@ import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.settings.HierarchicalRepository;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class AddressSettingsTest extends ServiceTestBase
+public class AddressSettingsTest extends ActiveMQTestBase
 {
    private final SimpleString addressA = new SimpleString("addressA");
 
@@ -66,12 +66,12 @@ public class AddressSettingsTest extends ServiceTestBase
       ActiveMQServer server = createServer(false);
 
       server.start();
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setDeadLetterAddress(dlaA);
-      addressSettings.setMaxDeliveryAttempts(1);
-      AddressSettings addressSettings2 = new AddressSettings();
-      addressSettings2.setDeadLetterAddress(dlaB);
-      addressSettings2.setMaxDeliveryAttempts(1);
+      AddressSettings addressSettings = new AddressSettings()
+              .setDeadLetterAddress(dlaA)
+              .setMaxDeliveryAttempts(1);
+      AddressSettings addressSettings2 = new AddressSettings()
+              .setDeadLetterAddress(dlaB)
+              .setMaxDeliveryAttempts(1);
       HierarchicalRepository<AddressSettings> repos = server.getAddressSettingsRepository();
       repos.addMatch(addressA.toString(), addressSettings);
       repos.addMatch(addressB.toString(), addressSettings2);
@@ -123,12 +123,12 @@ public class AddressSettingsTest extends ServiceTestBase
       ActiveMQServer server = createServer(false);
 
       server.start();
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setDeadLetterAddress(dlaA);
-      addressSettings.setMaxDeliveryAttempts(1);
-      AddressSettings addressSettings2 = new AddressSettings();
-      addressSettings2.setDeadLetterAddress(dlaB);
-      addressSettings2.setMaxDeliveryAttempts(1);
+      AddressSettings addressSettings = new AddressSettings()
+              .setDeadLetterAddress(dlaA)
+              .setMaxDeliveryAttempts(1);
+      AddressSettings addressSettings2 = new AddressSettings()
+              .setDeadLetterAddress(dlaB)
+              .setMaxDeliveryAttempts(1);
       HierarchicalRepository<AddressSettings> repos = server.getAddressSettingsRepository();
       repos.addMatch(addressA.toString(), addressSettings);
       repos.addMatch("#", addressSettings2);
@@ -179,12 +179,12 @@ public class AddressSettingsTest extends ServiceTestBase
    {
       ActiveMQServer server = createServer(false);
       server.start();
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setDeadLetterAddress(dlaA);
-      addressSettings.setMaxDeliveryAttempts(1);
-      AddressSettings addressSettings2 = new AddressSettings();
-      addressSettings2.setDeadLetterAddress(dlaB);
-      addressSettings2.setMaxDeliveryAttempts(1);
+      AddressSettings addressSettings = new AddressSettings()
+              .setDeadLetterAddress(dlaA)
+              .setMaxDeliveryAttempts(1);
+      AddressSettings addressSettings2 = new AddressSettings()
+              .setDeadLetterAddress(dlaB)
+              .setMaxDeliveryAttempts(1);
       HierarchicalRepository<AddressSettings> repos = server.getAddressSettingsRepository();
       repos.addMatch(addressA.toString(), addressSettings);
       repos.addMatch("*", addressSettings2);
@@ -235,15 +235,15 @@ public class AddressSettingsTest extends ServiceTestBase
       ActiveMQServer server = createServer(false);
 
       server.start();
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setDeadLetterAddress(dlaA);
-      addressSettings.setMaxDeliveryAttempts(1);
-      AddressSettings addressSettings2 = new AddressSettings();
-      addressSettings2.setDeadLetterAddress(dlaB);
-      addressSettings2.setMaxDeliveryAttempts(1);
-      AddressSettings addressSettings3 = new AddressSettings();
-      addressSettings3.setDeadLetterAddress(dlaC);
-      addressSettings3.setMaxDeliveryAttempts(1);
+      AddressSettings addressSettings = new AddressSettings()
+              .setDeadLetterAddress(dlaA)
+              .setMaxDeliveryAttempts(1);
+      AddressSettings addressSettings2 = new AddressSettings()
+              .setDeadLetterAddress(dlaB)
+              .setMaxDeliveryAttempts(1);
+      AddressSettings addressSettings3 = new AddressSettings()
+              .setDeadLetterAddress(dlaC)
+              .setMaxDeliveryAttempts(1);
       HierarchicalRepository<AddressSettings> repos = server.getAddressSettingsRepository();
       repos.addMatch(addressA2.toString(), addressSettings);
       repos.addMatch("add.*", addressSettings2);
@@ -311,13 +311,13 @@ public class AddressSettingsTest extends ServiceTestBase
       ActiveMQServer server = createServer(false);
 
       server.start();
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setMaxDeliveryAttempts(1);
-      AddressSettings addressSettings2 = new AddressSettings();
-      addressSettings2.setMaxDeliveryAttempts(1);
-      AddressSettings addressSettings3 = new AddressSettings();
-      addressSettings3.setDeadLetterAddress(dlaC);
-      addressSettings3.setMaxDeliveryAttempts(1);
+      AddressSettings addressSettings = new AddressSettings()
+              .setMaxDeliveryAttempts(1);
+      AddressSettings addressSettings2 = new AddressSettings()
+              .setMaxDeliveryAttempts(1);
+      AddressSettings addressSettings3 = new AddressSettings()
+              .setDeadLetterAddress(dlaC)
+              .setMaxDeliveryAttempts(1);
       HierarchicalRepository<AddressSettings> repos = server.getAddressSettingsRepository();
       repos.addMatch(addressA2.toString(), addressSettings);
       repos.addMatch("add.*", addressSettings2);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/AutoCloseCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/AutoCloseCoreTest.java
@@ -31,7 +31,7 @@ public class AutoCloseCoreTest extends SingleServerTestBase
       ServerLocator locatorx;
       ClientSession sessionx;
       ClientSessionFactory factoryx;
-      try (ServerLocator locator = createLocator();
+      try (ServerLocator locator = createInVMNonHALocator();
            ClientSessionFactory factory = locator.createSessionFactory();
            ClientSession session = factory.createSession(false, false))
       {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/AutogroupIdTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/AutogroupIdTest.java
@@ -29,11 +29,12 @@ import org.apache.activemq.artemis.api.core.client.MessageHandler;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
-public class AutogroupIdTest extends ServiceTestBase
+public class AutogroupIdTest extends ActiveMQTestBase
 {
    private static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
 
@@ -47,7 +48,26 @@ public class AutogroupIdTest extends ServiceTestBase
 
    private final SimpleString groupTestQ = new SimpleString("testGroupQueue");
 
+   private ActiveMQServer server;
+
+   private ServerLocator locator;
+
    /* auto group id tests*/
+
+   @Override
+   @Before
+   public void setUp() throws Exception
+   {
+      super.setUp();
+
+      server = createServer(false);
+
+      server.start();
+
+      waitForServerToStart(server);
+
+      locator = createInVMNonHALocator();
+   }
 
    /*
    * tests when the autogroupid is set only 1 consumer (out of 2) gets all the messages from a single producer
@@ -56,11 +76,6 @@ public class AutogroupIdTest extends ServiceTestBase
    @Test
    public void testGroupIdAutomaticallySet() throws Exception
    {
-      ActiveMQServer server = createServer(false);
-
-      server.start();
-
-      ServerLocator locator = createInVMNonHALocator();
       locator.setAutoGroup(true);
       ClientSessionFactory sf = createSessionFactory(locator);
       ClientSession session = sf.createSession(false, true, true);
@@ -106,12 +121,6 @@ public class AutogroupIdTest extends ServiceTestBase
    @Test
    public void testGroupIdAutomaticallySetMultipleProducers() throws Exception
    {
-      ActiveMQServer server = createServer(false);
-
-      server.start();
-
-
-      ServerLocator locator = createInVMNonHALocator();
       locator.setAutoGroup(true);
       ClientSessionFactory sf = createSessionFactory(locator);
       ClientSession session = sf.createSession(false, true, true);
@@ -161,12 +170,6 @@ public class AutogroupIdTest extends ServiceTestBase
    @Test
    public void testGroupIdAutomaticallyNotSet() throws Exception
    {
-      ActiveMQServer server = createServer(false);
-
-      server.start();
-
-
-      ServerLocator locator = createInVMNonHALocator();
       ClientSessionFactory sf = createSessionFactory(locator);
 
       ClientSession session = sf.createSession(false, true, true);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/BlockingSendTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/BlockingSendTest.java
@@ -23,11 +23,11 @@ import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class BlockingSendTest extends ServiceTestBase
+public class BlockingSendTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------
@@ -55,8 +55,8 @@ public class BlockingSendTest extends ServiceTestBase
       server.start();
 
       System.out.println("sync = " + server.getConfiguration().isJournalSyncNonTransactional());
-      locator = createFactory(false);
-      locator.setBlockOnDurableSend(true);
+      locator = createInVMNonHALocator()
+              .setBlockOnDurableSend(true);
       factory = createSessionFactory(locator);
 
       session = factory.createSession();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/CommitRollbackTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/CommitRollbackTest.java
@@ -28,13 +28,13 @@ import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.MessageHandler;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class CommitRollbackTest extends ServiceTestBase
+public class CommitRollbackTest extends ActiveMQTestBase
 {
    public final SimpleString addressA = new SimpleString("addressA");
 
@@ -169,9 +169,9 @@ public class CommitRollbackTest extends ServiceTestBase
    {
       ActiveMQServer server = createServer(false);
       server.start();
-      ServerLocator locator = createInVMNonHALocator();
-      locator.setBlockOnAcknowledge(true);
-      locator.setAckBatchSize(0);
+      ServerLocator locator = createInVMNonHALocator()
+              .setBlockOnAcknowledge(true)
+              .setAckBatchSize(0);
       ClientSessionFactory cf = createSessionFactory(locator);
       ClientSession sendSession = cf.createSession(false, true, true);
       final ClientSession session = cf.createSession(false, true, false);
@@ -224,9 +224,9 @@ public class CommitRollbackTest extends ServiceTestBase
    {
       ActiveMQServer server = createServer(false);
       server.start();
-      ServerLocator locator = createInVMNonHALocator();
-      locator.setBlockOnAcknowledge(true);
-      locator.setAckBatchSize(0);
+      ServerLocator locator = createInVMNonHALocator()
+              .setBlockOnAcknowledge(true)
+              .setAckBatchSize(0);
       ClientSessionFactory cf = createSessionFactory(locator);
       ClientSession sendSession = cf.createSession(false, true, true);
       final ClientSession session = cf.createSession(false, true, false);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ConcurrentCreateDeleteProduceTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ConcurrentCreateDeleteProduceTest.java
@@ -26,7 +26,7 @@ import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.Queue;
@@ -40,7 +40,7 @@ import org.junit.Test;
  * the NPE happened during depaging what let the server to recover itself on the next depage.
  * To verify a fix on this test against the previous version of QueueImpl look for NPEs on System.err
  */
-public class ConcurrentCreateDeleteProduceTest extends ServiceTestBase
+public class ConcurrentCreateDeleteProduceTest extends ActiveMQTestBase
 {
 
    volatile boolean running = true;
@@ -62,19 +62,18 @@ public class ConcurrentCreateDeleteProduceTest extends ServiceTestBase
    {
       super.setUp();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false)
          .setJournalSyncTransactional(false);
 
-      server =
-         createServer(true, config,
-                      PAGE_SIZE,
-                      PAGE_MAX,
-                      new HashMap<String, AddressSettings>());
+      server = createServer(true, config,
+                            PAGE_SIZE,
+                            PAGE_MAX,
+                            new HashMap<String, AddressSettings>());
       server.start();
-      locator = createNonHALocator(false);
-      locator.setBlockOnDurableSend(false);
-      locator.setBlockOnAcknowledge(true);
+      locator = createNonHALocator(false)
+              .setBlockOnDurableSend(false)
+              .setBlockOnAcknowledge(true);
    }
 
    @Test

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ConsumerCloseTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ConsumerCloseTest.java
@@ -19,7 +19,6 @@ package org.apache.activemq.artemis.tests.integration.client;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
@@ -29,12 +28,11 @@ import org.apache.activemq.artemis.api.core.client.MessageHandler;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.client.impl.ClientConsumerImpl;
 import org.apache.activemq.artemis.core.config.Configuration;
-import org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,7 +40,7 @@ import org.junit.Test;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-public class ConsumerCloseTest extends ServiceTestBase
+public class ConsumerCloseTest extends ActiveMQTestBase
 {
 
    private ClientSessionFactory sf;
@@ -165,8 +163,7 @@ public class ConsumerCloseTest extends ServiceTestBase
    {
 
 
-      AddressSettings settings = new AddressSettings();
-      settings.setRedeliveryDelay(50000);
+      AddressSettings settings = new AddressSettings().setRedeliveryDelay(50000);
       server.getAddressSettingsRepository().addMatch("#", settings);
 
       ClientConsumer consumer = session.createConsumer(queue);
@@ -223,8 +220,7 @@ public class ConsumerCloseTest extends ServiceTestBase
    {
 
 
-      AddressSettings settings = new AddressSettings();
-      settings.setRedeliveryDelay(1000);
+      AddressSettings settings = new AddressSettings().setRedeliveryDelay(1000);
       server.getAddressSettingsRepository().addMatch("#", settings);
 
       ClientProducer producer = session.createProducer(address);
@@ -302,9 +298,7 @@ public class ConsumerCloseTest extends ServiceTestBase
    {
       super.setUp();
 
-      Configuration config = createDefaultConfig()
-         .addAcceptorConfiguration(new TransportConfiguration(InVMAcceptorFactory.class.getCanonicalName()))
-         .setSecurityEnabled(false);
+      Configuration config = createDefaultInVMConfig();
 
       server = addServer(ActiveMQServers.newActiveMQServer(config, false));
       server.start();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ConsumerFilterTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ConsumerFilterTest.java
@@ -25,11 +25,11 @@ import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.impl.QueueImpl;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ConsumerFilterTest extends ServiceTestBase
+public class ConsumerFilterTest extends ActiveMQTestBase
 {
    private static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ConsumerRoundRobinTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ConsumerRoundRobinTest.java
@@ -29,9 +29,9 @@ import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 
-public class ConsumerRoundRobinTest extends ServiceTestBase
+public class ConsumerRoundRobinTest extends ActiveMQTestBase
 {
    private static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ConsumerStuckTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ConsumerStuckTest.java
@@ -27,11 +27,11 @@ import org.apache.activemq.artemis.core.client.impl.ClientSessionFactoryImpl;
 import org.apache.activemq.artemis.core.protocol.core.impl.RemotingConnectionImpl;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnection;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ConsumerStuckTest extends ServiceTestBase
+public class ConsumerStuckTest extends ActiveMQTestBase
 {
    private ActiveMQServer server;
 
@@ -57,10 +57,10 @@ public class ConsumerStuckTest extends ServiceTestBase
    public void testClientStuckTest() throws Exception
    {
 
-      ServerLocator locator = createNettyNonHALocator();
-      locator.setConnectionTTL(1000);
-      locator.setClientFailureCheckPeriod(100);
-      locator.setConsumerWindowSize(10 * 1024 * 1024);
+      ServerLocator locator = createNettyNonHALocator()
+              .setConnectionTTL(1000)
+              .setClientFailureCheckPeriod(100)
+              .setConsumerWindowSize(10 * 1024 * 1024);
       ClientSessionFactory sf = locator.createSessionFactory();
       ((ClientSessionFactoryImpl) sf).stopPingingAfterOne();
 
@@ -168,10 +168,10 @@ public class ConsumerStuckTest extends ServiceTestBase
    public void testClientStuckTestWithDirectDelivery() throws Exception
    {
 
-      ServerLocator locator = createNettyNonHALocator();
-      locator.setConnectionTTL(1000);
-      locator.setClientFailureCheckPeriod(100);
-      locator.setConsumerWindowSize(10 * 1024 * 1024);
+      ServerLocator locator = createNettyNonHALocator()
+              .setConnectionTTL(1000)
+              .setClientFailureCheckPeriod(100)
+              .setConsumerWindowSize(10 * 1024 * 1024);
       ClientSessionFactory sf = locator.createSessionFactory();
       ((ClientSessionFactoryImpl) sf).stopPingingAfterOne();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ConsumerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ConsumerTest.java
@@ -39,7 +39,7 @@ import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.ConcurrentHashSet;
 import org.junit.Assert;
 import org.junit.Before;
@@ -48,7 +48,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(value = Parameterized.class)
-public class ConsumerTest extends ServiceTestBase
+public class ConsumerTest extends ActiveMQTestBase
 {
    @Parameterized.Parameters(name = "isNetty={0}")
    public static Collection getParameters()
@@ -95,8 +95,8 @@ public class ConsumerTest extends ServiceTestBase
 
       for (int i = 0; i < 10; i++)
       {
-         ServerLocator locatorSendx = createFactory(isNetty());
-         locatorSendx.setReconnectAttempts(-1);
+         ServerLocator locatorSendx = createFactory(isNetty())
+                 .setReconnectAttempts(-1);
          ClientSessionFactory factoryx = locatorSendx.createSessionFactory();
          factoryx.close();
          locatorSendx.close();
@@ -287,9 +287,9 @@ public class ConsumerTest extends ServiceTestBase
             return true;
          }
       });
-      ServerLocator locator = createInVMNonHALocator();
-      locator.setConfirmationWindowSize(100);
-      locator.setAckBatchSize(-1);
+      ServerLocator locator = createInVMNonHALocator()
+              .setConfirmationWindowSize(100)
+              .setAckBatchSize(-1);
       ClientSessionFactory sfReceive = createSessionFactory(locator);
       ClientSession sessionRec = sfReceive.createSession(false, true, true);
       ClientConsumer consumer = sessionRec.createConsumer(QUEUE);
@@ -456,8 +456,8 @@ public class ConsumerTest extends ServiceTestBase
                {
                   try
                   {
-                     ServerLocator locatorSendx = createFactory(isNetty());
-                     locatorSendx.setReconnectAttempts(-1);
+                     ServerLocator locatorSendx = createFactory(isNetty())
+                             .setReconnectAttempts(-1);
                      ClientSessionFactory factoryx = locatorSendx.createSessionFactory();
                      ClientSession sessionSend = factoryx.createSession(true, true);
 
@@ -624,9 +624,8 @@ public class ConsumerTest extends ServiceTestBase
    @Test
    public void testConsumerCreditsOnRollbackLargeMessages() throws Exception
    {
-
-      locator.setConsumerWindowSize(10000);
-      locator.setMinLargeMessageSize(1000);
+      locator.setConsumerWindowSize(10000)
+              .setMinLargeMessageSize(1000);
 
       ClientSessionFactory sf = createSessionFactory(locator);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ConsumerWindowSizeTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ConsumerWindowSizeTest.java
@@ -33,7 +33,7 @@ import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.MessageHandler;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.client.impl.ClientConsumerInternal;
 import org.apache.activemq.artemis.core.postoffice.Binding;
 import org.apache.activemq.artemis.core.postoffice.Bindings;
@@ -46,7 +46,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ConsumerWindowSizeTest extends ServiceTestBase
+public class ConsumerWindowSizeTest extends ActiveMQTestBase
 {
    private final SimpleString addressA = new SimpleString("addressA");
 
@@ -923,9 +923,8 @@ public class ConsumerWindowSizeTest extends ServiceTestBase
 
          server.start();
 
-         locator.setConsumerWindowSize(0);
-
-         locator.setMinLargeMessageSize(100);
+         locator.setConsumerWindowSize(0)
+                 .setMinLargeMessageSize(100);
 
          ClientSessionFactory sf = createSessionFactory(locator);
 
@@ -1027,8 +1026,7 @@ public class ConsumerWindowSizeTest extends ServiceTestBase
 
       ActiveMQServer server = createServer(false, isNetty());
 
-      AddressSettings settings = new AddressSettings();
-      settings.setMaxDeliveryAttempts(-1);
+      AddressSettings settings = new AddressSettings().setMaxDeliveryAttempts(-1);
       server.getAddressSettingsRepository().addMatch("#", settings);
 
       ClientSession session = null;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/CoreClientTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/CoreClientTest.java
@@ -17,27 +17,22 @@
 package org.apache.activemq.artemis.tests.integration.client;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
-import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.junit.Test;
-
-import org.junit.Assert;
-
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
 import org.apache.activemq.artemis.jms.client.ActiveMQTextMessage;
+import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.junit.Assert;
+import org.junit.Test;
 
-public class CoreClientTest extends ServiceTestBase
+public class CoreClientTest extends ActiveMQTestBase
 {
    private static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
 
@@ -54,29 +49,23 @@ public class CoreClientTest extends ServiceTestBase
    @Test
    public void testCoreClientNetty() throws Exception
    {
-      testCoreClient(NETTY_ACCEPTOR_FACTORY, NETTY_CONNECTOR_FACTORY);
+      testCoreClient(true);
    }
 
    @Test
    public void testCoreClientInVM() throws Exception
    {
-      testCoreClient(INVM_ACCEPTOR_FACTORY, INVM_CONNECTOR_FACTORY);
+      testCoreClient(false);
    }
 
-   private void testCoreClient(final String acceptorFactoryClassName, final String connectorFactoryClassName) throws Exception
+   private void testCoreClient(final boolean netty) throws Exception
    {
       final SimpleString QUEUE = new SimpleString("CoreClientTestQueue");
 
-      Configuration conf = createDefaultConfig()
-         .setSecurityEnabled(false)
-         .addAcceptorConfiguration(new TransportConfiguration(acceptorFactoryClassName));
-
-      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(conf, false));
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(createDefaultConfig(netty), false));
 
       server.start();
-      ServerLocator locator =
-               addServerLocator(ActiveMQClient.createServerLocatorWithoutHA(new TransportConfiguration(
-                  connectorFactoryClassName)));
+      ServerLocator locator = createNonHALocator(netty);
 
       ClientSessionFactory sf = createSessionFactory(locator);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/CreateQueueIdempotentTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/CreateQueueIdempotentTest.java
@@ -16,24 +16,22 @@
  */
 package org.apache.activemq.artemis.tests.integration.client;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.ActiveMQQueueExistsException;
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class CreateQueueIdempotentTest extends ServiceTestBase
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class CreateQueueIdempotentTest extends ActiveMQTestBase
 {
 
    private ActiveMQServer server;
@@ -43,12 +41,7 @@ public class CreateQueueIdempotentTest extends ServiceTestBase
    public void setUp() throws Exception
    {
       super.setUp();
-
-      Configuration conf = createDefaultConfig()
-         .setSecurityEnabled(false)
-         .addAcceptorConfiguration(new TransportConfiguration(INVM_ACCEPTOR_FACTORY));
-
-      server = addServer(ActiveMQServers.newActiveMQServer(conf, true));
+      server = addServer(ActiveMQServers.newActiveMQServer(createDefaultInVMConfig(), true));
       server.start();
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/DeadLetterAddressTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/DeadLetterAddressTest.java
@@ -19,8 +19,6 @@ package org.apache.activemq.artemis.tests.integration.client;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
@@ -28,14 +26,13 @@ import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.MessageHandler;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,7 +42,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-public class DeadLetterAddressTest extends ServiceTestBase
+public class DeadLetterAddressTest extends ActiveMQTestBase
 {
    private static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
 
@@ -60,9 +57,9 @@ public class DeadLetterAddressTest extends ServiceTestBase
       SimpleString dla = new SimpleString("DLA");
       SimpleString qName = new SimpleString("q1");
       SimpleString adName = new SimpleString("ad1");
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setMaxDeliveryAttempts(1);
-      addressSettings.setDeadLetterAddress(dla);
+      AddressSettings addressSettings = new AddressSettings()
+              .setMaxDeliveryAttempts(1)
+              .setDeadLetterAddress(dla);
       server.getAddressSettingsRepository().addMatch(adName.toString(), addressSettings);
       SimpleString dlq = new SimpleString("DLQ1");
       clientSession.createQueue(dla, dlq, null, false);
@@ -94,9 +91,9 @@ public class DeadLetterAddressTest extends ServiceTestBase
    {
       SimpleString dla = new SimpleString("DLA");
       SimpleString qName = new SimpleString("q1");
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setMaxDeliveryAttempts(1);
-      addressSettings.setDeadLetterAddress(dla);
+      AddressSettings addressSettings = new AddressSettings()
+              .setMaxDeliveryAttempts(1)
+              .setDeadLetterAddress(dla);
       server.getAddressSettingsRepository().addMatch(qName.toString(), addressSettings);
       //SimpleString dlq = new SimpleString("DLQ1");
       //clientSession.createQueue(dla, dlq, null, false);
@@ -123,9 +120,9 @@ public class DeadLetterAddressTest extends ServiceTestBase
    {
       SimpleString dla = new SimpleString("DLA");
       SimpleString qName = new SimpleString("q1");
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setMaxDeliveryAttempts(2);
-      addressSettings.setDeadLetterAddress(dla);
+      AddressSettings addressSettings = new AddressSettings()
+              .setMaxDeliveryAttempts(2)
+              .setDeadLetterAddress(dla);
       server.getAddressSettingsRepository().addMatch(qName.toString(), addressSettings);
       SimpleString dlq = new SimpleString("DLQ1");
       clientSession.createQueue(dla, dlq, null, false);
@@ -161,9 +158,9 @@ public class DeadLetterAddressTest extends ServiceTestBase
    {
       SimpleString dla = new SimpleString("DLA");
       SimpleString qName = new SimpleString("q1");
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setMaxDeliveryAttempts(2);
-      addressSettings.setDeadLetterAddress(dla);
+      AddressSettings addressSettings = new AddressSettings()
+              .setMaxDeliveryAttempts(2)
+              .setDeadLetterAddress(dla);
       server.getAddressSettingsRepository().addMatch(qName.toString(), addressSettings);
       SimpleString dlq = new SimpleString("DLQ1");
       clientSession.createQueue(dla, dlq, null, false);
@@ -217,9 +214,9 @@ public class DeadLetterAddressTest extends ServiceTestBase
    {
       SimpleString dla = new SimpleString("DLA");
       SimpleString qName = new SimpleString("q1");
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setMaxDeliveryAttempts(1);
-      addressSettings.setDeadLetterAddress(dla);
+      AddressSettings addressSettings = new AddressSettings()
+              .setMaxDeliveryAttempts(1)
+              .setDeadLetterAddress(dla);
       server.getAddressSettingsRepository().addMatch(qName.toString(), addressSettings);
       SimpleString dlq = new SimpleString("DLQ1");
       SimpleString dlq2 = new SimpleString("DLQ2");
@@ -257,8 +254,7 @@ public class DeadLetterAddressTest extends ServiceTestBase
    public void testBasicSendToNoQueue() throws Exception
    {
       SimpleString qName = new SimpleString("q1");
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setMaxDeliveryAttempts(1);
+      AddressSettings addressSettings = new AddressSettings().setMaxDeliveryAttempts(1);
       server.getAddressSettingsRepository().addMatch(qName.toString(), addressSettings);
       clientSession.createQueue(qName, qName, null, false);
       ClientProducer producer = clientSession.createProducer(qName);
@@ -283,9 +279,9 @@ public class DeadLetterAddressTest extends ServiceTestBase
       final int NUM_MESSAGES = 5;
       SimpleString dla = new SimpleString("DLA");
       SimpleString qName = new SimpleString("q1");
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setMaxDeliveryAttempts(MAX_DELIVERIES);
-      addressSettings.setDeadLetterAddress(dla);
+      AddressSettings addressSettings = new AddressSettings()
+              .setMaxDeliveryAttempts(MAX_DELIVERIES)
+              .setDeadLetterAddress(dla);
       server.getAddressSettingsRepository().addMatch(qName.toString(), addressSettings);
       SimpleString dlq = new SimpleString("DLQ1");
       clientSession.createQueue(dla, dlq, null, false);
@@ -371,9 +367,9 @@ public class DeadLetterAddressTest extends ServiceTestBase
       SimpleString queue = RandomUtil.randomSimpleString();
       SimpleString deadLetterAddress = RandomUtil.randomSimpleString();
       SimpleString deadLetterQueue = RandomUtil.randomSimpleString();
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setMaxDeliveryAttempts(deliveryAttempt);
-      addressSettings.setDeadLetterAddress(deadLetterAddress);
+      AddressSettings addressSettings = new AddressSettings()
+              .setMaxDeliveryAttempts(deliveryAttempt)
+              .setDeadLetterAddress(deadLetterAddress);
       server.getAddressSettingsRepository().setDefault(addressSettings);
 
       clientSession.createQueue(address, queue, false);
@@ -414,9 +410,9 @@ public class DeadLetterAddressTest extends ServiceTestBase
       SimpleString queue = RandomUtil.randomSimpleString();
       SimpleString deadLetterAddress = RandomUtil.randomSimpleString();
       SimpleString deadLetterQueue = RandomUtil.randomSimpleString();
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setMaxDeliveryAttempts(deliveryAttempt);
-      addressSettings.setDeadLetterAddress(deadLetterAddress);
+      AddressSettings addressSettings = new AddressSettings()
+              .setMaxDeliveryAttempts(deliveryAttempt)
+              .setDeadLetterAddress(deadLetterAddress);
       server.getAddressSettingsRepository().addMatch("*", addressSettings);
 
       clientSession.createQueue(address, queue, false);
@@ -459,13 +455,13 @@ public class DeadLetterAddressTest extends ServiceTestBase
       SimpleString specificDeadLetterAddress = RandomUtil.randomSimpleString();
       SimpleString specificDeadLetterQueue = RandomUtil.randomSimpleString();
 
-      AddressSettings defaultAddressSettings = new AddressSettings();
-      defaultAddressSettings.setMaxDeliveryAttempts(defaultDeliveryAttempt);
-      defaultAddressSettings.setDeadLetterAddress(defaultDeadLetterAddress);
+      AddressSettings defaultAddressSettings = new AddressSettings()
+              .setMaxDeliveryAttempts(defaultDeliveryAttempt)
+              .setDeadLetterAddress(defaultDeadLetterAddress);
       server.getAddressSettingsRepository().addMatch("*", defaultAddressSettings);
-      AddressSettings specificAddressSettings = new AddressSettings();
-      specificAddressSettings.setMaxDeliveryAttempts(specificeDeliveryAttempt);
-      specificAddressSettings.setDeadLetterAddress(specificDeadLetterAddress);
+      AddressSettings specificAddressSettings = new AddressSettings()
+              .setMaxDeliveryAttempts(specificeDeliveryAttempt)
+              .setDeadLetterAddress(specificDeadLetterAddress);
       server.getAddressSettingsRepository().addMatch(address.toString(), specificAddressSettings);
 
       clientSession.createQueue(address, queue, false);
@@ -509,18 +505,10 @@ public class DeadLetterAddressTest extends ServiceTestBase
    public void setUp() throws Exception
    {
       super.setUp();
-      TransportConfiguration transportConfig = new TransportConfiguration(ServiceTestBase.INVM_ACCEPTOR_FACTORY);
-
-      Configuration configuration = createDefaultConfig()
-         .setSecurityEnabled(false)
-         .addAcceptorConfiguration(transportConfig);
-      server = addServer(ActiveMQServers.newActiveMQServer(configuration, false));
-      // start the server
+      server = addServer(ActiveMQServers.newActiveMQServer(createDefaultInVMConfig(), false));
       server.start();
       // then we create a client as normal
-      locator =
-               addServerLocator(ActiveMQClient.createServerLocatorWithoutHA(new TransportConfiguration(
-                  INVM_CONNECTOR_FACTORY)));
+      locator = createInVMNonHALocator();
       ClientSessionFactory sessionFactory = createSessionFactory(locator);
       clientSession = addClientSession(sessionFactory.createSession(false, true, false));
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/DeliveryOrderTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/DeliveryOrderTest.java
@@ -29,13 +29,13 @@ import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.MessageHandler;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class DeliveryOrderTest extends ServiceTestBase
+public class DeliveryOrderTest extends ActiveMQTestBase
 {
    public final SimpleString addressA = new SimpleString("addressA");
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/DurableQueueTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/DurableQueueTest.java
@@ -31,9 +31,9 @@ import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 
-public class DurableQueueTest extends ServiceTestBase
+public class DurableQueueTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ExpireTestOnRestartTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ExpireTestOnRestartTest.java
@@ -27,11 +27,11 @@ import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ExpireTestOnRestartTest extends ServiceTestBase
+public class ExpireTestOnRestartTest extends ActiveMQTestBase
 {
 
    ActiveMQServer server;
@@ -43,11 +43,11 @@ public class ExpireTestOnRestartTest extends ServiceTestBase
    {
       super.setUp();
       server = createServer(true);
-      AddressSettings setting = new AddressSettings();
-      setting.setExpiryAddress(SimpleString.toSimpleString("exp"));
-      setting.setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
-      setting.setPageSizeBytes(100 * 1024);
-      setting.setMaxSizeBytes(200 * 1024);
+      AddressSettings setting = new AddressSettings()
+              .setExpiryAddress(SimpleString.toSimpleString("exp"))
+              .setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE)
+              .setPageSizeBytes(100 * 1024)
+              .setMaxSizeBytes(200 * 1024);
       server.getConfiguration().setJournalSyncNonTransactional(false);
       server.getConfiguration().setMessageExpiryScanPeriod(-1);
       server.getConfiguration().setJournalSyncTransactional(false);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ExpiryAddressTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ExpiryAddressTest.java
@@ -18,27 +18,24 @@ package org.apache.activemq.artemis.tests.integration.client;
 
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.message.impl.MessageImpl;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ExpiryAddressTest extends ServiceTestBase
+public class ExpiryAddressTest extends ActiveMQTestBase
 {
    private static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
 
@@ -54,8 +51,7 @@ public class ExpiryAddressTest extends ServiceTestBase
       SimpleString adSend = new SimpleString("a1");
       SimpleString qName = new SimpleString("q1");
       SimpleString eq = new SimpleString("EA1");
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setExpiryAddress(ea);
+      AddressSettings addressSettings = new AddressSettings().setExpiryAddress(ea);
       server.getAddressSettingsRepository().addMatch("#", addressSettings);
       clientSession.createQueue(ea, eq, null, false);
       clientSession.createQueue(adSend, qName, null, false);
@@ -89,8 +85,7 @@ public class ExpiryAddressTest extends ServiceTestBase
       SimpleString expiryAddress1 = new SimpleString("expiryAddress1");
       SimpleString qName = new SimpleString("q1");
       SimpleString expiryQueue1 = new SimpleString("expiryQueue1");
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setExpiryAddress(expiryAddress1);
+      AddressSettings addressSettings = new AddressSettings().setExpiryAddress(expiryAddress1);
       server.getAddressSettingsRepository().addMatch(qName.toString(), addressSettings);
       clientSession.createQueue(expiryAddress1, expiryQueue1, null, false);
       clientSession.createQueue(qName, qName, null, false);
@@ -98,8 +93,7 @@ public class ExpiryAddressTest extends ServiceTestBase
       // override "original" address settings
       SimpleString expiryAddress2 = new SimpleString("expiryAddress2");
       SimpleString expiryQueue2 = new SimpleString("expiryQueue2");
-      addressSettings = new AddressSettings();
-      addressSettings.setExpiryAddress(expiryAddress2);
+      addressSettings = new AddressSettings().setExpiryAddress(expiryAddress2);
       server.getAddressSettingsRepository().addMatch(qName.toString(), addressSettings);
       clientSession.createQueue(expiryAddress2, expiryQueue2, null, false);
 
@@ -142,8 +136,7 @@ public class ExpiryAddressTest extends ServiceTestBase
       SimpleString qName = new SimpleString("q1");
       SimpleString eq = new SimpleString("EQ1");
       SimpleString eq2 = new SimpleString("EQ2");
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setExpiryAddress(ea);
+      AddressSettings addressSettings = new AddressSettings().setExpiryAddress(ea);
       server.getAddressSettingsRepository().addMatch(qName.toString(), addressSettings);
       clientSession.createQueue(ea, eq, null, false);
       clientSession.createQueue(ea, eq2, null, false);
@@ -225,15 +218,12 @@ public class ExpiryAddressTest extends ServiceTestBase
       final int NUM_MESSAGES = 5;
       SimpleString ea = new SimpleString("DLA");
       SimpleString qName = new SimpleString("q1");
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setExpiryAddress(ea);
+      AddressSettings addressSettings = new AddressSettings().setExpiryAddress(ea);
       server.getAddressSettingsRepository().addMatch(qName.toString(), addressSettings);
       SimpleString eq = new SimpleString("EA1");
       clientSession.createQueue(ea, eq, null, false);
       clientSession.createQueue(qName, qName, null, false);
-      ServerLocator locator1 =
-               addServerLocator(ActiveMQClient.createServerLocatorWithoutHA(new TransportConfiguration(
-                  INVM_CONNECTOR_FACTORY)));
+      ServerLocator locator1 = createInVMNonHALocator();
 
       ClientSessionFactory sessionFactory = createSessionFactory(locator1);
 
@@ -282,8 +272,7 @@ public class ExpiryAddressTest extends ServiceTestBase
       SimpleString ea = new SimpleString("EA");
       SimpleString qName = new SimpleString("q1");
       SimpleString eq = new SimpleString("EA1");
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setExpiryAddress(ea);
+      AddressSettings addressSettings = new AddressSettings().setExpiryAddress(ea);
       server.getAddressSettingsRepository().setDefault(addressSettings);
       clientSession.createQueue(ea, eq, null, false);
       clientSession.createQueue(qName, qName, null, false);
@@ -312,8 +301,7 @@ public class ExpiryAddressTest extends ServiceTestBase
       SimpleString ea = new SimpleString("EA");
       SimpleString qName = new SimpleString("q1");
       SimpleString eq = new SimpleString("EA1");
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setExpiryAddress(ea);
+      AddressSettings addressSettings = new AddressSettings().setExpiryAddress(ea);
       server.getAddressSettingsRepository().addMatch("*", addressSettings);
       clientSession.createQueue(ea, eq, null, false);
       clientSession.createQueue(qName, qName, null, false);
@@ -346,11 +334,9 @@ public class ExpiryAddressTest extends ServiceTestBase
       SimpleString specificExpiryAddress = RandomUtil.randomSimpleString();
       SimpleString specificExpiryQueue = RandomUtil.randomSimpleString();
 
-      AddressSettings defaultAddressSettings = new AddressSettings();
-      defaultAddressSettings.setExpiryAddress(defaultExpiryAddress);
+      AddressSettings defaultAddressSettings = new AddressSettings().setExpiryAddress(defaultExpiryAddress);
       server.getAddressSettingsRepository().addMatch("prefix.*", defaultAddressSettings);
-      AddressSettings specificAddressSettings = new AddressSettings();
-      specificAddressSettings.setExpiryAddress(specificExpiryAddress);
+      AddressSettings specificAddressSettings = new AddressSettings().setExpiryAddress(specificExpiryAddress);
       server.getAddressSettingsRepository().addMatch("prefix.address", specificAddressSettings);
 
       clientSession.createQueue(address, queue, false);
@@ -385,21 +371,14 @@ public class ExpiryAddressTest extends ServiceTestBase
    public void setUp() throws Exception
    {
       super.setUp();
-      TransportConfiguration transportConfig = new TransportConfiguration(ServiceTestBase.INVM_ACCEPTOR_FACTORY);
-
-      Configuration configuration = createDefaultConfig()
-         .setSecurityEnabled(false)
-         .addAcceptorConfiguration(transportConfig);
-      server = addServer(ActiveMQServers.newActiveMQServer(configuration, false));
-      // start the server
+      server = addServer(ActiveMQServers.newActiveMQServer(createDefaultInVMConfig(), false));
       server.start();
       // then we create a client as normal
-      locator = createInVMNonHALocator();
-      locator.setBlockOnAcknowledge(true);
+      locator = createInVMNonHALocator()
+              .setBlockOnAcknowledge(true);
       ClientSessionFactory sessionFactory = createSessionFactory(locator);
       // There are assertions over sizes that needs to be done after the ACK
       // was received on server
       clientSession = addClientSession(sessionFactory.createSession(null, null, false, true, true, false, 0));
    }
-
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ExpiryLargeMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ExpiryLargeMessageTest.java
@@ -27,7 +27,7 @@ import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
@@ -37,7 +37,7 @@ import org.junit.Test;
 /**
  * This test will send large messages in page-mode, DLQ then, expiry then, and they should be received fine
  */
-public class ExpiryLargeMessageTest extends ServiceTestBase
+public class ExpiryLargeMessageTest extends ActiveMQTestBase
 {
 
    private static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
@@ -69,20 +69,14 @@ public class ExpiryLargeMessageTest extends ServiceTestBase
 
       server.getConfiguration().setMessageExpiryScanPeriod(600000);
 
-      AddressSettings setting = new AddressSettings();
-      setting.setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
-      setting.setMaxDeliveryAttempts(5);
-      setting.setMaxSizeBytes(50 * 1024);
-      setting.setPageSizeBytes(10 * 1024);
-      setting.setExpiryAddress(EXPIRY);
-      setting.setDeadLetterAddress(DLQ);
+      AddressSettings setting = new AddressSettings()
+              .setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE)
+              .setMaxDeliveryAttempts(5)
+              .setMaxSizeBytes(50 * 1024)
+              .setPageSizeBytes(10 * 1024)
+              .setExpiryAddress(EXPIRY)
+              .setDeadLetterAddress(DLQ);
       server.getAddressSettingsRepository().addMatch(MY_QUEUE.toString(), setting);
-
-      setting.setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
-      setting.setMaxDeliveryAttempts(5);
-      setting.setMaxSizeBytes(50 * 1024);
-      setting.setPageSizeBytes(10 * 1024);
-      setting.setDeadLetterAddress(DLQ);
       server.getAddressSettingsRepository().addMatch(EXPIRY.toString(), setting);
 
       server.start();
@@ -281,20 +275,14 @@ public class ExpiryLargeMessageTest extends ServiceTestBase
 
       server.getConfiguration().setMessageExpiryScanPeriod(600000);
 
-      AddressSettings setting = new AddressSettings();
-      setting.setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
-      setting.setMaxDeliveryAttempts(5);
-      setting.setMaxSizeBytes(-1);
-      setting.setPageSizeBytes(10 * 1024);
-      setting.setExpiryAddress(EXPIRY);
-      setting.setDeadLetterAddress(DLQ);
+      AddressSettings setting = new AddressSettings()
+              .setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE)
+              .setMaxDeliveryAttempts(5)
+              .setMaxSizeBytes(-1)
+              .setPageSizeBytes(10 * 1024)
+              .setExpiryAddress(EXPIRY)
+              .setDeadLetterAddress(DLQ);
       server.getAddressSettingsRepository().addMatch(MY_QUEUE.toString(), setting);
-
-      setting.setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
-      setting.setMaxDeliveryAttempts(5);
-      setting.setMaxSizeBytes(-1);
-      setting.setPageSizeBytes(10 * 1024);
-      setting.setDeadLetterAddress(DLQ);
       server.getAddressSettingsRepository().addMatch(EXPIRY.toString(), setting);
 
       server.start();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/HeuristicXATest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/HeuristicXATest.java
@@ -29,8 +29,7 @@ import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.transaction.impl.XidImpl;
 import org.apache.activemq.artemis.tests.integration.management.ManagementControlHelper;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.junit.After;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,7 +39,7 @@ import javax.management.MBeanServerFactory;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 
-public class HeuristicXATest extends ServiceTestBase
+public class HeuristicXATest extends ActiveMQTestBase
 {
    // Constants -----------------------------------------------------
    final SimpleString ADDRESS = new SimpleString("ADDRESS");
@@ -62,7 +61,7 @@ public class HeuristicXATest extends ServiceTestBase
    @Test
    public void testInvalidCall() throws Exception
    {
-      Configuration configuration = createDefaultConfig()
+      Configuration configuration = createDefaultInVMConfig()
          .setJMXManagementEnabled(true);
 
       ActiveMQServer server = createServer(false, configuration);
@@ -88,7 +87,7 @@ public class HeuristicXATest extends ServiceTestBase
 
    private void internalTest(final boolean isCommit) throws Exception
    {
-      Configuration configuration = createDefaultConfig()
+      Configuration configuration = createDefaultInVMConfig()
          .setJMXManagementEnabled(true);
 
       ActiveMQServer server = createServer(false, configuration);
@@ -184,7 +183,7 @@ public class HeuristicXATest extends ServiceTestBase
 
    private void doHeuristicCompletionWithRestart(final boolean isCommit) throws Exception
    {
-      Configuration configuration = createDefaultConfig()
+      Configuration configuration = createDefaultInVMConfig()
          .setJMXManagementEnabled(true);
 
       ActiveMQServer server = createServer(true, configuration);
@@ -285,7 +284,7 @@ public class HeuristicXATest extends ServiceTestBase
 
    private void doRecoverHeuristicCompletedTxWithRestart(final boolean heuristicCommit) throws Exception
    {
-      Configuration configuration = createDefaultConfig()
+      Configuration configuration = createDefaultInVMConfig()
          .setJMXManagementEnabled(true);
 
       ActiveMQServer server = createServer(true, configuration);
@@ -356,7 +355,7 @@ public class HeuristicXATest extends ServiceTestBase
       server.stop();
 
       server.start();
-      // we need to recreate the locator and session factory
+      // we need to recreate the locator and session sf
       sf = createSessionFactory(locator);
       jmxServer = ManagementControlHelper.createActiveMQServerControl(mbeanServer);
       if (heuristicCommit)
@@ -395,7 +394,7 @@ public class HeuristicXATest extends ServiceTestBase
 
    private void doForgetHeuristicCompletedTxAndRestart(final boolean heuristicCommit) throws Exception
    {
-      Configuration configuration = createDefaultConfig()
+      Configuration configuration = createDefaultInVMConfig()
          .setJMXManagementEnabled(true);
 
       ActiveMQServer server = createServer(true, configuration);
@@ -479,15 +478,6 @@ public class HeuristicXATest extends ServiceTestBase
    // Package protected ---------------------------------------------
 
    // Protected -----------------------------------------------------
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      locator.close();
-      MBeanServerFactory.releaseMBeanServer(mbeanServer);
-      super.tearDown();
-   }
 
    @Override
    @Before

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/InVMNonPersistentMessageBufferTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/InVMNonPersistentMessageBufferTest.java
@@ -15,13 +15,6 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.client;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.junit.Before;
-import org.junit.After;
-
-import org.junit.Test;
-
-import org.junit.Assert;
 
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
@@ -31,10 +24,14 @@ import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
 import org.apache.activemq.artemis.utils.DataConstants;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
-public class InVMNonPersistentMessageBufferTest extends ServiceTestBase
+public class InVMNonPersistentMessageBufferTest extends ActiveMQTestBase
 {
    public static final String address = "testaddress";
 
@@ -260,22 +257,6 @@ public class InVMNonPersistentMessageBufferTest extends ServiceTestBase
       consumer = session.createConsumer(InVMNonPersistentMessageBufferTest.queueName);
 
       session.start();
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      if (session != null)
-      {
-         consumer.close();
-
-         session.deleteQueue(InVMNonPersistentMessageBufferTest.queueName);
-
-         session.close();
-      }
-
-      super.tearDown();
    }
 
    private ClientMessage sendAndReceive(final ClientMessage message) throws Exception

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/IncompatibleVersionTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/IncompatibleVersionTest.java
@@ -41,7 +41,7 @@ import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
 import org.apache.activemq.artemis.core.version.impl.VersionImpl;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.VersionLoader;
 import org.junit.After;
 import org.junit.Before;
@@ -49,7 +49,7 @@ import org.junit.Test;
 
 import static org.apache.activemq.artemis.tests.util.RandomUtil.randomString;
 
-public class IncompatibleVersionTest extends ServiceTestBase
+public class IncompatibleVersionTest extends ActiveMQTestBase
 {
    private static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
    // Constants -----------------------------------------------------
@@ -251,10 +251,10 @@ public class IncompatibleVersionTest extends ServiceTestBase
    {
       public void perform(String startedString) throws Exception
       {
-         Configuration conf = new ConfigurationImpl()
+         Configuration config = new ConfigurationImpl()
             .setSecurityEnabled(false)
-            .addAcceptorConfiguration(new TransportConfiguration("org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptorFactory"));
-         ActiveMQServer server = ActiveMQServers.newActiveMQServer(conf, false);
+            .addAcceptorConfiguration(new TransportConfiguration(NETTY_ACCEPTOR_FACTORY));
+         ActiveMQServer server = ActiveMQServers.newActiveMQServer(config, false);
          server.start();
 
          log.info("### server: " + startedString);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/InterruptedLargeMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/InterruptedLargeMessageTest.java
@@ -38,7 +38,7 @@ import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
 import org.apache.activemq.artemis.tests.integration.largemessage.LargeMessageTestBase;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.filter.Filter;
 import org.apache.activemq.artemis.core.paging.cursor.PageSubscription;
 import org.apache.activemq.artemis.core.persistence.StorageManager;
@@ -102,8 +102,8 @@ public class InterruptedLargeMessageTest extends LargeMessageTestBase
 
       server.start();
 
-      locator.setBlockOnNonDurableSend(false);
-      locator.setBlockOnDurableSend(false);
+      locator.setBlockOnNonDurableSend(false)
+              .setBlockOnDurableSend(false);
 
       ClientSessionFactory sf = createSessionFactory(locator);
 
@@ -128,7 +128,7 @@ public class InterruptedLargeMessageTest extends LargeMessageTestBase
 
       server.stop(false);
 
-      ServiceTestBase.forceGC();
+      ActiveMQTestBase.forceGC();
 
       server.start();
 
@@ -146,9 +146,9 @@ public class InterruptedLargeMessageTest extends LargeMessageTestBase
 
       server.start();
 
-      locator.setBlockOnNonDurableSend(false);
-      locator.setBlockOnDurableSend(false);
-      locator.addIncomingInterceptor(new LargeMessageTestInterceptorIgnoreLastPacket());
+      locator.setBlockOnNonDurableSend(false)
+              .setBlockOnDurableSend(false)
+              .addIncomingInterceptor(new LargeMessageTestInterceptorIgnoreLastPacket());
 
       ClientSessionFactory sf = createSessionFactory(locator);
 
@@ -226,8 +226,8 @@ public class InterruptedLargeMessageTest extends LargeMessageTestBase
 
       server.start();
 
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true);
 
       ClientSessionFactory sf = createSessionFactory(locator);
 
@@ -261,7 +261,7 @@ public class InterruptedLargeMessageTest extends LargeMessageTestBase
             Assert.assertNotNull(clientMessage);
             for (int countByte = 0; countByte < LARGE_MESSAGE_SIZE; countByte++)
             {
-               Assert.assertEquals(ServiceTestBase.getSamplebyte(countByte), clientMessage.getBodyBuffer().readByte());
+               Assert.assertEquals(ActiveMQTestBase.getSamplebyte(countByte), clientMessage.getBodyBuffer().readByte());
             }
             clientMessage.acknowledge();
          }
@@ -293,8 +293,8 @@ public class InterruptedLargeMessageTest extends LargeMessageTestBase
 
       server.start();
 
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true);
 
       ClientSessionFactory sf = createSessionFactory(locator);
 
@@ -314,7 +314,7 @@ public class InterruptedLargeMessageTest extends LargeMessageTestBase
       }
       session.commit();
 
-      validateNoFilesOnLargeDir(10);
+      validateNoFilesOnLargeDir(server.getConfiguration().getLargeMessagesDirectory(), 10);
 
       for (int h = 0; h < 5; h++)
       {
@@ -340,7 +340,7 @@ public class InterruptedLargeMessageTest extends LargeMessageTestBase
             Assert.assertNotNull(clientMessage);
             for (int countByte = 0; countByte < LARGE_MESSAGE_SIZE; countByte++)
             {
-               Assert.assertEquals(ServiceTestBase.getSamplebyte(countByte), clientMessage.getBodyBuffer().readByte());
+               Assert.assertEquals(ActiveMQTestBase.getSamplebyte(countByte), clientMessage.getBodyBuffer().readByte());
             }
             clientMessage.acknowledge();
          }
@@ -367,8 +367,6 @@ public class InterruptedLargeMessageTest extends LargeMessageTestBase
    @Test
    public void testSendPreparedXA() throws Exception
    {
-
-
       ClientSession session = null;
 
       LargeMessageTestInterceptorIgnoreLastPacket.disableInterrupt();
@@ -382,8 +380,8 @@ public class InterruptedLargeMessageTest extends LargeMessageTestBase
 
       server.start();
 
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true);
 
       ClientSessionFactory sf = createSessionFactory(locator);
 
@@ -469,7 +467,7 @@ public class InterruptedLargeMessageTest extends LargeMessageTestBase
       }
       server.stop();
 
-      validateNoFilesOnLargeDir(10);
+      validateNoFilesOnLargeDir(server.getConfiguration().getLargeMessagesDirectory(), 10);
 
       server.start();
 
@@ -615,8 +613,8 @@ public class InterruptedLargeMessageTest extends LargeMessageTestBase
                                                                                  server.getAddressSettingsRepository(),
                                                                                  server.getExecutorFactory()));
 
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true);
 
       ClientSessionFactory sf = createSessionFactory(locator);
 
@@ -678,8 +676,8 @@ public class InterruptedLargeMessageTest extends LargeMessageTestBase
 
       QueueFactory original = server.getQueueFactory();
 
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true);
 
       ClientSessionFactory sf = createSessionFactory(locator);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/JMSPagingFileDeleteTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/JMSPagingFileDeleteTest.java
@@ -16,6 +16,14 @@
  */
 package org.apache.activemq.artemis.tests.integration.client;
 
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.paging.PagingStore;
+import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
+import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
+import org.apache.activemq.artemis.tests.util.JMSTestBase;
+import org.junit.Before;
+import org.junit.Test;
+
 import javax.jms.BytesMessage;
 import javax.jms.Connection;
 import javax.jms.Message;
@@ -23,15 +31,6 @@ import javax.jms.MessageConsumer;
 import javax.jms.MessageProducer;
 import javax.jms.Session;
 import javax.jms.Topic;
-
-import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.JMSTestBase;
-import org.apache.activemq.artemis.core.paging.PagingStore;
-import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * This will perform cleanup tests on paging while using JMS topics
@@ -77,19 +76,10 @@ public class JMSPagingFileDeleteTest extends JMSTestBase
       topic1 = createTopic("topic1");
 
       // Paging Setting
-      AddressSettings setting = new AddressSettings();
-      setting.setPageSizeBytes(JMSPagingFileDeleteTest.PAGE_SIZE);
-      setting.setMaxSizeBytes(JMSPagingFileDeleteTest.PAGE_MAX);
+      AddressSettings setting = new AddressSettings()
+              .setPageSizeBytes(JMSPagingFileDeleteTest.PAGE_SIZE)
+              .setMaxSizeBytes(JMSPagingFileDeleteTest.PAGE_MAX);
       server.getAddressSettingsRepository().addMatch("#", setting);
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      log.info("#tearDown");
-      topic1 = null;
-      super.tearDown();
    }
 
    /**

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/JmsNettyNioStressTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/JmsNettyNioStressTest.java
@@ -28,7 +28,7 @@ import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.jms.client.ActiveMQDestination;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -62,7 +62,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * counting strategy is used to verify that the count has reached the expected
  * value.
  */
-public class JmsNettyNioStressTest extends ServiceTestBase
+public class JmsNettyNioStressTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------
@@ -92,8 +92,8 @@ public class JmsNettyNioStressTest extends ServiceTestBase
       // minimize threads to maximize possibility for deadlock
       params.put(TransportConstants.NIO_REMOTING_THREADS_PROPNAME, 1);
       params.put(TransportConstants.BATCH_DELAY, 50);
-      TransportConfiguration transportConfig = new TransportConfiguration(ServiceTestBase.NETTY_ACCEPTOR_FACTORY, params);
-      Configuration config = createBasicConfig(-1)
+      TransportConfiguration transportConfig = new TransportConfiguration(ActiveMQTestBase.NETTY_ACCEPTOR_FACTORY, params);
+      Configuration config = createBasicConfig()
               .setJMXManagementEnabled(false)
               .clearAcceptorConfigurations()
               .addAcceptorConfiguration(transportConfig);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/JournalCrashTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/JournalCrashTest.java
@@ -34,11 +34,11 @@ import org.apache.activemq.artemis.core.journal.RecordInfo;
 import org.apache.activemq.artemis.core.journal.impl.JournalImpl;
 import org.apache.activemq.artemis.core.journal.impl.NIOSequentialFileFactory;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class JournalCrashTest extends ServiceTestBase
+public class JournalCrashTest extends ActiveMQTestBase
 {
    private static final int FIRST_RUN = 4;
 
@@ -58,7 +58,7 @@ public class JournalCrashTest extends ServiceTestBase
 
    protected void startServer() throws Exception
    {
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalFileSize(ActiveMQDefaultConfiguration.getDefaultJournalFileSize())
          .setJournalCompactMinFiles(ActiveMQDefaultConfiguration.getDefaultJournalCompactMinFiles())
          .setJournalCompactPercentage(ActiveMQDefaultConfiguration.getDefaultJournalCompactPercentage())

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/LargeMessageAvoidLargeMessagesTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/LargeMessageAvoidLargeMessagesTest.java
@@ -25,7 +25,7 @@ import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.junit.Assert;
@@ -52,10 +52,9 @@ public class LargeMessageAvoidLargeMessagesTest extends LargeMessageTest
    @Override
    protected ServerLocator createFactory(final boolean isNetty) throws Exception
    {
-      ServerLocator locator1 = super.createFactory(isNetty);
-      locator1.setMinLargeMessageSize(10240);
-      locator1.setCompressLargeMessage(true);
-      return locator1;
+      return super.createFactory(isNetty)
+              .setMinLargeMessageSize(10240)
+              .setCompressLargeMessage(true);
    }
 
    @Test
@@ -194,7 +193,7 @@ public class LargeMessageAvoidLargeMessagesTest extends LargeMessageTest
       session.start();
 
       //no file should be in the dir as we send it as regular
-      validateNoFilesOnLargeDir(num);
+      validateNoFilesOnLargeDir(server.getConfiguration().getLargeMessagesDirectory(), num);
 
       ClientConsumer consumer = session.createConsumer(ADDRESS);
       for (int j = 0; j < num; j++)
@@ -259,7 +258,7 @@ public class LargeMessageAvoidLargeMessagesTest extends LargeMessageTest
       session.start();
 
       //half the messages are sent as large
-      validateNoFilesOnLargeDir(num / 2);
+      validateNoFilesOnLargeDir(server.getConfiguration().getLargeMessagesDirectory(), num / 2);
 
       ClientConsumer consumer = session.createConsumer(ADDRESS);
       for (int j = 0; j < num; j++)
@@ -316,10 +315,9 @@ public class LargeMessageAvoidLargeMessagesTest extends LargeMessageTest
 
       SimpleString ADDRESS_DLA = ADDRESS.concat("-dla");
 
-      AddressSettings addressSettings = new AddressSettings();
-
-      addressSettings.setDeadLetterAddress(ADDRESS_DLA);
-      addressSettings.setMaxDeliveryAttempts(1);
+      AddressSettings addressSettings = new AddressSettings()
+              .setDeadLetterAddress(ADDRESS_DLA)
+              .setMaxDeliveryAttempts(1);
 
       server.getAddressSettingsRepository().addMatch("*", addressSettings);
 
@@ -350,7 +348,7 @@ public class LargeMessageAvoidLargeMessagesTest extends LargeMessageTest
 
       for (int i = 0; i < messageSize; i++)
       {
-         Assert.assertEquals(ServiceTestBase.getSamplebyte(i), msg1
+         Assert.assertEquals(ActiveMQTestBase.getSamplebyte(i), msg1
             .getBodyBuffer().readByte());
       }
 
@@ -375,7 +373,7 @@ public class LargeMessageAvoidLargeMessagesTest extends LargeMessageTest
 
       for (int i = 0; i < messageSize; i++)
       {
-         Assert.assertEquals(ServiceTestBase.getSamplebyte(i), msg1
+         Assert.assertEquals(ActiveMQTestBase.getSamplebyte(i), msg1
             .getBodyBuffer().readByte());
       }
 
@@ -384,7 +382,7 @@ public class LargeMessageAvoidLargeMessagesTest extends LargeMessageTest
       session.commit();
 
       //large message becomes a regular at server.
-      validateNoFilesOnLargeDir(0);
+      validateNoFilesOnLargeDir(server.getConfiguration().getLargeMessagesDirectory(), 0);
 
       consumer = session.createConsumer(ADDRESS.concat("-2"));
 
@@ -394,7 +392,7 @@ public class LargeMessageAvoidLargeMessagesTest extends LargeMessageTest
 
       for (int i = 0; i < messageSize; i++)
       {
-         Assert.assertEquals(ServiceTestBase.getSamplebyte(i), msg1
+         Assert.assertEquals(ActiveMQTestBase.getSamplebyte(i), msg1
             .getBodyBuffer().readByte());
       }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/LargeMessageCompressTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/LargeMessageCompressTest.java
@@ -59,9 +59,8 @@ public class LargeMessageCompressTest extends LargeMessageTest
    @Override
    protected ServerLocator createFactory(final boolean isNetty) throws Exception
    {
-      ServerLocator locator1 = super.createFactory(isNetty);
-      locator1.setCompressLargeMessage(true);
-      return locator1;
+      return super.createFactory(isNetty)
+              .setCompressLargeMessage(true);
    }
 
    @Test

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/LargeMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/LargeMessageTest.java
@@ -49,7 +49,7 @@ import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -299,7 +299,7 @@ public class LargeMessageTest extends LargeMessageTestBase
       final int PAGE_SIZE = 10 * 1024;
       final int MESSAGE_SIZE = 1024; // 1k
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       ActiveMQServer server = createServer(true,
@@ -312,11 +312,10 @@ public class LargeMessageTest extends LargeMessageTestBase
 
       server.getAddressSettingsRepository().getMatch("#").setAddressFullMessagePolicy(AddressFullMessagePolicy.DROP);
 
-      locator = createInVMNonHALocator();
-
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator = createInVMNonHALocator()
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       ClientSessionFactory sf = createSessionFactory(locator);
 
@@ -456,10 +455,9 @@ public class LargeMessageTest extends LargeMessageTestBase
 
       SimpleString ADDRESS_DLA = ADDRESS.concat("-dla");
 
-      AddressSettings addressSettings = new AddressSettings();
-
-      addressSettings.setDeadLetterAddress(ADDRESS_DLA);
-      addressSettings.setMaxDeliveryAttempts(1);
+      AddressSettings addressSettings = new AddressSettings()
+              .setDeadLetterAddress(ADDRESS_DLA)
+              .setMaxDeliveryAttempts(1);
 
       server.getAddressSettingsRepository().addMatch("*", addressSettings);
 
@@ -490,7 +488,7 @@ public class LargeMessageTest extends LargeMessageTestBase
 
       for (int i = 0; i < messageSize; i++)
       {
-         Assert.assertEquals(ServiceTestBase.getSamplebyte(i), msg1.getBodyBuffer().readByte());
+         Assert.assertEquals(ActiveMQTestBase.getSamplebyte(i), msg1.getBodyBuffer().readByte());
       }
 
       session.close();
@@ -514,14 +512,14 @@ public class LargeMessageTest extends LargeMessageTestBase
 
       for (int i = 0; i < messageSize; i++)
       {
-         Assert.assertEquals(ServiceTestBase.getSamplebyte(i), msg1.getBodyBuffer().readByte());
+         Assert.assertEquals(ActiveMQTestBase.getSamplebyte(i), msg1.getBodyBuffer().readByte());
       }
 
       msg1.acknowledge();
 
       session.commit();
 
-      validateNoFilesOnLargeDir(isCompressedTest ? 0 : 1);
+      validateNoFilesOnLargeDir(server.getConfiguration().getLargeMessagesDirectory(), isCompressedTest ? 0 : 1);
 
       consumer = session.createConsumer(ADDRESS.concat("-2"));
 
@@ -531,7 +529,7 @@ public class LargeMessageTest extends LargeMessageTestBase
 
       for (int i = 0; i < messageSize; i++)
       {
-         Assert.assertEquals(ServiceTestBase.getSamplebyte(i), msg1.getBodyBuffer().readByte());
+         Assert.assertEquals(ActiveMQTestBase.getSamplebyte(i), msg1.getBodyBuffer().readByte());
       }
 
       msg1.acknowledge();
@@ -580,7 +578,7 @@ public class LargeMessageTest extends LargeMessageTestBase
 
       for (int i = 0; i < messageSize; i++)
       {
-         Assert.assertEquals(ServiceTestBase.getSamplebyte(i), msg.getBodyBuffer().readByte());
+         Assert.assertEquals(ActiveMQTestBase.getSamplebyte(i), msg.getBodyBuffer().readByte());
       }
       session.rollback();
 
@@ -595,7 +593,7 @@ public class LargeMessageTest extends LargeMessageTestBase
       msg.acknowledge();
       for (int i = 0; i < messageSize; i++)
       {
-         Assert.assertEquals(ServiceTestBase.getSamplebyte(i), msg.getBodyBuffer().readByte());
+         Assert.assertEquals(ActiveMQTestBase.getSamplebyte(i), msg.getBodyBuffer().readByte());
       }
       Assert.assertEquals(2, msg.getDeliveryCount());
       msg.acknowledge();
@@ -623,11 +621,10 @@ public class LargeMessageTest extends LargeMessageTestBase
       SimpleString ADDRESS_DLA = ADDRESS.concat("-dla");
       SimpleString ADDRESS_EXPIRY = ADDRESS.concat("-expiry");
 
-      AddressSettings addressSettings = new AddressSettings();
-
-      addressSettings.setDeadLetterAddress(ADDRESS_DLA);
-      addressSettings.setExpiryAddress(ADDRESS_EXPIRY);
-      addressSettings.setMaxDeliveryAttempts(1);
+      AddressSettings addressSettings = new AddressSettings()
+              .setDeadLetterAddress(ADDRESS_DLA)
+              .setExpiryAddress(ADDRESS_EXPIRY)
+              .setMaxDeliveryAttempts(1);
 
       server.getAddressSettingsRepository().addMatch("*", addressSettings);
 
@@ -663,7 +660,7 @@ public class LargeMessageTest extends LargeMessageTestBase
 
       for (int j = 0; j < messageSize; j++)
       {
-         Assert.assertEquals(ServiceTestBase.getSamplebyte(j), msg1.getBodyBuffer().readByte());
+         Assert.assertEquals(ActiveMQTestBase.getSamplebyte(j), msg1.getBodyBuffer().readByte());
       }
 
       session.rollback();
@@ -681,7 +678,7 @@ public class LargeMessageTest extends LargeMessageTestBase
 
          for (int j = 0; j < messageSize; j++)
          {
-            Assert.assertEquals(ServiceTestBase.getSamplebyte(j), msg1.getBodyBuffer().readByte());
+            Assert.assertEquals(ActiveMQTestBase.getSamplebyte(j), msg1.getBodyBuffer().readByte());
          }
 
          session.rollback();
@@ -705,7 +702,7 @@ public class LargeMessageTest extends LargeMessageTestBase
 
       for (int i = 0; i < messageSize; i++)
       {
-         Assert.assertEquals(ServiceTestBase.getSamplebyte(i), msg1.getBodyBuffer().readByte());
+         Assert.assertEquals(ActiveMQTestBase.getSamplebyte(i), msg1.getBodyBuffer().readByte());
       }
 
       session.commit();
@@ -740,11 +737,10 @@ public class LargeMessageTest extends LargeMessageTestBase
       SimpleString ADDRESS_DLA = ADDRESS.concat("-dla");
       SimpleString ADDRESS_EXPIRY = ADDRESS.concat("-expiry");
 
-      AddressSettings addressSettings = new AddressSettings();
-
-      addressSettings.setDeadLetterAddress(ADDRESS_DLA);
-      addressSettings.setExpiryAddress(ADDRESS_EXPIRY);
-      addressSettings.setMaxDeliveryAttempts(1);
+      AddressSettings addressSettings = new AddressSettings()
+              .setDeadLetterAddress(ADDRESS_DLA)
+              .setExpiryAddress(ADDRESS_EXPIRY)
+              .setMaxDeliveryAttempts(1);
 
       server.getAddressSettingsRepository().addMatch("*", addressSettings);
 
@@ -779,7 +775,7 @@ public class LargeMessageTest extends LargeMessageTestBase
 
       for (int j = 0; j < messageSize; j++)
       {
-         Assert.assertEquals(ServiceTestBase.getSamplebyte(j), msg1.getBodyBuffer().readByte());
+         Assert.assertEquals(ActiveMQTestBase.getSamplebyte(j), msg1.getBodyBuffer().readByte());
       }
 
       session.rollback();
@@ -796,7 +792,7 @@ public class LargeMessageTest extends LargeMessageTestBase
 
          for (int j = 0; j < messageSize; j++)
          {
-            Assert.assertEquals(ServiceTestBase.getSamplebyte(j), msg1.getBodyBuffer().readByte());
+            Assert.assertEquals(ActiveMQTestBase.getSamplebyte(j), msg1.getBodyBuffer().readByte());
          }
 
          session.rollback();
@@ -825,7 +821,7 @@ public class LargeMessageTest extends LargeMessageTestBase
 
       for (int i = 0; i < messageSize; i++)
       {
-         Assert.assertEquals(ServiceTestBase.getSamplebyte(i), msg1.getBodyBuffer().readByte());
+         Assert.assertEquals(ActiveMQTestBase.getSamplebyte(i), msg1.getBodyBuffer().readByte());
       }
 
       session.commit();
@@ -852,11 +848,9 @@ public class LargeMessageTest extends LargeMessageTestBase
 
          server.start();
 
-         AddressSettings addressSettings = new AddressSettings();
-
          SimpleString ADDRESS_EXPIRY = ADDRESS.concat("-expiry");
 
-         addressSettings.setExpiryAddress(ADDRESS_EXPIRY);
+         AddressSettings addressSettings = new AddressSettings().setExpiryAddress(ADDRESS_EXPIRY);
 
          server.getAddressSettingsRepository().addMatch("*", addressSettings);
 
@@ -892,7 +886,7 @@ public class LargeMessageTest extends LargeMessageTestBase
 
          for (int i = 0; i < messageSize; i++)
          {
-            Assert.assertEquals(ServiceTestBase.getSamplebyte(i), msg1.getBodyBuffer().readByte());
+            Assert.assertEquals(ActiveMQTestBase.getSamplebyte(i), msg1.getBodyBuffer().readByte());
          }
 
          session.close();
@@ -916,7 +910,7 @@ public class LargeMessageTest extends LargeMessageTestBase
 
          for (int i = 0; i < messageSize; i++)
          {
-            Assert.assertEquals(ServiceTestBase.getSamplebyte(i), msg1.getBodyBuffer().readByte());
+            Assert.assertEquals(ActiveMQTestBase.getSamplebyte(i), msg1.getBodyBuffer().readByte());
          }
 
          msg1.acknowledge();
@@ -1128,9 +1122,8 @@ public class LargeMessageTest extends LargeMessageTestBase
 
          server.start();
 
-         locator.setMinLargeMessageSize(200);
-
-         locator.setCacheLargeMessagesClient(true);
+         locator.setMinLargeMessageSize(200)
+                 .setCacheLargeMessagesClient(true);
 
          ClientSessionFactory sf = addSessionFactory(createSessionFactory(locator));
 
@@ -1196,7 +1189,7 @@ public class LargeMessageTest extends LargeMessageTestBase
       assertNotNull(msg);
       for (long i = 0; i < messageSize; i++)
       {
-         Assert.assertEquals("position " + i, ServiceTestBase.getSamplebyte(i), msg.getBodyBuffer().readByte());
+         Assert.assertEquals("position " + i, ActiveMQTestBase.getSamplebyte(i), msg.getBodyBuffer().readByte());
       }
    }
 
@@ -2434,8 +2427,8 @@ public class LargeMessageTest extends LargeMessageTestBase
 
          server.start();
 
-         locator.setMinLargeMessageSize(1024);
-         locator.setConsumerWindowSize(1024 * 1024);
+         locator.setMinLargeMessageSize(1024)
+                 .setConsumerWindowSize(1024 * 1024);
 
          ClientSessionFactory sf = addSessionFactory(createSessionFactory(locator));
 
@@ -2448,7 +2441,7 @@ public class LargeMessageTest extends LargeMessageTestBase
          for (int i = 0; i < NUMBER_OF_MESSAGES; i++)
          {
             ClientMessage clientFile = session.createMessage(true);
-            clientFile.setBodyInputStream(ServiceTestBase.createFakeLargeStream(SIZE));
+            clientFile.setBodyInputStream(ActiveMQTestBase.createFakeLargeStream(SIZE));
             producer.send(clientFile);
 
          }
@@ -2481,7 +2474,7 @@ public class LargeMessageTest extends LargeMessageTestBase
                {
                   for (int byteRead = 0; byteRead < SIZE; byteRead++)
                   {
-                     Assert.assertEquals(ServiceTestBase.getSamplebyte(byteRead), msg.getBodyBuffer().readByte());
+                     Assert.assertEquals(ActiveMQTestBase.getSamplebyte(byteRead), msg.getBodyBuffer().readByte());
                   }
                }
 
@@ -2538,8 +2531,8 @@ public class LargeMessageTest extends LargeMessageTestBase
 
          server.start();
 
-         locator.setMinLargeMessageSize(1024);
-         locator.setConsumerWindowSize(1024 * 1024);
+         locator.setMinLargeMessageSize(1024)
+                 .setConsumerWindowSize(1024 * 1024);
 
          ClientSessionFactory sf = addSessionFactory(createSessionFactory(locator));
 
@@ -2552,7 +2545,7 @@ public class LargeMessageTest extends LargeMessageTestBase
          for (int i = 0; i < NUMBER_OF_MESSAGES; i++)
          {
             ClientMessage clientFile = session.createMessage(true);
-            clientFile.setBodyInputStream(ServiceTestBase.createFakeLargeStream(SIZE));
+            clientFile.setBodyInputStream(ActiveMQTestBase.createFakeLargeStream(SIZE));
             producer.send(clientFile);
 
          }
@@ -2584,7 +2577,7 @@ public class LargeMessageTest extends LargeMessageTestBase
                {
                   for (int byteRead = 0; byteRead < SIZE; byteRead++)
                   {
-                     Assert.assertEquals(ServiceTestBase.getSamplebyte(byteRead), msg.getBodyBuffer().readByte());
+                     Assert.assertEquals(ActiveMQTestBase.getSamplebyte(byteRead), msg.getBodyBuffer().readByte());
                   }
                }
 
@@ -2649,9 +2642,9 @@ public class LargeMessageTest extends LargeMessageTestBase
 
       final int numberOfBytesBigMessage = 400000;
 
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       ClientSessionFactory sf = addSessionFactory(createSessionFactory(locator));
 
@@ -2788,10 +2781,10 @@ public class LargeMessageTest extends LargeMessageTestBase
 
       final int numberOfBytesBigMessage = 400000;
 
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
-      locator.setCompressLargeMessage(true);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true)
+              .setCompressLargeMessage(true);
 
       ClientSessionFactory sf = addSessionFactory(createSessionFactory(locator));
 
@@ -2911,7 +2904,7 @@ public class LargeMessageTest extends LargeMessageTestBase
          session.createQueue(ADDRESS, ADDRESS, null, true);
 
          ClientMessage clientFile = session.createMessage(true);
-         clientFile.setBodyInputStream(ServiceTestBase.createFakeLargeStream(SIZE));
+         clientFile.setBodyInputStream(ActiveMQTestBase.createFakeLargeStream(SIZE));
 
          ClientProducer producer = session.createProducer(ADDRESS);
 
@@ -2990,7 +2983,7 @@ public class LargeMessageTest extends LargeMessageTestBase
       for (int i = 0; i < NUMBER_OF_MESSAGES; i++)
       {
          ClientMessage msg = session.createMessage(true);
-         msg.setBodyInputStream(ServiceTestBase.createFakeLargeStream(SIZE));
+         msg.setBodyInputStream(ActiveMQTestBase.createFakeLargeStream(SIZE));
          msg.putIntProperty(new SimpleString("key"), i);
          producer.send(msg);
 
@@ -3048,7 +3041,7 @@ public class LargeMessageTest extends LargeMessageTestBase
 
       for (int i = 0; i < LARGE_MESSAGE_SIZE; i++)
       {
-         fileMessage.addBytes(new byte[]{ServiceTestBase.getSamplebyte(i)});
+         fileMessage.addBytes(new byte[]{ActiveMQTestBase.getSamplebyte(i)});
       }
 
       // The server would be doing this
@@ -3078,7 +3071,7 @@ public class LargeMessageTest extends LargeMessageTestBase
 
       for (int i = 0; i < LARGE_MESSAGE_SIZE; i++)
       {
-         Assert.assertEquals(ServiceTestBase.getSamplebyte(i), msg.getBodyBuffer().readByte());
+         Assert.assertEquals(ActiveMQTestBase.getSamplebyte(i), msg.getBodyBuffer().readByte());
       }
 
       msg.acknowledge();
@@ -3121,9 +3114,9 @@ public class LargeMessageTest extends LargeMessageTestBase
 
       if (sendBlocking)
       {
-         sf.getServerLocator().setBlockOnNonDurableSend(true);
-         sf.getServerLocator().setBlockOnDurableSend(true);
-         sf.getServerLocator().setBlockOnAcknowledge(true);
+         sf.getServerLocator().setBlockOnNonDurableSend(true)
+                 .setBlockOnDurableSend(true)
+                 .setBlockOnAcknowledge(true);
       }
 
       ClientSession session = sf.createSession(null, null, false, true, true, false, 0);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/LibaioDependencyCheckTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/LibaioDependencyCheckTest.java
@@ -19,7 +19,7 @@ package org.apache.activemq.artemis.tests.integration.client;
 import org.junit.Test;
 
 import org.apache.activemq.artemis.core.asyncio.impl.AsynchronousFileImpl;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 
 /**
  * This tests is placed in duplication here to validate that the libaio module is properly loaded on this
@@ -27,7 +27,7 @@ import org.apache.activemq.artemis.tests.util.ServiceTestBase;
  *
  * This test should be placed on each one of the tests modules to make sure the library is loaded correctly.
  */
-public class LibaioDependencyCheckTest extends ServiceTestBase
+public class LibaioDependencyCheckTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MessageConcurrencyTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MessageConcurrencyTest.java
@@ -16,11 +16,6 @@
  */
 package org.apache.activemq.artemis.tests.integration.client;
 
-import java.util.HashSet;
-import java.util.Set;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
-
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
@@ -29,15 +24,19 @@ import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.MessageHandler;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class MessageConcurrencyTest extends ServiceTestBase
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+public class MessageConcurrencyTest extends ActiveMQTestBase
 {
    private static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
 
@@ -60,19 +59,6 @@ public class MessageConcurrencyTest extends ServiceTestBase
       server.start();
 
       locator = createInVMNonHALocator();
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      locator.close();
-
-      server.stop();
-
-      server = null;
-
-      super.tearDown();
    }
 
    // Test that a created message can be sent via multiple producers on different sessions concurrently

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MessageConsumerRollbackTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MessageConsumerRollbackTest.java
@@ -28,22 +28,21 @@ import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.MessageHandler;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.jms.client.ActiveMQTextMessage;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class MessageConsumerRollbackTest extends ServiceTestBase
+public class MessageConsumerRollbackTest extends ActiveMQTestBase
 {
 
    ActiveMQServer server;
 
    ServerLocator locator;
 
-   ClientSessionFactory factory;
+   ClientSessionFactory sf;
 
    private static final String inQueue = "inqueue";
 
@@ -56,40 +55,22 @@ public class MessageConsumerRollbackTest extends ServiceTestBase
 
       server = createServer(true, true);
 
-      AddressSettings settings = new AddressSettings();
-      settings.setRedeliveryDelay(100);
+      AddressSettings settings = new AddressSettings().setRedeliveryDelay(100);
       server.getConfiguration().getAddressesSettings().put("#", settings);
 
       server.start();
 
       locator = createNettyNonHALocator();
 
-      factory = createSessionFactory(locator);
+      sf = createSessionFactory(locator);
 
-      ClientSession session = factory.createTransactedSession();
+      ClientSession session = sf.createTransactedSession();
 
       session.createQueue(inQueue, inQueue, true);
 
       session.createQueue(outQueue, outQueue, true);
 
       session.close();
-   }
-
-   @After
-   public void tearDown() throws Exception
-   {
-      try
-      {
-         factory.close();
-         locator.close();
-      }
-      catch (Exception ignored)
-      {
-      }
-
-      server.stop();
-
-      super.tearDown();
    }
 
    // Constants -----------------------------------------------------
@@ -109,7 +90,7 @@ public class MessageConsumerRollbackTest extends ServiceTestBase
       int numberOfMessages = 3000;
       int numberOfConsumers = 10;
 
-      ClientSession session = factory.createTransactedSession();
+      ClientSession session = sf.createTransactedSession();
 
       sendMessages(numberOfMessages, session);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MessageCounterTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MessageCounterTest.java
@@ -29,9 +29,9 @@ import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 
-public class MessageCounterTest extends ServiceTestBase
+public class MessageCounterTest extends ActiveMQTestBase
 {
    private ActiveMQServer server;
 
@@ -54,9 +54,8 @@ public class MessageCounterTest extends ServiceTestBase
    @Test
    public void testMessageCounter() throws Exception
    {
-
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true);
 
       ClientSessionFactory sf = createSessionFactory(locator);
       ClientSession session = sf.createSession(null, null, false, false, false, false, 0);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MessageDurabilityTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MessageDurabilityTest.java
@@ -27,12 +27,12 @@ import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class MessageDurabilityTest extends ServiceTestBase
+public class MessageDurabilityTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------
@@ -149,7 +149,7 @@ public class MessageDurabilityTest extends ServiceTestBase
 
       session.start();
 
-      ServiceTestBase.expectActiveMQException(ActiveMQExceptionType.QUEUE_DOES_NOT_EXIST, new ActiveMQAction()
+      ActiveMQTestBase.expectActiveMQException(ActiveMQExceptionType.QUEUE_DOES_NOT_EXIST, new ActiveMQAction()
       {
          public void run() throws ActiveMQException
          {
@@ -177,7 +177,7 @@ public class MessageDurabilityTest extends ServiceTestBase
       restart();
 
       session.start();
-      ServiceTestBase.expectActiveMQException(ActiveMQExceptionType.QUEUE_DOES_NOT_EXIST, new ActiveMQAction()
+      ActiveMQTestBase.expectActiveMQException(ActiveMQExceptionType.QUEUE_DOES_NOT_EXIST, new ActiveMQAction()
       {
          public void run() throws ActiveMQException
          {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MessageExpirationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MessageExpirationTest.java
@@ -33,9 +33,9 @@ import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 
-public class MessageExpirationTest extends ServiceTestBase
+public class MessageExpirationTest extends ActiveMQTestBase
 {
 
    private static final int EXPIRATION = 1000;
@@ -87,8 +87,7 @@ public class MessageExpirationTest extends ServiceTestBase
       ClientProducer producer = session.createProducer(address);
       ClientMessage message = session.createMessage(false);
 
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setExpiryDelay((long) MessageExpirationTest.EXPIRATION);
+      AddressSettings addressSettings = new AddressSettings().setExpiryDelay((long) MessageExpirationTest.EXPIRATION);
       server.getAddressSettingsRepository().addMatch(address.toString(), addressSettings);
 
       producer.send(message);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MessageGroupingConnectionFactoryTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MessageGroupingConnectionFactoryTest.java
@@ -18,8 +18,6 @@ package org.apache.activemq.artemis.tests.integration.client;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
@@ -27,10 +25,9 @@ import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.MessageHandler;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,7 +36,7 @@ import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-public class MessageGroupingConnectionFactoryTest extends ServiceTestBase
+public class MessageGroupingConnectionFactoryTest extends ActiveMQTestBase
 {
    private ActiveMQServer server;
 
@@ -118,22 +115,10 @@ public class MessageGroupingConnectionFactoryTest extends ServiceTestBase
    public void setUp() throws Exception
    {
       super.setUp();
-      TransportConfiguration transportConfig = new TransportConfiguration(ServiceTestBase.INVM_ACCEPTOR_FACTORY);
-
-      Configuration configuration = createDefaultConfig()
-         .setSecurityEnabled(false)
-         .addAcceptorConfiguration(transportConfig);
-      server = addServer(ActiveMQServers.newActiveMQServer(configuration, false));
-      // start the server
+      server = addServer(ActiveMQServers.newActiveMQServer(createDefaultInVMConfig(), false));
       server.start();
-
-      // then we create a client as normal
-
-      ServerLocator locator =
-               addServerLocator(ActiveMQClient.createServerLocatorWithoutHA(new TransportConfiguration(
-                  ServiceTestBase.INVM_CONNECTOR_FACTORY)));
-
-      locator.setGroupID("grp1");
+      ServerLocator locator = createInVMNonHALocator()
+              .setGroupID("grp1");
       ClientSessionFactory sessionFactory = createSessionFactory(locator);
       clientSession = addClientSession(sessionFactory.createSession(false, true, true));
       clientSession.createQueue(qName, qName, null, false);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MessageGroupingTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MessageGroupingTest.java
@@ -19,8 +19,6 @@ package org.apache.activemq.artemis.tests.integration.client;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
@@ -33,7 +31,7 @@ import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
 import org.apache.activemq.artemis.core.transaction.impl.XidImpl;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
@@ -45,7 +43,7 @@ import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-public class MessageGroupingTest extends ServiceTestBase
+public class MessageGroupingTest extends ActiveMQTestBase
 {
    private static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
 
@@ -608,19 +606,10 @@ public class MessageGroupingTest extends ServiceTestBase
    public void setUp() throws Exception
    {
       super.setUp();
-      TransportConfiguration transportConfig = new TransportConfiguration(ServiceTestBase.INVM_ACCEPTOR_FACTORY);
-
-      Configuration configuration = createDefaultConfig()
-         .setSecurityEnabled(false)
-         .addAcceptorConfiguration(transportConfig);
+      Configuration configuration = createDefaultInVMConfig();
       server = addServer(ActiveMQServers.newActiveMQServer(configuration, false));
-      // start the server
       server.start();
-
-      // then we create a client as normal
-      locator =
-               addServerLocator(ActiveMQClient.createServerLocatorWithoutHA(new TransportConfiguration(
-                  INVM_CONNECTOR_FACTORY)));
+      locator = createInVMNonHALocator();
       clientSessionFactory = createSessionFactory(locator);
       clientSession = addClientSession(clientSessionFactory.createSession(false, true, true));
       clientSession.createQueue(qName, qName, null, false);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MessageHandlerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MessageHandlerTest.java
@@ -34,9 +34,9 @@ import org.apache.activemq.artemis.api.core.client.MessageHandler;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 
-public class MessageHandlerTest extends ServiceTestBase
+public class MessageHandlerTest extends ActiveMQTestBase
 {
    private static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MessagePriorityTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MessagePriorityTest.java
@@ -17,8 +17,6 @@
 package org.apache.activemq.artemis.tests.integration.client;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
@@ -26,17 +24,16 @@ import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.config.Configuration;
-import org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class MessagePriorityTest extends ServiceTestBase
+public class MessagePriorityTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------
@@ -334,17 +331,12 @@ public class MessagePriorityTest extends ServiceTestBase
    public void setUp() throws Exception
    {
       super.setUp();
-
-      Configuration config = createDefaultConfig()
-         .addAcceptorConfiguration(new TransportConfiguration(InVMAcceptorFactory.class.getCanonicalName()))
-         .setSecurityEnabled(false);
+      Configuration config = createDefaultInVMConfig();
       server = addServer(ActiveMQServers.newActiveMQServer(config, false));
       server.start();
-      locator =
-         addServerLocator(ActiveMQClient.createServerLocatorWithoutHA(new TransportConfiguration(
-            ServiceTestBase.INVM_CONNECTOR_FACTORY)));
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
+      locator = createInVMNonHALocator()
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true);
       sf = createSessionFactory(locator);
       session = addClientSession(sf.createSession(false, true, true));
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MessageRateTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MessageRateTest.java
@@ -29,12 +29,12 @@ import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.MessageHandler;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class MessageRateTest extends ServiceTestBase
+public class MessageRateTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MultipleThreadFilterOneTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MultipleThreadFilterOneTest.java
@@ -17,7 +17,7 @@
 package org.apache.activemq.artemis.tests.integration.client;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -38,7 +38,7 @@ import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
  * Multiple Threads producing Messages, with Multiple Consumers with different queues, each queue with a different filter
  * This is similar to MultipleThreadFilterTwoTest but it uses multiple queues
  */
-public class MultipleThreadFilterOneTest extends ServiceTestBase
+public class MultipleThreadFilterOneTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/NIOvsOIOTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/NIOvsOIOTest.java
@@ -32,7 +32,7 @@ import org.apache.activemq.artemis.core.settings.HierarchicalRepository;
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
 import org.junit.Test;
 
@@ -42,7 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
-public class NIOvsOIOTest extends ServiceTestBase
+public class NIOvsOIOTest extends ActiveMQTestBase
 {
    private static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
 
@@ -153,24 +153,19 @@ public class NIOvsOIOTest extends ServiceTestBase
 
    private void testPerf(boolean nio) throws Exception
    {
-      String acceptorFactoryClassName = "org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptorFactory";
-
-      Configuration conf = createDefaultConfig()
-         .setSecurityEnabled(false);
+      Configuration config = createDefaultInVMConfig();
 
       Map<String, Object> params = new HashMap<String, Object>();
 
       params.put(TransportConstants.USE_NIO_PROP_NAME, nio);
 
-      conf.getAcceptorConfigurations().add(new TransportConfiguration(acceptorFactoryClassName, params));
+      config.getAcceptorConfigurations().add(new TransportConfiguration(NETTY_ACCEPTOR_FACTORY, params));
 
-      ActiveMQServer server = ActiveMQServers.newActiveMQServer(conf, false);
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(config, false));
 
-      AddressSettings addressSettings = new AddressSettings();
-
-      addressSettings.setAddressFullMessagePolicy(AddressFullMessagePolicy.BLOCK);
-
-      addressSettings.setMaxSizeBytes(10 * 1024 * 1024);
+      AddressSettings addressSettings = new AddressSettings()
+              .setAddressFullMessagePolicy(AddressFullMessagePolicy.BLOCK)
+              .setMaxSizeBytes(10 * 1024 * 1024);
 
       final String dest = "test-destination";
 
@@ -184,8 +179,6 @@ public class NIOvsOIOTest extends ServiceTestBase
       {
          doTest(dest);
       }
-
-      server.stop();
    }
 
    private class Sender extends Thread

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/NettyConnectorTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/NettyConnectorTest.java
@@ -21,16 +21,14 @@ import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.client.impl.ClientSessionFactoryImpl;
-import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnector;
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.junit.After;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 import org.junit.Test;
 
-public class NettyConnectorTest extends ServiceTestBase
+public class NettyConnectorTest extends ActiveMQTestBase
 {
    private ActiveMQServer server;
 
@@ -40,8 +38,7 @@ public class NettyConnectorTest extends ServiceTestBase
    {
       super.setUp();
 
-      Configuration config = this.createDefaultConfig(true);
-      server = this.createServer(false, config);
+      server = createServer(false, createDefaultNettyConfig());
       server.start();
    }
 
@@ -64,13 +61,5 @@ public class NettyConnectorTest extends ServiceTestBase
 
       factory.close();
       locator.close();
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      super.tearDown();
-      server.stop();
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/NewDeadLetterAddressTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/NewDeadLetterAddressTest.java
@@ -15,34 +15,27 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.client;
-import org.apache.activemq.artemis.api.core.ActiveMQException;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.junit.Before;
-import org.junit.After;
-
-import org.junit.Test;
-
-import org.junit.Assert;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  *
  * A NewDeadLetterAddressTest
  */
-public class NewDeadLetterAddressTest extends ServiceTestBase
+public class NewDeadLetterAddressTest extends ActiveMQTestBase
 {
    private ActiveMQServer server;
 
@@ -54,9 +47,9 @@ public class NewDeadLetterAddressTest extends ServiceTestBase
    {
       SimpleString dla = new SimpleString("DLA");
       SimpleString address = new SimpleString("empty_address");
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setDeadLetterAddress(dla);
-      addressSettings.setSendToDLAOnNoRoute(true);
+      AddressSettings addressSettings = new AddressSettings()
+              .setDeadLetterAddress(dla)
+              .setSendToDLAOnNoRoute(true);
       server.getAddressSettingsRepository().addMatch(address.toString(), addressSettings);
       SimpleString dlq = new SimpleString("DLQ1");
       clientSession.createQueue(dla, dlq, null, false);
@@ -75,39 +68,10 @@ public class NewDeadLetterAddressTest extends ServiceTestBase
    public void setUp() throws Exception
    {
       super.setUp();
-      TransportConfiguration transportConfig = new TransportConfiguration(ServiceTestBase.INVM_ACCEPTOR_FACTORY);
-
-      Configuration configuration = createDefaultConfig()
-         .setSecurityEnabled(false)
-         .addAcceptorConfiguration(transportConfig);
-      server = addServer(ActiveMQServers.newActiveMQServer(configuration, false));
-      // start the server
+      server = addServer(ActiveMQServers.newActiveMQServer(createDefaultInVMConfig(), false));
       server.start();
-      // then we create a client as normal
-      locator =
-               addServerLocator(ActiveMQClient.createServerLocatorWithoutHA(new TransportConfiguration(
-                  INVM_CONNECTOR_FACTORY)));
+      locator = createInVMNonHALocator();
       ClientSessionFactory sessionFactory = createSessionFactory(locator);
       clientSession = sessionFactory.createSession(false, true, false);
    }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      if (clientSession != null)
-      {
-         try
-         {
-            clientSession.close();
-         }
-         catch (ActiveMQException e1)
-         {
-            //
-         }
-      }
-      clientSession = null;
-      super.tearDown();
-   }
-
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/OrderTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/OrderTest.java
@@ -25,7 +25,7 @@ import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.junit.Assert;
@@ -35,7 +35,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
-public class OrderTest extends ServiceTestBase
+public class OrderTest extends ActiveMQTestBase
 {
 
    private boolean persistent;
@@ -79,9 +79,9 @@ public class OrderTest extends ServiceTestBase
       server = createServer(persistent, true);
       server.start();
 
-      locator.setBlockOnNonDurableSend(false);
-      locator.setBlockOnDurableSend(false);
-      locator.setBlockOnAcknowledge(true);
+      locator.setBlockOnNonDurableSend(false)
+              .setBlockOnDurableSend(false)
+              .setBlockOnAcknowledge(true);
 
       ClientSessionFactory sf = createSessionFactory(locator);
 
@@ -154,9 +154,9 @@ public class OrderTest extends ServiceTestBase
 
       server.start();
 
-      locator.setBlockOnNonDurableSend(false);
-      locator.setBlockOnDurableSend(false);
-      locator.setBlockOnAcknowledge(false);
+      locator.setBlockOnNonDurableSend(false)
+              .setBlockOnDurableSend(false)
+              .setBlockOnAcknowledge(false);
 
       ClientSessionFactory sf = createSessionFactory(locator);
       ClientSession session = sf.createSession(true, true, 0);
@@ -214,15 +214,14 @@ public class OrderTest extends ServiceTestBase
       server = createServer(persistent, true);
 
       server.getAddressSettingsRepository().clear();
-      AddressSettings setting = new AddressSettings();
-      setting.setRedeliveryDelay(500);
+      AddressSettings setting = new AddressSettings().setRedeliveryDelay(500);
       server.getAddressSettingsRepository().addMatch("#", setting);
 
       server.start();
 
-      locator.setBlockOnNonDurableSend(false);
-      locator.setBlockOnDurableSend(false);
-      locator.setBlockOnAcknowledge(false);
+      locator.setBlockOnNonDurableSend(false)
+              .setBlockOnDurableSend(false)
+              .setBlockOnAcknowledge(false);
 
       ClientSessionFactory sf = createSessionFactory(locator);
       ClientSession session = sf.createSession(true, true, 0);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/PagingOrderTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/PagingOrderTest.java
@@ -16,17 +16,6 @@
  */
 package org.apache.activemq.artemis.tests.integration.client;
 
-import javax.jms.BytesMessage;
-import javax.jms.Connection;
-import javax.jms.DeliveryMode;
-import javax.jms.MessageProducer;
-import javax.jms.Session;
-import javax.jms.TextMessage;
-import javax.jms.Topic;
-import java.nio.ByteBuffer;
-import java.util.HashMap;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
@@ -38,7 +27,6 @@ import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
 import org.apache.activemq.artemis.api.jms.JMSFactoryType;
-import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.paging.PagingStore;
 import org.apache.activemq.artemis.core.postoffice.Binding;
@@ -52,15 +40,26 @@ import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.jms.client.ActiveMQJMSConnectionFactory;
 import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.junit.After;
+import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
+
+import javax.jms.BytesMessage;
+import javax.jms.Connection;
+import javax.jms.DeliveryMode;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import javax.jms.Topic;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * A PagingOrderTest. PagingTest has a lot of tests already. I decided to create a newer one more
  * specialized on Ordering and counters
  */
-public class PagingOrderTest extends ServiceTestBase
+public class PagingOrderTest extends ActiveMQTestBase
 {
 
    private static final int PAGE_MAX = 100 * 1024;
@@ -75,27 +74,12 @@ public class PagingOrderTest extends ServiceTestBase
 
    private Connection conn;
 
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      try
-      {
-         if (conn != null)
-            conn.close();
-      }
-      finally
-      {
-         super.tearDown();
-      }
-   }
-
    @Test
    public void testOrder1() throws Throwable
    {
       boolean persistentMessages = true;
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       ActiveMQServer server = createServer(true, config, PAGE_SIZE, PAGE_MAX, new HashMap<String, AddressSettings>());
@@ -105,16 +89,15 @@ public class PagingOrderTest extends ServiceTestBase
       final int messageSize = 1024;
 
       final int numberOfMessages = 500;
-      ServerLocator locator = createInVMNonHALocator();
 
-      locator.setClientFailureCheckPeriod(1000);
-      locator.setConnectionTTL(2000);
-      locator.setReconnectAttempts(0);
-
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
-      locator.setConsumerWindowSize(1024 * 1024);
+      ServerLocator locator = createInVMNonHALocator()
+              .setClientFailureCheckPeriod(1000)
+              .setConnectionTTL(2000)
+              .setReconnectAttempts(0)
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true)
+              .setConsumerWindowSize(1024 * 1024);
 
       ClientSessionFactory sf = createSessionFactory(locator);
 
@@ -175,12 +158,8 @@ public class PagingOrderTest extends ServiceTestBase
 
       session.close();
 
-      session = null;
-
       sf.close();
       sf = createSessionFactory(locator);
-
-      locator = createInVMNonHALocator();
 
       session = sf.createSession(true, true, 0);
 
@@ -204,7 +183,7 @@ public class PagingOrderTest extends ServiceTestBase
    {
       boolean persistentMessages = true;
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       ActiveMQServer server = createServer(true, config, PAGE_SIZE, PAGE_MAX, new HashMap<String, AddressSettings>());
@@ -215,16 +194,14 @@ public class PagingOrderTest extends ServiceTestBase
 
       final int numberOfMessages = 500;
 
-      ServerLocator locator = createInVMNonHALocator();
-
-      locator.setClientFailureCheckPeriod(1000);
-      locator.setConnectionTTL(2000);
-      locator.setReconnectAttempts(0);
-
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
-      locator.setConsumerWindowSize(1024 * 1024);
+      ServerLocator locator = createInVMNonHALocator()
+              .setClientFailureCheckPeriod(1000)
+              .setConnectionTTL(2000)
+              .setReconnectAttempts(0)
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true)
+              .setConsumerWindowSize(1024 * 1024);
 
       ClientSessionFactory sf = createSessionFactory(locator);
 
@@ -357,7 +334,7 @@ public class PagingOrderTest extends ServiceTestBase
    {
       boolean persistentMessages = true;
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       ActiveMQServer server = createServer(true, config, PAGE_SIZE, PAGE_MAX, new HashMap<String, AddressSettings>());
@@ -368,16 +345,14 @@ public class PagingOrderTest extends ServiceTestBase
 
       final int numberOfMessages = 500;
 
-      ServerLocator locator = createInVMNonHALocator();
-
-      locator.setClientFailureCheckPeriod(1000);
-      locator.setConnectionTTL(2000);
-      locator.setReconnectAttempts(0);
-
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
-      locator.setConsumerWindowSize(1024 * 1024);
+      ServerLocator locator = createInVMNonHALocator()
+              .setClientFailureCheckPeriod(1000)
+              .setConnectionTTL(2000)
+              .setReconnectAttempts(0)
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true)
+              .setConsumerWindowSize(1024 * 1024);
 
       ClientSessionFactory sf = createSessionFactory(locator);
 
@@ -471,7 +446,7 @@ public class PagingOrderTest extends ServiceTestBase
    {
       boolean persistentMessages = true;
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       ActiveMQServer server = createServer(true, config, PAGE_SIZE, PAGE_MAX, new HashMap<String, AddressSettings>());
@@ -482,16 +457,14 @@ public class PagingOrderTest extends ServiceTestBase
 
       final int numberOfMessages = 3000;
 
-      ServerLocator locator = createInVMNonHALocator();
-
-      locator.setClientFailureCheckPeriod(1000);
-      locator.setConnectionTTL(2000);
-      locator.setReconnectAttempts(0);
-
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
-      locator.setConsumerWindowSize(1024 * 1024);
+      ServerLocator locator = createInVMNonHALocator()
+              .setClientFailureCheckPeriod(1000)
+              .setConnectionTTL(2000)
+              .setReconnectAttempts(0)
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true)
+              .setConsumerWindowSize(1024 * 1024);
 
       ClientSessionFactory sf = createSessionFactory(locator);
 
@@ -571,7 +544,7 @@ public class PagingOrderTest extends ServiceTestBase
    {
       boolean persistentMessages = true;
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       ActiveMQServer server = createServer(true, config, PAGE_SIZE, PAGE_MAX, new HashMap<String, AddressSettings>());
@@ -582,16 +555,14 @@ public class PagingOrderTest extends ServiceTestBase
 
       final int numberOfMessages = 200;
 
-      ServerLocator locator = createInVMNonHALocator();
-
-      locator.setClientFailureCheckPeriod(1000);
-      locator.setConnectionTTL(2000);
-      locator.setReconnectAttempts(0);
-
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
-      locator.setConsumerWindowSize(0);
+      ServerLocator locator = createInVMNonHALocator()
+              .setClientFailureCheckPeriod(1000)
+              .setConnectionTTL(2000)
+              .setReconnectAttempts(0)
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true)
+              .setConsumerWindowSize(0);
 
       ClientSessionFactory sf = createSessionFactory(locator);
 
@@ -682,16 +653,14 @@ public class PagingOrderTest extends ServiceTestBase
 
       server.start();
 
-      locator = createInVMNonHALocator();
-
-      locator.setClientFailureCheckPeriod(1000);
-      locator.setConnectionTTL(2000);
-      locator.setReconnectAttempts(0);
-
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
-      locator.setConsumerWindowSize(0);
+      locator = createInVMNonHALocator()
+              .setClientFailureCheckPeriod(1000)
+              .setConnectionTTL(2000)
+              .setReconnectAttempts(0)
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true)
+              .setConsumerWindowSize(0);
 
       sf = createSessionFactory(locator);
 
@@ -718,7 +687,7 @@ public class PagingOrderTest extends ServiceTestBase
    public void testPagingOverCreatedDestinationTopics() throws Exception
    {
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       ActiveMQServer server = createServer(true, config, PAGE_SIZE, -1, new HashMap<String, AddressSettings>());
@@ -797,7 +766,7 @@ public class PagingOrderTest extends ServiceTestBase
    public void testPagingOverCreatedDestinationQueues() throws Exception
    {
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       ActiveMQServer server = createServer(true, config, -1, -1, new HashMap<String, AddressSettings>());

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/PagingSyncTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/PagingSyncTest.java
@@ -26,7 +26,7 @@ import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
@@ -37,7 +37,7 @@ import org.junit.Test;
  * <p/>
  * PagingTest has a lot of tests already. I decided to create a newer one more specialized on Ordering and counters
  */
-public class PagingSyncTest extends ServiceTestBase
+public class PagingSyncTest extends ActiveMQTestBase
 {
 
    private static final int PAGE_MAX = 100 * 1024;
@@ -55,7 +55,7 @@ public class PagingSyncTest extends ServiceTestBase
    {
       boolean persistentMessages = true;
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       ActiveMQServer server = createServer(true, config, PAGE_SIZE, PAGE_MAX, new HashMap<String, AddressSettings>());
@@ -66,16 +66,14 @@ public class PagingSyncTest extends ServiceTestBase
 
       final int numberOfMessages = 500;
 
-      ServerLocator locator = createInVMNonHALocator();
-
-      locator.setClientFailureCheckPeriod(1000);
-      locator.setConnectionTTL(2000);
-      locator.setReconnectAttempts(0);
-
-      locator.setBlockOnNonDurableSend(false);
-      locator.setBlockOnDurableSend(false);
-      locator.setBlockOnAcknowledge(false);
-      locator.setConsumerWindowSize(1024 * 1024);
+      ServerLocator locator = createInVMNonHALocator()
+              .setClientFailureCheckPeriod(1000)
+              .setConnectionTTL(2000)
+              .setReconnectAttempts(0)
+              .setBlockOnNonDurableSend(false)
+              .setBlockOnDurableSend(false)
+              .setBlockOnAcknowledge(false)
+              .setConsumerWindowSize(1024 * 1024);
 
       ClientSessionFactory sf = createSessionFactory(locator);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/PagingTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/PagingTest.java
@@ -57,7 +57,7 @@ import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.logs.AssertionLoggerHandler;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -79,7 +79,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class PagingTest extends ServiceTestBase
+public class PagingTest extends ActiveMQTestBase
 {
    private ServerLocator locator;
    private ActiveMQServer server;
@@ -107,7 +107,7 @@ public class PagingTest extends ServiceTestBase
    @Test
    public void testPageOnLargeMessageMultipleQueues() throws Exception
    {
-      Configuration config = createDefaultConfig();
+      Configuration config = createDefaultInVMConfig();
 
       final int PAGE_MAX = 20 * 1024;
 
@@ -122,9 +122,9 @@ public class PagingTest extends ServiceTestBase
 
       final int numberOfBytes = 1024;
 
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       ClientSessionFactory sf = addSessionFactory(createSessionFactory(locator));
 
@@ -223,7 +223,7 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       server =
@@ -236,11 +236,10 @@ public class PagingTest extends ServiceTestBase
 
       final int numberOfMessages = 5000;
 
-      locator = createInVMNonHALocator();
-
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator = createInVMNonHALocator()
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       sf = createSessionFactory(locator);
 
@@ -362,7 +361,7 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       server =
@@ -375,11 +374,10 @@ public class PagingTest extends ServiceTestBase
 
       final int numberOfMessages = 20;
 
-      locator = createInVMNonHALocator();
-
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator = createInVMNonHALocator()
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       sf = createSessionFactory(locator);
 
@@ -482,7 +480,7 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       server = createServer(true,
@@ -495,12 +493,11 @@ public class PagingTest extends ServiceTestBase
 
       final int numberOfMessages = 50;
 
-      locator = createInVMNonHALocator();
-
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
-      locator.setAckBatchSize(0);
+      locator = createInVMNonHALocator()
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true)
+              .setAckBatchSize(0);
 
       sf = createSessionFactory(locator);
 
@@ -699,7 +696,7 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalDirectory(getJournalDir())
          .setJournalSyncNonTransactional(false)
          .setJournalCompactMinFiles(0) // disable compact
@@ -711,12 +708,11 @@ public class PagingTest extends ServiceTestBase
                             PagingTest.PAGE_MAX,
                             new HashMap<String, AddressSettings>());
 
-      AddressSettings defaultSetting = new AddressSettings();
-      defaultSetting.setPageSizeBytes(PAGE_SIZE);
-      defaultSetting.setMaxSizeBytes(PAGE_MAX);
-      // defaultSetting.setRedeliveryDelay(500);
-      defaultSetting.setExpiryAddress(new SimpleString("EXP"));
-      defaultSetting.setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
+      AddressSettings defaultSetting = new AddressSettings()
+              .setPageSizeBytes(PAGE_SIZE)
+              .setMaxSizeBytes(PAGE_MAX)
+              .setExpiryAddress(new SimpleString("EXP"))
+              .setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
 
       server.getAddressSettingsRepository().clear();
 
@@ -726,13 +722,11 @@ public class PagingTest extends ServiceTestBase
 
       final int numberOfMessages = 5000;
 
-      locator = createInVMNonHALocator();
-
-      locator.setConsumerWindowSize(10 * 1024 * 1024);
-
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator = createInVMNonHALocator()
+              .setConsumerWindowSize(10 * 1024 * 1024)
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       ClientSessionFactory sf = locator.createSessionFactory();
 
@@ -841,7 +835,7 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalDirectory(getJournalDir())
          .setJournalSyncNonTransactional(false)
          .setJournalCompactMinFiles(0); // disable compact
@@ -856,13 +850,11 @@ public class PagingTest extends ServiceTestBase
 
       final int numberOfMessages = 5000;
 
-      locator = createInVMNonHALocator();
-
-      locator.setConsumerWindowSize(10 * 1024 * 1024);
-
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator = createInVMNonHALocator()
+              .setConsumerWindowSize(10 * 1024 * 1024)
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       SimpleString QUEUE2 = ADDRESS.concat("-2");
 
@@ -1025,7 +1017,7 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       server = createServer(true,
@@ -1044,9 +1036,9 @@ public class PagingTest extends ServiceTestBase
 
       locator = createInVMNonHALocator();
 
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       sf = createSessionFactory(locator);
 
@@ -1155,7 +1147,7 @@ public class PagingTest extends ServiceTestBase
                             new HashMap<String, AddressSettings>());
       server.start();
 
-      waitForServer(server);
+      waitForServerToStart(server);
 
       queue = server.locateQueue(ADDRESS);
 
@@ -1232,7 +1224,7 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
@@ -1244,13 +1236,12 @@ public class PagingTest extends ServiceTestBase
 
       final int numberOfMessages = 500;
 
-      locator = createInVMNonHALocator();
-
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
-      locator.setProducerWindowSize(-1);
-      locator.setMinLargeMessageSize(1024 * 1024);
+      locator = createInVMNonHALocator()
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true)
+              .setProducerWindowSize(-1)
+              .setMinLargeMessageSize(1024 * 1024);
 
       sf = createSessionFactory(locator);
 
@@ -1315,7 +1306,7 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       server = createServer(true,
@@ -1328,11 +1319,10 @@ public class PagingTest extends ServiceTestBase
 
       final int numberOfMessages = 1000;
 
-      locator = createInVMNonHALocator();
-
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator = createInVMNonHALocator()
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       sf = createSessionFactory(locator);
 
@@ -1444,7 +1434,7 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setPersistDeliveryCountBeforeDelivery(true);
 
       config.setJournalSyncNonTransactional(false);
@@ -1459,11 +1449,10 @@ public class PagingTest extends ServiceTestBase
 
       final int numberOfMessages = 1000;
 
-      locator = createInVMNonHALocator();
-
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator = createInVMNonHALocator()
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       sf = createSessionFactory(locator);
 
@@ -1578,10 +1567,10 @@ public class PagingTest extends ServiceTestBase
                             new HashMap<String, AddressSettings>());
       server.start();
 
-      locator = createInVMNonHALocator();
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator = createInVMNonHALocator()
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       sf = createSessionFactory(locator);
 
@@ -1662,7 +1651,7 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       server = createServer(true,
@@ -1681,11 +1670,10 @@ public class PagingTest extends ServiceTestBase
 
       try
       {
-         locator = createInVMNonHALocator();
-
-         locator.setBlockOnNonDurableSend(true);
-         locator.setBlockOnDurableSend(true);
-         locator.setBlockOnAcknowledge(true);
+         locator = createInVMNonHALocator()
+                 .setBlockOnNonDurableSend(true)
+                 .setBlockOnDurableSend(true)
+                 .setBlockOnAcknowledge(true);
 
          sf = createSessionFactory(locator);
 
@@ -1746,7 +1734,7 @@ public class PagingTest extends ServiceTestBase
                                         2,
                                         0,
                                         0,
-                                        new NIOSequentialFileFactory(getJournalDir()),
+                                        new NIOSequentialFileFactory(server.getConfiguration().getJournalDirectory()),
                                         "activemq-data",
                                         "amq",
                                         1);
@@ -1798,11 +1786,10 @@ public class PagingTest extends ServiceTestBase
 
       server.stop();
 
-      locator = createInVMNonHALocator();
-
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator = createInVMNonHALocator()
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       server = createServer(true,
                             config,
@@ -1847,7 +1834,7 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       server = createServer(true,
@@ -1866,11 +1853,10 @@ public class PagingTest extends ServiceTestBase
 
       try
       {
-         locator = createInVMNonHALocator();
-
-         locator.setBlockOnNonDurableSend(true);
-         locator.setBlockOnDurableSend(true);
-         locator.setBlockOnAcknowledge(true);
+         locator = createInVMNonHALocator()
+                 .setBlockOnNonDurableSend(true)
+                 .setBlockOnDurableSend(true)
+                 .setBlockOnAcknowledge(true);
 
          sf = createSessionFactory(locator);
 
@@ -1959,9 +1945,9 @@ public class PagingTest extends ServiceTestBase
 
       locator = createInVMNonHALocator();
 
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       ClientSessionFactory csf = createSessionFactory(locator);
 
@@ -2006,7 +1992,7 @@ public class PagingTest extends ServiceTestBase
 
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       server = createServer(true,
@@ -2019,11 +2005,10 @@ public class PagingTest extends ServiceTestBase
 
       final int numberOfMessages = 1000;
 
-      locator = createInVMNonHALocator();
-
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator = createInVMNonHALocator()
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       sf = createSessionFactory(locator);
 
@@ -2124,7 +2109,7 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       server = createServer(true,
@@ -2142,6 +2127,8 @@ public class PagingTest extends ServiceTestBase
             .setForwardingAddress(PagingTest.ADDRESS.toString() + "-1")
             .setExclusive(true);
 
+         config.addDivertConfiguration(divert1);
+
          DivertConfiguration divert2 = new DivertConfiguration()
             .setName("dv2")
             .setRoutingName("nm2")
@@ -2149,11 +2136,7 @@ public class PagingTest extends ServiceTestBase
             .setForwardingAddress(PagingTest.ADDRESS.toString() + "-2")
             .setExclusive(true);
 
-         ArrayList<DivertConfiguration> divertList = new ArrayList<DivertConfiguration>();
-         divertList.add(divert1);
-         divertList.add(divert2);
-
-         config.setDivertConfigurations(divertList);
+         config.addDivertConfiguration(divert2);
       }
 
       server.start();
@@ -2206,11 +2189,10 @@ public class PagingTest extends ServiceTestBase
       try
       {
          {
-            locator = createInVMNonHALocator();
-
-            locator.setBlockOnNonDurableSend(true);
-            locator.setBlockOnDurableSend(true);
-            locator.setBlockOnAcknowledge(true);
+            locator = createInVMNonHALocator()
+                    .setBlockOnNonDurableSend(true)
+                    .setBlockOnDurableSend(true)
+                    .setBlockOnAcknowledge(true);
 
             sf = createSessionFactory(locator);
 
@@ -2337,10 +2319,10 @@ public class PagingTest extends ServiceTestBase
                         }
                         catch (AssertionError e)
                         {
-                           PagingTest.log.info("Expected buffer:" + ServiceTestBase.dumbBytesHex(body, 40));
-                           PagingTest.log.info("Arriving buffer:" + ServiceTestBase.dumbBytesHex(message2.getBodyBuffer()
-                                                                                                 .toByteBuffer()
-                                                                                                 .array(), 40));
+                           PagingTest.log.info("Expected buffer:" + ActiveMQTestBase.dumpBytesHex(body, 40));
+                           PagingTest.log.info("Arriving buffer:" + ActiveMQTestBase.dumpBytesHex(message2.getBodyBuffer()
+                                                                                                          .toByteBuffer()
+                                                                                                          .array(), 40));
                            throw e;
                         }
                      }
@@ -2420,7 +2402,7 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       server = createServer(true,
@@ -2445,9 +2427,9 @@ public class PagingTest extends ServiceTestBase
       {
          locator = createInVMNonHALocator();
 
-         locator.setBlockOnNonDurableSend(true);
-         locator.setBlockOnDurableSend(true);
-         locator.setBlockOnAcknowledge(true);
+         locator.setBlockOnNonDurableSend(true)
+                 .setBlockOnDurableSend(true)
+                 .setBlockOnAcknowledge(true);
 
          sf = createSessionFactory(locator);
 
@@ -2536,10 +2518,10 @@ public class PagingTest extends ServiceTestBase
                   }
                   catch (AssertionError e)
                   {
-                     PagingTest.log.info("Expected buffer:" + ServiceTestBase.dumbBytesHex(body, 40));
-                     PagingTest.log.info("Arriving buffer:" + ServiceTestBase.dumbBytesHex(message2.getBodyBuffer()
-                                                                                           .toByteBuffer()
-                                                                                           .array(), 40));
+                     PagingTest.log.info("Expected buffer:" + ActiveMQTestBase.dumpBytesHex(body, 40));
+                     PagingTest.log.info("Arriving buffer:" + ActiveMQTestBase.dumpBytesHex(message2.getBodyBuffer()
+                                                                                                    .toByteBuffer()
+                                                                                                    .array(), 40));
                      throw e;
                   }
                }
@@ -2587,7 +2569,7 @@ public class PagingTest extends ServiceTestBase
 
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       server = createServer(true,
@@ -2601,11 +2583,10 @@ public class PagingTest extends ServiceTestBase
       final int numberOfIntegers = 256;
 
       final int numberOfMessages = 1000;
-      locator = createInVMNonHALocator();
-
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator = createInVMNonHALocator()
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       sf = createSessionFactory(locator);
 
@@ -2689,10 +2670,10 @@ public class PagingTest extends ServiceTestBase
          }
          catch (AssertionError e)
          {
-            PagingTest.log.info("Expected buffer:" + ServiceTestBase.dumbBytesHex(body, 40));
-            PagingTest.log.info("Arriving buffer:" + ServiceTestBase.dumbBytesHex(message2.getBodyBuffer()
-                                                                                  .toByteBuffer()
-                                                                                  .array(), 40));
+            PagingTest.log.info("Expected buffer:" + ActiveMQTestBase.dumpBytesHex(body, 40));
+            PagingTest.log.info("Arriving buffer:" + ActiveMQTestBase.dumpBytesHex(message2.getBodyBuffer()
+                                                                                           .toByteBuffer()
+                                                                                           .array(), 40));
             throw e;
          }
       }
@@ -2708,7 +2689,7 @@ public class PagingTest extends ServiceTestBase
 
       buffer.readBytes(other);
 
-      ServiceTestBase.assertEqualsByteArrays(body, other);
+      ActiveMQTestBase.assertEqualsByteArrays(body, other);
    }
 
    /**
@@ -2723,7 +2704,7 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig();
+      Configuration config = createDefaultInVMConfig();
 
       server = createServer(true,
                             config,
@@ -2733,10 +2714,10 @@ public class PagingTest extends ServiceTestBase
 
       server.start();
 
-      locator = createInVMNonHALocator();
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator = createInVMNonHALocator()
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       sf = createSessionFactory(locator);
 
@@ -2847,7 +2828,7 @@ public class PagingTest extends ServiceTestBase
       boolean IS_DURABLE_MESSAGE = true;
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig();
+      Configuration config = createDefaultInVMConfig();
 
       server = createServer(true,
                             config,
@@ -2857,10 +2838,10 @@ public class PagingTest extends ServiceTestBase
 
       server.start();
 
-      locator = createInVMNonHALocator();
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator = createInVMNonHALocator()
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       sf = createSessionFactory(locator);
 
@@ -2972,7 +2953,7 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig();
+      Configuration config = createDefaultInVMConfig();
 
       server = createServer(true,
                             config,
@@ -2982,10 +2963,10 @@ public class PagingTest extends ServiceTestBase
 
       server.start();
 
-      locator = createInVMNonHALocator();
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator = createInVMNonHALocator()
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       sf = createSessionFactory(locator);
 
@@ -3080,7 +3061,9 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig();
+      Configuration config = createDefaultInVMConfig()
+              .setJournalSyncNonTransactional(false)
+              .setJournalSyncTransactional(false);
 
       server = createServer(true,
                             config,
@@ -3088,20 +3071,17 @@ public class PagingTest extends ServiceTestBase
                             PagingTest.PAGE_MAX,
                             new HashMap<String, AddressSettings>());
 
-      server.getConfiguration().setJournalSyncNonTransactional(false);
-      server.getConfiguration().setJournalSyncTransactional(false);
-
       server.start();
 
       final AtomicInteger errors = new AtomicInteger(0);
 
       final int numberOfMessages = 10000;
 
-      locator = createInVMNonHALocator();
+      locator = createInVMNonHALocator()
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(false);
 
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(false);
       sf = createSessionFactory(locator);
 
       final byte[] body = new byte[MESSAGE_SIZE];
@@ -3194,7 +3174,9 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig();
+      Configuration config = createDefaultInVMConfig()
+              .setJournalSyncNonTransactional(false)
+              .setJournalSyncTransactional(false);
 
       server = createServer(true,
                             config,
@@ -3202,8 +3184,8 @@ public class PagingTest extends ServiceTestBase
                             PagingTest.PAGE_SIZE * 2,
                             new HashMap<String, AddressSettings>());
 
-      server.getConfiguration().setJournalSyncNonTransactional(false);
-      server.getConfiguration().setJournalSyncTransactional(false);
+      server.getConfiguration();
+      server.getConfiguration();
 
       server.start();
 
@@ -3211,9 +3193,10 @@ public class PagingTest extends ServiceTestBase
 
       final int numberOfMessages = 2000;
 
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
+
       sf = createSessionFactory(locator);
 
       final CountDownLatch ready = new CountDownLatch(1);
@@ -3323,7 +3306,7 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       server = createServer(true,
@@ -3338,9 +3321,9 @@ public class PagingTest extends ServiceTestBase
 
       final int numberOfBytes = 1024;
 
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       sf = createSessionFactory(locator);
       ClientSession session = sf.createSession(null, null, false, true, true, false, 0);
@@ -3355,7 +3338,7 @@ public class PagingTest extends ServiceTestBase
 
       for (int j = 0; j < numberOfBytes; j++)
       {
-         body[j] = ServiceTestBase.getSamplebyte(j);
+         body[j] = ActiveMQTestBase.getSamplebyte(j);
       }
 
       long scheduledTime = System.currentTimeMillis() + 5000;
@@ -3424,10 +3407,10 @@ public class PagingTest extends ServiceTestBase
          }
          catch (AssertionError e)
          {
-            PagingTest.log.info("Expected buffer:" + ServiceTestBase.dumbBytesHex(body, 40));
-            PagingTest.log.info("Arriving buffer:" + ServiceTestBase.dumbBytesHex(message2.getBodyBuffer()
-                                                                                  .toByteBuffer()
-                                                                                  .array(), 40));
+            PagingTest.log.info("Expected buffer:" + ActiveMQTestBase.dumpBytesHex(body, 40));
+            PagingTest.log.info("Arriving buffer:" + ActiveMQTestBase.dumpBytesHex(message2.getBodyBuffer()
+                                                                                           .toByteBuffer()
+                                                                                           .array(), 40));
             throw e;
          }
       }
@@ -3442,7 +3425,7 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig();
+      Configuration config = createDefaultInVMConfig();
 
       server = createServer(true,
                             config,
@@ -3456,9 +3439,9 @@ public class PagingTest extends ServiceTestBase
 
       final int numberOfMessages = 10;
 
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       sf = createSessionFactory(locator);
       ClientSession session = sf.createSession(null, null, false, false, true, false, 0);
@@ -3501,7 +3484,7 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig();
+      Configuration config = createDefaultInVMConfig();
 
       server = createServer(true,
                             config,
@@ -3515,9 +3498,9 @@ public class PagingTest extends ServiceTestBase
 
       final int numberOfMessages = 500;
 
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       sf = createSessionFactory(locator);
       ClientSession session = sf.createSession(null, null, false, false, false, false, 0);
@@ -3589,7 +3572,7 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig();
+      Configuration config = createDefaultInVMConfig();
 
       server = createServer(true,
                             config,
@@ -3601,9 +3584,9 @@ public class PagingTest extends ServiceTestBase
 
       final int numberOfMessages = 1000;
 
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       sf = createSessionFactory(locator);
       ClientSession session = sf.createSession(null, null, false, false, false, false, 0);
@@ -3714,8 +3697,6 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig();
-
       HashMap<String, AddressSettings> settings = new HashMap<String, AddressSettings>();
 
       AddressSettings set = new AddressSettings();
@@ -3723,15 +3704,15 @@ public class PagingTest extends ServiceTestBase
 
       settings.put(PagingTest.ADDRESS.toString(), set);
 
-      server = createServer(true, config, 1024, 10 * 1024, settings);
+      server = createServer(true, createDefaultInVMConfig(), 1024, 10 * 1024, settings);
 
       server.start();
 
       final int numberOfMessages = 1000;
 
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       sf = createSessionFactory(locator);
       ClientSession session = sf.createSession(null, null, false, true, true, false, 0);
@@ -3837,8 +3818,6 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig();
-
       HashMap<String, AddressSettings> settings = new HashMap<String, AddressSettings>();
 
       AddressSettings set = new AddressSettings();
@@ -3846,7 +3825,7 @@ public class PagingTest extends ServiceTestBase
 
       settings.put(PagingTest.ADDRESS.toString(), set);
 
-      server = createServer(true, config, 1024, 1024 * 1024, settings);
+      server = createServer(true, createDefaultInVMConfig(), 1024, 1024 * 1024, settings);
 
       server.start();
 
@@ -3922,7 +3901,7 @@ public class PagingTest extends ServiceTestBase
 
    private void internalTestPageMultipleDestinations(final boolean transacted) throws Exception
    {
-      Configuration config = createDefaultConfig();
+      Configuration config = createDefaultInVMConfig();
 
       final int NUMBER_OF_BINDINGS = 100;
 
@@ -3935,9 +3914,10 @@ public class PagingTest extends ServiceTestBase
                             new HashMap<String, AddressSettings>());
 
       server.start();
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       ClientSessionFactory sf = createSessionFactory(locator);
       ClientSession session = sf.createSession(null, null, false, !transacted, true, false, 0);
@@ -4017,7 +3997,7 @@ public class PagingTest extends ServiceTestBase
    @Test
    public void testSyncPage() throws Exception
    {
-      Configuration config = createDefaultConfig();
+      Configuration config = createDefaultInVMConfig();
 
       server = createServer(true,
                             config,
@@ -4069,7 +4049,7 @@ public class PagingTest extends ServiceTestBase
    @Test
    public void testSyncPageTX() throws Exception
    {
-      Configuration config = createDefaultConfig();
+      Configuration config = createDefaultInVMConfig();
 
       server = createServer(true,
                             config,
@@ -4104,15 +4084,15 @@ public class PagingTest extends ServiceTestBase
       SimpleString PAGED_ADDRESS = new SimpleString("paged");
       SimpleString NON_PAGED_ADDRESS = new SimpleString("non-paged");
 
-      Configuration configuration = createDefaultConfig();
+      Configuration configuration = createDefaultInVMConfig();
 
       Map<String, AddressSettings> addresses = new HashMap<String, AddressSettings>();
 
       addresses.put("#", new AddressSettings());
 
-      AddressSettings pagedDestination = new AddressSettings();
-      pagedDestination.setPageSizeBytes(1024);
-      pagedDestination.setMaxSizeBytes(10 * 1024);
+      AddressSettings pagedDestination = new AddressSettings()
+              .setPageSizeBytes(1024)
+              .setMaxSizeBytes(10 * 1024);
 
       addresses.put(PAGED_ADDRESS.toString(), pagedDestination);
 
@@ -4195,23 +4175,23 @@ public class PagingTest extends ServiceTestBase
       SimpleString PAGED_ADDRESS_A = new SimpleString("paged-a");
       SimpleString PAGED_ADDRESS_B = new SimpleString("paged-b");
 
-      Configuration configuration = createDefaultConfig();
+      Configuration configuration = createDefaultInVMConfig();
 
       Map<String, AddressSettings> addresses = new HashMap<String, AddressSettings>();
 
       addresses.put("#", new AddressSettings());
 
-      AddressSettings pagedDestinationA = new AddressSettings();
-      pagedDestinationA.setPageSizeBytes(1024);
-      pagedDestinationA.setMaxSizeBytes(10 * 1024);
+      AddressSettings pagedDestinationA = new AddressSettings()
+              .setPageSizeBytes(1024)
+              .setMaxSizeBytes(10 * 1024);
 
       int NUMBER_MESSAGES_BEFORE_PAGING = 11;
 
       addresses.put(PAGED_ADDRESS_A.toString(), pagedDestinationA);
 
-      AddressSettings pagedDestinationB = new AddressSettings();
-      pagedDestinationB.setPageSizeBytes(2024);
-      pagedDestinationB.setMaxSizeBytes(25 * 1024);
+      AddressSettings pagedDestinationB = new AddressSettings()
+              .setPageSizeBytes(2024)
+              .setMaxSizeBytes(25 * 1024);
 
       addresses.put(PAGED_ADDRESS_B.toString(), pagedDestinationB);
 
@@ -4316,7 +4296,7 @@ public class PagingTest extends ServiceTestBase
 
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false)
          .setJournalFileSize(10 * 1024 * 1024);
 
@@ -4328,11 +4308,10 @@ public class PagingTest extends ServiceTestBase
 
       final int numberOfMessages = 200;
 
-      locator = createInVMNonHALocator();
-
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator = createInVMNonHALocator()
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       sf = createSessionFactory(locator);
 
@@ -4438,7 +4417,7 @@ public class PagingTest extends ServiceTestBase
 
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       server = createServer(true,
@@ -4450,15 +4429,13 @@ public class PagingTest extends ServiceTestBase
       server.start();
 
       final int numberOfMessages = 200;
-      locator = createInVMNonHALocator();
-
-      locator.setClientFailureCheckPeriod(120000);
-      locator.setConnectionTTL(5000000);
-      locator.setCallTimeout(120000);
-
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator = createInVMNonHALocator()
+              .setClientFailureCheckPeriod(120000)
+              .setConnectionTTL(5000000)
+              .setCallTimeout(120000)
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       sf = createSessionFactory(locator);
 
@@ -4543,7 +4520,7 @@ public class PagingTest extends ServiceTestBase
 
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       server = createServer(true,
@@ -4560,15 +4537,13 @@ public class PagingTest extends ServiceTestBase
 
       try
       {
-         ServerLocator locator = createInVMNonHALocator();
-
-         locator.setClientFailureCheckPeriod(120000);
-         locator.setConnectionTTL(5000000);
-         locator.setCallTimeout(120000);
-
-         locator.setBlockOnNonDurableSend(true);
-         locator.setBlockOnDurableSend(true);
-         locator.setBlockOnAcknowledge(true);
+         ServerLocator locator = createInVMNonHALocator()
+                 .setClientFailureCheckPeriod(120000)
+                 .setConnectionTTL(5000000)
+                 .setCallTimeout(120000)
+                 .setBlockOnNonDurableSend(true)
+                 .setBlockOnDurableSend(true)
+                 .setBlockOnAcknowledge(true);
 
          ClientSessionFactory sf = locator.createSessionFactory();
 
@@ -4662,7 +4637,7 @@ public class PagingTest extends ServiceTestBase
 
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       server = createServer(true,
@@ -4675,15 +4650,13 @@ public class PagingTest extends ServiceTestBase
 
       try
       {
-         ServerLocator locator = createInVMNonHALocator();
-
-         locator.setClientFailureCheckPeriod(120000);
-         locator.setConnectionTTL(5000000);
-         locator.setCallTimeout(120000);
-
-         locator.setBlockOnNonDurableSend(true);
-         locator.setBlockOnDurableSend(true);
-         locator.setBlockOnAcknowledge(true);
+         ServerLocator locator = createInVMNonHALocator()
+                 .setClientFailureCheckPeriod(120000)
+                 .setConnectionTTL(5000000)
+                 .setCallTimeout(120000)
+                 .setBlockOnNonDurableSend(true)
+                 .setBlockOnDurableSend(true)
+                 .setBlockOnAcknowledge(true);
 
          ClientSessionFactory sf = locator.createSessionFactory();
 
@@ -4761,7 +4734,7 @@ public class PagingTest extends ServiceTestBase
 
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       server = createServer(true,
@@ -4778,15 +4751,13 @@ public class PagingTest extends ServiceTestBase
 
       try
       {
-         ServerLocator locator = createInVMNonHALocator();
-
-         locator.setClientFailureCheckPeriod(120000);
-         locator.setConnectionTTL(5000000);
-         locator.setCallTimeout(120000);
-
-         locator.setBlockOnNonDurableSend(true);
-         locator.setBlockOnDurableSend(true);
-         locator.setBlockOnAcknowledge(true);
+         ServerLocator locator = createInVMNonHALocator()
+                 .setClientFailureCheckPeriod(120000)
+                 .setConnectionTTL(5000000)
+                 .setCallTimeout(120000)
+                 .setBlockOnNonDurableSend(true)
+                 .setBlockOnDurableSend(true)
+                 .setBlockOnAcknowledge(true);
 
          ClientSessionFactory sf = locator.createSessionFactory();
 
@@ -4885,14 +4856,14 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setThreadPoolMaxSize(5)
          .setJournalSyncNonTransactional(false);
 
       Map<String, AddressSettings> settings = new HashMap<String, AddressSettings>();
-      AddressSettings dla = new AddressSettings();
-      dla.setMaxDeliveryAttempts(5);
-      dla.setDeadLetterAddress(new SimpleString("DLA"));
+      AddressSettings dla = new AddressSettings()
+              .setMaxDeliveryAttempts(5)
+              .setDeadLetterAddress(new SimpleString("DLA"));
       settings.put(ADDRESS.toString(), dla);
 
       server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, settings);
@@ -5129,15 +5100,15 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setMessageExpiryScanPeriod(500)
          .setJournalSyncNonTransactional(false);
 
       Map<String, AddressSettings> settings = new HashMap<String, AddressSettings>();
-      AddressSettings dla = new AddressSettings();
-      dla.setMaxDeliveryAttempts(5);
-      dla.setDeadLetterAddress(new SimpleString("DLA"));
-      dla.setExpiryAddress(new SimpleString("DLA"));
+      AddressSettings dla = new AddressSettings()
+              .setMaxDeliveryAttempts(5)
+              .setDeadLetterAddress(new SimpleString("DLA"))
+              .setExpiryAddress(new SimpleString("DLA"));
       settings.put(ADDRESS.toString(), dla);
 
       server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, settings);
@@ -5148,11 +5119,10 @@ public class PagingTest extends ServiceTestBase
 
       try
       {
-         ServerLocator locator = createInVMNonHALocator();
-
-         locator.setBlockOnNonDurableSend(true);
-         locator.setBlockOnDurableSend(true);
-         locator.setBlockOnAcknowledge(true);
+         ServerLocator locator = createInVMNonHALocator()
+                 .setBlockOnNonDurableSend(true)
+                 .setBlockOnDurableSend(true)
+                 .setBlockOnAcknowledge(true);
 
          ClientSessionFactory sf = locator.createSessionFactory();
 
@@ -5297,7 +5267,7 @@ public class PagingTest extends ServiceTestBase
       {
          clearDataRecreateServerDirs();
 
-         Configuration config = createDefaultConfig();
+         Configuration config = createDefaultInVMConfig();
 
          HashMap<String, AddressSettings> settings = new HashMap<String, AddressSettings>();
 
@@ -5310,9 +5280,9 @@ public class PagingTest extends ServiceTestBase
 
          server.start();
 
-         locator.setBlockOnNonDurableSend(false);
-         locator.setBlockOnDurableSend(false);
-         locator.setBlockOnAcknowledge(true);
+         locator.setBlockOnNonDurableSend(false)
+                 .setBlockOnDurableSend(false)
+                 .setBlockOnAcknowledge(true);
 
          sf = createSessionFactory(locator);
          ClientSession session = sf.createSession(true, true, 0);
@@ -5389,7 +5359,7 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig();
+      Configuration config = createDefaultInVMConfig();
 
       HashMap<String, AddressSettings> settings = new HashMap<String, AddressSettings>();
 
@@ -5402,9 +5372,9 @@ public class PagingTest extends ServiceTestBase
 
       server.start();
 
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       sf = createSessionFactory(locator);
       ClientSession session = sf.createSession(true, true, 0);
@@ -5473,7 +5443,7 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig();
+      Configuration config = createDefaultInVMConfig();
 
       HashMap<String, AddressSettings> settings = new HashMap<String, AddressSettings>();
 
@@ -5486,9 +5456,9 @@ public class PagingTest extends ServiceTestBase
 
       server.start();
 
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       sf = createSessionFactory(locator);
       ClientSession session = addClientSession(sf.createSession(true, true, 0));
@@ -5592,7 +5562,7 @@ public class PagingTest extends ServiceTestBase
    public void testRouteOnTopWithMultipleQueues() throws Exception
    {
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       server = createServer(true,
@@ -5603,11 +5573,10 @@ public class PagingTest extends ServiceTestBase
 
       server.start();
 
-      ServerLocator locator = createInVMNonHALocator();
-      locator.setBlockOnDurableSend(false);
+      ServerLocator locator = createInVMNonHALocator()
+              .setBlockOnDurableSend(false);
       ClientSessionFactory sf = createSessionFactory(locator);
       ClientSession session = sf.createSession(false, true, 0);
-
 
       session.createQueue("Q", "Q1", "dest=1", true);
       session.createQueue("Q", "Q2", "dest=2", true);
@@ -5666,7 +5635,7 @@ public class PagingTest extends ServiceTestBase
 
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       server = createServer(true,
@@ -5868,7 +5837,7 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       server = createServer(true,
@@ -5881,8 +5850,8 @@ public class PagingTest extends ServiceTestBase
 
       try
       {
-         ServerLocator locator = createInVMNonHALocator();
-         locator.setBlockOnDurableSend(true);
+         ServerLocator locator = createInVMNonHALocator()
+                 .setBlockOnDurableSend(true);
          ClientSessionFactory sf = locator.createSessionFactory();
          ClientSession session = sf.createSession(true, true, 0);
 
@@ -5979,7 +5948,7 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       server = createServer(true,
@@ -5992,8 +5961,8 @@ public class PagingTest extends ServiceTestBase
 
       try
       {
-         ServerLocator locator = createInVMNonHALocator();
-         locator.setBlockOnDurableSend(true);
+         ServerLocator locator = createInVMNonHALocator()
+                 .setBlockOnDurableSend(true);
          ClientSessionFactory sf = locator.createSessionFactory();
          ClientSession session = sf.createSession(true, true, 0);
 
@@ -6082,7 +6051,7 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       server = createServer(true,
@@ -6183,7 +6152,7 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       server = createServer(true,
@@ -6267,7 +6236,7 @@ public class PagingTest extends ServiceTestBase
    @Test
    public void testNoCursors() throws Exception
    {
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       server = createServer(true,
@@ -6312,7 +6281,7 @@ public class PagingTest extends ServiceTestBase
    {
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
 
       server = createServer(true,
@@ -6426,9 +6395,9 @@ public class PagingTest extends ServiceTestBase
 
 
    @Override
-   protected Configuration createDefaultConfig() throws Exception
+   protected Configuration createDefaultInVMConfig() throws Exception
    {
-      return super.createDefaultConfig()
+      return super.createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false);
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ProducerCloseTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ProducerCloseTest.java
@@ -18,21 +18,19 @@ package org.apache.activemq.artemis.tests.integration.client;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.config.Configuration;
-import org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ProducerCloseTest extends ServiceTestBase
+public class ProducerCloseTest extends ActiveMQTestBase
 {
 
    private ActiveMQServer server;
@@ -51,7 +49,7 @@ public class ProducerCloseTest extends ServiceTestBase
 
       Assert.assertTrue(producer.isClosed());
 
-      ServiceTestBase.expectActiveMQException(ActiveMQExceptionType.OBJECT_CLOSED, new ActiveMQAction()
+      ActiveMQTestBase.expectActiveMQException(ActiveMQExceptionType.OBJECT_CLOSED, new ActiveMQAction()
       {
          public void run() throws ActiveMQException
          {
@@ -69,9 +67,7 @@ public class ProducerCloseTest extends ServiceTestBase
    public void setUp() throws Exception
    {
       super.setUp();
-      Configuration config = createDefaultConfig()
-         .addAcceptorConfiguration(new TransportConfiguration(InVMAcceptorFactory.class.getCanonicalName()))
-         .setSecurityEnabled(false);
+      Configuration config = createDefaultInVMConfig();
       server = createServer(false, config);
       server.start();
       locator = createInVMNonHALocator();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ProducerFlowControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ProducerFlowControlTest.java
@@ -35,7 +35,7 @@ import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -47,7 +47,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class ProducerFlowControlTest extends ServiceTestBase
+public class ProducerFlowControlTest extends ActiveMQTestBase
 {
    private static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
 
@@ -224,19 +224,19 @@ public class ProducerFlowControlTest extends ServiceTestBase
 
       server = createServer(realFiles, isNetty());
 
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setMaxSizeBytes(maxSize);
-      addressSettings.setAddressFullMessagePolicy(AddressFullMessagePolicy.BLOCK);
+      AddressSettings addressSettings = new AddressSettings()
+              .setMaxSizeBytes(maxSize)
+              .setAddressFullMessagePolicy(AddressFullMessagePolicy.BLOCK);
 
       HierarchicalRepository<AddressSettings> repos = server.getAddressSettingsRepository();
       repos.addMatch(address.toString(), addressSettings);
 
       server.start();
-      waitForServer(server);
+      waitForServerToStart(server);
 
-      locator.setProducerWindowSize(producerWindowSize);
-      locator.setConsumerWindowSize(consumerWindowSize);
-      locator.setAckBatchSize(ackBatchSize);
+      locator.setProducerWindowSize(producerWindowSize)
+              .setConsumerWindowSize(consumerWindowSize)
+              .setAckBatchSize(ackBatchSize);
 
       if (minLargeMessageSize != -1)
       {
@@ -273,7 +273,7 @@ public class ProducerFlowControlTest extends ServiceTestBase
 
                message.getBodyBuffer().readBytes(bytesRead);
 
-               ServiceTestBase.assertEqualsByteArrays(bytes, bytesRead);
+               ActiveMQTestBase.assertEqualsByteArrays(bytes, bytesRead);
 
                message.acknowledge();
 
@@ -367,19 +367,19 @@ public class ProducerFlowControlTest extends ServiceTestBase
 
       server = createServer(false, isNetty());
 
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setMaxSizeBytes(1024);
-      addressSettings.setAddressFullMessagePolicy(AddressFullMessagePolicy.BLOCK);
+      AddressSettings addressSettings = new AddressSettings()
+              .setMaxSizeBytes(1024)
+              .setAddressFullMessagePolicy(AddressFullMessagePolicy.BLOCK);
 
       HierarchicalRepository<AddressSettings> repos = server.getAddressSettingsRepository();
       repos.addMatch(address.toString(), addressSettings);
 
       server.start();
-      waitForServer(server);
+      waitForServerToStart(server);
 
-      locator.setProducerWindowSize(1024);
-      locator.setConsumerWindowSize(1024);
-      locator.setAckBatchSize(1024);
+      locator.setProducerWindowSize(1024)
+              .setConsumerWindowSize(1024)
+              .setAckBatchSize(1024);
 
       sf = createSessionFactory(locator);
       session = sf.createSession(false, true, true, true);
@@ -442,19 +442,19 @@ public class ProducerFlowControlTest extends ServiceTestBase
 
       server = createServer(false, isNetty());
 
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setMaxSizeBytes(1024);
-      addressSettings.setAddressFullMessagePolicy(AddressFullMessagePolicy.BLOCK);
+      AddressSettings addressSettings = new AddressSettings()
+              .setMaxSizeBytes(1024)
+              .setAddressFullMessagePolicy(AddressFullMessagePolicy.BLOCK);
 
       HierarchicalRepository<AddressSettings> repos = server.getAddressSettingsRepository();
       repos.addMatch(address.toString(), addressSettings);
 
       server.start();
-      waitForServer(server);
+      waitForServerToStart(server);
 
-      locator.setProducerWindowSize(1024);
-      locator.setConsumerWindowSize(1024);
-      locator.setAckBatchSize(1024);
+      locator.setProducerWindowSize(1024)
+              .setConsumerWindowSize(1024)
+              .setAckBatchSize(1024);
 
       sf = createSessionFactory(locator);
 
@@ -483,7 +483,7 @@ public class ProducerFlowControlTest extends ServiceTestBase
       server = createServer(false, isNetty());
 
       server.start();
-      waitForServer(server);
+      waitForServerToStart(server);
 
       sf = createSessionFactory(locator);
 
@@ -548,7 +548,7 @@ public class ProducerFlowControlTest extends ServiceTestBase
       server = createServer(false, isNetty());
 
       server.start();
-      waitForServer(server);
+      waitForServerToStart(server);
 
       sf = createSessionFactory(locator);
 
@@ -583,7 +583,7 @@ public class ProducerFlowControlTest extends ServiceTestBase
       server = createServer(false, isNetty());
 
       server.start();
-      waitForServer(server);
+      waitForServerToStart(server);
       sf = createSessionFactory(locator);
 
       session = sf.createSession(false, true, true, true);
@@ -619,7 +619,7 @@ public class ProducerFlowControlTest extends ServiceTestBase
       server = createServer(false, isNetty());
 
       server.start();
-      waitForServer(server);
+      waitForServerToStart(server);
 
       sf = createSessionFactory(locator);
 
@@ -654,7 +654,7 @@ public class ProducerFlowControlTest extends ServiceTestBase
       server = createServer(false, isNetty());
 
       server.start();
-      waitForServer(server);
+      waitForServerToStart(server);
       sf = createSessionFactory(locator);
 
       session = sf.createSession(false, true, true, true);
@@ -690,7 +690,7 @@ public class ProducerFlowControlTest extends ServiceTestBase
       server = createServer(false, isNetty());
 
       server.start();
-      waitForServer(server);
+      waitForServerToStart(server);
 
       sf = createSessionFactory(locator);
 
@@ -755,7 +755,7 @@ public class ProducerFlowControlTest extends ServiceTestBase
       server = createServer(false, isNetty());
 
       server.start();
-      waitForServer(server);
+      waitForServerToStart(server);
       sf = createSessionFactory(locator);
 
       session = sf.createSession(false, true, true, true);
@@ -780,7 +780,7 @@ public class ProducerFlowControlTest extends ServiceTestBase
       server = createServer(false, isNetty());
 
       server.start();
-      waitForServer(server);
+      waitForServerToStart(server);
 
       sf = createSessionFactory(locator);
 
@@ -830,7 +830,7 @@ public class ProducerFlowControlTest extends ServiceTestBase
       server = createServer(false, isNetty());
 
       server.start();
-      waitForServer(server);
+      waitForServerToStart(server);
 
       sf = createSessionFactory(locator);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ProducerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ProducerTest.java
@@ -34,12 +34,12 @@ import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ProducerTest extends ServiceTestBase
+public class ProducerTest extends ActiveMQTestBase
 {
    private ActiveMQServer server;
 
@@ -71,8 +71,8 @@ public class ProducerTest extends ServiceTestBase
             return true;
          }
       });
-      ServerLocator locator = createInVMNonHALocator();
-      locator.setConfirmationWindowSize(100);
+      ServerLocator locator = createInVMNonHALocator()
+              .setConfirmationWindowSize(100);
       ClientSessionFactory cf = locator.createSessionFactory();
       ClientSession session = cf.createSession(false, true, true);
       ClientProducer producer = session.createProducer(QUEUE);
@@ -90,9 +90,9 @@ public class ProducerTest extends ServiceTestBase
    public void testProducerMultiThread() throws Exception
    {
       final ServerLocator locator = createInVMNonHALocator();
-      AddressSettings setting = new AddressSettings();
-      setting.setAddressFullMessagePolicy(AddressFullMessagePolicy.BLOCK);
-      setting.setMaxSizeBytes(10 * 1024);
+      AddressSettings setting = new AddressSettings()
+              .setAddressFullMessagePolicy(AddressFullMessagePolicy.BLOCK)
+              .setMaxSizeBytes(10 * 1024);
       server.stop();
       server.getConfiguration().getAddressesSettings().clear();
       server.getConfiguration().getAddressesSettings().put(QUEUE.toString(), setting);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/QueueBrowserTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/QueueBrowserTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.client;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 
 import org.junit.Test;
@@ -32,7 +32,7 @@ import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.Queue;
 
-public class QueueBrowserTest extends ServiceTestBase
+public class QueueBrowserTest extends ActiveMQTestBase
 {
    private ActiveMQServer server;
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ReceiveImmediateTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ReceiveImmediateTest.java
@@ -34,9 +34,9 @@ import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.Queue;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 
-public class ReceiveImmediateTest extends ServiceTestBase
+public class ReceiveImmediateTest extends ActiveMQTestBase
 {
    private ActiveMQServer server;
 
@@ -51,8 +51,7 @@ public class ReceiveImmediateTest extends ServiceTestBase
    public void setUp() throws Exception
    {
       super.setUp();
-
-      Configuration config = createDefaultConfig();
+      Configuration config = createDefaultInVMConfig();
       server = createServer(false, config);
       server.start();
       locator = createInVMNonHALocator();
@@ -87,9 +86,10 @@ public class ReceiveImmediateTest extends ServiceTestBase
    @Test
    public void testConsumerReceiveImmediateWithSessionStop() throws Exception
    {
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
-      locator.setAckBatchSize(0);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnAcknowledge(true)
+              .setAckBatchSize(0);
+
       sf = createSessionFactory(locator);
       ClientSession session = sf.createSession(false, true, true);
 
@@ -195,9 +195,10 @@ public class ReceiveImmediateTest extends ServiceTestBase
 
    private void doConsumerReceiveImmediateWithNoMessages(final boolean browser) throws Exception
    {
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
-      locator.setAckBatchSize(0);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnAcknowledge(true)
+              .setAckBatchSize(0);
+
       sf = createSessionFactory(locator);
 
       ClientSession session = sf.createSession(false, true, false);
@@ -215,10 +216,10 @@ public class ReceiveImmediateTest extends ServiceTestBase
 
    private void doConsumerReceiveImmediate(final boolean browser) throws Exception
    {
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnAcknowledge(true)
+              .setAckBatchSize(0);
 
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
-      locator.setAckBatchSize(0);
       sf = createSessionFactory(locator);
       ClientSession session = sf.createSession(false, true, true);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ReceiveTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ReceiveTest.java
@@ -27,13 +27,13 @@ import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.MessageHandler;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ReceiveTest extends ServiceTestBase
+public class ReceiveTest extends ActiveMQTestBase
 {
    SimpleString addressA = new SimpleString("addressA");
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/RedeliveryConsumerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/RedeliveryConsumerTest.java
@@ -36,11 +36,11 @@ import org.apache.activemq.artemis.core.journal.impl.NIOSequentialFileFactory;
 import org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class RedeliveryConsumerTest extends ServiceTestBase
+public class RedeliveryConsumerTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------
@@ -351,7 +351,7 @@ public class RedeliveryConsumerTest extends ServiceTestBase
     */
    private void setUp(final boolean persistDeliveryCountBeforeDelivery) throws Exception
    {
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setPersistDeliveryCountBeforeDelivery(persistDeliveryCountBeforeDelivery);
 
       server = createServer(true, config);
@@ -360,7 +360,7 @@ public class RedeliveryConsumerTest extends ServiceTestBase
       locator = createInVMNonHALocator();
       factory = createSessionFactory(locator);
 
-      ClientSession session = factory.createSession(false, false, false);
+      ClientSession session = addClientSession(factory.createSession(false, false, false));
       try
       {
          session.createQueue(ADDRESS, ADDRESS, true);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/RoutingTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/RoutingTest.java
@@ -23,13 +23,13 @@ import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class RoutingTest extends ServiceTestBase
+public class RoutingTest extends ActiveMQTestBase
 {
    public final SimpleString addressA = new SimpleString("addressA");
    public final SimpleString queueA = new SimpleString("queueA");

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SelfExpandingBufferTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SelfExpandingBufferTest.java
@@ -27,11 +27,11 @@ import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class SelfExpandingBufferTest extends ServiceTestBase
+public class SelfExpandingBufferTest extends ActiveMQTestBase
 {
 
    private static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
@@ -117,7 +117,7 @@ public class SelfExpandingBufferTest extends ServiceTestBase
 
          msg2.getBodyBuffer().readBytes(receivedBytes);
 
-         ServiceTestBase.assertEqualsByteArrays(bytes, receivedBytes);
+         ActiveMQTestBase.assertEqualsByteArrays(bytes, receivedBytes);
 
          msg2 = cons.receive(3000);
 
@@ -125,7 +125,7 @@ public class SelfExpandingBufferTest extends ServiceTestBase
 
          msg2.getBodyBuffer().readBytes(receivedBytes);
 
-         ServiceTestBase.assertEqualsByteArrays(bytes, receivedBytes);
+         ActiveMQTestBase.assertEqualsByteArrays(bytes, receivedBytes);
       }
       finally
       {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ServerLocatorConnectTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ServerLocatorConnectTest.java
@@ -28,11 +28,11 @@ import org.apache.activemq.artemis.core.client.impl.ClientSessionFactoryInternal
 import org.apache.activemq.artemis.core.client.impl.ServerLocatorInternal;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ServerLocatorConnectTest extends ServiceTestBase
+public class ServerLocatorConnectTest extends ActiveMQTestBase
 {
    private ActiveMQServer server;
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SessionCloseOnGCTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SessionCloseOnGCTest.java
@@ -21,14 +21,14 @@ import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.client.impl.ClientSessionFactoryImpl;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.lang.ref.WeakReference;
 
-public class SessionCloseOnGCTest extends ServiceTestBase
+public class SessionCloseOnGCTest extends ActiveMQTestBase
 {
    private ActiveMQServer server;
    private ServerLocator locator;
@@ -69,7 +69,7 @@ public class SessionCloseOnGCTest extends ServiceTestBase
       locator.close();
 
       locator = null;
-      ServiceTestBase.checkWeakReferences(wrs1, wrs2);
+      ActiveMQTestBase.checkWeakReferences(wrs1, wrs2);
 
       WeakReference<ClientSessionFactory> fref = new WeakReference<ClientSessionFactory>(factory);
 
@@ -77,7 +77,7 @@ public class SessionCloseOnGCTest extends ServiceTestBase
 
       factory = null;
 
-      ServiceTestBase.checkWeakReferences(fref, wrs1, wrs2);
+      ActiveMQTestBase.checkWeakReferences(fref, wrs1, wrs2);
    }
 
    @Test
@@ -102,7 +102,7 @@ public class SessionCloseOnGCTest extends ServiceTestBase
       locator.close();
 
       locator = null;
-      ServiceTestBase.checkWeakReferences(wrs1, wrs2);
+      ActiveMQTestBase.checkWeakReferences(wrs1, wrs2);
 
       WeakReference<ClientSessionFactory> fref = new WeakReference<ClientSessionFactory>(factory);
 
@@ -110,7 +110,7 @@ public class SessionCloseOnGCTest extends ServiceTestBase
 
       factory = null;
 
-      ServiceTestBase.checkWeakReferences(fref, wrs1, wrs2);
+      ActiveMQTestBase.checkWeakReferences(fref, wrs1, wrs2);
    }
 
    @Test
@@ -133,13 +133,13 @@ public class SessionCloseOnGCTest extends ServiceTestBase
       locator.close();
 
       locator = null;
-      ServiceTestBase.checkWeakReferences(wrs1, wrs2);
+      ActiveMQTestBase.checkWeakReferences(wrs1, wrs2);
 
       WeakReference<ClientSessionFactory> fref = new WeakReference<ClientSessionFactory>(factory);
 
       factory = null;
 
-      ServiceTestBase.checkWeakReferences(fref, wrs1, wrs2);
+      ActiveMQTestBase.checkWeakReferences(fref, wrs1, wrs2);
    }
 
    @Test
@@ -159,13 +159,13 @@ public class SessionCloseOnGCTest extends ServiceTestBase
       locator.close();
 
       locator = null;
-      ServiceTestBase.checkWeakReferences(wrs1, wrs2);
+      ActiveMQTestBase.checkWeakReferences(wrs1, wrs2);
 
       WeakReference<ClientSessionFactory> fref = new WeakReference<ClientSessionFactory>(factory);
 
       factory = null;
 
-      ServiceTestBase.checkWeakReferences(fref, wrs1, wrs2);
+      ActiveMQTestBase.checkWeakReferences(fref, wrs1, wrs2);
    }
 
    @Test
@@ -180,7 +180,7 @@ public class SessionCloseOnGCTest extends ServiceTestBase
       locator.close();
 
       locator = null;
-      ServiceTestBase.checkWeakReferences(fref);
+      ActiveMQTestBase.checkWeakReferences(fref);
    }
 
    @Test
@@ -196,7 +196,7 @@ public class SessionCloseOnGCTest extends ServiceTestBase
 
       session = null;
 
-      ServiceTestBase.checkWeakReferences(wses);
+      ActiveMQTestBase.checkWeakReferences(wses);
 
       Assert.assertEquals(0, sf.numSessions());
       Assert.assertEquals(1, sf.numConnections());
@@ -222,7 +222,7 @@ public class SessionCloseOnGCTest extends ServiceTestBase
       session2 = null;
       session3 = null;
 
-      ServiceTestBase.checkWeakReferences(ref1, ref2, ref3);
+      ActiveMQTestBase.checkWeakReferences(ref1, ref2, ref3);
 
       int count = 0;
       final int TOTAL_SLEEP_TIME = 400;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SessionCloseTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SessionCloseTest.java
@@ -19,19 +19,15 @@ package org.apache.activemq.artemis.tests.integration.client;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.core.config.Configuration;
-import org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,7 +35,7 @@ import org.junit.Test;
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 
-public class SessionCloseTest extends ServiceTestBase
+public class SessionCloseTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------
@@ -66,7 +62,7 @@ public class SessionCloseTest extends ServiceTestBase
 
       Assert.assertTrue(session.isClosed());
 
-      ServiceTestBase.expectActiveMQException(ActiveMQExceptionType.OBJECT_CLOSED, new ActiveMQAction()
+      ActiveMQTestBase.expectActiveMQException(ActiveMQExceptionType.OBJECT_CLOSED, new ActiveMQAction()
       {
          public void run() throws ActiveMQException
          {
@@ -74,7 +70,7 @@ public class SessionCloseTest extends ServiceTestBase
          }
       });
 
-      ServiceTestBase.expectActiveMQException(ActiveMQExceptionType.OBJECT_CLOSED, new ActiveMQAction()
+      ActiveMQTestBase.expectActiveMQException(ActiveMQExceptionType.OBJECT_CLOSED, new ActiveMQAction()
       {
          public void run() throws ActiveMQException
          {
@@ -82,7 +78,7 @@ public class SessionCloseTest extends ServiceTestBase
          }
       });
 
-      ServiceTestBase.expectActiveMQException(ActiveMQExceptionType.OBJECT_CLOSED, new ActiveMQAction()
+      ActiveMQTestBase.expectActiveMQException(ActiveMQExceptionType.OBJECT_CLOSED, new ActiveMQAction()
       {
          public void run() throws ActiveMQException
          {
@@ -92,7 +88,7 @@ public class SessionCloseTest extends ServiceTestBase
          }
       });
 
-      ServiceTestBase.expectActiveMQException(ActiveMQExceptionType.OBJECT_CLOSED, new ActiveMQAction()
+      ActiveMQTestBase.expectActiveMQException(ActiveMQExceptionType.OBJECT_CLOSED, new ActiveMQAction()
       {
          public void run() throws ActiveMQException
          {
@@ -100,7 +96,7 @@ public class SessionCloseTest extends ServiceTestBase
          }
       });
 
-      ServiceTestBase.expectActiveMQException(ActiveMQExceptionType.OBJECT_CLOSED, new ActiveMQAction()
+      ActiveMQTestBase.expectActiveMQException(ActiveMQExceptionType.OBJECT_CLOSED, new ActiveMQAction()
       {
          public void run() throws ActiveMQException
          {
@@ -108,7 +104,7 @@ public class SessionCloseTest extends ServiceTestBase
          }
       });
 
-      ServiceTestBase.expectActiveMQException(ActiveMQExceptionType.OBJECT_CLOSED, new ActiveMQAction()
+      ActiveMQTestBase.expectActiveMQException(ActiveMQExceptionType.OBJECT_CLOSED, new ActiveMQAction()
       {
          public void run() throws ActiveMQException
          {
@@ -116,7 +112,7 @@ public class SessionCloseTest extends ServiceTestBase
          }
       });
 
-      ServiceTestBase.expectActiveMQException(ActiveMQExceptionType.OBJECT_CLOSED, new ActiveMQAction()
+      ActiveMQTestBase.expectActiveMQException(ActiveMQExceptionType.OBJECT_CLOSED, new ActiveMQAction()
       {
          public void run() throws ActiveMQException
          {
@@ -124,7 +120,7 @@ public class SessionCloseTest extends ServiceTestBase
          }
       });
 
-      ServiceTestBase.expectActiveMQException(ActiveMQExceptionType.OBJECT_CLOSED, new ActiveMQAction()
+      ActiveMQTestBase.expectActiveMQException(ActiveMQExceptionType.OBJECT_CLOSED, new ActiveMQAction()
       {
          public void run() throws ActiveMQException
          {
@@ -132,7 +128,7 @@ public class SessionCloseTest extends ServiceTestBase
          }
       });
 
-      ServiceTestBase.expectActiveMQException(ActiveMQExceptionType.OBJECT_CLOSED, new ActiveMQAction()
+      ActiveMQTestBase.expectActiveMQException(ActiveMQExceptionType.OBJECT_CLOSED, new ActiveMQAction()
       {
          public void run() throws ActiveMQException
          {
@@ -140,7 +136,7 @@ public class SessionCloseTest extends ServiceTestBase
          }
       });
 
-      ServiceTestBase.expectActiveMQException(ActiveMQExceptionType.OBJECT_CLOSED, new ActiveMQAction()
+      ActiveMQTestBase.expectActiveMQException(ActiveMQExceptionType.OBJECT_CLOSED, new ActiveMQAction()
       {
          public void run() throws ActiveMQException
          {
@@ -161,7 +157,7 @@ public class SessionCloseTest extends ServiceTestBase
       Assert.assertTrue(session.isXA());
       Assert.assertTrue(session.isClosed());
 
-      ServiceTestBase.expectXAException(XAException.XA_RETRY, new ActiveMQAction()
+      ActiveMQTestBase.expectXAException(XAException.XA_RETRY, new ActiveMQAction()
       {
          public void run() throws XAException
          {
@@ -169,7 +165,7 @@ public class SessionCloseTest extends ServiceTestBase
          }
       });
 
-      ServiceTestBase.expectXAException(XAException.XAER_RMERR, new ActiveMQAction()
+      ActiveMQTestBase.expectXAException(XAException.XAER_RMERR, new ActiveMQAction()
       {
          public void run() throws XAException
          {
@@ -177,7 +173,7 @@ public class SessionCloseTest extends ServiceTestBase
          }
       });
 
-      ServiceTestBase.expectXAException(XAException.XAER_RMERR, new ActiveMQAction()
+      ActiveMQTestBase.expectXAException(XAException.XAER_RMERR, new ActiveMQAction()
       {
          public void run() throws XAException
          {
@@ -185,7 +181,7 @@ public class SessionCloseTest extends ServiceTestBase
          }
       });
 
-      ServiceTestBase.expectXAException(XAException.XAER_RMERR, new ActiveMQAction()
+      ActiveMQTestBase.expectXAException(XAException.XAER_RMERR, new ActiveMQAction()
       {
          public void run() throws XAException
          {
@@ -193,7 +189,7 @@ public class SessionCloseTest extends ServiceTestBase
          }
       });
 
-      ServiceTestBase.expectXAException(XAException.XAER_RMERR, new ActiveMQAction()
+      ActiveMQTestBase.expectXAException(XAException.XAER_RMERR, new ActiveMQAction()
       {
          public void run() throws XAException
          {
@@ -201,7 +197,7 @@ public class SessionCloseTest extends ServiceTestBase
          }
       });
 
-      ServiceTestBase.expectXAException(XAException.XAER_RMERR, new ActiveMQAction()
+      ActiveMQTestBase.expectXAException(XAException.XAER_RMERR, new ActiveMQAction()
       {
          public void run() throws XAException
          {
@@ -209,7 +205,7 @@ public class SessionCloseTest extends ServiceTestBase
          }
       });
 
-      ServiceTestBase.expectXAException(XAException.XAER_RMERR, new ActiveMQAction()
+      ActiveMQTestBase.expectXAException(XAException.XAER_RMERR, new ActiveMQAction()
       {
          public void run() throws XAException
          {
@@ -249,38 +245,10 @@ public class SessionCloseTest extends ServiceTestBase
    public void setUp() throws Exception
    {
       super.setUp();
-
-      Configuration config = createDefaultConfig()
-         .addAcceptorConfiguration(new TransportConfiguration(InVMAcceptorFactory.class.getCanonicalName()))
-         .setSecurityEnabled(false);
-      server = ActiveMQServers.newActiveMQServer(config, false);
-
+      server = addServer(ActiveMQServers.newActiveMQServer(createDefaultInVMConfig(), false));
       server.start();
-
       ServerLocator locator = createInVMNonHALocator();
       sf = createSessionFactory(locator);
-
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      if (sf != null)
-      {
-         sf.close();
-      }
-
-      if (server != null)
-      {
-         server.stop();
-      }
-
-      sf = null;
-
-      server = null;
-
-      super.tearDown();
    }
 
    // Private -------------------------------------------------------

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SessionClosedOnRemotingConnectionFailureTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SessionClosedOnRemotingConnectionFailureTest.java
@@ -19,7 +19,6 @@ package org.apache.activemq.artemis.tests.integration.client;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.ActiveMQNotConnectedException;
 import org.apache.activemq.artemis.api.core.ActiveMQObjectClosedException;
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
@@ -29,12 +28,12 @@ import org.apache.activemq.artemis.core.client.impl.ClientSessionInternal;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class SessionClosedOnRemotingConnectionFailureTest extends ServiceTestBase
+public class SessionClosedOnRemotingConnectionFailureTest extends ActiveMQTestBase
 {
    private ActiveMQServer server;
 
@@ -109,12 +108,8 @@ public class SessionClosedOnRemotingConnectionFailureTest extends ServiceTestBas
    public void setUp() throws Exception
    {
       super.setUp();
-
-      Configuration config = createDefaultConfig()
-         .addAcceptorConfiguration(new TransportConfiguration(INVM_ACCEPTOR_FACTORY))
-         .setSecurityEnabled(false);
+      Configuration config = createDefaultInVMConfig();
       server = createServer(false, config);
-
       server.start();
       ServerLocator locator = createInVMNonHALocator();
       sf = createSessionFactory(locator);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SessionCreateAndDeleteQueueTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SessionCreateAndDeleteQueueTest.java
@@ -26,12 +26,12 @@ import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.server.impl.LastValueQueue;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class SessionCreateAndDeleteQueueTest extends ServiceTestBase
+public class SessionCreateAndDeleteQueueTest extends ActiveMQTestBase
 {
    private ActiveMQServer server;
 
@@ -106,9 +106,7 @@ public class SessionCreateAndDeleteQueueTest extends ServiceTestBase
    @Test
    public void testAddressSettingUSed() throws Exception
    {
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setLastValueQueue(true);
-      server.getAddressSettingsRepository().addMatch(address.toString(), addressSettings);
+      server.getAddressSettingsRepository().addMatch(address.toString(), new AddressSettings().setLastValueQueue(true));
       ClientSession session = createSessionFactory(locator).createSession(false, true, true);
       SimpleString filterString = new SimpleString("x=y");
       session.createQueue(address, queueName, filterString, false);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SessionCreateConsumerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SessionCreateConsumerTest.java
@@ -24,12 +24,12 @@ import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.client.impl.ClientSessionInternal;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class SessionCreateConsumerTest extends ServiceTestBase
+public class SessionCreateConsumerTest extends ActiveMQTestBase
 {
    private final String queueName = "ClientSessionCreateConsumerTestQ";
 
@@ -47,9 +47,9 @@ public class SessionCreateConsumerTest extends ServiceTestBase
 
       service = createServer(false);
       service.start();
-      locator.setProducerMaxRate(99);
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnNonDurableSend(true);
+      locator.setProducerMaxRate(99)
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnNonDurableSend(true);
       cf = createSessionFactory(locator);
       clientSession = (ClientSessionInternal) addClientSession(cf.createSession(false, true, true));
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SessionCreateProducerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SessionCreateProducerTest.java
@@ -21,14 +21,14 @@ import org.apache.activemq.artemis.api.core.ActiveMQObjectClosedException;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.client.impl.ClientSessionInternal;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class SessionCreateProducerTest extends ServiceTestBase
+public class SessionCreateProducerTest extends ActiveMQTestBase
 {
    private ServerLocator locator;
    private ClientSessionInternal clientSession;
@@ -42,9 +42,9 @@ public class SessionCreateProducerTest extends ServiceTestBase
       locator = createInVMNonHALocator();
       ActiveMQServer service = createServer(false);
       service.start();
-      locator.setProducerMaxRate(99);
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnNonDurableSend(true);
+      locator.setProducerMaxRate(99)
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnNonDurableSend(true);
       cf = createSessionFactory(locator);
       clientSession = (ClientSessionInternal) addClientSession(cf.createSession(false, true, true));
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SessionFactoryTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SessionFactoryTest.java
@@ -16,30 +16,26 @@
  */
 package org.apache.activemq.artemis.tests.integration.client;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import org.apache.activemq.artemis.api.core.BroadcastGroupConfiguration;
 import org.apache.activemq.artemis.api.core.DiscoveryGroupConfiguration;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.UDPBroadcastEndpointFactory;
+import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.ha.SharedStoreMasterPolicyConfiguration;
-import org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory;
-import org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnectorFactory;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class SessionFactoryTest extends ServiceTestBase
+import java.util.Arrays;
+
+public class SessionFactoryTest extends ActiveMQTestBase
 {
    private final DiscoveryGroupConfiguration groupConfiguration = new DiscoveryGroupConfiguration()
       .setBroadcastEndpointFactory(new UDPBroadcastEndpointFactory()
@@ -152,10 +148,6 @@ public class SessionFactoryTest extends ServiceTestBase
    @Test
    public void testGettersAndSetters() throws Exception
    {
-
-      TransportConfiguration[] tc = new TransportConfiguration[]{liveTC};
-      ServerLocator locator = ActiveMQClient.createServerLocatorWithoutHA(tc);
-
       long clientFailureCheckPeriod = RandomUtil.randomPositiveLong();
       long connectionTTL = RandomUtil.randomPositiveLong();
       long callTimeout = RandomUtil.randomPositiveLong();
@@ -177,28 +169,30 @@ public class SessionFactoryTest extends ServiceTestBase
       long retryInterval = RandomUtil.randomPositiveLong();
       double retryIntervalMultiplier = RandomUtil.randomDouble();
       int reconnectAttempts = RandomUtil.randomPositiveInt();
+      TransportConfiguration[] tc = new TransportConfiguration[]{liveTC};
 
-      locator.setClientFailureCheckPeriod(clientFailureCheckPeriod);
-      locator.setConnectionTTL(connectionTTL);
-      locator.setCallTimeout(callTimeout);
-      locator.setMinLargeMessageSize(minLargeMessageSize);
-      locator.setConsumerWindowSize(consumerWindowSize);
-      locator.setConsumerMaxRate(consumerMaxRate);
-      locator.setConfirmationWindowSize(confirmationWindowSize);
-      locator.setProducerMaxRate(producerMaxRate);
-      locator.setBlockOnAcknowledge(blockOnAcknowledge);
-      locator.setBlockOnDurableSend(blockOnDurableSend);
-      locator.setBlockOnNonDurableSend(blockOnNonDurableSend);
-      locator.setAutoGroup(autoGroup);
-      locator.setPreAcknowledge(preAcknowledge);
-      locator.setConnectionLoadBalancingPolicyClassName(loadBalancingPolicyClassName);
-      locator.setAckBatchSize(ackBatchSize);
-      locator.setUseGlobalPools(useGlobalPools);
-      locator.setScheduledThreadPoolMaxSize(scheduledThreadPoolMaxSize);
-      locator.setThreadPoolMaxSize(threadPoolMaxSize);
-      locator.setRetryInterval(retryInterval);
-      locator.setRetryIntervalMultiplier(retryIntervalMultiplier);
-      locator.setReconnectAttempts(reconnectAttempts);
+      ServerLocator locator = ActiveMQClient.createServerLocatorWithoutHA(tc)
+              .setClientFailureCheckPeriod(clientFailureCheckPeriod)
+              .setConnectionTTL(connectionTTL)
+              .setCallTimeout(callTimeout)
+              .setMinLargeMessageSize(minLargeMessageSize)
+              .setConsumerWindowSize(consumerWindowSize)
+              .setConsumerMaxRate(consumerMaxRate)
+              .setConfirmationWindowSize(confirmationWindowSize)
+              .setProducerMaxRate(producerMaxRate)
+              .setBlockOnAcknowledge(blockOnAcknowledge)
+              .setBlockOnDurableSend(blockOnDurableSend)
+              .setBlockOnNonDurableSend(blockOnNonDurableSend)
+              .setAutoGroup(autoGroup)
+              .setPreAcknowledge(preAcknowledge)
+              .setConnectionLoadBalancingPolicyClassName(loadBalancingPolicyClassName)
+              .setAckBatchSize(ackBatchSize)
+              .setUseGlobalPools(useGlobalPools)
+              .setScheduledThreadPoolMaxSize(scheduledThreadPoolMaxSize)
+              .setThreadPoolMaxSize(threadPoolMaxSize)
+              .setRetryInterval(retryInterval)
+              .setRetryIntervalMultiplier(retryIntervalMultiplier)
+              .setReconnectAttempts(reconnectAttempts);
 
       assertEqualsTransportConfigurations(tc, locator.getStaticTransportConfigurations());
       Assert.assertEquals(clientFailureCheckPeriod, locator.getClientFailureCheckPeriod());
@@ -214,8 +208,7 @@ public class SessionFactoryTest extends ServiceTestBase
       Assert.assertEquals(blockOnNonDurableSend, locator.isBlockOnNonDurableSend());
       Assert.assertEquals(autoGroup, locator.isAutoGroup());
       Assert.assertEquals(preAcknowledge, locator.isPreAcknowledge());
-      Assert.assertEquals(loadBalancingPolicyClassName, locator
-         .getConnectionLoadBalancingPolicyClassName());
+      Assert.assertEquals(loadBalancingPolicyClassName, locator.getConnectionLoadBalancingPolicyClassName());
       Assert.assertEquals(ackBatchSize, locator.getAckBatchSize());
       Assert.assertEquals(useGlobalPools, locator.isUseGlobalPools());
       Assert.assertEquals(scheduledThreadPoolMaxSize, locator.getScheduledThreadPoolMaxSize());
@@ -223,7 +216,6 @@ public class SessionFactoryTest extends ServiceTestBase
       Assert.assertEquals(retryInterval, locator.getRetryInterval());
       Assert.assertEquals(retryIntervalMultiplier, locator.getRetryIntervalMultiplier(), 0.000001);
       Assert.assertEquals(reconnectAttempts, locator.getReconnectAttempts());
-
    }
 
    private void testSettersThrowException(final ClientSessionFactory cf)
@@ -526,7 +518,7 @@ public class SessionFactoryTest extends ServiceTestBase
 
    private void startServer() throws Exception
    {
-      liveTC = new TransportConfiguration(InVMConnectorFactory.class.getName());
+      liveTC = new TransportConfiguration(INVM_CONNECTOR_FACTORY);
 
       final long broadcastPeriod = 250;
 
@@ -534,7 +526,7 @@ public class SessionFactoryTest extends ServiceTestBase
 
       final int localBindPort = 5432;
 
-      BroadcastGroupConfiguration bcConfig1 = new BroadcastGroupConfiguration()
+      BroadcastGroupConfiguration broadcastGroupConfiguration = new BroadcastGroupConfiguration()
          .setName(bcGroupName)
          .setBroadcastPeriod(broadcastPeriod)
          .setConnectorInfos(Arrays.asList(liveTC.getName()))
@@ -543,15 +535,10 @@ public class SessionFactoryTest extends ServiceTestBase
                                    .setGroupPort(getUDPDiscoveryPort())
                                    .setLocalBindPort(localBindPort));
 
-      List<BroadcastGroupConfiguration> bcConfigs1 = new ArrayList<BroadcastGroupConfiguration>();
-      bcConfigs1.add(bcConfig1);
-
-      Configuration liveConf = createDefaultConfig()
-         .setSecurityEnabled(false)
-         .addAcceptorConfiguration(new TransportConfiguration(InVMAcceptorFactory.class.getName()))
+      Configuration liveConf = createDefaultInVMConfig()
          .addConnectorConfiguration(liveTC.getName(), liveTC)
          .setHAPolicyConfiguration(new SharedStoreMasterPolicyConfiguration())
-         .setBroadcastGroupConfigurations(bcConfigs1);
+         .addBroadcastGroupConfiguration(broadcastGroupConfiguration);
 
       liveService = createServer(false, liveConf);
       liveService.start();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SessionSendAcknowledgementHandlerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SessionSendAcknowledgementHandlerTest.java
@@ -28,12 +28,12 @@ import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.SendAcknowledgementHandler;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class SessionSendAcknowledgementHandlerTest extends ServiceTestBase
+public class SessionSendAcknowledgementHandlerTest extends ActiveMQTestBase
 {
    private ActiveMQServer server;
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SessionStopStartTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SessionStopStartTest.java
@@ -34,9 +34,9 @@ import org.apache.activemq.artemis.api.core.client.MessageHandler;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 
-public class SessionStopStartTest extends ServiceTestBase
+public class SessionStopStartTest extends ActiveMQTestBase
 {
    private static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SessionTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SessionTest.java
@@ -31,7 +31,7 @@ import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.api.core.client.SessionFailureListener;
 import org.apache.activemq.artemis.tests.util.CountDownSessionFailureListener;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.client.impl.ClientSessionFactoryInternal;
 import org.apache.activemq.artemis.core.client.impl.ClientSessionInternal;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
@@ -44,7 +44,7 @@ import org.junit.Test;
 /**
  * This test covers the API for ClientSession although XA tests are tested separately.
  */
-public class SessionTest extends ServiceTestBase
+public class SessionTest extends ActiveMQTestBase
 {
    private final String queueName = "ClientSessionTestQ";
 
@@ -61,7 +61,7 @@ public class SessionTest extends ServiceTestBase
       locator = createInVMNonHALocator();
       server = createServer(false);
       server.start();
-      waitForServer(server);
+      waitForServerToStart(server);
    }
 
    @Test
@@ -398,8 +398,8 @@ public class SessionTest extends ServiceTestBase
    @Test
    public void testCommitWithReceive() throws Exception
    {
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true);
       cf = createSessionFactory(locator);
       ClientSession sendSession = cf.createSession(false, true, true);
       ClientProducer cp = sendSession.createProducer(queueName);
@@ -458,8 +458,8 @@ public class SessionTest extends ServiceTestBase
    @Test
    public void testRollbackWithReceive() throws Exception
    {
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true);
       cf = createSessionFactory(locator);
       ClientSession sendSession = cf.createSession(false, true, true);
       ClientProducer cp = sendSession.createProducer(queueName);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SimpleSendMultipleQueuesTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SimpleSendMultipleQueuesTest.java
@@ -15,12 +15,6 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.client;
-import org.junit.Before;
-import org.junit.After;
-
-import org.junit.Test;
-
-import org.junit.Assert;
 
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
@@ -29,10 +23,13 @@ import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
-public class SimpleSendMultipleQueuesTest extends ServiceTestBase
+public class SimpleSendMultipleQueuesTest extends ActiveMQTestBase
 {
    public static final String address = "testaddress";
 
@@ -111,27 +108,4 @@ public class SimpleSendMultipleQueuesTest extends ServiceTestBase
 
       session.start();
    }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      if (session != null)
-      {
-         consumer1.close();
-
-         consumer2.close();
-
-         consumer3.close();
-
-         session.deleteQueue("queue1");
-         session.deleteQueue("queue2");
-         session.deleteQueue("queue3");
-
-         session.close();
-      }
-
-      super.tearDown();
-   }
-
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SlowConsumerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SlowConsumerTest.java
@@ -40,14 +40,14 @@ import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.core.settings.impl.SlowConsumerPolicy;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(value = Parameterized.class)
-public class SlowConsumerTest extends ServiceTestBase
+public class SlowConsumerTest extends ActiveMQTestBase
 {
    private boolean isNetty = false;
 
@@ -81,10 +81,10 @@ public class SlowConsumerTest extends ServiceTestBase
 
       server = createServer(false, isNetty);
 
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setSlowConsumerCheckPeriod(2);
-      addressSettings.setSlowConsumerThreshold(10);
-      addressSettings.setSlowConsumerPolicy(SlowConsumerPolicy.KILL);
+      AddressSettings addressSettings = new AddressSettings()
+              .setSlowConsumerCheckPeriod(2)
+              .setSlowConsumerThreshold(10)
+              .setSlowConsumerPolicy(SlowConsumerPolicy.KILL);
 
       server.start();
 
@@ -137,10 +137,10 @@ public class SlowConsumerTest extends ServiceTestBase
 
       session.createQueue(QUEUE, QUEUE, null, false);
 
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setSlowConsumerCheckPeriod(2);
-      addressSettings.setSlowConsumerThreshold(10);
-      addressSettings.setSlowConsumerPolicy(SlowConsumerPolicy.NOTIFY);
+      AddressSettings addressSettings = new AddressSettings()
+              .setSlowConsumerCheckPeriod(2)
+              .setSlowConsumerThreshold(10)
+              .setSlowConsumerPolicy(SlowConsumerPolicy.NOTIFY);
 
       server.getAddressSettingsRepository().removeMatch(QUEUE.toString());
       server.getAddressSettingsRepository().addMatch(QUEUE.toString(), addressSettings);
@@ -320,10 +320,10 @@ public class SlowConsumerTest extends ServiceTestBase
       SimpleString queueName2 = new SimpleString("Q2");
       SimpleString queueName = new SimpleString("Q");
 
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setSlowConsumerCheckPeriod(2);
-      addressSettings.setSlowConsumerThreshold(10);
-      addressSettings.setSlowConsumerPolicy(SlowConsumerPolicy.KILL);
+      AddressSettings addressSettings = new AddressSettings()
+              .setSlowConsumerCheckPeriod(2)
+              .setSlowConsumerThreshold(10)
+              .setSlowConsumerPolicy(SlowConsumerPolicy.KILL);
 
       server.getAddressSettingsRepository().addMatch(address.toString(), addressSettings);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/TransactionDurabilityTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/TransactionDurabilityTest.java
@@ -16,24 +16,19 @@
  */
 package org.apache.activemq.artemis.tests.integration.client;
 
-import org.junit.Test;
-
-import org.junit.Assert;
-
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.junit.Assert;
+import org.junit.Test;
 
-public class TransactionDurabilityTest extends ServiceTestBase
+public class TransactionDurabilityTest extends ActiveMQTestBase
 {
 
    /*
@@ -54,27 +49,23 @@ public class TransactionDurabilityTest extends ServiceTestBase
    @Test
    public void testRolledBackAcknowledgeWithSameMessageAckedByOtherSession() throws Exception
    {
-      Configuration conf = createDefaultConfig();
-
       final SimpleString testAddress = new SimpleString("testAddress");
 
       final SimpleString queue1 = new SimpleString("queue1");
 
       final SimpleString queue2 = new SimpleString("queue2");
 
-      ActiveMQServer server = createServer(true, conf);
+      ActiveMQServer server = createServer(true, createDefaultInVMConfig());
 
       server.start();
 
-      ServerLocator locator =
-               addServerLocator(ActiveMQClient.createServerLocatorWithoutHA(new TransportConfiguration(
-                  ServiceTestBase.INVM_CONNECTOR_FACTORY)));
+      ServerLocator locator = createInVMNonHALocator();
 
       ClientSessionFactory sf = createSessionFactory(locator);
 
-      ClientSession session1 = sf.createSession(false, true, true);
+      ClientSession session1 = addClientSession(sf.createSession(false, true, true));
 
-      ClientSession session2 = sf.createSession(false, false, false);
+      ClientSession session2 = addClientSession(sf.createSession(false, false, false));
 
       session1.createQueue(testAddress, queue1, null, true);
 
@@ -120,9 +111,9 @@ public class TransactionDurabilityTest extends ServiceTestBase
 
       sf = createSessionFactory(locator);
 
-      session1 = sf.createSession(false, true, true);
+      session1 = addClientSession(sf.createSession(false, true, true));
 
-      session2 = sf.createSession(false, true, true);
+      session2 = addClientSession(sf.createSession(false, true, true));
 
       session1.start();
 
@@ -152,9 +143,9 @@ public class TransactionDurabilityTest extends ServiceTestBase
 
       sf = createSessionFactory(locator);
 
-      session1 = sf.createSession(false, true, true);
+      session1 = addClientSession(sf.createSession(false, true, true));
 
-      session2 = sf.createSession(false, true, true);
+      session2 = addClientSession(sf.createSession(false, true, true));
 
       session1.start();
 
@@ -179,7 +170,5 @@ public class TransactionDurabilityTest extends ServiceTestBase
       locator.close();
 
       server.stop();
-
    }
-
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/TransactionalSendTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/TransactionalSendTest.java
@@ -23,12 +23,12 @@ import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.Queue;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class TransactionalSendTest extends ServiceTestBase
+public class TransactionalSendTest extends ActiveMQTestBase
 {
    public final SimpleString addressA = new SimpleString("addressA");
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/TransientQueueTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/TransientQueueTest.java
@@ -140,7 +140,6 @@ public class TransientQueueTest extends SingleServerTestBase
 
    }
 
-
    @Test
    public void testQueueDifferentConfigs() throws Exception
    {
@@ -225,19 +224,14 @@ public class TransientQueueTest extends SingleServerTestBase
       }
 
       assertTrue(exHappened);
-
-
    }
-
 
    protected ServerLocator createLocator()
    {
-      ServerLocator retlocator = super.createLocator();
-      retlocator.setConsumerWindowSize(0);
-      retlocator.setBlockOnAcknowledge(true);
-      retlocator.setBlockOnDurableSend(false);
-      retlocator.setBlockOnNonDurableSend(false);
-      return retlocator;
+      return super.createLocator()
+              .setConsumerWindowSize(0)
+              .setBlockOnAcknowledge(true)
+              .setBlockOnDurableSend(false)
+              .setBlockOnNonDurableSend(false);
    }
-
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/WildCardRoutingTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/WildCardRoutingTest.java
@@ -16,9 +16,7 @@
  */
 package org.apache.activemq.artemis.tests.integration.client;
 
-import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
@@ -28,18 +26,17 @@ import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.junit.After;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class WildCardRoutingTest extends ServiceTestBase
+public class WildCardRoutingTest extends ActiveMQTestBase
 {
    private ActiveMQServer server;
    private ServerLocator locator;
    private ClientSession clientSession;
-   private ClientSessionFactory sessionFactory;
+   private ClientSessionFactory sf;
 
    @Test
    public void testBasicWildcardRouting() throws Exception
@@ -781,45 +778,14 @@ public class WildCardRoutingTest extends ServiceTestBase
    public void setUp() throws Exception
    {
       super.setUp();
-      TransportConfiguration transportConfig = new TransportConfiguration(ServiceTestBase.INVM_ACCEPTOR_FACTORY);
-
-      Configuration configuration = createDefaultConfig()
+      Configuration configuration = createDefaultInVMConfig()
          .setWildcardRoutingEnabled(true)
-         .setSecurityEnabled(false)
-         .setTransactionTimeoutScanPeriod(500)
-         .addAcceptorConfiguration(transportConfig);
-
-      server = ActiveMQServers.newActiveMQServer(configuration, false);
-      // start the server
+         .setTransactionTimeoutScanPeriod(500);
+      server = addServer(ActiveMQServers.newActiveMQServer(configuration, false));
       server.start();
       server.getManagementService().enableNotifications(false);
-      // then we create a client as normal
       locator = createInVMNonHALocator();
-      sessionFactory = createSessionFactory(locator);
-      clientSession = sessionFactory.createSession(false, true, true);
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      if (clientSession != null)
-      {
-         try
-         {
-            clientSession.close();
-         }
-         catch (ActiveMQException e1)
-         {
-            //
-         }
-      }
-      closeSessionFactory(sessionFactory);
-      stopComponent(server);
-      closeServerLocator(locator);
-      locator = null;
-      server = null;
-      clientSession = null;
-      super.tearDown();
+      sf = createSessionFactory(locator);
+      clientSession = addClientSession(sf.createSession(false, true, true));
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/clientcrash/ClientCrashTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/clientcrash/ClientCrashTest.java
@@ -125,8 +125,7 @@ public class ClientCrashTest extends ClientTestBase
    public void testCrashClient2() throws Exception
    {
       // set the redelivery delay to avoid an attempt to redeliver the message to the dead client
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setRedeliveryDelay(ClientCrashTest.CONNECTION_TTL + ClientCrashTest.PING_PERIOD);
+      AddressSettings addressSettings = new AddressSettings().setRedeliveryDelay(ClientCrashTest.CONNECTION_TTL + ClientCrashTest.PING_PERIOD);
       server.getAddressSettingsRepository().addMatch(ClientCrashTest.QUEUE2.toString(), addressSettings);
 
       assertActiveConnections(1);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/clientcrash/ClientExitTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/clientcrash/ClientExitTest.java
@@ -15,22 +15,18 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.clientcrash;
-import org.junit.Before;
-
-import org.junit.Test;
 
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
 import org.apache.activemq.artemis.tests.util.SpawnedVMSupport;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * A test that makes sure that a ActiveMQ Artemis client gracefully exists after the last session is
@@ -106,7 +102,7 @@ public class ClientExitTest extends ClientTestBase
    {
       super.setUp();
 
-      ServerLocator locator = ActiveMQClient.createServerLocatorWithoutHA(new TransportConfiguration(NettyConnectorFactory.class.getName()));
+      ServerLocator locator = createNettyNonHALocator();
       addServerLocator(locator);
       ClientSessionFactory sf = createSessionFactory(locator);
       session = sf.createSession(false, true, true);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/clientcrash/ClientTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/clientcrash/ClientTestBase.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.clientcrash;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 
 import org.junit.Assert;
@@ -23,7 +23,7 @@ import org.junit.Assert;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 
-public abstract class ClientTestBase extends ServiceTestBase
+public abstract class ClientTestBase extends ActiveMQTestBase
 {
 
    protected ActiveMQServer server;
@@ -34,8 +34,7 @@ public abstract class ClientTestBase extends ServiceTestBase
    {
       super.setUp();
 
-      Configuration config = createDefaultConfig(true)
-         .setSecurityEnabled(false);
+      Configuration config = createDefaultNettyConfig();
       server = createServer(false, config);
       server.start();
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/ClusterControllerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/ClusterControllerTest.java
@@ -23,7 +23,6 @@ import org.apache.activemq.artemis.core.server.cluster.ActiveMQServerSideProtoco
 import org.apache.activemq.artemis.core.server.cluster.ClusterControl;
 import org.apache.activemq.artemis.core.server.cluster.ClusterController;
 import org.apache.activemq.artemis.tests.integration.cluster.distribution.ClusterTestBase;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -54,15 +53,6 @@ public class ClusterControllerTest extends ClusterTestBase
 
       startServers(0);
       startServers(1);
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      stopServers();
-
-      super.tearDown();
    }
 
    @Test

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/NodeManagerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/NodeManagerTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 import org.apache.activemq.artemis.core.server.NodeManager;
 import org.apache.activemq.artemis.core.server.impl.InVMNodeManager;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 
 import static org.apache.activemq.artemis.tests.integration.cluster.NodeManagerAction.AWAIT_LIVE;
@@ -36,7 +36,7 @@ import static org.apache.activemq.artemis.tests.integration.cluster.NodeManagerA
 import static org.apache.activemq.artemis.tests.integration.cluster.NodeManagerAction.START_LIVE;
 import static org.apache.activemq.artemis.tests.integration.cluster.NodeManagerAction.STOP_BACKUP;
 
-public class NodeManagerTest extends ServiceTestBase
+public class NodeManagerTest extends ActiveMQTestBase
 {
    @Test
    public void testLive() throws Exception

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/RealNodeManagerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/RealNodeManagerTest.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.activemq.artemis.tests.util.SpawnedVMSupport;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.server.NodeManager;
 import org.apache.activemq.artemis.core.server.impl.FileLockNodeManager;
 import org.apache.activemq.artemis.utils.UUID;
@@ -37,7 +37,7 @@ public class RealNodeManagerTest extends NodeManagerTest
       UUID id1 = nodeManager.getUUID();
       nodeManager.stop();
       nodeManager.start();
-      ServiceTestBase.assertEqualsByteArrays(id1.asBytes(), nodeManager.getUUID().asBytes());
+      ActiveMQTestBase.assertEqualsByteArrays(id1.asBytes(), nodeManager.getUUID().asBytes());
       nodeManager.stop();
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/bridge/BridgeFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/bridge/BridgeFailoverTest.java
@@ -200,7 +200,7 @@ public class BridgeFailoverTest extends MultiServerTestBase
 
       locatorConsumer.close();
 
-      waitForServer(backupServers[4]);
+      waitForServerToStart(backupServers[4]);
 
       for (int i = 100; i < 200; i++)
       {
@@ -268,7 +268,7 @@ public class BridgeFailoverTest extends MultiServerTestBase
       waitForTopology(servers[4], getNumberOfServers() - 1, getNumberOfServers() - 1);
 
       crashAndWaitForFailure(servers[4], createLocator(false, 4));
-      waitForServer(backupServers[4]);
+      waitForServerToStart(backupServers[4]);
 
       startBackups(2);
       startServers(2);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/bridge/BridgeReconnectTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/bridge/BridgeReconnectTest.java
@@ -16,22 +16,17 @@
  */
 package org.apache.activemq.artemis.tests.integration.cluster.bridge;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
 import org.apache.activemq.artemis.api.core.ActiveMQNotConnectedException;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.api.core.management.QueueControl;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
@@ -47,9 +42,13 @@ import org.apache.activemq.artemis.core.server.impl.InVMNodeManager;
 import org.apache.activemq.artemis.core.server.management.ManagementService;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class BridgeReconnectTest extends BridgeTestBase
 {
@@ -99,14 +98,6 @@ public class BridgeReconnectTest extends BridgeTestBase
       connectors.put(server1tc.getName(), server1tc);
       staticConnectors = new ArrayList<String>();
       staticConnectors.add(server1tc.getName());
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      locator = null;
-      super.tearDown();
    }
 
    protected boolean isNetty()
@@ -329,8 +320,8 @@ public class BridgeReconnectTest extends BridgeTestBase
       // Now we will simulate a failure of the bridge connection between server0 and server1
       server0.stop(true);
 
-      locator = addServerLocator(ActiveMQClient.createServerLocatorWithHA(server2tc));
-      locator.setReconnectAttempts(100);
+      locator = addServerLocator(ActiveMQClient.createServerLocatorWithHA(server2tc))
+              .setReconnectAttempts(100);
       ClientSessionFactory csf0 = addSessionFactory(locator.createSessionFactory(server2tc));
       session0 = csf0.createSession(false, true, true);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/bridge/BridgeStartTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/bridge/BridgeStartTest.java
@@ -33,7 +33,7 @@ import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.config.BridgeConfiguration;
 import org.apache.activemq.artemis.core.config.CoreQueueConfiguration;
 import org.apache.activemq.artemis.core.remoting.impl.invm.TransportConstants;
@@ -45,7 +45,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(value = Parameterized.class)
-public class BridgeStartTest extends ServiceTestBase
+public class BridgeStartTest extends ActiveMQTestBase
 {
 
    @Parameterized.Parameters(name = "isNetty={0}")
@@ -145,10 +145,10 @@ public class BridgeStartTest extends ServiceTestBase
          server1.getConfiguration().setQueueConfigurations(queueConfigs1);
 
          server1.start();
-         waitForServer(server1);
+         waitForServerToStart(server1);
 
          server0.start();
-         waitForServer(server0);
+         waitForServerToStart(server0);
 
          locator = ActiveMQClient.createServerLocatorWithoutHA(server0tc, server1tc);
          ClientSessionFactory sf0 = locator.createSessionFactory(server0tc);
@@ -316,7 +316,7 @@ public class BridgeStartTest extends ServiceTestBase
          // Don't start server 1 yet
 
          server0.start();
-         waitForServer(server0);
+         waitForServerToStart(server0);
 
          locator = ActiveMQClient.createServerLocatorWithoutHA(server0tc, server1tc);
          ClientSessionFactory sf0 = locator.createSessionFactory(server0tc);
@@ -343,7 +343,7 @@ public class BridgeStartTest extends ServiceTestBase
          Thread.sleep(1000);
 
          server1.start();
-         waitForServer(server1);
+         waitForServerToStart(server1);
 
          ClientSessionFactory sf1 = locator.createSessionFactory(server1tc);
 
@@ -410,7 +410,7 @@ public class BridgeStartTest extends ServiceTestBase
          BridgeStartTest.log.info("sent some more messages");
 
          server1.start();
-         waitForServer(server1);
+         waitForServerToStart(server1);
 
          BridgeStartTest.log.info("started server1");
 
@@ -528,7 +528,7 @@ public class BridgeStartTest extends ServiceTestBase
          // Don't start server 1 yet
 
          server0.start();
-         waitForServer(server0);
+         waitForServerToStart(server0);
 
          locator = ActiveMQClient.createServerLocatorWithoutHA(server0tc, server1tc);
          ClientSessionFactory sf0 = locator.createSessionFactory(server0tc);
@@ -557,7 +557,7 @@ public class BridgeStartTest extends ServiceTestBase
          // JMSBridge should be stopped since retries = 0
 
          server1.start();
-         waitForServer(server1);
+         waitForServerToStart(server1);
 
          ClientSessionFactory sf1 = locator.createSessionFactory(server1tc);
 
@@ -679,10 +679,10 @@ public class BridgeStartTest extends ServiceTestBase
          server1.getConfiguration().setQueueConfigurations(queueConfigs1);
 
          server1.start();
-         waitForServer(server1);
+         waitForServerToStart(server1);
 
          server0.start();
-         waitForServer(server0);
+         waitForServerToStart(server0);
 
          locator = ActiveMQClient.createServerLocatorWithoutHA(server0tc, server1tc);
          ClientSessionFactory sf0 = locator.createSessionFactory(server0tc);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/bridge/BridgeTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/bridge/BridgeTest.java
@@ -51,8 +51,8 @@ import org.apache.activemq.artemis.core.server.cluster.impl.BridgeImpl;
 import org.apache.activemq.artemis.core.transaction.impl.TransactionImpl;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
 import org.apache.activemq.artemis.utils.LinkedListIterator;
 import org.apache.activemq.artemis.utils.ReusableLatch;
 import org.junit.Assert;
@@ -74,7 +74,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @RunWith(value = Parameterized.class)
-public class BridgeTest extends ServiceTestBase
+public class BridgeTest extends ActiveMQTestBase
 {
 
    private ActiveMQServer server0;
@@ -233,7 +233,7 @@ public class BridgeTest extends ServiceTestBase
 
          if (largeMessage)
          {
-            message.setBodyInputStream(ServiceTestBase.createFakeLargeStream(1024 * 1024));
+            message.setBodyInputStream(ActiveMQTestBase.createFakeLargeStream(1024 * 1024));
          }
 
          message.putIntProperty(propKey, i);
@@ -270,8 +270,10 @@ public class BridgeTest extends ServiceTestBase
       sf1.close();
 
       closeFields();
-      assertEquals(0, loadQueues(server0).size());
-
+      if (server0.getConfiguration().isPersistenceEnabled())
+      {
+         assertEquals(0, loadQueues(server0).size());
+      }
    }
 
 
@@ -410,7 +412,7 @@ public class BridgeTest extends ServiceTestBase
 
          if (largeMessage)
          {
-            message.setBodyInputStream(ServiceTestBase.createFakeLargeStream(1024 * 1024));
+            message.setBodyInputStream(ActiveMQTestBase.createFakeLargeStream(1024 * 1024));
          }
 
          message.putIntProperty(propKey, i);
@@ -595,7 +597,7 @@ public class BridgeTest extends ServiceTestBase
 
          if (largeMessage)
          {
-            message.setBodyInputStream(ServiceTestBase.createFakeLargeStream(1024 * 1024));
+            message.setBodyInputStream(ActiveMQTestBase.createFakeLargeStream(1024 * 1024));
          }
 
          producer0.send(message);
@@ -613,7 +615,7 @@ public class BridgeTest extends ServiceTestBase
 
          if (largeMessage)
          {
-            message.setBodyInputStream(ServiceTestBase.createFakeLargeStream(1024 * 1024));
+            message.setBodyInputStream(ActiveMQTestBase.createFakeLargeStream(1024 * 1024));
          }
 
          producer0.send(message);
@@ -1076,9 +1078,10 @@ public class BridgeTest extends ServiceTestBase
 
       sf1.close();
 
-      assertEquals(0, loadQueues(server0).size());
-
-
+      if (server0.getConfiguration().isPersistenceEnabled())
+      {
+         assertEquals(0, loadQueues(server0).size());
+      }
    }
 
    @Test
@@ -1210,8 +1213,8 @@ public class BridgeTest extends ServiceTestBase
             {
                ServerLocator locator = addServerLocator(ActiveMQClient.createServerLocatorWithoutHA(server0tc));
 
-               locator.setBlockOnDurableSend(false);
-               locator.setBlockOnNonDurableSend(false);
+               locator.setBlockOnDurableSend(false)
+                       .setBlockOnNonDurableSend(false);
 
                ClientSessionFactory sf = null;
 
@@ -1871,10 +1874,6 @@ public class BridgeTest extends ServiceTestBase
 
       sf1.close();
       closeFields();
-
-      assertEquals(0, loadQueues(server0).size());
-
-
    }
 
    /**

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/bridge/BridgeTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/bridge/BridgeTestBase.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.ha.SharedStoreMasterPolicyConfiguration;
 import org.apache.activemq.artemis.core.config.ha.SharedStoreSlavePolicyConfiguration;
@@ -31,7 +31,7 @@ import org.apache.activemq.artemis.core.server.NodeManager;
 import org.apache.activemq.artemis.tests.util.InVMNodeManagerServer;
 import org.junit.After;
 
-public abstract class BridgeTestBase extends ServiceTestBase
+public abstract class BridgeTestBase extends ActiveMQTestBase
 {
 
    @Override
@@ -46,11 +46,6 @@ public abstract class BridgeTestBase extends ServiceTestBase
    protected ActiveMQServer createActiveMQServer(final int id, final boolean netty, final Map<String, Object> params) throws Exception
    {
       return createActiveMQServer(id, params, netty, null);
-   }
-
-   protected ActiveMQServer createActiveMQServer(final int id, final boolean netty, final Map<String, Object> params, NodeManager nodeManager) throws Exception
-   {
-      return createActiveMQServer(id, params, netty, nodeManager);
    }
 
    protected ActiveMQServer createActiveMQServer(final int id,
@@ -84,17 +79,17 @@ public abstract class BridgeTestBase extends ServiceTestBase
          .addAcceptorConfiguration(tc)
          .setHAPolicyConfiguration(new SharedStoreMasterPolicyConfiguration());
 
-      ActiveMQServer service;
+      ActiveMQServer server;
       if (nodeManager == null)
       {
-         service = ActiveMQServers.newActiveMQServer(serviceConf, true);
+         server = ActiveMQServers.newActiveMQServer(serviceConf, true);
       }
       else
       {
-         service = new InVMNodeManagerServer(serviceConf, nodeManager);
+         server = new InVMNodeManagerServer(serviceConf, nodeManager);
       }
 
-      return addServer(service);
+      return addServer(server);
    }
 
    protected ActiveMQServer createBackupActiveMQServer(final int id,
@@ -130,16 +125,16 @@ public abstract class BridgeTestBase extends ServiceTestBase
          .addAcceptorConfiguration(tc)
          .setHAPolicyConfiguration(new SharedStoreSlavePolicyConfiguration());
 
-      ActiveMQServer service;
+      ActiveMQServer server;
       if (nodeManager == null)
       {
-         service = ActiveMQServers.newActiveMQServer(serviceConf, true);
+         server = ActiveMQServers.newActiveMQServer(serviceConf, true);
       }
       else
       {
-         service = new InVMNodeManagerServer(serviceConf, nodeManager);
+         server = new InVMNodeManagerServer(serviceConf, nodeManager);
       }
-      return addServer(service);
+      return addServer(server);
    }
 
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/bridge/BridgeWithDiscoveryGroupStartTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/bridge/BridgeWithDiscoveryGroupStartTest.java
@@ -42,14 +42,14 @@ import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactor
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.cluster.Bridge;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(value = Parameterized.class)
-public class BridgeWithDiscoveryGroupStartTest extends ServiceTestBase
+public class BridgeWithDiscoveryGroupStartTest extends ActiveMQTestBase
 {
 
    @Parameterized.Parameters(name = "isNetty={0}")

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/ClusteredGroupingTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/ClusteredGroupingTest.java
@@ -16,15 +16,6 @@
  */
 package org.apache.activemq.artemis.tests.integration.cluster.distribution;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.SimpleString;
@@ -34,7 +25,6 @@ import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.management.CoreNotificationType;
-import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
 import org.apache.activemq.artemis.core.postoffice.impl.BindingsImpl;
 import org.apache.activemq.artemis.core.server.group.GroupingHandler;
 import org.apache.activemq.artemis.core.server.group.UnproposalListener;
@@ -47,8 +37,17 @@ import org.apache.activemq.artemis.core.server.management.Notification;
 import org.apache.activemq.artemis.core.server.management.NotificationListener;
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
-import org.junit.After;
+import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class ClusteredGroupingTest extends ClusterTestBase
 {
@@ -1731,16 +1730,6 @@ public class ClusteredGroupingTest extends ClusterTestBase
       }
 
       verifyReceiveAllWithGroupIDRoundRobin(0, 30, 0, 1, 2);
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      closeAllConsumers();
-      closeAllSessionFactories();
-      closeAllServerLocatorsFactories();
-      super.tearDown();
    }
 
    public boolean isNetty()

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/MessageRedistributionTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/MessageRedistributionTest.java
@@ -475,8 +475,7 @@ public class MessageRedistributionTest extends ClusterTestBase
    {
       setupCluster(false);
 
-      AddressSettings setting = new AddressSettings();
-      setting.setRedeliveryDelay(10000);
+      AddressSettings setting = new AddressSettings().setRedeliveryDelay(10000);
       servers[0].getAddressSettingsRepository().addMatch("queues.testaddress", setting);
       servers[0].getAddressSettingsRepository().addMatch("queue0", setting);
       servers[1].getAddressSettingsRepository().addMatch("queue0", setting);
@@ -1072,10 +1071,10 @@ public class MessageRedistributionTest extends ClusterTestBase
    {
       setupCluster(false);
 
-      AddressSettings as = new AddressSettings();
-      as.setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
-      as.setPageSizeBytes(10000);
-      as.setMaxSizeBytes(20000);
+      AddressSettings as = new AddressSettings()
+              .setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE)
+              .setPageSizeBytes(10000)
+              .setMaxSizeBytes(20000);
 
       getServer(0).getAddressSettingsRepository().addMatch("queues.*", as);
       getServer(1).getAddressSettingsRepository().addMatch("queues.*", as);
@@ -1148,8 +1147,7 @@ public class MessageRedistributionTest extends ClusterTestBase
 
    protected void setRedistributionDelay(final long delay)
    {
-      AddressSettings as = new AddressSettings();
-      as.setRedistributionDelay(delay);
+      AddressSettings as = new AddressSettings().setRedistributionDelay(delay);
 
       getServer(0).getAddressSettingsRepository().addMatch("queues.*", as);
       getServer(1).getAddressSettingsRepository().addMatch("queues.*", as);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/MessageRedistributionWithDiscoveryTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/MessageRedistributionWithDiscoveryTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.cluster.distribution;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 
@@ -34,9 +34,9 @@ import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 
 public class MessageRedistributionWithDiscoveryTest extends ClusterTestBase
 {
-   protected final String groupAddress = ServiceTestBase.getUDPDiscoveryAddress();
+   protected final String groupAddress = ActiveMQTestBase.getUDPDiscoveryAddress();
 
-   protected final int groupPort = ServiceTestBase.getUDPDiscoveryPort();
+   protected final int groupPort = ActiveMQTestBase.getUDPDiscoveryPort();
 
    protected boolean isNetty()
    {
@@ -77,9 +77,9 @@ public class MessageRedistributionWithDiscoveryTest extends ClusterTestBase
                                    isNetty(),
                                    false);
 
-      AddressSettings setting = new AddressSettings();
-      setting.setRedeliveryDelay(0);
-      setting.setRedistributionDelay(0);
+      AddressSettings setting = new AddressSettings()
+              .setRedeliveryDelay(0)
+              .setRedistributionDelay(0);
 
       servers[server].getAddressSettingsRepository().addMatch("#", setting);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/SimpleSymmetricClusterTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/SimpleSymmetricClusterTest.java
@@ -17,8 +17,6 @@
 package org.apache.activemq.artemis.tests.integration.cluster.distribution;
 
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 public class SimpleSymmetricClusterTest extends ClusterTestBase
@@ -35,22 +33,6 @@ public class SimpleSymmetricClusterTest extends ClusterTestBase
    // Constructors --------------------------------------------------
 
    // Public --------------------------------------------------------
-
-   @Override
-   @Before
-   public void setUp() throws Exception
-   {
-      super.setUp();
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      log.info("#test tearDown " + loopNumber);
-      stopServers(0, 1, 2, 3, 4);
-      super.tearDown();
-   }
 
    public boolean isNetty()
    {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/SymmetricClusterTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/SymmetricClusterTest.java
@@ -15,11 +15,10 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.cluster.distribution;
-import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.junit.Before;
-import org.junit.After;
 
+import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -38,16 +37,6 @@ public class SymmetricClusterTest extends ClusterTestBase
       super.setUp();
 
       setupServers();
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      log.info("#test tearDown");
-      stopServers();
-
-      super.tearDown();
    }
 
    protected boolean isNetty()
@@ -153,7 +142,7 @@ public class SymmetricClusterTest extends ClusterTestBase
       }
       catch (Throwable e)
       {
-         System.out.println(ServiceTestBase.threadDump("SymmetricClusterTest::testStopAllStartAll"));
+         System.out.println(ActiveMQTestBase.threadDump("SymmetricClusterTest::testStopAllStartAll"));
          throw e;
       }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/SymmetricClusterWithBackupTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/SymmetricClusterWithBackupTest.java
@@ -18,7 +18,7 @@ package org.apache.activemq.artemis.tests.integration.cluster.distribution;
 
 import org.apache.activemq.artemis.core.config.ha.SharedStoreSlavePolicyConfiguration;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 
 public class SymmetricClusterWithBackupTest extends SymmetricClusterTest
@@ -121,7 +121,7 @@ public class SymmetricClusterWithBackupTest extends SymmetricClusterTest
       }
       catch (Throwable e)
       {
-         System.out.println(ServiceTestBase.threadDump("SymmetricClusterWithBackupTest::testStopAllStartAll"));
+         System.out.println(ActiveMQTestBase.threadDump("SymmetricClusterWithBackupTest::testStopAllStartAll"));
          throw e;
       }
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/SymmetricClusterWithDiscoveryTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/SymmetricClusterWithDiscoveryTest.java
@@ -18,15 +18,15 @@ package org.apache.activemq.artemis.tests.integration.cluster.distribution;
 
 
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 
 public class SymmetricClusterWithDiscoveryTest extends SymmetricClusterTest
 {
    private static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
 
-   protected final String groupAddress = ServiceTestBase.getUDPDiscoveryAddress();
+   protected final String groupAddress = ActiveMQTestBase.getUDPDiscoveryAddress();
 
-   protected final int groupPort = ServiceTestBase.getUDPDiscoveryPort();
+   protected final int groupPort = ActiveMQTestBase.getUDPDiscoveryPort();
 
    protected boolean isNetty()
    {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/AlmostLargeAsynchronousFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/AlmostLargeAsynchronousFailoverTest.java
@@ -36,10 +36,9 @@ public class AlmostLargeAsynchronousFailoverTest extends AsynchronousFailoverTes
    @Override
    protected ServerLocatorInternal getServerLocator() throws Exception
    {
-      ServerLocatorInternal locator = super.getServerLocator();
-      locator.setMinLargeMessageSize(1024 * 1024);
-      locator.setProducerWindowSize(10 * 1024);
-      return locator;
+      return (ServerLocatorInternal) super.getServerLocator()
+              .setMinLargeMessageSize(1024 * 1024)
+              .setProducerWindowSize(10 * 1024);
    }
 
    @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/AsynchronousFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/AsynchronousFailoverTest.java
@@ -162,11 +162,11 @@ public class AsynchronousFailoverTest extends FailoverTestBase
          for (int i = 0; i < numIts; i++)
          {
             AsynchronousFailoverTest.log.info("Iteration " + i);
-            ServerLocator locator = getServerLocator();
-            locator.setBlockOnNonDurableSend(true);
-            locator.setBlockOnDurableSend(true);
-            locator.setReconnectAttempts(-1);
-            locator.setConfirmationWindowSize(10 * 1024 * 1024);
+            ServerLocator locator = getServerLocator()
+                    .setBlockOnNonDurableSend(true)
+                    .setBlockOnDurableSend(true)
+                    .setReconnectAttempts(-1)
+                    .setConfirmationWindowSize(10 * 1024 * 1024);
             sf = createSessionFactoryAndWaitForTopology(locator, 2);
             try
             {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/AutomaticColocatedQuorumVoteTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/AutomaticColocatedQuorumVoteTest.java
@@ -32,7 +32,7 @@ import org.apache.activemq.artemis.core.config.ha.SharedStoreMasterPolicyConfigu
 import org.apache.activemq.artemis.core.config.ha.SharedStoreSlavePolicyConfiguration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -47,7 +47,7 @@ import java.util.Map;
 import java.util.Set;
 
 @RunWith(value = Parameterized.class)
-public class AutomaticColocatedQuorumVoteTest extends ServiceTestBase
+public class AutomaticColocatedQuorumVoteTest extends ActiveMQTestBase
 {
    private final boolean replicated;
 
@@ -309,7 +309,7 @@ public class AutomaticColocatedQuorumVoteTest extends ServiceTestBase
 
    private Configuration getConfiguration(String identity, boolean scaleDown, TransportConfiguration liveConnector, TransportConfiguration liveAcceptor, TransportConfiguration... otherLiveNodes) throws Exception
    {
-      Configuration configuration = createDefaultConfig()
+      Configuration configuration = createDefaultInVMConfig()
          .clearAcceptorConfigurations()
          .addAcceptorConfiguration(liveAcceptor)
          .addConnectorConfiguration(liveConnector.getName(), liveConnector)

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/BackupAuthenticationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/BackupAuthenticationTest.java
@@ -46,7 +46,7 @@ public class BackupAuthenticationTest extends FailoverTestBase
    @Test
    public void testPasswordSetting() throws Exception
    {
-      waitForServer(liveServer.getServer());
+      waitForServerToStart(liveServer.getServer());
       backupServer.start();
       assertTrue(latch.await(5, TimeUnit.SECONDS));
       /*

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/BackupSyncJournalTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/BackupSyncJournalTest.java
@@ -16,14 +16,6 @@
  */
 package org.apache.activemq.artemis.tests.integration.cluster.failover;
 
-import java.io.File;
-import java.io.RandomAccessFile;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.Pair;
 import org.apache.activemq.artemis.api.core.SimpleString;
@@ -45,9 +37,16 @@ import org.apache.activemq.artemis.tests.integration.cluster.util.BackupSyncDela
 import org.apache.activemq.artemis.tests.integration.cluster.util.TestableServer;
 import org.apache.activemq.artemis.tests.util.TransportConfigurationUtils;
 import org.apache.activemq.artemis.utils.UUID;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.io.File;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 public class BackupSyncJournalTest extends FailoverTestBase
 {
@@ -77,34 +76,13 @@ public class BackupSyncJournalTest extends FailoverTestBase
       startBackupServer = false;
       super.setUp();
       setNumberOfMessages(defaultNMsgs);
-      locator = getServerLocator();
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setReconnectAttempts(-1);
+      locator = (ServerLocatorInternal) getServerLocator()
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setReconnectAttempts(-1);
       sessionFactory = createSessionFactoryAndWaitForTopology(locator, 1);
       syncDelay = new BackupSyncDelay(backupServer, liveServer);
 
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      try
-      {
-         File dir = new File(backupServer.getServer()
-                                .getConfiguration()
-                                .getLargeMessagesDirectory());
-         deleteDirectory(dir);
-         dir = new File(liveServer.getServer()
-                           .getConfiguration()
-                           .getLargeMessagesDirectory());
-         deleteDirectory(dir);
-      }
-      finally
-      {
-         super.tearDown();
-      }
    }
 
    @Test
@@ -338,7 +316,7 @@ public class BackupSyncJournalTest extends FailoverTestBase
       assertFalse("must NOT be a backup", liveServer.getServer().getHAPolicy().isBackup());
       adaptLiveConfigForReplicatedFailBack(liveServer);
       liveServer.start();
-      waitForServer(liveServer.getServer());
+      waitForServerToStart(liveServer.getServer());
       assertTrue("must have become a backup", liveServer.getServer().getHAPolicy().isBackup());
 
       assertTrue("Fail-back must initialize live!", liveServer.getServer().waitForActivation(15, TimeUnit.SECONDS));

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/BackupSyncPagingTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/BackupSyncPagingTest.java
@@ -44,10 +44,10 @@ public class BackupSyncPagingTest extends BackupSyncJournalTest
             final NodeManager nodeManager, int id)
    {
       Map<String, AddressSettings> conf = new HashMap<String, AddressSettings>();
-      AddressSettings as = new AddressSettings();
-      as.setMaxSizeBytes(PAGE_MAX);
-      as.setPageSizeBytes(PAGE_SIZE);
-      as.setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
+      AddressSettings as = new AddressSettings()
+              .setMaxSizeBytes(PAGE_MAX)
+              .setPageSizeBytes(PAGE_SIZE)
+              .setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
       conf.put(ADDRESS.toString(), as);
       return createInVMFailoverServer(realFiles, configuration, PAGE_SIZE, PAGE_MAX, conf, nodeManager, id);
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailBackAutoTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailBackAutoTest.java
@@ -238,10 +238,10 @@ public class FailBackAutoTest extends FailoverTestBase
 
    private void createSessionFactory() throws Exception
    {
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setFailoverOnInitialConnection(true); // unnecessary?
-      locator.setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setFailoverOnInitialConnection(true) // unnecessary?
+              .setReconnectAttempts(-1);
       sf = createSessionFactoryAndWaitForTopology(locator, 2);
    }
 
@@ -260,10 +260,9 @@ public class FailBackAutoTest extends FailoverTestBase
       TransportConfiguration liveConnector = getConnectorTransportConfiguration(true);
       TransportConfiguration backupConnector = getConnectorTransportConfiguration(false);
 
-      backupConfig = super.createDefaultConfig()
+      backupConfig = super.createDefaultInVMConfig()
          .clearAcceptorConfigurations()
          .addAcceptorConfiguration(getAcceptorTransportConfiguration(false))
-         .setSecurityEnabled(false)
          .setHAPolicyConfiguration(new SharedStoreSlavePolicyConfiguration()
                                       .setFailbackDelay(1000)
                                       .setRestartBackup(true))
@@ -273,10 +272,9 @@ public class FailBackAutoTest extends FailoverTestBase
 
       backupServer = createTestableServer(backupConfig);
 
-      liveConfig = super.createDefaultConfig()
+      liveConfig = super.createDefaultInVMConfig()
          .clearAcceptorConfigurations()
          .addAcceptorConfiguration(getAcceptorTransportConfiguration(true))
-         .setSecurityEnabled(false)
          .setHAPolicyConfiguration(new SharedStoreMasterPolicyConfiguration()
                                       .setFailbackDelay(100))
          .addClusterConfiguration(basicClusterConnectionConfig(liveConnector.getName(), backupConnector.getName()))

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailBackManualTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailBackManualTest.java
@@ -52,10 +52,11 @@ public class FailBackManualTest extends FailoverTestBase
    @Test
    public void testNoAutoFailback() throws Exception
    {
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setFailoverOnInitialConnection(true);
-      locator.setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setFailoverOnInitialConnection(true)
+              .setReconnectAttempts(-1);
+
       ClientSessionFactoryInternal sf = createSessionFactoryAndWaitForTopology(locator, 2);
 
       ClientSession session = sendAndConsume(sf, true);
@@ -93,7 +94,7 @@ public class FailBackManualTest extends FailoverTestBase
 
       backupServer.crash();
 
-      waitForServer(liveServer.getServer());
+      waitForServerToStart(liveServer.getServer());
 
       assertTrue(liveServer.isStarted());
 
@@ -112,10 +113,9 @@ public class FailBackManualTest extends FailoverTestBase
       TransportConfiguration liveConnector = getConnectorTransportConfiguration(true);
       TransportConfiguration backupConnector = getConnectorTransportConfiguration(false);
 
-      backupConfig = super.createDefaultConfig()
+      backupConfig = super.createDefaultInVMConfig()
          .clearAcceptorConfigurations()
          .addAcceptorConfiguration(getAcceptorTransportConfiguration(false))
-         .setSecurityEnabled(false)
          .setHAPolicyConfiguration(new SharedStoreSlavePolicyConfiguration()
                                       .setAllowFailBack(false))
          .addConnectorConfiguration(liveConnector.getName(), liveConnector)
@@ -124,10 +124,9 @@ public class FailBackManualTest extends FailoverTestBase
 
       backupServer = createTestableServer(backupConfig);
 
-      liveConfig = super.createDefaultConfig()
+      liveConfig = super.createDefaultInVMConfig()
          .clearAcceptorConfigurations()
          .addAcceptorConfiguration(getAcceptorTransportConfiguration(true))
-         .setSecurityEnabled(false)
          .setHAPolicyConfiguration(new SharedStoreMasterPolicyConfiguration())
          .addConnectorConfiguration(liveConnector.getName(), liveConnector)
          .addConnectorConfiguration(backupConnector.getName(), backupConnector)

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailoverListenerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailoverListenerTest.java
@@ -150,10 +150,10 @@ public class FailoverListenerTest extends FailoverTestBase
    @Test
    public void testFailoverFailed() throws Exception
    {
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setFailoverOnInitialConnection(true); // unnecessary?
-      locator.setReconnectAttempts(1);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setFailoverOnInitialConnection(true) // unnecessary?
+              .setReconnectAttempts(1);
       sf = createSessionFactoryAndWaitForTopology(locator, 2);
 
       //make sure no backup server is running
@@ -179,10 +179,10 @@ public class FailoverListenerTest extends FailoverTestBase
 
    private void createSessionFactory(int members) throws Exception
    {
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setFailoverOnInitialConnection(true); // unnecessary?
-      locator.setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setFailoverOnInitialConnection(true) // unnecessary?
+              .setReconnectAttempts(-1);
       sf = createSessionFactoryAndWaitForTopology(locator, members);
    }
 
@@ -200,10 +200,9 @@ public class FailoverListenerTest extends FailoverTestBase
       TransportConfiguration liveConnector = getConnectorTransportConfiguration(true);
       TransportConfiguration backupConnector = getConnectorTransportConfiguration(false);
 
-      backupConfig = super.createDefaultConfig()
+      backupConfig = super.createDefaultInVMConfig()
          .clearAcceptorConfigurations()
          .addAcceptorConfiguration(getAcceptorTransportConfiguration(false))
-         .setSecurityEnabled(false)
          .setHAPolicyConfiguration(new SharedStoreSlavePolicyConfiguration()
                                       .setFailbackDelay(1000))
          .addConnectorConfiguration(liveConnector.getName(), liveConnector)
@@ -212,10 +211,9 @@ public class FailoverListenerTest extends FailoverTestBase
 
       backupServer = createTestableServer(backupConfig);
 
-      liveConfig = super.createDefaultConfig()
+      liveConfig = super.createDefaultInVMConfig()
          .clearAcceptorConfigurations()
          .addAcceptorConfiguration(getAcceptorTransportConfiguration(true))
-         .setSecurityEnabled(false)
          .setHAPolicyConfiguration(new SharedStoreMasterPolicyConfiguration()
                                       .setFailbackDelay(1000))
          .addClusterConfiguration(basicClusterConnectionConfig(liveConnector.getName(), backupConnector.getName()))

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailoverOnFlowControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailoverOnFlowControlTest.java
@@ -45,12 +45,12 @@ public class FailoverOnFlowControlTest extends FailoverTestBase
    @Test
    public void testOverflowSend() throws Exception
    {
-      ServerLocator locator = getServerLocator();
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setReconnectAttempts(-1);
-      locator.setProducerWindowSize(1000);
-      locator.setRetryInterval(123);
+      ServerLocator locator = getServerLocator()
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setReconnectAttempts(-1)
+              .setProducerWindowSize(1000)
+              .setRetryInterval(123);
       final ArrayList<ClientSession> sessionList = new ArrayList<ClientSession>();
       Interceptor interceptorClient = new Interceptor()
       {
@@ -126,10 +126,9 @@ public class FailoverOnFlowControlTest extends FailoverTestBase
    @Override
    protected ServerLocatorInternal getServerLocator() throws Exception
    {
-      ServerLocatorInternal locator = super.getServerLocator();
-      locator.setMinLargeMessageSize(1024 * 1024);
-      locator.setProducerWindowSize(10 * 1024);
-      return locator;
+      return (ServerLocatorInternal) super.getServerLocator()
+              .setMinLargeMessageSize(1024 * 1024)
+              .setProducerWindowSize(10 * 1024);
    }
 
    @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailoverTest.java
@@ -111,11 +111,12 @@ public class FailoverTest extends FailoverTestBase
    @Test
    public void testTimeoutOnFailover() throws Exception
    {
-      locator.setCallTimeout(1000);
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setAckBatchSize(0);
-      locator.setReconnectAttempts(-1);
+      locator.setCallTimeout(1000)
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setAckBatchSize(0)
+              .setReconnectAttempts(-1);
+
       ((InVMNodeManager) nodeManager).failoverPause = 500;
 
       ClientSessionFactoryInternal sf1 = (ClientSessionFactoryInternal) createSessionFactory(locator);
@@ -192,13 +193,14 @@ public class FailoverTest extends FailoverTestBase
    @Test
    public void testTimeoutOnFailoverConsume() throws Exception
    {
-      locator.setCallTimeout(5000);
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setAckBatchSize(0);
-      locator.setBlockOnAcknowledge(true);
-      locator.setReconnectAttempts(-1);
-      locator.setAckBatchSize(0);
+      locator.setCallTimeout(5000)
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setAckBatchSize(0)
+              .setBlockOnAcknowledge(true)
+              .setReconnectAttempts(-1)
+              .setAckBatchSize(0);
+
       ((InVMNodeManager) nodeManager).failoverPause = 5000L;
 
       ClientSessionFactoryInternal sf1 = (ClientSessionFactoryInternal) createSessionFactory(locator);
@@ -266,14 +268,15 @@ public class FailoverTest extends FailoverTestBase
    @Test
    public void testTimeoutOnFailoverConsumeBlocked() throws Exception
    {
-      locator.setCallTimeout(5000);
-      locator.setBlockOnNonDurableSend(true);
-      locator.setConsumerWindowSize(0);
-      locator.setBlockOnDurableSend(true);
-      locator.setAckBatchSize(0);
-      locator.setBlockOnAcknowledge(true);
-      locator.setReconnectAttempts(-1);
-      locator.setAckBatchSize(0);
+      locator.setCallTimeout(5000)
+              .setBlockOnNonDurableSend(true)
+              .setConsumerWindowSize(0)
+              .setBlockOnDurableSend(true)
+              .setAckBatchSize(0)
+              .setBlockOnAcknowledge(true)
+              .setReconnectAttempts(-1)
+              .setAckBatchSize(0);
+
       ((InVMNodeManager) nodeManager).failoverPause = 5000L;
 
       ClientSessionFactoryInternal sf1 = (ClientSessionFactoryInternal) createSessionFactory(locator);
@@ -387,11 +390,12 @@ public class FailoverTest extends FailoverTestBase
    @Test
    public void testTimeoutOnFailoverTransactionCommit() throws Exception
    {
-      locator.setCallTimeout(2000);
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setAckBatchSize(0);
-      locator.setReconnectAttempts(-1);
+      locator.setCallTimeout(2000)
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setAckBatchSize(0)
+              .setReconnectAttempts(-1);
+
       ((InVMNodeManager) nodeManager).failoverPause = 5000L;
 
       ClientSessionFactoryInternal sf1 = (ClientSessionFactoryInternal) createSessionFactory(locator);
@@ -442,11 +446,12 @@ public class FailoverTest extends FailoverTestBase
    @Test
    public void testTimeoutOnFailoverTransactionRollback() throws Exception
    {
-      locator.setCallTimeout(2000);
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setAckBatchSize(0);
-      locator.setReconnectAttempts(-1);
+      locator.setCallTimeout(2000)
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setAckBatchSize(0)
+              .setReconnectAttempts(-1);
+
       ((InVMNodeManager) nodeManager).failoverPause = 5000L;
 
       ClientSessionFactoryInternal sf1 = (ClientSessionFactoryInternal) createSessionFactory(locator);
@@ -499,10 +504,10 @@ public class FailoverTest extends FailoverTestBase
    @Test
    public void testNonTransactedWithZeroConsumerWindowSize() throws Exception
    {
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setAckBatchSize(0);
-      locator.setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setAckBatchSize(0)
+              .setReconnectAttempts(-1);
 
       createClientSessionFactory();
 
@@ -773,9 +778,9 @@ public class FailoverTest extends FailoverTestBase
 
    protected void createSessionFactory() throws Exception
    {
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setReconnectAttempts(-1);
 
       sf = createSessionFactoryAndWaitForTopology(locator, 2);
    }
@@ -865,10 +870,10 @@ public class FailoverTest extends FailoverTestBase
    @Test
    public void testFailoverOnInitialConnection() throws Exception
    {
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setFailoverOnInitialConnection(true);
-      locator.setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setFailoverOnInitialConnection(true)
+              .setReconnectAttempts(-1);
 
       sf = createSessionFactoryAndWaitForTopology(locator, 2);
 
@@ -1542,9 +1547,9 @@ public class FailoverTest extends FailoverTestBase
    public void testCreateNewFactoryAfterFailover() throws Exception
    {
       this.disableCheckThread();
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setFailoverOnInitialConnection(true);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setFailoverOnInitialConnection(true);
       sf = createSessionFactoryAndWaitForTopology(locator, 2);
 
       ClientSession session = sendAndConsume(sf, true);
@@ -1757,10 +1762,11 @@ public class FailoverTest extends FailoverTestBase
    @Test
    public void testFailThenReceiveMoreMessagesAfterFailover2() throws Exception
    {
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
-      locator.setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true)
+              .setReconnectAttempts(-1);
+
       sf = createSessionFactoryAndWaitForTopology(locator, 2);
 
       ClientSession session = createSession(sf, true, true, 0);
@@ -1818,10 +1824,11 @@ public class FailoverTest extends FailoverTestBase
 
    private void doSimpleSendAfterFailover(final boolean durable, final boolean temporary) throws Exception
    {
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
-      locator.setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true)
+              .setReconnectAttempts(-1);
+
       sf = createSessionFactoryAndWaitForTopology(locator, 2);
 
       ClientSession session = createSession(sf, true, true, 0);
@@ -1851,10 +1858,11 @@ public class FailoverTest extends FailoverTestBase
    @Test
    public void testForceBlockingReturn() throws Exception
    {
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
-      locator.setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true)
+              .setReconnectAttempts(-1);
+
       createClientSessionFactory();
 
       // Add an interceptor to delay the send method so we can get time to cause failover before it returns
@@ -1910,11 +1918,10 @@ public class FailoverTest extends FailoverTestBase
    @Test
    public void testCommitOccurredUnblockedAndResendNoDuplicates() throws Exception
    {
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setReconnectAttempts(-1);
-
-      locator.setBlockOnAcknowledge(true);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setReconnectAttempts(-1)
+              .setBlockOnAcknowledge(true);
 
       sf = createSessionFactoryAndWaitForTopology(locator, 2);
 
@@ -2069,10 +2076,11 @@ public class FailoverTest extends FailoverTestBase
    @Test
    public void testCommitDidNotOccurUnblockedAndResend() throws Exception
    {
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
-      locator.setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true)
+              .setReconnectAttempts(-1);
+
       sf = createSessionFactoryAndWaitForTopology(locator, 2);
 
       final ClientSession session = createSession(sf, false, false);
@@ -2292,10 +2300,11 @@ public class FailoverTest extends FailoverTestBase
    @Test
    public void testLiveAndBackupBackupComesBackNewFactory() throws Exception
    {
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setFailoverOnInitialConnection(true);
-      locator.setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setFailoverOnInitialConnection(true)
+              .setReconnectAttempts(-1);
+
       sf = createSessionFactoryAndWaitForTopology(locator, 2);
 
       ClientSession session = sendAndConsume(sf, true);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/GroupingFailoverTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/GroupingFailoverTestBase.java
@@ -29,7 +29,7 @@ import org.apache.activemq.artemis.core.config.ha.ReplicatedPolicyConfiguration;
 import org.apache.activemq.artemis.core.server.group.impl.GroupingHandlerConfiguration;
 import org.apache.activemq.artemis.core.server.impl.SharedNothingBackupActivation;
 import org.apache.activemq.artemis.tests.integration.cluster.distribution.ClusterTestBase;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 
 public abstract class GroupingFailoverTestBase extends ClusterTestBase
@@ -129,7 +129,7 @@ public abstract class GroupingFailoverTestBase extends ClusterTestBase
 
          Thread.sleep(10);
       }
-      while (System.currentTimeMillis() - start < ServiceTestBase.WAIT_TIMEOUT);
+      while (System.currentTimeMillis() - start < ActiveMQTestBase.WAIT_TIMEOUT);
 
       throw new IllegalStateException("Timed out waiting for backup announce");
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/LargeMessageFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/LargeMessageFailoverTest.java
@@ -17,7 +17,6 @@
 package org.apache.activemq.artemis.tests.integration.cluster.failover;
 
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
-import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.client.impl.ServerLocatorInternal;
 import org.junit.Test;
 
@@ -54,9 +53,8 @@ public class LargeMessageFailoverTest extends FailoverTest
    @Override
    protected ServerLocatorInternal getServerLocator() throws Exception
    {
-      ServerLocator locator = super.getServerLocator();
-      locator.setMinLargeMessageSize(MIN_LARGE_MESSAGE);
-      return (ServerLocatorInternal)locator;
+      return (ServerLocatorInternal) super.getServerLocator()
+              .setMinLargeMessageSize(MIN_LARGE_MESSAGE);
    }
 
    /**

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/LiveToLiveFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/LiveToLiveFailoverTest.java
@@ -32,7 +32,6 @@ import org.apache.activemq.artemis.tests.util.TransportConfigurationUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -57,7 +56,7 @@ public class LiveToLiveFailoverTest extends FailoverTest
       TransportConfiguration liveConnector0 = getConnectorTransportConfiguration(true, 0);
       TransportConfiguration liveConnector1 = getConnectorTransportConfiguration(true, 1);
 
-      backupConfig = super.createDefaultConfig(1, new HashMap<String, Object>(), INVM_ACCEPTOR_FACTORY)
+      backupConfig = super.createDefaultInVMConfig(1)
          .clearAcceptorConfigurations()
          .addAcceptorConfiguration(getAcceptorTransportConfiguration(true, 1))
          .setHAPolicyConfiguration(new ColocatedPolicyConfiguration()
@@ -73,7 +72,7 @@ public class LiveToLiveFailoverTest extends FailoverTest
 
       backupServer = createColocatedTestableServer(backupConfig, nodeManager1, nodeManager0, 1);
 
-      liveConfig = super.createDefaultConfig(0, new HashMap<String, Object>(), INVM_ACCEPTOR_FACTORY)
+      liveConfig = super.createDefaultInVMConfig(0)
          .clearAcceptorConfigurations()
          .addAcceptorConfiguration(getAcceptorTransportConfiguration(true, 0))
          .setHAPolicyConfiguration(new ColocatedPolicyConfiguration()
@@ -204,9 +203,9 @@ public class LiveToLiveFailoverTest extends FailoverTest
 
    protected void createSessionFactory() throws Exception
    {
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setReconnectAttempts(-1);
 
       sf = createSessionFactoryAndWaitForTopology(locator, getConnectorTransportConfiguration(true, 0),  2);
 
@@ -264,10 +263,10 @@ public class LiveToLiveFailoverTest extends FailoverTest
    @Test
    public void testFailoverOnInitialConnection() throws Exception
    {
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setFailoverOnInitialConnection(true);
-      locator.setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setFailoverOnInitialConnection(true)
+              .setReconnectAttempts(-1);
 
       sf = createSessionFactoryAndWaitForTopology(locator, 2);
 
@@ -296,9 +295,9 @@ public class LiveToLiveFailoverTest extends FailoverTest
    public void testCreateNewFactoryAfterFailover() throws Exception
    {
       this.disableCheckThread();
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setFailoverOnInitialConnection(true);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setFailoverOnInitialConnection(true);
       sf = createSessionFactoryAndWaitForTopology(locator, 2);
 
       ClientSession session = sendAndConsume(sf, true);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/MultipleBackupsFailoverTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/MultipleBackupsFailoverTestBase.java
@@ -29,14 +29,14 @@ import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
 import org.apache.activemq.artemis.tests.integration.cluster.util.TestableServer;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.client.impl.ClientSessionFactoryInternal;
 import org.apache.activemq.artemis.core.client.impl.ServerLocatorImpl;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.jms.client.ActiveMQTextMessage;
 import org.junit.Assert;
 
-public abstract class MultipleBackupsFailoverTestBase extends ServiceTestBase
+public abstract class MultipleBackupsFailoverTestBase extends ActiveMQTestBase
 {
    IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/NettyFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/NettyFailoverTest.java
@@ -53,12 +53,12 @@ public class NettyFailoverTest extends FailoverTest
       params.put(TransportConstants.HOST_PROP_NAME, "127.0.0.1");
       TransportConfiguration tc = createTransportConfiguration(true, false, params);
 
-      ServerLocator locator = addServerLocator(ActiveMQClient.createServerLocatorWithHA(tc));
+      ServerLocator locator = addServerLocator(ActiveMQClient.createServerLocatorWithHA(tc))
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true)
+              .setReconnectAttempts(-1);
 
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
-      locator.setReconnectAttempts(-1);
       ClientSessionFactoryInternal sf = createSessionFactoryAndWaitForTopology(locator, 2);
 
       ClientSession session = createSession(sf, true, true, 0);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/PagingFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/PagingFailoverTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.activemq.artemis.tests.integration.cluster.failover;
 
-import java.util.HashMap;
-
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
@@ -25,18 +23,19 @@ import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.tests.integration.cluster.util.SameProcessActiveMQServer;
-import org.apache.activemq.artemis.tests.integration.cluster.util.TestableServer;
-import org.apache.activemq.artemis.tests.util.TransportConfigurationUtils;
 import org.apache.activemq.artemis.core.client.impl.ClientSessionFactoryInternal;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
-import org.junit.After;
+import org.apache.activemq.artemis.tests.integration.cluster.util.SameProcessActiveMQServer;
+import org.apache.activemq.artemis.tests.integration.cluster.util.TestableServer;
+import org.apache.activemq.artemis.tests.util.TransportConfigurationUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.HashMap;
 
 /**
  * A PagingFailoverTest
@@ -69,20 +68,11 @@ public class PagingFailoverTest extends FailoverTestBase
       locator = getServerLocator();
    }
 
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      addClientSession(session);
-      super.tearDown();
-   }
-
    @Test
    public void testPageFailBeforeConsume() throws Exception
    {
       internalTestPage(false, true);
    }
-
 
    @Test
    public void testPage() throws Exception
@@ -104,12 +94,12 @@ public class PagingFailoverTest extends FailoverTestBase
 
    public void internalTestPage(final boolean transacted, final boolean failBeforeConsume) throws Exception
    {
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setReconnectAttempts(-1);
 
       sf = createSessionFactoryAndWaitForTopology(locator, 2);
-      session = sf.createSession(!transacted, !transacted, 0);
+      session = addClientSession(sf.createSession(!transacted, !transacted, 0));
 
       session.createQueue(PagingFailoverTest.ADDRESS, PagingFailoverTest.ADDRESS, true);
 
@@ -192,9 +182,9 @@ public class PagingFailoverTest extends FailoverTestBase
    @Test
    public void testExpireMessage() throws Exception
    {
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setReconnectAttempts(-1);
 
       ClientSessionFactoryInternal sf = createSessionFactoryAndWaitForTopology(locator, 2);
       session = sf.createSession(true, true, 0);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/QuorumVoteServerConnectTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/QuorumVoteServerConnectTest.java
@@ -17,7 +17,7 @@
 package org.apache.activemq.artemis.tests.integration.cluster.failover;
 
 
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.server.cluster.qourum.BooleanVote;
 import org.apache.activemq.artemis.core.server.cluster.qourum.QuorumVoteServerConnect;
 import org.apache.activemq.artemis.tests.integration.server.FakeStorageManager;
@@ -29,7 +29,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 @RunWith(Parameterized.class)
-public class QuorumVoteServerConnectTest extends ServiceTestBase
+public class QuorumVoteServerConnectTest extends ActiveMQTestBase
 {
 
    private final int size;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/ReplicatedDistributionTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/ReplicatedDistributionTest.java
@@ -16,24 +16,23 @@
  */
 package org.apache.activemq.artemis.tests.integration.cluster.failover;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 import org.apache.activemq.artemis.api.core.ActiveMQNotConnectedException;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
-import org.apache.activemq.artemis.tests.integration.cluster.distribution.ClusterTestBase;
-import org.apache.activemq.artemis.tests.util.CountDownSessionFailureListener;
 import org.apache.activemq.artemis.core.client.impl.ClientSessionInternal;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
-import org.junit.After;
+import org.apache.activemq.artemis.tests.integration.cluster.distribution.ClusterTestBase;
+import org.apache.activemq.artemis.tests.util.CountDownSessionFailureListener;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 public class ReplicatedDistributionTest extends ClusterTestBase
 {
@@ -199,8 +198,7 @@ public class ReplicatedDistributionTest extends ClusterTestBase
       setupClusterConnectionWithBackups("test", address, false, 1, true, 3, new int[]{2, 1});
       setupClusterConnectionWithBackups("test", address, false, 1, true, 2, new int[]{3});
 
-      AddressSettings as = new AddressSettings();
-      as.setRedistributionDelay(0);
+      AddressSettings as = new AddressSettings().setRedistributionDelay(0);
 
       for (int i : new int[]{1, 2, 3})
       {
@@ -220,27 +218,6 @@ public class ReplicatedDistributionTest extends ClusterTestBase
       consThree = sessionThree.createConsumer(ReplicatedDistributionTest.ADDRESS);
 
       sessionThree.start();
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      try
-      {
-         if (consThree != null)
-            consThree.close();
-         if (producer != null)
-            producer.close();
-         if (sessionOne != null)
-            sessionOne.close();
-         if (sessionThree != null)
-            sessionThree.close();
-      }
-      finally
-      {
-         super.tearDown();
-      }
    }
 
    @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/ReplicatedFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/ReplicatedFailoverTest.java
@@ -75,7 +75,7 @@ public class ReplicatedFailoverTest extends FailoverTest
 
          waitForRemoteBackupSynchronization(backupServer.getServer());
 
-         waitForServer(liveServer.getServer());
+         waitForServerToStart(liveServer.getServer());
 
          session = createSession(sf, true, true);
 
@@ -91,7 +91,7 @@ public class ReplicatedFailoverTest extends FailoverTest
 
          waitForRemoteBackupSynchronization(backupServer.getServer());
 
-         waitForServer(liveServer.getServer());
+         waitForServerToStart(liveServer.getServer());
 
          session = createSession(sf, true, true);
 
@@ -105,7 +105,7 @@ public class ReplicatedFailoverTest extends FailoverTest
 
          waitForRemoteBackupSynchronization(liveServer.getServer());
 
-         waitForServer(liveServer.getServer());
+         waitForServerToStart(liveServer.getServer());
 
          //this will give the backup time to stop fully
          waitForServerToStop(backupServer.getServer());

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/ReplicatedMultipleServerFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/ReplicatedMultipleServerFailoverTest.java
@@ -162,7 +162,7 @@ public class ReplicatedMultipleServerFailoverTest extends MultipleServerFailover
    }
 
    @Override
-   public boolean useNetty()
+   public boolean isNetty()
    {
       return false;
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/ReplicatedWithDelayFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/ReplicatedWithDelayFailoverTest.java
@@ -36,7 +36,7 @@ public class ReplicatedWithDelayFailoverTest extends ReplicatedFailoverTest
       super.setUp();
       syncDelay = new BackupSyncDelay(backupServer, liveServer);
       backupServer.start();
-      waitForServer(backupServer.getServer());
+      waitForServerToStart(backupServer.getServer());
    }
 
    @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/SecurityFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/SecurityFailoverTest.java
@@ -94,7 +94,7 @@ public class SecurityFailoverTest extends FailoverTest
       TransportConfiguration liveConnector = getConnectorTransportConfiguration(true);
       TransportConfiguration backupConnector = getConnectorTransportConfiguration(false);
 
-      backupConfig = super.createDefaultConfig()
+      backupConfig = super.createDefaultInVMConfig()
          .clearAcceptorConfigurations()
          .addAcceptorConfiguration(getAcceptorTransportConfiguration(false))
          .setSecurityEnabled(true)
@@ -108,7 +108,7 @@ public class SecurityFailoverTest extends FailoverTest
       ActiveMQSecurityManagerImpl securityManager = installSecurity(backupServer);
       securityManager.getConfiguration().setDefaultUser(null);
 
-      liveConfig = super.createDefaultConfig()
+      liveConfig = super.createDefaultInVMConfig()
          .clearAcceptorConfigurations()
          .addAcceptorConfiguration(getAcceptorTransportConfiguration(true))
          .setSecurityEnabled(true)

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/MultiThreadRandomReattachTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/MultiThreadRandomReattachTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.activemq.artemis.tests.integration.cluster.reattach;
 
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.core.config.Configuration;
 
@@ -29,12 +28,10 @@ public class MultiThreadRandomReattachTest extends MultiThreadRandomReattachTest
    @Override
    protected void start() throws Exception
    {
-      Configuration liveConf = createDefaultConfig()
-         .setSecurityEnabled(false)
-         .addAcceptorConfiguration(new TransportConfiguration(INVM_ACCEPTOR_FACTORY));
-      liveServer = createServer(false, liveConf);
-      liveServer.start();
-      waitForServer(liveServer);
+      Configuration liveConf = createDefaultInVMConfig();
+      server = createServer(false, liveConf);
+      server.start();
+      waitForServerToStart(server);
    }
 
    @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/MultiThreadRandomReattachTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/MultiThreadRandomReattachTestBase.java
@@ -15,23 +15,8 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.cluster.reattach;
+
 import org.apache.activemq.artemis.api.core.ActiveMQException;
-import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.junit.Before;
-import org.junit.After;
-
-import org.junit.Test;
-
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
-import org.junit.Assert;
-
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
@@ -44,7 +29,18 @@ import org.apache.activemq.artemis.core.remoting.impl.invm.InVMRegistry;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.jms.client.ActiveMQBytesMessage;
 import org.apache.activemq.artemis.jms.client.ActiveMQTextMessage;
+import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 public abstract class MultiThreadRandomReattachTestBase extends MultiThreadReattachSupportTestBase
 {
@@ -61,7 +57,7 @@ public abstract class MultiThreadRandomReattachTestBase extends MultiThreadReatt
    // Attributes ----------------------------------------------------
    protected static final SimpleString ADDRESS = new SimpleString("FailoverTestAddress");
 
-   protected ActiveMQServer liveServer;
+   protected ActiveMQServer server;
 
    // Static --------------------------------------------------------
 
@@ -1264,26 +1260,6 @@ public abstract class MultiThreadRandomReattachTestBase extends MultiThreadReatt
       return 10;
    }
 
-   @Override
-   @Before
-   public void setUp() throws Exception
-   {
-      super.setUp();
-
-      log.info("************ Starting test " + getName());
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      ServiceTestBase.stopComponent(liveServer);
-
-      liveServer = null;
-
-      super.tearDown();
-   }
-
    // Private -------------------------------------------------------
 
    private void runTestMultipleThreads(final RunnableT runnable,
@@ -1308,16 +1284,16 @@ public abstract class MultiThreadRandomReattachTestBase extends MultiThreadReatt
    @Override
    protected ServerLocator createLocator() throws Exception
    {
-      ServerLocator locator = createInVMNonHALocator();
-      locator.setReconnectAttempts(-1);
-      locator.setConfirmationWindowSize(1024 * 1024);
+      ServerLocator locator = createInVMNonHALocator()
+              .setReconnectAttempts(-1)
+              .setConfirmationWindowSize(1024 * 1024);
       return locator;
    }
 
    @Override
    protected void stop() throws Exception
    {
-      ServiceTestBase.stopComponent(liveServer);
+      ActiveMQTestBase.stopComponent(server);
 
       System.gc();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/MultiThreadReattachSupportTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/MultiThreadReattachSupportTestBase.java
@@ -25,7 +25,7 @@ import org.apache.activemq.artemis.core.client.impl.ClientSessionInternal;
 import org.apache.activemq.artemis.core.protocol.core.impl.RemotingConnectionImpl;
 import org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnector;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
 
-public abstract class MultiThreadReattachSupportTestBase extends ServiceTestBase
+public abstract class MultiThreadReattachSupportTestBase extends ActiveMQTestBase
 {
 
    private final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
@@ -120,8 +120,8 @@ public abstract class MultiThreadReattachSupportTestBase extends ServiceTestBase
 
                   // Case a failure happened here, it should print the Thread dump
                   // Sending it to System.out, as it would show on the Tests report
-                  System.out.println(ServiceTestBase.threadDump(" - fired by MultiThreadRandomReattachTestBase::runTestMultipleThreads (" + t.getLocalizedMessage() +
-                                                             ")"));
+                  System.out.println(ActiveMQTestBase.threadDump(" - fired by MultiThreadRandomReattachTestBase::runTestMultipleThreads (" + t.getLocalizedMessage() +
+                                                                         ")"));
                }
             }
          }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/NettyMultiThreadRandomReattachTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/NettyMultiThreadRandomReattachTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.activemq.artemis.tests.integration.cluster.reattach;
 
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.config.Configuration;
 
@@ -25,24 +24,19 @@ public class NettyMultiThreadRandomReattachTest extends MultiThreadRandomReattac
    @Override
    protected void start() throws Exception
    {
-      Configuration liveConf = createDefaultConfig()
-         .setJMXManagementEnabled(false)
-         .setSecurityEnabled(false)
-         .clearAcceptorConfigurations()
-         .addAcceptorConfiguration(new TransportConfiguration(NETTY_ACCEPTOR_FACTORY));
-      liveServer = createServer(false, liveConf);
-      liveServer.start();
-      waitForServer(liveServer);
+      Configuration liveConf = createDefaultNettyConfig();
+      server = createServer(false, liveConf);
+      server.start();
+      waitForServerToStart(server);
    }
 
    @Override
    protected ServerLocator createLocator() throws Exception
    {
-      ServerLocator locator = createNettyNonHALocator();
-      locator.setReconnectAttempts(-1);
-      locator.setConfirmationWindowSize(1024 * 1024);
-      locator.setAckBatchSize(0);
-      return  locator;
+      return createNettyNonHALocator()
+              .setReconnectAttempts(-1)
+              .setConfirmationWindowSize(1024 * 1024)
+              .setAckBatchSize(0);
    }
 
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/OrderReattachTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/OrderReattachTest.java
@@ -40,9 +40,9 @@ import org.apache.activemq.artemis.core.protocol.core.impl.RemotingConnectionImp
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.jms.client.ActiveMQTextMessage;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 
-public class OrderReattachTest extends ServiceTestBase
+public class OrderReattachTest extends ActiveMQTestBase
 {
    // Constants -----------------------------------------------------
 
@@ -70,11 +70,12 @@ public class OrderReattachTest extends ServiceTestBase
       server = createServer(false, isNetty);
 
       server.start();
-      ServerLocator locator = createFactory(isNetty);
-      locator.setReconnectAttempts(-1);
-      locator.setConfirmationWindowSize(1024 * 1024);
-      locator.setBlockOnNonDurableSend(false);
-      locator.setBlockOnAcknowledge(false);
+      ServerLocator locator = createFactory(isNetty)
+              .setReconnectAttempts(-1)
+              .setConfirmationWindowSize(1024 * 1024)
+              .setBlockOnNonDurableSend(false)
+              .setBlockOnAcknowledge(false);
+
       ClientSessionFactory sf = createSessionFactory(locator);
 
       final ClientSession session = sf.createSession(false, true, true);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/ReattachTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/ReattachTest.java
@@ -16,11 +16,6 @@
  */
 package org.apache.activemq.artemis.tests.integration.cluster.reattach;
 
-import java.util.Timer;
-import java.util.TimerTask;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
 import org.apache.activemq.artemis.api.core.ActiveMQNotConnectedException;
@@ -33,28 +28,32 @@ import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.api.core.client.SessionFailureListener;
-import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
 import org.apache.activemq.artemis.core.client.impl.ClientSessionFactoryInternal;
 import org.apache.activemq.artemis.core.client.impl.ClientSessionInternal;
 import org.apache.activemq.artemis.core.protocol.core.Packet;
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionProducerCreditsMessage;
 import org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnector;
-import org.apache.activemq.artemis.core.remoting.impl.invm.InVMRegistry;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.jms.client.ActiveMQTextMessage;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
+import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ReattachTest extends ServiceTestBase
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ReattachTest extends ActiveMQTestBase
 {
    private static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
 
    private static final SimpleString ADDRESS = new SimpleString("FailoverTestAddress");
-   private ActiveMQServer service;
+   private ActiveMQServer server;
    private ServerLocator locator;
 
    /*
@@ -69,10 +68,11 @@ public class ReattachTest extends ServiceTestBase
 
       final int reconnectAttempts = 1;
 
-      locator.setRetryInterval(retryInterval);
-      locator.setRetryIntervalMultiplier(retryMultiplier);
-      locator.setReconnectAttempts(reconnectAttempts);
-      locator.setConfirmationWindowSize(1024 * 1024);
+      locator.setRetryInterval(retryInterval)
+              .setRetryIntervalMultiplier(retryMultiplier)
+              .setReconnectAttempts(reconnectAttempts)
+              .setConfirmationWindowSize(1024 * 1024);
+
       ClientSessionFactoryInternal sf = (ClientSessionFactoryInternal) createSessionFactory(locator);
 
       ClientSession session = sf.createSession(false, true, true);
@@ -146,11 +146,11 @@ public class ReattachTest extends ServiceTestBase
 
       final int reconnectAttempts = 1;
 
-      locator.setRetryInterval(retryInterval);
-      locator.setRetryIntervalMultiplier(retryMultiplier);
-      locator.setReconnectAttempts(reconnectAttempts);
-      locator.setConfirmationWindowSize(1024 * 1024);
-      locator.setProducerWindowSize(1000);
+      locator.setRetryInterval(retryInterval)
+              .setRetryIntervalMultiplier(retryMultiplier)
+              .setReconnectAttempts(reconnectAttempts)
+              .setConfirmationWindowSize(1024 * 1024)
+              .setProducerWindowSize(1000);
 
       final AtomicInteger count = new AtomicInteger(0);
 
@@ -219,10 +219,11 @@ public class ReattachTest extends ServiceTestBase
 
       final int reconnectAttempts = -1;
 
-      locator.setRetryInterval(retryInterval);
-      locator.setRetryIntervalMultiplier(retryMultiplier);
-      locator.setReconnectAttempts(reconnectAttempts);
-      locator.setConfirmationWindowSize(1024 * 1024);
+      locator.setRetryInterval(retryInterval)
+              .setRetryIntervalMultiplier(retryMultiplier)
+              .setReconnectAttempts(reconnectAttempts)
+              .setConfirmationWindowSize(1024 * 1024);
+
       ClientSessionFactoryInternal sf = (ClientSessionFactoryInternal) createSessionFactory(locator);
 
       ClientSession session = sf.createSession(false, true, true);
@@ -310,10 +311,11 @@ public class ReattachTest extends ServiceTestBase
 
       final long asyncFailDelay = 2000;
 
-      locator.setRetryInterval(retryInterval);
-      locator.setRetryIntervalMultiplier(retryMultiplier);
-      locator.setReconnectAttempts(reconnectAttempts);
-      locator.setConfirmationWindowSize(1024 * 1024);
+      locator.setRetryInterval(retryInterval)
+              .setRetryIntervalMultiplier(retryMultiplier)
+              .setReconnectAttempts(reconnectAttempts)
+              .setConfirmationWindowSize(1024 * 1024);
+
       ClientSessionFactoryInternal sf = (ClientSessionFactoryInternal) createSessionFactory(locator);
 
       ClientSession session = sf.createSession(false, true, true);
@@ -432,10 +434,11 @@ public class ReattachTest extends ServiceTestBase
 
       final int reconnectAttempts = 3;
 
-      locator.setRetryInterval(retryInterval);
-      locator.setRetryIntervalMultiplier(retryMultiplier);
-      locator.setReconnectAttempts(reconnectAttempts);
-      locator.setConfirmationWindowSize(1024 * 1024);
+      locator.setRetryInterval(retryInterval)
+              .setRetryIntervalMultiplier(retryMultiplier)
+              .setReconnectAttempts(reconnectAttempts)
+              .setConfirmationWindowSize(1024 * 1024);
+
       ClientSessionFactoryInternal sf = (ClientSessionFactoryInternal) createSessionFactory(locator);
 
       ClientSession session = sf.createSession(false, true, true);
@@ -527,10 +530,11 @@ public class ReattachTest extends ServiceTestBase
 
          final int reconnectAttempts = -1;
 
-         locator.setRetryInterval(retryInterval);
-         locator.setRetryIntervalMultiplier(retryMultiplier);
-         locator.setReconnectAttempts(reconnectAttempts);
-         locator.setConfirmationWindowSize(1024 * 1024);
+         locator.setRetryInterval(retryInterval)
+                 .setRetryIntervalMultiplier(retryMultiplier)
+                 .setReconnectAttempts(reconnectAttempts)
+                 .setConfirmationWindowSize(1024 * 1024);
+
          final ClientSessionFactoryInternal sf = (ClientSessionFactoryInternal) createSessionFactory(locator);
 
          session = sf.createSession();
@@ -638,10 +642,11 @@ public class ReattachTest extends ServiceTestBase
 
       final int reconnectAttempts = -1;
 
-      locator.setRetryInterval(retryInterval);
-      locator.setRetryIntervalMultiplier(retryMultiplier);
-      locator.setReconnectAttempts(reconnectAttempts);
-      locator.setConfirmationWindowSize(1024 * 1024);
+      locator.setRetryInterval(retryInterval)
+              .setRetryIntervalMultiplier(retryMultiplier)
+              .setReconnectAttempts(reconnectAttempts)
+              .setConfirmationWindowSize(1024 * 1024);
+
       final ClientSessionFactoryInternal sf = (ClientSessionFactoryInternal) createSessionFactory(locator);
 
       InVMConnector.failOnCreateConnection = true;
@@ -737,10 +742,11 @@ public class ReattachTest extends ServiceTestBase
 
       final int reconnectAttempts = -1;
 
-      locator.setRetryInterval(retryInterval);
-      locator.setRetryIntervalMultiplier(retryMultiplier);
-      locator.setReconnectAttempts(reconnectAttempts);
-      locator.setConfirmationWindowSize(1024 * 1024);
+      locator.setRetryInterval(retryInterval)
+              .setRetryIntervalMultiplier(retryMultiplier)
+              .setReconnectAttempts(reconnectAttempts)
+              .setConfirmationWindowSize(1024 * 1024);
+
       ClientSessionFactoryInternal sf = (ClientSessionFactoryInternal) createSessionFactory(locator);
 
       ClientSession session = sf.createSession(false, true, true);
@@ -810,10 +816,11 @@ public class ReattachTest extends ServiceTestBase
 
       final int reconnectAttempts = 10;
 
-      locator.setRetryInterval(retryInterval);
-      locator.setRetryIntervalMultiplier(retryMultiplier);
-      locator.setReconnectAttempts(reconnectAttempts);
-      locator.setConfirmationWindowSize(1024 * 1024);
+      locator.setRetryInterval(retryInterval)
+              .setRetryIntervalMultiplier(retryMultiplier)
+              .setReconnectAttempts(reconnectAttempts)
+              .setConfirmationWindowSize(1024 * 1024);
+
       ClientSessionFactoryInternal sf = (ClientSessionFactoryInternal) createSessionFactory(locator);
 
       ClientSession session = sf.createSession(false, true, true);
@@ -878,10 +885,11 @@ public class ReattachTest extends ServiceTestBase
 
       final int reconnectAttempts = -1;
 
-      locator.setRetryInterval(retryInterval);
-      locator.setRetryIntervalMultiplier(retryMultiplier);
-      locator.setReconnectAttempts(reconnectAttempts);
-      locator.setConfirmationWindowSize(1024 * 1024);
+      locator.setRetryInterval(retryInterval)
+              .setRetryIntervalMultiplier(retryMultiplier)
+              .setReconnectAttempts(reconnectAttempts)
+              .setConfirmationWindowSize(1024 * 1024);
+
       ClientSessionFactoryInternal sf = (ClientSessionFactoryInternal) createSessionFactory(locator);
 
       ClientSession session = sf.createSession(false, true, true);
@@ -971,10 +979,11 @@ public class ReattachTest extends ServiceTestBase
 
       final int reconnectAttempts = -1;
 
-      locator.setRetryInterval(retryInterval);
-      locator.setRetryIntervalMultiplier(retryMultiplier);
-      locator.setReconnectAttempts(reconnectAttempts);
-      locator.setConfirmationWindowSize(1024 * 1024);
+      locator.setRetryInterval(retryInterval)
+              .setRetryIntervalMultiplier(retryMultiplier)
+              .setReconnectAttempts(reconnectAttempts)
+              .setConfirmationWindowSize(1024 * 1024);
+
       ClientSessionFactoryInternal sf = (ClientSessionFactoryInternal) createSessionFactory(locator);
 
       ClientSession session = sf.createSession(false, true, true);
@@ -1049,11 +1058,12 @@ public class ReattachTest extends ServiceTestBase
 
       final long maxRetryInterval = 1000;
 
-      locator.setRetryInterval(retryInterval);
-      locator.setRetryIntervalMultiplier(retryMultiplier);
-      locator.setReconnectAttempts(reconnectAttempts);
-      locator.setMaxRetryInterval(maxRetryInterval);
-      locator.setConfirmationWindowSize(1024 * 1024);
+      locator.setRetryInterval(retryInterval)
+              .setRetryIntervalMultiplier(retryMultiplier)
+              .setReconnectAttempts(reconnectAttempts)
+              .setMaxRetryInterval(maxRetryInterval)
+              .setConfirmationWindowSize(1024 * 1024);
+
       ClientSessionFactoryInternal sf = (ClientSessionFactoryInternal) createSessionFactory(locator);
 
       ClientSession session = sf.createSession(false, true, true);
@@ -1129,11 +1139,11 @@ public class ReattachTest extends ServiceTestBase
    {
       super.setUp();
 
-      service = createServer(false, false);
+      server = createServer(false, false);
 
-      service.start();
+      server.start();
 
-      locator = createFactory(false);
+      locator = createInVMNonHALocator();
    }
 
    @Override
@@ -1141,11 +1151,6 @@ public class ReattachTest extends ServiceTestBase
    public void tearDown() throws Exception
    {
       InVMConnector.resetFailures();
-
-      closeServerLocator(locator);
-      stopComponent(service);
-
-      Assert.assertEquals(0, InVMRegistry.instance.size());
 
       super.tearDown();
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/topology/HAClientTopologyTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/topology/HAClientTopologyTest.java
@@ -19,7 +19,7 @@ package org.apache.activemq.artemis.tests.integration.cluster.topology;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 
 public class HAClientTopologyTest extends TopologyClusterTestBase
 {
@@ -57,10 +57,10 @@ public class HAClientTopologyTest extends TopologyClusterTestBase
    @Override
    protected ServerLocator createHAServerLocator()
    {
-      TransportConfiguration tc = ServiceTestBase.createTransportConfiguration(isNetty(), false, ServiceTestBase.generateParams(0, isNetty()));
+      TransportConfiguration tc = ActiveMQTestBase.createTransportConfiguration(isNetty(), false, ActiveMQTestBase.generateParams(0, isNetty()));
       ServerLocator locator = addServerLocator(ActiveMQClient.createServerLocatorWithHA(tc));
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true);
       return locator;
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/topology/HAClientTopologyWithDiscoveryTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/topology/HAClientTopologyWithDiscoveryTest.java
@@ -65,8 +65,8 @@ public class HAClientTopologyWithDiscoveryTest extends TopologyClusterTestBase
                                                                           .setBroadcastEndpointFactory(new UDPBroadcastEndpointFactory()
                                                                                                              .setGroupAddress(groupAddress)
                                                                                                              .setGroupPort(groupPort)));
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true);
       addServerLocator(locator);
       return locator;
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/topology/IsolatedTopologyTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/topology/IsolatedTopologyTest.java
@@ -23,7 +23,7 @@ import org.apache.activemq.artemis.core.config.ClusterConnectionConfiguration;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -32,7 +32,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class IsolatedTopologyTest extends ServiceTestBase
+public class IsolatedTopologyTest extends ActiveMQTestBase
 {
 
    @Test
@@ -108,7 +108,7 @@ public class IsolatedTopologyTest extends ServiceTestBase
       params.put(TransportConstants.CLUSTER_CONNECTION, "cc1");
       params.put(org.apache.activemq.artemis.core.remoting.impl.invm.TransportConstants.SERVER_ID_PROP_NAME, "1");
 
-      TransportConfiguration acceptor1VM1 = new TransportConfiguration(ServiceTestBase.INVM_ACCEPTOR_FACTORY,
+      TransportConfiguration acceptor1VM1 = new TransportConfiguration(ActiveMQTestBase.INVM_ACCEPTOR_FACTORY,
                                                                        params,
                                                                        "acceptor-cc1");
 
@@ -116,7 +116,7 @@ public class IsolatedTopologyTest extends ServiceTestBase
       params.put(TransportConstants.CLUSTER_CONNECTION, "cc2");
       params.put(org.apache.activemq.artemis.core.remoting.impl.invm.TransportConstants.SERVER_ID_PROP_NAME, "2");
 
-      TransportConfiguration acceptor2VM1 = new TransportConfiguration(ServiceTestBase.INVM_ACCEPTOR_FACTORY,
+      TransportConfiguration acceptor2VM1 = new TransportConfiguration(ActiveMQTestBase.INVM_ACCEPTOR_FACTORY,
                                                                        params,
                                                                        "acceptor-cc2");
 
@@ -145,7 +145,7 @@ public class IsolatedTopologyTest extends ServiceTestBase
       // Server1 with two acceptors, each acceptor on a different cluster connection
       // talking to a different connector.
       // i.e. two cluster connections isolated on the same node
-      Configuration config1 = createBasicConfig(0)
+      Configuration config1 = createBasicConfig(1)
          .addConnectorConfiguration("local-cc1", createInVMTransportConnectorConfig(1, "local-cc1"))
          .addConnectorConfiguration("local-cc2", createInVMTransportConnectorConfig(2, "local-cc2"))
          .addConnectorConfiguration("other-cc1", createInVMTransportConnectorConfig(3, "other-cc1"))
@@ -165,7 +165,7 @@ public class IsolatedTopologyTest extends ServiceTestBase
       params.put(TransportConstants.CLUSTER_CONNECTION, "cc1");
       params.put(org.apache.activemq.artemis.core.remoting.impl.invm.TransportConstants.SERVER_ID_PROP_NAME, "3");
 
-      TransportConfiguration acceptor1VM1 = new TransportConfiguration(ServiceTestBase.INVM_ACCEPTOR_FACTORY,
+      TransportConfiguration acceptor1VM1 = new TransportConfiguration(ActiveMQTestBase.INVM_ACCEPTOR_FACTORY,
                                                                        params,
                                                                        "acceptor-cc1");
 
@@ -173,7 +173,7 @@ public class IsolatedTopologyTest extends ServiceTestBase
       params.put(TransportConstants.CLUSTER_CONNECTION, "cc2");
       params.put(org.apache.activemq.artemis.core.remoting.impl.invm.TransportConstants.SERVER_ID_PROP_NAME, "4");
 
-      TransportConfiguration acceptor2VM1 = new TransportConfiguration(ServiceTestBase.INVM_ACCEPTOR_FACTORY,
+      TransportConfiguration acceptor2VM1 = new TransportConfiguration(ActiveMQTestBase.INVM_ACCEPTOR_FACTORY,
                                                                        params,
                                                                        "acceptor-cc2");
 
@@ -199,10 +199,10 @@ public class IsolatedTopologyTest extends ServiceTestBase
          .setConfirmationWindowSize(1024)
          .setStaticConnectors(connectTo2);
 
-      // Server1 with two acceptors, each acceptor on a different cluster connection
+      // Server2 with two acceptors, each acceptor on a different cluster connection
       // talking to a different connector.
       // i.e. two cluster connections isolated on the same node
-      Configuration config1 = createBasicConfig(3)
+      Configuration config1 = createBasicConfig(2)
          .addAcceptorConfiguration(acceptor1VM1)
          .addAcceptorConfiguration(acceptor2VM1)
          .addConnectorConfiguration("local-cc1", createInVMTransportConnectorConfig(3, "local-cc1"))

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/topology/NonHATopologyTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/topology/NonHATopologyTest.java
@@ -30,7 +30,7 @@ import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnectorFactory;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 
 /**
  * I have added this test to help validate if the connectors from Recovery will be
@@ -38,7 +38,7 @@ import org.apache.activemq.artemis.tests.util.ServiceTestBase;
  *
  * Created to verify HORNETQ-913 / AS7-4548
  */
-public class NonHATopologyTest extends ServiceTestBase
+public class NonHATopologyTest extends ActiveMQTestBase
 {
 
    @Test

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/topology/TopologyClusterTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/topology/TopologyClusterTestBase.java
@@ -34,9 +34,8 @@ import org.apache.activemq.artemis.core.server.cluster.ClusterConnection;
 import org.apache.activemq.artemis.core.server.cluster.ClusterManager;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
 import org.apache.activemq.artemis.tests.integration.cluster.distribution.ClusterTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -111,15 +110,6 @@ public abstract class TopologyClusterTestBase extends ClusterTestBase
       setupServers();
 
       setupCluster();
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      stopServers(0, 1, 2, 3, 4);
-
-      super.tearDown();
    }
 
    /**
@@ -224,7 +214,7 @@ public abstract class TopologyClusterTestBase extends ClusterTestBase
 
          Thread.sleep(10);
       }
-      while (System.currentTimeMillis() - start < ServiceTestBase.WAIT_TIMEOUT);
+      while (System.currentTimeMillis() - start < ActiveMQTestBase.WAIT_TIMEOUT);
 
       log.error(clusterDescription(servers[node]));
       Assert.assertEquals("Timed out waiting for cluster connections for server " + node, expected, nodesCount);
@@ -395,7 +385,7 @@ public abstract class TopologyClusterTestBase extends ClusterTestBase
             s.getConfiguration().setSecurityEnabled(true);
          }
       }
-      Assert.assertEquals(ServiceTestBase.CLUSTER_PASSWORD, config.getClusterPassword());
+      Assert.assertEquals(ActiveMQTestBase.CLUSTER_PASSWORD, config.getClusterPassword());
       config.setClusterPassword(config.getClusterPassword() + "-1-2-3-");
       startServers(0, 1, 2, 4, 3);
       int n = 0;
@@ -411,7 +401,7 @@ public abstract class TopologyClusterTestBase extends ClusterTestBase
       final String address = "foo1235";
       ServerLocator locator = createNonHALocator(isNetty());
       ClientSessionFactory sf = createSessionFactory(locator);
-      ClientSession session = sf.createSession(config.getClusterUser(), ServiceTestBase.CLUSTER_PASSWORD, false, true, true, false, 1);
+      ClientSession session = sf.createSession(config.getClusterUser(), ActiveMQTestBase.CLUSTER_PASSWORD, false, true, true, false, 1);
       session.createQueue(address, address, true);
       ClientProducer producer = session.createProducer(address);
       sendMessages(session, producer, 100);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/util/MultiServerTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/util/MultiServerTestBase.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.cluster.util;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.config.ha.ReplicaPolicyConfiguration;
 import org.apache.activemq.artemis.core.config.ha.ReplicatedPolicyConfiguration;
 import org.apache.activemq.artemis.core.config.ha.SharedStoreMasterPolicyConfiguration;
@@ -36,7 +36,7 @@ import org.apache.activemq.artemis.core.server.ActiveMQServers;
 import org.apache.activemq.artemis.core.server.NodeManager;
 import org.apache.activemq.artemis.core.server.impl.InVMNodeManager;
 
-public class MultiServerTestBase extends ServiceTestBase
+public class MultiServerTestBase extends ActiveMQTestBase
 {
 
 
@@ -131,7 +131,7 @@ public class MultiServerTestBase extends ServiceTestBase
 
       for (ActiveMQServer server: servers)
       {
-         waitForServer(server);
+         waitForServerToStart(server);
       }
 
       if (backupServers != null)
@@ -143,7 +143,7 @@ public class MultiServerTestBase extends ServiceTestBase
 
          for (ActiveMQServer server: backupServers)
          {
-            waitForServer(server);
+            waitForServerToStart(server);
          }
 
       }
@@ -159,7 +159,7 @@ public class MultiServerTestBase extends ServiceTestBase
       for (int s : serverID)
       {
          servers[s].start();
-         waitForServer(servers[s]);
+         waitForServerToStart(servers[s]);
       }
    }
 
@@ -168,7 +168,7 @@ public class MultiServerTestBase extends ServiceTestBase
       for (int s : serverID)
       {
          backupServers[s].start();
-         waitForServer(backupServers[s]);
+         waitForServerToStart(backupServers[s]);
       }
 
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/discovery/DiscoveryBaseTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/discovery/DiscoveryBaseTest.java
@@ -28,7 +28,7 @@ import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.UDPBroadcastEndpointFactory;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.cluster.DiscoveryEntry;
 import org.apache.activemq.artemis.core.cluster.DiscoveryGroup;
 import org.apache.activemq.artemis.core.cluster.DiscoveryListener;
@@ -39,7 +39,7 @@ import org.apache.activemq.artemis.core.server.management.NotificationService;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
 import org.junit.Assert;
 
-public class DiscoveryBaseTest extends ServiceTestBase
+public class DiscoveryBaseTest extends ActiveMQTestBase
 {
    protected static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/divert/DivertTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/divert/DivertTest.java
@@ -16,9 +16,6 @@
  */
 package org.apache.activemq.artemis.tests.integration.divert;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
@@ -32,18 +29,17 @@ import org.apache.activemq.artemis.core.message.impl.MessageImpl;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class DivertTest extends ServiceTestBase
+public class DivertTest extends ActiveMQTestBase
 {
    private static final int TIMEOUT = 500;
 
    @Test
    public void testSingleNonExclusiveDivert() throws Exception
    {
-      Configuration conf = createDefaultConfig();
       final String testAddress = "testAddress";
 
       final String forwardAddress = "forwardAddress";
@@ -54,15 +50,12 @@ public class DivertTest extends ServiceTestBase
          .setAddress(testAddress)
          .setForwardingAddress(forwardAddress);
 
-      List<DivertConfiguration> divertConfs = new ArrayList<DivertConfiguration>();
+      Configuration config = createDefaultInVMConfig()
+              .addDivertConfiguration(divertConf);
 
-      divertConfs.add(divertConf);
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(config, false));
 
-      conf.setDivertConfigurations(divertConfs);
-
-      ActiveMQServer messagingService = addServer(ActiveMQServers.newActiveMQServer(conf, false));
-
-      messagingService.start();
+      server.start();
 
       ServerLocator locator = createInVMNonHALocator();
 
@@ -124,31 +117,20 @@ public class DivertTest extends ServiceTestBase
       }
 
       Assert.assertNull(consumer2.receiveImmediate());
-
-      session.close();
-
-      sf.close();
-
-      messagingService.stop();
    }
 
 
    @Test
    public void testSingleDivertWithExpiry() throws Exception
    {
-      Configuration conf = createDefaultConfig();
       final String testAddress = "testAddress";
 
       final String forwardAddress = "forwardAddress";
 
       final String expiryAddress = "expiryAddress";
 
-      conf.getAddressesSettings().clear();
-
-      AddressSettings expirySettings = new AddressSettings();
-      expirySettings.setExpiryAddress(new SimpleString(expiryAddress));
-
-      conf.getAddressesSettings().put("#", expirySettings);
+      AddressSettings expirySettings = new AddressSettings()
+              .setExpiryAddress(new SimpleString(expiryAddress));
 
       DivertConfiguration divertConf = new DivertConfiguration()
          .setName("divert1")
@@ -156,16 +138,14 @@ public class DivertTest extends ServiceTestBase
          .setAddress(testAddress)
          .setForwardingAddress(forwardAddress);
 
-      List<DivertConfiguration> divertConfs = new ArrayList<DivertConfiguration>();
+      Configuration config = createDefaultInVMConfig()
+              .addDivertConfiguration(divertConf)
+              .clearAddressesSettings()
+              .addAddressesSetting("#", expirySettings);
 
-      divertConfs.add(divertConf);
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(config, true));
 
-      conf.setDivertConfigurations(divertConfs);
-
-      ActiveMQServer messagingService = addServer(ActiveMQServers.newActiveMQServer(conf, true));
-
-      messagingService.start();
-
+      server.start();
 
       ServerLocator locator = createInVMNonHALocator();
 
@@ -263,18 +243,11 @@ public class DivertTest extends ServiceTestBase
 
       assertEquals(numMessages, countOriginal1);
       assertEquals(numMessages, countOriginal2);
-
-      session.close();
-
-      sf.close();
-
-      messagingService.stop();
    }
 
    @Test
    public void testSingleNonExclusiveDivert2() throws Exception
    {
-      Configuration conf = createDefaultConfig();
       final String testAddress = "testAddress";
 
       final String forwardAddress = "forwardAddress";
@@ -285,15 +258,12 @@ public class DivertTest extends ServiceTestBase
          .setAddress(testAddress)
          .setForwardingAddress(forwardAddress);
 
-      List<DivertConfiguration> divertConfs = new ArrayList<DivertConfiguration>();
+      Configuration config = createDefaultInVMConfig()
+              .addDivertConfiguration(divertConf);
 
-      divertConfs.add(divertConf);
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(config, false));
 
-      conf.setDivertConfigurations(divertConfs);
-
-      ActiveMQServer messagingService = addServer(ActiveMQServers.newActiveMQServer(conf, false));
-
-      messagingService.start();
+      server.start();
 
       ServerLocator locator = createInVMNonHALocator();
 
@@ -393,18 +363,11 @@ public class DivertTest extends ServiceTestBase
       }
 
       Assert.assertNull(consumer4.receiveImmediate());
-
-      session.close();
-
-      sf.close();
-
-      messagingService.stop();
    }
 
    @Test
    public void testSingleNonExclusiveDivert3() throws Exception
    {
-      Configuration conf = createDefaultConfig();
       final String testAddress = "testAddress";
 
       final String forwardAddress = "forwardAddress";
@@ -415,15 +378,12 @@ public class DivertTest extends ServiceTestBase
          .setAddress(testAddress)
          .setForwardingAddress(forwardAddress);
 
-      List<DivertConfiguration> divertConfs = new ArrayList<DivertConfiguration>();
+      Configuration config = createDefaultInVMConfig()
+              .addDivertConfiguration(divertConf);
 
-      divertConfs.add(divertConf);
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(config, false));
 
-      conf.setDivertConfigurations(divertConfs);
-
-      ActiveMQServer messagingService = addServer(ActiveMQServers.newActiveMQServer(conf, false));
-
-      messagingService.start();
+      server.start();
 
       ServerLocator locator = createInVMNonHALocator();
       ClientSessionFactory sf = createSessionFactory(locator);
@@ -465,18 +425,11 @@ public class DivertTest extends ServiceTestBase
       }
 
       Assert.assertNull(consumer1.receiveImmediate());
-
-      session.close();
-
-      sf.close();
-
-      messagingService.stop();
    }
 
    @Test
    public void testSingleExclusiveDivert() throws Exception
    {
-      Configuration conf = createDefaultConfig();
       final String testAddress = "testAddress";
 
       final String forwardAddress = "forwardAddress";
@@ -488,15 +441,12 @@ public class DivertTest extends ServiceTestBase
          .setForwardingAddress(forwardAddress)
          .setExclusive(true);
 
-      List<DivertConfiguration> divertConfs = new ArrayList<DivertConfiguration>();
+      Configuration config = createDefaultInVMConfig()
+              .addDivertConfiguration(divertConf);
 
-      divertConfs.add(divertConf);
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(config, false));
 
-      conf.setDivertConfigurations(divertConfs);
-
-      ActiveMQServer messagingService = addServer(ActiveMQServers.newActiveMQServer(conf, false));
-
-      messagingService.start();
+      server.start();
 
       ServerLocator locator = createInVMNonHALocator();
       ClientSessionFactory sf = createSessionFactory(locator);
@@ -560,19 +510,11 @@ public class DivertTest extends ServiceTestBase
       Assert.assertNull(consumer3.receiveImmediate());
 
       Assert.assertNull(consumer4.receiveImmediate());
-
-      session.close();
-
-      sf.close();
-
-      messagingService.stop();
    }
 
    @Test
    public void testMultipleNonExclusiveDivert() throws Exception
    {
-      Configuration conf = createDefaultConfig();
-
       final String testAddress = "testAddress";
 
       final String forwardAddress1 = "forwardAddress1";
@@ -597,17 +539,14 @@ public class DivertTest extends ServiceTestBase
          .setAddress(testAddress)
          .setForwardingAddress(forwardAddress3);
 
-      List<DivertConfiguration> divertConfs = new ArrayList<DivertConfiguration>();
+      Configuration config = createDefaultInVMConfig()
+              .addDivertConfiguration(divertConf1)
+              .addDivertConfiguration(divertConf2)
+              .addDivertConfiguration(divertConf3);
 
-      divertConfs.add(divertConf1);
-      divertConfs.add(divertConf2);
-      divertConfs.add(divertConf3);
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(config, false));
 
-      conf.setDivertConfigurations(divertConfs);
-
-      ActiveMQServer messagingService = addServer(ActiveMQServers.newActiveMQServer(conf, false));
-
-      messagingService.start();
+      server.start();
 
       ServerLocator locator = createInVMNonHALocator();
       ClientSessionFactory sf = createSessionFactory(locator);
@@ -706,18 +645,11 @@ public class DivertTest extends ServiceTestBase
       }
 
       Assert.assertNull(consumer4.receiveImmediate());
-
-      session.close();
-
-      sf.close();
-
-      messagingService.stop();
    }
 
    @Test
    public void testMultipleExclusiveDivert() throws Exception
    {
-      Configuration conf = createDefaultConfig();
       final String testAddress = "testAddress";
 
       final String forwardAddress1 = "forwardAddress1";
@@ -745,19 +677,17 @@ public class DivertTest extends ServiceTestBase
          .setForwardingAddress(forwardAddress3)
          .setExclusive(true);
 
-      List<DivertConfiguration> divertConfs = new ArrayList<DivertConfiguration>();
+      Configuration config = createDefaultInVMConfig()
+              .addDivertConfiguration(divertConf1)
+              .addDivertConfiguration(divertConf2)
+              .addDivertConfiguration(divertConf3);
 
-      divertConfs.add(divertConf1);
-      divertConfs.add(divertConf2);
-      divertConfs.add(divertConf3);
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(config, false));
 
-      conf.setDivertConfigurations(divertConfs);
-
-      ActiveMQServer messagingService = addServer(ActiveMQServers.newActiveMQServer(conf, false));
-
-      messagingService.start();
+      server.start();
 
       ServerLocator locator = createInVMNonHALocator();
+
       ClientSessionFactory sf = createSessionFactory(locator);
 
       ClientSession session = sf.createSession(false, true, true);
@@ -843,19 +773,11 @@ public class DivertTest extends ServiceTestBase
       Assert.assertNull(consumer3.receiveImmediate());
 
       Assert.assertNull(consumer4.receiveImmediate());
-
-      session.close();
-
-      sf.close();
-
-      messagingService.stop();
    }
 
    @Test
    public void testMixExclusiveAndNonExclusiveDiverts() throws Exception
    {
-      Configuration conf = createDefaultConfig();
-
       final String testAddress = "testAddress";
 
       final String forwardAddress1 = "forwardAddress1";
@@ -882,17 +804,14 @@ public class DivertTest extends ServiceTestBase
          .setAddress(testAddress)
          .setForwardingAddress(forwardAddress3);
 
-      List<DivertConfiguration> divertConfs = new ArrayList<DivertConfiguration>();
+      Configuration config = createDefaultInVMConfig()
+              .addDivertConfiguration(divertConf1)
+              .addDivertConfiguration(divertConf2)
+              .addDivertConfiguration(divertConf3);
 
-      divertConfs.add(divertConf1);
-      divertConfs.add(divertConf2);
-      divertConfs.add(divertConf3);
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(config, false));
 
-      conf.setDivertConfigurations(divertConfs);
-
-      ActiveMQServer messagingService = addServer(ActiveMQServers.newActiveMQServer(conf, false));
-
-      messagingService.start();
+      server.start();
 
       ServerLocator locator = createInVMNonHALocator();
       ClientSessionFactory sf = createSessionFactory(locator);
@@ -969,19 +888,12 @@ public class DivertTest extends ServiceTestBase
       Assert.assertNull(consumer3.receiveImmediate());
 
       Assert.assertNull(consumer4.receiveImmediate());
-
-      session.close();
-
-      sf.close();
-
-      messagingService.stop();
    }
 
    // If no exclusive diverts match then non exclusive ones should be called
    @Test
    public void testSingleExclusiveNonMatchingAndNonExclusiveDiverts() throws Exception
    {
-      Configuration conf = createDefaultConfig();
       final String testAddress = "testAddress";
 
       final String forwardAddress1 = "forwardAddress1";
@@ -1010,19 +922,17 @@ public class DivertTest extends ServiceTestBase
          .setAddress(testAddress)
          .setForwardingAddress(forwardAddress3);
 
-      List<DivertConfiguration> divertConfs = new ArrayList<DivertConfiguration>();
+      Configuration config = createDefaultInVMConfig()
+              .addDivertConfiguration(divertConf1)
+              .addDivertConfiguration(divertConf2)
+              .addDivertConfiguration(divertConf3);
 
-      divertConfs.add(divertConf1);
-      divertConfs.add(divertConf2);
-      divertConfs.add(divertConf3);
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(config, false));
 
-      conf.setDivertConfigurations(divertConfs);
-
-      ActiveMQServer messagingService = addServer(ActiveMQServers.newActiveMQServer(conf, false));
-
-      messagingService.start();
+      server.start();
 
       ServerLocator locator = createInVMNonHALocator();
+
       ClientSessionFactory sf = createSessionFactory(locator);
 
       ClientSession session = sf.createSession(false, true, true);
@@ -1151,18 +1061,11 @@ public class DivertTest extends ServiceTestBase
       Assert.assertNull(consumer3.receiveImmediate());
 
       Assert.assertNull(consumer4.receiveImmediate());
-
-      session.close();
-
-      sf.close();
-
-      messagingService.stop();
    }
 
    @Test
    public void testRoundRobinDiverts() throws Exception
    {
-      Configuration conf = createDefaultConfig();
       final String testAddress = "testAddress";
 
       final String forwardAddress1 = "forwardAddress1";
@@ -1187,19 +1090,17 @@ public class DivertTest extends ServiceTestBase
          .setAddress(testAddress)
          .setForwardingAddress(forwardAddress3);
 
-      List<DivertConfiguration> divertConfs = new ArrayList<DivertConfiguration>();
+      Configuration config = createDefaultInVMConfig()
+              .addDivertConfiguration(divertConf1)
+              .addDivertConfiguration(divertConf2)
+              .addDivertConfiguration(divertConf3);
 
-      divertConfs.add(divertConf1);
-      divertConfs.add(divertConf2);
-      divertConfs.add(divertConf3);
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(config, false));
 
-      conf.setDivertConfigurations(divertConfs);
-
-      ActiveMQServer messagingService = addServer(ActiveMQServers.newActiveMQServer(conf, false));
-
-      messagingService.start();
+      server.start();
 
       ServerLocator locator = createInVMNonHALocator();
+
       ClientSessionFactory sf = createSessionFactory(locator);
 
       ClientSession session = sf.createSession(false, true, true);
@@ -1304,19 +1205,11 @@ public class DivertTest extends ServiceTestBase
       }
 
       Assert.assertNull(consumer4.receiveImmediate());
-
-      session.close();
-
-      sf.close();
-
-      messagingService.stop();
    }
 
    @Test
    public void testDeployDivertsSameUniqueName() throws Exception
    {
-      Configuration conf = createDefaultConfig();
-
       final String testAddress = "testAddress";
 
       final String forwardAddress1 = "forwardAddress1";
@@ -1341,21 +1234,19 @@ public class DivertTest extends ServiceTestBase
          .setAddress(testAddress)
          .setForwardingAddress(forwardAddress3);
 
-      List<DivertConfiguration> divertConfs = new ArrayList<DivertConfiguration>();
+      Configuration config = createDefaultInVMConfig()
+              .addDivertConfiguration(divertConf1)
+              .addDivertConfiguration(divertConf2)
+              .addDivertConfiguration(divertConf3);
 
-      divertConfs.add(divertConf1);
-      divertConfs.add(divertConf2);
-      divertConfs.add(divertConf3);
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(config, false));
 
-      conf.setDivertConfigurations(divertConfs);
-
-      ActiveMQServer messagingService = addServer(ActiveMQServers.newActiveMQServer(conf, false));
-
-      messagingService.start();
+      server.start();
 
       // Only the first and third should be deployed
 
       ServerLocator locator = createInVMNonHALocator();
+
       ClientSessionFactory sf = createSessionFactory(locator);
 
       ClientSession session = sf.createSession(false, true, true);
@@ -1441,12 +1332,6 @@ public class DivertTest extends ServiceTestBase
       }
 
       Assert.assertNull(consumer4.receiveImmediate());
-
-      session.close();
-
-      sf.close();
-
-      messagingService.stop();
    }
 
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/embedded/ValidateAIOTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/embedded/ValidateAIOTest.java
@@ -20,22 +20,21 @@ import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
 import org.apache.activemq.artemis.core.server.JournalType;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 
 /**
  * Validate if the embedded server will start even with AIO selected
  */
-public class ValidateAIOTest extends ServiceTestBase
+public class ValidateAIOTest extends ActiveMQTestBase
 {
-
    @Test
    public void testValidateAIO() throws Exception
    {
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          // This will force AsyncIO
          .setJournalType(JournalType.ASYNCIO);
-      ActiveMQServer server = ActiveMQServers.newActiveMQServer(config, true);
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(config, true));
       try
       {
          server.start();
@@ -44,6 +43,5 @@ public class ValidateAIOTest extends ServiceTestBase
       {
          server.stop();
       }
-
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/http/CoreClientOverHttpTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/http/CoreClientOverHttpTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.http;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 
 import org.junit.Test;
@@ -40,7 +40,7 @@ import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
 import org.apache.activemq.artemis.jms.client.ActiveMQTextMessage;
 
-public class CoreClientOverHttpTest extends ServiceTestBase
+public class CoreClientOverHttpTest extends ActiveMQTestBase
 {
    private static final SimpleString QUEUE = new SimpleString("CoreClientOverHttpTestQueue");
    private Configuration conf;
@@ -55,15 +55,13 @@ public class CoreClientOverHttpTest extends ServiceTestBase
       HashMap<String, Object> params = new HashMap<String, Object>();
       params.put(TransportConstants.HTTP_ENABLED_PROP_NAME, true);
 
-      conf = createDefaultConfig()
-         .setSecurityEnabled(false)
-         .addAcceptorConfiguration(new TransportConfiguration(NETTY_ACCEPTOR_FACTORY));
+      conf = createDefaultInVMConfig()
+              .clearAcceptorConfigurations()
+              .addAcceptorConfiguration(new TransportConfiguration(NETTY_ACCEPTOR_FACTORY, params));
 
       server = addServer(ActiveMQServers.newActiveMQServer(conf, false));
-
       server.start();
-      locator = ActiveMQClient.createServerLocatorWithoutHA(new TransportConfiguration(NETTY_CONNECTOR_FACTORY, params));
-      addServerLocator(locator);
+      locator = addServerLocator(ActiveMQClient.createServerLocatorWithoutHA(new TransportConfiguration(NETTY_CONNECTOR_FACTORY, params)));
    }
 
    @Test

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/ActiveMQConnectionFactoryTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/ActiveMQConnectionFactoryTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.activemq.artemis.tests.integration.jms;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.config.ha.SharedStoreMasterPolicyConfiguration;
 import org.junit.Before;
 
@@ -50,7 +50,7 @@ import org.apache.activemq.artemis.tests.util.RandomUtil;
  *
  * A ActiveMQConnectionFactoryTest
  */
-public class ActiveMQConnectionFactoryTest extends ServiceTestBase
+public class ActiveMQConnectionFactoryTest extends ActiveMQTestBase
 {
    private static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/FloodServerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/FloodServerTest.java
@@ -15,15 +15,22 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.jms;
-import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
+
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
+import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
+import org.apache.activemq.artemis.api.jms.JMSFactoryType;
+import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.registry.JndiBindingRegistry;
+import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.ActiveMQServers;
+import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
+import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
+import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
-import org.junit.After;
-
 import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import javax.jms.BytesMessage;
 import javax.jms.Connection;
@@ -33,25 +40,14 @@ import javax.jms.Message;
 import javax.jms.MessageConsumer;
 import javax.jms.MessageProducer;
 import javax.jms.Session;
-
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
-import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
-import org.apache.activemq.artemis.api.jms.JMSFactoryType;
-import org.apache.activemq.artemis.core.config.Configuration;
-import org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptorFactory;
-import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
-import org.apache.activemq.artemis.core.server.ActiveMQServers;
-import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
-import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  *
  * A FloodServerTest
  */
-public class FloodServerTest extends ServiceTestBase
+public class FloodServerTest extends ActiveMQTestBase
 {
    // Constants -----------------------------------------------------
 
@@ -85,9 +81,8 @@ public class FloodServerTest extends ServiceTestBase
    {
       super.setUp();
 
-      Configuration conf = createBasicConfig()
-         .addAcceptorConfiguration(new TransportConfiguration(NettyAcceptorFactory.class.getName()));
-      server = ActiveMQServers.newActiveMQServer(conf, false);
+      Configuration config = createDefaultNettyConfig();
+      server = addServer(ActiveMQServers.newActiveMQServer(config, false));
       server.start();
 
       serverManager = new JMSServerManagerImpl(server);
@@ -98,22 +93,6 @@ public class FloodServerTest extends ServiceTestBase
 
       serverManager.createTopic(false, topicName, topicName);
       registerConnectionFactory();
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-
-      serverManager.stop();
-
-      server.stop();
-
-      server = null;
-
-      serverManager = null;
-
-      super.tearDown();
    }
 
    // Private -------------------------------------------------------

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/ManualReconnectionToSingleServerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/ManualReconnectionToSingleServerTest.java
@@ -15,18 +15,23 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.jms;
-import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
+
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.registry.JndiBindingRegistry;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.jms.server.JMSServerManager;
+import org.apache.activemq.artemis.jms.server.config.ConnectionFactoryConfiguration;
+import org.apache.activemq.artemis.jms.server.config.JMSConfiguration;
+import org.apache.activemq.artemis.jms.server.config.impl.ConnectionFactoryConfigurationImpl;
+import org.apache.activemq.artemis.jms.server.config.impl.JMSConfigurationImpl;
+import org.apache.activemq.artemis.jms.server.config.impl.JMSQueueConfigurationImpl;
+import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
+import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
+import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.junit.Assert;
 import org.junit.Before;
-import org.junit.After;
-
 import org.junit.Test;
-
-import static java.util.concurrent.TimeUnit.SECONDS;
-
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.concurrent.CountDownLatch;
 
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
@@ -40,23 +45,13 @@ import javax.jms.MessageProducer;
 import javax.jms.Queue;
 import javax.jms.Session;
 import javax.naming.Context;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.concurrent.CountDownLatch;
 
-import org.junit.Assert;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
-import org.apache.activemq.artemis.core.config.Configuration;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
-import org.apache.activemq.artemis.jms.server.JMSServerManager;
-import org.apache.activemq.artemis.jms.server.config.ConnectionFactoryConfiguration;
-import org.apache.activemq.artemis.jms.server.config.JMSConfiguration;
-import org.apache.activemq.artemis.jms.server.config.impl.ConnectionFactoryConfigurationImpl;
-import org.apache.activemq.artemis.jms.server.config.impl.JMSConfigurationImpl;
-import org.apache.activemq.artemis.jms.server.config.impl.JMSQueueConfigurationImpl;
-import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
-import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-
-public class ManualReconnectionToSingleServerTest extends ServiceTestBase
+public class ManualReconnectionToSingleServerTest extends ActiveMQTestBase
 {
    // Constants -----------------------------------------------------
 
@@ -152,10 +147,7 @@ public class ManualReconnectionToSingleServerTest extends ServiceTestBase
 
       context = new InVMNamingContext();
 
-      Configuration conf = createBasicConfig()
-         .addAcceptorConfiguration(new TransportConfiguration(NETTY_ACCEPTOR_FACTORY));
-
-      server = createServer(false, conf);
+      server = createServer(false, createDefaultNettyConfig());
 
       JMSConfiguration configuration = new JMSConfigurationImpl();
       serverManager = new JMSServerManagerImpl(server, configuration);
@@ -179,26 +171,6 @@ public class ManualReconnectionToSingleServerTest extends ServiceTestBase
       exceptionLatch = new CountDownLatch(1);
       reconnectionLatch = new CountDownLatch(1);
       allMessagesReceived = new CountDownLatch(1);
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      try
-      {
-         serverManager.stop();
-         serverManager = null;
-         if (connection != null)
-         {
-            connection.close();
-         }
-         connection = null;
-      }
-      finally
-      {
-         super.tearDown();
-      }
    }
 
    // Private -------------------------------------------------------

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/SimpleJNDIClientTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/SimpleJNDIClientTest.java
@@ -40,7 +40,7 @@ import org.apache.activemq.artemis.api.core.JGroupsPropertiesBroadcastEndpointFa
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.UDPBroadcastEndpointFactory;
 import org.apache.activemq.artemis.api.jms.JMSFactoryType;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.ha.SharedStoreMasterPolicyConfiguration;
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
@@ -56,7 +56,7 @@ import org.junit.Test;
  *
  * A ActiveMQConnectionFactoryTest
  */
-public class SimpleJNDIClientTest extends ServiceTestBase
+public class SimpleJNDIClientTest extends ActiveMQTestBase
 {
    private final String groupAddress = getUDPDiscoveryAddress();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/ConnectionTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/ConnectionTest.java
@@ -16,6 +16,11 @@
  */
 package org.apache.activemq.artemis.tests.integration.jms.client;
 
+import org.apache.activemq.artemis.tests.util.JMSTestBase;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
 import javax.jms.InvalidClientIDException;
@@ -30,11 +35,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-
-import org.apache.activemq.artemis.tests.util.JMSTestBase;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
 
 public class ConnectionTest extends JMSTestBase
 {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/ExpiryMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/ExpiryMessageTest.java
@@ -43,16 +43,13 @@ public class ExpiryMessageTest extends JMSTestBase
    @Override
    protected Configuration createDefaultConfig(boolean netty) throws Exception
    {
-      Configuration conf = super.createDefaultConfig(netty)
-         .setMessageExpiryScanPeriod(1000);
-
-      return conf;
+      return super.createDefaultConfig(netty)
+              .setMessageExpiryScanPeriod(1000);
    }
 
    @Test
    public void testSendTopicNoSubscription() throws Exception
    {
-
       Topic topic = createTopic("test-topic");
       TopicControl control = ManagementControlHelper.createTopicControl(topic, mbeanServer);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/GroupingTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/GroupingTest.java
@@ -15,6 +15,18 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.jms.client;
+
+import org.apache.activemq.artemis.api.core.ActiveMQNotConnectedException;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.apache.activemq.artemis.jms.client.ActiveMQMessage;
+import org.apache.activemq.artemis.jms.client.ActiveMQTextMessage;
+import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
+import org.apache.activemq.artemis.tests.util.JMSTestBase;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
 import javax.jms.JMSException;
@@ -24,18 +36,6 @@ import javax.jms.MessageProducer;
 import javax.jms.Queue;
 import javax.jms.Session;
 import javax.jms.TextMessage;
-
-import org.apache.activemq.artemis.api.core.ActiveMQNotConnectedException;
-import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.tests.util.JMSTestBase;
-import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
-import org.apache.activemq.artemis.jms.client.ActiveMQMessage;
-import org.apache.activemq.artemis.jms.client.ActiveMQTextMessage;
-import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
-import org.junit.After;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * GroupingTest
@@ -51,15 +51,6 @@ public class GroupingTest extends JMSTestBase
       super.setUp();
 
       queue = createQueue("TestQueue");
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      jmsServer.destroyQueue("TestQueue");
-
-      super.tearDown();
    }
 
    protected void setProperty(Message message)

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/PreACKJMSTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/PreACKJMSTest.java
@@ -16,6 +16,13 @@
  */
 package org.apache.activemq.artemis.tests.integration.jms.client;
 
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
+import org.apache.activemq.artemis.api.jms.JMSFactoryType;
+import org.apache.activemq.artemis.tests.util.JMSTestBase;
+import org.junit.Before;
+import org.junit.Test;
+
 import javax.jms.MessageConsumer;
 import javax.jms.MessageProducer;
 import javax.jms.Queue;
@@ -23,14 +30,6 @@ import javax.jms.Session;
 import javax.jms.TextMessage;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
-import org.apache.activemq.artemis.api.jms.JMSFactoryType;
-import org.apache.activemq.artemis.tests.util.JMSTestBase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 public class PreACKJMSTest extends JMSTestBase
 {
@@ -151,14 +150,6 @@ public class PreACKJMSTest extends JMSTestBase
    {
       super.setUp();
       queue = createQueue("queue1");
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      queue = null;
-      super.tearDown();
    }
 
    @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/ReSendMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/ReSendMessageTest.java
@@ -16,6 +16,16 @@
  */
 package org.apache.activemq.artemis.tests.integration.jms.client;
 
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
+import org.apache.activemq.artemis.api.jms.ActiveMQJMSConstants;
+import org.apache.activemq.artemis.api.jms.JMSFactoryType;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.apache.activemq.artemis.tests.util.JMSTestBase;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
 import javax.jms.BytesMessage;
 import javax.jms.MapMessage;
 import javax.jms.Message;
@@ -28,17 +38,6 @@ import javax.jms.TextMessage;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
-import org.apache.activemq.artemis.api.jms.ActiveMQJMSConstants;
-import org.apache.activemq.artemis.api.jms.JMSFactoryType;
-import org.apache.activemq.artemis.tests.util.JMSTestBase;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * Receive Messages and resend them, like the bridge would do
@@ -71,7 +70,7 @@ public class ReSendMessageTest extends JMSTestBase
       {
          BytesMessage bm = sess.createBytesMessage();
          bm.setObjectProperty(ActiveMQJMSConstants.JMS_ACTIVEMQ_INPUT_STREAM,
-                              ServiceTestBase.createFakeLargeStream(2 * ActiveMQClient.DEFAULT_MIN_LARGE_MESSAGE_SIZE));
+                              ActiveMQTestBase.createFakeLargeStream(2 * ActiveMQClient.DEFAULT_MIN_LARGE_MESSAGE_SIZE));
          msgs.add(bm);
 
          MapMessage mm = sess.createMapMessage();
@@ -168,7 +167,7 @@ public class ReSendMessageTest extends JMSTestBase
 
             for (int i = 0; i < copiedBytes.getBodyLength(); i++)
             {
-               Assert.assertEquals(ServiceTestBase.getSamplebyte(i), copiedBytes.readByte());
+               Assert.assertEquals(ActiveMQTestBase.getSamplebyte(i), copiedBytes.readByte());
             }
          }
          else if (copiedMessage instanceof MapMessage)
@@ -313,14 +312,6 @@ public class ReSendMessageTest extends JMSTestBase
    {
       super.setUp();
       queue = createQueue("queue1");
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      queue = null;
-      super.tearDown();
    }
 
    // Private -------------------------------------------------------

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/ReceiveNoWaitTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/ReceiveNoWaitTest.java
@@ -15,10 +15,9 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.jms.client;
+
 import org.apache.activemq.artemis.tests.util.JMSTestBase;
 import org.junit.Before;
-import org.junit.After;
-
 import org.junit.Test;
 
 import javax.jms.Connection;
@@ -45,16 +44,6 @@ public class ReceiveNoWaitTest extends JMSTestBase
 
       queue = createQueue("TestQueue");
    }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      jmsServer.destroyQueue("TestQueue");
-
-      super.tearDown();
-   }
-
 
    /*
     * Test that after sending persistent messages to a queue (these will be sent blocking)

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/RemoteConnectionStressTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/RemoteConnectionStressTest.java
@@ -16,6 +16,19 @@
  */
 package org.apache.activemq.artemis.tests.integration.jms.client;
 
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
+import org.apache.activemq.artemis.api.jms.JMSFactoryType;
+import org.apache.activemq.artemis.core.registry.JndiBindingRegistry;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.ActiveMQServers;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
+import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.junit.Before;
+import org.junit.Test;
+
 import javax.jms.Connection;
 import javax.jms.MessageProducer;
 import javax.jms.Queue;
@@ -24,28 +37,11 @@ import javax.jms.TextMessage;
 import javax.management.MBeanServer;
 import javax.management.MBeanServerFactory;
 
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
-import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
-import org.apache.activemq.artemis.api.jms.JMSFactoryType;
-import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
-import org.apache.activemq.artemis.core.config.Configuration;
-import org.apache.activemq.artemis.core.registry.JndiBindingRegistry;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
-import org.apache.activemq.artemis.core.server.ActiveMQServers;
-import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
-import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
 /**
  * test Written to replicate https://issues.jboss.org/browse/HORNETQ-1312
  */
-public class RemoteConnectionStressTest extends ServiceTestBase
+public class RemoteConnectionStressTest extends ActiveMQTestBase
 {
-
-
    ActiveMQServer server;
    MBeanServer mbeanServer;
    JMSServerManagerImpl jmsServer;
@@ -55,12 +51,9 @@ public class RemoteConnectionStressTest extends ServiceTestBase
    {
       super.setUp();
 
-      Configuration conf = ServiceTestBase.createBasicConfigNoDataFolder();
-      conf.getAcceptorConfigurations().add(new TransportConfiguration("org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptorFactory"));
-
       mbeanServer = MBeanServerFactory.createMBeanServer();
 
-      server = ActiveMQServers.newActiveMQServer(conf, mbeanServer, false);
+      server = addServer(ActiveMQServers.newActiveMQServer(createDefaultNettyConfig(), mbeanServer, false));
 
       InVMNamingContext namingContext = new InVMNamingContext();
       jmsServer = new JMSServerManagerImpl(server);
@@ -69,14 +62,6 @@ public class RemoteConnectionStressTest extends ServiceTestBase
       jmsServer.start();
 
       jmsServer.createQueue(true, "SomeQueue", null, true, "/jms/SomeQueue");
-   }
-
-   @After
-   public void tearDown() throws Exception
-   {
-      jmsServer.stop();
-
-      super.tearDown();
    }
 
    @Test

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/TextMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/TextMessageTest.java
@@ -16,22 +16,21 @@
  */
 package org.apache.activemq.artemis.tests.integration.jms.client;
 
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
+import org.apache.activemq.artemis.api.jms.JMSFactoryType;
+import org.apache.activemq.artemis.tests.util.JMSTestBase;
+import org.apache.activemq.artemis.tests.util.RandomUtil;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
 import javax.jms.MessageConsumer;
 import javax.jms.MessageProducer;
 import javax.jms.Queue;
 import javax.jms.Session;
 import javax.jms.TextMessage;
 import java.util.List;
-
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
-import org.apache.activemq.artemis.api.jms.JMSFactoryType;
-import org.apache.activemq.artemis.tests.util.JMSTestBase;
-import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 public class TextMessageTest extends JMSTestBase
 {
@@ -189,14 +188,6 @@ public class TextMessageTest extends JMSTestBase
    {
       super.setUp();
       queue = createQueue("queue1");
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      queue = null;
-      super.tearDown();
    }
 
    @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/cluster/BindingsClusterTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/cluster/BindingsClusterTest.java
@@ -139,7 +139,7 @@ public class BindingsClusterTest extends JMSClusteredTestBase
          prod1.send(session1.createTextMessage("m3"));
 
          cf2 = ActiveMQJMSClient.createConnectionFactoryWithoutHA(JMSFactoryType.CF, new TransportConfiguration(InVMConnectorFactory.class.getName(),
-                                                                                                                generateInVMParams(1)));
+                                                                                                                generateInVMParams(2)));
 
          conn2 = cf2.createConnection();
 
@@ -250,7 +250,7 @@ public class BindingsClusterTest extends JMSClusteredTestBase
          prod1.send(session1.createTextMessage("m6"));
 
          cf2 = ActiveMQJMSClient.createConnectionFactoryWithoutHA(JMSFactoryType.CF, new TransportConfiguration(InVMConnectorFactory.class.getName(),
-                                                                                                                generateInVMParams(1)));
+                                                                                                                generateInVMParams(2)));
 
          conn2 = cf2.createConnection();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/cluster/LargeMessageOverBridgeTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/cluster/LargeMessageOverBridgeTest.java
@@ -16,18 +16,6 @@
  */
 package org.apache.activemq.artemis.tests.integration.jms.cluster;
 
-import javax.jms.BytesMessage;
-import javax.jms.Connection;
-import javax.jms.MapMessage;
-import javax.jms.MessageConsumer;
-import javax.jms.MessageProducer;
-import javax.jms.Queue;
-import javax.jms.Session;
-import javax.jms.TextMessage;
-
-import java.util.Arrays;
-import java.util.Collection;
-
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
 import org.apache.activemq.artemis.api.jms.JMSFactoryType;
@@ -39,6 +27,17 @@ import org.apache.activemq.artemis.tests.util.JMSClusteredTestBase;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import javax.jms.BytesMessage;
+import javax.jms.Connection;
+import javax.jms.MapMessage;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import java.util.Arrays;
+import java.util.Collection;
 
 @RunWith(value = Parameterized.class)
 public class LargeMessageOverBridgeTest extends JMSClusteredTestBase
@@ -168,16 +167,6 @@ public class LargeMessageOverBridgeTest extends JMSClusteredTestBase
    }
 
 
-   protected Configuration createConfigServer2()
-   {
-      Configuration config = super.createConfigServer2();
-
-      installHack(config);
-
-      return config;
-   }
-
-
    /**
     * the hack to create the failing condition in certain tests
     *
@@ -194,12 +183,11 @@ public class LargeMessageOverBridgeTest extends JMSClusteredTestBase
       }
    }
 
-   protected Configuration createConfigServer1()
+   protected Configuration createConfigServer(final int source, final int destination) throws Exception
    {
-      Configuration config = super.createConfigServer1();
+      Configuration config = super.createConfigServer(source, destination);
 
       installHack(config);
-
 
       return config;
    }
@@ -273,7 +261,7 @@ public class LargeMessageOverBridgeTest extends JMSClusteredTestBase
       Queue queue = (Queue) context1.lookup("queue/Q1");
 
 
-      ActiveMQConnectionFactory cf1 = ActiveMQJMSClient.createConnectionFactoryWithHA(JMSFactoryType.CF, new TransportConfiguration(INVM_CONNECTOR_FACTORY, generateInVMParams(0)));
+      ActiveMQConnectionFactory cf1 = ActiveMQJMSClient.createConnectionFactoryWithHA(JMSFactoryType.CF, new TransportConfiguration(INVM_CONNECTOR_FACTORY, generateInVMParams(1)));
       cf1.setMinLargeMessageSize(200 * 1024);
 
       Connection conn1 = cf1.createConnection();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/cluster/MultipleThreadsOpeningTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/cluster/MultipleThreadsOpeningTest.java
@@ -34,7 +34,7 @@ public class MultipleThreadsOpeningTest extends JMSClusteredTestBase
    public void testMultipleOpen() throws Exception
    {
       cf1 = ActiveMQJMSClient.createConnectionFactoryWithHA(JMSFactoryType.CF, new TransportConfiguration(InVMConnectorFactory.class.getName(),
-                                                                                                          generateInVMParams(0)));
+                                                                                                          generateInVMParams(1)));
 
       final int numberOfOpens = 2000;
       int numberOfThreads = 20;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/cluster/ReplicatedJMSFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/cluster/ReplicatedJMSFailoverTest.java
@@ -45,18 +45,18 @@ public class ReplicatedJMSFailoverTest extends JMSFailoverTest
          .setLargeMessagesDirectory(getLargeMessagesDir(0, true))
          .setHAPolicyConfiguration(new ReplicaPolicyConfiguration());
 
-      backupService = ActiveMQServers.newActiveMQServer(backupConf, true);
+      backupServer = addServer(ActiveMQServers.newActiveMQServer(backupConf, true));
 
-      backupJMSService = new JMSServerManagerImpl(backupService);
+      backupJMSServer = new JMSServerManagerImpl(backupServer);
 
-      backupJMSService.setRegistry(new JndiBindingRegistry(ctx2));
+      backupJMSServer.setRegistry(new JndiBindingRegistry(ctx2));
 
-      backupJMSService.start();
+      backupJMSServer.start();
 
       liveConf = createBasicConfig()
          .setJournalType(getDefaultJournalType())
          .addConnectorConfiguration("toBackup", new TransportConfiguration(INVM_CONNECTOR_FACTORY, backupParams))
-         .addAcceptorConfiguration(new TransportConfiguration("org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory"))
+         .addAcceptorConfiguration(new TransportConfiguration(INVM_ACCEPTOR_FACTORY))
          .setBindingsDirectory(getBindingsDir(0, false))
          .setJournalMinFiles(2)
          .setJournalDirectory(getJournalDir(0, false))
@@ -64,13 +64,13 @@ public class ReplicatedJMSFailoverTest extends JMSFailoverTest
          .setLargeMessagesDirectory(getLargeMessagesDir(0, false))
          .setHAPolicyConfiguration(new ReplicatedPolicyConfiguration());
 
-      liveService = ActiveMQServers.newActiveMQServer(liveConf, true);
+      liveServer = addServer(ActiveMQServers.newActiveMQServer(liveConf, true));
 
-      liveJMSService = new JMSServerManagerImpl(liveService);
+      liveJMSServer = new JMSServerManagerImpl(liveServer);
 
-      liveJMSService.setRegistry(new JndiBindingRegistry(ctx1));
+      liveJMSServer.setRegistry(new JndiBindingRegistry(ctx1));
 
-      liveJMSService.start();
+      liveJMSServer.start();
    }
 
    // Private -------------------------------------------------------

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/cluster/TemporaryQueueClusterTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/cluster/TemporaryQueueClusterTest.java
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.jms.cluster;
-import org.junit.Before;
-import org.junit.After;
 
+import org.apache.activemq.artemis.tests.util.JMSClusteredTestBase;
 import org.junit.Test;
 
 import javax.jms.Connection;
@@ -26,8 +25,6 @@ import javax.jms.MessageProducer;
 import javax.jms.Queue;
 import javax.jms.Session;
 import javax.jms.TextMessage;
-
-import org.apache.activemq.artemis.tests.util.JMSClusteredTestBase;
 
 public class TemporaryQueueClusterTest extends JMSClusteredTestBase
 {
@@ -41,20 +38,6 @@ public class TemporaryQueueClusterTest extends JMSClusteredTestBase
    // Constructors --------------------------------------------------
 
    // Public --------------------------------------------------------
-
-   @After
-   public void tearDown() throws Exception
-   {
-      super.tearDown();
-   }
-
-   @Before
-   public void setUp() throws Exception
-   {
-      super.setUp();
-   }
-
-
 
    @Test
    public void testClusteredQueue() throws Exception

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/cluster/TopicClusterTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/cluster/TopicClusterTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.activemq.artemis.tests.integration.jms.cluster;
 
+import org.apache.activemq.artemis.tests.util.JMSClusteredTestBase;
+import org.junit.Test;
+
 import javax.jms.Connection;
 import javax.jms.DeliveryMode;
 import javax.jms.MessageConsumer;
@@ -23,11 +26,6 @@ import javax.jms.MessageProducer;
 import javax.jms.Session;
 import javax.jms.TextMessage;
 import javax.jms.Topic;
-
-import org.apache.activemq.artemis.tests.util.JMSClusteredTestBase;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 public class TopicClusterTest extends JMSClusteredTestBase
 {
@@ -41,20 +39,6 @@ public class TopicClusterTest extends JMSClusteredTestBase
    // Constructors --------------------------------------------------
 
    // Public --------------------------------------------------------
-
-
-   @After
-   public void tearDown() throws Exception
-   {
-      super.tearDown();
-   }
-
-
-   @Before
-   public void setUp() throws Exception
-   {
-      super.setUp();
-   }
 
    @Test
    public void testDeleteTopicAfterClusteredSend() throws Exception

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/connection/CloseConnectionFactoryOnGCest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/connection/CloseConnectionFactoryOnGCest.java
@@ -53,7 +53,7 @@ public class CloseConnectionFactoryOnGCest extends JMSTestBase
          for (int i = 0; i < 100; i++)
          {
             ActiveMQConnectionFactory cf = ActiveMQJMSClient.createConnectionFactoryWithoutHA(JMSFactoryType.CF,
-                                                                                              new TransportConfiguration("org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnectorFactory"));
+                                                                                              new TransportConfiguration(INVM_CONNECTOR_FACTORY));
             Connection conn = cf.createConnection();
             cf = null;
             conn.close();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/connection/CloseConnectionOnGCTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/connection/CloseConnectionOnGCTest.java
@@ -15,22 +15,6 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.jms.connection;
-import org.apache.activemq.artemis.tests.util.JMSTestBase;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.junit.Before;
-import org.junit.After;
-
-import org.junit.Test;
-
-import java.lang.ref.WeakReference;
-import java.util.Iterator;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
-import javax.jms.Connection;
-import javax.jms.Session;
-
-import org.junit.Assert;
 
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
@@ -38,6 +22,18 @@ import org.apache.activemq.artemis.api.jms.JMSFactoryType;
 import org.apache.activemq.artemis.core.remoting.CloseListener;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.apache.activemq.artemis.tests.util.JMSTestBase;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.jms.Connection;
+import javax.jms.Session;
+import java.lang.ref.WeakReference;
+import java.util.Iterator;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 /**
  *
@@ -53,19 +49,9 @@ public class CloseConnectionOnGCTest extends JMSTestBase
    {
       super.setUp();
 
-      cf = ActiveMQJMSClient.createConnectionFactoryWithoutHA(JMSFactoryType.CF, new TransportConfiguration("org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnectorFactory"));
+      cf = ActiveMQJMSClient.createConnectionFactoryWithoutHA(JMSFactoryType.CF, new TransportConfiguration(INVM_CONNECTOR_FACTORY));
       cf.setBlockOnDurableSend(true);
       cf.setPreAcknowledge(true);
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      if (cf != null)
-         cf.close();
-
-      super.tearDown();
    }
 
    @Test
@@ -93,7 +79,7 @@ public class CloseConnectionOnGCTest extends JMSTestBase
 
       conn = null;
 
-      ServiceTestBase.checkWeakReferences(wr);
+      ActiveMQTestBase.checkWeakReferences(wr);
 
       latch.await(5000, TimeUnit.MILLISECONDS);
       Assert.assertEquals(0, server.getRemotingService().getConnections().size());
@@ -130,7 +116,7 @@ public class CloseConnectionOnGCTest extends JMSTestBase
       conn2 = null;
       conn3 = null;
 
-      ServiceTestBase.checkWeakReferences(wr1, wr2, wr3);
+      ActiveMQTestBase.checkWeakReferences(wr1, wr2, wr3);
 
       latch.await(5000, TimeUnit.MILLISECONDS);
 
@@ -174,7 +160,7 @@ public class CloseConnectionOnGCTest extends JMSTestBase
       conn2 = null;
       conn3 = null;
 
-      ServiceTestBase.checkWeakReferences(wr1, wr2, wr3);
+      ActiveMQTestBase.checkWeakReferences(wr1, wr2, wr3);
 
       latch.await(5000, TimeUnit.MILLISECONDS);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/connection/CloseDestroyedConnectionTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/connection/CloseDestroyedConnectionTest.java
@@ -15,21 +15,10 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.jms.connection;
+
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
 import org.apache.activemq.artemis.api.core.ActiveMQInternalErrorException;
-import org.junit.Before;
-import org.junit.After;
-
-import org.junit.Test;
-
-import javax.jms.Connection;
-import javax.jms.JMSException;
-import javax.jms.Queue;
-import javax.jms.Session;
-
-import org.junit.Assert;
-
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
@@ -40,6 +29,14 @@ import org.apache.activemq.artemis.jms.client.ActiveMQSession;
 import org.apache.activemq.artemis.jms.client.ActiveMQTemporaryTopic;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
 import org.apache.activemq.artemis.tests.util.JMSTestBase;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.jms.Connection;
+import javax.jms.JMSException;
+import javax.jms.Queue;
+import javax.jms.Session;
 
 public class CloseDestroyedConnectionTest extends JMSTestBase
 {
@@ -59,23 +56,6 @@ public class CloseDestroyedConnectionTest extends JMSTestBase
                                                                   new TransportConfiguration(INVM_CONNECTOR_FACTORY));
       cf.setBlockOnDurableSend(true);
       cf.setPreAcknowledge(true);
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      if (session1 != null)
-         session1.close();
-      if (session2 != null)
-         session2.close();
-      if (conn != null)
-         conn.close();
-      if (conn2 != null)
-         conn2.close();
-      cf = null;
-
-      super.tearDown();
    }
 
    @Test

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/connection/ConcurrentSessionCloseTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/connection/ConcurrentSessionCloseTest.java
@@ -15,21 +15,18 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.jms.connection;
-import org.apache.activemq.artemis.tests.util.JMSTestBase;
-import org.junit.Before;
-import org.junit.After;
-
-import org.junit.Test;
-
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import javax.jms.Connection;
-import javax.jms.Session;
 
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
 import org.apache.activemq.artemis.api.jms.JMSFactoryType;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.apache.activemq.artemis.tests.util.JMSTestBase;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.jms.Connection;
+import javax.jms.Session;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  *
@@ -45,21 +42,7 @@ public class ConcurrentSessionCloseTest extends JMSTestBase
    {
       super.setUp();
 
-      cf =
-               ActiveMQJMSClient.createConnectionFactoryWithoutHA(JMSFactoryType.CF,
-                                                                  new TransportConfiguration(INVM_CONNECTOR_FACTORY));
-
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      if (cf != null)
-         cf.close();
-      cf = null;
-
-      super.tearDown();
+      cf = ActiveMQJMSClient.createConnectionFactoryWithoutHA(JMSFactoryType.CF, new TransportConfiguration(INVM_CONNECTOR_FACTORY));
    }
 
    // https://jira.jboss.org/browse/HORNETQ-525
@@ -112,8 +95,5 @@ public class ConcurrentSessionCloseTest extends JMSTestBase
 
          assertFalse(failed.get());
       }
-
-      jmsServer.stop();
    }
-
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/connection/ExceptionListenerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/connection/ExceptionListenerTest.java
@@ -15,29 +15,13 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.jms.connection;
+
 import org.apache.activemq.artemis.api.core.ActiveMQInternalErrorException;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.apache.activemq.artemis.core.registry.JndiBindingRegistry;
-import org.junit.Before;
-import org.junit.After;
-
-import org.junit.Test;
-
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
-import javax.jms.Connection;
-import javax.jms.ExceptionListener;
-import javax.jms.JMSException;
-import javax.jms.Session;
-
-import org.junit.Assert;
-
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
 import org.apache.activemq.artemis.api.jms.JMSFactoryType;
 import org.apache.activemq.artemis.core.client.impl.ClientSessionInternal;
-import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.registry.JndiBindingRegistry;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnection;
@@ -45,12 +29,23 @@ import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.jms.client.ActiveMQSession;
 import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
 import org.apache.activemq.artemis.tests.integration.jms.server.management.NullInitialContext;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.jms.Connection;
+import javax.jms.ExceptionListener;
+import javax.jms.JMSException;
+import javax.jms.Session;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 /**
  *
  * A ExceptionListenerTest
  */
-public class ExceptionListenerTest extends ServiceTestBase
+public class ExceptionListenerTest extends ActiveMQTestBase
 {
    private ActiveMQServer server;
 
@@ -66,30 +61,14 @@ public class ExceptionListenerTest extends ServiceTestBase
    {
       super.setUp();
 
-      Configuration conf = createBasicConfig()
-         .addAcceptorConfiguration(new TransportConfiguration("org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory"));
-      server = addServer(ActiveMQServers.newActiveMQServer(conf, false));
+      server = addServer(ActiveMQServers.newActiveMQServer(createDefaultInVMConfig(), false));
       jmsServer = new JMSServerManagerImpl(server);
       jmsServer.setRegistry(new JndiBindingRegistry(new NullInitialContext()));
       jmsServer.start();
       jmsServer.createQueue(false, ExceptionListenerTest.Q_NAME, null, true, ExceptionListenerTest.Q_NAME);
-      cf = ActiveMQJMSClient.createConnectionFactoryWithoutHA(JMSFactoryType.CF, new TransportConfiguration("org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnectorFactory"));
+      cf = ActiveMQJMSClient.createConnectionFactoryWithoutHA(JMSFactoryType.CF, new TransportConfiguration(INVM_CONNECTOR_FACTORY));
       cf.setBlockOnDurableSend(true);
       cf.setPreAcknowledge(true);
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      jmsServer.stop();
-      cf = null;
-
-      server = null;
-      jmsServer = null;
-      cf = null;
-
-      super.tearDown();
    }
 
    private class MyExceptionListener implements ExceptionListener

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/connection/InvalidConnectorTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/connection/InvalidConnectorTest.java
@@ -15,10 +15,6 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.jms.connection;
-import org.junit.Before;
-import org.junit.After;
-
-import org.junit.Test;
 
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
@@ -26,6 +22,7 @@ import org.apache.activemq.artemis.api.jms.JMSFactoryType;
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.tests.util.JMSTestBase;
+import org.junit.Test;
 
 import java.net.InetAddress;
 import java.util.ArrayList;
@@ -35,22 +32,6 @@ import java.util.Map;
 
 public class InvalidConnectorTest extends JMSTestBase
 {
-   @Override
-   @Before
-   public void setUp() throws Exception
-   {
-      super.setUp();
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      cf = null;
-
-      super.tearDown();
-   }
-
    @Test
    public void testInvalidConnector() throws Exception
    {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/consumer/ConsumerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/consumer/ConsumerTest.java
@@ -16,6 +16,21 @@
  */
 package org.apache.activemq.artemis.tests.integration.jms.consumer;
 
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
+import org.apache.activemq.artemis.api.jms.ActiveMQJMSConstants;
+import org.apache.activemq.artemis.api.jms.JMSFactoryType;
+import org.apache.activemq.artemis.core.server.Queue;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.apache.activemq.artemis.jms.client.ActiveMQDestination;
+import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
+import org.apache.activemq.artemis.tests.util.JMSTestBase;
+import org.apache.activemq.artemis.utils.ReusableLatch;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
 import javax.jms.Connection;
 import javax.jms.JMSConsumer;
 import javax.jms.JMSContext;
@@ -28,25 +43,8 @@ import javax.jms.MessageProducer;
 import javax.jms.QueueBrowser;
 import javax.jms.Session;
 import javax.jms.TextMessage;
-
 import java.util.Enumeration;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
-import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
-import org.apache.activemq.artemis.api.jms.ActiveMQJMSConstants;
-import org.apache.activemq.artemis.api.jms.JMSFactoryType;
-import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.JMSTestBase;
-import org.apache.activemq.artemis.core.server.Queue;
-import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
-import org.apache.activemq.artemis.jms.client.ActiveMQDestination;
-import org.apache.activemq.artemis.utils.ReusableLatch;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 public class ConsumerTest extends JMSTestBase
 {
@@ -68,24 +66,13 @@ public class ConsumerTest extends JMSTestBase
    {
       super.setUp();
 
-
       topic = ActiveMQJMSClient.createTopic(T_NAME);
       topic2 = ActiveMQJMSClient.createTopic(T2_NAME);
-
 
       jmsServer.createQueue(false, ConsumerTest.Q_NAME, null, true, ConsumerTest.Q_NAME);
       jmsServer.createTopic(true, T_NAME, "/topic/" + T_NAME);
       jmsServer.createTopic(true, T2_NAME, "/topic/" + T2_NAME);
-      cf = ActiveMQJMSClient.createConnectionFactoryWithoutHA(JMSFactoryType.CF, new TransportConfiguration("org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnectorFactory"));
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      cf = null;
-
-      super.tearDown();
+      cf = ActiveMQJMSClient.createConnectionFactoryWithoutHA(JMSFactoryType.CF, new TransportConfiguration(INVM_CONNECTOR_FACTORY));
    }
 
    @Test

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/divert/DivertAndACKClientTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/divert/DivertAndACKClientTest.java
@@ -16,11 +16,14 @@
  */
 package org.apache.activemq.artemis.tests.integration.jms.divert;
 
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
+import org.apache.activemq.artemis.api.jms.JMSFactoryType;
+import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.config.DivertConfiguration;
 import org.apache.activemq.artemis.tests.util.JMSTestBase;
+import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import javax.jms.Connection;
 import javax.jms.MessageConsumer;
@@ -28,14 +31,7 @@ import javax.jms.MessageProducer;
 import javax.jms.Queue;
 import javax.jms.Session;
 import javax.jms.TextMessage;
-
-import org.junit.Assert;
-
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
-import org.apache.activemq.artemis.api.jms.JMSFactoryType;
-import org.apache.activemq.artemis.core.config.Configuration;
-import org.apache.activemq.artemis.core.config.DivertConfiguration;
+import java.util.List;
 
 /**
  * A DivertAndACKClientTest
@@ -102,8 +98,6 @@ public class DivertAndACKClientTest extends JMSTestBase
    @Override
    protected Configuration createDefaultConfig(final boolean netty) throws Exception
    {
-      Configuration config = super.createDefaultConfig(netty);
-
       DivertConfiguration divert = new DivertConfiguration()
          .setName("local-divert")
          .setRoutingName("some-name")
@@ -111,10 +105,8 @@ public class DivertAndACKClientTest extends JMSTestBase
          .setForwardingAddress("jms.queue.Dest")
          .setExclusive(true);
 
-      ArrayList<DivertConfiguration> divertList = new ArrayList<DivertConfiguration>();
-      divertList.add(divert);
-
-      config.setDivertConfigurations(divertList);
+      Configuration config = super.createDefaultConfig(netty)
+              .addDivertConfiguration(divert);
 
       return config;
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/largemessage/JMSLargeMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/largemessage/JMSLargeMessageTest.java
@@ -16,6 +16,13 @@
  */
 package org.apache.activemq.artemis.tests.integration.jms.largemessage;
 
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.apache.activemq.artemis.tests.util.JMSTestBase;
+import org.apache.activemq.artemis.utils.UUIDGenerator;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
 import javax.jms.BytesMessage;
 import javax.jms.JMSException;
 import javax.jms.MessageConsumer;
@@ -29,14 +36,6 @@ import java.io.OutputStream;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-
-import org.apache.activemq.artemis.tests.util.JMSTestBase;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.apache.activemq.artemis.utils.UUIDGenerator;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 public class JMSLargeMessageTest extends JMSTestBase
 {
@@ -66,14 +65,6 @@ public class JMSLargeMessageTest extends JMSTestBase
       queue1 = createQueue("queue1");
    }
 
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      queue1 = null;
-      super.tearDown();
-   }
-
    @Test
    public void testSimpleLargeMessage() throws Exception
    {
@@ -86,7 +77,7 @@ public class JMSLargeMessageTest extends JMSTestBase
 
       BytesMessage m = session.createBytesMessage();
 
-      m.setObjectProperty("JMS_AMQ_InputStream", ServiceTestBase.createFakeLargeStream(1024 * 1024));
+      m.setObjectProperty("JMS_AMQ_InputStream", ActiveMQTestBase.createFakeLargeStream(1024 * 1024));
 
       prod.send(m);
 
@@ -112,7 +103,7 @@ public class JMSLargeMessageTest extends JMSTestBase
          Assert.assertEquals(1024, numberOfBytes);
          for (int j = 0; j < 1024; j++)
          {
-            Assert.assertEquals(ServiceTestBase.getSamplebyte(i + j), data[j]);
+            Assert.assertEquals(ActiveMQTestBase.getSamplebyte(i + j), data[j]);
          }
       }
 
@@ -130,7 +121,7 @@ public class JMSLargeMessageTest extends JMSTestBase
 
       BytesMessage m = session.createBytesMessage();
 
-      m.setObjectProperty("JMS_AMQ_InputStream", ServiceTestBase.createFakeLargeStream(10));
+      m.setObjectProperty("JMS_AMQ_InputStream", ActiveMQTestBase.createFakeLargeStream(10));
 
       prod.send(m);
 
@@ -154,7 +145,7 @@ public class JMSLargeMessageTest extends JMSTestBase
       Assert.assertEquals(10, numberOfBytes);
       for (int j = 0; j < numberOfBytes; j++)
       {
-         Assert.assertEquals(ServiceTestBase.getSamplebyte(j), data[j]);
+         Assert.assertEquals(ActiveMQTestBase.getSamplebyte(j), data[j]);
       }
 
       Assert.assertNotNull(rm);
@@ -171,7 +162,7 @@ public class JMSLargeMessageTest extends JMSTestBase
 
       try
       {
-         msg.setObjectProperty("JMS_AMQ_InputStream", ServiceTestBase.createFakeLargeStream(10));
+         msg.setObjectProperty("JMS_AMQ_InputStream", ActiveMQTestBase.createFakeLargeStream(10));
          Assert.fail("Exception was expected");
       }
       catch (JMSException e)
@@ -232,7 +223,7 @@ public class JMSLargeMessageTest extends JMSTestBase
 
       BytesMessage m = session.createBytesMessage();
 
-      m.setObjectProperty("JMS_AMQ_InputStream", ServiceTestBase.createFakeLargeStream(msgSize));
+      m.setObjectProperty("JMS_AMQ_InputStream", ActiveMQTestBase.createFakeLargeStream(msgSize));
 
       prod.send(m);
 
@@ -262,7 +253,7 @@ public class JMSLargeMessageTest extends JMSTestBase
          public void write(final int b) throws IOException
          {
             numberOfBytes.incrementAndGet();
-            if (ServiceTestBase.getSamplebyte(position++) != b)
+            if (ActiveMQTestBase.getSamplebyte(position++) != b)
             {
                System.out.println("Wrong byte at position " + position);
                numberOfErrors.incrementAndGet();
@@ -273,7 +264,7 @@ public class JMSLargeMessageTest extends JMSTestBase
 
       try
       {
-         rm.setObjectProperty("JMS_AMQ_InputStream", ServiceTestBase.createFakeLargeStream(100));
+         rm.setObjectProperty("JMS_AMQ_InputStream", ActiveMQTestBase.createFakeLargeStream(100));
          Assert.fail("Exception expected!");
       }
       catch (MessageNotWriteableException expected)
@@ -318,7 +309,7 @@ public class JMSLargeMessageTest extends JMSTestBase
 
       conn.close();
 
-      validateNoFilesOnLargeDir(1);
+      validateNoFilesOnLargeDir(server.getConfiguration().getLargeMessagesDirectory(), 1);
 
       conn = cf.createConnection();
 
@@ -334,7 +325,7 @@ public class JMSLargeMessageTest extends JMSTestBase
       String str = rm.getText();
       Assert.assertEquals(originalString, str);
       conn.close();
-      validateNoFilesOnLargeDir(0);
+      validateNoFilesOnLargeDir(server.getConfiguration().getLargeMessagesDirectory(), 0);
 
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/JMSServerDeployerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/JMSServerDeployerTest.java
@@ -16,28 +16,27 @@
  */
 package org.apache.activemq.artemis.tests.integration.jms.server;
 
-import javax.jms.Queue;
-import javax.jms.Topic;
-import javax.naming.Context;
-
 import org.apache.activemq.artemis.api.core.DiscoveryGroupConfiguration;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.UDPBroadcastEndpointFactory;
-import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.registry.JndiBindingRegistry;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.jms.server.JMSServerManager;
 import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
-import org.junit.After;
+import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
+import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class JMSServerDeployerTest extends ServiceTestBase
+import javax.jms.Queue;
+import javax.jms.Topic;
+import javax.naming.Context;
+
+public class JMSServerDeployerTest extends ActiveMQTestBase
 {
    // Constants -----------------------------------------------------
 
@@ -136,18 +135,6 @@ public class JMSServerDeployerTest extends ServiceTestBase
       context = new InVMNamingContext();
       jmsServer.setRegistry(new JndiBindingRegistry(context));
       jmsServer.start();
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      jmsServer.stop();
-      jmsServer = null;
-      context = null;
-      config = null;
-
-      super.tearDown();
    }
 
    // Private -------------------------------------------------------

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/config/JMSConfigurationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/config/JMSConfigurationTest.java
@@ -16,24 +16,8 @@
  */
 package org.apache.activemq.artemis.tests.integration.jms.server.config;
 
-import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.apache.activemq.artemis.core.registry.JndiBindingRegistry;
-import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.jms.Connection;
-import javax.jms.ConnectionFactory;
-import javax.jms.Queue;
-import javax.jms.Topic;
-import javax.naming.Context;
-
-import org.junit.Assert;
-
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
-import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.registry.JndiBindingRegistry;
 import org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnectorFactory;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl;
@@ -46,18 +30,28 @@ import org.apache.activemq.artemis.jms.server.config.impl.JMSConfigurationImpl;
 import org.apache.activemq.artemis.jms.server.config.impl.JMSQueueConfigurationImpl;
 import org.apache.activemq.artemis.jms.server.config.impl.TopicConfigurationImpl;
 import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
+import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
+import org.junit.Assert;
+import org.junit.Test;
 
-public class JMSConfigurationTest extends ServiceTestBase
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Queue;
+import javax.jms.Topic;
+import javax.naming.Context;
+import java.util.ArrayList;
+import java.util.List;
+
+public class JMSConfigurationTest extends ActiveMQTestBase
 {
-
    @Test
    public void testSetupJMSConfiguration() throws Exception
    {
       Context context = new InVMNamingContext();
 
-      Configuration coreConfiguration = createDefaultConfig();
-      ActiveMQServer coreServer = new ActiveMQServerImpl(coreConfiguration);
+      ActiveMQServer coreServer = new ActiveMQServerImpl(createDefaultInVMConfig());
 
       JMSConfiguration jmsConfiguration = new JMSConfigurationImpl();
       TransportConfiguration connectorConfig = new TransportConfiguration(InVMConnectorFactory.class.getName());

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/config/JMSServerConfigParserTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/config/JMSServerConfigParserTest.java
@@ -24,9 +24,9 @@ import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.jms.server.config.JMSQueueConfiguration;
 import org.apache.activemq.artemis.jms.server.config.TopicConfiguration;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 
-public class JMSServerConfigParserTest extends ServiceTestBase
+public class JMSServerConfigParserTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------
@@ -43,7 +43,7 @@ public class JMSServerConfigParserTest extends ServiceTestBase
    @Test
    public void testParsing() throws Exception
    {
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          // anything so the parsing will work
          .addConnectorConfiguration("netty", new TransportConfiguration());
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/management/JMSQueueControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/management/JMSQueueControlTest.java
@@ -16,21 +16,6 @@
  */
 package org.apache.activemq.artemis.tests.integration.jms.server.management;
 
-import javax.jms.Connection;
-import javax.jms.JMSException;
-import javax.jms.Message;
-import javax.jms.MessageConsumer;
-import javax.jms.MessageProducer;
-import javax.jms.Session;
-import javax.management.Notification;
-import javax.naming.Context;
-
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
@@ -44,7 +29,6 @@ import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
 import org.apache.activemq.artemis.api.jms.JMSFactoryType;
 import org.apache.activemq.artemis.api.jms.management.JMSQueueControl;
 import org.apache.activemq.artemis.api.jms.management.JMSServerControl;
-import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.registry.JndiBindingRegistry;
 import org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnectorFactory;
@@ -59,13 +43,27 @@ import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
 import org.apache.activemq.artemis.jms.server.management.JMSNotificationType;
 import org.apache.activemq.artemis.tests.integration.management.ManagementControlHelper;
 import org.apache.activemq.artemis.tests.integration.management.ManagementTestBase;
+import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
 import org.apache.activemq.artemis.utils.json.JSONArray;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import javax.jms.Connection;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.management.Notification;
+import javax.naming.Context;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * A QueueControlTest
@@ -486,8 +484,7 @@ public class JMSQueueControlTest extends ManagementTestBase
 
       Assert.assertNull(queueControl.getExpiryAddress());
 
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setExpiryAddress(new SimpleString(expiryAddress));
+      AddressSettings addressSettings = new AddressSettings().setExpiryAddress(new SimpleString(expiryAddress));
       server.getAddressSettingsRepository().addMatch(queue.getAddress(), addressSettings);
 
       Assert.assertEquals(expiryAddress, queueControl.getExpiryAddress());
@@ -520,8 +517,7 @@ public class JMSQueueControlTest extends ManagementTestBase
       ActiveMQQueue expiryQueue = (ActiveMQQueue) ActiveMQJMSClient.createQueue(expiryQueueName);
       serverManager.createQueue(false, expiryQueueName, null, true, expiryQueueName);
 
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setExpiryAddress(new SimpleString(expiryQueue.getAddress()));
+      AddressSettings addressSettings = new AddressSettings().setExpiryAddress(new SimpleString(expiryQueue.getAddress()));
       server.getAddressSettingsRepository().addMatch(queue.getAddress(), addressSettings);
 //      queueControl.setExpiryAddress(expiryQueue.getAddress());
 
@@ -649,8 +645,7 @@ public class JMSQueueControlTest extends ManagementTestBase
 
       Assert.assertNull(queueControl.getDeadLetterAddress());
 
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setDeadLetterAddress(new SimpleString(deadLetterAddress));
+      AddressSettings addressSettings = new AddressSettings().setDeadLetterAddress(new SimpleString(deadLetterAddress));
       server.getAddressSettingsRepository().addMatch(queue.getAddress(), addressSettings);
 
       Assert.assertEquals(deadLetterAddress, queueControl.getDeadLetterAddress());
@@ -663,8 +658,7 @@ public class JMSQueueControlTest extends ManagementTestBase
       serverManager.createQueue(false, deadLetterQueue, null, true, deadLetterQueue);
       ActiveMQQueue dlq = (ActiveMQQueue) ActiveMQJMSClient.createQueue(deadLetterQueue);
 
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setDeadLetterAddress(new SimpleString(dlq.getAddress()));
+      AddressSettings addressSettings = new AddressSettings().setDeadLetterAddress(new SimpleString(dlq.getAddress()));
       server.getAddressSettingsRepository().addMatch(queue.getAddress(), addressSettings);
 
       Connection conn = createConnection();
@@ -730,8 +724,7 @@ public class JMSQueueControlTest extends ManagementTestBase
       serverManager.createQueue(false, deadLetterQueue, null, true, deadLetterQueue);
       ActiveMQQueue dlq = (ActiveMQQueue) ActiveMQJMSClient.createQueue(deadLetterQueue);
 
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setDeadLetterAddress(new SimpleString(dlq.getAddress()));
+      AddressSettings addressSettings = new AddressSettings().setDeadLetterAddress(new SimpleString(dlq.getAddress()));
       server.getAddressSettingsRepository().addMatch(queue.getAddress(), addressSettings);
 
       Connection conn = createConnection();
@@ -1137,10 +1130,10 @@ public class JMSQueueControlTest extends ManagementTestBase
    @Test
    public void testDeleteWithPaging() throws Exception
    {
-      AddressSettings pagedSetting = new AddressSettings();
-      pagedSetting.setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
-      pagedSetting.setPageSizeBytes(10 * 1024);
-      pagedSetting.setMaxSizeBytes(100 * 1024);
+      AddressSettings pagedSetting = new AddressSettings()
+              .setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE)
+              .setPageSizeBytes(10 * 1024)
+              .setMaxSizeBytes(100 * 1024);
       server.getAddressSettingsRepository().addMatch("#", pagedSetting);
 
       serverManager.createQueue(true, "pagedTest", null, true, "/queue/pagedTest");
@@ -1186,10 +1179,10 @@ public class JMSQueueControlTest extends ManagementTestBase
    @Test
    public void testDeleteWithPagingAndFilter() throws Exception
    {
-      AddressSettings pagedSetting = new AddressSettings();
-      pagedSetting.setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
-      pagedSetting.setPageSizeBytes(10 * 1024);
-      pagedSetting.setMaxSizeBytes(100 * 1024);
+      AddressSettings pagedSetting = new AddressSettings()
+              .setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE)
+              .setPageSizeBytes(10 * 1024)
+              .setMaxSizeBytes(100 * 1024);
       server.getAddressSettingsRepository().addMatch("#", pagedSetting);
 
       serverManager.createQueue(true, "pagedTest", null, true, "/queue/pagedTest");
@@ -1386,9 +1379,9 @@ public class JMSQueueControlTest extends ManagementTestBase
    {
       super.setUp();
 
-      Configuration conf = createBasicConfig()
-         .addAcceptorConfiguration(new TransportConfiguration(INVM_ACCEPTOR_FACTORY));
-      server = createServer(this.getName().contains("WithRealData"), conf);
+      Configuration config = createDefaultInVMConfig()
+              .setJMXManagementEnabled(true);
+      server = createServer(this.getName().contains("WithRealData"), config);
       server.setMBeanServer(mbeanServer);
 
       serverManager = new JMSServerManagerImpl(server);
@@ -1400,24 +1393,6 @@ public class JMSQueueControlTest extends ManagementTestBase
       queueName = RandomUtil.randomString();
       serverManager.createQueue(false, queueName, null, true, queueName);
       queue = (ActiveMQQueue) ActiveMQJMSClient.createQueue(queueName);
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      stopComponent(serverManager);
-      serverManager = null;
-
-      server = null;
-
-      queue = null;
-
-      context.close();
-
-      context = null;
-
-      super.tearDown();
    }
 
    protected JMSQueueControl createManagementControl() throws Exception

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/management/JMSQueueControlUsingJMSTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/management/JMSQueueControlUsingJMSTest.java
@@ -15,14 +15,6 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.jms.server.management;
-import org.junit.Before;
-import org.junit.After;
-
-import java.util.Map;
-
-import javax.jms.QueueConnection;
-import javax.jms.QueueSession;
-import javax.jms.Session;
 
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
@@ -32,8 +24,14 @@ import org.apache.activemq.artemis.api.jms.management.JMSQueueControl;
 import org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnectorFactory;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.jms.client.ActiveMQQueue;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+
+import javax.jms.QueueConnection;
+import javax.jms.QueueSession;
+import javax.jms.Session;
+import java.util.Map;
 
 /**
  *
@@ -65,19 +63,6 @@ public class JMSQueueControlUsingJMSTest extends JMSQueueControlTest
       connection = cf.createQueueConnection();
       session = connection.createQueueSession(false, Session.AUTO_ACKNOWLEDGE);
       connection.start();
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      connection.close();
-
-      connection = null;
-
-      session = null;
-
-      super.tearDown();
    }
 
    @Ignore

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/management/JMSServerControl2Test.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/management/JMSServerControl2Test.java
@@ -16,22 +16,6 @@
  */
 package org.apache.activemq.artemis.tests.integration.jms.server.management;
 
-import javax.jms.Connection;
-import javax.jms.ConnectionFactory;
-import javax.jms.ExceptionListener;
-import javax.jms.JMSException;
-import javax.jms.MessageConsumer;
-import javax.jms.MessageProducer;
-import javax.jms.Queue;
-import javax.jms.QueueBrowser;
-import javax.jms.Session;
-import javax.jms.TemporaryTopic;
-import javax.jms.TextMessage;
-import javax.jms.Topic;
-import java.util.Arrays;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.management.QueueControl;
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
@@ -39,9 +23,6 @@ import org.apache.activemq.artemis.api.jms.management.JMSConnectionInfo;
 import org.apache.activemq.artemis.api.jms.management.JMSConsumerInfo;
 import org.apache.activemq.artemis.api.jms.management.JMSServerControl;
 import org.apache.activemq.artemis.api.jms.management.JMSSessionInfo;
-import org.apache.activemq.artemis.tests.unit.ra.BootstrapContext;
-import org.apache.activemq.artemis.tests.unit.ra.MessageEndpointFactory;
-import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.registry.JndiBindingRegistry;
 import org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory;
@@ -57,10 +38,28 @@ import org.apache.activemq.artemis.ra.inflow.ActiveMQActivation;
 import org.apache.activemq.artemis.ra.inflow.ActiveMQActivationSpec;
 import org.apache.activemq.artemis.tests.integration.management.ManagementControlHelper;
 import org.apache.activemq.artemis.tests.integration.management.ManagementTestBase;
+import org.apache.activemq.artemis.tests.unit.ra.BootstrapContext;
+import org.apache.activemq.artemis.tests.unit.ra.MessageEndpointFactory;
+import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.ExceptionListener;
+import javax.jms.JMSException;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.QueueBrowser;
+import javax.jms.Session;
+import javax.jms.TemporaryTopic;
+import javax.jms.TextMessage;
+import javax.jms.Topic;
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 public class JMSServerControl2Test extends ManagementTestBase
 {
@@ -78,9 +77,9 @@ public class JMSServerControl2Test extends ManagementTestBase
 
    private void startActiveMQServer(final String acceptorFactory) throws Exception
    {
-      Configuration conf = createBasicConfig()
+      Configuration config = createBasicConfig()
          .addAcceptorConfiguration(new TransportConfiguration(acceptorFactory));
-      server = addServer(ActiveMQServers.newActiveMQServer(conf, mbeanServer, true));
+      server = addServer(ActiveMQServers.newActiveMQServer(config, mbeanServer, true));
       server.start();
 
       context = new InVMNamingContext();
@@ -522,7 +521,7 @@ public class JMSServerControl2Test extends ManagementTestBase
 
          ra = new ActiveMQResourceAdapter();
 
-         ra.setConnectorClassName("org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnectorFactory");
+         ra.setConnectorClassName(INVM_CONNECTOR_FACTORY);
          ra.setUserName("userGlobal");
          ra.setPassword("passwordGlobal");
          ra.start(new BootstrapContext());
@@ -688,17 +687,6 @@ public class JMSServerControl2Test extends ManagementTestBase
    protected JMSServerControl createManagementControl() throws Exception
    {
       return ManagementControlHelper.createJMSServerControl(mbeanServer);
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      serverManager = null;
-
-      server = null;
-
-      super.tearDown();
    }
 
    // Private -------------------------------------------------------

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/management/JMSServerControlUsingJMSTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/management/JMSServerControlUsingJMSTest.java
@@ -15,15 +15,6 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.jms.server.management;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.After;
-
-import org.junit.Test;
-
-import javax.jms.QueueConnection;
-import javax.jms.QueueSession;
-import javax.jms.Session;
 
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
@@ -35,6 +26,13 @@ import org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnectorFactory;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.jms.client.ActiveMQQueue;
 import org.apache.activemq.artemis.jms.client.ActiveMQQueueConnectionFactory;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.jms.QueueConnection;
+import javax.jms.QueueSession;
+import javax.jms.Session;
 
 public class JMSServerControlUsingJMSTest extends JMSServerControlTest
 {
@@ -155,19 +153,6 @@ public class JMSServerControlUsingJMSTest extends JMSServerControlTest
       connection = cf.createQueueConnection();
       session = connection.createQueueSession(false, Session.AUTO_ACKNOWLEDGE);
       connection.start();
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      connection.close();
-
-      connection = null;
-
-      session = null;
-
-      super.tearDown();
    }
 
    @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/management/TopicControlClusterTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/management/TopicControlClusterTest.java
@@ -15,14 +15,11 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.jms.server.management;
-import org.junit.Before;
-import org.junit.After;
-
-import org.junit.Test;
 
 import org.apache.activemq.artemis.api.jms.management.TopicControl;
 import org.apache.activemq.artemis.tests.integration.management.ManagementControlHelper;
 import org.apache.activemq.artemis.tests.util.JMSClusteredTestBase;
+import org.junit.Test;
 
 import javax.jms.Connection;
 import javax.jms.Session;
@@ -31,19 +28,6 @@ import javax.jms.Topic;
 
 public class TopicControlClusterTest extends JMSClusteredTestBase
 {
-   @After
-   public void tearDown() throws Exception
-   {
-      super.tearDown();
-   }
-
-
-   @Before
-   public void setUp() throws Exception
-   {
-      super.setUp();
-   }
-
    @Test
    public void testClusteredSubscriptionCount() throws Exception
    {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/management/TopicControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/management/TopicControlTest.java
@@ -16,29 +16,11 @@
  */
 package org.apache.activemq.artemis.tests.integration.jms.server.management;
 
-import javax.jms.Connection;
-import javax.jms.Message;
-import javax.jms.MessageConsumer;
-import javax.jms.MessageProducer;
-import javax.jms.Session;
-import javax.jms.TextMessage;
-import javax.jms.TopicSubscriber;
-import javax.management.Notification;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.management.ObjectNameBuilder;
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
 import org.apache.activemq.artemis.api.jms.management.JMSServerControl;
 import org.apache.activemq.artemis.api.jms.management.SubscriptionInfo;
 import org.apache.activemq.artemis.api.jms.management.TopicControl;
-import org.apache.activemq.artemis.tests.integration.management.ManagementControlHelper;
-import org.apache.activemq.artemis.tests.integration.management.ManagementTestBase;
-import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.postoffice.Binding;
 import org.apache.activemq.artemis.core.postoffice.impl.LocalQueueBinding;
@@ -50,12 +32,27 @@ import org.apache.activemq.artemis.jms.client.ActiveMQDestination;
 import org.apache.activemq.artemis.jms.client.ActiveMQTopic;
 import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
 import org.apache.activemq.artemis.jms.server.management.JMSNotificationType;
+import org.apache.activemq.artemis.tests.integration.management.ManagementControlHelper;
+import org.apache.activemq.artemis.tests.integration.management.ManagementTestBase;
+import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
 import org.apache.activemq.artemis.utils.json.JSONArray;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import javax.jms.Connection;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import javax.jms.TopicSubscriber;
+import javax.management.Notification;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 public class TopicControlTest extends ManagementTestBase
 {
@@ -599,9 +596,9 @@ public class TopicControlTest extends ManagementTestBase
    {
       super.setUp();
 
-      Configuration conf = createBasicConfig()
-         .addAcceptorConfiguration(new TransportConfiguration("org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory"));
-      server = ActiveMQServers.newActiveMQServer(conf, mbeanServer, false);
+      Configuration config = createDefaultInVMConfig()
+              .setJMXManagementEnabled(true);
+      server = addServer(ActiveMQServers.newActiveMQServer(config, mbeanServer, false));
       server.start();
 
       serverManager = new JMSServerManagerImpl(server);
@@ -615,23 +612,6 @@ public class TopicControlTest extends ManagementTestBase
       String topicName = RandomUtil.randomString();
       serverManager.createTopic(false, topicName, topicBinding);
       topic = (ActiveMQTopic) ActiveMQJMSClient.createTopic(topicName);
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      serverManager.stop();
-
-      server.stop();
-
-      serverManager = null;
-
-      server = null;
-
-      topic = null;
-
-      super.tearDown();
    }
 
    protected TopicControl createManagementControl() throws Exception

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/management/TopicControlUsingJMSTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/management/TopicControlUsingJMSTest.java
@@ -15,30 +15,13 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.jms.server.management;
-import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
-import org.apache.activemq.artemis.core.registry.JndiBindingRegistry;
-import org.junit.Before;
-import org.junit.After;
-
-import org.junit.Test;
-
-import static org.apache.activemq.artemis.tests.util.RandomUtil.randomString;
-
-import javax.jms.Connection;
-import javax.jms.Message;
-import javax.jms.MessageConsumer;
-import javax.jms.QueueConnection;
-import javax.jms.QueueSession;
-import javax.jms.Session;
-import javax.jms.TopicSubscriber;
-
-import org.junit.Assert;
 
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
 import org.apache.activemq.artemis.api.jms.JMSFactoryType;
 import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.registry.JndiBindingRegistry;
 import org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnectorFactory;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
@@ -48,7 +31,21 @@ import org.apache.activemq.artemis.jms.client.ActiveMQQueue;
 import org.apache.activemq.artemis.jms.client.ActiveMQTopic;
 import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
 import org.apache.activemq.artemis.tests.integration.management.ManagementTestBase;
+import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.jms.Connection;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.QueueConnection;
+import javax.jms.QueueSession;
+import javax.jms.Session;
+import javax.jms.TopicSubscriber;
+
+import static org.apache.activemq.artemis.tests.util.RandomUtil.randomString;
 
 public class TopicControlUsingJMSTest extends ManagementTestBase
 {
@@ -443,9 +440,9 @@ public class TopicControlUsingJMSTest extends ManagementTestBase
    {
       super.setUp();
 
-      Configuration conf = createBasicConfig()
-         .addAcceptorConfiguration(new TransportConfiguration("org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory"));
-      server = ActiveMQServers.newActiveMQServer(conf, mbeanServer, false);
+      Configuration config = createDefaultInVMConfig()
+              .setJMXManagementEnabled(true);
+      server = addServer(ActiveMQServers.newActiveMQServer(config, mbeanServer, false));
       server.start();
 
       serverManager = new JMSServerManagerImpl(server);
@@ -469,32 +466,6 @@ public class TopicControlUsingJMSTest extends ManagementTestBase
 
       ActiveMQQueue managementQueue = (ActiveMQQueue) ActiveMQJMSClient.createQueue("activemq.management");
       proxy = new JMSMessagingProxy(session, managementQueue, ResourceNames.JMS_TOPIC + topic.getTopicName());
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-
-      session.close();
-
-      connection.close();
-
-      serverManager.stop();
-
-      server.stop();
-
-      serverManager = null;
-
-      server = null;
-
-      session = null;
-
-      connection = null;
-
-      proxy = null;
-
-      super.tearDown();
    }
 
    // Private -------------------------------------------------------

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/journal/AIOImportExportTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/journal/AIOImportExportTest.java
@@ -18,7 +18,7 @@ package org.apache.activemq.artemis.tests.integration.journal;
 
 import java.io.File;
 
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.journal.SequentialFileFactory;
 import org.apache.activemq.artemis.core.journal.impl.AIOSequentialFileFactory;
 import org.junit.BeforeClass;
@@ -36,7 +36,7 @@ public class AIOImportExportTest extends NIOImportExportTest
    {
       File file = new File(getTestDir());
 
-      ServiceTestBase.deleteDirectory(file);
+      ActiveMQTestBase.deleteDirectory(file);
 
       file.mkdir();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/journal/AIOJournalCompactTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/journal/AIOJournalCompactTest.java
@@ -18,7 +18,7 @@ package org.apache.activemq.artemis.tests.integration.journal;
 
 import java.io.File;
 
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.journal.SequentialFileFactory;
 import org.apache.activemq.artemis.core.journal.impl.AIOSequentialFileFactory;
 import org.apache.activemq.artemis.core.journal.impl.JournalConstants;
@@ -37,7 +37,7 @@ public class AIOJournalCompactTest extends NIOJournalCompactTest
    {
       File file = new File(getTestDir());
 
-      ServiceTestBase.deleteDirectory(file);
+      ActiveMQTestBase.deleteDirectory(file);
 
       file.mkdir();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/journal/JournalPerfTuneTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/journal/JournalPerfTuneTest.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.journal.EncodingSupport;
 import org.apache.activemq.artemis.core.journal.IOCompletion;
 import org.apache.activemq.artemis.core.journal.Journal;
@@ -37,7 +37,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 @Ignore
-public class JournalPerfTuneTest extends ServiceTestBase
+public class JournalPerfTuneTest extends ActiveMQTestBase
 {
    private static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/journal/NIOBufferedJournalCompactTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/journal/NIOBufferedJournalCompactTest.java
@@ -18,7 +18,7 @@ package org.apache.activemq.artemis.tests.integration.journal;
 
 import java.io.File;
 
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.journal.SequentialFileFactory;
 import org.apache.activemq.artemis.core.journal.impl.NIOSequentialFileFactory;
 
@@ -30,7 +30,7 @@ public class NIOBufferedJournalCompactTest extends NIOJournalCompactTest
    {
       File file = new File(getTestDir());
 
-      ServiceTestBase.deleteDirectory(file);
+      ActiveMQTestBase.deleteDirectory(file);
 
       file.mkdir();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/journal/NIOImportExportTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/journal/NIOImportExportTest.java
@@ -15,18 +15,16 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.journal;
-import org.apache.activemq.artemis.tests.unit.core.journal.impl.JournalImplTestBase;
-import org.apache.activemq.artemis.tests.unit.core.journal.impl.fakes.SimpleEncoding;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.junit.After;
-
-import org.junit.Test;
-
-import java.io.File;
 
 import org.apache.activemq.artemis.core.journal.EncodingSupport;
 import org.apache.activemq.artemis.core.journal.SequentialFileFactory;
 import org.apache.activemq.artemis.core.journal.impl.NIOSequentialFileFactory;
+import org.apache.activemq.artemis.tests.unit.core.journal.impl.JournalImplTestBase;
+import org.apache.activemq.artemis.tests.unit.core.journal.impl.fakes.SimpleEncoding;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.junit.Test;
+
+import java.io.File;
 
 public class NIOImportExportTest extends JournalImplTestBase
 {
@@ -39,7 +37,7 @@ public class NIOImportExportTest extends JournalImplTestBase
    {
       File file = new File(getTestDir());
 
-      ServiceTestBase.deleteDirectory(file);
+      ActiveMQTestBase.deleteDirectory(file);
 
       file.mkdir();
 
@@ -55,12 +53,6 @@ public class NIOImportExportTest extends JournalImplTestBase
    // Constructors --------------------------------------------------
 
    // Public --------------------------------------------------------
-
-   @After
-   public void tearDown() throws Exception
-   {
-      super.tearDown();
-   }
 
    @Test
    public void testExportImport() throws Exception

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/journal/NIOJournalCompactTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/journal/NIOJournalCompactTest.java
@@ -48,7 +48,7 @@ import org.apache.activemq.artemis.core.persistence.impl.journal.OperationContex
 import org.apache.activemq.artemis.core.server.impl.ServerMessageImpl;
 import org.apache.activemq.artemis.tests.unit.core.journal.impl.JournalImplTestBase;
 import org.apache.activemq.artemis.tests.unit.core.journal.impl.fakes.SimpleEncoding;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.IDGenerator;
 import org.apache.activemq.artemis.utils.OrderedExecutorFactory;
 import org.apache.activemq.artemis.utils.SimpleIDGenerator;
@@ -556,7 +556,7 @@ public class NIOJournalCompactTest extends JournalImplTestBase
             System.out.println("Waiting on Compact");
             try
             {
-               ServiceTestBase.waitForLatch(latchWait);
+               ActiveMQTestBase.waitForLatch(latchWait);
             }
             catch (InterruptedException e)
             {
@@ -650,7 +650,7 @@ public class NIOJournalCompactTest extends JournalImplTestBase
 
       t.start();
 
-      ServiceTestBase.waitForLatch(latchDone);
+      ActiveMQTestBase.waitForLatch(latchDone);
 
       int nextID = NIOJournalCompactTest.NUMBER_OF_RECORDS;
 
@@ -1917,7 +1917,6 @@ public class NIOJournalCompactTest extends JournalImplTestBase
    @After
    public void tearDown() throws Exception
    {
-
       File testDir = new File(getTestDir());
 
       File[] files = testDir.listFiles(new FilenameFilter()

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/journal/NIOJournalImplTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/journal/NIOJournalImplTest.java
@@ -20,7 +20,7 @@ import java.io.File;
 
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
 import org.apache.activemq.artemis.tests.unit.core.journal.impl.JournalImplTestUnit;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.journal.SequentialFileFactory;
 import org.apache.activemq.artemis.core.journal.impl.NIOSequentialFileFactory;
 
@@ -35,7 +35,7 @@ public class NIOJournalImplTest extends JournalImplTestUnit
 
       NIOJournalImplTest.log.debug("deleting directory " + getTestDir());
 
-      ServiceTestBase.deleteDirectory(file);
+      ActiveMQTestBase.deleteDirectory(file);
 
       file.mkdir();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/journal/ValidateTransactionHealthTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/journal/ValidateTransactionHealthTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.activemq.artemis.tests.util.SpawnedVMSupport;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.asyncio.impl.AsynchronousFileImpl;
 import org.apache.activemq.artemis.core.journal.LoaderCallback;
 import org.apache.activemq.artemis.core.journal.PreparedTransactionInfo;
@@ -37,7 +37,7 @@ import org.junit.Test;
 /**
  * This test spawns a remote VM, as we want to "crash" the VM right after the journal is filled with data
  */
-public class ValidateTransactionHealthTest extends ServiceTestBase
+public class ValidateTransactionHealthTest extends ActiveMQTestBase
 {
 
    private static final int OK = 10;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/largemessage/LargeMessageTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/largemessage/LargeMessageTestBase.java
@@ -31,7 +31,7 @@ import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.DataConstants;
 import org.apache.activemq.artemis.utils.DeflaterReader;
 import org.junit.Assert;
@@ -47,7 +47,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-public abstract class LargeMessageTestBase extends ServiceTestBase
+public abstract class LargeMessageTestBase extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------
@@ -125,9 +125,9 @@ public abstract class LargeMessageTestBase extends ServiceTestBase
 
          if (sendingBlocking)
          {
-            locator.setBlockOnNonDurableSend(true);
-            locator.setBlockOnDurableSend(true);
-            locator.setBlockOnAcknowledge(true);
+            locator.setBlockOnNonDurableSend(true)
+                    .setBlockOnDurableSend(true)
+                    .setBlockOnAcknowledge(true);
          }
 
          if (producerWindow > 0)
@@ -299,7 +299,7 @@ public abstract class LargeMessageTestBase extends ServiceTestBase
                               @Override
                               public void write(final byte[] b) throws IOException
                               {
-                                 if (b[0] == ServiceTestBase.getSamplebyte(bytesRead.get()))
+                                 if (b[0] == ActiveMQTestBase.getSamplebyte(bytesRead.get()))
                                  {
                                     bytesRead.addAndGet(b.length);
                                     LargeMessageTestBase.log.debug("Read position " + bytesRead.get() + " on consumer");
@@ -313,7 +313,7 @@ public abstract class LargeMessageTestBase extends ServiceTestBase
                               @Override
                               public void write(final int b) throws IOException
                               {
-                                 if (b == ServiceTestBase.getSamplebyte(bytesRead.get()))
+                                 if (b == ActiveMQTestBase.getSamplebyte(bytesRead.get()))
                                  {
                                     bytesRead.incrementAndGet();
                                  }
@@ -338,7 +338,7 @@ public abstract class LargeMessageTestBase extends ServiceTestBase
                                  LargeMessageTestBase.log.debug("Read " + b + " bytes");
                               }
 
-                              Assert.assertEquals(ServiceTestBase.getSamplebyte(b), buffer.readByte());
+                              Assert.assertEquals(ActiveMQTestBase.getSamplebyte(b), buffer.readByte());
                            }
 
                            try
@@ -418,7 +418,7 @@ public abstract class LargeMessageTestBase extends ServiceTestBase
                         @Override
                         public void write(final byte[] b) throws IOException
                         {
-                           if (b[0] == ServiceTestBase.getSamplebyte(bytesRead.get()))
+                           if (b[0] == ActiveMQTestBase.getSamplebyte(bytesRead.get()))
                            {
                               bytesRead.addAndGet(b.length);
                            }
@@ -460,7 +460,7 @@ public abstract class LargeMessageTestBase extends ServiceTestBase
                         {
                            LargeMessageTestBase.log.debug("Read " + b + " bytes");
                         }
-                        Assert.assertEquals(ServiceTestBase.getSamplebyte(b), buffer.readByte());
+                        Assert.assertEquals(ActiveMQTestBase.getSamplebyte(b), buffer.readByte());
                      }
                   }
 
@@ -546,7 +546,7 @@ public abstract class LargeMessageTestBase extends ServiceTestBase
          if (numberOfBytes > 1024 * 1024 || i % 2 == 0)
          {
             LargeMessageTestBase.log.debug("Sending message (stream)" + i);
-            message.setBodyInputStream(ServiceTestBase.createFakeLargeStream(numberOfBytes));
+            message.setBodyInputStream(ActiveMQTestBase.createFakeLargeStream(numberOfBytes));
          }
          else
          {
@@ -554,7 +554,7 @@ public abstract class LargeMessageTestBase extends ServiceTestBase
             byte[] bytes = new byte[(int) numberOfBytes];
             for (int j = 0; j < bytes.length; j++)
             {
-               bytes[j] = ServiceTestBase.getSamplebyte(j);
+               bytes[j] = ActiveMQTestBase.getSamplebyte(j);
             }
             message.getBodyBuffer().writeBytes(bytes);
          }
@@ -606,7 +606,7 @@ public abstract class LargeMessageTestBase extends ServiceTestBase
 
       ClientMessage clientMessage = session.createMessage(persistent);
 
-      clientMessage.setBodyInputStream(ServiceTestBase.createFakeLargeStream(numberOfBytes));
+      clientMessage.setBodyInputStream(ActiveMQTestBase.createFakeLargeStream(numberOfBytes));
 
       return clientMessage;
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/largemessage/ServerLargeMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/largemessage/ServerLargeMessageTest.java
@@ -27,11 +27,11 @@ import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager;
 import org.apache.activemq.artemis.core.persistence.impl.journal.LargeServerMessageImpl;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class ServerLargeMessageTest extends ServiceTestBase
+public class ServerLargeMessageTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------
@@ -52,7 +52,7 @@ public class ServerLargeMessageTest extends ServiceTestBase
 
       server.start();
 
-      ServerLocator locator = createFactory(false);
+      ServerLocator locator = createInVMNonHALocator();
 
       ClientSessionFactory sf = createSessionFactory(locator);
 
@@ -66,7 +66,7 @@ public class ServerLargeMessageTest extends ServiceTestBase
 
          for (int i = 0; i < 2 * ActiveMQClient.DEFAULT_MIN_LARGE_MESSAGE_SIZE; i++)
          {
-            fileMessage.addBytes(new byte[]{ServiceTestBase.getSamplebyte(i)});
+            fileMessage.addBytes(new byte[]{ActiveMQTestBase.getSamplebyte(i)});
          }
          // The server would be doing this
          fileMessage.putLongProperty(Message.HDR_LARGE_BODY_SIZE, 2 * ActiveMQClient.DEFAULT_MIN_LARGE_MESSAGE_SIZE);
@@ -96,7 +96,7 @@ public class ServerLargeMessageTest extends ServiceTestBase
 
          for (int i = 0; i < 2 * ActiveMQClient.DEFAULT_MIN_LARGE_MESSAGE_SIZE; i++)
          {
-            Assert.assertEquals(ServiceTestBase.getSamplebyte(i), msg.getBodyBuffer().readByte());
+            Assert.assertEquals(ActiveMQTestBase.getSamplebyte(i), msg.getBodyBuffer().readByte());
          }
 
          msg.acknowledge();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/AcceptorControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/AcceptorControlTest.java
@@ -51,9 +51,9 @@ public class AcceptorControlTest extends ManagementTestBase
                                                                          new HashMap<String, Object>(),
                                                                          RandomUtil.randomString());
 
-      Configuration conf = createBasicConfig()
+      Configuration config = createBasicConfig()
          .addAcceptorConfiguration(acceptorConfig);
-      ActiveMQServer service = createServer(false, conf);
+      ActiveMQServer service = createServer(false, config);
       service.setMBeanServer(mbeanServer);
       service.start();
 
@@ -69,9 +69,9 @@ public class AcceptorControlTest extends ManagementTestBase
       TransportConfiguration acceptorConfig = new TransportConfiguration(InVMAcceptorFactory.class.getName(),
                                                                          new HashMap<String, Object>(),
                                                                          RandomUtil.randomString());
-      Configuration conf = createBasicConfig()
+      Configuration config = createBasicConfig()
          .addAcceptorConfiguration(acceptorConfig);
-      ActiveMQServer service = createServer(false, conf);
+      ActiveMQServer service = createServer(false, config);
       service.setMBeanServer(mbeanServer);
       service.start();
 
@@ -129,9 +129,9 @@ public class AcceptorControlTest extends ManagementTestBase
       TransportConfiguration acceptorConfig = new TransportConfiguration(InVMAcceptorFactory.class.getName(),
                                                                          new HashMap<String, Object>(),
                                                                          RandomUtil.randomString());
-      Configuration conf = createBasicConfig()
+      Configuration config = createBasicConfig()
          .addAcceptorConfiguration(acceptorConfig);
-      ActiveMQServer service = createServer(false, conf);
+      ActiveMQServer service = createServer(false, config);
       service.setMBeanServer(mbeanServer);
       service.start();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
@@ -22,7 +22,6 @@ import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl;
 import org.apache.activemq.artemis.api.core.management.Parameter;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
-import org.junit.After;
 import org.junit.Before;
 
 public class ActiveMQServerControlUsingCoreTest extends ActiveMQServerControlTest
@@ -63,20 +62,6 @@ public class ActiveMQServerControlUsingCoreTest extends ActiveMQServerControlTes
       ClientSessionFactory sf = createSessionFactory(locator);
       session = sf.createSession(false, true, true);
       session.start();
-
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      session.close();
-
-      session = null;
-
-      locator.close();
-
-      super.tearDown();
    }
 
    protected void restartServer() throws Exception

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/AddressControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/AddressControlUsingCoreTest.java
@@ -15,31 +15,26 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.management;
-import org.junit.Before;
-import org.junit.After;
-
-import org.junit.Test;
-
-import static org.apache.activemq.artemis.tests.util.RandomUtil.randomString;
-
-import java.util.HashSet;
-import java.util.Set;
-
-import org.junit.Assert;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.api.core.management.AddressControl;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
 import org.apache.activemq.artemis.core.config.Configuration;
-import org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory;
 import org.apache.activemq.artemis.core.security.CheckType;
 import org.apache.activemq.artemis.core.security.Role;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.apache.activemq.artemis.tests.util.RandomUtil.randomString;
 
 public class AddressControlUsingCoreTest extends ManagementTestBase
 {
@@ -179,15 +174,14 @@ public class AddressControlUsingCoreTest extends ManagementTestBase
    {
       super.setUp();
 
-      Configuration conf = createBasicConfig()
-         .addAcceptorConfiguration(new TransportConfiguration(InVMAcceptorFactory.class.getName()));
-      server = createServer(false, conf);
+      Configuration config = createDefaultInVMConfig()
+         .setJMXManagementEnabled(true);
+      server = createServer(false, config);
       server.setMBeanServer(mbeanServer);
       server.start();
 
-      ServerLocator locator = createInVMNonHALocator();
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnNonDurableSend(true);
+      ServerLocator locator = createInVMNonHALocator()
+              .setBlockOnNonDurableSend(true);
       ClientSessionFactory sf = createSessionFactory(locator);
       session = sf.createSession(false, true, false);
       session.start();
@@ -198,15 +192,6 @@ public class AddressControlUsingCoreTest extends ManagementTestBase
       CoreMessagingProxy proxy = new CoreMessagingProxy(session, ResourceNames.CORE_ADDRESS + address);
 
       return proxy;
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      session.close();
-      session = null;
-      super.tearDown();
    }
 
    protected AddressControl createManagementControl(final SimpleString address) throws Exception

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/BridgeControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/BridgeControlTest.java
@@ -171,11 +171,11 @@ public class BridgeControlTest extends ManagementTestBase
          .addQueueConfiguration(sourceQueueConfig)
          .addBridgeConfiguration(bridgeConfig);
 
-      server_1 = ActiveMQServers.newActiveMQServer(conf_1, MBeanServerFactory.createMBeanServer(), false);
+      server_1 = addServer(ActiveMQServers.newActiveMQServer(conf_1, MBeanServerFactory.createMBeanServer(), false));
       addServer(server_1);
       server_1.start();
 
-      server_0 = ActiveMQServers.newActiveMQServer(conf_0, mbeanServer, false);
+      server_0 = addServer(ActiveMQServers.newActiveMQServer(conf_0, mbeanServer, false));
       addServer(server_0);
       server_0.start();
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/BridgeControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/BridgeControlUsingCoreTest.java
@@ -15,23 +15,10 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.management;
-import org.junit.Before;
-
-import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.management.MBeanServerFactory;
-
-import org.junit.Assert;
 
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.api.core.management.ObjectNameBuilder;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
@@ -44,6 +31,15 @@ import org.apache.activemq.artemis.core.remoting.impl.invm.TransportConstants;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.management.MBeanServerFactory;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class BridgeControlUsingCoreTest extends ManagementTestBase
 {
@@ -166,9 +162,7 @@ public class BridgeControlUsingCoreTest extends ManagementTestBase
 
       server_0 = addServer(ActiveMQServers.newActiveMQServer(conf_0, mbeanServer, false));
       server_0.start();
-      ServerLocator locator =
-               addServerLocator(ActiveMQClient.createServerLocatorWithoutHA(new TransportConfiguration(
-                  INVM_CONNECTOR_FACTORY)));
+      ServerLocator locator = createInVMNonHALocator();
       ClientSessionFactory sf = createSessionFactory(locator);
       session = addClientSession(sf.createSession(false, true, true));
       session.start();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ClusterConnectionControl2Test.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ClusterConnectionControl2Test.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.management;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 import org.junit.After;
 
@@ -76,7 +76,7 @@ public class ClusterConnectionControl2Test extends ManagementTestBase
       Assert.assertEquals(0, nodes.size());
 
       server1.start();
-      waitForServer(server1);
+      waitForServerToStart(server1);
       long start = System.currentTimeMillis();
 
       while (true)
@@ -108,12 +108,12 @@ public class ClusterConnectionControl2Test extends ManagementTestBase
 
       Map<String, Object> acceptorParams_1 = new HashMap<String, Object>();
       acceptorParams_1.put(TransportConstants.PORT_PROP_NAME, port_1);
-      TransportConfiguration acceptorConfig_0 = new TransportConfiguration(ServiceTestBase.NETTY_ACCEPTOR_FACTORY);
+      TransportConfiguration acceptorConfig_0 = new TransportConfiguration(ActiveMQTestBase.NETTY_ACCEPTOR_FACTORY);
 
-      TransportConfiguration acceptorConfig_1 = new TransportConfiguration(ServiceTestBase.NETTY_ACCEPTOR_FACTORY, acceptorParams_1);
+      TransportConfiguration acceptorConfig_1 = new TransportConfiguration(ActiveMQTestBase.NETTY_ACCEPTOR_FACTORY, acceptorParams_1);
 
-      TransportConfiguration connectorConfig_1 = new TransportConfiguration(ServiceTestBase.NETTY_CONNECTOR_FACTORY, acceptorParams_1);
-      TransportConfiguration connectorConfig_0 = new TransportConfiguration(ServiceTestBase.NETTY_CONNECTOR_FACTORY);
+      TransportConfiguration connectorConfig_1 = new TransportConfiguration(ActiveMQTestBase.NETTY_CONNECTOR_FACTORY, acceptorParams_1);
+      TransportConfiguration connectorConfig_0 = new TransportConfiguration(ActiveMQTestBase.NETTY_CONNECTOR_FACTORY);
 
       CoreQueueConfiguration queueConfig = new CoreQueueConfiguration()
          .setAddress(RandomUtil.randomString())
@@ -169,19 +169,14 @@ public class ClusterConnectionControl2Test extends ManagementTestBase
 
       server0 = addServer(ActiveMQServers.newActiveMQServer(conf_0, mbeanServer, false));
       server0.start();
-      waitForServer(server0);
+      waitForServerToStart(server0);
    }
 
    @Override
    @After
    public void tearDown() throws Exception
    {
-      server0 = null;
-      server1 = null;
-
       MBeanServerFactory.releaseMBeanServer(mbeanServer_1);
-      mbeanServer_1 = null;
-
       super.tearDown();
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ClusterConnectionControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ClusterConnectionControlTest.java
@@ -277,16 +277,7 @@ public class ClusterConnectionControlTest extends ManagementTestBase
    @After
    public void tearDown() throws Exception
    {
-      server_0.stop();
-      server_1.stop();
-
-      server_0 = null;
-
-      server_1 = null;
-
       MBeanServerFactory.releaseMBeanServer(mbeanServer_1);
-      mbeanServer_1 = null;
-
       super.tearDown();
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ClusterConnectionControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ClusterConnectionControlUsingCoreTest.java
@@ -21,7 +21,6 @@ import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.api.core.management.ClusterConnectionControl;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
-import org.junit.After;
 import org.junit.Before;
 
 import java.util.Map;
@@ -146,27 +145,6 @@ public class ClusterConnectionControlUsingCoreTest extends ClusterConnectionCont
       super.setUp();
 
       locator = createInVMNonHALocator();
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      if (session != null)
-      {
-         session.close();
-      }
-
-      if (locator != null)
-      {
-         locator.close();
-      }
-
-      locator = null;
-
-      session = null;
-
-      super.tearDown();
    }
 
    // Private -------------------------------------------------------

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/DivertControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/DivertControlUsingCoreTest.java
@@ -21,7 +21,6 @@ import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.api.core.management.DivertControl;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
-import org.junit.After;
 import org.junit.Before;
 
 public class DivertControlUsingCoreTest extends DivertControlTest
@@ -103,23 +102,6 @@ public class DivertControlUsingCoreTest extends DivertControlTest
       super.setUp();
 
       locator = createInVMNonHALocator();
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      if (session != null)
-      {
-         session.close();
-      }
-
-      if (locator != null)
-      {
-         locator.close();
-      }
-
-      super.tearDown();
    }
 
    // Private -------------------------------------------------------

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/JMXDomainTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/JMXDomainTest.java
@@ -16,9 +16,6 @@
  */
 package org.apache.activemq.artemis.tests.integration.management;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.management.ObjectNameBuilder;
@@ -27,8 +24,10 @@ import org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory;
 import org.apache.activemq.artemis.core.remoting.impl.invm.TransportConstants;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
-import org.junit.After;
 import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class JMXDomainTest extends ManagementTestBase
 {
@@ -38,7 +37,7 @@ public class JMXDomainTest extends ManagementTestBase
    @Test
    public void test2ActiveMQServersManagedFrom1MBeanServer() throws Exception
    {
-      Configuration config_0 = createDefaultConfig()
+      Configuration config_0 = createDefaultInVMConfig()
          .setJMXManagementEnabled(true);
 
       String jmxDomain_1 = ActiveMQDefaultConfiguration.getDefaultJmxDomain() + ".1";
@@ -49,8 +48,8 @@ public class JMXDomainTest extends ManagementTestBase
          .addAcceptorConfiguration(new TransportConfiguration(InVMAcceptorFactory.class.getName(), params))
          .setJMXDomain(jmxDomain_1);
 
-      server_0 = ActiveMQServers.newActiveMQServer(config_0, mbeanServer, false);
-      server_1 = ActiveMQServers.newActiveMQServer(config_1, mbeanServer, false);
+      server_0 = addServer(ActiveMQServers.newActiveMQServer(config_0, mbeanServer, false));
+      server_1 = addServer(ActiveMQServers.newActiveMQServer(config_1, mbeanServer, false));
 
       ObjectNameBuilder builder_0 = ObjectNameBuilder.DEFAULT;
       ObjectNameBuilder builder_1 = ObjectNameBuilder.create(jmxDomain_1);
@@ -77,22 +76,5 @@ public class JMXDomainTest extends ManagementTestBase
 
       checkNoResource(builder_0.getActiveMQServerObjectName());
       checkNoResource(builder_1.getActiveMQServerObjectName());
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      if (server_0 != null)
-      {
-         server_0.stop();
-      }
-
-      if (server_1 != null)
-      {
-         server_1.stop();
-      }
-
-      super.tearDown();
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ManagementActivationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ManagementActivationTest.java
@@ -16,24 +16,23 @@
  */
 package org.apache.activemq.artemis.tests.integration.management;
 
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.apache.activemq.artemis.core.registry.JndiBindingRegistry;
+import org.apache.activemq.artemis.jms.server.config.ConnectionFactoryConfiguration;
+import org.apache.activemq.artemis.jms.server.config.impl.ConnectionFactoryConfigurationImpl;
+import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
+import org.apache.activemq.artemis.tests.integration.cluster.failover.FailoverTestBase;
+import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
+import org.apache.activemq.artemis.tests.util.TransportConfigurationUtils;
+import org.junit.Before;
+import org.junit.Test;
+
 import javax.jms.ConnectionFactory;
 import javax.jms.Queue;
 import javax.jms.Topic;
 import javax.naming.NameNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
-import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
-import org.apache.activemq.artemis.core.registry.JndiBindingRegistry;
-import org.apache.activemq.artemis.jms.server.config.ConnectionFactoryConfiguration;
-import org.apache.activemq.artemis.jms.server.config.impl.ConnectionFactoryConfigurationImpl;
-import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
-import org.apache.activemq.artemis.tests.integration.cluster.failover.FailoverTestBase;
-import org.apache.activemq.artemis.tests.util.TransportConfigurationUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * Validates if a JMS management operations will wait until the server is activated.  If the server is not active
@@ -69,14 +68,6 @@ public class ManagementActivationTest extends FailoverTestBase
       context = new InVMNamingContext();
       backupJmsServer.setRegistry(new JndiBindingRegistry(context));
       backupJmsServer.start();
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      backupJmsServer.stop();
-      super.tearDown();
    }
 
    @Test

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ManagementServiceImplTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ManagementServiceImplTest.java
@@ -17,7 +17,7 @@
 package org.apache.activemq.artemis.tests.integration.management;
 
 import org.apache.activemq.artemis.tests.unit.core.postoffice.impl.FakeQueue;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 
 import org.junit.Assert;
@@ -38,7 +38,7 @@ import org.apache.activemq.artemis.core.server.management.impl.ManagementService
 import org.apache.activemq.artemis.tests.integration.server.FakeStorageManager;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
 
-public class ManagementServiceImplTest extends ServiceTestBase
+public class ManagementServiceImplTest extends ActiveMQTestBase
 {
    @Test
    public void testHandleManagementMessageWithOperation() throws Exception
@@ -46,10 +46,10 @@ public class ManagementServiceImplTest extends ServiceTestBase
       String queue = RandomUtil.randomString();
       String address = RandomUtil.randomString();
 
-      Configuration conf = createBasicConfig()
+      Configuration config = createBasicConfig()
          .setJMXManagementEnabled(false);
 
-      ActiveMQServer server = ActiveMQServers.newActiveMQServer(conf, false);
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(config, false));
       server.start();
 
       // invoke attribute and operation on the server
@@ -59,17 +59,15 @@ public class ManagementServiceImplTest extends ServiceTestBase
       ServerMessage reply = server.getManagementService().handleMessage(message);
 
       Assert.assertTrue(ManagementHelper.hasOperationSucceeded(reply));
-
-      server.stop();
    }
 
    @Test
    public void testHandleManagementMessageWithOperationWhichFails() throws Exception
    {
-      Configuration conf = createBasicConfig()
+      Configuration config = createBasicConfig()
          .setJMXManagementEnabled(false);
 
-      ActiveMQServer server = ActiveMQServers.newActiveMQServer(conf, false);
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(config, false));
       server.start();
 
       // invoke attribute and operation on the server
@@ -80,16 +78,15 @@ public class ManagementServiceImplTest extends ServiceTestBase
 
       Assert.assertFalse(ManagementHelper.hasOperationSucceeded(reply));
       Assert.assertNotNull(ManagementHelper.getResult(reply));
-      server.stop();
    }
 
    @Test
    public void testHandleManagementMessageWithUnknowResource() throws Exception
    {
-      Configuration conf = createBasicConfig()
+      Configuration config = createBasicConfig()
          .setJMXManagementEnabled(false);
 
-      ActiveMQServer server = ActiveMQServers.newActiveMQServer(conf, false);
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(config, false));
       server.start();
 
       // invoke attribute and operation on the server
@@ -100,16 +97,15 @@ public class ManagementServiceImplTest extends ServiceTestBase
 
       Assert.assertFalse(ManagementHelper.hasOperationSucceeded(reply));
       Assert.assertNotNull(ManagementHelper.getResult(reply));
-      server.stop();
    }
 
    @Test
    public void testHandleManagementMessageWithUnknownAttribute() throws Exception
    {
-      Configuration conf = createBasicConfig()
+      Configuration config = createBasicConfig()
          .setJMXManagementEnabled(false);
 
-      ActiveMQServer server = ActiveMQServers.newActiveMQServer(conf, false);
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(config, false));
       server.start();
 
       // invoke attribute and operation on the server
@@ -120,17 +116,16 @@ public class ManagementServiceImplTest extends ServiceTestBase
       ServerMessage reply = server.getManagementService().handleMessage(message);
 
       Assert.assertTrue(ManagementHelper.hasOperationSucceeded(reply));
-      Assert.assertTrue((Boolean)ManagementHelper.getResult(reply));
-      server.stop();
+      Assert.assertTrue((Boolean) ManagementHelper.getResult(reply));
    }
 
    @Test
    public void testHandleManagementMessageWithKnownAttribute() throws Exception
    {
-      Configuration conf = createBasicConfig()
+      Configuration config = createBasicConfig()
          .setJMXManagementEnabled(false);
 
-      ActiveMQServer server = ActiveMQServers.newActiveMQServer(conf, false);
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(config, false));
       server.start();
 
       // invoke attribute and operation on the server
@@ -142,15 +137,14 @@ public class ManagementServiceImplTest extends ServiceTestBase
 
       Assert.assertFalse(ManagementHelper.hasOperationSucceeded(reply));
       Assert.assertNotNull(ManagementHelper.getResult(reply));
-      server.stop();
    }
 
    @Test
    public void testGetResources() throws Exception
    {
-      Configuration conf = createBasicConfig()
+      Configuration config = createBasicConfig()
          .setJMXManagementEnabled(false);
-      ManagementServiceImpl managementService = new ManagementServiceImpl(null, conf);
+      ManagementServiceImpl managementService = new ManagementServiceImpl(null, config);
       managementService.setStorageManager(new NullStorageManager());
 
       SimpleString address = RandomUtil.randomSimpleString();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ManagementTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ManagementTestBase.java
@@ -30,9 +30,9 @@ import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 
-public abstract class ManagementTestBase extends ServiceTestBase
+public abstract class ManagementTestBase extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------
@@ -91,9 +91,6 @@ public abstract class ManagementTestBase extends ServiceTestBase
    public void tearDown() throws Exception
    {
       MBeanServerFactory.releaseMBeanServer(mbeanServer);
-
-      mbeanServer = null;
-
       super.tearDown();
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ManagementWithPagingServerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ManagementWithPagingServerTest.java
@@ -16,11 +16,8 @@
  */
 package org.apache.activemq.artemis.tests.integration.management;
 
-import java.nio.ByteBuffer;
-
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
@@ -35,10 +32,11 @@ import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
 import org.apache.activemq.artemis.utils.json.JSONArray;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.nio.ByteBuffer;
 
 /**
  * This class contains tests for core management
@@ -200,45 +198,28 @@ public class ManagementWithPagingServerTest extends ManagementTestBase
    {
       super.setUp();
 
-      Configuration conf = createBasicConfig()
-         .addAcceptorConfiguration(new TransportConfiguration(INVM_ACCEPTOR_FACTORY));
+      Configuration config = createDefaultInVMConfig()
+              .setJMXManagementEnabled(true);
 
-      server = addServer(ActiveMQServers.newActiveMQServer(conf, mbeanServer, true));
+      server = addServer(ActiveMQServers.newActiveMQServer(config, mbeanServer, true));
 
-      AddressSettings defaultSetting = new AddressSettings();
-      defaultSetting.setPageSizeBytes(5120);
-      defaultSetting.setMaxSizeBytes(10240);
-      defaultSetting.setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
+      AddressSettings defaultSetting = new AddressSettings()
+              .setPageSizeBytes(5120)
+              .setMaxSizeBytes(10240)
+              .setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
 
       server.getAddressSettingsRepository().addMatch("#", defaultSetting);
 
       server.start();
 
-      locator = createInVMNonHALocator();
-      locator.setBlockOnNonDurableSend(false);
-      locator.setBlockOnNonDurableSend(false);
-      locator.setConsumerWindowSize(0);
+      locator = createInVMNonHALocator()
+              .setBlockOnNonDurableSend(false)
+              .setConsumerWindowSize(0);
       ClientSessionFactory sf = createSessionFactory(locator);
       session1 = sf.createSession(false, true, false);
       session1.start();
       session2 = sf.createSession(false, true, false);
       session2.start();
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      session1.close();
-      session1 = null;
-      session2.close();
-      session2 = null;
-      locator.close();
-      locator = null;
-      server.stop();
-      server = null;
-
-      super.tearDown();
    }
 
    private class SenderThread extends Thread

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlTest.java
@@ -19,7 +19,6 @@ package org.apache.activemq.artemis.tests.integration.management;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
@@ -43,7 +42,6 @@ import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.tests.integration.jms.server.management.JMSUtil;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
 import org.apache.activemq.artemis.utils.json.JSONArray;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -135,8 +133,7 @@ public class QueueControlTest extends ManagementTestBase
 
       QueueControl queueControl = createManagementControl(address, queue);
 
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setDeadLetterAddress(new SimpleString(deadLetterAddress));
+      AddressSettings addressSettings = new AddressSettings().setDeadLetterAddress(new SimpleString(deadLetterAddress));
       server.getAddressSettingsRepository().addMatch(address.toString(), addressSettings);
 
       Assert.assertEquals(deadLetterAddress, queueControl.getDeadLetterAddress());
@@ -183,8 +180,7 @@ public class QueueControlTest extends ManagementTestBase
 
       QueueControl queueControl = createManagementControl(address, queue);
 
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setExpiryAddress(new SimpleString(expiryAddress));
+      AddressSettings addressSettings = new AddressSettings().setExpiryAddress(new SimpleString(expiryAddress));
       server.getAddressSettingsRepository().addMatch(address.toString(), addressSettings);
 
       Assert.assertEquals(expiryAddress, queueControl.getExpiryAddress());
@@ -389,10 +385,10 @@ public class QueueControlTest extends ManagementTestBase
    @Test
    public void testListDeliveringMessagesWithRASession() throws Exception
    {
-      ServerLocator locator1 = createInVMNonHALocator();
-      locator1.setBlockOnNonDurableSend(true);
-      locator1.setConsumerWindowSize(10240);
-      locator1.setAckBatchSize(0);
+      ServerLocator locator1 = createInVMNonHALocator()
+              .setBlockOnNonDurableSend(true)
+              .setConsumerWindowSize(10240)
+              .setAckBatchSize(0);
       ClientSessionFactory sf = locator1.createSessionFactory();
       final ClientSession transSession = sf.createSession(false, true, false);
       ClientConsumer consumer = null;
@@ -1443,8 +1439,7 @@ public class QueueControlTest extends ManagementTestBase
       Assert.assertEquals(1, messages.length);
       long messageID = (Long) messages[0].get("messageID");
 
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setExpiryAddress(expiryAddress);
+      AddressSettings addressSettings = new AddressSettings().setExpiryAddress(expiryAddress);
       server.getAddressSettingsRepository().addMatch(address.toString(), addressSettings);
 
       boolean expired = queueControl.expireMessage(messageID);
@@ -1485,8 +1480,7 @@ public class QueueControlTest extends ManagementTestBase
       Assert.assertEquals(2, messages.length);
       long messageID = (Long) messages[0].get("messageID");
 
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setDeadLetterAddress(deadLetterAddress);
+      AddressSettings addressSettings = new AddressSettings().setDeadLetterAddress(deadLetterAddress);
       server.getAddressSettingsRepository().addMatch(address.toString(), addressSettings);
 
       Assert.assertEquals(0, getMessageCount(deadLetterQueueControl));
@@ -2027,30 +2021,18 @@ public class QueueControlTest extends ManagementTestBase
    public void setUp() throws Exception
    {
       super.setUp();
-
-      Configuration conf = createBasicConfig()
-         .addAcceptorConfiguration(new TransportConfiguration(INVM_ACCEPTOR_FACTORY));
+      Configuration conf = createDefaultInVMConfig()
+              .setJMXManagementEnabled(true);
       server = addServer(ActiveMQServers.newActiveMQServer(conf, mbeanServer, false));
+
       server.start();
 
-      locator = createInVMNonHALocator();
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnNonDurableSend(true);
-      locator.setConsumerWindowSize(0);
+      locator = createInVMNonHALocator()
+              .setBlockOnNonDurableSend(true)
+              .setConsumerWindowSize(0);
       ClientSessionFactory sf = createSessionFactory(locator);
       session = sf.createSession(false, true, false);
       session.start();
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      session = null;
-      locator = null;
-      server = null;
-
-      super.tearDown();
    }
 
    protected QueueControl createManagementControl(final SimpleString address, final SimpleString queue) throws Exception

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/SecurityManagementTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/SecurityManagementTestBase.java
@@ -15,32 +15,28 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.management;
+
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.junit.Before;
-import org.junit.After;
-
-import org.junit.Assert;
-
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientRequestor;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.api.core.management.ManagementHelper;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.junit.Assert;
+import org.junit.Before;
 
-public abstract class SecurityManagementTestBase extends ServiceTestBase
+public abstract class SecurityManagementTestBase extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------
 
    // Attributes ----------------------------------------------------
 
-   private ActiveMQServer service;
+   private ActiveMQServer server;
 
    // Static --------------------------------------------------------
 
@@ -58,27 +54,14 @@ public abstract class SecurityManagementTestBase extends ServiceTestBase
    {
       super.setUp();
 
-      service = setupAndStartActiveMQServer();
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      service.stop();
-
-      service = null;
-
-      super.tearDown();
+      server = setupAndStartActiveMQServer();
    }
 
    protected abstract ActiveMQServer setupAndStartActiveMQServer() throws Exception;
 
    protected void doSendManagementMessage(final String user, final String password, final boolean expectSuccess) throws Exception
    {
-      ServerLocator locator =
-               addServerLocator(ActiveMQClient.createServerLocatorWithoutHA(new TransportConfiguration(
-                  INVM_CONNECTOR_FACTORY)));
+      ServerLocator locator = createInVMNonHALocator();
       ClientSessionFactory sf = locator.createSessionFactory();
       try
       {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/SecurityManagementWithConfiguredAdminUserTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/SecurityManagementWithConfiguredAdminUserTest.java
@@ -17,17 +17,15 @@
 package org.apache.activemq.artemis.tests.integration.management;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
-import org.junit.Test;
-
-import java.util.Set;
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.config.Configuration;
-import org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory;
 import org.apache.activemq.artemis.core.security.Role;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
 import org.apache.activemq.artemis.core.settings.HierarchicalRepository;
 import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManagerImpl;
+import org.junit.Test;
+
+import java.util.Set;
 
 public class SecurityManagementWithConfiguredAdminUserTest extends SecurityManagementTestBase
 {
@@ -85,10 +83,9 @@ public class SecurityManagementWithConfiguredAdminUserTest extends SecurityManag
    @Override
    protected ActiveMQServer setupAndStartActiveMQServer() throws Exception
    {
-      Configuration conf = createBasicConfig()
-         .setSecurityEnabled(true)
-         .addAcceptorConfiguration(new TransportConfiguration(InVMAcceptorFactory.class.getName()));
-      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(conf, false));
+      Configuration config = createDefaultInVMConfig()
+         .setSecurityEnabled(true);
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(config, false));
       server.start();
       HierarchicalRepository<Set<Role>> securityRepository = server.getSecurityRepository();
       ActiveMQSecurityManagerImpl securityManager = (ActiveMQSecurityManagerImpl)server.getSecurityManager();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/SecurityManagementWithDefaultConfigurationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/SecurityManagementWithDefaultConfigurationTest.java
@@ -17,13 +17,10 @@
 package org.apache.activemq.artemis.tests.integration.management;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
-import org.junit.Test;
-
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.config.Configuration;
-import org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
+import org.junit.Test;
 
 public class SecurityManagementWithDefaultConfigurationTest extends SecurityManagementTestBase
 {
@@ -55,11 +52,10 @@ public class SecurityManagementWithDefaultConfigurationTest extends SecurityMana
    @Override
    protected ActiveMQServer setupAndStartActiveMQServer() throws Exception
    {
-      Configuration conf = createBasicConfig()
+      Configuration config = createDefaultInVMConfig()
          .setClusterPassword(ActiveMQDefaultConfiguration.getDefaultClusterPassword())
-         .setSecurityEnabled(true)
-         .addAcceptorConfiguration(new TransportConfiguration(InVMAcceptorFactory.class.getName()));
-      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(conf, false));
+         .setSecurityEnabled(true);
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(config, false));
       server.start();
 
       return server;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/SecurityManagementWithModifiedConfigurationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/SecurityManagementWithModifiedConfigurationTest.java
@@ -17,13 +17,10 @@
 package org.apache.activemq.artemis.tests.integration.management;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
-import org.junit.Test;
-
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
-import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
-import org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory;
+import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
+import org.junit.Test;
 
 public class SecurityManagementWithModifiedConfigurationTest extends SecurityManagementTestBase
 {
@@ -73,11 +70,10 @@ public class SecurityManagementWithModifiedConfigurationTest extends SecurityMan
    @Override
    protected ActiveMQServer setupAndStartActiveMQServer() throws Exception
    {
-      ConfigurationImpl conf = createBasicConfig()
+      Configuration conf = createDefaultInVMConfig()
          .setSecurityEnabled(true)
-         .setClusterPassword(configuredClusterPassword)
-         .addAcceptorConfiguration(new TransportConfiguration(InVMAcceptorFactory.class.getName()));
-      ActiveMQServer server = ActiveMQServers.newActiveMQServer(conf, false);
+         .setClusterPassword(configuredClusterPassword);
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(conf, false));
       server.start();
 
       return server;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/SecurityNotificationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/SecurityNotificationTest.java
@@ -19,7 +19,6 @@ package org.apache.activemq.artemis.tests.integration.management;
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
@@ -27,15 +26,13 @@ import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.api.core.management.ManagementHelper;
 import org.apache.activemq.artemis.core.config.Configuration;
-import org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory;
 import org.apache.activemq.artemis.core.security.CheckType;
 import org.apache.activemq.artemis.core.security.Role;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
 import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManagerImpl;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -46,7 +43,7 @@ import java.util.Set;
 import static org.apache.activemq.artemis.api.core.management.CoreNotificationType.SECURITY_AUTHENTICATION_VIOLATION;
 import static org.apache.activemq.artemis.api.core.management.CoreNotificationType.SECURITY_PERMISSION_VIOLATION;
 
-public class SecurityNotificationTest extends ServiceTestBase
+public class SecurityNotificationTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------
@@ -143,12 +140,9 @@ public class SecurityNotificationTest extends ServiceTestBase
    {
       super.setUp();
 
-      Configuration conf = createBasicConfig()
-         .setSecurityEnabled(true)
-         // the notifications are independent of JMX
-         .setJMXManagementEnabled(false)
-         .addAcceptorConfiguration(new TransportConfiguration(InVMAcceptorFactory.class.getName()));
-      server = ActiveMQServers.newActiveMQServer(conf, false);
+      Configuration config = createDefaultInVMConfig()
+         .setSecurityEnabled(true);
+      server = addServer(ActiveMQServers.newActiveMQServer(config, false));
       server.start();
 
       notifQueue = RandomUtil.randomSimpleString();
@@ -174,20 +168,6 @@ public class SecurityNotificationTest extends ServiceTestBase
       adminSession.createTemporaryQueue(ActiveMQDefaultConfiguration.getDefaultManagementNotificationAddress(), notifQueue);
 
       notifConsumer = adminSession.createConsumer(notifQueue);
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      notifConsumer.close();
-
-      adminSession.deleteQueue(notifQueue);
-      adminSession.close();
-
-      server.stop();
-
-      super.tearDown();
    }
 
    // Private -------------------------------------------------------

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/BasicOpenWireTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/BasicOpenWireTest.java
@@ -244,8 +244,6 @@ public class BasicOpenWireTest extends OpenWireTestBase
       {
       }
    }
-
-
 }
 
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/OpenWireTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/OpenWireTestBase.java
@@ -31,7 +31,7 @@ import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.jms.management.JMSServerControl;
 import org.apache.activemq.artemis.tests.integration.management.ManagementControlHelper;
 import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.registry.JndiBindingRegistry;
 import org.apache.activemq.artemis.core.security.Role;
@@ -44,7 +44,7 @@ import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManagerImpl
 import org.junit.After;
 import org.junit.Before;
 
-public class OpenWireTestBase extends ServiceTestBase
+public class OpenWireTestBase extends ActiveMQTestBase
 {
    public static final String OWHOST = "localhost";
    public static final int OWPORT = 61616;
@@ -66,20 +66,14 @@ public class OpenWireTestBase extends ServiceTestBase
    {
       super.setUp();
       server = this.createServer(realStore, true);
-      HashMap<String, Object> params = new HashMap<String, Object>();
-      TransportConfiguration transportConfiguration = new TransportConfiguration(NETTY_ACCEPTOR_FACTORY, params);
 
       Configuration serverConfig = server.getConfiguration();
 
-      Map<String, AddressSettings> addressSettings = serverConfig.getAddressesSettings();
-      String match = "jms.queue.#";
-      AddressSettings dlaSettings = new AddressSettings();
-      dlaSettings.setAutoCreateJmsQueues(false);
-      SimpleString dla = new SimpleString("jms.queue.ActiveMQ.DLQ");
-      dlaSettings.setDeadLetterAddress(dla);
-      addressSettings.put(match, dlaSettings);
+      serverConfig.getAddressesSettings().put("jms.queue.#", new AddressSettings()
+              .setAutoCreateJmsQueues(false)
+              .setDeadLetterAddress(new SimpleString("jms.queue.ActiveMQ.DLQ")));
 
-      serverConfig.getAcceptorConfigurations().add(transportConfiguration);
+      serverConfig.getAcceptorConfigurations().add(new TransportConfiguration(NETTY_ACCEPTOR_FACTORY));
       serverConfig.setSecurityEnabled(enableSecurity);
 
       extraServerConfig(serverConfig);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/amq/ProducerFlowControlSendFailTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/amq/ProducerFlowControlSendFailTest.java
@@ -63,9 +63,9 @@ public class ProducerFlowControlSendFailTest extends ProducerFlowControlTest
    {
       String match = "jms.queue.#";
       Map<String, AddressSettings> asMap = serverConfig.getAddressesSettings();
-      AddressSettings settings = asMap.get(match);
-      settings.setMaxSizeBytes(1);
-      settings.setAddressFullMessagePolicy(AddressFullMessagePolicy.FAIL);
+      asMap.get(match)
+              .setMaxSizeBytes(1)
+              .setAddressFullMessagePolicy(AddressFullMessagePolicy.FAIL);
    }
 
    @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/amq/ProducerFlowControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/amq/ProducerFlowControlTest.java
@@ -365,9 +365,9 @@ public class ProducerFlowControlTest extends BasicOpenWireTest
    {
       String match = "jms.queue.#";
       Map<String, AddressSettings> asMap = serverConfig.getAddressesSettings();
-      AddressSettings settings = asMap.get(match);
-      settings.setMaxSizeBytes(1);
-      settings.setAddressFullMessagePolicy(AddressFullMessagePolicy.BLOCK);
+      asMap.get(match)
+              .setMaxSizeBytes(1)
+              .setAddressFullMessagePolicy(AddressFullMessagePolicy.BLOCK);
    }
 
    @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/interop/GeneralInteropTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/interop/GeneralInteropTest.java
@@ -16,7 +16,13 @@
  */
 package org.apache.activemq.artemis.tests.integration.openwire.interop;
 
-import java.io.Serializable;
+import org.apache.activemq.ActiveMQMessageConsumer;
+import org.apache.activemq.ActiveMQMessageProducer;
+import org.apache.activemq.artemis.api.core.client.ServerLocator;
+import org.apache.activemq.artemis.tests.integration.openwire.BasicOpenWireTest;
+import org.apache.activemq.command.ActiveMQDestination;
+import org.junit.Before;
+import org.junit.Test;
 
 import javax.jms.BytesMessage;
 import javax.jms.Connection;
@@ -28,15 +34,7 @@ import javax.jms.Queue;
 import javax.jms.Session;
 import javax.jms.StreamMessage;
 import javax.jms.TextMessage;
-
-import org.apache.activemq.ActiveMQMessageConsumer;
-import org.apache.activemq.ActiveMQMessageProducer;
-import org.apache.activemq.command.ActiveMQDestination;
-import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.tests.integration.openwire.BasicOpenWireTest;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import java.io.Serializable;
 
 /**
  * This test covers interactions between core clients and
@@ -53,14 +51,6 @@ public class GeneralInteropTest extends BasicOpenWireTest
    {
       super.setUp();
       locator = this.createInVMNonHALocator();
-   }
-
-   @After
-   @Override
-   public void tearDown() throws Exception
-   {
-      locator.close();
-      super.tearDown();
    }
 
    @Test

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/MultipleProducersPagingTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/MultipleProducersPagingTest.java
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptorFactory;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory;
@@ -52,7 +52,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class MultipleProducersPagingTest extends ServiceTestBase
+public class MultipleProducersPagingTest extends ActiveMQTestBase
 {
    private static final int CONSUMER_WAIT_TIME_MS = 250;
    private static final int PRODUCERS = 5;
@@ -76,10 +76,10 @@ public class MultipleProducersPagingTest extends ServiceTestBase
       super.setUp();
       executor = Executors.newCachedThreadPool();
 
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
-      addressSettings.setPageSizeBytes(50000);
-      addressSettings.setMaxSizeBytes(404850);
+      AddressSettings addressSettings = new AddressSettings()
+              .setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE)
+              .setPageSizeBytes(50000)
+              .setMaxSizeBytes(404850);
 
       Configuration config = createBasicConfig()
          .setPersistenceEnabled(false)

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PageCountSyncOnNonTXTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PageCountSyncOnNonTXTest.java
@@ -26,11 +26,11 @@ import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 import org.junit.Test;
 
-public class PageCountSyncOnNonTXTest extends ServiceTestBase
+public class PageCountSyncOnNonTXTest extends ActiveMQTestBase
 {
 
    // We will add a random factor on the wait time
@@ -58,12 +58,11 @@ public class PageCountSyncOnNonTXTest extends ServiceTestBase
 
       try
       {
-         locator = createNettyNonHALocator();
-         locator.setReconnectAttempts(0);
-         locator.setInitialConnectAttempts(10);
-         locator.setRetryInterval(500);
-
-         locator.setBlockOnDurableSend(false);
+         locator = createNettyNonHALocator()
+                 .setReconnectAttempts(0)
+                 .setInitialConnectAttempts(10)
+                 .setRetryInterval(500)
+                 .setBlockOnDurableSend(false);
 
          ClientSessionFactory factory = locator.createSessionFactory();
          ClientSession session = factory.createSession(true, true);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingCounterTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingCounterTest.java
@@ -22,7 +22,7 @@ import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.paging.cursor.PageSubscription;
 import org.apache.activemq.artemis.core.paging.cursor.PageSubscriptionCounter;
 import org.apache.activemq.artemis.core.paging.cursor.impl.PageSubscriptionCounterImpl;
@@ -36,7 +36,7 @@ import org.apache.activemq.artemis.core.transaction.impl.TransactionImpl;
 import org.junit.Before;
 import org.junit.Test;
 
-public class PagingCounterTest extends ServiceTestBase
+public class PagingCounterTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------
@@ -340,9 +340,9 @@ public class PagingCounterTest extends ServiceTestBase
 
       ActiveMQServer server = super.createServer(true, false);
 
-      AddressSettings defaultSetting = new AddressSettings();
-      defaultSetting.setPageSizeBytes(10 * 1024);
-      defaultSetting.setMaxSizeBytes(20 * 1024);
+      AddressSettings defaultSetting = new AddressSettings()
+              .setPageSizeBytes(10 * 1024)
+              .setMaxSizeBytes(20 * 1024);
 
       server.getAddressSettingsRepository().addMatch("#", defaultSetting);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingReceiveTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingReceiveTest.java
@@ -23,7 +23,7 @@ import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
@@ -31,7 +31,7 @@ import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.junit.Before;
 import org.junit.Test;
 
-public class PagingReceiveTest extends ServiceTestBase
+public class PagingReceiveTest extends ActiveMQTestBase
 {
 
    private static final SimpleString ADDRESS = new SimpleString("jms.queue.catalog-service.price.change.bm");
@@ -101,7 +101,7 @@ public class PagingReceiveTest extends ServiceTestBase
 
       server.start();
 
-      waitForServer(server);
+      waitForServerToStart(server);
 
       locator = createFactory(isNetty());
       return server;
@@ -135,12 +135,12 @@ public class PagingReceiveTest extends ServiceTestBase
    {
       final ActiveMQServer server = createServer(true, isNetty());
 
-      final AddressSettings settings = new AddressSettings();
-      settings.setMaxSizeBytes(67108864);
-      settings.setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
-      settings.setMaxRedeliveryDelay(3600000);
-      settings.setRedeliveryMultiplier(2.0);
-      settings.setRedeliveryDelay(500);
+      final AddressSettings settings = new AddressSettings()
+              .setMaxSizeBytes(67108864)
+              .setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE)
+              .setMaxRedeliveryDelay(3600000)
+              .setRedeliveryMultiplier(2.0)
+              .setRedeliveryDelay(500);
 
       server.getAddressSettingsRepository().addMatch("#", settings);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingSendTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingSendTest.java
@@ -34,7 +34,7 @@ import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
@@ -46,7 +46,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class PagingSendTest extends ServiceTestBase
+public class PagingSendTest extends ActiveMQTestBase
 {
    public static final SimpleString ADDRESS = new SimpleString("SimpleAddress");
 
@@ -68,7 +68,7 @@ public class PagingSendTest extends ServiceTestBase
       server = newActiveMQServer();
 
       server.start();
-      waitForServer(server);
+      waitForServerToStart(server);
       locator = createFactory(isNetty());
    }
 
@@ -76,9 +76,9 @@ public class PagingSendTest extends ServiceTestBase
    {
       ActiveMQServer server = createServer(true, isNetty());
 
-      AddressSettings defaultSetting = new AddressSettings();
-      defaultSetting.setPageSizeBytes(10 * 1024);
-      defaultSetting.setMaxSizeBytes(20 * 1024);
+      AddressSettings defaultSetting = new AddressSettings()
+              .setPageSizeBytes(10 * 1024)
+              .setMaxSizeBytes(20 * 1024);
 
       server.getAddressSettingsRepository().addMatch("#", defaultSetting);
 
@@ -103,9 +103,9 @@ public class PagingSendTest extends ServiceTestBase
       // page-store becomes in
       // page mode
       // and we could only guarantee that by setting it to synchronous
-      locator.setBlockOnNonDurableSend(blocking);
-      locator.setBlockOnDurableSend(blocking);
-      locator.setBlockOnAcknowledge(blocking);
+      locator.setBlockOnNonDurableSend(blocking)
+              .setBlockOnDurableSend(blocking)
+              .setBlockOnAcknowledge(blocking);
 
       ClientSessionFactory sf = createSessionFactory(locator);
       ClientSession session = sf.createSession(null, null, false, true, true, false, 0);
@@ -247,11 +247,11 @@ public class PagingSendTest extends ServiceTestBase
       session.createQueue(queueAddr, queueAddr, null, true);
 
       // Set up paging on the queue address
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setPageSizeBytes(10 * 1024);
-      /** This actually causes the address to start paging messages after 10 x messages with 1024 payload is sent.
-       Presumably due to additional meta-data, message headers etc... **/
-      addressSettings.setMaxSizeBytes(16 * 1024);
+      AddressSettings addressSettings = new AddressSettings()
+              .setPageSizeBytes(10 * 1024)
+              /** This actually causes the address to start paging messages after 10 x messages with 1024 payload is sent.
+               Presumably due to additional meta-data, message headers etc... **/
+              .setMaxSizeBytes(16 * 1024);
       server.getAddressSettingsRepository().addMatch("#", addressSettings);
 
       sendMessageBatch(batchSize, session, queueAddr);
@@ -282,11 +282,11 @@ public class PagingSendTest extends ServiceTestBase
       session.createQueue(queueAddr, queueAddr, null, true);
 
       // Set up paging on the queue address
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setPageSizeBytes(10 * 1024);
-      /** This actually causes the address to start paging messages after 10 x messages with 1024 payload is sent.
-       Presumably due to additional meta-data, message headers etc... **/
-      addressSettings.setMaxSizeBytes(16 * 1024);
+      AddressSettings addressSettings = new AddressSettings()
+              .setPageSizeBytes(10 * 1024)
+              /** This actually causes the address to start paging messages after 10 x messages with 1024 payload is sent.
+               Presumably due to additional meta-data, message headers etc... **/
+              .setMaxSizeBytes(16 * 1024);
       server.getAddressSettingsRepository().addMatch("#", addressSettings);
 
       int numberOfMessages = 0;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingWithFailoverAndCountersTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingWithFailoverAndCountersTest.java
@@ -27,11 +27,11 @@ import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.Queue;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.After;
 import org.junit.Test;
 
-public class PagingWithFailoverAndCountersTest extends ServiceTestBase
+public class PagingWithFailoverAndCountersTest extends ActiveMQTestBase
 {
 
    Process liveProcess;
@@ -288,15 +288,15 @@ public class PagingWithFailoverAndCountersTest extends ServiceTestBase
          ActiveMQServer server = inProcessBackup.getServer();
          try
          {
-            waitForServer(server);
+            waitForServerToStart(server);
 
             // The best to way to validate if the server is ready and operating is to send and consume at least one message
             // before we could do valid monitoring
             try
             {
-               ServerLocator locator = PagingWithFailoverServer.createLocator(PORT2);
-               locator.setInitialConnectAttempts(100);
-               locator.setRetryInterval(100);
+               ServerLocator locator = PagingWithFailoverServer.createLocator(PORT2)
+                       .setInitialConnectAttempts(100)
+                       .setRetryInterval(100);
                ClientSessionFactory factory = locator.createSessionFactory();
                ClientSession session = factory.createSession();
 
@@ -345,18 +345,17 @@ public class PagingWithFailoverAndCountersTest extends ServiceTestBase
    {
       startLive();
 
-      ServerLocator locator = PagingWithFailoverServer.createLocator(PORT1);
-      locator.setInitialConnectAttempts(100);
-      locator.setReconnectAttempts(-1);
-      locator.setRetryInterval(100);
-      ClientSessionFactory factory = locator.createSessionFactory();
+      ServerLocator locator = PagingWithFailoverServer.createLocator(PORT1)
+              .setInitialConnectAttempts(100)
+              .setReconnectAttempts(-1)
+              .setRetryInterval(100);
 
+      ClientSessionFactory factory = locator.createSessionFactory();
 
       ClientSession session = factory.createSession();
 
       session.createQueue("myAddress", "DeadConsumer", true);
       session.createQueue("myAddress", "cons2", true);
-
 
       startBackupInProcess();
 
@@ -365,11 +364,9 @@ public class PagingWithFailoverAndCountersTest extends ServiceTestBase
       ConsumerThread tConsumer = new ConsumerThread(factory, "cons2", 0, 10);
       tConsumer.start();
 
-
       MonitorThread monitor = new MonitorThread();
 
       ClientProducer prod = session.createProducer("myAddress");
-
 
       long i = 0;
 
@@ -410,7 +407,6 @@ public class PagingWithFailoverAndCountersTest extends ServiceTestBase
       factory.close();
 
       verifyServer();
-
    }
 
    public void verifyServer() throws Exception
@@ -423,7 +419,7 @@ public class PagingWithFailoverAndCountersTest extends ServiceTestBase
 
       server.start();
 
-      waitForServer(server);
+      waitForServerToStart(server);
       Queue queue = server.locateQueue(SimpleString.toSimpleString("cons2"));
 
 
@@ -431,10 +427,11 @@ public class PagingWithFailoverAndCountersTest extends ServiceTestBase
 
       assertTrue(messageCount >= 0);
 
-      locator = PagingWithFailoverServer.createLocator(PORT1);
-      locator.setInitialConnectAttempts(100);
-      locator.setReconnectAttempts(-1);
-      locator.setRetryInterval(100);
+      locator = PagingWithFailoverServer.createLocator(PORT1)
+              .setInitialConnectAttempts(100)
+              .setReconnectAttempts(-1)
+              .setRetryInterval(100);
+
       factory = locator.createSessionFactory();
 
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/SpawnedServerSupport.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/SpawnedServerSupport.java
@@ -36,7 +36,7 @@ import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 
 /**
  * Support class for server that are using an external process on the testsuite
@@ -46,35 +46,34 @@ public class SpawnedServerSupport
 
    static ActiveMQServer createServer(String folder)
    {
-      Configuration conf = createConfig(folder);
-      return ActiveMQServers.newActiveMQServer(conf, true);
+      return ActiveMQServers.newActiveMQServer(createConfig(folder), true);
    }
 
    static Configuration createConfig(String folder)
    {
-      AddressSettings settings = new AddressSettings();
-      settings.setMaxDeliveryAttempts(-1);
-      settings.setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
-      settings.setPageSizeBytes(10 * 1024);
-      settings.setMaxSizeBytes(100 * 1024);
+      AddressSettings settings = new AddressSettings()
+              .setMaxDeliveryAttempts(-1)
+              .setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE)
+              .setPageSizeBytes(10 * 1024)
+              .setMaxSizeBytes(100 * 1024);
 
-      Configuration conf = new ConfigurationImpl()
+      Configuration config = new ConfigurationImpl()
               .setSecurityEnabled(false)
               .setJournalMinFiles(2)
               .setJournalFileSize(100 * 1024)
-              .setJournalType(ServiceTestBase.getDefaultJournalType())
+              .setJournalType(ActiveMQTestBase.getDefaultJournalType())
               .setJournalCompactMinFiles(0)
               .setJournalCompactPercentage(0)
-              .setClusterPassword(ServiceTestBase.CLUSTER_PASSWORD)
-              .setJournalDirectory(ServiceTestBase.getJournalDir(folder, 0, false))
-              .setBindingsDirectory(ServiceTestBase.getBindingsDir(folder, 0, false))
-              .setPagingDirectory(ServiceTestBase.getPageDir(folder, 0, false))
-              .setLargeMessagesDirectory(ServiceTestBase.getLargeMessagesDir(folder, 0, false))
+              .setClusterPassword(ActiveMQTestBase.CLUSTER_PASSWORD)
+              .setJournalDirectory(ActiveMQTestBase.getJournalDir(folder, 0, false))
+              .setBindingsDirectory(ActiveMQTestBase.getBindingsDir(folder, 0, false))
+              .setPagingDirectory(ActiveMQTestBase.getPageDir(folder, 0, false))
+              .setLargeMessagesDirectory(ActiveMQTestBase.getLargeMessagesDir(folder, 0, false))
               .setPersistenceEnabled(true)
               .addAddressesSetting("#", settings)
-              .addAcceptorConfiguration(new TransportConfiguration("org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptorFactory"));
+              .addAcceptorConfiguration(new TransportConfiguration(ActiveMQTestBase.NETTY_ACCEPTOR_FACTORY));
 
-      return conf;
+      return config;
    }
 
    static Configuration createSharedFolderConfig(String folder, int thisport, int otherport, boolean isBackup)
@@ -91,7 +90,7 @@ public class SpawnedServerSupport
          haPolicyConfiguration = new SharedStoreMasterPolicyConfiguration();
       }
 
-      Configuration conf = createConfig(folder)
+      Configuration config = createConfig(folder)
          .clearAcceptorConfigurations()
          .setJournalFileSize(15 * 1024 * 1024)
          .addAcceptorConfiguration(createTransportConfigiguration(true, thisport))
@@ -101,7 +100,7 @@ public class SpawnedServerSupport
          .addClusterConfiguration(isBackup ? setupClusterConn("thisServer", "otherServer") : setupClusterConn("thisServer"))
          .setHAPolicyConfiguration(haPolicyConfiguration);
 
-      return conf;
+      return config;
    }
 
    protected static final ClusterConnectionConfiguration setupClusterConn(String connectorName, String... connectors)
@@ -153,7 +152,6 @@ public class SpawnedServerSupport
 
    static ActiveMQServer createSharedFolderServer(String folder, int thisPort, int otherPort, boolean isBackup)
    {
-      Configuration conf = createSharedFolderConfig(folder, thisPort, otherPort, isBackup);
-      return ActiveMQServers.newActiveMQServer(conf, true);
+      return ActiveMQServers.newActiveMQServer(createSharedFolderConfig(folder, thisPort, otherPort, isBackup), true);
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/AddressSettingsConfigurationStorageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/AddressSettingsConfigurationStorageTest.java
@@ -15,24 +15,21 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.persistence;
-import org.junit.Before;
-import org.junit.After;
-
-import org.junit.Test;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.persistence.config.PersistedAddressSetting;
 import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager;
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class AddressSettingsConfigurationStorageTest extends StorageManagerTestBase
 {
-
    private Map<SimpleString, PersistedAddressSetting> mapExpectedAddresses;
 
    @Override
@@ -42,15 +39,6 @@ public class AddressSettingsConfigurationStorageTest extends StorageManagerTestB
       super.setUp();
 
       mapExpectedAddresses = new HashMap<SimpleString, PersistedAddressSetting>();
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      mapExpectedAddresses = null;
-
-      super.tearDown();
    }
 
    protected void addAddress(JournalStorageManager journal1, String address, AddressSettings setting) throws Exception
@@ -68,11 +56,9 @@ public class AddressSettingsConfigurationStorageTest extends StorageManagerTestB
 
       AddressSettings setting = new AddressSettings();
 
-      setting = new AddressSettings();
-
-      setting.setAddressFullMessagePolicy(AddressFullMessagePolicy.BLOCK);
-
-      setting.setDeadLetterAddress(new SimpleString("some-test"));
+      setting = new AddressSettings()
+              .setAddressFullMessagePolicy(AddressFullMessagePolicy.BLOCK)
+              .setDeadLetterAddress(new SimpleString("some-test"));
 
       addAddress(journal, "a2", setting);
 
@@ -82,9 +68,7 @@ public class AddressSettingsConfigurationStorageTest extends StorageManagerTestB
 
       checkAddresses(journal);
 
-      setting = new AddressSettings();
-
-      setting.setDeadLetterAddress(new SimpleString("new-adddress"));
+      setting = new AddressSettings().setDeadLetterAddress(new SimpleString("new-adddress"));
 
       // Replacing the first setting
       addAddress(journal, "a1", setting);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/DeleteMessagesOnStartupTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/DeleteMessagesOnStartupTest.java
@@ -35,7 +35,6 @@ import org.junit.Test;
 
 public class DeleteMessagesOnStartupTest extends StorageManagerTestBase
 {
-
    volatile boolean deleteMessages = false;
 
    ArrayList<Long> deletedMessage = new ArrayList<Long>();
@@ -89,7 +88,6 @@ public class DeleteMessagesOnStartupTest extends StorageManagerTestBase
             deletedMessage.add(messageID);
             super.deleteMessage(messageID);
          }
-
       };
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/DeleteQueueRestartTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/DeleteQueueRestartTest.java
@@ -27,11 +27,11 @@ import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.jms.client.ActiveMQBytesMessage;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class DeleteQueueRestartTest extends ServiceTestBase
+public class DeleteQueueRestartTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------
@@ -65,11 +65,10 @@ public class DeleteQueueRestartTest extends ServiceTestBase
 
       server.start();
 
-      ServerLocator locator = createInVMNonHALocator();
-
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnNonDurableSend(true);
-      locator.setMinLargeMessageSize(1024 * 1024);
+      ServerLocator locator = createInVMNonHALocator()
+              .setBlockOnDurableSend(true)
+              .setBlockOnNonDurableSend(true)
+              .setMinLargeMessageSize(1024 * 1024);
 
       ClientSessionFactory factory = createSessionFactory(locator);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/ExportFormatTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/ExportFormatTest.java
@@ -27,11 +27,11 @@ import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.cli.commands.tools.DecodeJournal;
 import org.apache.activemq.artemis.cli.commands.tools.EncodeJournal;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Ignore;
 import org.junit.Test;
 
-public class ExportFormatTest extends ServiceTestBase
+public class ExportFormatTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/JMSConnectionFactoryConfigurationStorageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/JMSConnectionFactoryConfigurationStorageTest.java
@@ -16,11 +16,6 @@
  */
 package org.apache.activemq.artemis.tests.integration.persistence;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
 import org.apache.activemq.artemis.api.core.Pair;
@@ -29,9 +24,13 @@ import org.apache.activemq.artemis.jms.persistence.config.PersistedConnectionFac
 import org.apache.activemq.artemis.jms.server.config.ConnectionFactoryConfiguration;
 import org.apache.activemq.artemis.jms.server.config.impl.ConnectionFactoryConfigurationImpl;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class JMSConnectionFactoryConfigurationStorageTest extends StorageManagerTestBase
 {
@@ -45,15 +44,6 @@ public class JMSConnectionFactoryConfigurationStorageTest extends StorageManager
       super.setUp();
 
       mapExpectedCFs = new HashMap<String, PersistedConnectionFactory>();
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      mapExpectedCFs = null;
-
-      super.tearDown();
    }
 
    protected void addSetting(PersistedConnectionFactory setting) throws Exception

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/RestartSMTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/RestartSMTest.java
@@ -15,6 +15,20 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.persistence;
+
+import org.apache.activemq.artemis.core.persistence.GroupingInfo;
+import org.apache.activemq.artemis.core.persistence.QueueBindingInfo;
+import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager;
+import org.apache.activemq.artemis.core.postoffice.PostOffice;
+import org.apache.activemq.artemis.core.server.Queue;
+import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
+import org.apache.activemq.artemis.tests.unit.core.server.impl.fakes.FakeJournalLoader;
+import org.apache.activemq.artemis.tests.unit.core.server.impl.fakes.FakePostOffice;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.apache.activemq.artemis.utils.ExecutorFactory;
+import org.junit.Before;
+import org.junit.Test;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -22,21 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
-import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.unit.core.server.impl.fakes.FakePostOffice;
-import org.apache.activemq.artemis.core.config.Configuration;
-import org.apache.activemq.artemis.core.persistence.GroupingInfo;
-import org.apache.activemq.artemis.core.persistence.QueueBindingInfo;
-import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager;
-import org.apache.activemq.artemis.core.postoffice.PostOffice;
-import org.apache.activemq.artemis.core.server.Queue;
-import org.apache.activemq.artemis.tests.unit.core.server.impl.fakes.FakeJournalLoader;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.apache.activemq.artemis.utils.ExecutorFactory;
-import org.junit.Before;
-import org.junit.Test;
-
-public class RestartSMTest extends ServiceTestBase
+public class RestartSMTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------
@@ -69,11 +69,9 @@ public class RestartSMTest extends ServiceTestBase
       File testdir = new File(getTestDir());
       deleteDirectory(testdir);
 
-      Configuration configuration = createDefaultConfig();
-
       PostOffice postOffice = new FakePostOffice();
 
-      final JournalStorageManager journal = new JournalStorageManager(configuration, execFactory, null);
+      final JournalStorageManager journal = new JournalStorageManager(createDefaultInVMConfig(), execFactory, null);
 
       try
       {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/StorageManagerTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/StorageManagerTestBase.java
@@ -15,29 +15,26 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.persistence;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.ExecutorService;
 
-import org.apache.activemq.artemis.tests.unit.core.server.impl.fakes.FakePostOffice;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.persistence.GroupingInfo;
 import org.apache.activemq.artemis.core.persistence.QueueBindingInfo;
 import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager;
-import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.jms.persistence.JMSStorageManager;
 import org.apache.activemq.artemis.jms.persistence.impl.journal.JMSJournalStorageManagerImpl;
 import org.apache.activemq.artemis.tests.unit.core.server.impl.fakes.FakeJournalLoader;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.unit.core.server.impl.fakes.FakePostOffice;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.ExecutorFactory;
 import org.apache.activemq.artemis.utils.TimeAndCounterIDGenerator;
 import org.junit.After;
 import org.junit.Before;
 
-public abstract class StorageManagerTestBase extends ServiceTestBase
-{
+import java.util.ArrayList;
+import java.util.concurrent.ExecutorService;
 
+public abstract class StorageManagerTestBase extends ActiveMQTestBase
+{
    protected ExecutorService executor;
 
    protected ExecutorFactory execFactory;
@@ -100,15 +97,11 @@ public abstract class StorageManagerTestBase extends ServiceTestBase
     */
    protected void createStorage() throws Exception
    {
-      Configuration configuration = createDefaultConfig();
-
-      journal = createJournalStorageManager(configuration);
+      journal = createJournalStorageManager(createDefaultInVMConfig());
 
       journal.start();
 
       journal.loadBindingJournal(new ArrayList<QueueBindingInfo>(), new ArrayList<GroupingInfo>());
-
-      Map<Long, Queue> queues = new HashMap<Long, Queue>();
 
       journal.loadMessageJournal(new FakePostOffice(), null, null, null, null, null, null, new FakeJournalLoader());
    }
@@ -128,12 +121,9 @@ public abstract class StorageManagerTestBase extends ServiceTestBase
     */
    protected void createJMSStorage() throws Exception
    {
-      Configuration configuration = createDefaultConfig();
-
-      jmsJournal = new JMSJournalStorageManagerImpl(new TimeAndCounterIDGenerator(), configuration, null);
-
+      jmsJournal = new JMSJournalStorageManagerImpl(new TimeAndCounterIDGenerator(), createDefaultInVMConfig(), null);
+      addActiveMQComponent(jmsJournal);
       jmsJournal.start();
-
       jmsJournal.load();
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/XmlImportExportTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/XmlImportExportTest.java
@@ -49,14 +49,14 @@ import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.jms.server.JMSServerManager;
 import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
 import org.apache.activemq.artemis.tests.unit.util.InVMContext;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
 import org.junit.Test;
 
 /**
  * A test of the XML export/import functionality
  */
-public class XmlImportExportTest extends ServiceTestBase
+public class XmlImportExportTest extends ActiveMQTestBase
 {
    public static final int CONSUMER_TIMEOUT = 5000;
    private static final String QUEUE_NAME = "A1";
@@ -112,7 +112,7 @@ public class XmlImportExportTest extends ServiceTestBase
 
       ByteArrayOutputStream xmlOutputStream = new ByteArrayOutputStream();
       XmlDataExporter xmlDataExporter = new XmlDataExporter();
-      xmlDataExporter.process(xmlOutputStream, getBindingsDir(), getJournalDir(), getPageDir(), getLargeMessagesDir());
+      xmlDataExporter.process(xmlOutputStream, server.getConfiguration().getBindingsDirectory(), server.getConfiguration().getJournalDirectory(), server.getConfiguration().getPagingDirectory(), server.getConfiguration().getLargeMessagesDirectory());
       System.out.print(new String(xmlOutputStream.toByteArray()));
 
       clearDataRecreateServerDirs();
@@ -207,7 +207,7 @@ public class XmlImportExportTest extends ServiceTestBase
 
       ByteArrayOutputStream xmlOutputStream = new ByteArrayOutputStream();
       XmlDataExporter xmlDataExporter = new XmlDataExporter();
-      xmlDataExporter.process(xmlOutputStream, getBindingsDir(), getJournalDir(), getPageDir(), getLargeMessagesDir());
+      xmlDataExporter.process(xmlOutputStream, server.getConfiguration().getBindingsDirectory(), server.getConfiguration().getJournalDirectory(), server.getConfiguration().getPagingDirectory(), server.getConfiguration().getLargeMessagesDirectory());
       System.out.print(new String(xmlOutputStream.toByteArray()));
 
       clearDataRecreateServerDirs();
@@ -261,7 +261,7 @@ public class XmlImportExportTest extends ServiceTestBase
 
       ByteArrayOutputStream xmlOutputStream = new ByteArrayOutputStream();
       XmlDataExporter xmlDataExporter = new XmlDataExporter();
-      xmlDataExporter.process(xmlOutputStream, getBindingsDir(), getJournalDir(), getPageDir(), getLargeMessagesDir());
+      xmlDataExporter.process(xmlOutputStream, server.getConfiguration().getBindingsDirectory(), server.getConfiguration().getJournalDirectory(), server.getConfiguration().getPagingDirectory(), server.getConfiguration().getLargeMessagesDirectory());
       System.out.print(new String(xmlOutputStream.toByteArray()));
 
       clearDataRecreateServerDirs();
@@ -297,7 +297,7 @@ public class XmlImportExportTest extends ServiceTestBase
 
       ByteArrayOutputStream xmlOutputStream = new ByteArrayOutputStream();
       XmlDataExporter xmlDataExporter = new XmlDataExporter();
-      xmlDataExporter.process(xmlOutputStream, getBindingsDir(), getJournalDir(), getPageDir(), getLargeMessagesDir());
+      xmlDataExporter.process(xmlOutputStream, server.getConfiguration().getBindingsDirectory(), server.getConfiguration().getJournalDirectory(), server.getConfiguration().getPagingDirectory(), server.getConfiguration().getLargeMessagesDirectory());
       System.out.print(new String(xmlOutputStream.toByteArray()));
 
       clearDataRecreateServerDirs();
@@ -409,7 +409,7 @@ public class XmlImportExportTest extends ServiceTestBase
 
       ByteArrayOutputStream xmlOutputStream = new ByteArrayOutputStream();
       XmlDataExporter xmlDataExporter = new XmlDataExporter();
-      xmlDataExporter.process(xmlOutputStream, getBindingsDir(), getJournalDir(), getPageDir(), getLargeMessagesDir());
+      xmlDataExporter.process(xmlOutputStream, server.getConfiguration().getBindingsDirectory(), server.getConfiguration().getJournalDirectory(), server.getConfiguration().getPagingDirectory(), server.getConfiguration().getLargeMessagesDirectory());
       System.out.print(new String(xmlOutputStream.toByteArray()));
 
       clearDataRecreateServerDirs();
@@ -477,7 +477,7 @@ public class XmlImportExportTest extends ServiceTestBase
 
       ByteArrayOutputStream xmlOutputStream = new ByteArrayOutputStream();
       XmlDataExporter xmlDataExporter = new XmlDataExporter();
-      xmlDataExporter.process(xmlOutputStream, getBindingsDir(), getJournalDir(), getPageDir(), getLargeMessagesDir());
+      xmlDataExporter.process(xmlOutputStream, server.getConfiguration().getBindingsDirectory(), server.getConfiguration().getJournalDirectory(), server.getConfiguration().getPagingDirectory(), server.getConfiguration().getLargeMessagesDirectory());
       System.out.print(new String(xmlOutputStream.toByteArray()));
 
       clearDataRecreateServerDirs();
@@ -554,12 +554,12 @@ public class XmlImportExportTest extends ServiceTestBase
 
       ByteArrayOutputStream xmlOutputStream = new ByteArrayOutputStream();
       XmlDataExporter xmlDataExporter = new XmlDataExporter();
-      xmlDataExporter.process(xmlOutputStream, getBindingsDir(), getJournalDir(), getPageDir(), getLargeMessagesDir());
+      xmlDataExporter.process(xmlOutputStream, server.getConfiguration().getBindingsDirectory(), server.getConfiguration().getJournalDirectory(), server.getConfiguration().getPagingDirectory(), server.getConfiguration().getLargeMessagesDirectory());
       System.out.print(new String(xmlOutputStream.toByteArray()));
 
       clearDataRecreateServerDirs();
       server.start();
-      locator = createFactory(false);
+      locator = createInVMNonHALocator();
       factory = createSessionFactory(locator);
       session = factory.createSession(false, true, true);
 
@@ -613,7 +613,7 @@ public class XmlImportExportTest extends ServiceTestBase
 
       ByteArrayOutputStream xmlOutputStream = new ByteArrayOutputStream();
       XmlDataExporter xmlDataExporter = new XmlDataExporter();
-      xmlDataExporter.process(xmlOutputStream, getBindingsDir(), getJournalDir(), getPageDir(), getLargeMessagesDir());
+      xmlDataExporter.process(xmlOutputStream, server.getConfiguration().getBindingsDirectory(), server.getConfiguration().getJournalDirectory(), server.getConfiguration().getPagingDirectory(), server.getConfiguration().getLargeMessagesDirectory());
       System.out.print(new String(xmlOutputStream.toByteArray()));
 
       clearDataRecreateServerDirs();
@@ -645,18 +645,18 @@ public class XmlImportExportTest extends ServiceTestBase
 
       ActiveMQServer server = createServer(true);
 
-      AddressSettings defaultSetting = new AddressSettings();
-      defaultSetting.setPageSizeBytes(10 * 1024);
-      defaultSetting.setMaxSizeBytes(20 * 1024);
+      AddressSettings defaultSetting = new AddressSettings()
+              .setPageSizeBytes(10 * 1024)
+              .setMaxSizeBytes(20 * 1024);
       server.getAddressSettingsRepository().addMatch("#", defaultSetting);
       server.start();
 
-      ServerLocator locator = createInVMNonHALocator();
-      // Making it synchronous, just because we want to stop sending messages as soon as the page-store becomes in
-      // page mode and we could only guarantee that by setting it to synchronous
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      ServerLocator locator = createInVMNonHALocator()
+              // Making it synchronous, just because we want to stop sending messages as soon as the page-store becomes in
+              // page mode and we could only guarantee that by setting it to synchronous
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       ClientSessionFactory factory = locator.createSessionFactory();
       ClientSession session = factory.createSession(false, true, true);
@@ -682,7 +682,7 @@ public class XmlImportExportTest extends ServiceTestBase
 
       ByteArrayOutputStream xmlOutputStream = new ByteArrayOutputStream();
       XmlDataExporter xmlDataExporter = new XmlDataExporter();
-      xmlDataExporter.process(xmlOutputStream, getBindingsDir(), getJournalDir(), getPageDir(), getLargeMessagesDir());
+      xmlDataExporter.process(xmlOutputStream, server.getConfiguration().getBindingsDirectory(), server.getConfiguration().getJournalDirectory(), server.getConfiguration().getPagingDirectory(), server.getConfiguration().getLargeMessagesDirectory());
       System.out.print(new String(xmlOutputStream.toByteArray()));
 
       clearDataRecreateServerDirs();
@@ -719,18 +719,18 @@ public class XmlImportExportTest extends ServiceTestBase
 
       server = createServer(true);
 
-      AddressSettings defaultSetting = new AddressSettings();
-      defaultSetting.setPageSizeBytes(10 * 1024);
-      defaultSetting.setMaxSizeBytes(20 * 1024);
+      AddressSettings defaultSetting = new AddressSettings()
+              .setPageSizeBytes(10 * 1024)
+              .setMaxSizeBytes(20 * 1024);
       server.getAddressSettingsRepository().addMatch("#", defaultSetting);
       server.start();
 
-      locator = createInVMNonHALocator();
-      // Making it synchronous, just because we want to stop sending messages as soon as the page-store becomes in
-      // page mode and we could only guarantee that by setting it to synchronous
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      locator = createInVMNonHALocator()
+              // Making it synchronous, just because we want to stop sending messages as soon as the page-store becomes in
+              // page mode and we could only guarantee that by setting it to synchronous
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       factory = createSessionFactory(locator);
       ClientSession session = factory.createSession(false, true, true);
@@ -753,7 +753,7 @@ public class XmlImportExportTest extends ServiceTestBase
 
       ByteArrayOutputStream xmlOutputStream = new ByteArrayOutputStream();
       XmlDataExporter xmlDataExporter = new XmlDataExporter();
-      xmlDataExporter.process(xmlOutputStream, getBindingsDir(), getJournalDir(), getPageDir(), getLargeMessagesDir());
+      xmlDataExporter.process(xmlOutputStream, server.getConfiguration().getBindingsDirectory(), server.getConfiguration().getJournalDirectory(), server.getConfiguration().getPagingDirectory(), server.getConfiguration().getLargeMessagesDirectory());
       System.out.print(new String(xmlOutputStream.toByteArray()));
 
       clearDataRecreateServerDirs();
@@ -786,18 +786,18 @@ public class XmlImportExportTest extends ServiceTestBase
 
       ActiveMQServer server = createServer(true);
 
-      AddressSettings defaultSetting = new AddressSettings();
-      defaultSetting.setPageSizeBytes(10 * 1024);
-      defaultSetting.setMaxSizeBytes(20 * 1024);
+      AddressSettings defaultSetting = new AddressSettings()
+              .setPageSizeBytes(10 * 1024)
+              .setMaxSizeBytes(20 * 1024);
       server.getAddressSettingsRepository().addMatch("#", defaultSetting);
       server.start();
 
-      ServerLocator locator = createInVMNonHALocator();
-      // Making it synchronous, just because we want to stop sending messages as soon as the page-store becomes in
-      // page mode and we could only guarantee that by setting it to synchronous
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      ServerLocator locator = createInVMNonHALocator()
+              // Making it synchronous, just because we want to stop sending messages as soon as the page-store becomes in
+              // page mode and we could only guarantee that by setting it to synchronous
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       ClientSessionFactory factory = locator.createSessionFactory();
       ClientSession session = factory.createSession(false, true, true);
@@ -838,7 +838,7 @@ public class XmlImportExportTest extends ServiceTestBase
 
       ByteArrayOutputStream xmlOutputStream = new ByteArrayOutputStream();
       XmlDataExporter xmlDataExporter = new XmlDataExporter();
-      xmlDataExporter.process(xmlOutputStream, getBindingsDir(), getJournalDir(), getPageDir(), getLargeMessagesDir());
+      xmlDataExporter.process(xmlOutputStream, server.getConfiguration().getBindingsDirectory(), server.getConfiguration().getJournalDirectory(), server.getConfiguration().getPagingDirectory(), server.getConfiguration().getLargeMessagesDirectory());
       //System.out.print(new String(xmlOutputStream.toByteArray()));
 
       clearDataRecreateServerDirs();
@@ -897,7 +897,7 @@ public class XmlImportExportTest extends ServiceTestBase
 
       ByteArrayOutputStream xmlOutputStream = new ByteArrayOutputStream();
       XmlDataExporter xmlDataExporter = new XmlDataExporter();
-      xmlDataExporter.process(xmlOutputStream, getBindingsDir(), getJournalDir(), getPageDir(), getLargeMessagesDir());
+      xmlDataExporter.process(xmlOutputStream, server.getConfiguration().getBindingsDirectory(), server.getConfiguration().getJournalDirectory(), server.getConfiguration().getPagingDirectory(), server.getConfiguration().getLargeMessagesDirectory());
       System.out.print(new String(xmlOutputStream.toByteArray()));
 
       clearDataRecreateServerDirs();
@@ -941,7 +941,7 @@ public class XmlImportExportTest extends ServiceTestBase
 
       ByteArrayOutputStream xmlOutputStream = new ByteArrayOutputStream();
       XmlDataExporter xmlDataExporter = new XmlDataExporter();
-      xmlDataExporter.process(xmlOutputStream, getBindingsDir(), getJournalDir(), getPageDir(), getLargeMessagesDir());
+      xmlDataExporter.process(xmlOutputStream, server.getConfiguration().getBindingsDirectory(), server.getConfiguration().getJournalDirectory(), server.getConfiguration().getPagingDirectory(), server.getConfiguration().getLargeMessagesDirectory());
       System.out.print(new String(xmlOutputStream.toByteArray()));
 
       clearDataRecreateServerDirs();
@@ -996,7 +996,7 @@ public class XmlImportExportTest extends ServiceTestBase
 
       ByteArrayOutputStream xmlOutputStream = new ByteArrayOutputStream();
       XmlDataExporter xmlDataExporter = new XmlDataExporter();
-      xmlDataExporter.process(xmlOutputStream, getBindingsDir(), getJournalDir(), getPageDir(), getLargeMessagesDir());
+      xmlDataExporter.process(xmlOutputStream, server.getConfiguration().getBindingsDirectory(), server.getConfiguration().getJournalDirectory(), server.getConfiguration().getPagingDirectory(), server.getConfiguration().getLargeMessagesDirectory());
       System.out.print(new String(xmlOutputStream.toByteArray()));
 
       clearDataRecreateServerDirs();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/proton/ProtonTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/proton/ProtonTest.java
@@ -41,7 +41,7 @@ import java.util.HashMap;
 import java.util.Random;
 
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
 import org.apache.qpid.amqp_1_0.client.Receiver;
 import org.apache.qpid.amqp_1_0.client.Sender;
@@ -64,7 +64,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
-public class ProtonTest extends ServiceTestBase
+public class ProtonTest extends ActiveMQTestBase
 {
 
    // this will ensure that all tests in this class are run twice,

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ra/ActiveMQActivationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ra/ActiveMQActivationTest.java
@@ -20,9 +20,9 @@ import org.apache.activemq.artemis.ra.inflow.ActiveMQActivationSpec;
 import org.junit.Test;
 
 import org.apache.activemq.artemis.ra.ActiveMQResourceAdapter;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 
-public class ActiveMQActivationTest extends ServiceTestBase
+public class ActiveMQActivationTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ra/ActiveMQRAClusteredTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ra/ActiveMQRAClusteredTestBase.java
@@ -25,7 +25,7 @@ import org.apache.activemq.artemis.core.remoting.impl.invm.TransportConstants;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
 import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 
 public class ActiveMQRAClusteredTestBase extends ActiveMQRATestBase
@@ -45,27 +45,17 @@ public class ActiveMQRAClusteredTestBase extends ActiveMQRATestBase
       HashMap<String, Object> params = new HashMap();
       params.put(TransportConstants.SERVER_ID_PROP_NAME, "1");
       secondaryConnector = new TransportConfiguration(INVM_CONNECTOR_FACTORY, params);
-      Configuration conf = createSecondaryDefaultConfig(true, true);
 
-      secondaryServer = ActiveMQServers.newActiveMQServer(conf, mbeanServer, usePersistence());
+      secondaryServer = addServer(ActiveMQServers.newActiveMQServer(createSecondaryDefaultConfig(true, true), mbeanServer, usePersistence()));
       addServer(secondaryServer);
       secondaryJmsServer = new JMSServerManagerImpl(secondaryServer);
       secondaryJmsServer.start();
       waitForTopology(secondaryServer, 2);
    }
 
-   @Override
-   public void tearDown() throws Exception
-   {
-      if (secondaryJmsServer != null)
-         secondaryJmsServer.stop();
-      super.tearDown();
-   }
-
    protected Configuration createDefaultConfig(boolean netty) throws Exception
    {
-      Configuration conf = createSecondaryDefaultConfig(netty, false);
-      return conf;
+      return createSecondaryDefaultConfig(netty, false);
    }
 
    protected Configuration createSecondaryDefaultConfig(boolean netty, boolean secondary) throws Exception
@@ -85,7 +75,7 @@ public class ActiveMQRAClusteredTestBase extends ActiveMQRATestBase
          directoryPrefix = "second";
       }
 
-      ConfigurationImpl configuration = createBasicConfig(-1)
+      ConfigurationImpl configuration = createBasicConfig()
          .setJMXManagementEnabled(false)
          .clearAcceptorConfigurations()
          .addAcceptorConfiguration(new TransportConfiguration(INVM_ACCEPTOR_FACTORY, invmMap))
@@ -96,7 +86,7 @@ public class ActiveMQRAClusteredTestBase extends ActiveMQRATestBase
          .setPagingDirectory(getTestDir() + "/" + directoryPrefix + "Page / ")
          .addConnectorConfiguration(secondaryConnectorName, secondaryConnector)
          .addConnectorConfiguration(primaryConnectorName, primaryConnector)
-         .addClusterConfiguration(ServiceTestBase.basicClusterConnectionConfig(secondaryConnectorName, primaryConnectorName));
+         .addClusterConfiguration(ActiveMQTestBase.basicClusterConnectionConfig(secondaryConnectorName, primaryConnectorName));
 
       return configuration;
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ra/ActiveMQRATestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ra/ActiveMQRATestBase.java
@@ -23,7 +23,6 @@ import org.apache.activemq.artemis.jms.client.ActiveMQMessage;
 import org.apache.activemq.artemis.ra.ActiveMQResourceAdapter;
 import org.apache.activemq.artemis.ra.inflow.ActiveMQActivation;
 import org.apache.activemq.artemis.tests.util.JMSTestBase;
-import org.junit.After;
 import org.junit.Before;
 
 import javax.jms.Message;
@@ -68,19 +67,10 @@ public abstract class ActiveMQRATestBase extends JMSTestBase
 
    protected void setupDLQ(int maxDeliveries)
    {
-      AddressSettings settings = new AddressSettings();
-      settings.setDeadLetterAddress(SimpleString.toSimpleString("jms.queue." + DLQ));
-      settings.setMaxDeliveryAttempts(maxDeliveries);
+      AddressSettings settings = new AddressSettings()
+              .setDeadLetterAddress(SimpleString.toSimpleString("jms.queue." + DLQ))
+              .setMaxDeliveryAttempts(maxDeliveries);
       server.getAddressSettingsRepository().addMatch("#", settings);
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      locator.close();
-
-      super.tearDown();
    }
 
    protected ActiveMQActivation lookupActivation(ActiveMQResourceAdapter qResourceAdapter)

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ra/ResourceAdapterTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ra/ResourceAdapterTest.java
@@ -59,7 +59,7 @@ public class ResourceAdapterTest extends ActiveMQRATestBase
 
       ActiveMQResourceAdapter ra = new ActiveMQResourceAdapter();
 
-      ra.setConnectorClassName("org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnectorFactory");
+      ra.setConnectorClassName(INVM_CONNECTOR_FACTORY);
       ra.setUserName("userGlobal");
       ra.setPassword("passwordGlobal");
       ra.start(new BootstrapContext());

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/remoting/BatchDelayTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/remoting/BatchDelayTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.remoting;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 
@@ -36,7 +36,7 @@ import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 
-public class BatchDelayTest extends ServiceTestBase
+public class BatchDelayTest extends ActiveMQTestBase
 {
 
    private static final int N = 1000;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/remoting/DestroyConsumerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/remoting/DestroyConsumerTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.activemq.artemis.tests.integration.remoting;
 
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 
-public class DestroyConsumerTest extends ServiceTestBase
+public class DestroyConsumerTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------
@@ -39,7 +39,7 @@ public class DestroyConsumerTest extends ServiceTestBase
 
    // public void testDestroyConsumer() throws Exception
    // {
-   // ActiveMQServer server = createService(false, false, createDefaultConfig(), new HashMap<String, AddressSettings>());
+   // ActiveMQServer server = createService(false, false, createDefaultInVMConfig(), new HashMap<String, AddressSettings>());
    // server.start();
    //
    // SimpleString queue = new SimpleString("add1");

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/remoting/DirectDeliverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/remoting/DirectDeliverTest.java
@@ -15,13 +15,6 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.remoting;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.junit.Before;
-
-import org.junit.Test;
-
-import java.util.HashMap;
-import java.util.Map;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
@@ -30,18 +23,22 @@ import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.postoffice.Binding;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptorFactory;
-import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory;
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.server.impl.QueueImpl;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.junit.Before;
+import org.junit.Test;
 
-public class DirectDeliverTest extends ServiceTestBase
+import java.util.HashMap;
+import java.util.Map;
+
+public class DirectDeliverTest extends ActiveMQTestBase
 {
 
    private ActiveMQServer server;
@@ -64,7 +61,7 @@ public class DirectDeliverTest extends ServiceTestBase
       server = createServer(false, config);
       server.start();
 
-      locator = ActiveMQClient.createServerLocatorWithoutHA(new TransportConfiguration(NettyConnectorFactory.class.getName()));
+      locator = createNettyNonHALocator();
       addServerLocator(locator);
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/remoting/NetworkAddressTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/remoting/NetworkAddressTestBase.java
@@ -31,14 +31,14 @@ import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
 import org.junit.Assert;
 import org.junit.Test;
 
-public abstract class NetworkAddressTestBase extends ServiceTestBase
+public abstract class NetworkAddressTestBase extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------
@@ -208,7 +208,7 @@ public abstract class NetworkAddressTestBase extends ServiceTestBase
       Set<TransportConfiguration> transportConfigs = new HashSet<TransportConfiguration>();
       transportConfigs.add(acceptorConfig);
 
-      Configuration config = createDefaultConfig(true);
+      Configuration config = createDefaultNettyConfig();
       config.setAcceptorConfigurations(transportConfigs);
       ActiveMQServer messagingService = createServer(false, config);
       try

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/remoting/PingTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/remoting/PingTest.java
@@ -17,38 +17,34 @@
 package org.apache.activemq.artemis.tests.integration.remoting;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
-import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.api.core.Interceptor;
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
+import org.apache.activemq.artemis.api.core.client.ClientSession;
+import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
+import org.apache.activemq.artemis.api.core.client.ServerLocator;
+import org.apache.activemq.artemis.api.core.client.SessionFailureListener;
+import org.apache.activemq.artemis.core.client.impl.ClientSessionFactoryImpl;
+import org.apache.activemq.artemis.core.client.impl.ClientSessionFactoryInternal;
+import org.apache.activemq.artemis.core.protocol.core.CoreRemotingConnection;
+import org.apache.activemq.artemis.core.protocol.core.Packet;
+import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.Ping;
+import org.apache.activemq.artemis.core.remoting.CloseListener;
+import org.apache.activemq.artemis.core.remoting.server.impl.RemotingServiceImpl;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
+import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.junit.Assert;
 import org.junit.Before;
-
 import org.junit.Test;
 
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Assert;
-
-import org.apache.activemq.artemis.api.core.Interceptor;
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
-import org.apache.activemq.artemis.api.core.client.ClientSession;
-import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
-import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.api.core.client.SessionFailureListener;
-import org.apache.activemq.artemis.core.client.impl.ClientSessionFactoryImpl;
-import org.apache.activemq.artemis.core.client.impl.ClientSessionFactoryInternal;
-import org.apache.activemq.artemis.core.config.Configuration;
-import org.apache.activemq.artemis.core.protocol.core.CoreRemotingConnection;
-import org.apache.activemq.artemis.core.protocol.core.Packet;
-import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
-import org.apache.activemq.artemis.core.remoting.CloseListener;
-import org.apache.activemq.artemis.core.remoting.server.impl.RemotingServiceImpl;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
-import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
-
-public class PingTest extends ServiceTestBase
+public class PingTest extends ActiveMQTestBase
 {
    // Constants -----------------------------------------------------
 
@@ -71,8 +67,7 @@ public class PingTest extends ServiceTestBase
    public void setUp() throws Exception
    {
       super.setUp();
-      Configuration config = createDefaultConfig(true);
-      server = createServer(false, config);
+      server = createServer(false, createDefaultNettyConfig());
       server.start();
    }
 
@@ -170,7 +165,7 @@ public class PingTest extends ServiceTestBase
    @Test
    public void testNoFailureNoPinging() throws Exception
    {
-      TransportConfiguration transportConfig = new TransportConfiguration("org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory");
+      TransportConfiguration transportConfig = new TransportConfiguration(INVM_CONNECTOR_FACTORY);
       ServerLocator locator = addServerLocator(ActiveMQClient.createServerLocatorWithoutHA(transportConfig));
       locator.setClientFailureCheckPeriod(-1);
       locator.setConnectionTTL(-1);
@@ -272,7 +267,7 @@ public class PingTest extends ServiceTestBase
    @Test
    public void testServerFailureNoPing() throws Exception
    {
-      TransportConfiguration transportConfig = new TransportConfiguration("org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory");
+      TransportConfiguration transportConfig = new TransportConfiguration(INVM_CONNECTOR_FACTORY);
       ServerLocator locator = addServerLocator(ActiveMQClient.createServerLocatorWithoutHA(transportConfig));
       locator.setClientFailureCheckPeriod(PingTest.CLIENT_FAILURE_CHECK_PERIOD);
       locator.setConnectionTTL(PingTest.CLIENT_FAILURE_CHECK_PERIOD * 2);
@@ -368,7 +363,7 @@ public class PingTest extends ServiceTestBase
          }
       });
 
-      TransportConfiguration transportConfig = new TransportConfiguration("org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory");
+      TransportConfiguration transportConfig = new TransportConfiguration(INVM_CONNECTOR_FACTORY);
       ServerLocator locator = addServerLocator(ActiveMQClient.createServerLocatorWithoutHA(transportConfig));
       locator.setClientFailureCheckPeriod(PingTest.CLIENT_FAILURE_CHECK_PERIOD);
       locator.setConnectionTTL(PingTest.CLIENT_FAILURE_CHECK_PERIOD * 2);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/remoting/ReconnectTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/remoting/ReconnectTest.java
@@ -32,9 +32,9 @@ import org.apache.activemq.artemis.api.core.client.SessionFailureListener;
 import org.apache.activemq.artemis.core.client.impl.ClientSessionFactoryInternal;
 import org.apache.activemq.artemis.core.client.impl.ClientSessionInternal;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 
-public class ReconnectTest extends ServiceTestBase
+public class ReconnectTest extends ActiveMQTestBase
 {
 
    @Test
@@ -61,12 +61,12 @@ public class ReconnectTest extends ServiceTestBase
 
       try
       {
-         ServerLocator locator = createFactory(isNetty);
-         locator.setClientFailureCheckPeriod(pingPeriod);
-         locator.setRetryInterval(500);
-         locator.setRetryIntervalMultiplier(1d);
-         locator.setReconnectAttempts(-1);
-         locator.setConfirmationWindowSize(1024 * 1024);
+         ServerLocator locator = createFactory(isNetty)
+                 .setClientFailureCheckPeriod(pingPeriod)
+                 .setRetryInterval(500)
+                 .setRetryIntervalMultiplier(1d)
+                 .setReconnectAttempts(-1)
+                 .setConfirmationWindowSize(1024 * 1024);
          ClientSessionFactory factory = createSessionFactory(locator);
 
 
@@ -161,12 +161,12 @@ public class ReconnectTest extends ServiceTestBase
 
       try
       {
-         ServerLocator locator = createFactory(isNetty);
-         locator.setClientFailureCheckPeriod(pingPeriod);
-         locator.setRetryInterval(500);
-         locator.setRetryIntervalMultiplier(1d);
-         locator.setReconnectAttempts(-1);
-         locator.setConfirmationWindowSize(1024 * 1024);
+         ServerLocator locator = createFactory(isNetty)
+                 .setClientFailureCheckPeriod(pingPeriod)
+                 .setRetryInterval(500)
+                 .setRetryIntervalMultiplier(1d)
+                 .setReconnectAttempts(-1)
+                 .setConfirmationWindowSize(1024 * 1024);
          ClientSessionFactoryInternal factory = (ClientSessionFactoryInternal)locator.createSessionFactory();
 
          // One for beforeReconnecto from the Factory, and one for the commit about to be done

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/remoting/SynchronousCloseTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/remoting/SynchronousCloseTest.java
@@ -15,22 +15,18 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.remoting;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.junit.Before;
 
-import org.junit.Test;
-
-import org.junit.Assert;
-
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
-public class SynchronousCloseTest extends ServiceTestBase
+public class SynchronousCloseTest extends ActiveMQTestBase
 {
 
    private ActiveMQServer server;
@@ -67,11 +63,11 @@ public class SynchronousCloseTest extends ServiceTestBase
       ServerLocator locator;
       if (isNetty())
       {
-         locator = ActiveMQClient.createServerLocatorWithoutHA(new TransportConfiguration(ServiceTestBase.NETTY_CONNECTOR_FACTORY));
+         locator = createNettyNonHALocator();
       }
       else
       {
-         locator = ActiveMQClient.createServerLocatorWithoutHA(new TransportConfiguration(ServiceTestBase.INVM_CONNECTOR_FACTORY));
+         locator = createInVMNonHALocator();
       }
 
       return createSessionFactory(locator);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/replication/ReplicationOrderTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/replication/ReplicationOrderTest.java
@@ -55,8 +55,8 @@ public class ReplicationOrderTest extends FailoverTestBase
       String queue = RandomUtil.randomString();
       ServerLocator locator = ActiveMQClient.createServerLocatorWithoutHA(getConnectorTransportConfiguration(true));
       addServerLocator(locator);
-      locator.setBlockOnNonDurableSend(false);
-      locator.setBlockOnDurableSend(false);
+      locator.setBlockOnNonDurableSend(false)
+              .setBlockOnDurableSend(false);
       ClientSessionFactory csf = createSessionFactory(locator);
       ClientSession session = null;
       if (transactional)

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/replication/ReplicationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/replication/ReplicationTest.java
@@ -68,7 +68,7 @@ import org.apache.activemq.artemis.core.settings.HierarchicalRepository;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
 import org.apache.activemq.artemis.tests.util.ReplicatedBackupUtils;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.tests.util.TransportConfigurationUtils;
 import org.apache.activemq.artemis.utils.ActiveMQThreadFactory;
 import org.apache.activemq.artemis.utils.ExecutorFactory;
@@ -92,7 +92,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public final class ReplicationTest extends ServiceTestBase
+public final class ReplicationTest extends ActiveMQTestBase
 {
 
    private ThreadFactory tFactory;
@@ -139,9 +139,9 @@ public final class ReplicationTest extends ServiceTestBase
          backupAcceptor = TransportConfigurationUtils.getInVMAcceptor(false);
       }
 
-      Configuration liveConfig = createDefaultConfig();
+      Configuration liveConfig = createDefaultInVMConfig();
 
-      Configuration backupConfig = createDefaultConfig()
+      Configuration backupConfig = createDefaultInVMConfig()
          .setHAPolicyConfiguration(new SharedStoreSlavePolicyConfiguration())
          .setBindingsDirectory(getBindingsDir(0, true))
          .setJournalDirectory(getJournalDir(0, true))
@@ -176,7 +176,7 @@ public final class ReplicationTest extends ServiceTestBase
       backupServer.start();
       if (backup)
       {
-         ServiceTestBase.waitForRemoteBackup(null, 5, true, backupServer);
+         ActiveMQTestBase.waitForRemoteBackup(null, 5, true, backupServer);
       }
       int count = 0;
       waitForReplication(count);
@@ -479,7 +479,7 @@ public final class ReplicationTest extends ServiceTestBase
     */
    private JournalStorageManager getStorage() throws Exception
    {
-      return new JournalStorageManager(createDefaultConfig(), factory, null);
+      return new JournalStorageManager(createDefaultInVMConfig(), factory, null);
    }
 
    /**

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/scheduling/DelayedMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/scheduling/DelayedMessageTest.java
@@ -22,21 +22,18 @@ import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.jms.client.ActiveMQTextMessage;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class DelayedMessageTest extends ServiceTestBase
+public class DelayedMessageTest extends ActiveMQTestBase
 {
    private static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
-
-   private Configuration configuration;
 
    private ActiveMQServer server;
 
@@ -59,15 +56,11 @@ public class DelayedMessageTest extends ServiceTestBase
     */
    protected void initServer() throws Exception
    {
-      configuration = createDefaultConfig()
-         .setSecurityEnabled(false)
-         .setJournalMinFiles(2);
-      server = createServer(true, configuration);
+      server = createServer(true, createDefaultInVMConfig());
       server.start();
 
       AddressSettings qs = server.getAddressSettingsRepository().getMatch("*");
-      AddressSettings newSets = new AddressSettings();
-      newSets.setRedeliveryDelay(DelayedMessageTest.DELAY);
+      AddressSettings newSets = new AddressSettings().setRedeliveryDelay(DelayedMessageTest.DELAY);
       newSets.merge(qs);
       server.getAddressSettingsRepository().addMatch(qName, newSets);
       locator = createInVMNonHALocator();
@@ -87,7 +80,7 @@ public class DelayedMessageTest extends ServiceTestBase
 
       final int NUM_MESSAGES = 5;
 
-      ServiceTestBase.forceGC();
+      ActiveMQTestBase.forceGC();
 
       for (int i = 0; i < NUM_MESSAGES; i++)
       {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/scheduling/MultipliedDelayedMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/scheduling/MultipliedDelayedMessageTest.java
@@ -22,21 +22,18 @@ import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.jms.client.ActiveMQTextMessage;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class MultipliedDelayedMessageTest extends ServiceTestBase
+public class MultipliedDelayedMessageTest extends ActiveMQTestBase
 {
    private static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
-
-   private Configuration configuration;
 
    private ActiveMQServer server;
 
@@ -63,18 +60,15 @@ public class MultipliedDelayedMessageTest extends ServiceTestBase
     */
    protected void initServer() throws Exception
    {
-      configuration = createDefaultConfig()
-         .setSecurityEnabled(false)
-         .setJournalMinFiles(2);
-      server = createServer(true, configuration);
+      server = createServer(true, createDefaultInVMConfig());
       server.start();
 
       // Create settings to enable multiplied redelivery delay
       AddressSettings addressSettings = server.getAddressSettingsRepository().getMatch("*");
-      AddressSettings newAddressSettings = new AddressSettings();
-      newAddressSettings.setRedeliveryDelay(DELAY);
-      newAddressSettings.setRedeliveryMultiplier(MULTIPLIER);
-      newAddressSettings.setMaxRedeliveryDelay(MAX_DELAY);
+      AddressSettings newAddressSettings = new AddressSettings()
+              .setRedeliveryDelay(DELAY)
+              .setRedeliveryMultiplier(MULTIPLIER)
+              .setMaxRedeliveryDelay(MAX_DELAY);
       newAddressSettings.merge(addressSettings);
       server.getAddressSettingsRepository().addMatch(queueName, newAddressSettings);
       locator = createInVMNonHALocator();
@@ -93,7 +87,7 @@ public class MultipliedDelayedMessageTest extends ServiceTestBase
       // Session for sending the message
       session = sessionFactory.createSession(false, true, true);
       ClientProducer producer = session.createProducer(queueName);
-      ServiceTestBase.forceGC();
+      ActiveMQTestBase.forceGC();
       ClientMessage tm = createDurableMessage(session, "message");
       producer.send(tm);
       session.close();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/scheduling/ScheduledMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/scheduling/ScheduledMessageTest.java
@@ -30,7 +30,7 @@ import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.core.transaction.impl.XidImpl;
 import org.apache.activemq.artemis.jms.client.ActiveMQTextMessage;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
 import org.junit.Assert;
 import org.junit.Before;
@@ -41,7 +41,7 @@ import javax.transaction.xa.Xid;
 import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class ScheduledMessageTest extends ServiceTestBase
+public class ScheduledMessageTest extends ActiveMQTestBase
 {
    private static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
 
@@ -68,9 +68,7 @@ public class ScheduledMessageTest extends ServiceTestBase
     */
    protected void startServer() throws Exception
    {
-      configuration = createDefaultConfig()
-         .setSecurityEnabled(false)
-         .setJournalMinFiles(2);
+      configuration = createDefaultInVMConfig();
       server = createServer(true, configuration);
       server.start();
       locator = createInVMNonHALocator();
@@ -173,8 +171,7 @@ public class ScheduledMessageTest extends ServiceTestBase
    @Test
    public void testPagedMessageDeliveredMultipleConsumersCorrectly() throws Exception
    {
-      AddressSettings qs = new AddressSettings();
-      qs.setRedeliveryDelay(5000L);
+      AddressSettings qs = new AddressSettings().setRedeliveryDelay(5000L);
       server.getAddressSettingsRepository().addMatch(atestq.toString(), qs);
       // then we create a client as normal
       ClientSessionFactory sessionFactory = createSessionFactory(locator);
@@ -227,8 +224,7 @@ public class ScheduledMessageTest extends ServiceTestBase
    public void testPagedMessageDeliveredMultipleConsumersAfterRecoverCorrectly() throws Exception
    {
 
-      AddressSettings qs = new AddressSettings();
-      qs.setRedeliveryDelay(5000L);
+      AddressSettings qs = new AddressSettings().setRedeliveryDelay(5000L);
       server.getAddressSettingsRepository().addMatch(atestq.toString(), qs);
       // then we create a client as normal
       ClientSessionFactory sessionFactory = createSessionFactory(locator);
@@ -751,8 +747,7 @@ public class ScheduledMessageTest extends ServiceTestBase
    @Test
    public void testRedeliveryAfterPrepare() throws Exception
    {
-      AddressSettings qs = new AddressSettings();
-      qs.setRedeliveryDelay(5000L);
+      AddressSettings qs = new AddressSettings().setRedeliveryDelay(5000L);
       server.getAddressSettingsRepository().addMatch(atestq.toString(), qs);
 
       ClientSessionFactory sessionFactory = createSessionFactory(locator);
@@ -797,9 +792,7 @@ public class ScheduledMessageTest extends ServiceTestBase
 
       server.stop();
 
-      configuration = createDefaultConfig()
-         .setSecurityEnabled(false)
-         .setJournalMinFiles(2)
+      configuration = createDefaultInVMConfig()
          .addAddressesSetting(atestq.toString(), qs);
 
       server = createServer(true, configuration);
@@ -863,7 +856,7 @@ public class ScheduledMessageTest extends ServiceTestBase
 
    private void scheduledDelivery(final boolean tx) throws Exception
    {
-      ServiceTestBase.forceGC();
+      ActiveMQTestBase.forceGC();
 
       Xid xid = new XidImpl("xa1".getBytes(), 1, UUIDGenerator.getInstance().generateStringUUID().getBytes());
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/security/NettySecurityClientTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/security/NettySecurityClientTest.java
@@ -23,13 +23,13 @@ import java.net.URL;
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.tests.util.SpawnedVMSupport;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class NettySecurityClientTest extends ServiceTestBase
+public class NettySecurityClientTest extends ActiveMQTestBase
 {
 
    private static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
@@ -58,7 +58,7 @@ public class NettySecurityClientTest extends ServiceTestBase
          .addAcceptorConfiguration(getNettyAcceptorTransportConfiguration(true));
       messagingService = createServer(false, config);
       messagingService.start();
-      waitForServer(messagingService);
+      waitForServerToStart(messagingService);
    }
 
    private void doTestProducerConsumerClient(final boolean withSecurityManager) throws Exception

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/security/SecurityTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/security/SecurityTest.java
@@ -31,7 +31,7 @@ import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.tests.util.CreateMessage;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.security.Role;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
@@ -42,7 +42,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class SecurityTest extends ServiceTestBase
+public class SecurityTest extends ActiveMQTestBase
 {
    /*
     * create session tests
@@ -92,7 +92,7 @@ public class SecurityTest extends ServiceTestBase
     */
    private ActiveMQServer createServer() throws Exception
    {
-      configuration = createDefaultConfig()
+      configuration = createDefaultInVMConfig()
          .setSecurityEnabled(true);
       ActiveMQServer server = createServer(false, configuration);
       return server;
@@ -569,7 +569,7 @@ public class SecurityTest extends ServiceTestBase
    @Test
    public void testSendMessageUpdateRoleCached() throws Exception
    {
-      Configuration configuration = createDefaultConfig()
+      Configuration configuration = createDefaultInVMConfig()
          .setSecurityEnabled(true)
          .setSecurityInvalidationInterval(10000);
       ActiveMQServer server = createServer(false, configuration);
@@ -625,7 +625,7 @@ public class SecurityTest extends ServiceTestBase
    @Test
    public void testSendMessageUpdateRoleCached2() throws Exception
    {
-      Configuration configuration = createDefaultConfig()
+      Configuration configuration = createDefaultInVMConfig()
          .setSecurityEnabled(true)
          .setSecurityInvalidationInterval(0);
       ActiveMQServer server = createServer(false, configuration);
@@ -695,7 +695,7 @@ public class SecurityTest extends ServiceTestBase
    @Test
    public void testSendMessageUpdateSender() throws Exception
    {
-      Configuration configuration = createDefaultConfig()
+      Configuration configuration = createDefaultInVMConfig()
          .setSecurityEnabled(true)
          .setSecurityInvalidationInterval(-1);
       ActiveMQServer server = createServer(false, configuration);
@@ -919,8 +919,8 @@ public class SecurityTest extends ServiceTestBase
       ClientSession andrewConnection = null;
       ClientSession frankConnection = null;
       ClientSession samConnection = null;
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
+      locator.setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true);
       ClientSessionFactory factory = createSessionFactory(locator);
 
       ClientSession adminSession = factory.createSession("all", "all", false, true, true, false, -1);
@@ -1059,8 +1059,8 @@ public class SecurityTest extends ServiceTestBase
       ClientSession frankConnection = null;
       ClientSession samConnection = null;
       ClientSessionFactory factory = createSessionFactory(locator);
-      factory.getServerLocator().setBlockOnNonDurableSend(true);
-      factory.getServerLocator().setBlockOnDurableSend(true);
+      factory.getServerLocator().setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true);
 
       ClientSession adminSession = factory.createSession("all", "all", false, true, true, false, -1);
       String genericQueueName = "genericQueue";

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/AddressFullLoggingTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/AddressFullLoggingTest.java
@@ -34,13 +34,13 @@ import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.logs.AssertionLoggerHandler;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class AddressFullLoggingTest extends ServiceTestBase
+public class AddressFullLoggingTest extends ActiveMQTestBase
 {
    @BeforeClass
    public static void prepareLogger()
@@ -62,17 +62,17 @@ public class AddressFullLoggingTest extends ServiceTestBase
 
       ActiveMQServer server = createServer(false);
 
-      AddressSettings defaultSetting = new AddressSettings();
-      defaultSetting.setPageSizeBytes(10 * 1024);
-      defaultSetting.setMaxSizeBytes(20 * 1024);
-      defaultSetting.setAddressFullMessagePolicy(AddressFullMessagePolicy.BLOCK);
+      AddressSettings defaultSetting = new AddressSettings()
+              .setPageSizeBytes(10 * 1024)
+              .setMaxSizeBytes(20 * 1024)
+              .setAddressFullMessagePolicy(AddressFullMessagePolicy.BLOCK);
       server.getAddressSettingsRepository().addMatch("#", defaultSetting);
       server.start();
 
-      ServerLocator locator = createInVMNonHALocator();
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      ServerLocator locator = createInVMNonHALocator()
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       ClientSessionFactory factory = createSessionFactory(locator);
       ClientSession session = factory.createSession(false, true, true);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/ConnectionLimitTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/ConnectionLimitTest.java
@@ -26,14 +26,14 @@ import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class ConnectionLimitTest extends ServiceTestBase
+public class ConnectionLimitTest extends ActiveMQTestBase
 {
    private ActiveMQServer server;
 
@@ -77,8 +77,8 @@ public class ConnectionLimitTest extends ServiceTestBase
    @Test
    public void testNettyConnectionLimit() throws Exception
    {
-      ServerLocator locator = addServerLocator(createNonHALocator(true));
-      locator.setCallTimeout(3000);
+      ServerLocator locator = createNonHALocator(true)
+              .setCallTimeout(3000);
       ClientSessionFactory clientSessionFactory = locator.createSessionFactory();
       ClientSession clientSession = addClientSession(clientSessionFactory.createSession());
       ClientSessionFactory extraClientSessionFactory = locator.createSessionFactory();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/FileLockTimeoutTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/FileLockTimeoutTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.asyncio.impl.AsynchronousFileImpl;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.ha.SharedStoreMasterPolicyConfiguration;
@@ -33,7 +33,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 
-public class FileLockTimeoutTest extends ServiceTestBase
+public class FileLockTimeoutTest extends ActiveMQTestBase
 {
    @BeforeClass
    public static void prepareLogger()
@@ -56,7 +56,7 @@ public class FileLockTimeoutTest extends ServiceTestBase
                            AsynchronousFileImpl.isLoaded()
          );
       }
-      Configuration config = super.createDefaultConfig()
+      Configuration config = super.createDefaultInVMConfig()
          .setHAPolicyConfiguration(new SharedStoreMasterPolicyConfiguration())
          .clearAcceptorConfigurations();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/GracefulShutdownTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/GracefulShutdownTest.java
@@ -18,8 +18,6 @@ package org.apache.activemq.artemis.tests.integration.server;
 
 import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
 import org.apache.activemq.artemis.api.core.ActiveMQSessionCreationException;
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
@@ -27,23 +25,22 @@ import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 
-public class GracefulShutdownTest extends ServiceTestBase
+public class GracefulShutdownTest extends ActiveMQTestBase
 {
    @Test
    public void testGracefulShutdown() throws Exception
    {
-      Configuration conf = createDefaultConfig();
+      Configuration config = createDefaultInVMConfig()
+              .setGracefulShutdownEnabled(true);
 
-      conf.setGracefulShutdownEnabled(true);
-
-      final ActiveMQServer server = ActiveMQServers.newActiveMQServer(conf, false);
+      final ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(config, false));
 
       server.start();
 
-      ServerLocator locator = ActiveMQClient.createServerLocatorWithoutHA(new TransportConfiguration(ServiceTestBase.INVM_CONNECTOR_FACTORY));
+      ServerLocator locator = createInVMNonHALocator();
 
       ClientSessionFactory sf = createSessionFactory(locator);
 
@@ -117,20 +114,17 @@ public class GracefulShutdownTest extends ServiceTestBase
    {
       long timeout = 10000;
 
-      Configuration conf = createDefaultConfig();
+      Configuration config = createDefaultInVMConfig()
+              .setGracefulShutdownEnabled(true)
+              .setGracefulShutdownTimeout(timeout);
 
-      conf.setGracefulShutdownEnabled(true);
-      conf.setGracefulShutdownTimeout(timeout);
-
-      final ActiveMQServer server = ActiveMQServers.newActiveMQServer(conf, false);
+      final ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(config, false));
 
       server.start();
 
-      ServerLocator locator = ActiveMQClient.createServerLocatorWithoutHA(new TransportConfiguration(ServiceTestBase.INVM_CONNECTOR_FACTORY));
+      ServerLocator locator = createInVMNonHALocator();
 
       ClientSessionFactory sf = createSessionFactory(locator);
-
-      ClientSession session = sf.createSession();
 
       Thread t = new Thread(new Runnable()
       {
@@ -179,7 +173,5 @@ public class GracefulShutdownTest extends ServiceTestBase
       }
 
       assertTrue("thread terminated too soon, the graceful shutdown timeout wasn't enforced properly", System.currentTimeMillis() - start >= timeout);
-
-      locator.close();
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/ResourceLimitTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/ResourceLimitTest.java
@@ -26,11 +26,11 @@ import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
 import org.apache.activemq.artemis.core.settings.impl.ResourceLimitSettings;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ResourceLimitTest extends ServiceTestBase
+public class ResourceLimitTest extends ActiveMQTestBase
 {
    private ActiveMQServer server;
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/ScaleDown3NodeTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/ScaleDown3NodeTest.java
@@ -19,10 +19,10 @@ package org.apache.activemq.artemis.tests.integration.server;
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.core.config.ScaleDownConfiguration;
 import org.apache.activemq.artemis.core.config.ha.LiveOnlyPolicyConfiguration;
 import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager;
@@ -33,8 +33,7 @@ import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
 import org.apache.activemq.artemis.tests.integration.cluster.distribution.ClusterTestBase;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.junit.After;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -81,17 +80,6 @@ public class ScaleDown3NodeTest extends ClusterTestBase
       return true;
    }
 
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      closeAllConsumers();
-      closeAllSessionFactories();
-      closeAllServerLocatorsFactories();
-      stopServers(0, 1, 2);
-      super.tearDown();
-   }
-
    @Test
    public void testBasicScaleDownWithDefaultReconnectAttempts() throws Exception
    {
@@ -112,8 +100,7 @@ public class ScaleDown3NodeTest extends ClusterTestBase
 
    private void testBasicScaleDownInternal(int reconnectAttempts, boolean large) throws Exception
    {
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setRedistributionDelay(0);
+      AddressSettings addressSettings = new AddressSettings().setRedistributionDelay(0);
       servers[0].getAddressSettingsRepository().addMatch("#", addressSettings);
       servers[1].getAddressSettingsRepository().addMatch("#", addressSettings);
       servers[2].getAddressSettingsRepository().addMatch("#", addressSettings);
@@ -149,7 +136,7 @@ public class ScaleDown3NodeTest extends ClusterTestBase
 
          for (int i = 0; i < 2 * ActiveMQClient.DEFAULT_MIN_LARGE_MESSAGE_SIZE; i++)
          {
-            fileMessage.addBytes(new byte[]{ServiceTestBase.getSamplebyte(i)});
+            fileMessage.addBytes(new byte[]{ActiveMQTestBase.getSamplebyte(i)});
          }
 
          fileMessage.putLongProperty(Message.HDR_LARGE_BODY_SIZE, 2 * ActiveMQClient.DEFAULT_MIN_LARGE_MESSAGE_SIZE);
@@ -254,7 +241,7 @@ public class ScaleDown3NodeTest extends ClusterTestBase
 
             for (int j = 0; j < 2 * ActiveMQClient.DEFAULT_MIN_LARGE_MESSAGE_SIZE; j++)
             {
-               Assert.assertEquals(ServiceTestBase.getSamplebyte(j), clientMessage.getBodyBuffer().readByte());
+               Assert.assertEquals(ActiveMQTestBase.getSamplebyte(j), clientMessage.getBodyBuffer().readByte());
             }
          }
          IntegrationTestLogger.LOGGER.info("Received: " + clientMessage);
@@ -270,8 +257,7 @@ public class ScaleDown3NodeTest extends ClusterTestBase
    @Test
    public void testScaleDownWithMultipleQueues() throws Exception
    {
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setRedistributionDelay(0);
+      AddressSettings addressSettings = new AddressSettings().setRedistributionDelay(0);
       servers[0].getAddressSettingsRepository().addMatch("#", addressSettings);
       servers[1].getAddressSettingsRepository().addMatch("#", addressSettings);
       servers[2].getAddressSettingsRepository().addMatch("#", addressSettings);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/ScaleDownDirectTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/ScaleDownDirectTest.java
@@ -17,9 +17,6 @@
 
 package org.apache.activemq.artemis.tests.integration.server;
 
-import java.util.Arrays;
-import java.util.Collection;
-
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
@@ -32,12 +29,14 @@ import org.apache.activemq.artemis.core.postoffice.impl.LocalQueueBinding;
 import org.apache.activemq.artemis.core.server.impl.ScaleDownHandler;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.tests.integration.cluster.distribution.ClusterTestBase;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
 
 /**
  * On this test we will run ScaleDown directly as an unit-test in several cases,
@@ -46,8 +45,6 @@ import org.junit.runners.Parameterized;
 @RunWith(value = Parameterized.class)
 public class ScaleDownDirectTest extends ClusterTestBase
 {
-
-
    @Parameterized.Parameters(name = "isNetty={0}")
    public static Collection getParameters()
    {
@@ -75,13 +72,6 @@ public class ScaleDownDirectTest extends ClusterTestBase
       setupSessionFactory(0, isNetty);
       setupSessionFactory(1, isNetty);
 
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      super.tearDown();
    }
 
    @Test
@@ -193,9 +183,9 @@ public class ScaleDownDirectTest extends ClusterTestBase
       ClientSession session = addClientSession(sf.createSession(false, false));
       ClientProducer producer = addClientProducer(session.createProducer(addressName));
 
-      AddressSettings defaultSetting = new AddressSettings();
-      defaultSetting.setPageSizeBytes(10 * 1024);
-      defaultSetting.setMaxSizeBytes(20 * 1024);
+      AddressSettings defaultSetting = new AddressSettings()
+              .setPageSizeBytes(10 * 1024)
+              .setMaxSizeBytes(20 * 1024);
       servers[0].getAddressSettingsRepository().addMatch("#", defaultSetting);
 
       while (!servers[0].getPagingManager().getPageStore(new SimpleString(addressName)).isPaging())

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/ScaleDownTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/ScaleDownTest.java
@@ -16,31 +16,30 @@
  */
 package org.apache.activemq.artemis.tests.integration.server;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Map;
-
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.core.config.ScaleDownConfiguration;
 import org.apache.activemq.artemis.core.config.ha.LiveOnlyPolicyConfiguration;
 import org.apache.activemq.artemis.core.postoffice.Binding;
 import org.apache.activemq.artemis.core.postoffice.impl.LocalQueueBinding;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.tests.integration.cluster.distribution.ClusterTestBase;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.junit.After;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
 
 @RunWith(value = Parameterized.class)
 public class ScaleDownTest extends ClusterTestBase
@@ -91,21 +90,6 @@ public class ScaleDownTest extends ClusterTestBase
    protected boolean isNetty()
    {
       return true;
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      closeAllConsumers();
-      closeAllSessionFactories();
-      closeAllServerLocatorsFactories();
-      LiveOnlyPolicyConfiguration haPolicyConfiguration0 = (LiveOnlyPolicyConfiguration) servers[0].getConfiguration().getHAPolicyConfiguration();
-      LiveOnlyPolicyConfiguration haPolicyConfiguration1 = (LiveOnlyPolicyConfiguration) servers[1].getConfiguration().getHAPolicyConfiguration();
-      haPolicyConfiguration0.setScaleDownConfiguration(null);
-      haPolicyConfiguration1.setScaleDownConfiguration(null);
-      stopServers(0, 1);
-      super.tearDown();
    }
 
    @Test
@@ -414,7 +398,7 @@ public class ScaleDownTest extends ClusterTestBase
          for (int i = 0; i < 2 * ActiveMQClient.DEFAULT_MIN_LARGE_MESSAGE_SIZE; i++)
          {
             byte byteRead = msg.getBodyBuffer().readByte();
-            Assert.assertEquals(msg + " Is different", ServiceTestBase.getSamplebyte(i), byteRead);
+            Assert.assertEquals(msg + " Is different", ActiveMQTestBase.getSamplebyte(i), byteRead);
          }
 
          msg.acknowledge();
@@ -437,9 +421,9 @@ public class ScaleDownTest extends ClusterTestBase
       ClientSession session = addClientSession(sf.createSession(false, false));
       ClientProducer producer = addClientProducer(session.createProducer(addressName));
 
-      AddressSettings defaultSetting = new AddressSettings();
-      defaultSetting.setPageSizeBytes(10 * 1024);
-      defaultSetting.setMaxSizeBytes(20 * 1024);
+      AddressSettings defaultSetting = new AddressSettings()
+              .setPageSizeBytes(10 * 1024)
+              .setMaxSizeBytes(20 * 1024);
       servers[0].getAddressSettingsRepository().addMatch("#", defaultSetting);
 
       while (!servers[0].getPagingManager().getPageStore(new SimpleString(addressName)).isPaging())
@@ -481,9 +465,9 @@ public class ScaleDownTest extends ClusterTestBase
       ClientSession session = addClientSession(sf.createSession(false, false));
       ClientProducer producer = addClientProducer(session.createProducer(addressName));
 
-      AddressSettings defaultSetting = new AddressSettings();
-      defaultSetting.setPageSizeBytes(10 * 1024);
-      defaultSetting.setMaxSizeBytes(20 * 1024);
+      AddressSettings defaultSetting = new AddressSettings()
+              .setPageSizeBytes(10 * 1024)
+              .setMaxSizeBytes(20 * 1024);
       servers[0].getAddressSettingsRepository().addMatch("#", defaultSetting);
 
       while (!servers[0].getPagingManager().getPageStore(new SimpleString(addressName)).isPaging())

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/SimpleStartStopTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/SimpleStartStopTest.java
@@ -23,11 +23,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.logs.AssertionLoggerHandler;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.jboss.logmanager.Level;
 import org.junit.Test;
 
-public class SimpleStartStopTest extends ServiceTestBase
+public class SimpleStartStopTest extends ActiveMQTestBase
 {
 
    /**

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/SuppliedThreadPoolTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/SuppliedThreadPoolTest.java
@@ -24,7 +24,7 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl;
 import org.apache.activemq.artemis.core.server.impl.ServiceRegistry;
@@ -32,7 +32,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class SuppliedThreadPoolTest extends ServiceTestBase
+public class SuppliedThreadPoolTest extends ActiveMQTestBase
 {
    private ActiveMQServer server;
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/spring/SpringIntegrationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/spring/SpringIntegrationTest.java
@@ -19,7 +19,7 @@ package org.apache.activemq.artemis.tests.integration.spring;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.jms.server.embedded.EmbeddedJMS;
 import org.junit.Assert;
@@ -29,7 +29,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.jms.listener.DefaultMessageListenerContainer;
 
-public class SpringIntegrationTest extends ServiceTestBase
+public class SpringIntegrationTest extends ActiveMQTestBase
 {
    IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ssl/CoreClientOverOneWaySSLTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ssl/CoreClientOverOneWaySSLTest.java
@@ -37,7 +37,7 @@ import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.core.remoting.impl.ssl.SSLSupport;
@@ -50,7 +50,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(value = Parameterized.class)
-public class CoreClientOverOneWaySSLTest extends ServiceTestBase
+public class CoreClientOverOneWaySSLTest extends ActiveMQTestBase
 {
    @Parameterized.Parameters(name = "storeType={0}")
    public static Collection getParameters()
@@ -545,8 +545,8 @@ public class CoreClientOverOneWaySSLTest extends ServiceTestBase
       createCustomSslServer();
       tc.getParams().put(TransportConstants.SSL_ENABLED_PROP_NAME, false);
 
-      ServerLocator locator = addServerLocator(ActiveMQClient.createServerLocatorWithoutHA(tc));
-      locator.setCallTimeout(2000);
+      ServerLocator locator = addServerLocator(ActiveMQClient.createServerLocatorWithoutHA(tc))
+              .setCallTimeout(2000);
       try
       {
          createSessionFactory(locator);
@@ -602,7 +602,7 @@ public class CoreClientOverOneWaySSLTest extends ServiceTestBase
          .addAcceptorConfiguration(new TransportConfiguration(NETTY_ACCEPTOR_FACTORY, params));
       server = createServer(false, config);
       server.start();
-      waitForServer(server);
+      waitForServerToStart(server);
       tc = new TransportConfiguration(NETTY_CONNECTOR_FACTORY);
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ssl/CoreClientOverTwoWaySSLTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ssl/CoreClientOverTwoWaySSLTest.java
@@ -37,7 +37,7 @@ import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
 import org.apache.activemq.artemis.core.protocol.core.Packet;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
@@ -52,7 +52,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(value = Parameterized.class)
-public class CoreClientOverTwoWaySSLTest extends ServiceTestBase
+public class CoreClientOverTwoWaySSLTest extends ActiveMQTestBase
 {
    @Parameterized.Parameters(name = "storeType={0}")
    public static Collection getParameters()
@@ -201,7 +201,7 @@ public class CoreClientOverTwoWaySSLTest extends ServiceTestBase
          .addAcceptorConfiguration(new TransportConfiguration(NETTY_ACCEPTOR_FACTORY, params));
       server = createServer(false, config);
       server.start();
-      waitForServer(server);
+      waitForServerToStart(server);
       tc = new TransportConfiguration(NETTY_CONNECTOR_FACTORY);
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/ExtraStompTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/ExtraStompTest.java
@@ -16,21 +16,9 @@
  */
 package org.apache.activemq.artemis.tests.integration.stomp;
 
-import javax.jms.Message;
-import javax.jms.MessageConsumer;
-import javax.jms.QueueBrowser;
-import javax.jms.TextMessage;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.activemq.artemis.api.core.Interceptor;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
-import org.apache.activemq.artemis.tests.integration.largemessage.LargeMessageTestBase;
-import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.protocol.core.Packet;
 import org.apache.activemq.artemis.core.protocol.stomp.Stomp;
@@ -50,13 +38,24 @@ import org.apache.activemq.artemis.jms.server.config.impl.JMSQueueConfigurationI
 import org.apache.activemq.artemis.jms.server.config.impl.TopicConfigurationImpl;
 import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
+import org.apache.activemq.artemis.tests.integration.largemessage.LargeMessageTestBase;
 import org.apache.activemq.artemis.tests.integration.stomp.util.ClientStompFrame;
 import org.apache.activemq.artemis.tests.integration.stomp.util.StompClientConnection;
 import org.apache.activemq.artemis.tests.integration.stomp.util.StompClientConnectionFactory;
-import org.junit.After;
+import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.QueueBrowser;
+import javax.jms.TextMessage;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class ExtraStompTest extends StompTestBase
 {
@@ -67,14 +66,6 @@ public class ExtraStompTest extends StompTestBase
       autoCreateServer = false;
       super.setUp();
    }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      super.tearDown();
-   }
-
 
    @Test
    public void testConnectionTTL() throws Exception
@@ -700,7 +691,7 @@ public class ExtraStompTest extends StompTestBase
          .addAcceptorConfiguration(stompTransport)
          .addAcceptorConfiguration(new TransportConfiguration(InVMAcceptorFactory.class.getName()));
 
-      ActiveMQServer activeMQServer = ActiveMQServers.newActiveMQServer(config, defUser, defPass);
+      ActiveMQServer activeMQServer = addServer(ActiveMQServers.newActiveMQServer(config, defUser, defPass));
 
       JMSConfiguration jmsConfig = new JMSConfigurationImpl();
       jmsConfig.getQueueConfigurations().add(new JMSQueueConfigurationImpl()

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/StompTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/StompTestBase.java
@@ -51,7 +51,7 @@ import io.netty.handler.codec.string.StringDecoder;
 import io.netty.handler.codec.string.StringEncoder;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.protocol.stomp.StompProtocolManagerFactory;
 import org.apache.activemq.artemis.core.registry.JndiBindingRegistry;
@@ -72,7 +72,7 @@ import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
 import org.junit.After;
 import org.junit.Before;
 
-public abstract class StompTestBase extends ServiceTestBase
+public abstract class StompTestBase extends ActiveMQTestBase
 {
    protected final int port = 61613;
 
@@ -206,7 +206,7 @@ public abstract class StompTestBase extends ServiceTestBase
          .addAcceptorConfiguration(stompTransport)
          .addAcceptorConfiguration(new TransportConfiguration(InVMAcceptorFactory.class.getName()));
 
-      ActiveMQServer activeMQServer = ActiveMQServers.newActiveMQServer(config, defUser, defPass);
+      ActiveMQServer activeMQServer = addServer(ActiveMQServers.newActiveMQServer(config, defUser, defPass));
 
       JMSConfiguration jmsConfig = new JMSConfigurationImpl();
       jmsConfig.getQueueConfigurations().add(new JMSQueueConfigurationImpl()

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/StompWebSocketTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/StompWebSocketTest.java
@@ -16,11 +16,7 @@
  */
 package org.apache.activemq.artemis.tests.integration.stomp;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.CoreQueueConfiguration;
 import org.apache.activemq.artemis.core.protocol.stomp.StompProtocolManagerFactory;
@@ -33,11 +29,14 @@ import org.apache.activemq.artemis.jms.server.JMSServerManager;
 import org.apache.activemq.artemis.jms.server.config.JMSConfiguration;
 import org.apache.activemq.artemis.jms.server.config.impl.JMSConfigurationImpl;
 import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
-import org.junit.After;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 import org.junit.Test;
 
-public class StompWebSocketTest extends ServiceTestBase
+import java.util.HashMap;
+import java.util.Map;
+
+public class StompWebSocketTest extends ActiveMQTestBase
 {
    private JMSServerManager server;
 
@@ -87,13 +86,6 @@ public class StompWebSocketTest extends ServiceTestBase
       server = new JMSServerManagerImpl(activeMQServer, jmsConfig);
       server.setRegistry(null);
       return server;
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      server.stop();
    }
 
    protected String getQueueName()

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/v11/StompV11TestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/v11/StompV11TestBase.java
@@ -15,29 +15,11 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.stomp.v11;
-import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.apache.activemq.artemis.core.registry.JndiBindingRegistry;
-import org.junit.Before;
-import org.junit.After;
 
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.jms.BytesMessage;
-import javax.jms.Connection;
-import javax.jms.ConnectionFactory;
-import javax.jms.Destination;
-import javax.jms.MessageProducer;
-import javax.jms.Queue;
-import javax.jms.Session;
-import javax.jms.TextMessage;
-import javax.jms.Topic;
-
-import org.apache.activemq.artemis.core.protocol.stomp.StompProtocolManagerFactory;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.protocol.stomp.StompProtocolManagerFactory;
+import org.apache.activemq.artemis.core.registry.JndiBindingRegistry;
 import org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory;
 import org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnectorFactory;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptorFactory;
@@ -51,8 +33,24 @@ import org.apache.activemq.artemis.jms.server.config.impl.JMSConfigurationImpl;
 import org.apache.activemq.artemis.jms.server.config.impl.JMSQueueConfigurationImpl;
 import org.apache.activemq.artemis.jms.server.config.impl.TopicConfigurationImpl;
 import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
+import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.junit.Before;
 
-public abstract class StompV11TestBase extends ServiceTestBase
+import javax.jms.BytesMessage;
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import javax.jms.Topic;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class StompV11TestBase extends ActiveMQTestBase
 {
    protected String hostname = "127.0.0.1";
 
@@ -124,23 +122,6 @@ public abstract class StompV11TestBase extends ServiceTestBase
       server = new JMSServerManagerImpl(activeMQServer, jmsConfig);
       server.setRegistry(new JndiBindingRegistry(new InVMNamingContext()));
       return server;
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      try
-      {
-         if (connection != null)
-            connection.close();
-         if (server != null)
-            server.stop();
-      }
-      finally
-      {
-         super.tearDown();
-      }
    }
 
    protected ConnectionFactory createConnectionFactory()

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/transports/netty/ActiveMQFrameDecoder2Test.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/transports/netty/ActiveMQFrameDecoder2Test.java
@@ -16,21 +16,19 @@
  */
 package org.apache.activemq.artemis.tests.integration.transports.netty;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.apache.activemq.artemis.core.remoting.impl.netty.ActiveMQFrameDecoder2;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-import io.netty.channel.embedded.EmbeddedChannel;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.apache.activemq.artemis.core.remoting.impl.netty.ActiveMQFrameDecoder2;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
-public class ActiveMQFrameDecoder2Test extends ServiceTestBase
+public class ActiveMQFrameDecoder2Test extends ActiveMQTestBase
 {
    private static final int MSG_CNT = 10000;
 
@@ -39,18 +37,6 @@ public class ActiveMQFrameDecoder2Test extends ServiceTestBase
    private static final int FRAGMENT_MAX_LEN = 1500;
 
    private static final Random rand = new Random();
-
-   @Before
-   public void setUp() throws Exception
-   {
-      super.setUp();
-   }
-
-   @After
-   public void tearDown() throws Exception
-   {
-      super.tearDown();
-   }
 
    @Test
    public void testOrdinaryFragmentation() throws Exception

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/transports/netty/NettyConnectorWithHTTPUpgradeTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/transports/netty/NettyConnectorWithHTTPUpgradeTest.java
@@ -45,7 +45,7 @@ import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptor;
 import org.apache.activemq.artemis.core.remoting.impl.netty.PartialPooledByteBufAllocator;
@@ -69,7 +69,7 @@ import static org.apache.activemq.artemis.tests.util.RandomUtil.randomString;
 /**
  * Test that Netty Connector can connect to a Web Server and upgrade from a HTTP request to its remoting protocol.
  */
-public class NettyConnectorWithHTTPUpgradeTest extends ServiceTestBase
+public class NettyConnectorWithHTTPUpgradeTest extends ActiveMQTestBase
 {
 
    private static final SimpleString QUEUE = new SimpleString("NettyConnectorWithHTTPUpgradeTest");
@@ -94,12 +94,9 @@ public class NettyConnectorWithHTTPUpgradeTest extends ServiceTestBase
       httpParams.put(TransportConstants.HTTP_UPGRADE_ENABLED_PROP_NAME, true);
       httpParams.put(TransportConstants.PORT_PROP_NAME, HTTP_PORT);
       acceptorName = randomString();
-      HashMap<String, Object> emptyParams = new HashMap<>();
 
-      conf = createDefaultConfig()
-         .setSecurityEnabled(false)
-         .addAcceptorConfiguration(new TransportConfiguration(NETTY_ACCEPTOR_FACTORY, httpParams, acceptorName))
-         .addAcceptorConfiguration(new TransportConfiguration(NETTY_ACCEPTOR_FACTORY, emptyParams, randomString()));
+      conf = createDefaultNettyConfig()
+         .addAcceptorConfiguration(new TransportConfiguration(NETTY_ACCEPTOR_FACTORY, httpParams, acceptorName));
 
       server = addServer(ActiveMQServers.newActiveMQServer(conf, false));
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/vertx/ActiveMQVertxUnitTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/vertx/ActiveMQVertxUnitTest.java
@@ -17,8 +17,6 @@
 package org.apache.activemq.artemis.tests.integration.vertx;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
@@ -31,7 +29,7 @@ import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.integration.vertx.VertxConstants;
 import org.apache.activemq.artemis.integration.vertx.VertxIncomingConnectorServiceFactory;
 import org.apache.activemq.artemis.integration.vertx.VertxOutgoingConnectorServiceFactory;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -51,7 +49,7 @@ import java.util.HashMap;
  * This class tests the basics of ActiveMQ
  * vertx integration
  */
-public class ActiveMQVertxUnitTest extends ServiceTestBase
+public class ActiveMQVertxUnitTest extends ActiveMQTestBase
 {
    protected PlatformManager vertxManager;
    protected ActiveMQServer server;
@@ -155,7 +153,7 @@ public class ActiveMQVertxUnitTest extends ServiceTestBase
          .setParams(config5)
          .setName("test-vertx-outgoing-connector2");
 
-      Configuration configuration = createDefaultConfig()
+      Configuration configuration = createDefaultInVMConfig()
          .addQueueConfiguration(qc1)
          .addQueueConfiguration(qc2)
          .addQueueConfiguration(qc3)
@@ -681,8 +679,7 @@ public class ActiveMQVertxUnitTest extends ServiceTestBase
 
       try
       {
-         TransportConfiguration tpconf = new TransportConfiguration(INVM_CONNECTOR_FACTORY);
-         locator = ActiveMQClient.createServerLocatorWithoutHA(tpconf);
+         locator = createInVMNonHALocator();
 
          sf = createSessionFactory(locator);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/xa/BasicXaRecoveryTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/xa/BasicXaRecoveryTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.activemq.artemis.tests.integration.xa;
 
-import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
@@ -33,7 +32,7 @@ import org.apache.activemq.artemis.jms.client.ActiveMQBytesMessage;
 import org.apache.activemq.artemis.jms.client.ActiveMQTextMessage;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
 import org.apache.activemq.artemis.tests.integration.management.ManagementControlHelper;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
 import org.junit.After;
 import org.junit.Assert;
@@ -48,7 +47,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-public class BasicXaRecoveryTest extends ServiceTestBase
+public class BasicXaRecoveryTest extends ActiveMQTestBase
 {
    private static IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
 
@@ -79,10 +78,7 @@ public class BasicXaRecoveryTest extends ServiceTestBase
       super.setUp();
 
       addressSettings.clear();
-      configuration = createDefaultConfig()
-         .setSecurityEnabled(false)
-         .setJournalMinFiles(2)
-         .setPagingDirectory(getPageDir())
+      configuration = createDefaultInVMConfig()
          .setJMXManagementEnabled(true);
 
       mbeanServer = MBeanServerFactory.createMBeanServer();
@@ -102,45 +98,6 @@ public class BasicXaRecoveryTest extends ServiceTestBase
    public void tearDown() throws Exception
    {
       MBeanServerFactory.releaseMBeanServer(mbeanServer);
-
-      mbeanServer = null;
-
-      if (clientSession != null)
-      {
-         try
-         {
-            clientSession.close();
-         }
-         catch (ActiveMQException e1)
-         {
-            //
-         }
-      }
-      if (server != null && server.isStarted())
-      {
-         try
-         {
-            server.stop();
-         }
-         catch (Exception e1)
-         {
-            //
-         }
-      }
-      server = null;
-
-      clientSession = null;
-
-      server = null;
-
-      clientProducer = null;
-
-      clientConsumer = null;
-
-      sessionFactory = null;
-
-      configuration = null;
-
       super.tearDown();
    }
 
@@ -295,9 +252,9 @@ public class BasicXaRecoveryTest extends ServiceTestBase
 
       SimpleString pageQueue = new SimpleString("pagequeue");
 
-      AddressSettings pageAddressSettings = new AddressSettings();
-      pageAddressSettings.setMaxSizeBytes(100 * 1024);
-      pageAddressSettings.setPageSizeBytes(10 * 1024);
+      AddressSettings pageAddressSettings = new AddressSettings()
+              .setMaxSizeBytes(100 * 1024)
+              .setPageSizeBytes(10 * 1024);
 
       addressSettings.put(pageQueue.toString(), pageAddressSettings);
 
@@ -334,8 +291,8 @@ public class BasicXaRecoveryTest extends ServiceTestBase
       Xid[] xids = clientSession.recover(XAResource.TMSTARTRSCAN);
       Assert.assertEquals(xids.length, 1);
       Assert.assertEquals(xids[0].getFormatId(), xid.getFormatId());
-      ServiceTestBase.assertEqualsByteArrays(xids[0].getBranchQualifier(), xid.getBranchQualifier());
-      ServiceTestBase.assertEqualsByteArrays(xids[0].getGlobalTransactionId(), xid.getGlobalTransactionId());
+      ActiveMQTestBase.assertEqualsByteArrays(xids[0].getBranchQualifier(), xid.getBranchQualifier());
+      ActiveMQTestBase.assertEqualsByteArrays(xids[0].getGlobalTransactionId(), xid.getGlobalTransactionId());
 
       clientSession.commit(xid, false);
 
@@ -378,9 +335,9 @@ public class BasicXaRecoveryTest extends ServiceTestBase
 
       SimpleString pageQueue = new SimpleString("pagequeue");
 
-      AddressSettings pageAddressSettings = new AddressSettings();
-      pageAddressSettings.setMaxSizeBytes(100 * 1024);
-      pageAddressSettings.setPageSizeBytes(10 * 1024);
+      AddressSettings pageAddressSettings = new AddressSettings()
+              .setMaxSizeBytes(100 * 1024)
+              .setPageSizeBytes(10 * 1024);
 
       addressSettings.put(pageQueue.toString(), pageAddressSettings);
 
@@ -413,8 +370,8 @@ public class BasicXaRecoveryTest extends ServiceTestBase
       Xid[] xids = clientSession.recover(XAResource.TMSTARTRSCAN);
       Assert.assertEquals(1, xids.length);
       Assert.assertEquals(xids[0].getFormatId(), xid.getFormatId());
-      ServiceTestBase.assertEqualsByteArrays(xids[0].getBranchQualifier(), xid.getBranchQualifier());
-      ServiceTestBase.assertEqualsByteArrays(xids[0].getGlobalTransactionId(), xid.getGlobalTransactionId());
+      ActiveMQTestBase.assertEqualsByteArrays(xids[0].getBranchQualifier(), xid.getBranchQualifier());
+      ActiveMQTestBase.assertEqualsByteArrays(xids[0].getGlobalTransactionId(), xid.getGlobalTransactionId());
 
       clientSession.rollback(xid);
 
@@ -458,8 +415,8 @@ public class BasicXaRecoveryTest extends ServiceTestBase
 
       Assert.assertEquals(xids.length, 1);
       Assert.assertEquals(xids[0].getFormatId(), xid.getFormatId());
-      ServiceTestBase.assertEqualsByteArrays(xids[0].getBranchQualifier(), xid.getBranchQualifier());
-      ServiceTestBase.assertEqualsByteArrays(xids[0].getGlobalTransactionId(), xid.getGlobalTransactionId());
+      ActiveMQTestBase.assertEqualsByteArrays(xids[0].getBranchQualifier(), xid.getBranchQualifier());
+      ActiveMQTestBase.assertEqualsByteArrays(xids[0].getGlobalTransactionId(), xid.getGlobalTransactionId());
       xids = clientSession.recover(XAResource.TMENDRSCAN);
       Assert.assertEquals(xids.length, 0);
       if (commit)
@@ -537,8 +494,8 @@ public class BasicXaRecoveryTest extends ServiceTestBase
       Xid[] xids = clientSession.recover(XAResource.TMSTARTRSCAN);
       Assert.assertEquals(xids.length, 1);
       Assert.assertEquals(xids[0].getFormatId(), xid.getFormatId());
-      ServiceTestBase.assertEqualsByteArrays(xids[0].getBranchQualifier(), xid.getBranchQualifier());
-      ServiceTestBase.assertEqualsByteArrays(xids[0].getGlobalTransactionId(), xid.getGlobalTransactionId());
+      ActiveMQTestBase.assertEqualsByteArrays(xids[0].getBranchQualifier(), xid.getBranchQualifier());
+      ActiveMQTestBase.assertEqualsByteArrays(xids[0].getGlobalTransactionId(), xid.getGlobalTransactionId());
 
       xids = clientSession.recover(XAResource.TMENDRSCAN);
       Assert.assertEquals(xids.length, 0);
@@ -593,8 +550,8 @@ public class BasicXaRecoveryTest extends ServiceTestBase
 
       Assert.assertEquals(xids.length, 1);
       Assert.assertEquals(xids[0].getFormatId(), xid.getFormatId());
-      ServiceTestBase.assertEqualsByteArrays(xids[0].getBranchQualifier(), xid.getBranchQualifier());
-      ServiceTestBase.assertEqualsByteArrays(xids[0].getGlobalTransactionId(), xid.getGlobalTransactionId());
+      ActiveMQTestBase.assertEqualsByteArrays(xids[0].getBranchQualifier(), xid.getBranchQualifier());
+      ActiveMQTestBase.assertEqualsByteArrays(xids[0].getGlobalTransactionId(), xid.getGlobalTransactionId());
       xids = clientSession.recover(XAResource.TMENDRSCAN);
       Assert.assertEquals(xids.length, 0);
       clientSession.rollback(xid);
@@ -642,8 +599,8 @@ public class BasicXaRecoveryTest extends ServiceTestBase
 
       Assert.assertEquals(xids.length, 1);
       Assert.assertEquals(xids[0].getFormatId(), xid.getFormatId());
-      ServiceTestBase.assertEqualsByteArrays(xids[0].getBranchQualifier(), xid.getBranchQualifier());
-      ServiceTestBase.assertEqualsByteArrays(xids[0].getGlobalTransactionId(), xid.getGlobalTransactionId());
+      ActiveMQTestBase.assertEqualsByteArrays(xids[0].getBranchQualifier(), xid.getBranchQualifier());
+      ActiveMQTestBase.assertEqualsByteArrays(xids[0].getGlobalTransactionId(), xid.getGlobalTransactionId());
       xids = clientSession.recover(XAResource.TMENDRSCAN);
       Assert.assertEquals(xids.length, 0);
       clientSession.commit(xid, false);
@@ -893,8 +850,8 @@ public class BasicXaRecoveryTest extends ServiceTestBase
 
       Assert.assertEquals(xids.length, 1);
       Assert.assertEquals(xids[0].getFormatId(), xid.getFormatId());
-      ServiceTestBase.assertEqualsByteArrays(xids[0].getBranchQualifier(), xid.getBranchQualifier());
-      ServiceTestBase.assertEqualsByteArrays(xids[0].getGlobalTransactionId(), xid.getGlobalTransactionId());
+      ActiveMQTestBase.assertEqualsByteArrays(xids[0].getBranchQualifier(), xid.getBranchQualifier());
+      ActiveMQTestBase.assertEqualsByteArrays(xids[0].getGlobalTransactionId(), xid.getGlobalTransactionId());
       xids = clientSession.recover(XAResource.TMENDRSCAN);
       Assert.assertEquals(xids.length, 0);
       clientSession.commit(xid, false);
@@ -973,8 +930,8 @@ public class BasicXaRecoveryTest extends ServiceTestBase
 
       Assert.assertEquals(xids.length, 1);
       Assert.assertEquals(xids[0].getFormatId(), xid.getFormatId());
-      ServiceTestBase.assertEqualsByteArrays(xids[0].getBranchQualifier(), xid.getBranchQualifier());
-      ServiceTestBase.assertEqualsByteArrays(xids[0].getGlobalTransactionId(), xid.getGlobalTransactionId());
+      ActiveMQTestBase.assertEqualsByteArrays(xids[0].getBranchQualifier(), xid.getBranchQualifier());
+      ActiveMQTestBase.assertEqualsByteArrays(xids[0].getGlobalTransactionId(), xid.getGlobalTransactionId());
       xids = clientSession.recover(XAResource.TMENDRSCAN);
       Assert.assertEquals(xids.length, 0);
       clientSession.commit(xid, false);
@@ -1047,8 +1004,8 @@ public class BasicXaRecoveryTest extends ServiceTestBase
 
       Assert.assertEquals(1, xids.length);
       Assert.assertEquals(xids[0].getFormatId(), xid.getFormatId());
-      ServiceTestBase.assertEqualsByteArrays(xids[0].getBranchQualifier(), xid.getBranchQualifier());
-      ServiceTestBase.assertEqualsByteArrays(xids[0].getGlobalTransactionId(), xid.getGlobalTransactionId());
+      ActiveMQTestBase.assertEqualsByteArrays(xids[0].getBranchQualifier(), xid.getBranchQualifier());
+      ActiveMQTestBase.assertEqualsByteArrays(xids[0].getGlobalTransactionId(), xid.getGlobalTransactionId());
       xids = clientSession.recover(XAResource.TMENDRSCAN);
       Assert.assertEquals(xids.length, 0);
       clientSession.rollback(xid);
@@ -1347,8 +1304,8 @@ public class BasicXaRecoveryTest extends ServiceTestBase
             if (found)
             {
                Assert.assertEquals(xid.getFormatId(), origXid.getFormatId());
-               ServiceTestBase.assertEqualsByteArrays(xid.getBranchQualifier(), origXid.getBranchQualifier());
-               ServiceTestBase.assertEqualsByteArrays(xid.getGlobalTransactionId(), origXid.getGlobalTransactionId());
+               ActiveMQTestBase.assertEqualsByteArrays(xid.getBranchQualifier(), origXid.getBranchQualifier());
+               ActiveMQTestBase.assertEqualsByteArrays(xid.getGlobalTransactionId(), origXid.getGlobalTransactionId());
                break;
             }
          }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/xa/BasicXaTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/xa/BasicXaTest.java
@@ -39,13 +39,13 @@ import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.core.transaction.impl.XidImpl;
 import org.apache.activemq.artemis.ra.ActiveMQRAXAResource;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class BasicXaTest extends ServiceTestBase
+public class BasicXaTest extends ActiveMQTestBase
 {
    private static IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
 
@@ -70,10 +70,7 @@ public class BasicXaTest extends ServiceTestBase
       super.setUp();
 
       addressSettings.clear();
-      configuration = createDefaultConfig(true)
-         .setSecurityEnabled(false)
-         .setJournalMinFiles(2)
-         .setPagingDirectory(getPageDir());
+      configuration = createDefaultNettyConfig();
 
       messagingService = createServer(false, configuration, -1, -1, addressSettings);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/util/JMSTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/util/JMSTestBase.java
@@ -51,7 +51,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 
-public class JMSTestBase extends ServiceTestBase
+public class JMSTestBase extends ActiveMQTestBase
 {
    protected ActiveMQServer server;
 
@@ -148,12 +148,11 @@ public class JMSTestBase extends ServiceTestBase
 
       mbeanServer = MBeanServerFactory.createMBeanServer();
 
-      Configuration conf = createDefaultConfig(true)
+      Configuration config = createDefaultConfig(true)
          .setSecurityEnabled(useSecurity())
          .addConnectorConfiguration("invm", new TransportConfiguration(INVM_CONNECTOR_FACTORY));
 
-      server = ActiveMQServers.newActiveMQServer(conf, mbeanServer, usePersistence());
-      addServer(server);
+      server = addServer(ActiveMQServers.newActiveMQServer(config, mbeanServer, usePersistence()));
       jmsServer = new JMSServerManagerImpl(server);
       namingContext = new InVMNamingContext();
       jmsServer.setRegistry(new JndiBindingRegistry(namingContext));
@@ -165,11 +164,8 @@ public class JMSTestBase extends ServiceTestBase
    @Override
    protected Configuration createDefaultConfig(boolean netty) throws Exception
    {
-      Configuration conf = super.createDefaultConfig(netty)
-         .setSecurityEnabled(false)
+      return super.createDefaultConfig(netty)
          .setJMXManagementEnabled(true);
-
-      return conf;
    }
 
    protected void restartServer() throws Exception

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/util/ReplicatedBackupUtils.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/util/ReplicatedBackupUtils.java
@@ -49,14 +49,14 @@ public final class ReplicatedBackupUtils
 
       backupConfig.addConnectorConfiguration(BACKUP_NODE_NAME, backupConnector)
          .addConnectorConfiguration(LIVE_NODE_NAME, liveConnector)
-         .addClusterConfiguration(ServiceTestBase.basicClusterConnectionConfig(BACKUP_NODE_NAME, LIVE_NODE_NAME))
+         .addClusterConfiguration(ActiveMQTestBase.basicClusterConnectionConfig(BACKUP_NODE_NAME, LIVE_NODE_NAME))
          .setHAPolicyConfiguration(new ReplicaPolicyConfiguration());
 
       liveConfig.setName(LIVE_NODE_NAME)
          .addConnectorConfiguration(LIVE_NODE_NAME, liveConnector)
          .addConnectorConfiguration(BACKUP_NODE_NAME, backupConnector)
          .setSecurityEnabled(false)
-         .addClusterConfiguration(ServiceTestBase.basicClusterConnectionConfig(LIVE_NODE_NAME, BACKUP_NODE_NAME))
+         .addClusterConfiguration(ActiveMQTestBase.basicClusterConnectionConfig(LIVE_NODE_NAME, BACKUP_NODE_NAME))
          .setHAPolicyConfiguration(new ReplicatedPolicyConfiguration());
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/util/TransportConfigurationUtils.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/util/TransportConfigurationUtils.java
@@ -32,52 +32,52 @@ public final class TransportConfigurationUtils
 
    public static TransportConfiguration getInVMAcceptor(final boolean live)
    {
-      return transportConfiguration(ServiceTestBase.INVM_ACCEPTOR_FACTORY, live);
+      return transportConfiguration(ActiveMQTestBase.INVM_ACCEPTOR_FACTORY, live);
    }
 
    public static TransportConfiguration getInVMConnector(final boolean live)
    {
-      return transportConfiguration(ServiceTestBase.INVM_CONNECTOR_FACTORY, live);
+      return transportConfiguration(ActiveMQTestBase.INVM_CONNECTOR_FACTORY, live);
    }
 
    public static TransportConfiguration getInVMAcceptor(final boolean live, int server)
    {
-      return transportConfiguration(ServiceTestBase.INVM_ACCEPTOR_FACTORY, live, server);
+      return transportConfiguration(ActiveMQTestBase.INVM_ACCEPTOR_FACTORY, live, server);
    }
 
    public static TransportConfiguration getInVMConnector(final boolean live, int server)
    {
-      return transportConfiguration(ServiceTestBase.INVM_CONNECTOR_FACTORY, live, server);
+      return transportConfiguration(ActiveMQTestBase.INVM_CONNECTOR_FACTORY, live, server);
    }
 
    public static TransportConfiguration getNettyAcceptor(final boolean live, int server)
    {
-      return transportConfiguration(ServiceTestBase.NETTY_ACCEPTOR_FACTORY, live, server);
+      return transportConfiguration(ActiveMQTestBase.NETTY_ACCEPTOR_FACTORY, live, server);
    }
 
    public static TransportConfiguration getNettyConnector(final boolean live, int server)
    {
-      return transportConfiguration(ServiceTestBase.NETTY_CONNECTOR_FACTORY, live, server);
+      return transportConfiguration(ActiveMQTestBase.NETTY_CONNECTOR_FACTORY, live, server);
    }
 
    public static TransportConfiguration getInVMAcceptor(final boolean live, int server, String name)
    {
-      return transportConfiguration(ServiceTestBase.INVM_ACCEPTOR_FACTORY, live, server, name);
+      return transportConfiguration(ActiveMQTestBase.INVM_ACCEPTOR_FACTORY, live, server, name);
    }
 
    public static TransportConfiguration getInVMConnector(final boolean live, int server, String name)
    {
-      return transportConfiguration(ServiceTestBase.INVM_CONNECTOR_FACTORY, live, server, name);
+      return transportConfiguration(ActiveMQTestBase.INVM_CONNECTOR_FACTORY, live, server, name);
    }
 
    public static TransportConfiguration getNettyAcceptor(final boolean live, int server, String name)
    {
-      return transportConfiguration(ServiceTestBase.NETTY_ACCEPTOR_FACTORY, live, server, name);
+      return transportConfiguration(ActiveMQTestBase.NETTY_ACCEPTOR_FACTORY, live, server, name);
    }
 
    public static TransportConfiguration getNettyConnector(final boolean live, int server, String name)
    {
-      return transportConfiguration(ServiceTestBase.NETTY_CONNECTOR_FACTORY, live, server, name);
+      return transportConfiguration(ActiveMQTestBase.NETTY_CONNECTOR_FACTORY, live, server, name);
    }
 
    /**

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/MessageConsumerTest.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/MessageConsumerTest.java
@@ -45,7 +45,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.activemq.artemis.jms.tests.util.ProxyAssertSupport;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -4336,7 +4336,7 @@ public class MessageConsumerTest extends JMSTestCase
 
       public void waitForMessages() throws InterruptedException
       {
-         ServiceTestBase.waitForLatch(latch);
+         ActiveMQTestBase.waitForLatch(latch);
       }
 
       public ExceptionRedelMessageListenerImpl(final Session sess)
@@ -4459,7 +4459,7 @@ public class MessageConsumerTest extends JMSTestCase
        */
       public void waitForMessages() throws InterruptedException
       {
-         ServiceTestBase.waitForLatch(latch);
+         ActiveMQTestBase.waitForLatch(latch);
       }
 
       public void onMessage(final Message m)
@@ -4557,7 +4557,7 @@ public class MessageConsumerTest extends JMSTestCase
        */
       public void waitForMessages() throws InterruptedException
       {
-         ServiceTestBase.waitForLatch(latch);
+         ActiveMQTestBase.waitForLatch(latch);
       }
 
       public void onMessage(final Message m)

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/JMSExpirationHeaderTest.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/JMSExpirationHeaderTest.java
@@ -23,7 +23,7 @@ import javax.jms.Message;
 
 import org.apache.activemq.artemis.jms.client.ActiveMQMessage;
 import org.apache.activemq.artemis.jms.tests.util.ProxyAssertSupport;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -141,7 +141,7 @@ public class JMSExpirationHeaderTest extends MessageHeaderTestBase
       }, "receiver thread");
       receiverThread.start();
 
-      ServiceTestBase.waitForLatch(latch);
+      ActiveMQTestBase.waitForLatch(latch);
       ProxyAssertSupport.assertNull(expectedMessage);
    }
 
@@ -213,8 +213,8 @@ public class JMSExpirationHeaderTest extends MessageHeaderTestBase
       }, "sender thread");
       senderThread.start();
 
-      ServiceTestBase.waitForLatch(senderLatch);
-      ServiceTestBase.waitForLatch(receiverLatch);
+      ActiveMQTestBase.waitForLatch(senderLatch);
+      ActiveMQTestBase.waitForLatch(receiverLatch);
 
       if (testFailed)
       {
@@ -298,7 +298,7 @@ public class JMSExpirationHeaderTest extends MessageHeaderTestBase
       queueConsumer.close();
 
       // wait for the reading thread to conclude
-      ServiceTestBase.waitForLatch(latch);
+      ActiveMQTestBase.waitForLatch(latch);
 
       log.trace("Expected message:" + expectedMessage);
 

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/selector/SelectorTest.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/selector/SelectorTest.java
@@ -31,7 +31,7 @@ import java.util.concurrent.CountDownLatch;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.jms.tests.ActiveMQServerTestCase;
 import org.apache.activemq.artemis.jms.tests.util.ProxyAssertSupport;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -635,8 +635,8 @@ public class SelectorTest extends ActiveMQServerTestCase
             }
          }, "consumer thread 2").start();
 
-         ServiceTestBase.waitForLatch(latch);
-         ServiceTestBase.waitForLatch(latch2);
+         ActiveMQTestBase.waitForLatch(latch);
+         ActiveMQTestBase.waitForLatch(latch2);
 
          ProxyAssertSupport.assertEquals(5, received.size());
          for (Message m : received)

--- a/tests/joram-tests/src/test/java/org/apache/activemq/artemis/jms/SpawnedJMSServer.java
+++ b/tests/joram-tests/src/test/java/org/apache/activemq/artemis/jms/SpawnedJMSServer.java
@@ -42,14 +42,13 @@ public class SpawnedJMSServer
    {
       try
       {
-         Configuration conf = new ConfigurationImpl()
-            .addAcceptorConfiguration(new TransportConfiguration(NettyAcceptorFactory.class.getName()))
-            .setSecurityEnabled(false);
-
-         conf.getConnectorConfigurations().put("netty", new TransportConfiguration(NettyConnectorFactory.class.getName()));
+         Configuration config = new ConfigurationImpl()
+                 .addAcceptorConfiguration(new TransportConfiguration(NettyAcceptorFactory.class.getName()))
+                 .setSecurityEnabled(false)
+                 .addConnectorConfiguration("netty", new TransportConfiguration(NettyConnectorFactory.class.getName()));
 
          // disable server persistence since JORAM tests do not restart server
-         final ActiveMQServer server = ActiveMQServers.newActiveMQServer(conf, false);
+         final ActiveMQServer server = ActiveMQServers.newActiveMQServer(config, false);
 
          JMSServerManager serverManager = new JMSServerManagerImpl(server);
          serverManager.start();

--- a/tests/performance-tests/src/test/java/org/apache/activemq/artemis/tests/performance/paging/MeasurePagingMultiThreadTest.java
+++ b/tests/performance-tests/src/test/java/org/apache/activemq/artemis/tests/performance/paging/MeasurePagingMultiThreadTest.java
@@ -23,16 +23,15 @@ import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.concurrent.CountDownLatch;
 
-public class MeasurePagingMultiThreadTest extends ServiceTestBase
+public class MeasurePagingMultiThreadTest extends ActiveMQTestBase
 {
 
    @Test
@@ -43,16 +42,13 @@ public class MeasurePagingMultiThreadTest extends ServiceTestBase
       final int NUMBER_OF_MESSAGES = 50000;
       final int SIZE_OF_MESSAGE = 1024;
 
-      Configuration config = createDefaultConfig();
-
       HashMap<String, AddressSettings> settings = new HashMap<String, AddressSettings>();
 
-      ActiveMQServer messagingService = createServer(true, config, 10 * 1024, 20 * 1024, settings);
+      ActiveMQServer messagingService = createServer(true, createDefaultInVMConfig(), 10 * 1024, 20 * 1024, settings);
       messagingService.start();
       ServerLocator locator = createInVMNonHALocator();
       try
       {
-
          final ClientSessionFactory factory = createSessionFactory(locator);
          final SimpleString adr = new SimpleString("test-adr");
 
@@ -98,7 +94,7 @@ public class MeasurePagingMultiThreadTest extends ServiceTestBase
                try
                {
                   latchAlign.countDown();
-                  ServiceTestBase.waitForLatch(latchStart);
+                  ActiveMQTestBase.waitForLatch(latchStart);
 
                   long start = System.currentTimeMillis();
                   sendMessages(NUMBER_OF_MESSAGES, producer, msg);
@@ -125,7 +121,7 @@ public class MeasurePagingMultiThreadTest extends ServiceTestBase
             senders[i].start();
          }
 
-         ServiceTestBase.waitForLatch(latchAlign);
+         ActiveMQTestBase.waitForLatch(latchAlign);
 
          long timeStart = System.currentTimeMillis();
 

--- a/tests/performance-tests/src/test/java/org/apache/activemq/artemis/tests/performance/sends/AbstractSendReceivePerfTest.java
+++ b/tests/performance-tests/src/test/java/org/apache/activemq/artemis/tests/performance/sends/AbstractSendReceivePerfTest.java
@@ -58,9 +58,9 @@ public abstract class AbstractSendReceivePerfTest extends JMSTestBase
       jmsServer.createQueue(false, Q_NAME, null, true, Q_NAME);
       queue = ActiveMQJMSClient.createQueue(Q_NAME);
 
-      AddressSettings settings = new AddressSettings();
-      settings.setAddressFullMessagePolicy(AddressFullMessagePolicy.BLOCK);
-      settings.setMaxSizeBytes(Long.MAX_VALUE);
+      AddressSettings settings = new AddressSettings()
+              .setAddressFullMessagePolicy(AddressFullMessagePolicy.BLOCK)
+              .setMaxSizeBytes(Long.MAX_VALUE);
       server.getAddressSettingsRepository().clear();
       server.getAddressSettingsRepository().addMatch("#", settings);
 

--- a/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/client/ClientNonDivertedSoakTest.java
+++ b/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/client/ClientNonDivertedSoakTest.java
@@ -28,11 +28,11 @@ import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ClientNonDivertedSoakTest extends ServiceTestBase
+public class ClientNonDivertedSoakTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------
@@ -41,11 +41,14 @@ public class ClientNonDivertedSoakTest extends ServiceTestBase
 
    private static final SimpleString ADDRESS = new SimpleString("ADD");
 
-   private static final boolean IS_NETTY = false;
-
    private static final boolean IS_JOURNAL = false;
 
    public static final int MIN_MESSAGES_ON_QUEUE = 5000;
+
+   protected boolean isNetty()
+   {
+      return false;
+   }
 
    // Static --------------------------------------------------------
 
@@ -61,14 +64,14 @@ public class ClientNonDivertedSoakTest extends ServiceTestBase
    {
       super.setUp();
 
-      Configuration config = createDefaultConfig(ClientNonDivertedSoakTest.IS_NETTY)
+      Configuration config = createDefaultConfig(isNetty())
          .setJournalFileSize(10 * 1024 * 1024);
 
       server = createServer(IS_JOURNAL, config, -1, -1, new HashMap<String, AddressSettings>());
 
       server.start();
 
-      ServerLocator locator = createFactory(ClientNonDivertedSoakTest.IS_NETTY);
+      ServerLocator locator = createFactory(isNetty());
 
       ClientSessionFactory sf = createSessionFactory(locator);
 
@@ -87,7 +90,7 @@ public class ClientNonDivertedSoakTest extends ServiceTestBase
    @Test
    public void testSoakClient() throws Exception
    {
-      ServerLocator locator = createFactory(ClientNonDivertedSoakTest.IS_NETTY);
+      ServerLocator locator = createFactory(isNetty());
 
       final ClientSessionFactory sf = createSessionFactory(locator);
 

--- a/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/client/ClientSoakTest.java
+++ b/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/client/ClientSoakTest.java
@@ -16,26 +16,25 @@
  */
 package org.apache.activemq.artemis.tests.soak.client;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.concurrent.TimeUnit;
-
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.DivertConfiguration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
-import org.junit.After;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ClientSoakTest extends ServiceTestBase
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
+
+public class ClientSoakTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------
@@ -48,11 +47,14 @@ public class ClientSoakTest extends ServiceTestBase
 
    private static final SimpleString DIVERTED_AD2 = ClientSoakTest.ADDRESS.concat("-2");
 
-   private static final boolean IS_NETTY = true;
-
    private static final boolean IS_JOURNAL = true;
 
    public static final int MIN_MESSAGES_ON_QUEUE = 5000;
+
+   protected boolean isNetty()
+   {
+      return true;
+   }
 
    // Static --------------------------------------------------------
 
@@ -66,9 +68,10 @@ public class ClientSoakTest extends ServiceTestBase
    @Before
    public void setUp() throws Exception
    {
+      super.setUp();
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig(ClientSoakTest.IS_NETTY)
+      Configuration config = createDefaultConfig(isNetty())
          .setJournalFileSize(10 * 1024 * 1024);
 
       server = createServer(IS_JOURNAL, config, -1, -1, new HashMap<String, AddressSettings>());
@@ -95,7 +98,7 @@ public class ClientSoakTest extends ServiceTestBase
 
       server.start();
 
-      ServerLocator locator = createFactory(IS_NETTY);
+      ServerLocator locator = createFactory(isNetty());
 
       ClientSessionFactory sf = createSessionFactory(locator);
 
@@ -115,18 +118,10 @@ public class ClientSoakTest extends ServiceTestBase
 
    }
 
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      server.stop();
-      server = null;
-   }
-
    @Test
    public void testSoakClient() throws Exception
    {
-      final ServerLocator locator = createFactory(IS_NETTY);
+      final ServerLocator locator = createFactory(isNetty());
       final ClientSessionFactory sf = createSessionFactory(locator);
 
       ClientSession session = sf.createSession(false, false);

--- a/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/client/SimpleSendReceiveSoakTest.java
+++ b/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/client/SimpleSendReceiveSoakTest.java
@@ -31,9 +31,9 @@ import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 
-public class SimpleSendReceiveSoakTest extends ServiceTestBase
+public class SimpleSendReceiveSoakTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------
@@ -42,11 +42,14 @@ public class SimpleSendReceiveSoakTest extends ServiceTestBase
 
    private static final SimpleString ADDRESS = new SimpleString("ADD");
 
-   private static final boolean IS_NETTY = false;
-
    private static final boolean IS_JOURNAL = false;
 
    public static final int MIN_MESSAGES_ON_QUEUE = 1000;
+
+   protected boolean isNetty()
+   {
+      return false;
+   }
 
    // Static --------------------------------------------------------
 
@@ -64,14 +67,14 @@ public class SimpleSendReceiveSoakTest extends ServiceTestBase
 
       clearDataRecreateServerDirs();
 
-      Configuration config = createDefaultConfig(SimpleSendReceiveSoakTest.IS_NETTY)
+      Configuration config = createDefaultConfig(isNetty())
          .setJournalFileSize(10 * 1024 * 1024);
 
       server = createServer(IS_JOURNAL, config, -1, -1, new HashMap<String, AddressSettings>());
 
       server.start();
 
-      ServerLocator locator = createFactory(IS_NETTY);
+      ServerLocator locator = createFactory(isNetty());
 
       ClientSessionFactory sf = createSessionFactory(locator);
 
@@ -85,7 +88,7 @@ public class SimpleSendReceiveSoakTest extends ServiceTestBase
    @Test
    public void testSoakClientTransactions() throws Exception
    {
-      final ServerLocator locator = createFactory(IS_NETTY);
+      final ServerLocator locator = createFactory(isNetty());
 
       final ClientSessionFactory sf = createSessionFactory(locator);
 

--- a/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/client/SendStressTest.java
+++ b/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/client/SendStressTest.java
@@ -23,11 +23,11 @@ import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class SendStressTest extends ServiceTestBase
+public class SendStressTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------

--- a/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/journal/AddAndRemoveStressTest.java
+++ b/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/journal/AddAndRemoveStressTest.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.activemq.artemis.tests.unit.core.journal.impl.fakes.SimpleEncoding;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.journal.LoaderCallback;
 import org.apache.activemq.artemis.core.journal.PreparedTransactionInfo;
 import org.apache.activemq.artemis.core.journal.RecordInfo;
@@ -29,7 +29,7 @@ import org.apache.activemq.artemis.core.journal.impl.JournalImpl;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class AddAndRemoveStressTest extends ServiceTestBase
+public class AddAndRemoveStressTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------

--- a/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/journal/CompactingStressTest.java
+++ b/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/journal/CompactingStressTest.java
@@ -28,14 +28,14 @@ import org.apache.activemq.artemis.core.asyncio.impl.AsynchronousFileImpl;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.JournalType;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class CompactingStressTest extends ServiceTestBase
+public class CompactingStressTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------
@@ -233,7 +233,7 @@ public class CompactingStressTest extends ServiceTestBase
             latchReady.countDown();
             try
             {
-               ServiceTestBase.waitForLatch(latchStart);
+               ActiveMQTestBase.waitForLatch(latchStart);
                session = sf.createSession(true, true);
                sessionSlow = sf.createSession(false, false);
                ClientProducer prod = session.createProducer(CompactingStressTest.AD2);
@@ -296,7 +296,7 @@ public class CompactingStressTest extends ServiceTestBase
             latchReady.countDown();
             try
             {
-               ServiceTestBase.waitForLatch(latchStart);
+               ActiveMQTestBase.waitForLatch(latchStart);
                session = sf.createSession(true, true);
                session.start();
                ClientConsumer cons = session.createConsumer(CompactingStressTest.Q2);
@@ -332,7 +332,7 @@ public class CompactingStressTest extends ServiceTestBase
       FastProducer p1 = new FastProducer();
       p1.start();
 
-      ServiceTestBase.waitForLatch(latchReady);
+      ActiveMQTestBase.waitForLatch(latchReady);
       latchStart.countDown();
 
       p1.join();
@@ -409,7 +409,7 @@ public class CompactingStressTest extends ServiceTestBase
 
    private void setupServer(final JournalType journalType) throws Exception
    {
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false)
          .setJournalFileSize(ActiveMQDefaultConfiguration.getDefaultJournalFileSize())
          .setJournalType(journalType)
@@ -421,9 +421,9 @@ public class CompactingStressTest extends ServiceTestBase
       server.start();
 
 
-      ServerLocator locator = createInVMNonHALocator();
-      locator.setBlockOnDurableSend(false);
-      locator.setBlockOnAcknowledge(false);
+      ServerLocator locator = createInVMNonHALocator()
+              .setBlockOnDurableSend(false)
+              .setBlockOnAcknowledge(false);
 
       sf = createSessionFactory(locator);
       ClientSession sess = addClientSession(sf.createSession());

--- a/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/journal/JournalCleanupCompactStressTest.java
+++ b/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/journal/JournalCleanupCompactStressTest.java
@@ -28,7 +28,7 @@ import org.apache.activemq.artemis.core.journal.impl.JournalImpl;
 import org.apache.activemq.artemis.core.journal.impl.NIOSequentialFileFactory;
 import org.apache.activemq.artemis.core.persistence.impl.journal.OperationContextImpl;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.ActiveMQThreadFactory;
 import org.apache.activemq.artemis.utils.OrderedExecutorFactory;
 import org.apache.activemq.artemis.utils.SimpleIDGenerator;
@@ -52,7 +52,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-public class JournalCleanupCompactStressTest extends ServiceTestBase
+public class JournalCleanupCompactStressTest extends ActiveMQTestBase
 {
 
    public static SimpleIDGenerator idGen = new SimpleIDGenerator(1);
@@ -266,7 +266,7 @@ public class JournalCleanupCompactStressTest extends ServiceTestBase
          }
       });
 
-      ServiceTestBase.waitForLatch(latchExecutorDone);
+      ActiveMQTestBase.waitForLatch(latchExecutorDone);
 
       journal.stop();
 

--- a/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/journal/JournalRestartStressTest.java
+++ b/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/journal/JournalRestartStressTest.java
@@ -27,7 +27,7 @@ import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 
 /**
@@ -35,7 +35,7 @@ import org.junit.Test;
  * and having multiple restarts,
  * To make sure the journal would survive at multiple restarts of the server
  */
-public class JournalRestartStressTest extends ServiceTestBase
+public class JournalRestartStressTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------
@@ -62,9 +62,9 @@ public class JournalRestartStressTest extends ServiceTestBase
       {
          server2.start();
 
-         ServerLocator locator = createFactory(false);
-         locator.setMinLargeMessageSize(1024 * 1024);
-         locator.setBlockOnDurableSend(false);
+         ServerLocator locator = createInVMNonHALocator()
+                 .setMinLargeMessageSize(1024 * 1024)
+                 .setBlockOnDurableSend(false);
 
          ClientSessionFactory sf = createSessionFactory(locator);
 

--- a/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/journal/LargeJournalStressTest.java
+++ b/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/journal/LargeJournalStressTest.java
@@ -26,7 +26,7 @@ import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.JournalType;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -35,7 +35,7 @@ import org.junit.Test;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class LargeJournalStressTest extends ServiceTestBase
+public class LargeJournalStressTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------
@@ -103,7 +103,7 @@ public class LargeJournalStressTest extends ServiceTestBase
             latchReady.countDown();
             try
             {
-               ServiceTestBase.waitForLatch(latchStart);
+               ActiveMQTestBase.waitForLatch(latchStart);
                session = sf.createSession(true, true);
                sessionSlow = sf.createSession(false, false);
                ClientProducer prod = session.createProducer(LargeJournalStressTest.AD2);
@@ -169,7 +169,7 @@ public class LargeJournalStressTest extends ServiceTestBase
             latchReady.countDown();
             try
             {
-               ServiceTestBase.waitForLatch(latchStart);
+               ActiveMQTestBase.waitForLatch(latchStart);
                session = sf.createSession(true, true);
                session.start();
                ClientConsumer cons = session.createConsumer(LargeJournalStressTest.Q2);
@@ -205,7 +205,7 @@ public class LargeJournalStressTest extends ServiceTestBase
       FastProducer p1 = new FastProducer();
       p1.start();
 
-      ServiceTestBase.waitForLatch(latchReady);
+      ActiveMQTestBase.waitForLatch(latchReady);
       latchStart.countDown();
 
       p1.join();
@@ -261,12 +261,10 @@ public class LargeJournalStressTest extends ServiceTestBase
 
       clearDataRecreateServerDirs();
 
-      locator = createInVMNonHALocator();
-
-      locator.setBlockOnAcknowledge(false);
-      locator.setBlockOnNonDurableSend(false);
-      locator.setBlockOnDurableSend(false);
-
+      locator = createInVMNonHALocator()
+              .setBlockOnAcknowledge(false)
+              .setBlockOnNonDurableSend(false)
+              .setBlockOnDurableSend(false);
    }
 
    /**
@@ -274,7 +272,7 @@ public class LargeJournalStressTest extends ServiceTestBase
     */
    private void setupServer(final JournalType journalType) throws Exception
    {
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(false)
          .setJournalFileSize(ActiveMQDefaultConfiguration.getDefaultJournalFileSize())
          .setJournalType(journalType)

--- a/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/journal/MultiThreadConsumerStressTest.java
+++ b/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/journal/MultiThreadConsumerStressTest.java
@@ -27,7 +27,7 @@ import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.JournalType;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,7 +40,7 @@ import java.util.concurrent.CountDownLatch;
  * <p/>
  * This test validates consuming / sending messages while compacting is working
  */
-public class MultiThreadConsumerStressTest extends ServiceTestBase
+public class MultiThreadConsumerStressTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------
@@ -112,7 +112,7 @@ public class MultiThreadConsumerStressTest extends ServiceTestBase
          threads.add(cons[i]);
       }
 
-      ServiceTestBase.waitForLatch(latchReady);
+      ActiveMQTestBase.waitForLatch(latchReady);
       latchStart.countDown();
 
       for (BaseThread t : threads)
@@ -154,7 +154,7 @@ public class MultiThreadConsumerStressTest extends ServiceTestBase
 
    private void setupServer(final JournalType journalType) throws Exception
    {
-      Configuration config = createDefaultConfig(true)
+      Configuration config = createDefaultNettyConfig()
          .setJournalType(journalType)
          .setJournalFileSize(ActiveMQDefaultConfiguration.getDefaultJournalFileSize())
          .setJournalMinFiles(ActiveMQDefaultConfiguration.getDefaultJournalMinFiles())
@@ -165,13 +165,10 @@ public class MultiThreadConsumerStressTest extends ServiceTestBase
 
       server.start();
 
-      ServerLocator locator = createNettyNonHALocator();
-
-      locator.setBlockOnDurableSend(false);
-
-      locator.setBlockOnNonDurableSend(false);
-
-      locator.setBlockOnAcknowledge(false);
+      ServerLocator locator = createNettyNonHALocator()
+              .setBlockOnDurableSend(false)
+              .setBlockOnNonDurableSend(false)
+              .setBlockOnAcknowledge(false);
 
       sf = createSessionFactory(locator);
 
@@ -242,7 +239,7 @@ public class MultiThreadConsumerStressTest extends ServiceTestBase
          latchReady.countDown();
          try
          {
-            ServiceTestBase.waitForLatch(latchStart);
+            ActiveMQTestBase.waitForLatch(latchStart);
             session = sf.createSession(false, false);
             ClientProducer prod = session.createProducer(ADDRESS);
             for (int i = 0; i < numberOfMessages; i++)
@@ -303,7 +300,7 @@ public class MultiThreadConsumerStressTest extends ServiceTestBase
          latchReady.countDown();
          try
          {
-            ServiceTestBase.waitForLatch(latchStart);
+            ActiveMQTestBase.waitForLatch(latchStart);
             session = sf.createSession(false, false);
             session.start();
             ClientConsumer cons = session.createConsumer(QUEUE);

--- a/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/journal/NIOMultiThreadCompactorStressTest.java
+++ b/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/journal/NIOMultiThreadCompactorStressTest.java
@@ -33,7 +33,7 @@ import org.apache.activemq.artemis.core.journal.impl.JournalImpl;
 import org.apache.activemq.artemis.core.journal.impl.NIOSequentialFileFactory;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.JournalType;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,7 +44,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
-public class NIOMultiThreadCompactorStressTest extends ServiceTestBase
+public class NIOMultiThreadCompactorStressTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------
@@ -72,10 +72,9 @@ public class NIOMultiThreadCompactorStressTest extends ServiceTestBase
    {
       super.setUp();
 
-      locator = createInVMNonHALocator();
-      locator.setBlockOnNonDurableSend(false);
-      locator.setBlockOnAcknowledge(false);
-
+      locator = createInVMNonHALocator()
+              .setBlockOnNonDurableSend(false)
+              .setBlockOnAcknowledge(false);
    }
 
    @Test
@@ -230,7 +229,7 @@ public class NIOMultiThreadCompactorStressTest extends ServiceTestBase
          threads.add(cons[i]);
       }
 
-      ServiceTestBase.waitForLatch(latchReady);
+      ActiveMQTestBase.waitForLatch(latchReady);
       latchStart.countDown();
 
       for (BaseThread t : threads)
@@ -345,7 +344,7 @@ public class NIOMultiThreadCompactorStressTest extends ServiceTestBase
       }
       if (server == null)
       {
-         Configuration config = createDefaultConfig(true)
+         Configuration config = createDefaultNettyConfig()
             .setJournalFileSize(ActiveMQDefaultConfiguration.getDefaultJournalFileSize())
             .setJournalType(journalType)
             .setJMXManagementEnabled(false)
@@ -364,9 +363,9 @@ public class NIOMultiThreadCompactorStressTest extends ServiceTestBase
 
       server.start();
 
-      ServerLocator locator = createNettyNonHALocator();
-      locator.setBlockOnDurableSend(false);
-      locator.setBlockOnAcknowledge(false);
+      ServerLocator locator = createNettyNonHALocator()
+              .setBlockOnDurableSend(false)
+              .setBlockOnAcknowledge(false);
 
       sf = createSessionFactory(locator);
 
@@ -439,7 +438,7 @@ public class NIOMultiThreadCompactorStressTest extends ServiceTestBase
          latchReady.countDown();
          try
          {
-            ServiceTestBase.waitForLatch(latchStart);
+            ActiveMQTestBase.waitForLatch(latchStart);
             session = sf.createSession(!transactional, !transactional);
             ClientProducer prod = session.createProducer(ADDRESS);
             for (int i = 0; i < numberOfMessages; i++)
@@ -508,7 +507,7 @@ public class NIOMultiThreadCompactorStressTest extends ServiceTestBase
          latchReady.countDown();
          try
          {
-            ServiceTestBase.waitForLatch(latchStart);
+            ActiveMQTestBase.waitForLatch(latchStart);
             session = sf.createSession(!transactional, !transactional);
             session.start();
             ClientConsumer cons = session.createConsumer(QUEUE);

--- a/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/journal/XmlImportExportStressTest.java
+++ b/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/journal/XmlImportExportStressTest.java
@@ -30,10 +30,10 @@ import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.cli.commands.tools.XmlDataExporter;
 import org.apache.activemq.artemis.cli.commands.tools.XmlDataImporter;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 
-public class XmlImportExportStressTest extends ServiceTestBase
+public class XmlImportExportStressTest extends ActiveMQTestBase
 {
    public static final int CONSUMER_TIMEOUT = 5000;
 

--- a/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/paging/MultipleConsumersPageStressTest.java
+++ b/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/paging/MultipleConsumersPageStressTest.java
@@ -15,17 +15,6 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.stress.paging;
-import org.junit.Before;
-import org.junit.After;
-
-import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Random;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import org.junit.Assert;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
@@ -34,14 +23,21 @@ import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.impl.QueueImpl;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.tests.unit.UnitTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
-public class MultipleConsumersPageStressTest extends ServiceTestBase
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class MultipleConsumersPageStressTest extends ActiveMQTestBase
 {
 
    private final UnitTestLogger log = UnitTestLogger.LOGGER;
@@ -64,7 +60,7 @@ public class MultipleConsumersPageStressTest extends ServiceTestBase
 
    private boolean openConsumerOnEveryLoop = true;
 
-   private ActiveMQServer messagingService;
+   private ActiveMQServer server;
 
    private ServerLocator sharedLocator;
 
@@ -90,8 +86,8 @@ public class MultipleConsumersPageStressTest extends ServiceTestBase
       numberOfProducers = 1;
       numberOfConsumers = 1;
 
-      sharedLocator = createInVMNonHALocator();
-      sharedLocator.setConsumerWindowSize(0);
+      sharedLocator = createInVMNonHALocator()
+              .setConsumerWindowSize(0);
 
       sharedSf = createSessionFactory(sharedLocator);
 
@@ -103,33 +99,14 @@ public class MultipleConsumersPageStressTest extends ServiceTestBase
    public void setUp() throws Exception
    {
       super.setUp();
-      Configuration config = createDefaultConfig();
 
       HashMap<String, AddressSettings> settings = new HashMap<String, AddressSettings>();
 
-      messagingService = createServer(true, config, 10024, 200024, settings);
-      messagingService.start();
+      server = createServer(true, createDefaultInVMConfig(), 10024, 200024, settings);
+      server.start();
 
-      pagedServerQueue = (QueueImpl)messagingService.createQueue(ADDRESS, ADDRESS, null, true, false);
+      pagedServerQueue = (QueueImpl) server.createQueue(ADDRESS, ADDRESS, null, true, false);
 
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      for (Tester tst : producers)
-      {
-         tst.close();
-      }
-      for (Tester tst : consumers)
-      {
-         tst.close();
-      }
-      sharedSf.close();
-      sharedLocator.close();
-      messagingService.stop();
-      super.tearDown();
    }
 
    @Test
@@ -158,8 +135,8 @@ public class MultipleConsumersPageStressTest extends ServiceTestBase
       numberOfProducers = 1;
       numberOfConsumers = 1;
 
-      sharedLocator = createInVMNonHALocator();
-      sharedLocator.setConsumerWindowSize(0);
+      sharedLocator = createInVMNonHALocator()
+              .setConsumerWindowSize(0);
 
       sharedSf = createSessionFactory(sharedLocator);
 

--- a/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/paging/PageCursorStressTest.java
+++ b/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/paging/PageCursorStressTest.java
@@ -16,18 +16,8 @@
  */
 package org.apache.activemq.artemis.tests.stress.paging;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
-
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.tests.unit.core.postoffice.impl.FakeQueue;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.filter.Filter;
 import org.apache.activemq.artemis.core.paging.cursor.PageCache;
@@ -47,14 +37,23 @@ import org.apache.activemq.artemis.core.server.impl.ServerMessageImpl;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.core.transaction.Transaction;
 import org.apache.activemq.artemis.core.transaction.impl.TransactionImpl;
+import org.apache.activemq.artemis.tests.unit.core.postoffice.impl.FakeQueue;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
 import org.apache.activemq.artemis.utils.LinkedListIterator;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class PageCursorStressTest extends ServiceTestBase
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
+
+public class PageCursorStressTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------
@@ -857,15 +856,6 @@ public class PageCursorStressTest extends ServiceTestBase
    // Protected -----------------------------------------------------
 
    @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      queue = null;
-      queueList = null;
-      super.tearDown();
-   }
-
-   @Override
    @Before
    public void setUp() throws Exception
    {
@@ -884,7 +874,7 @@ public class PageCursorStressTest extends ServiceTestBase
    {
       OperationContextImpl.clearContext();
 
-      Configuration config = createDefaultConfig()
+      Configuration config = createDefaultInVMConfig()
          .setJournalSyncNonTransactional(true);
 
       server = createServer(true, config, PAGE_SIZE, PAGE_MAX, new HashMap<String, AddressSettings>());

--- a/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/remote/PingStressTest.java
+++ b/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/remote/PingStressTest.java
@@ -15,30 +15,26 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.stress.remote;
+
 import org.apache.activemq.artemis.api.core.ActiveMQException;
-import org.junit.Before;
-
-import org.junit.Test;
-
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 import org.apache.activemq.artemis.api.core.Interceptor;
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.protocol.core.Packet;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
 import org.apache.activemq.artemis.tests.unit.UnitTestLogger;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.junit.Before;
+import org.junit.Test;
 
-public class PingStressTest extends ServiceTestBase
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class PingStressTest extends ActiveMQTestBase
 {
    private static final UnitTestLogger log = UnitTestLogger.LOGGER;
 
@@ -51,8 +47,7 @@ public class PingStressTest extends ServiceTestBase
    public void setUp() throws Exception
    {
       super.setUp();
-      Configuration config = createDefaultConfig(true);
-      server = createServer(false, config);
+      server = createServer(false, createDefaultNettyConfig());
       server.start();
    }
 
@@ -81,8 +76,6 @@ public class PingStressTest extends ServiceTestBase
     */
    private void internalTest() throws Exception
    {
-      final TransportConfiguration transportConfig = new TransportConfiguration("org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory");
-
       Interceptor noPongInterceptor = new Interceptor()
       {
          public boolean intercept(final Packet packet, final RemotingConnection conn) throws ActiveMQException
@@ -101,10 +94,10 @@ public class PingStressTest extends ServiceTestBase
       };
 
       server.getRemotingService().addIncomingInterceptor(noPongInterceptor);
-      ServerLocator locator = addServerLocator(ActiveMQClient.createServerLocatorWithoutHA(transportConfig));
-      locator.setClientFailureCheckPeriod(PingStressTest.PING_INTERVAL);
-      locator.setConnectionTTL((long)(PingStressTest.PING_INTERVAL * 1.5));
-      locator.setCallTimeout(PingStressTest.PING_INTERVAL * 10);
+      ServerLocator locator = createNettyNonHALocator()
+              .setClientFailureCheckPeriod(PingStressTest.PING_INTERVAL)
+              .setConnectionTTL((long) (PingStressTest.PING_INTERVAL * 1.5))
+              .setCallTimeout(PingStressTest.PING_INTERVAL * 10);
       final ClientSessionFactory csf1 = createSessionFactory(locator);
 
 
@@ -132,10 +125,10 @@ public class PingStressTest extends ServiceTestBase
             try
             {
 
-               ServerLocator locator = addServerLocator(ActiveMQClient.createServerLocatorWithoutHA(transportConfig));
-               locator.setClientFailureCheckPeriod(PingStressTest.PING_INTERVAL);
-               locator.setConnectionTTL((long)(PingStressTest.PING_INTERVAL * 1.5));
-               locator.setCallTimeout(PingStressTest.PING_INTERVAL * 10);
+               ServerLocator locator = createNettyNonHALocator()
+                       .setClientFailureCheckPeriod(PingStressTest.PING_INTERVAL)
+                       .setConnectionTTL((long) (PingStressTest.PING_INTERVAL * 1.5))
+                       .setCallTimeout(PingStressTest.PING_INTERVAL * 10);
 
                final ClientSessionFactory csf2 = createSessionFactory(locator);
 

--- a/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/stomp/StompStressTest.java
+++ b/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/stomp/StompStressTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.stress.stomp;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 import org.junit.After;
 
@@ -43,7 +43,7 @@ import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
 
-public class StompStressTest extends ServiceTestBase
+public class StompStressTest extends ActiveMQTestBase
 {
    private static final int COUNT = 1000;
 

--- a/tests/timing-tests/src/test/java/org/apache/activemq/artemis/tests/timing/core/journal/impl/AIOJournalImplTest.java
+++ b/tests/timing-tests/src/test/java/org/apache/activemq/artemis/tests/timing/core/journal/impl/AIOJournalImplTest.java
@@ -17,7 +17,7 @@
 package org.apache.activemq.artemis.tests.timing.core.journal.impl;
 import java.io.File;
 
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.journal.SequentialFileFactory;
 import org.apache.activemq.artemis.core.journal.impl.AIOSequentialFileFactory;
 import org.junit.BeforeClass;
@@ -35,7 +35,7 @@ public class AIOJournalImplTest extends JournalImplTestUnit
    {
       File file = new File(getTestDir());
 
-      ServiceTestBase.deleteDirectory(file);
+      ActiveMQTestBase.deleteDirectory(file);
 
       file.mkdir();
 

--- a/tests/timing-tests/src/test/java/org/apache/activemq/artemis/tests/timing/core/journal/impl/NIOJournalImplTest.java
+++ b/tests/timing-tests/src/test/java/org/apache/activemq/artemis/tests/timing/core/journal/impl/NIOJournalImplTest.java
@@ -18,7 +18,7 @@ package org.apache.activemq.artemis.tests.timing.core.journal.impl;
 
 import java.io.File;
 
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.journal.SequentialFileFactory;
 import org.apache.activemq.artemis.core.journal.impl.NIOSequentialFileFactory;
 import org.apache.activemq.artemis.tests.unit.UnitTestLogger;
@@ -36,7 +36,7 @@ public class NIOJournalImplTest extends JournalImplTestUnit
 
       NIOJournalImplTest.log.debug("deleting directory " + journalDir);
 
-      ServiceTestBase.deleteDirectory(file);
+      ActiveMQTestBase.deleteDirectory(file);
 
       file.mkdir();
 

--- a/tests/timing-tests/src/test/java/org/apache/activemq/artemis/tests/timing/core/server/impl/QueueConcurrentTest.java
+++ b/tests/timing-tests/src/test/java/org/apache/activemq/artemis/tests/timing/core/server/impl/QueueConcurrentTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.activemq.artemis.tests.timing.core.server.impl;
 import org.apache.activemq.artemis.tests.unit.core.server.impl.fakes.FakeQueueFactory;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 import org.junit.After;
 
@@ -40,7 +40,7 @@ import org.apache.activemq.artemis.tests.unit.core.server.impl.fakes.FakeConsume
  *
  * All the concurrent queue tests go in here
  */
-public class QueueConcurrentTest extends ServiceTestBase
+public class QueueConcurrentTest extends ActiveMQTestBase
 {
    private static final UnitTestLogger log = UnitTestLogger.LOGGER;
 

--- a/tests/timing-tests/src/test/java/org/apache/activemq/artemis/tests/timing/core/server/impl/QueueImplTest.java
+++ b/tests/timing-tests/src/test/java/org/apache/activemq/artemis/tests/timing/core/server/impl/QueueImplTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.timing.core.server.impl;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 import org.junit.After;
 
@@ -38,7 +38,7 @@ import org.apache.activemq.artemis.core.server.MessageReference;
 import org.apache.activemq.artemis.core.server.impl.QueueImpl;
 import org.apache.activemq.artemis.tests.unit.core.server.impl.fakes.FakeConsumer;
 
-public class QueueImplTest extends ServiceTestBase
+public class QueueImplTest extends ActiveMQTestBase
 {
    private static final SimpleString queue1 = new SimpleString("queue1");
 

--- a/tests/timing-tests/src/test/java/org/apache/activemq/artemis/tests/timing/jms/bridge/impl/JMSBridgeImplTest.java
+++ b/tests/timing-tests/src/test/java/org/apache/activemq/artemis/tests/timing/jms/bridge/impl/JMSBridgeImplTest.java
@@ -16,6 +16,33 @@
  */
 package org.apache.activemq.artemis.tests.timing.jms.bridge.impl;
 
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.apache.activemq.artemis.api.core.management.ObjectNameBuilder;
+import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
+import org.apache.activemq.artemis.api.jms.JMSFactoryType;
+import org.apache.activemq.artemis.api.jms.management.JMSQueueControl;
+import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.registry.JndiBindingRegistry;
+import org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory;
+import org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnectorFactory;
+import org.apache.activemq.artemis.core.server.ActiveMQServers;
+import org.apache.activemq.artemis.jms.bridge.ConnectionFactoryFactory;
+import org.apache.activemq.artemis.jms.bridge.DestinationFactory;
+import org.apache.activemq.artemis.jms.bridge.QualityOfServiceMode;
+import org.apache.activemq.artemis.jms.bridge.impl.JMSBridgeImpl;
+import org.apache.activemq.artemis.jms.client.ActiveMQJMSConnectionFactory;
+import org.apache.activemq.artemis.jms.server.JMSServerManager;
+import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
+import org.apache.activemq.artemis.tests.unit.UnitTestLogger;
+import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.apache.activemq.artemis.tests.util.RandomUtil;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
 import javax.jms.Destination;
@@ -43,35 +70,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.apache.activemq.artemis.api.core.TransportConfiguration;
-import org.apache.activemq.artemis.api.core.management.ObjectNameBuilder;
-import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
-import org.apache.activemq.artemis.api.jms.JMSFactoryType;
-import org.apache.activemq.artemis.api.jms.management.JMSQueueControl;
-import org.apache.activemq.artemis.tests.unit.UnitTestLogger;
-import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.apache.activemq.artemis.core.config.Configuration;
-import org.apache.activemq.artemis.core.registry.JndiBindingRegistry;
-import org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory;
-import org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnectorFactory;
-import org.apache.activemq.artemis.core.server.ActiveMQServers;
-import org.apache.activemq.artemis.jms.bridge.ConnectionFactoryFactory;
-import org.apache.activemq.artemis.jms.bridge.DestinationFactory;
-import org.apache.activemq.artemis.jms.bridge.QualityOfServiceMode;
-import org.apache.activemq.artemis.jms.bridge.impl.JMSBridgeImpl;
-import org.apache.activemq.artemis.jms.client.ActiveMQJMSConnectionFactory;
-import org.apache.activemq.artemis.jms.server.JMSServerManager;
-import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
-import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
-public class JMSBridgeImplTest extends ServiceTestBase
+public class JMSBridgeImplTest extends ActiveMQTestBase
 {
    // Constants -----------------------------------------------------
 
@@ -618,22 +617,13 @@ public class JMSBridgeImplTest extends ServiceTestBase
       Configuration config = createBasicConfig()
          .addAcceptorConfiguration(new TransportConfiguration(InVMAcceptorFactory.class.getName()));
       InVMNamingContext context = new InVMNamingContext();
-      jmsServer = new JMSServerManagerImpl(ActiveMQServers.newActiveMQServer(config, false));
+      jmsServer = new JMSServerManagerImpl(addServer(ActiveMQServers.newActiveMQServer(config, false)));
       jmsServer.setRegistry(new JndiBindingRegistry(context));
       jmsServer.start();
 
       jmsServer.createQueue(false, JMSBridgeImplTest.SOURCE, null, true, "/queue/" + JMSBridgeImplTest.SOURCE);
       jmsServer.createQueue(false, JMSBridgeImplTest.TARGET, null, true, "/queue/" + JMSBridgeImplTest.TARGET);
 
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      jmsServer.stop();
-
-      super.tearDown();
    }
 
    @Test

--- a/tests/timing-tests/src/test/java/org/apache/activemq/artemis/tests/timing/util/ReusableLatchTest.java
+++ b/tests/timing-tests/src/test/java/org/apache/activemq/artemis/tests/timing/util/ReusableLatchTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.activemq.artemis.tests.timing.util;
 
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 
 import org.junit.Assert;
 
 import org.apache.activemq.artemis.utils.ReusableLatch;
 
-public class ReusableLatchTest extends ServiceTestBase
+public class ReusableLatchTest extends ActiveMQTestBase
 {
    @Test
    public void testTimeout() throws Exception

--- a/tests/timing-tests/src/test/java/org/apache/activemq/artemis/tests/timing/util/TokenBucketLimiterImplTest.java
+++ b/tests/timing-tests/src/test/java/org/apache/activemq/artemis/tests/timing/util/TokenBucketLimiterImplTest.java
@@ -21,12 +21,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.activemq.artemis.tests.unit.UnitTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.TokenBucketLimiterImpl;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class TokenBucketLimiterImplTest extends ServiceTestBase
+public class TokenBucketLimiterImplTest extends ActiveMQTestBase
 {
    private static final UnitTestLogger log = UnitTestLogger.LOGGER;
 

--- a/tests/timing-tests/src/test/java/org/apache/activemq/artemis/tests/timing/util/UTF8Test.java
+++ b/tests/timing-tests/src/test/java/org/apache/activemq/artemis/tests/timing/util/UTF8Test.java
@@ -23,10 +23,10 @@ import org.junit.Test;
 
 import org.junit.Assert;
 
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.UTF8Util;
 
-public class UTF8Test extends ServiceTestBase
+public class UTF8Test extends ActiveMQTestBase
 {
 
    private final String str = "abcdef&^*&!^ghijkl\uB5E2\uCAC7\uB2BB\uB7DD\uB7C7\uB3A3\uBCE4\uB5A5" + "abcdef&^*&!^ghijkl\uB5E2\uCAC7\uB2BB\uB7DD\uB7C7\uB3A3\uBCE4\uB5A5"

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/asyncio/AIOTestBase.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/asyncio/AIOTestBase.java
@@ -22,7 +22,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.asyncio.AIOCallback;
 import org.apache.activemq.artemis.core.asyncio.impl.AsynchronousFileImpl;
 import org.junit.After;
@@ -32,7 +32,7 @@ import org.junit.Before;
 /**
  * The base class for AIO Tests
  */
-public abstract class AIOTestBase extends ServiceTestBase
+public abstract class AIOTestBase extends ActiveMQTestBase
 {
    // The AIO Test must use a local filesystem. Sometimes $HOME is on a NFS on
    // most enterprise systems

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/asyncio/AsynchronousFileTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/asyncio/AsynchronousFileTest.java
@@ -39,7 +39,7 @@ import org.apache.activemq.artemis.core.asyncio.BufferCallback;
 import org.apache.activemq.artemis.core.asyncio.impl.AsynchronousFileImpl;
 import org.apache.activemq.artemis.core.journal.impl.AIOSequentialFileFactory;
 import org.apache.activemq.artemis.tests.unit.UnitTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.ActiveMQThreadFactory;
 import org.junit.After;
 import org.junit.Assert;
@@ -151,7 +151,7 @@ public class AsynchronousFileTest extends AIOTestBase
 
       for (int i = 0; i < 1024; i++)
       {
-         write.put(ServiceTestBase.getSamplebyte(i));
+         write.put(ActiveMQTestBase.getSamplebyte(i));
       }
 
       final CountDownLatch latch = new CountDownLatch(1);
@@ -177,7 +177,7 @@ public class AsynchronousFileTest extends AIOTestBase
 
       write = null;
 
-      ServiceTestBase.forceGC(bufferCheck2, 5000);
+      ActiveMQTestBase.forceGC(bufferCheck2, 5000);
 
       assertNull(bufferCheck2.get());
 
@@ -185,7 +185,7 @@ public class AsynchronousFileTest extends AIOTestBase
 
       controller = null;
 
-      ServiceTestBase.forceGC(bufferCheck, 5000);
+      ActiveMQTestBase.forceGC(bufferCheck, 5000);
 
       assertNull(bufferCheck.get());
    }
@@ -272,8 +272,8 @@ public class AsynchronousFileTest extends AIOTestBase
 
          }
 
-         ServiceTestBase.waitForLatch(latchDone);
-         ServiceTestBase.waitForLatch(latchDone2);
+         ActiveMQTestBase.waitForLatch(latchDone);
+         ActiveMQTestBase.waitForLatch(latchDone2);
 
          CountDownCallback.checkResults(numberOfLines, listResult1);
          CountDownCallback.checkResults(numberOfLines, listResult2);
@@ -626,7 +626,7 @@ public class AsynchronousFileTest extends AIOTestBase
             final ByteBuffer buffer0 = AsynchronousFileImpl.newBuffer(SIZE);
             for (int j = 0; j < SIZE; j++)
             {
-               buffer0.put(ServiceTestBase.getSamplebyte(j));
+               buffer0.put(ActiveMQTestBase.getSamplebyte(j));
             }
 
             CountDownCallback aio = new CountDownCallback(latch, errors, result, i);
@@ -673,7 +673,7 @@ public class AsynchronousFileTest extends AIOTestBase
          for (int count = 0; count < SIZE; count++)
          {
             Assert.assertEquals("byte position " + count + " differs on line " + i + " position = " + count,
-                                ServiceTestBase.getSamplebyte(count),
+                                ActiveMQTestBase.getSamplebyte(count),
                                 bytesRead[count]);
          }
       }
@@ -803,7 +803,7 @@ public class AsynchronousFileTest extends AIOTestBase
 
       }
 
-      ServiceTestBase.waitForLatch(latchDone);
+      ActiveMQTestBase.waitForLatch(latchDone);
 
       long timeTotal = System.currentTimeMillis() - valueInitial;
 
@@ -853,7 +853,7 @@ public class AsynchronousFileTest extends AIOTestBase
          CountDownLatch latchDone = new CountDownLatch(1);
          CountDownCallback aioBlock = new CountDownCallback(latchDone, null, null, 0);
          controller.write(i * 512, 512, buffer, aioBlock);
-         ServiceTestBase.waitForLatch(latchDone);
+         ActiveMQTestBase.waitForLatch(latchDone);
          assertTrue(aioBlock.doneCalled);
          assertEquals(0, aioBlock.errorCalled);
       }
@@ -922,7 +922,7 @@ public class AsynchronousFileTest extends AIOTestBase
       CountDownCallback aioBlock = new CountDownCallback(latchDone, null, null, 0);
       controller.write(11, 512, buffer, aioBlock);
 
-      ServiceTestBase.waitForLatch(latchDone);
+      ActiveMQTestBase.waitForLatch(latchDone);
 
       assertTrue(aioBlock.errorCalled != 0);
       assertFalse(aioBlock.doneCalled);

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/asyncio/MultiThreadAsynchronousFileTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/asyncio/MultiThreadAsynchronousFileTest.java
@@ -16,6 +16,18 @@
  */
 package org.apache.activemq.artemis.tests.unit.core.asyncio;
 
+import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
+import org.apache.activemq.artemis.core.asyncio.AIOCallback;
+import org.apache.activemq.artemis.core.asyncio.impl.AsynchronousFileImpl;
+import org.apache.activemq.artemis.core.journal.impl.AIOSequentialFileFactory;
+import org.apache.activemq.artemis.tests.unit.UnitTestLogger;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.apache.activemq.artemis.utils.ActiveMQThreadFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -23,18 +35,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.apache.activemq.artemis.core.asyncio.AIOCallback;
-import org.apache.activemq.artemis.core.asyncio.impl.AsynchronousFileImpl;
-import org.apache.activemq.artemis.core.journal.impl.AIOSequentialFileFactory;
-import org.apache.activemq.artemis.tests.unit.UnitTestLogger;
-import org.apache.activemq.artemis.utils.ActiveMQThreadFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
 
 /**
  * you need to define -Djava.library.path=${project-root}/native/src/.libs when calling the JVM
@@ -125,7 +125,7 @@ public class MultiThreadAsynchronousFileTest extends AIOTestBase
          }
 
          latchStart.countDown();
-         ServiceTestBase.waitForLatch(latchStart);
+         ActiveMQTestBase.waitForLatch(latchStart);
 
          long startTime = System.currentTimeMillis();
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/client/impl/LargeMessageBufferTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/client/impl/LargeMessageBufferTest.java
@@ -5,9 +5,9 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,6 +15,28 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.unit.core.client.impl;
+
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
+import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.api.core.client.ClientMessage;
+import org.apache.activemq.artemis.api.core.client.ClientSession;
+import org.apache.activemq.artemis.api.core.client.MessageHandler;
+import org.apache.activemq.artemis.core.client.impl.ClientConsumerInternal;
+import org.apache.activemq.artemis.core.client.impl.ClientLargeMessageInternal;
+import org.apache.activemq.artemis.core.client.impl.ClientMessageInternal;
+import org.apache.activemq.artemis.core.client.impl.ClientSessionInternal;
+import org.apache.activemq.artemis.core.client.impl.LargeMessageControllerImpl;
+import org.apache.activemq.artemis.core.protocol.core.impl.ActiveMQConsumerContext;
+import org.apache.activemq.artemis.spi.core.remoting.ConsumerContext;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.apache.activemq.artemis.tests.util.RandomUtil;
+import org.apache.activemq.artemis.utils.ActiveMQBufferInputStream;
+import org.apache.activemq.artemis.utils.FutureLatch;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -29,30 +51,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
-import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
-import org.apache.activemq.artemis.api.core.ActiveMQException;
-import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.api.core.client.ClientMessage;
-import org.apache.activemq.artemis.api.core.client.ClientSession;
-import org.apache.activemq.artemis.api.core.client.MessageHandler;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
-import org.apache.activemq.artemis.core.client.impl.ClientConsumerInternal;
-import org.apache.activemq.artemis.core.client.impl.ClientLargeMessageInternal;
-import org.apache.activemq.artemis.core.client.impl.ClientMessageInternal;
-import org.apache.activemq.artemis.core.client.impl.ClientSessionInternal;
-import org.apache.activemq.artemis.core.client.impl.LargeMessageControllerImpl;
-import org.apache.activemq.artemis.core.protocol.core.impl.ActiveMQConsumerContext;
-import org.apache.activemq.artemis.spi.core.remoting.ConsumerContext;
-import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.apache.activemq.artemis.utils.FutureLatch;
-import org.apache.activemq.artemis.utils.ActiveMQBufferInputStream;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
-public class LargeMessageBufferTest extends ServiceTestBase
+public class LargeMessageBufferTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------
@@ -77,13 +76,6 @@ public class LargeMessageBufferTest extends ServiceTestBase
 
       File tmp = new File(getTestDir());
       tmp.mkdirs();
-   }
-
-   @Override
-   @After
-   public void tearDown() throws Exception
-   {
-      super.tearDown();
    }
 
    // Test Simple getBytes
@@ -340,7 +332,7 @@ public class LargeMessageBufferTest extends ServiceTestBase
 
       t.start();
 
-      ServiceTestBase.waitForLatch(latchGo);
+      ActiveMQTestBase.waitForLatch(latchGo);
 
       buffer.cancel();
 
@@ -632,7 +624,7 @@ public class LargeMessageBufferTest extends ServiceTestBase
          }
       });
 
-      ServiceTestBase.waitForLatch(latchBytesWritten1);
+      ActiveMQTestBase.waitForLatch(latchBytesWritten1);
 
       try
       {

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/config/impl/ConfigurationValidationTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/config/impl/ConfigurationValidationTest.java
@@ -22,11 +22,11 @@ import org.junit.Test;
 import org.junit.Assert;
 
 import org.apache.activemq.artemis.core.config.impl.FileConfiguration;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.XMLUtil;
 import org.w3c.dom.Element;
 
-public class ConfigurationValidationTest extends ServiceTestBase
+public class ConfigurationValidationTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/config/impl/ConnectorsServiceTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/config/impl/ConnectorsServiceTest.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import org.apache.activemq.artemis.tests.unit.core.config.impl.fakes.FakeConnectorServiceFactory;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.ConnectorServiceConfiguration;
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
@@ -32,7 +32,7 @@ import org.apache.activemq.artemis.tests.unit.core.config.impl.fakes.FakeConnect
 import org.junit.Before;
 import org.junit.Test;
 
-public class ConnectorsServiceTest extends ServiceTestBase
+public class ConnectorsServiceTest extends ActiveMQTestBase
 {
    private Configuration configuration;
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/config/impl/TransportConfigurationTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/config/impl/TransportConfigurationTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.activemq.artemis.tests.unit.core.config.impl;
 
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 
 import org.junit.Assert;
 
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 
-public class TransportConfigurationTest extends ServiceTestBase
+public class TransportConfigurationTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/AlignedJournalImplTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/AlignedJournalImplTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.activemq.artemis.tests.unit.core.journal.impl;
 import org.apache.activemq.artemis.tests.unit.core.journal.impl.fakes.FakeSequentialFileFactory;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 import org.junit.After;
 
@@ -44,7 +44,7 @@ import org.apache.activemq.artemis.core.journal.impl.JournalImpl;
 import org.apache.activemq.artemis.tests.unit.UnitTestLogger;
 import org.apache.activemq.artemis.tests.unit.core.journal.impl.fakes.SimpleEncoding;
 
-public class AlignedJournalImplTest extends ServiceTestBase
+public class AlignedJournalImplTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------
@@ -1223,7 +1223,7 @@ public class AlignedJournalImplTest extends ServiceTestBase
             try
             {
                latchReady.countDown();
-               ServiceTestBase.waitForLatch(latchStart);
+               ActiveMQTestBase.waitForLatch(latchStart);
                for (int i = 0; i < NUMBER_OF_ELEMENTS; i++)
                {
                   journalImpl.appendAddRecordTransactional(i, i, (byte)1, new SimpleEncoding(50, (byte)1));
@@ -1247,7 +1247,7 @@ public class AlignedJournalImplTest extends ServiceTestBase
             try
             {
                latchReady.countDown();
-               ServiceTestBase.waitForLatch(latchStart);
+               ActiveMQTestBase.waitForLatch(latchStart);
                for (int i = 0; i < NUMBER_OF_ELEMENTS; i++)
                {
                   Integer toDelete = queueDelete.poll(10, TimeUnit.SECONDS);
@@ -1269,7 +1269,7 @@ public class AlignedJournalImplTest extends ServiceTestBase
       t1.start();
       t2.start();
 
-      ServiceTestBase.waitForLatch(latchReady);
+      ActiveMQTestBase.waitForLatch(latchReady);
       latchStart.countDown();
 
       t1.join();

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/CleanBufferTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/CleanBufferTest.java
@@ -17,7 +17,7 @@
 package org.apache.activemq.artemis.tests.unit.core.journal.impl;
 
 import org.apache.activemq.artemis.tests.unit.core.journal.impl.fakes.FakeSequentialFileFactory;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
@@ -29,7 +29,7 @@ import org.apache.activemq.artemis.core.journal.SequentialFileFactory;
 import org.apache.activemq.artemis.core.journal.impl.AIOSequentialFileFactory;
 import org.apache.activemq.artemis.core.journal.impl.NIOSequentialFileFactory;
 
-public class CleanBufferTest extends ServiceTestBase
+public class CleanBufferTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/FileFactoryTestBase.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/FileFactoryTestBase.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.unit.core.journal.impl;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 
 import java.nio.ByteBuffer;
@@ -25,7 +25,7 @@ import org.junit.Assert;
 import org.apache.activemq.artemis.core.journal.SequentialFile;
 import org.apache.activemq.artemis.core.journal.SequentialFileFactory;
 
-public abstract class FileFactoryTestBase extends ServiceTestBase
+public abstract class FileFactoryTestBase extends ActiveMQTestBase
 {
    protected abstract SequentialFileFactory createFactory();
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/JournalAsyncTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/JournalAsyncTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.activemq.artemis.tests.unit.core.journal.impl.fakes.FakeSequentialFileFactory;
 import org.apache.activemq.artemis.tests.unit.core.journal.impl.fakes.SimpleEncoding;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.journal.PreparedTransactionInfo;
 import org.apache.activemq.artemis.core.journal.RecordInfo;
 import org.apache.activemq.artemis.core.journal.impl.JournalImpl;
@@ -31,7 +31,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class JournalAsyncTest extends ServiceTestBase
+public class JournalAsyncTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/JournalImplTestBase.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/JournalImplTestBase.java
@@ -33,13 +33,13 @@ import org.apache.activemq.artemis.core.journal.RecordInfo;
 import org.apache.activemq.artemis.core.journal.SequentialFileFactory;
 import org.apache.activemq.artemis.core.journal.TestableJournal;
 import org.apache.activemq.artemis.core.journal.impl.JournalImpl;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.ReusableLatch;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 
-public abstract class JournalImplTestBase extends ServiceTestBase
+public abstract class JournalImplTestBase extends ActiveMQTestBase
 {
    protected List<RecordInfo> records = new LinkedList<RecordInfo>();
 
@@ -568,7 +568,7 @@ public abstract class JournalImplTestBase extends ServiceTestBase
 
          Assert.assertEquals("type not same", rexpected.isUpdate, ractual.isUpdate);
 
-         ServiceTestBase.assertEqualsByteArrays(rexpected.data, ractual.data);
+         ActiveMQTestBase.assertEqualsByteArrays(rexpected.data, ractual.data);
       }
    }
 
@@ -602,7 +602,7 @@ public abstract class JournalImplTestBase extends ServiceTestBase
       for (int i = 0; i < length; i++)
       {
          // record[i] = RandomUtil.randomByte();
-         record[i] = ServiceTestBase.getSamplebyte(i);
+         record[i] = ActiveMQTestBase.getSamplebyte(i);
       }
       return record;
    }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/ReclaimerTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/ReclaimerTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.unit.core.journal.impl;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 
 import org.junit.Test;
@@ -32,7 +32,7 @@ import org.apache.activemq.artemis.core.journal.impl.JournalFile;
 import org.apache.activemq.artemis.core.journal.impl.JournalImpl;
 import org.apache.activemq.artemis.core.journal.impl.Reclaimer;
 
-public class ReclaimerTest extends ServiceTestBase
+public class ReclaimerTest extends ActiveMQTestBase
 {
    private JournalFile[] files;
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/SequentialFileFactoryTestBase.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/SequentialFileFactoryTestBase.java
@@ -17,7 +17,7 @@
 package org.apache.activemq.artemis.tests.unit.core.journal.impl;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 import org.junit.After;
 
@@ -35,7 +35,7 @@ import org.apache.activemq.artemis.core.asyncio.impl.AsynchronousFileImpl;
 import org.apache.activemq.artemis.core.journal.SequentialFile;
 import org.apache.activemq.artemis.core.journal.SequentialFileFactory;
 
-public abstract class SequentialFileFactoryTestBase extends ServiceTestBase
+public abstract class SequentialFileFactoryTestBase extends ActiveMQTestBase
 {
    @Override
    @Before
@@ -58,7 +58,7 @@ public abstract class SequentialFileFactoryTestBase extends ServiceTestBase
 
       factory = null;
 
-      ServiceTestBase.forceGC();
+      ActiveMQTestBase.forceGC();
 
       super.tearDown();
    }
@@ -337,14 +337,14 @@ public abstract class SequentialFileFactoryTestBase extends ServiceTestBase
          Assert.assertEquals(rb3.limit(), bytesRead);
          rb3.rewind();
          rb3.get(rbytes3);
-         ServiceTestBase.assertEqualsByteArrays(bytes3, rbytes3);
+         ActiveMQTestBase.assertEqualsByteArrays(bytes3, rbytes3);
 
          sf.position(rb1.limit());
 
          bytesRead = sf.read(rb2);
          Assert.assertEquals(rb2.limit(), bytesRead);
          rb2.get(rbytes2);
-         ServiceTestBase.assertEqualsByteArrays(bytes2, rbytes2);
+         ActiveMQTestBase.assertEqualsByteArrays(bytes2, rbytes2);
 
          sf.position(0);
 
@@ -352,7 +352,7 @@ public abstract class SequentialFileFactoryTestBase extends ServiceTestBase
          Assert.assertEquals(rb1.limit(), bytesRead);
          rb1.get(rbytes1);
 
-         ServiceTestBase.assertEqualsByteArrays(bytes1, rbytes1);
+         ActiveMQTestBase.assertEqualsByteArrays(bytes1, rbytes1);
 
       }
       finally

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/TimedBufferTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/TimedBufferTest.java
@@ -18,7 +18,7 @@ package org.apache.activemq.artemis.tests.unit.core.journal.impl;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
@@ -34,7 +34,7 @@ import org.apache.activemq.artemis.core.journal.IOAsyncTask;
 import org.apache.activemq.artemis.core.journal.impl.TimedBuffer;
 import org.apache.activemq.artemis.core.journal.impl.TimedBufferObserver;
 
-public class TimedBufferTest extends ServiceTestBase
+public class TimedBufferTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------
@@ -104,7 +104,7 @@ public class TimedBufferTest extends ServiceTestBase
             byte[] bytes = new byte[10];
             for (int j = 0; j < 10; j++)
             {
-               bytes[j] = ServiceTestBase.getSamplebyte(x++);
+               bytes[j] = ActiveMQTestBase.getSamplebyte(x++);
             }
 
             ActiveMQBuffer buff = ActiveMQBuffers.wrappedBuffer(bytes);
@@ -127,7 +127,7 @@ public class TimedBufferTest extends ServiceTestBase
 
          for (int i = 0; i < 100; i++)
          {
-            Assert.assertEquals(ServiceTestBase.getSamplebyte(i), flushedBuffer.get());
+            Assert.assertEquals(ActiveMQTestBase.getSamplebyte(i), flushedBuffer.get());
          }
       }
       finally
@@ -178,7 +178,7 @@ public class TimedBufferTest extends ServiceTestBase
          byte[] bytes = new byte[10];
          for (int j = 0; j < 10; j++)
          {
-            bytes[j] = ServiceTestBase.getSamplebyte(x++);
+            bytes[j] = ActiveMQTestBase.getSamplebyte(x++);
          }
 
          ActiveMQBuffer buff = ActiveMQBuffers.wrappedBuffer(bytes);
@@ -193,7 +193,7 @@ public class TimedBufferTest extends ServiceTestBase
          bytes = new byte[10];
          for (int j = 0; j < 10; j++)
          {
-            bytes[j] = ServiceTestBase.getSamplebyte(x++);
+            bytes[j] = ActiveMQTestBase.getSamplebyte(x++);
          }
 
          buff = ActiveMQBuffers.wrappedBuffer(bytes);
@@ -215,7 +215,7 @@ public class TimedBufferTest extends ServiceTestBase
 
          for (int i = 0; i < 20; i++)
          {
-            Assert.assertEquals(ServiceTestBase.getSamplebyte(i), flushedBuffer.get());
+            Assert.assertEquals(ActiveMQTestBase.getSamplebyte(i), flushedBuffer.get());
          }
       }
       finally
@@ -291,7 +291,7 @@ public class TimedBufferTest extends ServiceTestBase
          byte[] bytes = new byte[10];
          for (int j = 0; j < 10; j++)
          {
-            bytes[j] = ServiceTestBase.getSamplebyte(x++);
+            bytes[j] = ActiveMQTestBase.getSamplebyte(x++);
          }
 
          ActiveMQBuffer buff = ActiveMQBuffers.wrappedBuffer(bytes);
@@ -378,7 +378,7 @@ public class TimedBufferTest extends ServiceTestBase
          byte[] bytes = new byte[10];
          for (int j = 0; j < 10; j++)
          {
-            bytes[j] = ServiceTestBase.getSamplebyte(x++);
+            bytes[j] = ActiveMQTestBase.getSamplebyte(x++);
          }
 
          ActiveMQBuffer buff = ActiveMQBuffers.wrappedBuffer(bytes);

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/message/impl/MessageImplTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/message/impl/MessageImplTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.client.impl.ClientMessageImpl;
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionSendMessage;
 import org.apache.activemq.artemis.core.server.impl.ServerMessageImpl;
@@ -31,7 +31,7 @@ import org.apache.activemq.artemis.tests.util.RandomUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class MessageImplTest extends ServiceTestBase
+public class MessageImplTest extends ActiveMQTestBase
 {
    @Test
    public void getSetAttributes()

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/paging/impl/PagePositionTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/paging/impl/PagePositionTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.activemq.artemis.tests.unit.core.paging.impl;
 
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 
-public class PagePositionTest extends ServiceTestBase
+public class PagePositionTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/paging/impl/PageTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/paging/impl/PageTest.java
@@ -23,7 +23,7 @@ import java.util.List;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.tests.unit.core.journal.impl.fakes.FakeSequentialFileFactory;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.journal.SequentialFile;
 import org.apache.activemq.artemis.core.journal.SequentialFileFactory;
 import org.apache.activemq.artemis.core.journal.impl.NIOSequentialFileFactory;
@@ -36,7 +36,7 @@ import org.apache.activemq.artemis.core.server.impl.ServerMessageImpl;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class PageTest extends ServiceTestBase
+public class PageTest extends ActiveMQTestBase
 {
    // Constants -----------------------------------------------------
 
@@ -114,11 +114,11 @@ public class PageTest extends ServiceTestBase
       {
          Assert.assertEquals(simpleDestination, msgs.get(i).getMessage().getAddress());
 
-         ServiceTestBase.assertEqualsByteArrays(buffers.get(i).toByteBuffer().array(), msgs.get(i)
-            .getMessage()
-            .getBodyBuffer()
-            .toByteBuffer()
-            .array());
+         ActiveMQTestBase.assertEqualsByteArrays(buffers.get(i).toByteBuffer().array(), msgs.get(i)
+                 .getMessage()
+                 .getBodyBuffer()
+                 .toByteBuffer()
+                 .array());
       }
 
       impl.delete(null);
@@ -186,11 +186,11 @@ public class PageTest extends ServiceTestBase
       {
          Assert.assertEquals(simpleDestination, msgs.get(i).getMessage().getAddress());
 
-         ServiceTestBase.assertEqualsByteArrays(buffers.get(i).toByteBuffer().array(), msgs.get(i)
-            .getMessage()
-            .getBodyBuffer()
-            .toByteBuffer()
-            .array());
+         ActiveMQTestBase.assertEqualsByteArrays(buffers.get(i).toByteBuffer().array(), msgs.get(i)
+                 .getMessage()
+                 .getBodyBuffer()
+                 .toByteBuffer()
+                 .array());
       }
 
       impl.delete(null);

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/paging/impl/PagingManagerImplTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/paging/impl/PagingManagerImplTest.java
@@ -38,12 +38,12 @@ import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.core.settings.impl.HierarchicalObjectRepository;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class PagingManagerImplTest extends ServiceTestBase
+public class PagingManagerImplTest extends ActiveMQTestBase
 {
    private final ReadLock lock = new ReentrantReadWriteLock().readLock();
 
@@ -52,9 +52,7 @@ public class PagingManagerImplTest extends ServiceTestBase
    {
 
       HierarchicalRepository<AddressSettings> addressSettings = new HierarchicalObjectRepository<AddressSettings>();
-      AddressSettings settings = new AddressSettings();
-      settings.setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
-      addressSettings.setDefault(settings);
+      addressSettings.setDefault(new AddressSettings().setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE));
 
       final StorageManager storageManager = new NullStorageManager();
 
@@ -86,11 +84,11 @@ public class PagingManagerImplTest extends ServiceTestBase
 
       Assert.assertEquals(1, msgs.size());
 
-      ServiceTestBase.assertEqualsByteArrays(msg.getBodyBuffer().writerIndex(), msg.getBodyBuffer().toByteBuffer().array(), msgs.get(0)
-         .getMessage()
-         .getBodyBuffer()
-         .toByteBuffer()
-         .array());
+      ActiveMQTestBase.assertEqualsByteArrays(msg.getBodyBuffer().writerIndex(), msg.getBodyBuffer().toByteBuffer().array(), msgs.get(0)
+              .getMessage()
+              .getBodyBuffer()
+              .toByteBuffer()
+              .array());
 
       Assert.assertTrue(store.isPaging());
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/paging/impl/PagingStoreImplTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/paging/impl/PagingStoreImplTest.java
@@ -55,14 +55,14 @@ import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.tests.unit.core.journal.impl.fakes.FakeSequentialFileFactory;
 import org.apache.activemq.artemis.tests.unit.util.FakePagingManager;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.ExecutorFactory;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class PagingStoreImplTest extends ServiceTestBase
+public class PagingStoreImplTest extends ActiveMQTestBase
 {
 
    private static final SimpleString destinationTestName = new SimpleString("test");
@@ -108,13 +108,10 @@ public class PagingStoreImplTest extends ServiceTestBase
    {
       SequentialFileFactory factory = new FakeSequentialFileFactory();
 
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
-
       PagingStore storeImpl =
          new PagingStoreImpl(PagingStoreImplTest.destinationTestName, null, 100, createMockManager(),
                              createStorageManagerMock(), factory, null, PagingStoreImplTest.destinationTestName,
-                             addressSettings, getExecutorFactory().getExecutor(), true);
+                             new AddressSettings().setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE), getExecutorFactory().getExecutor(), true);
 
       storeImpl.start();
 
@@ -130,7 +127,7 @@ public class PagingStoreImplTest extends ServiceTestBase
    @Test
    public void testPageWithNIO() throws Exception
    {
-      ServiceTestBase.recreateDirectory(getTestDir());
+      ActiveMQTestBase.recreateDirectory(getTestDir());
       testConcurrentPaging(new NIOSequentialFileFactory(getTestDir()), 1);
    }
 
@@ -141,8 +138,8 @@ public class PagingStoreImplTest extends ServiceTestBase
 
       PagingStoreFactory storeFactory = new FakeStoreFactory(factory);
 
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
+      AddressSettings addressSettings = new AddressSettings().setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
+
       PagingStore storeImpl =
          new PagingStoreImpl(PagingStoreImplTest.destinationTestName, null, 100, createMockManager(),
                              createStorageManagerMock(), factory, storeFactory,
@@ -195,12 +192,10 @@ public class PagingStoreImplTest extends ServiceTestBase
 
       PagingStoreFactory storeFactory = new FakeStoreFactory(factory);
 
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
       PagingStoreImpl storeImpl =
          new PagingStoreImpl(PagingStoreImplTest.destinationTestName, null, 100, createMockManager(),
                              createStorageManagerMock(), factory, storeFactory,
-                             PagingStoreImplTest.destinationTestName, addressSettings,
+                             PagingStoreImplTest.destinationTestName, new AddressSettings().setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE),
                              getExecutorFactory().getExecutor(), true);
 
       storeImpl.start();
@@ -268,12 +263,10 @@ public class PagingStoreImplTest extends ServiceTestBase
 
       PagingStoreFactory storeFactory = new FakeStoreFactory(factory);
 
-      AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
       PagingStoreImpl store =
          new PagingStoreImpl(PagingStoreImplTest.destinationTestName, null, 100, createMockManager(),
                              createStorageManagerMock(), factory, storeFactory,
-                             PagingStoreImplTest.destinationTestName, addressSettings,
+                             PagingStoreImplTest.destinationTestName, new AddressSettings().setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE),
                              getExecutorFactory().getExecutor(), true);
 
       store.start();
@@ -327,7 +320,7 @@ public class PagingStoreImplTest extends ServiceTestBase
          for (int i = 0; i < 5; i++)
          {
             Assert.assertEquals(sequence++, msg.get(i).getMessage().getMessageID());
-            ServiceTestBase.assertEqualsBuffers(18, buffers.get(pageNr * 5 + i), msg.get(i).getMessage().getBodyBuffer());
+            ActiveMQTestBase.assertEqualsBuffers(18, buffers.get(pageNr * 5 + i), msg.get(i).getMessage().getBodyBuffer());
          }
       }
 
@@ -378,7 +371,7 @@ public class PagingStoreImplTest extends ServiceTestBase
 
       Assert.assertEquals(1L, msgs.get(0).getMessage().getMessageID());
 
-      ServiceTestBase.assertEqualsBuffers(18, buffers.get(0), msgs.get(0).getMessage().getBodyBuffer());
+      ActiveMQTestBase.assertEqualsBuffers(18, buffers.get(0), msgs.get(0).getMessage().getBodyBuffer());
 
       Assert.assertEquals(1, store.getNumberOfPages());
 
@@ -416,9 +409,9 @@ public class PagingStoreImplTest extends ServiceTestBase
 
       final ArrayList<Page> readPages = new ArrayList<Page>();
 
-      AddressSettings settings = new AddressSettings();
-      settings.setPageSizeBytes(MAX_SIZE);
-      settings.setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
+      AddressSettings settings = new AddressSettings()
+              .setPageSizeBytes(MAX_SIZE)
+              .setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
 
       final PagingStore storeImpl =
          new PagingStoreImpl(PagingStoreImplTest.destinationTestName, null, 100, createMockManager(),
@@ -496,7 +489,7 @@ public class PagingStoreImplTest extends ServiceTestBase
             try
             {
                // Wait every producer to produce at least one message
-               ServiceTestBase.waitForLatch(latchStart);
+               ActiveMQTestBase.waitForLatch(latchStart);
 
                while (aliveProducers.get() > 0)
                {
@@ -559,7 +552,7 @@ public class PagingStoreImplTest extends ServiceTestBase
             buffers2.put(id, msg.getMessage());
             Assert.assertNotNull(msgWritten);
             Assert.assertEquals(msg.getMessage().getAddress(), msgWritten.getAddress());
-            ServiceTestBase.assertEqualsBuffers(10, msgWritten.getBodyBuffer(), msg.getMessage().getBodyBuffer());
+            ActiveMQTestBase.assertEqualsBuffers(10, msgWritten.getBodyBuffer(), msg.getMessage().getBodyBuffer());
          }
       }
 
@@ -627,10 +620,10 @@ public class PagingStoreImplTest extends ServiceTestBase
             ServerMessage msgWritten = buffers2.remove(id);
             Assert.assertNotNull(msgWritten);
             Assert.assertEquals(msg.getMessage().getAddress(), msgWritten.getAddress());
-            ServiceTestBase.assertEqualsByteArrays(msgWritten.getBodyBuffer().writerIndex(), msgWritten.getBodyBuffer()
-               .toByteBuffer()
-               .array(),
-                                                msg.getMessage().getBodyBuffer().toByteBuffer().array());
+            ActiveMQTestBase.assertEqualsByteArrays(msgWritten.getBodyBuffer().writerIndex(), msgWritten.getBodyBuffer()
+                                                            .toByteBuffer()
+                                                            .array(),
+                                                    msg.getMessage().getBodyBuffer().toByteBuffer().array());
          }
       }
 
@@ -657,9 +650,9 @@ public class PagingStoreImplTest extends ServiceTestBase
 
       final int MAX_SIZE = 1024 * 10;
 
-      AddressSettings settings = new AddressSettings();
-      settings.setPageSizeBytes(MAX_SIZE);
-      settings.setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
+      AddressSettings settings = new AddressSettings()
+              .setPageSizeBytes(MAX_SIZE)
+              .setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
 
       final PagingStore storeImpl =
          new PagingStoreImpl(PagingStoreImplTest.destinationTestName, null, 100, createMockManager(),
@@ -694,9 +687,9 @@ public class PagingStoreImplTest extends ServiceTestBase
 
       final int MAX_SIZE = 1024 * 10;
 
-      AddressSettings settings = new AddressSettings();
-      settings.setPageSizeBytes(MAX_SIZE);
-      settings.setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
+      AddressSettings settings = new AddressSettings()
+              .setPageSizeBytes(MAX_SIZE)
+              .setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
 
       final PagingStore store =
          new PagingStoreImpl(PagingStoreImplTest.destinationTestName, null, 100, createMockManager(),

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/persistence/impl/BatchIDGeneratorUnitTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/persistence/impl/BatchIDGeneratorUnitTest.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.journal.Journal;
 import org.apache.activemq.artemis.core.journal.PreparedTransactionInfo;
 import org.apache.activemq.artemis.core.journal.RecordInfo;
@@ -32,7 +32,7 @@ import org.apache.activemq.artemis.core.persistence.impl.nullpm.NullStorageManag
 import org.junit.Assert;
 import org.junit.Test;
 
-public class BatchIDGeneratorUnitTest extends ServiceTestBase
+public class BatchIDGeneratorUnitTest extends ActiveMQTestBase
 {
 
    @Test

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/persistence/impl/OperationContextUnitTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/persistence/impl/OperationContextUnitTest.java
@@ -23,13 +23,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.journal.IOAsyncTask;
 import org.apache.activemq.artemis.core.persistence.impl.journal.OperationContextImpl;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class OperationContextUnitTest extends ServiceTestBase
+public class OperationContextUnitTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/AddressImplTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/AddressImplTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.activemq.artemis.tests.unit.core.postoffice.impl;
 
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 
 import org.junit.Assert;
@@ -25,7 +25,7 @@ import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.postoffice.Address;
 import org.apache.activemq.artemis.core.postoffice.impl.AddressImpl;
 
-public class AddressImplTest extends ServiceTestBase
+public class AddressImplTest extends ActiveMQTestBase
 {
    @Test
    public void testNoDots()

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/BindingsImplTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/BindingsImplTest.java
@@ -17,7 +17,7 @@
 package org.apache.activemq.artemis.tests.unit.core.postoffice.impl;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.server.impl.RefsOperation;
 import org.junit.Test;
 
@@ -42,7 +42,7 @@ import org.apache.activemq.artemis.core.server.impl.ServerMessageImpl;
 import org.apache.activemq.artemis.core.transaction.Transaction;
 import org.apache.activemq.artemis.core.transaction.TransactionOperation;
 
-public class BindingsImplTest extends ServiceTestBase
+public class BindingsImplTest extends ActiveMQTestBase
 {
    // Constants -----------------------------------------------------
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/DuplicateDetectionUnitTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/DuplicateDetectionUnitTest.java
@@ -28,7 +28,7 @@ import org.apache.activemq.artemis.api.core.Pair;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.tests.unit.core.server.impl.fakes.FakePostOffice;
 import org.apache.activemq.artemis.tests.unit.util.FakePagingManager;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.persistence.GroupingInfo;
 import org.apache.activemq.artemis.core.persistence.QueueBindingInfo;
@@ -45,7 +45,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class DuplicateDetectionUnitTest extends ServiceTestBase
+public class DuplicateDetectionUnitTest extends ActiveMQTestBase
 {
    // Constants -----------------------------------------------------
 
@@ -90,7 +90,7 @@ public class DuplicateDetectionUnitTest extends ServiceTestBase
 
          SimpleString ADDRESS = new SimpleString("address");
 
-         Configuration configuration = createDefaultConfig();
+         Configuration configuration = createDefaultInVMConfig();
 
          PostOffice postOffice = new FakePostOffice();
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/WildcardAddressManagerUnitTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/WildcardAddressManagerUnitTest.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.filter.Filter;
 import org.apache.activemq.artemis.core.postoffice.Binding;
 import org.apache.activemq.artemis.core.postoffice.BindingType;
@@ -37,7 +37,7 @@ import org.junit.Test;
 /**
  * This test is replicating the behaviour from https://issues.jboss.org/browse/HORNETQ-988.
  */
-public class WildcardAddressManagerUnitTest extends ServiceTestBase
+public class WildcardAddressManagerUnitTest extends ActiveMQTestBase
 {
 
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/ActiveMQBufferTestBase.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/ActiveMQBufferTestBase.java
@@ -16,7 +16,7 @@
  */
 package org.apache.activemq.artemis.tests.unit.core.remoting;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 import org.junit.After;
 
@@ -27,7 +27,7 @@ import org.junit.Assert;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
 
-public abstract class ActiveMQBufferTestBase extends ServiceTestBase
+public abstract class ActiveMQBufferTestBase extends ActiveMQTestBase
 {
    // Constants -----------------------------------------------------
 
@@ -100,7 +100,7 @@ public abstract class ActiveMQBufferTestBase extends ServiceTestBase
       SimpleString result = putAndGetNullableSimpleString(emptySimpleString);
 
       Assert.assertNotNull(result);
-      ServiceTestBase.assertEqualsByteArrays(emptySimpleString.getData(), result.getData());
+      ActiveMQTestBase.assertEqualsByteArrays(emptySimpleString.getData(), result.getData());
    }
 
    @Test
@@ -110,7 +110,7 @@ public abstract class ActiveMQBufferTestBase extends ServiceTestBase
       SimpleString result = putAndGetNullableSimpleString(junk);
 
       Assert.assertNotNull(result);
-      ServiceTestBase.assertEqualsByteArrays(junk.getData(), result.getData());
+      ActiveMQTestBase.assertEqualsByteArrays(junk.getData(), result.getData());
    }
 
    @Test
@@ -144,7 +144,7 @@ public abstract class ActiveMQBufferTestBase extends ServiceTestBase
 
       byte[] b = new byte[bytes.length];
       wrapper.readBytes(b);
-      ServiceTestBase.assertEqualsByteArrays(bytes, b);
+      ActiveMQTestBase.assertEqualsByteArrays(bytes, b);
    }
 
    @Test
@@ -156,7 +156,7 @@ public abstract class ActiveMQBufferTestBase extends ServiceTestBase
 
       byte[] b = new byte[bytes.length / 2];
       wrapper.readBytes(b, 0, b.length);
-      ServiceTestBase.assertEqualsByteArrays(b.length, bytes, b);
+      ActiveMQTestBase.assertEqualsByteArrays(b.length, bytes, b);
    }
 
    @Test
@@ -289,7 +289,7 @@ public abstract class ActiveMQBufferTestBase extends ServiceTestBase
 
       byte[] array = wrapper.toByteBuffer().array();
       Assert.assertEquals(wrapper.capacity(), array.length);
-      ServiceTestBase.assertEqualsByteArrays(128, bytes, wrapper.toByteBuffer().array());
+      ActiveMQTestBase.assertEqualsByteArrays(128, bytes, wrapper.toByteBuffer().array());
    }
 
    @Test

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/netty/NettyAcceptorFactoryTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/netty/NettyAcceptorFactoryTest.java
@@ -30,11 +30,11 @@ import org.apache.activemq.artemis.spi.core.remoting.Acceptor;
 import org.apache.activemq.artemis.spi.core.remoting.BufferHandler;
 import org.apache.activemq.artemis.spi.core.remoting.Connection;
 import org.apache.activemq.artemis.spi.core.remoting.ConnectionLifeCycleListener;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class NettyAcceptorFactoryTest extends ServiceTestBase
+public class NettyAcceptorFactoryTest extends ActiveMQTestBase
 {
    @Test
    public void testCreateAcceptor() throws Exception

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/netty/NettyAcceptorTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/netty/NettyAcceptorTest.java
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptor;
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.core.server.ActiveMQComponent;
@@ -37,7 +37,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class NettyAcceptorTest extends ServiceTestBase
+public class NettyAcceptorTest extends ActiveMQTestBase
 {
    private ScheduledExecutorService pool2;
 
@@ -47,7 +47,7 @@ public class NettyAcceptorTest extends ServiceTestBase
    {
       super.setUp();
 
-      ServiceTestBase.checkFreePort(TransportConstants.DEFAULT_PORT);
+      ActiveMQTestBase.checkFreePort(TransportConstants.DEFAULT_PORT);
    }
 
    @Override
@@ -56,7 +56,7 @@ public class NettyAcceptorTest extends ServiceTestBase
    {
       try
       {
-         ServiceTestBase.checkFreePort(TransportConstants.DEFAULT_PORT);
+         ActiveMQTestBase.checkFreePort(TransportConstants.DEFAULT_PORT);
       }
       finally
       {
@@ -111,13 +111,13 @@ public class NettyAcceptorTest extends ServiceTestBase
       Assert.assertTrue(acceptor.isStarted());
       acceptor.stop();
       Assert.assertFalse(acceptor.isStarted());
-      ServiceTestBase.checkFreePort(TransportConstants.DEFAULT_PORT);
+      ActiveMQTestBase.checkFreePort(TransportConstants.DEFAULT_PORT);
 
       acceptor.start();
       Assert.assertTrue(acceptor.isStarted());
       acceptor.stop();
       Assert.assertFalse(acceptor.isStarted());
-      ServiceTestBase.checkFreePort(TransportConstants.DEFAULT_PORT);
+      ActiveMQTestBase.checkFreePort(TransportConstants.DEFAULT_PORT);
 
       pool2.shutdown();
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/netty/NettyConnectionTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/netty/NettyConnectionTest.java
@@ -26,7 +26,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnection;
 import org.apache.activemq.artemis.core.server.ActiveMQComponent;
 import org.apache.activemq.artemis.spi.core.remoting.Connection;
@@ -34,7 +34,7 @@ import org.apache.activemq.artemis.spi.core.remoting.ConnectionLifeCycleListener
 import org.junit.Assert;
 import org.junit.Test;
 
-public class NettyConnectionTest extends ServiceTestBase
+public class NettyConnectionTest extends ActiveMQTestBase
 {
    private static final Map<String, Object> emptyMap = Collections.emptyMap();
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/netty/NettyConnectorTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/netty/NettyConnectorTest.java
@@ -18,7 +18,7 @@ package org.apache.activemq.artemis.tests.unit.core.remoting.impl.netty;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -34,7 +34,7 @@ import org.apache.activemq.artemis.spi.core.remoting.BufferHandler;
 import org.apache.activemq.artemis.spi.core.remoting.Connection;
 import org.apache.activemq.artemis.spi.core.remoting.ConnectionLifeCycleListener;
 
-public class NettyConnectorTest extends ServiceTestBase
+public class NettyConnectorTest extends ActiveMQTestBase
 {
 
    @Test

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/ssl/SSLSupportTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/ssl/SSLSupportTest.java
@@ -21,7 +21,7 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.remoting.impl.ssl.SSLSupport;
 import org.junit.Assert;
 import org.junit.Before;
@@ -30,7 +30,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(value = Parameterized.class)
-public class SSLSupportTest extends ServiceTestBase
+public class SSLSupportTest extends ActiveMQTestBase
 {
    @Parameterized.Parameters(name = "storeType={0}")
    public static Collection getParameters()

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/security/impl/ActiveMQSecurityManagerImplTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/security/impl/ActiveMQSecurityManagerImplTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.unit.core.security.impl;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 import org.junit.After;
 
@@ -32,7 +32,7 @@ import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManagerImpl
 /**
  * tests ActiveMQSecurityManagerImpl
  */
-public class ActiveMQSecurityManagerImplTest extends ServiceTestBase
+public class ActiveMQSecurityManagerImplTest extends ActiveMQTestBase
 {
    private ActiveMQSecurityManagerImpl securityManager;
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/cluster/impl/ClusterConnectionBridgeTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/cluster/impl/ClusterConnectionBridgeTest.java
@@ -17,11 +17,11 @@
 package org.apache.activemq.artemis.tests.unit.core.server.cluster.impl;
 
 import org.apache.activemq.artemis.api.core.management.ManagementHelper;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.server.cluster.impl.ClusterConnectionBridge;
 import org.junit.Test;
 
-public class ClusterConnectionBridgeTest extends ServiceTestBase
+public class ClusterConnectionBridgeTest extends ActiveMQTestBase
 {
    @Test
    public void testCreateSelectorFromAddressForNormalMatches()

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/cluster/impl/RemoteQueueBindImplTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/cluster/impl/RemoteQueueBindImplTest.java
@@ -17,7 +17,7 @@
 package org.apache.activemq.artemis.tests.unit.core.server.cluster.impl;
 
 import org.apache.activemq.artemis.tests.unit.core.postoffice.impl.FakeQueue;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
@@ -25,7 +25,7 @@ import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.server.cluster.impl.RemoteQueueBindingImpl;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
 
-public class RemoteQueueBindImplTest extends ServiceTestBase
+public class RemoteQueueBindImplTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/group/impl/SystemPropertyOverrideTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/group/impl/SystemPropertyOverrideTest.java
@@ -17,10 +17,10 @@
 package org.apache.activemq.artemis.tests.unit.core.server.group.impl;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.server.group.impl.GroupingHandlerConfiguration;
 
-public class SystemPropertyOverrideTest extends ServiceTestBase
+public class SystemPropertyOverrideTest extends ActiveMQTestBase
 {
    // Constants -----------------------------------------------------
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/impl/FileLockTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/impl/FileLockTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.unit.core.server.impl;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 
 import org.junit.Test;
@@ -26,7 +26,7 @@ import org.apache.activemq.artemis.core.asyncio.impl.AsynchronousFileImpl;
 import org.apache.activemq.artemis.core.server.impl.AIOFileLockNodeManager;
 import org.apache.activemq.artemis.core.server.impl.FileLockNodeManager;
 
-public class FileLockTest extends ServiceTestBase
+public class FileLockTest extends ActiveMQTestBase
 {
 
    @Override

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/impl/QueueImplTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/impl/QueueImplTest.java
@@ -34,7 +34,7 @@ import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.tests.unit.core.server.impl.fakes.FakeConsumer;
 import org.apache.activemq.artemis.tests.unit.core.server.impl.fakes.FakeFilter;
 import org.apache.activemq.artemis.tests.unit.core.server.impl.fakes.FakePostOffice;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.filter.Filter;
 import org.apache.activemq.artemis.core.filter.impl.FilterImpl;
 import org.apache.activemq.artemis.core.postoffice.impl.LocalQueueBinding;
@@ -54,7 +54,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class QueueImplTest extends ServiceTestBase
+public class QueueImplTest extends ActiveMQTestBase
 {
    // The tests ----------------------------------------------------------------
 
@@ -1327,18 +1327,18 @@ public class QueueImplTest extends ServiceTestBase
       final String MY_ADDRESS = "myAddress";
       final String MY_QUEUE = "myQueue";
 
-      ActiveMQServer server = ActiveMQServers.newActiveMQServer(createDefaultConfig(), true);
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(createDefaultInVMConfig(), true));
 
-      AddressSettings defaultSetting = new AddressSettings();
-      defaultSetting.setPageSizeBytes(10 * 1024);
-      defaultSetting.setMaxSizeBytes(20 * 1024);
+      AddressSettings defaultSetting = new AddressSettings()
+              .setPageSizeBytes(10 * 1024)
+              .setMaxSizeBytes(20 * 1024);
       server.getAddressSettingsRepository().addMatch("#", defaultSetting);
       server.start();
 
-      ServerLocator locator = createInVMNonHALocator();
-      locator.setBlockOnNonDurableSend(true);
-      locator.setBlockOnDurableSend(true);
-      locator.setBlockOnAcknowledge(true);
+      ServerLocator locator = createInVMNonHALocator()
+              .setBlockOnNonDurableSend(true)
+              .setBlockOnDurableSend(true)
+              .setBlockOnAcknowledge(true);
 
       ClientSessionFactory factory = createSessionFactory(locator);
       ClientSession session = addClientSession(factory.createSession(false, true, true));

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/jms/ActiveMQDestinationTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/jms/ActiveMQDestinationTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.activemq.artemis.tests.unit.jms;
 
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 
 import javax.jms.JMSRuntimeException;
@@ -28,7 +28,7 @@ import org.junit.Assert;
 import org.apache.activemq.artemis.jms.client.ActiveMQDestination;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
 
-public class ActiveMQDestinationTest extends ServiceTestBase
+public class ActiveMQDestinationTest extends ActiveMQTestBase
 {
    // Constants -----------------------------------------------------
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/jms/client/ActiveMQMapMessageTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/jms/client/ActiveMQMapMessageTest.java
@@ -18,13 +18,13 @@ package org.apache.activemq.artemis.tests.unit.jms.client;
 import javax.jms.MessageFormatException;
 
 import org.apache.activemq.artemis.tests.util.RandomUtil;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.jms.client.ActiveMQMapMessage;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ActiveMQMapMessageTest extends ServiceTestBase
+public class ActiveMQMapMessageTest extends ActiveMQTestBase
 {
    // Constants -----------------------------------------------------
 
@@ -693,7 +693,7 @@ public class ActiveMQMapMessageTest extends ServiceTestBase
       ActiveMQMapMessage message = new ActiveMQMapMessage();
       message.setBytes(itemName, value);
 
-      ServiceTestBase.assertEqualsByteArrays(value, message.getBytes(itemName));
+      ActiveMQTestBase.assertEqualsByteArrays(value, message.getBytes(itemName));
    }
 
    @Test

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/jms/client/ActiveMQStreamMessageTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/jms/client/ActiveMQStreamMessageTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.activemq.artemis.tests.unit.jms.client;
 
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -29,7 +29,7 @@ import org.junit.Assert;
 import org.apache.activemq.artemis.jms.client.ActiveMQStreamMessage;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
 
-public class ActiveMQStreamMessageTest extends ServiceTestBase
+public class ActiveMQStreamMessageTest extends ActiveMQTestBase
 {
    // Constants -----------------------------------------------------
 
@@ -180,7 +180,7 @@ public class ActiveMQStreamMessageTest extends ServiceTestBase
       byte[] v = new byte[value.length];
       message.readBytes(v);
 
-      ServiceTestBase.assertEqualsByteArrays(value, v);
+      ActiveMQTestBase.assertEqualsByteArrays(value, v);
    }
 
    @Test
@@ -195,7 +195,7 @@ public class ActiveMQStreamMessageTest extends ServiceTestBase
       byte[] v = new byte[256];
       message.readBytes(v);
 
-      ServiceTestBase.assertEqualsByteArrays(256, value, v);
+      ActiveMQTestBase.assertEqualsByteArrays(256, value, v);
    }
 
    @Test
@@ -922,7 +922,7 @@ public class ActiveMQStreamMessageTest extends ServiceTestBase
       message.reset();
 
       byte[] v = (byte[])message.readObject();
-      ServiceTestBase.assertEqualsByteArrays(value, v);
+      ActiveMQTestBase.assertEqualsByteArrays(value, v);
    }
 
    @Test
@@ -1041,7 +1041,7 @@ public class ActiveMQStreamMessageTest extends ServiceTestBase
       Object v = reader.readType(message);
       if (value instanceof byte[])
       {
-         ServiceTestBase.assertEqualsByteArrays((byte[])value, (byte[])v);
+         ActiveMQTestBase.assertEqualsByteArrays((byte[]) value, (byte[]) v);
       }
       else
       {

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/jms/client/JMSExceptionHelperTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/jms/client/JMSExceptionHelperTest.java
@@ -28,12 +28,12 @@ import javax.jms.JMSSecurityException;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.jms.client.JMSExceptionHelper;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class JMSExceptionHelperTest extends ServiceTestBase
+public class JMSExceptionHelperTest extends ActiveMQTestBase
 {
    // Constants -----------------------------------------------------
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/jms/client/SelectorTranslatorTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/jms/client/SelectorTranslatorTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.activemq.artemis.tests.unit.jms.client;
 
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 
 import org.junit.Assert;
 
 import org.apache.activemq.artemis.jms.client.SelectorTranslator;
 
-public class SelectorTranslatorTest extends ServiceTestBase
+public class SelectorTranslatorTest extends ActiveMQTestBase
 {
    @Test
    public void testParseNull()

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/jms/misc/ManifestTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/jms/misc/ManifestTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.activemq.artemis.tests.unit.jms.misc;
 
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 
 import java.io.File;
@@ -35,7 +35,7 @@ import org.apache.activemq.artemis.core.server.ActiveMQServers;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionMetaData;
 import org.apache.activemq.artemis.tests.unit.UnitTestLogger;
 
-public class ManifestTest extends ServiceTestBase
+public class ManifestTest extends ActiveMQTestBase
 {
    // Constants -----------------------------------------------------
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/jms/referenceable/ConnectionFactoryObjectFactoryTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/jms/referenceable/ConnectionFactoryObjectFactoryTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.activemq.artemis.tests.unit.jms.referenceable;
 
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 
-public class ConnectionFactoryObjectFactoryTest extends ServiceTestBase
+public class ConnectionFactoryObjectFactoryTest extends ActiveMQTestBase
 {
    // Constants -----------------------------------------------------
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/jms/referenceable/DestinationObjectFactoryTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/jms/referenceable/DestinationObjectFactoryTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.activemq.artemis.tests.unit.jms.referenceable;
 
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 
 import javax.naming.Reference;
@@ -28,7 +28,7 @@ import org.apache.activemq.artemis.jms.client.ActiveMQDestination;
 import org.apache.activemq.artemis.jms.referenceable.DestinationObjectFactory;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
 
-public class DestinationObjectFactoryTest extends ServiceTestBase
+public class DestinationObjectFactoryTest extends ActiveMQTestBase
 {
    // Constants -----------------------------------------------------
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/ra/ActiveMQResourceAdapterConfigTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/ra/ActiveMQResourceAdapterConfigTest.java
@@ -25,7 +25,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.activemq.artemis.ra.ActiveMQResourceAdapter;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -39,7 +39,7 @@ import org.xml.sax.InputSource;
  * this test should fail, if it does paste the new commented out configs into the ra.xml file and in here. don't forget to
  * add a description for each new property added and try and put it in the config some where appropriate.
  */
-public class ActiveMQResourceAdapterConfigTest extends ServiceTestBase
+public class ActiveMQResourceAdapterConfigTest extends ActiveMQTestBase
 {
    private static String config = "" +
       "<config-property>\n" +

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/ra/ConnectionFactoryPropertiesTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/ra/ConnectionFactoryPropertiesTest.java
@@ -21,14 +21,14 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.ra.ActiveMQResourceAdapter;
 import org.junit.Test;
 
 import static java.beans.Introspector.getBeanInfo;
 
-public class ConnectionFactoryPropertiesTest extends ServiceTestBase
+public class ConnectionFactoryPropertiesTest extends ActiveMQTestBase
 {
 
    private static final SortedSet<String> UNSUPPORTED_CF_PROPERTIES;

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/ra/ResourceAdapterTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/ra/ResourceAdapterTest.java
@@ -29,7 +29,7 @@ import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnectorFactory;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
@@ -43,7 +43,7 @@ import org.apache.activemq.artemis.ra.inflow.ActiveMQActivationSpec;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class ResourceAdapterTest extends ServiceTestBase
+public class ResourceAdapterTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/ActiveMQBufferInputStreamTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/ActiveMQBufferInputStreamTest.java
@@ -18,11 +18,11 @@ package org.apache.activemq.artemis.tests.unit.util;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.ActiveMQBufferInputStream;
 import org.junit.Test;
 
-public class ActiveMQBufferInputStreamTest extends ServiceTestBase
+public class ActiveMQBufferInputStreamTest extends ActiveMQTestBase
 {
 
    @Test

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/LinkedListTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/LinkedListTest.java
@@ -22,13 +22,13 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.LinkedListImpl;
 import org.apache.activemq.artemis.utils.LinkedListIterator;
 import org.junit.Before;
 import org.junit.Test;
 
-public class LinkedListTest extends ServiceTestBase
+public class LinkedListTest extends ActiveMQTestBase
 {
    private LinkedListImpl<Integer> list;
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/ObjectInputStreamWithClassLoaderTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/ObjectInputStreamWithClassLoaderTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.activemq.artemis.tests.unit.util;
 
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -40,7 +40,7 @@ import org.junit.Assert;
 
 import org.apache.activemq.artemis.utils.ObjectInputStreamWithClassLoader;
 
-public class ObjectInputStreamWithClassLoaderTest extends ServiceTestBase
+public class ObjectInputStreamWithClassLoaderTest extends ActiveMQTestBase
 {
    // Constants -----------------------------------------------------
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/ReusableLatchTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/ReusableLatchTest.java
@@ -19,12 +19,12 @@ package org.apache.activemq.artemis.tests.unit.util;
 import java.util.concurrent.CountDownLatch;
 
 import org.apache.activemq.artemis.tests.unit.UnitTestLogger;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.ReusableLatch;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class ReusableLatchTest extends ServiceTestBase
+public class ReusableLatchTest extends ActiveMQTestBase
 {
    @Test
    public void testLatchWithParameterizedDown() throws Exception

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/SoftValueMapTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/SoftValueMapTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.activemq.artemis.tests.unit.util;
 
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.SoftValueHashMap;
 import org.junit.Test;
 
-public class SoftValueMapTest extends ServiceTestBase
+public class SoftValueMapTest extends ActiveMQTestBase
 {
 
    // Constants -----------------------------------------------------

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/UTF8Test.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/UTF8Test.java
@@ -17,7 +17,7 @@
 package org.apache.activemq.artemis.tests.unit.util;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.After;
 
 import org.junit.Test;
@@ -35,7 +35,7 @@ import org.apache.activemq.artemis.utils.DataConstants;
 import org.apache.activemq.artemis.utils.Random;
 import org.apache.activemq.artemis.utils.UTF8Util;
 
-public class UTF8Test extends ServiceTestBase
+public class UTF8Test extends ActiveMQTestBase
 {
 
    @Test

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/UUIDGeneratorTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/UUIDGeneratorTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.activemq.artemis.tests.unit.util;
 
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class UUIDGeneratorTest extends ServiceTestBase
+public class UUIDGeneratorTest extends ActiveMQTestBase
 {
    // Constants -----------------------------------------------------
 
@@ -58,15 +58,15 @@ public class UUIDGeneratorTest extends ServiceTestBase
 
       byte[] fiveBytes = new byte[]{1, 2, 3, 4, 5};
       byte[] zeroPaddedFiveBytes = UUIDGenerator.getZeroPaddedSixBytes(fiveBytes);
-      ServiceTestBase.assertEqualsByteArrays(new byte[]{1, 2, 3, 4, 5, 0}, zeroPaddedFiveBytes);
+      ActiveMQTestBase.assertEqualsByteArrays(new byte[]{1, 2, 3, 4, 5, 0}, zeroPaddedFiveBytes);
 
       byte[] fourBytes = new byte[]{1, 2, 3, 4};
       byte[] zeroPaddedFourBytes = UUIDGenerator.getZeroPaddedSixBytes(fourBytes);
-      ServiceTestBase.assertEqualsByteArrays(new byte[]{1, 2, 3, 4, 0, 0}, zeroPaddedFourBytes);
+      ActiveMQTestBase.assertEqualsByteArrays(new byte[]{1, 2, 3, 4, 0, 0}, zeroPaddedFourBytes);
 
       byte[] threeBytes = new byte[]{1, 2, 3};
       byte[] zeroPaddedThreeBytes = UUIDGenerator.getZeroPaddedSixBytes(threeBytes);
-      ServiceTestBase.assertEqualsByteArrays(new byte[]{1, 2, 3, 0, 0, 0}, zeroPaddedThreeBytes);
+      ActiveMQTestBase.assertEqualsByteArrays(new byte[]{1, 2, 3, 0, 0, 0}, zeroPaddedThreeBytes);
    }
 
    // Package protected ---------------------------------------------

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/UUIDTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/UUIDTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.activemq.artemis.tests.unit.util;
 
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 
 import java.util.HashSet;
@@ -27,7 +27,7 @@ import org.junit.Assert;
 import org.apache.activemq.artemis.utils.UUID;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
 
-public class UUIDTest extends ServiceTestBase
+public class UUIDTest extends ActiveMQTestBase
 {
    static final int MANY_TIMES = 100000;
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/VersionLoaderTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/VersionLoaderTest.java
@@ -19,13 +19,13 @@ package org.apache.activemq.artemis.tests.unit.util;
 import java.util.Properties;
 import java.util.StringTokenizer;
 
-import org.apache.activemq.artemis.tests.util.ServiceTestBase;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.core.version.Version;
 import org.apache.activemq.artemis.utils.VersionLoader;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class VersionLoaderTest extends ServiceTestBase
+public class VersionLoaderTest extends ActiveMQTestBase
 {
    // Constants -----------------------------------------------------
 


### PR DESCRIPTION
Lots of work on the test-suite in this commit including:
- Rename ServiceTestBase to ActiveMQTestBase
- Make AddressSettings fluent
- Remove unnecessary tearDown() implementations
- Use ActiveMQTestBase.create*Locator() instead of
  ActiveMQClient.createServerLocator*(..)
- Use fluent ServerLocator methods
- Make sure all ActiveMQServers.newActiveMQServer invocations
  are surrounded with addServer() where appropriate
- Create a few example tests to be references from hacking-guide
- Update hacking-guide with more info on writing tests