### PR TITLE
Pass JNDI name in XARecoveryConfig

### DIFF
--- a/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/bridge/impl/JMSBridgeImpl.java
+++ b/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/bridge/impl/JMSBridgeImpl.java
@@ -891,7 +891,7 @@ public final class JMSBridgeImpl implements JMSBridge {
       Object cf = cff.createConnectionFactory();
 
       if (cf instanceof ActiveMQConnectionFactory && registry != null) {
-         registry.register(XARecoveryConfig.newConfig((ActiveMQConnectionFactory) cf, username, password));
+         registry.register(XARecoveryConfig.newConfig((ActiveMQConnectionFactory) cf, username, password, null));
       }
 
       if (qualityOfServiceMode == QualityOfServiceMode.ONCE_AND_ONLY_ONCE && !(cf instanceof XAConnectionFactory)) {

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRAManagedConnectionFactory.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRAManagedConnectionFactory.java
@@ -26,7 +26,9 @@ import javax.resource.spi.ResourceAdapter;
 import javax.resource.spi.ResourceAdapterAssociation;
 import javax.security.auth.Subject;
 import java.io.PrintWriter;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
@@ -158,7 +160,10 @@ public final class ActiveMQRAManagedConnectionFactory implements ManagedConnecti
    private synchronized void registerRecovery() {
       if (recoveryConnectionFactory == null) {
          recoveryConnectionFactory = ra.createRecoveryActiveMQConnectionFactory(mcfProperties);
-         resourceRecovery = ra.getRecoveryManager().register(recoveryConnectionFactory, null, null);
+
+         Map<String, String> recoveryConfProps = new HashMap<String, String>();
+         recoveryConfProps.put(XARecoveryConfig.JNDI_NAME_PROPERTY_KEY, ra.getJndiName());
+         resourceRecovery = ra.getRecoveryManager().register(recoveryConnectionFactory, null, null, recoveryConfProps);
       }
    }
 

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
@@ -55,6 +55,7 @@ import org.apache.activemq.artemis.ra.inflow.ActiveMQActivationSpec;
 import org.apache.activemq.artemis.ra.recovery.RecoveryManager;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.service.extensions.ServiceUtils;
+import org.apache.activemq.artemis.service.extensions.xa.recovery.XARecoveryConfig;
 import org.apache.activemq.artemis.utils.SensitiveDataCodec;
 import org.jgroups.JChannel;
 
@@ -1545,7 +1546,10 @@ public class ActiveMQResourceAdapter implements ResourceAdapter, Serializable {
       raProperties.init();
       defaultActiveMQConnectionFactory = createActiveMQConnectionFactory(raProperties);
       recoveryActiveMQConnectionFactory = createRecoveryActiveMQConnectionFactory(raProperties);
-      recoveryManager.register(recoveryActiveMQConnectionFactory, raProperties.getUserName(), raProperties.getPassword());
+
+      Map<String, String> recoveryConfProps = new HashMap<String, String>();
+      recoveryConfProps.put(XARecoveryConfig.JNDI_NAME_PROPERTY_KEY, getJndiName());
+      recoveryManager.register(recoveryActiveMQConnectionFactory, raProperties.getUserName(), raProperties.getPassword(), recoveryConfProps);
    }
 
    public Map<ActivationSpec, ActiveMQActivation> getActivations() {

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQActivation.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQActivation.java
@@ -30,7 +30,9 @@ import javax.resource.spi.work.WorkManager;
 import javax.transaction.xa.XAResource;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
@@ -333,7 +335,9 @@ public class ActiveMQActivation {
          handler.start();
       }
 
-      resourceRecovery = ra.getRecoveryManager().register(factory, spec.getUser(), spec.getPassword());
+      Map<String, String> recoveryConfProps = new HashMap<String, String>();
+      recoveryConfProps.put(XARecoveryConfig.JNDI_NAME_PROPERTY_KEY, ra.getJndiName());
+      resourceRecovery = ra.getRecoveryManager().register(factory, spec.getUser(), spec.getPassword(), recoveryConfProps);
 
       ActiveMQRALogger.LOGGER.debug("Setup complete " + this);
    }

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/recovery/RecoveryManager.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/recovery/RecoveryManager.java
@@ -23,6 +23,7 @@ import org.apache.activemq.artemis.service.extensions.xa.recovery.ActiveMQRegist
 import org.apache.activemq.artemis.service.extensions.xa.recovery.XARecoveryConfig;
 import org.apache.activemq.artemis.utils.ConcurrentHashSet;
 
+import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
 
@@ -43,10 +44,10 @@ public final class RecoveryManager {
       }
    }
 
-   public XARecoveryConfig register(ActiveMQConnectionFactory factory, String userName, String password) {
+   public XARecoveryConfig register(ActiveMQConnectionFactory factory, String userName, String password,  Map<String, String> properties) {
       ActiveMQRALogger.LOGGER.debug("registering recovery for factory : " + factory);
 
-      XARecoveryConfig config = XARecoveryConfig.newConfig(factory, userName, password);
+      XARecoveryConfig config = XARecoveryConfig.newConfig(factory, userName, password, properties);
       resources.add(config);
       if (registry != null) {
          registry.register(config);

--- a/artemis-service-extensions/src/main/java/org/apache/activemq/artemis/service/extensions/xa/ActiveMQXAResourceWrapperImpl.java
+++ b/artemis-service-extensions/src/main/java/org/apache/activemq/artemis/service/extensions/xa/ActiveMQXAResourceWrapperImpl.java
@@ -49,8 +49,10 @@ public class ActiveMQXAResourceWrapperImpl implements ActiveMQXAResourceWrapper 
       //this.productVersion = VersionLoader.getVersion().getFullVersion();
       this.productVersion = (String) properties.get(ACTIVEMQ_PRODUCT_VERSION);
 
-      this.jndiNameNodeId = properties.get(ACTIVEMQ_JNDI_NAME) +
-         " NodeId:" + properties.get(ACTIVEMQ_NODE_ID);
+      String jndiName =  (String) properties.get(ACTIVEMQ_JNDI_NAME);
+      String nodeId = "NodeId:" + properties.get(ACTIVEMQ_NODE_ID);
+
+      this.jndiNameNodeId = jndiName == null ? nodeId : jndiName + " " + nodeId;
    }
 
    public XAResource getResource() {

--- a/artemis-service-extensions/src/main/java/org/apache/activemq/artemis/service/extensions/xa/recovery/ActiveMQXAResourceRecovery.java
+++ b/artemis-service-extensions/src/main/java/org/apache/activemq/artemis/service/extensions/xa/recovery/ActiveMQXAResourceRecovery.java
@@ -75,7 +75,7 @@ public class ActiveMQXAResourceRecovery {
          String username = parser.getUsername();
          String password = parser.getPassword();
          TransportConfiguration transportConfiguration = new TransportConfiguration(connectorFactoryClassName, connectorParams);
-         xaRecoveryConfigs[i] = new XARecoveryConfig(false, new TransportConfiguration[]{transportConfiguration}, username, password);
+         xaRecoveryConfigs[i] = new XARecoveryConfig(false, new TransportConfiguration[]{transportConfiguration}, username, password, null);
       }
 
       res = new ActiveMQXAResourceWrapper(xaRecoveryConfigs);

--- a/artemis-service-extensions/src/main/java/org/apache/activemq/artemis/service/extensions/xa/recovery/XARecoveryConfig.java
+++ b/artemis-service-extensions/src/main/java/org/apache/activemq/artemis/service/extensions/xa/recovery/XARecoveryConfig.java
@@ -17,6 +17,9 @@
 package org.apache.activemq.artemis.service.extensions.xa.recovery;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.activemq.artemis.api.core.DiscoveryGroupConfiguration;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
@@ -31,18 +34,21 @@ import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
  */
 public class XARecoveryConfig {
 
+   public static final String JNDI_NAME_PROPERTY_KEY = "JNDI_NAME";
+
    private final boolean ha;
    private final TransportConfiguration[] transportConfiguration;
    private final DiscoveryGroupConfiguration discoveryConfiguration;
    private final String username;
    private final String password;
+   private final Map<String, String> properties;
 
-   public static XARecoveryConfig newConfig(ActiveMQConnectionFactory factory, String userName, String password) {
+   public static XARecoveryConfig newConfig(ActiveMQConnectionFactory factory, String userName, String password, Map<String, String> properties) {
       if (factory.getServerLocator().getDiscoveryGroupConfiguration() != null) {
-         return new XARecoveryConfig(factory.getServerLocator().isHA(), factory.getServerLocator().getDiscoveryGroupConfiguration(), userName, password);
+         return new XARecoveryConfig(factory.getServerLocator().isHA(), factory.getServerLocator().getDiscoveryGroupConfiguration(), userName, password, properties);
       }
       else {
-         return new XARecoveryConfig(factory.getServerLocator().isHA(), factory.getServerLocator().getStaticTransportConfigurations(), userName, password);
+         return new XARecoveryConfig(factory.getServerLocator().isHA(), factory.getServerLocator().getStaticTransportConfigurations(), userName, password, properties);
       }
 
    }
@@ -50,23 +56,27 @@ public class XARecoveryConfig {
    public XARecoveryConfig(final boolean ha,
                            final TransportConfiguration[] transportConfiguration,
                            final String username,
-                           final String password) {
+                           final String password,
+                           final Map<String, String> properties) {
       this.transportConfiguration = transportConfiguration;
       this.discoveryConfiguration = null;
       this.username = username;
       this.password = password;
       this.ha = ha;
+      this.properties = properties == null ? Collections.unmodifiableMap(new HashMap<String, String>()) : Collections.unmodifiableMap(properties);
    }
 
    public XARecoveryConfig(final boolean ha,
                            final DiscoveryGroupConfiguration discoveryConfiguration,
                            final String username,
-                           final String password) {
+                           final String password,
+                           final Map<String, String> properties) {
       this.discoveryConfiguration = discoveryConfiguration;
       this.transportConfiguration = null;
       this.username = username;
       this.password = password;
       this.ha = ha;
+      this.properties = properties == null ? Collections.unmodifiableMap(new HashMap<String, String>()) : Collections.unmodifiableMap(properties);
    }
 
    public boolean isHA() {
@@ -87,6 +97,10 @@ public class XARecoveryConfig {
 
    public String getPassword() {
       return password;
+   }
+
+   public Map<String, String> getProperties() {
+      return properties;
    }
 
    /**
@@ -142,10 +156,18 @@ public class XARecoveryConfig {
     */
    @Override
    public String toString() {
-      return "XARecoveryConfig [transportConfiguration = " + Arrays.toString(transportConfiguration) +
-         ", discoveryConfiguration = " + discoveryConfiguration +
-         ", username=" +
-         username +
-         ", password=****]";
+      StringBuilder builder = new StringBuilder();
+
+      builder.append("XARecoveryConfig [transportConfiguration=" + Arrays.toString(transportConfiguration));
+      builder.append(", discoveryConfiguration=" + discoveryConfiguration);
+      builder.append(", username=" + username);
+      builder.append(", password=****");
+
+      for (Map.Entry<String, String> entry : properties.entrySet()) {
+         builder.append(", " + entry.getKey() + "=" + entry.getValue());
+      }
+      builder.append("]");
+
+      return builder.toString();
    }
 }


### PR DESCRIPTION
Some TX managers require JNDI name for recovery purposes.  This patch
passes JNDI name in RA to RecoveryRegistry implementations via
XARecoveryConfig objects.