### PR TITLE
Fix org.apache.activemq.JmsQueueCompositeSendReceiveTest#testDuplicate

### DIFF
--- a/tests/activemq5-unit-tests/pom.xml
+++ b/tests/activemq5-unit-tests/pom.xml
@@ -84,6 +84,12 @@
          <groupId>org.apache.activemq</groupId>
          <artifactId>activemq-leveldb-store</artifactId>
          <version>${activemq5.project.version}</version>
+         <exclusions>
+             <exclusion>
+                 <groupId>commons-beanutils</groupId>
+                 <artifactId>commons-beanutils-core</artifactId>
+             </exclusion>
+         </exclusions>
       </dependency>
 
       <dependency>

--- a/tests/activemq5-unit-tests/src/main/java/org/apache/activemq/broker/artemiswrapper/ArtemisBrokerWrapper.java
+++ b/tests/activemq5-unit-tests/src/main/java/org/apache/activemq/broker/artemiswrapper/ArtemisBrokerWrapper.java
@@ -62,7 +62,7 @@ public class ArtemisBrokerWrapper extends ArtemisBrokerBase
       server.getConfiguration().getAcceptorConfigurations().clear();
       HashMap<String, Object> params = new HashMap<String, Object>();
       params.put(TransportConstants.PORT_PROP_NAME, "61616");
-      params.put(TransportConstants.PROTOCOLS_PROP_NAME, "OPENWIRE");
+      params.put(TransportConstants.PROTOCOLS_PROP_NAME, "OPENWIRE,CORE");
       TransportConfiguration transportConfiguration = new TransportConfiguration(NETTY_ACCEPTOR_FACTORY, params);
 
       Configuration serverConfig = server.getConfiguration();


### PR DESCRIPTION
Openwire test fix
    This test uses activemq5 native API to examine queue message count
    The fix uses core's QueueQuery API to do the job instead.

