### PR TITLE
JAVA_HOME fix

### DIFF
--- a/artemis-distribution/src/main/resources/bin/artemis
+++ b/artemis-distribution/src/main/resources/bin/artemis
@@ -58,7 +58,7 @@ case "`uname`" in
     ;;
   Darwin*) darwin=true
     if [ -z "$JAVA_HOME" ] ; then
-     JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Home
+     JAVA_HOME=$(/usr/libexec/java_home)
     fi
     ;;
 esac


### PR DESCRIPTION
Putting the right JAVA_HOME correct attribution - Mac OS support, in order to fix:

Error: JAVA_HOME is not defined correctly.
  We cannot execute /System/Library/Frameworks/JavaVM.framework/Home/bin/java