### PR TITLE
JAVA_HOME fix at artemis-cli

### DIFF
--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis
@@ -64,7 +64,7 @@ case "`uname`" in
     ;;
   Darwin*) darwin=true
     if [ -z "$JAVA_HOME" ] ; then
-     JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Home
+     JAVA_HOME=$(/usr/libexec/java_home)
     fi
     ;;
 esac


### PR DESCRIPTION
After create a broker using main artemis script, this one needs to be created using JAVA_HOME environment correctly as well, otherwise the broker will be unable to find java_home. 
I did perform a search at the whole project and this is the only remaining place which needs to change the JAVA_HOME value at the script.