### PR TITLE
ARTEMIS-135 - Fix on journal load

### DIFF
--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalImpl.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalImpl.java
@@ -375,18 +375,25 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
       {
          SequentialFile file = fileFactory.createSequentialFile(fileName, filesRepository.getMaxAIO());
 
-         file.open(1, false);
-
-         try
+         if (file.size() >= SIZE_HEADER)
          {
+            file.open(1, false);
 
-            JournalFileImpl jrnFile = readFileHeader(file);
+            try
+            {
+               JournalFileImpl jrnFile = readFileHeader(file);
 
-            orderedFiles.add(jrnFile);
+               orderedFiles.add(jrnFile);
+            }
+            finally
+            {
+               file.close();
+            }
          }
-         finally
+         else
          {
-            file.close();
+            ActiveMQJournalLogger.LOGGER.ignoringShortFile(fileName);
+            file.delete();
          }
       }
 

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/journal/ActiveMQJournalLogger.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/journal/ActiveMQJournalLogger.java
@@ -269,4 +269,8 @@ public interface ActiveMQJournalLogger extends BasicLogger
    @Message(id = 144006, value = "IOError code {0}, {1}", format = Message.Format.MESSAGE_FORMAT)
    void ioError(final int errorCode, final String errorMessage);
 
+   @LogMessage(level = Logger.Level.WARN)
+   @Message(id = 144007, value = "Ignoring journal file {0}: file is shorter then minimum header size. This file is being removed.", format = Message.Format.MESSAGE_FORMAT)
+   void ignoringShortFile(String fileName);
+
 }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/JournalImplTestUnit.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/JournalImplTestUnit.java
@@ -18,6 +18,7 @@ package org.apache.activemq.artemis.tests.unit.core.journal.impl;
 
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.io.File;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.ActiveMQIOErrorException;
@@ -3220,6 +3221,26 @@ public abstract class JournalImplTestUnit extends JournalImplTestBase
       startJournal();
       loadAndCheck();
 
+   }
+
+   @Test
+   public void testLoadTruncatedFile() throws Exception
+   {
+      setup(2, 2 * 1024, true);
+      createJournal();
+      startJournal();
+
+      String testDir = getTestDir();
+      new File(testDir + File.separator + filePrefix + "-1." + fileExtension).createNewFile();
+
+      try
+      {
+         load();
+      }
+      catch (Exception e)
+      {
+         Assert.fail("Unexpected exception: " + e.toString());
+      }
    }
 
    protected abstract int getAlignment();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARTEMIS-135

This is importing a recent fix from the journal on the old version.
If a crash happened between the create file and the fill of the file the
file wouldn't be loaded and the server wouldn't start until you removed the offending file