### PR TITLE
Set default password properly in security manager

### DIFF
--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/security/impl/ActiveMQSecurityManagerImplTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/security/impl/ActiveMQSecurityManagerImplTest.java
@@ -57,11 +57,12 @@ public class ActiveMQSecurityManagerImplTest extends ActiveMQTestBase
    @Test
    public void testDefaultSecurity()
    {
-      securityManager.getConfiguration().addUser("guest", "guest");
+      securityManager.getConfiguration().addUser("guest", "password");
       securityManager.getConfiguration().addRole("guest", "guest");
       securityManager.getConfiguration().setDefaultUser("guest");
       Assert.assertTrue(securityManager.validateUser(null, null));
-      Assert.assertTrue(securityManager.validateUser("guest", "guest"));
+      Assert.assertTrue(securityManager.validateUser("guest", "password"));
+      Assert.assertFalse(securityManager.validateUser(null, "wrongpass"));
       HashSet<Role> roles = new HashSet<Role>();
       roles.add(new Role("guest", true, true, true, true, true, true, true));
       Assert.assertTrue(securityManager.validateUserAndRole(null, null, roles, CheckType.CREATE_DURABLE_QUEUE));


### PR DESCRIPTION
The current Security Manager implementation was returning the username
instead of the default password when validating  the default user.

This patch returns the correct value and cleans up the validate method.