### PR TITLE
Exclude an activemq5 openwire test that purely tests on client side

### DIFF
--- a/tests/activemq5-unit-tests/pom.xml
+++ b/tests/activemq5-unit-tests/pom.xml
@@ -402,6 +402,8 @@
                   <!-- exclude tests that can cause hang -->
                   <exclude>**/org/apache/activemq/PerDestinationStoreLimitTest.java</exclude>
                   <exclude>**/org/apache/activemq/ProducerFlowControlTest.java</exclude>
+                  <!-- exclude tests that are on client side only -->
+                  <exclude>**/org/apache/activemq/transport/tcp/TransportConnectorInvalidSocketOptionsTest.java</exclude>
                </excludes>
             </configuration>
          </plugin>


### PR DESCRIPTION
The tests are all test client side behavior, not relevant to broker functionalities.