### PR TITLE
ARTEMIS-307 JMSIndividualAckTest#testAckedMessageAreConsumed fails on slower machines

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/amq/JMSIndividualAckTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/amq/JMSIndividualAckTest.java
@@ -49,7 +49,7 @@ public class JMSIndividualAckTest extends BasicOpenWireTest {
 
       // Consume the message...
       MessageConsumer consumer = session.createConsumer(queue);
-      Message msg = consumer.receive(1000);
+      Message msg = consumer.receive(5000);
       assertNotNull(msg);
       msg.acknowledge();
 


### PR DESCRIPTION
The issue is solved by increasing timeout in consumer.receive method.