### PR TITLE
Change on buffer timeout...

### DIFF
--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/broker.xml
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/broker.xml
@@ -35,6 +35,12 @@ under the License.
 
       <paging-directory>${data.dir}/paging</paging-directory>
 
+      <!-- Nanosecond time for batching timeout before IO operations
+           This will batch multiple writes before IO writes.
+           Increasing this timeout would benefit scalabitility of multiple
+           producers and consumers -->
+      <journal-buffer-timeout>100</journal-buffer-timeout>
+
       <bindings-directory>${data.dir}/bindings</bindings-directory>
 
       <journal-directory>${data.dir}/journal</journal-directory>

--- a/artemis-cli/src/test/java/org/apache/activemq/cli/test/ArtemisTest.java
+++ b/artemis-cli/src/test/java/org/apache/activemq/cli/test/ArtemisTest.java
@@ -75,7 +75,7 @@ public class ArtemisTest
       Artemis.main("create", temporaryFolder.getRoot().getAbsolutePath(), "--force", "--silent-input", "--no-web");
       System.setProperty("artemis.instance", temporaryFolder.getRoot().getAbsolutePath());
       // Some exceptions may happen on the initialization, but they should be ok on start the basic core protocol
-      Artemis.main("run");
+      Artemis.execute("run");
       Assert.assertEquals(Integer.valueOf(70), Artemis.execute("producer", "--txt-size", "50", "--message-count", "70", "--verbose"));
       Assert.assertEquals(Integer.valueOf(70), Artemis.execute("consumer", "--txt-size", "50", "--verbose", "--break-on-null", "--receive-timeout", "100"));
 

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/AbstractSequentialFileFactory.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/AbstractSequentialFileFactory.java
@@ -71,7 +71,7 @@ abstract class AbstractSequentialFileFactory implements SequentialFileFactory
    {
       this.journalDir = journalDir;
 
-      if (buffered)
+      if (buffered && bufferTimeout > 0)
       {
          timedBuffer = new TimedBuffer(bufferSize, bufferTimeout, logRates);
       }


### PR DESCRIPTION
I had done a lot of tests today, and having 100 nanoseconds for the buffer timeout is a better default for the default installation created through the create command.
I have added some information on when to change as a comment on the xml