### PR TITLE
Don't auto-send STOMP content-length header if one was explicitly set

### DIFF
--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/v11/StompFrameV11.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/v11/StompFrameV11.java
@@ -66,7 +66,7 @@ public class StompFrameV11 extends StompFrame
             head.append(h.getEncodedValue());
             head.append(Stomp.NEWLINE);
          }
-         if (bytesBody != null && bytesBody.length > 0)
+         if (bytesBody != null && bytesBody.length > 0 && !hasHeader(Stomp.Headers.CONTENT_LENGTH))
          {
             head.append(Stomp.Headers.CONTENT_LENGTH);
             head.append(Stomp.Headers.SEPARATOR);


### PR DESCRIPTION
I'm not sure if a code path where this (= sending more than one content-length header) happens exists, but nothing prevents the issue from happening ATM.