### PR TITLE
Set content-type to STOMP ERROR frames

### DIFF
--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/ActiveMQStompException.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/ActiveMQStompException.java
@@ -91,6 +91,7 @@ public class ActiveMQStompException extends Exception
 
       if (body != null)
       {
+         frame.addHeader(Stomp.Headers.CONTENT_TYPE, "text/plain");
          frame.setByteBody(body.getBytes(StandardCharsets.UTF_8));
       }
       else

--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompSession.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompSession.java
@@ -211,6 +211,7 @@ public class StompSession implements SessionCallback
       if (stompSubscription != null)
       {
          StompFrame frame = connection.getFrameHandler().createStompFrame(Stomp.Responses.ERROR);
+         frame.addHeader(Stomp.Headers.CONTENT_TYPE, "text/plain");
          frame.setBody("consumer with ID " + consumerId + " disconnected by server");
          connection.sendFrame(frame);
       }

--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/v11/StompFrameHandlerV11.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/v11/StompFrameHandlerV11.java
@@ -105,6 +105,7 @@ public class StompFrameHandlerV11 extends VersionedStompFrameHandler implements 
             // not valid
             response = createStompFrame(Stomp.Responses.ERROR);
             response.setNeedsDisconnect(true);
+            response.addHeader(Stomp.Headers.CONTENT_TYPE, "text/plain");
             response.addHeader(Stomp.Headers.Error.MESSAGE, "Failed to connect");
             response.setBody("The login account is not valid.");
          }


### PR DESCRIPTION
Not setting it to directly instantiated 1.0 frames though, as
content-type is not in the 1.0 spec. However the 1.0 spec does not
actually forbid headers outside of the spec so it shouldn't hurt if we
end up setting it for some frames sent over a 1.0 connection.