### PR TITLE
Fix thread leak in test TransactionContextTest

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/amq/TransactionContextTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/amq/TransactionContextTest.java
@@ -35,6 +35,7 @@ public class TransactionContextTest extends BasicOpenWireTest {
 
    @Before
    public void setup() throws Exception {
+      connection.start();
       underTest = new TransactionContext(connection);
    }
 


### PR DESCRIPTION
  This leak happens with amq5.12.0. It didn't happen
  with amq5.11.1. Adding connection.start() can work
  around this seemingly 5.12.0 issue.