### PR TITLE
Checkstyle updates

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/utils/SoftValueHashMap.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/utils/SoftValueHashMap.java
@@ -50,7 +50,7 @@ public class SoftValueHashMap<K, V extends SoftValueHashMap.ValueCache> implemen
 
    // Static --------------------------------------------------------
 
-   public abstract interface ValueCache {
+   public interface ValueCache {
 
       boolean isLive();
    }

--- a/etc/checkstyle-suppressions.xml
+++ b/etc/checkstyle-suppressions.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<!DOCTYPE suppressions PUBLIC
+        "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+        "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<!-- http://checkstyle.sourceforge.net/config.html#SuppressionFilter -->
+<suppressions>
+
+   <!-- Suppress unfixable violations in JavaCC generated sources -->
+   <suppress checks="Indentation|Whitespace|Curly|Modifier|AvoidStarImport|EmptyStatement|ArrayTypeStyle|RegexpSingleline" files="[\\/]generated-sources[\\/]javacc[\\/]"/>
+
+</suppressions>

--- a/etc/checkstyle.xml
+++ b/etc/checkstyle.xml
@@ -23,7 +23,7 @@ under the License.
         "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
         "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 
-<!-- See http://checkstyle.sourceforge.net/availablechecks.html for documentation on available checks -->
+<!-- See http://checkstyle.sourceforge.net/checks.html for documentation on available checks -->
 <module name="Checker">
    <!-- Checks to see if a file contains a tab character. -->
    <module name="FileTabCharacter">

--- a/etc/checkstyle.xml
+++ b/etc/checkstyle.xml
@@ -20,8 +20,8 @@ under the License.
 -->
 
 <!DOCTYPE module PUBLIC
-        "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
-        "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 
 <!-- See http://checkstyle.sourceforge.net/checks.html for documentation on available checks -->
 <module name="Checker">

--- a/etc/checkstyle.xml
+++ b/etc/checkstyle.xml
@@ -54,10 +54,6 @@ under the License.
       <module name="EqualsHashCode"/>
       <!-- Checks for illegal instantiations where a factory method is preferred. -->
       <module name="IllegalInstantiation"/>
-      <!-- Checks for redundant exceptions declared in throws clause such as duplicates, unchecked exceptions or subclasses of another declared exception. -->
-      <module name="RedundantThrows">
-         <property name="allowUnchecked" value="true"/>
-      </module>
 
       <!-- Checks that long constants are defined with an upper ell. -->
       <module name="UpperEll"/>
@@ -90,6 +86,8 @@ under the License.
          <property name="basicOffset" value="3"/>
          <property name="caseIndent" value="3"/>
          <property name="throwsIndent" value="3"/>
+         <property name="arrayInitIndent" value="3"/>
+         <property name="lineWrappingIndentation" value="3"/>
       </module>
 
        <module name="IllegalImport">

--- a/pom.xml
+++ b/pom.xml
@@ -910,7 +910,7 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>2.12</version>
+            <version>2.16</version>
             <dependencies>
                <!-- This was initially done to enforce name on Parameter annotation
                     I've developed a customized check and I needed this jar to deploy the specialized checkstyle -->
@@ -1014,7 +1014,7 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>2.12</version>
+            <version>2.16</version>
             <configuration>
                <configLocation>${activemq.basedir}/etc/checkstyle.xml</configLocation>
                <failsOnError>false</failsOnError>

--- a/pom.xml
+++ b/pom.xml
@@ -924,6 +924,7 @@
             <configuration>
                <skip>${skipStyleCheck}</skip>
                <configLocation>${activemq.basedir}/etc/checkstyle.xml</configLocation>
+               <suppressionsLocation>${activemq.basedir}/etc/checkstyle-suppressions.xml</suppressionsLocation>
                <failsOnError>false</failsOnError>
                <failOnViolation>true</failOnViolation>
                <consoleOutput>true</consoleOutput>

--- a/tests/activemq5-unit-tests/pom.xml
+++ b/tests/activemq5-unit-tests/pom.xml
@@ -357,7 +357,7 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>2.12</version>
+            <version>2.16</version>
             <configuration>
                <skip>true</skip>
             </configuration>


### PR DESCRIPTION
This PR updates maven-checkstyle-plugin to 2.16 which brings in checkstyle 6.2, and contains some related tweaks and fixes here and there.

Among the obvious things this removes one source of pain when using Eclipse to work on Artemis -- Eclipse has quite a new checkstyle installed which didn't work with the old configuration that Artemis had.