### PR TITLE
ARTEMIS-103 Changed JGroupsBroadcastEndpoint to not close its JChanne…

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/ChannelBroadcastEndpointFactory.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/ChannelBroadcastEndpointFactory.java
@@ -18,6 +18,11 @@ package org.apache.activemq.artemis.api.core;
 
 import org.jgroups.JChannel;
 
+/**
+ * An implementation of BroadcastEndpointFactory that uses an externally managed JChannel for JGroups clustering.
+ *
+ * Note - the underlying JChannel is not closed in this implementation.
+ */
 public class ChannelBroadcastEndpointFactory implements BroadcastEndpointFactory
 {
    private final JChannel channel;

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/JGroupsBroadcastEndpoint.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/JGroupsBroadcastEndpoint.java
@@ -126,6 +126,15 @@ public abstract class JGroupsBroadcastEndpoint implements BroadcastEndpoint
          channel.removeReceiver(receiver);
          clientOpened = false;
       }
+      internalCloseChannel();
+   }
+
+   /**
+    * Closes the channel used in this JGroups Broadcast.
+    * Can be overridden by implementations that use an externally managed channel.
+    */
+   protected synchronized void internalCloseChannel()
+   {
       channel.close();
    }
 

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/JGroupsChannelBroadcastEndpoint.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/JGroupsChannelBroadcastEndpoint.java
@@ -18,6 +18,11 @@ package org.apache.activemq.artemis.api.core;
 
 import org.jgroups.JChannel;
 
+/**
+ * An implementation of JGroupsBroadcastEndpoint that uses an externally managed JChannel for its operations.
+ *
+ * Note - this implementation does not close the JChannel, since its externally created.
+ */
 public class JGroupsChannelBroadcastEndpoint extends JGroupsBroadcastEndpoint
 {
    private final JChannel jChannel;
@@ -32,5 +37,11 @@ public class JGroupsChannelBroadcastEndpoint extends JGroupsBroadcastEndpoint
    public JChannel createChannel() throws Exception
    {
       return jChannel;
+   }
+
+   @Override
+   protected synchronized void internalCloseChannel()
+   {
+      // no-op, this version takes an externally managed channel.
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/connection/ConnectionFactoryWithJGroupsSerializationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/connection/ConnectionFactoryWithJGroupsSerializationTest.java
@@ -25,6 +25,7 @@ import java.io.Serializable;
 
 import javax.jms.Queue;
 
+import org.apache.activemq.artemis.api.core.BroadcastEndpoint;
 import org.apache.activemq.artemis.api.core.BroadcastEndpointFactory;
 import org.apache.activemq.artemis.api.core.ChannelBroadcastEndpointFactory;
 import org.apache.activemq.artemis.api.core.DiscoveryGroupConfiguration;
@@ -171,8 +172,14 @@ public class ConnectionFactoryWithJGroupsSerializationTest extends JMSTestBase
    @After
    public void tearDown() throws Exception
    {
+      // small hack, the channel here is cached, so checking that it's not closed by any endpoint
+      BroadcastEndpoint broadcastEndpoint = jmsServer.getActiveMQServer().getConfiguration()
+              .getDiscoveryGroupConfigurations().get("dg1")
+              .getBroadcastEndpointFactory().createBroadcastEndpoint();
+      broadcastEndpoint.close(true);
       if (channel != null)
       {
+         assertFalse(channel.isClosed());
          channel.close();
       }
 


### PR DESCRIPTION
…l since its externally managed.  Added javadocs to impacted areas to clarify that the JChannel is not closed by these implementations.

I considered also changing the close behavior to take a second argument to determine whether the channel should be closed.  I chose this approach since it seems to be specific to RAs.