### PR TITLE
ARTEMIS-143 - expose idle-timeout

### DIFF
--- a/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/context/AMQPConstants.java
+++ b/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/context/AMQPConstants.java
@@ -1,30 +1,36 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.proton.plug;
+package org.proton.plug.context;
 
-public abstract class AMQPConnectionContextFactory
+/**
+ * Constants derived from the AMQP spec
+ */
+public class AMQPConstants
 {
-   /**
-    * @return
-    */
-   public abstract AMQPConnectionContext createConnection(AMQPConnectionCallback connectionCallback,int idleTimeout, int maxFrameSize, int channelMax);
+   /*
+   * Connection Properties
+   * http://docs.oasis-open.org/amqp/core/v1.0/amqp-core-complete-v1.0.pdf#subsection.2.7.1
+   * */
+   public static class Connection
+   {
+      public static final int DEFAULT_IDLE_TIMEOUT = -1;
 
-   /**
-    * @return
-    */
-   public abstract AMQPConnectionContext createConnection(AMQPConnectionCallback connectionCallback);
+      public static final int DEFAULT_MAX_FRAME_SIZE = -1;//it should be according to the spec 4294967295l;
+
+      public static final int DEFAULT_CHANNEL_MAX = 65535;
+   }
 }

--- a/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/context/AbstractConnectionContext.java
+++ b/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/context/AbstractConnectionContext.java
@@ -34,9 +34,12 @@ import org.proton.plug.handler.impl.DefaultEventHandler;
 import org.proton.plug.util.ByteUtil;
 import org.proton.plug.util.DebugInfo;
 
+import static org.proton.plug.context.AMQPConstants.Connection.DEFAULT_IDLE_TIMEOUT;
+import static org.proton.plug.context.AMQPConstants.Connection.DEFAULT_CHANNEL_MAX;
+import static org.proton.plug.context.AMQPConstants.Connection.DEFAULT_MAX_FRAME_SIZE;
+
 public abstract class AbstractConnectionContext extends ProtonInitializable implements AMQPConnectionContext
 {
-
 
    protected ProtonHandler handler = ProtonHandler.Factory.create();
 
@@ -48,8 +51,21 @@ public abstract class AbstractConnectionContext extends ProtonInitializable impl
 
    public AbstractConnectionContext(AMQPConnectionCallback connectionCallback)
    {
+      this(connectionCallback, DEFAULT_IDLE_TIMEOUT, DEFAULT_MAX_FRAME_SIZE, DEFAULT_CHANNEL_MAX);
+   }
+
+   public AbstractConnectionContext(AMQPConnectionCallback connectionCallback, int idleTimeout, int maxFrameSize, int channelMax)
+   {
       this.connectionCallback = connectionCallback;
       connectionCallback.setConnection(this);
+      Transport transport = handler.getTransport();
+      if (idleTimeout > 0)
+      {
+         transport.setIdleTimeout(idleTimeout);
+         transport.tick(idleTimeout / 2);
+      }
+      transport.setChannelMax(channelMax);
+      transport.setMaxFrameSize(maxFrameSize);
       handler.addEventHandler(listener);
    }
 

--- a/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/context/client/ProtonClientConnectionContext.java
+++ b/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/context/client/ProtonClientConnectionContext.java
@@ -36,6 +36,11 @@ public class ProtonClientConnectionContext extends AbstractConnectionContext imp
       super(connectionCallback);
    }
 
+   public ProtonClientConnectionContext(AMQPConnectionCallback connectionCallback, int idleTimeout, int maxFrameSize, int channelMax)
+   {
+      super(connectionCallback, idleTimeout, maxFrameSize, channelMax);
+   }
+
    // Maybe a client interface?
    public void clientOpen(ClientSASL sasl) throws Exception
    {

--- a/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/context/client/ProtonClientConnectionContextFactory.java
+++ b/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/context/client/ProtonClientConnectionContextFactory.java
@@ -34,5 +34,9 @@ public class ProtonClientConnectionContextFactory extends AMQPConnectionContextF
       return new ProtonClientConnectionContext(connectionCallback);
    }
 
-
+   @Override
+   public AMQPConnectionContext createConnection(AMQPConnectionCallback connectionCallback, int idleTimeout, int maxFrameSize, int channelMax)
+   {
+      return new ProtonClientConnectionContext(connectionCallback, idleTimeout, maxFrameSize, channelMax);
+   }
 }

--- a/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/context/server/ProtonServerConnectionContext.java
+++ b/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/context/server/ProtonServerConnectionContext.java
@@ -35,6 +35,11 @@ public class ProtonServerConnectionContext extends AbstractConnectionContext imp
       super(connectionSP);
    }
 
+   public ProtonServerConnectionContext(AMQPConnectionCallback connectionSP, int idleTimeout, int maxFrameSize, int channelMax)
+   {
+      super(connectionSP, idleTimeout, maxFrameSize, channelMax);
+   }
+
    protected AbstractProtonSessionContext newSessionExtension(Session realSession) throws ActiveMQAMQPException
    {
       AMQPSessionCallback sessionSPI = connectionCallback.createSessionCallback(this);

--- a/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/context/server/ProtonServerConnectionContextFactory.java
+++ b/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/context/server/ProtonServerConnectionContextFactory.java
@@ -20,6 +20,10 @@ import org.proton.plug.AMQPConnectionContextFactory;
 import org.proton.plug.AMQPConnectionCallback;
 import org.proton.plug.AMQPServerConnectionContext;
 
+import static org.proton.plug.context.AMQPConstants.Connection.DEFAULT_IDLE_TIMEOUT;
+import static org.proton.plug.context.AMQPConstants.Connection.DEFAULT_CHANNEL_MAX;
+import static org.proton.plug.context.AMQPConstants.Connection.DEFAULT_MAX_FRAME_SIZE;
+
 public class ProtonServerConnectionContextFactory extends AMQPConnectionContextFactory
 {
    private static final ProtonServerConnectionContextFactory theInstance = new ProtonServerConnectionContextFactory();
@@ -31,7 +35,15 @@ public class ProtonServerConnectionContextFactory extends AMQPConnectionContextF
 
    public AMQPServerConnectionContext createConnection(AMQPConnectionCallback connectionCallback)
    {
-      ProtonServerConnectionContext connection = new ProtonServerConnectionContext(connectionCallback);
-      return connection;
+      return createConnection(connectionCallback,DEFAULT_IDLE_TIMEOUT, DEFAULT_MAX_FRAME_SIZE, DEFAULT_CHANNEL_MAX);
+   }
+
+   @Override
+   public AMQPServerConnectionContext createConnection(AMQPConnectionCallback connectionCallback, int idleTimeout, int maxFrameSize, int channelMax)
+   {
+      return new ProtonServerConnectionContext(connectionCallback,
+            idleTimeout,
+            maxFrameSize,
+            channelMax);
    }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARTEMIS-143

Set the idle-timeout on the proton Transport object and also call tick so we send our own heartbeats.