### PR TITLE
[ARTEMIS-138] list will return empty list now on non existent folders

### DIFF
--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/AbstractSequentialFileFactory.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/AbstractSequentialFileFactory.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -198,7 +199,7 @@ abstract class AbstractSequentialFileFactory implements SequentialFileFactory
 
       if (fileNames == null)
       {
-         throw new IOException("Failed to list: " + journalDir);
+         return Collections.EMPTY_LIST;
       }
 
       return Arrays.asList(fileNames);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/journal/AIOSequentialFileFactoryTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/journal/AIOSequentialFileFactoryTest.java
@@ -35,9 +35,9 @@ public class AIOSequentialFileFactoryTest extends SequentialFileFactoryTestBase
    }
 
    @Override
-   protected SequentialFileFactory createFactory()
+   protected SequentialFileFactory createFactory(String folder)
    {
-      return new AIOSequentialFileFactory(getTestDir());
+      return new AIOSequentialFileFactory(folder);
    }
 
    @Test

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/journal/NIONonBufferedSequentialFileFactoryTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/journal/NIONonBufferedSequentialFileFactoryTest.java
@@ -15,17 +15,17 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.integration.journal;
-import org.apache.activemq.artemis.tests.unit.core.journal.impl.SequentialFileFactoryTestBase;
 import org.apache.activemq.artemis.core.journal.SequentialFileFactory;
 import org.apache.activemq.artemis.core.journal.impl.NIOSequentialFileFactory;
+import org.apache.activemq.artemis.tests.unit.core.journal.impl.SequentialFileFactoryTestBase;
 
 public class NIONonBufferedSequentialFileFactoryTest extends SequentialFileFactoryTestBase
 {
 
    @Override
-   protected SequentialFileFactory createFactory()
+   protected SequentialFileFactory createFactory(String folder)
    {
-      return new NIOSequentialFileFactory(getTestDir(), false);
+      return new NIOSequentialFileFactory(folder, false);
    }
 
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/journal/NIOSequentialFileFactoryTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/journal/NIOSequentialFileFactoryTest.java
@@ -23,9 +23,9 @@ public class NIOSequentialFileFactoryTest extends SequentialFileFactoryTestBase
 {
 
    @Override
-   protected SequentialFileFactory createFactory()
+   protected SequentialFileFactory createFactory(String folder)
    {
-      return new NIOSequentialFileFactory(getTestDir(), true);
+      return new NIOSequentialFileFactory(folder, true);
    }
 
 }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/FakeSequentialFileFactoryTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/FakeSequentialFileFactoryTest.java
@@ -23,7 +23,7 @@ public class FakeSequentialFileFactoryTest extends SequentialFileFactoryTestBase
 {
 
    @Override
-   protected SequentialFileFactory createFactory()
+   protected SequentialFileFactory createFactory(String folder)
    {
       return new FakeSequentialFileFactory();
    }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/SequentialFileFactoryTestBase.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/SequentialFileFactoryTestBase.java
@@ -15,25 +15,22 @@
  * limitations under the License.
  */
 package org.apache.activemq.artemis.tests.unit.core.journal.impl;
-import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
-import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
-import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
-import org.junit.Before;
-import org.junit.After;
-
-import org.junit.Test;
-
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import org.junit.Assert;
-
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
 import org.apache.activemq.artemis.core.asyncio.impl.AsynchronousFileImpl;
 import org.apache.activemq.artemis.core.journal.SequentialFile;
 import org.apache.activemq.artemis.core.journal.SequentialFileFactory;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 public abstract class SequentialFileFactoryTestBase extends ActiveMQTestBase
 {
@@ -43,7 +40,7 @@ public abstract class SequentialFileFactoryTestBase extends ActiveMQTestBase
    {
       super.setUp();
 
-      factory = createFactory();
+      factory = createFactory(getTestDir());
 
       factory.start();
    }
@@ -63,9 +60,18 @@ public abstract class SequentialFileFactoryTestBase extends ActiveMQTestBase
       super.tearDown();
    }
 
-   protected abstract SequentialFileFactory createFactory();
+   protected abstract SequentialFileFactory createFactory(String folder);
 
    protected SequentialFileFactory factory;
+
+   @Test
+   public void listFilesOnNonExistentFolder() throws Exception
+   {
+      SequentialFileFactory fileFactory = createFactory("./target/dontexist");
+      List list = fileFactory.listFiles("tmp");
+      Assert.assertNotNull(list);
+      Assert.assertEquals(0, list.size());
+   }
 
    @Test
    public void testCreateAndListFiles() throws Exception


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARTEMIS-138

The list method should return an empty list in case of non existent folders,
So this would unveil whatever is the cause for non existent folders at the next level where it's happening