### PR TITLE
ARTEMIS-179 excessive cluster bridge retry logging

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/impl/ClusterConnectionBridge.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/impl/ClusterConnectionBridge.java
@@ -155,7 +155,6 @@ public class ClusterConnectionBridge extends BridgeImpl
 
       if (factory == null)
       {
-         ActiveMQServerLogger.LOGGER.nodeNotAvailable(targetNodeID);
          return null;
       }
       factory.setReconnectAttempts(0);


### PR DESCRIPTION
The information about the bridge connection retries is already logged
at DEBUG level elsewhere and a WARN message is already logged when the
connection dies in the first place. I don't see any good reason to
keep this logging here.