### PR TITLE
ARTEMIS-297 Including acceptor name on logs

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMAcceptor.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMAcceptor.java
@@ -66,11 +66,17 @@ public final class InVMAcceptor implements Acceptor {
 
    private final long connectionsAllowed;
 
-   public InVMAcceptor(final ClusterConnection clusterConnection,
+   private final String name;
+
+   public InVMAcceptor(final String name,
+                       final ClusterConnection clusterConnection,
                        final Map<String, Object> configuration,
                        final BufferHandler handler,
                        final ConnectionLifeCycleListener listener,
                        final Executor threadPool) {
+
+      this.name = name;
+
       this.clusterConnection = clusterConnection;
 
       this.configuration = configuration;
@@ -84,6 +90,10 @@ public final class InVMAcceptor implements Acceptor {
       executorFactory = new OrderedExecutorFactory(threadPool);
 
       connectionsAllowed = ConfigurationHelper.getLongProperty(TransportConstants.CONNECTIONS_ALLOWED, TransportConstants.DEFAULT_CONNECTIONS_ALLOWED, configuration);
+   }
+
+   public String getName() {
+      return name;
    }
 
    public Map<String, Object> getConfiguration() {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMAcceptorFactory.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMAcceptorFactory.java
@@ -37,6 +37,6 @@ public class InVMAcceptorFactory implements AcceptorFactory {
                                   final Executor threadPool,
                                   final ScheduledExecutorService scheduledThreadPool,
                                   final Map<String, ProtocolManager> protocolHandler) {
-      return new InVMAcceptor(clusterConnection, configuration, handler, listener, threadPool);
+      return new InVMAcceptor(name, clusterConnection, configuration, handler, listener, threadPool);
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptor.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptor.java
@@ -411,6 +411,10 @@ public class NettyAcceptor implements Acceptor {
       }
    }
 
+   public String getName() {
+      return name;
+   }
+
    /**
     * Transfers the Netty channel that has been created outside of this NettyAcceptor
     * to control it and configure it according to this NettyAcceptor setting.

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/server/impl/RemotingServiceImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/server/impl/RemotingServiceImpl.java
@@ -304,7 +304,7 @@ public class RemotingServiceImpl implements RemotingService, ConnectionLifeCycle
             acceptor.pause();
          }
          catch (Exception e) {
-            ActiveMQServerLogger.LOGGER.errorStoppingAcceptor();
+            ActiveMQServerLogger.LOGGER.errorStoppingAcceptor(acceptor.getName());
          }
       }
    }
@@ -351,7 +351,7 @@ public class RemotingServiceImpl implements RemotingService, ConnectionLifeCycle
             acceptor.pause();
          }
          catch (Throwable t) {
-            ActiveMQServerLogger.LOGGER.errorStoppingAcceptor();
+            ActiveMQServerLogger.LOGGER.errorStoppingAcceptor(acceptor.getName());
          }
 
       }
@@ -379,7 +379,7 @@ public class RemotingServiceImpl implements RemotingService, ConnectionLifeCycle
             acceptor.stop();
          }
          catch (Throwable t) {
-            ActiveMQServerLogger.LOGGER.errorStoppingAcceptor();
+            ActiveMQServerLogger.LOGGER.errorStoppingAcceptor(acceptor.getName());
          }
       }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1292,8 +1292,8 @@ public interface ActiveMQServerLogger extends BasicLogger {
    void errorWritingToInvmConnector(@Cause Exception e, Runnable runnable);
 
    @LogMessage(level = Logger.Level.ERROR)
-   @Message(id = 224028, value = "Failed to stop acceptor", format = Message.Format.MESSAGE_FORMAT)
-   void errorStoppingAcceptor();
+   @Message(id = 224028, value = "Failed to stop accepto {0}r", format = Message.Format.MESSAGE_FORMAT)
+   void errorStoppingAcceptor(String name);
 
    @LogMessage(level = Logger.Level.ERROR)
    @Message(id = 224029, value = "large message sync: largeMessage instance is incompatible with it, ignoring data", format = Message.Format.MESSAGE_FORMAT)

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/remoting/Acceptor.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/remoting/Acceptor.java
@@ -29,6 +29,10 @@ import org.apache.activemq.artemis.core.server.management.NotificationService;
  */
 public interface Acceptor extends ActiveMQComponent {
 
+   /** The name of the acceptor used on the configuration.
+    *  for logging and debug purposes. */
+   String getName();
+
    /**
     * Pause the acceptor and stop it from receiving client requests.
     */

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/AcceptorsTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/AcceptorsTest.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.tests.unit.core.remoting.server.impl.fake.FakeAcceptorFactory;
 import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 
@@ -32,7 +33,7 @@ public class AcceptorsTest extends ActiveMQTestBase {
    @Test
    public void testMultipleAcceptorsWithSameHostPortDifferentName() throws Exception
    {
-      final String acceptorFactoryClass = "org.apache.activemq.artemis.tests.unit.core.remoting.server.impl.fake.FakeAcceptorFactory";
+      final String acceptorFactoryClass = FakeAcceptorFactory.class.getName();
 
       Map<String, Object> params = new HashMap<>();
       params.put("host", "localhost");

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/server/impl/fake/FakeAcceptorFactory.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/server/impl/fake/FakeAcceptorFactory.java
@@ -47,6 +47,10 @@ public class FakeAcceptorFactory implements AcceptorFactory {
 
    private final class FakeAcceptor implements Acceptor {
 
+      public String getName() {
+         return "fake";
+      }
+
       @Override
       public void pause() {
 


### PR DESCRIPTION
This is just so users will know the name of the acceptor that had the issue on logs