### PR TITLE
[ARTEMIS-220] Artemis RA does not close its connection factories when it is stopped.

### DIFF
--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
@@ -275,6 +275,9 @@ public class ActiveMQResourceAdapter implements ResourceAdapter, Serializable {
 
       managedConnectionFactories.clear();
 
+      for (ActiveMQConnectionFactory knownConnectionFactory : knownConnectionFactories.values()) {
+         knownConnectionFactory.close();
+      }
       knownConnectionFactories.clear();
 
       if (defaultActiveMQConnectionFactory != null) {


### PR DESCRIPTION
in stop(), close the knowConnectionFactories before clearing the collection.

JIRA: https://issues.apache.org/jira/browse/ARTEMIS-220