### PR TITLE
[ARTEMIS-147] Add WARN log when setting connection-ttl OR connection-…

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -1525,9 +1525,6 @@ public final class FileConfigurationParser extends XMLConfigurationUtil
          }
       }
 
-      // Warn if connection-ttl-override/connection-ttl == check-period
-      compareTTLWithCheckPeriod(mainConfig, connectionTTL, clientFailureCheckPeriod);
-
       ClusterConnectionConfiguration config = new ClusterConnectionConfiguration()
          .setName(name)
          .setAddress(address)
@@ -1689,8 +1686,6 @@ public final class FileConfigurationParser extends XMLConfigurationUtil
          }
       }
 
-      // Warn if connection-ttl-override/connection-ttl == check-period
-      compareTTLWithCheckPeriod(mainConfig, connectionTTL, clientFailureCheckPeriod);
 
       BridgeConfiguration config = new BridgeConfiguration()
          .setName(name)
@@ -1810,14 +1805,5 @@ public final class FileConfigurationParser extends XMLConfigurationUtil
          .setFactoryClassName(clazz)
          .setParams(params)
          .setName(name);
-   }
-
-   private void compareTTLWithCheckPeriod(final Configuration config, final long connectionTTL, final long checkPeriod)
-   {
-      if (config.getConnectionTTLOverride() == checkPeriod)
-          ActiveMQServerLogger.LOGGER.connectionTTLEqualsCheckPeriod("connection-ttl-override", "check-period");
-
-      if (connectionTTL == checkPeriod)
-          ActiveMQServerLogger.LOGGER.connectionTTLEqualsCheckPeriod("connection-ttl", "check-period");
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1168,11 +1168,11 @@ public interface ActiveMQServerLogger extends BasicLogger
 
    @LogMessage(level = Logger.Level.WARN)
    @Message(id = 222202,
-           value = "<{0}> should not be set to the same value as <{1}>.  " +
-                   "If a system is under high load, or there is a minor network delay, " +
-                   "there is a high probability of a cluster split/failure due to connection timeout.",
-           format = Message.Format.MESSAGE_FORMAT)
-   void connectionTTLEqualsCheckPeriod(String ttl, String checkPeriod);
+      value = "{0}: <{1}> should not be set to the same value as <{2}>.  " +
+         "If a system is under high load, or there is a minor network delay, " +
+         "there is a high probability of a cluster split/failure due to connection timeout.",
+      format = Message.Format.MESSAGE_FORMAT)
+   void connectionTTLEqualsCheckPeriod(String connectionName, String ttl, String checkPeriod);
 
    @LogMessage(level = Logger.Level.ERROR)
    @Message(id = 224000, value = "Failure in initialisation", format = Message.Format.MESSAGE_FORMAT)

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -316,6 +316,11 @@ public class ActiveMQServerImpl implements ActiveMQServer
       {
          configuration = new ConfigurationImpl();
       }
+      else
+      {
+         ConfigurationUtils.validateConfiguration(configuration);
+      }
+
       if (mbeanServer == null)
       {
          // Just use JVM mbean server


### PR DESCRIPTION
…ttl-override equal to check-period.

Now works when ARTEMIS is deployed in an application server as well as standalone.