### PR TITLE
ARTEMIS-252 adding Retry methods on JMX interface

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/QueueControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/QueueControl.java
@@ -216,6 +216,28 @@ public interface QueueControl {
    @Operation(desc = "Remove the message corresponding to the given messageID", impact = MBeanOperationInfo.ACTION)
    boolean expireMessage(@Parameter(name = "messageID", desc = "A message ID") long messageID) throws Exception;
 
+
+   /**
+    * Retries the message corresponding to the given messageID to the original queue.
+    * This is appropriate on dead messages on Dead letter queues only.
+    *
+    * @param messageID
+    * @return {@code true} if the message was retried, {@code false} else
+    * @throws Exception
+    */
+   @Operation(desc = "Retry the message corresponding to the given messageID to the original queue", impact = MBeanOperationInfo.ACTION)
+   boolean retryMessage(@Parameter(name = "messageID", desc = "A message ID") long messageID) throws Exception;
+
+   /**
+    * Retries all messages on a DLQ to their respective original queues.
+    * This is appropriate on dead messages on Dead letter queues only.
+    *
+    * @return the number of retried messages.
+    * @throws Exception
+    */
+   @Operation(desc = "Retry all messages on a DLQ to their respective original queues", impact = MBeanOperationInfo.ACTION)
+   int retryMessages() throws Exception;
+
    /**
     * Moves the message corresponding to the specified message ID to the specified other queue.
     *

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/api/jms/management/JMSQueueControl.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/api/jms/management/JMSQueueControl.java
@@ -228,6 +228,27 @@ public interface JMSQueueControl extends DestinationControl {
                     @Parameter(name = "rejectDuplicates", desc = "Reject messages identified as duplicate by the duplicate message") boolean rejectDuplicates) throws Exception;
 
    /**
+    * Retries the message corresponding to the given messageID to the original queue.
+    * This is appropriate on dead messages on Dead letter queues only.
+    *
+    * @param messageID
+    * @return {@code true} if the message was retried, {@code false} else
+    * @throws Exception
+    */
+   @Operation(desc = "Retry the message corresponding to the given messageID to the original queue", impact = MBeanOperationInfo.ACTION)
+   boolean retryMessage(@Parameter(name = "messageID", desc = "A message ID") String messageID) throws Exception;
+
+   /**
+    * Retries all messages on a DLQ to their respective original queues.
+    * This is appropriate on dead messages on Dead letter queues only.
+    *
+    * @return the number of retried messages.
+    * @throws Exception
+    */
+   @Operation(desc = "Retry all messages on a DLQ to their respective original queues", impact = MBeanOperationInfo.ACTION)
+   int retryMessages() throws Exception;
+
+   /**
     * Lists the message counter for this queue.
     */
    @Operation(desc = "List the message counters", impact = MBeanOperationInfo.INFO)

--- a/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/management/impl/JMSQueueControlImpl.java
+++ b/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/management/impl/JMSQueueControlImpl.java
@@ -275,6 +275,25 @@ public class JMSQueueControlImpl extends StandardMBean implements JMSQueueContro
       return coreQueueControl.changeMessagesPriority(filter, newPriority);
    }
 
+   public boolean retryMessage(final String jmsMessageID) throws Exception {
+
+      // Figure out messageID from JMSMessageID.
+      final String filter = createFilterForJMSMessageID(jmsMessageID);
+      Map<String,Object>[] messages = coreQueueControl.listMessages(filter);
+      if ( messages.length != 1) { // if no messages. There should not be more than one, JMSMessageID should be unique.
+         return false;
+      }
+
+      final Map<String,Object> messageToRedeliver = messages[0];
+      Long messageID = (Long)messageToRedeliver.get("messageID");
+      return messageID != null && coreQueueControl.retryMessage(messageID);
+   }
+
+   public int retryMessages() throws Exception {
+      return coreQueueControl.retryMessages();
+   }
+
+
    public boolean moveMessage(final String messageID, final String otherQueueName) throws Exception {
       return moveMessage(messageID, otherQueueName, false);
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/management/JMSQueueControlUsingJMSTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/management/JMSQueueControlUsingJMSTest.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.tests.integration.jms.server.management;
 
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.apache.activemq.artemis.api.core.management.Parameter;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
 import org.apache.activemq.artemis.api.jms.JMSFactoryType;
@@ -169,6 +170,18 @@ public class JMSQueueControlUsingJMSTest extends JMSQueueControlTest {
 
          public String listMessageCounterHistory() throws Exception {
             return (String) proxy.invokeOperation("listMessageCounterHistory");
+         }
+
+         public boolean retryMessage(@Parameter(name = "messageID", desc = "A message ID") long messageID) throws Exception {
+            return (Boolean) proxy.invokeOperation("retryMessage",messageID);
+         }
+
+         public int retryMessages() throws Exception {
+            return (Integer) proxy.invokeOperation("retryMessages");
+         }
+
+         public boolean retryMessage(final String messageID) throws Exception {
+            return (Boolean) proxy.invokeOperation("retryMessage",messageID);
          }
 
          @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlUsingCoreTest.java
@@ -229,6 +229,14 @@ public class QueueControlUsingCoreTest extends QueueControlTest {
             return (Boolean) proxy.invokeOperation("moveMessage", messageID, otherQueueName, rejectDuplicates);
          }
 
+         public boolean retryMessage(final long messageID) throws Exception {
+            return (Boolean) proxy.invokeOperation("retryMessage", messageID);
+         }
+
+         public int retryMessages() throws Exception {
+            return (Integer) proxy.invokeOperation("retryMessages");
+         }
+
          public int removeMessages(final String filter) throws Exception {
             return (Integer) proxy.invokeOperation("removeMessages", filter);
          }


### PR DESCRIPTION
A short-cut to move messages from DLQ to original queue via JMX operations retryMessage( messageId ) for a single message and retryMessages() for all messages.

Operations added to both JMS queue MBean and Core queue MBean.

https://issues.apache.org/jira/browse/ARTEMIS-252