### PR TITLE
Downgrade Paho SNAPSHOT dep to latest release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
          <dependency>
             <groupId>org.eclipse.paho</groupId>
             <artifactId>mqtt-client</artifactId>
-            <version>0.4.1-SNAPSHOT</version>
+            <version>0.4.0</version>
             <scope>test</scope>
             <!-- Eclipse Public License - v 1.0 -->
          </dependency>

--- a/tests/integration-tests/pom.xml
+++ b/tests/integration-tests/pom.xml
@@ -36,9 +36,9 @@
        <!-- for the paho dependency -->
        <repository>
            <id>eclipse.m2</id>
-           <url>https://repo.eclipse.org/content/groups/snapshots/</url>
-           <releases><enabled>false</enabled></releases>
-           <snapshots><enabled>true</enabled></snapshots>
+           <url>https://repo.eclipse.org/content/repositories/paho-releases/</url>
+           <releases><enabled>true</enabled></releases>
+           <snapshots><enabled>false</enabled></snapshots>
        </repository>
    </repositories>
 


### PR DESCRIPTION
We now support MQTT v3.1 protocol name, so we can remove this snapshot dep.