### PR TITLE
[ARTEMIS-294] Use doPriviledged block for ServiceLoader

### DIFF
--- a/artemis-service-extensions/src/test/java/org/apache/activemq/artemis/service/extensions/tests/xa/ServiceUtilsTest.java
+++ b/artemis-service-extensions/src/test/java/org/apache/activemq/artemis/service/extensions/tests/xa/ServiceUtilsTest.java
@@ -16,44 +16,20 @@
  */
 package org.apache.activemq.artemis.service.extensions.tests.xa;
 
-import java.lang.reflect.Field;
+import static org.jgroups.util.Util.assertTrue;
+
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.activemq.artemis.service.extensions.ServiceUtils;
-import org.apache.activemq.artemis.service.extensions.xa.ActiveMQXAResourceWrapperFactory;
-import org.apache.activemq.artemis.service.extensions.xa.ActiveMQXAResourceWrapperFactoryImpl;
 import org.junit.Test;
-
-import static org.jgroups.util.Util.assertTrue;
 
 public class ServiceUtilsTest {
 
    @Test
-   public void testSetActiveMQXAResourceWrapperFactorySetsDefaultImplWhenNoOther() throws Exception {
-      List<ActiveMQXAResourceWrapperFactory> factories = new ArrayList<ActiveMQXAResourceWrapperFactory>();
-
-      Method method = ServiceUtils.class.getDeclaredMethod("setActiveMQXAResourceWrapperFactory", Iterable.class);
+   public void testGetActiveMQXAResourceWrapperFactoryLoadsService() throws Exception {
+      Method method = ServiceUtils.class.getDeclaredMethod("getActiveMQXAResourceWrapperFactory");
       method.setAccessible(true);
-      method.invoke(null, factories);
-
-      Field field = ServiceUtils.class.getDeclaredField("activeMQXAResourceWrapperFactory");
-      field.setAccessible(true);
-      assertTrue(field.get(null) instanceof ActiveMQXAResourceWrapperFactoryImpl);
-   }
-
-   @Test
-   public void testSetActiveMQXAResourceWrapperFactorySetsExtensionImplWhenSupplied() throws Exception {
-      List<ActiveMQXAResourceWrapperFactory> factories = new ArrayList<ActiveMQXAResourceWrapperFactory>();
-      factories.add(new MockActiveMQResourceWrapperFactory());
-
-      Method method = ServiceUtils.class.getDeclaredMethod("setActiveMQXAResourceWrapperFactory", Iterable.class);
-      method.setAccessible(true);
-      method.invoke(null, factories);
-
-      Field field = ServiceUtils.class.getDeclaredField("activeMQXAResourceWrapperFactory");
-      field.setAccessible(true);
-      assertTrue(field.get(null) instanceof MockActiveMQResourceWrapperFactory);
+      Object o = method.invoke(null);
+      assertTrue(o instanceof MockActiveMQResourceWrapperFactory);
    }
 }

--- a/artemis-service-extensions/src/test/resources/META-INF/services/org.apache.activemq.artemis.service.extensions.xa.ActiveMQXAResourceWrapperFactory
+++ b/artemis-service-extensions/src/test/resources/META-INF/services/org.apache.activemq.artemis.service.extensions.xa.ActiveMQXAResourceWrapperFactory
@@ -1,0 +1,1 @@
+org.apache.activemq.artemis.service.extensions.tests.xa.MockActiveMQResourceWrapperFactory


### PR DESCRIPTION
In ServiceUtils, loads services from an AccessController.doPriviledged
block and use the ServiceUtils's own classloader instead of the TCCL
(that may be different depending on who's requesting a managed
connection factory first)

JIRA: https://issues.apache.org/jira/browse/ARTEMIS-294