### PR TITLE
Use .equals for string compare in LDAPLoginModule

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/jaas/LDAPLoginModule.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/jaas/LDAPLoginModule.java
@@ -489,14 +489,14 @@ public class LDAPLoginModule implements LoginModule {
 
    private String getLDAPPropertyValue(String propertyName) {
       for (int i = 0; i < config.length; i++)
-         if (config[i].getPropertyName() == propertyName)
+         if (config[i].getPropertyName().equals(propertyName))
             return config[i].getPropertyValue();
       return null;
    }
 
    private boolean isLoginPropertySet(String propertyName) {
       for (int i = 0; i < config.length; i++) {
-         if (config[i].getPropertyName() == propertyName && (config[i].getPropertyValue() != null && !"".equals(config[i].getPropertyValue())))
+         if (config[i].getPropertyName().equals(propertyName) && (config[i].getPropertyValue() != null && !"".equals(config[i].getPropertyValue())))
             return true;
       }
       return false;


### PR DESCRIPTION
String#equals implementations generally do a object reference == before anything else.  So there is no performance gain in doing == Strings in our codebase.  See: http://hg.openjdk.java.net/jdk7/jdk7/jdk/file/9b8c96f96a0f/src/share/classes/java/lang/String.java#l1013

This patch replaces String== with .equals, which removes compile warnings and is less brittle.
