### PR TITLE
ARTEMIS-93 Add default config to feature

### DIFF
--- a/artemis-features/pom.xml
+++ b/artemis-features/pom.xml
@@ -68,6 +68,15 @@
 									<file>target/classes/features.xml</file>
 									<type>xml</type>
 								</artifact>
+								<artifact>
+									<file>target/classes/artemis.xml</file>
+									<classifier>artemis</classifier>
+									<type>xml</type>
+								</artifact>
+								<artifact>
+									<file>target/classes/org.apache.activemq.artemis.cfg</file>
+									<type>cfg</type>
+								</artifact>
 							</artifacts>
 						</configuration>
 					</execution>

--- a/artemis-features/src/main/resources/artemis.xml
+++ b/artemis-features/src/main/resources/artemis.xml
@@ -1,0 +1,91 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration xmlns="urn:activemq"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+
+   <jms xmlns="urn:activemq:jms">
+      <queue name="DLQ"/>
+      <queue name="ExpiryQueue"/>
+   </jms>
+
+   <core xmlns="urn:activemq:core">
+
+      <!-- this could be ASYNCIO or NIO -->
+      <journal-type>NIO</journal-type>
+      <paging-directory>./data/paging</paging-directory>
+      <bindings-directory>./data/bindings</bindings-directory>
+      <journal-directory>./data/journal</journal-directory>
+      <large-messages-directory>./data/large-messages</large-messages-directory>
+      <journal-min-files>10</journal-min-files>
+
+      <!--
+       This value was determined through a calculation.
+       Your system could perform 0.63 writes per millisecond
+       on the current journal configuration.
+       That translates as a sync write every 1591999 nanoseconds
+      -->
+      <journal-buffer-timeout>1591999</journal-buffer-timeout>
+
+      <acceptors>
+         <!-- Default ActiveMQ Artemis Acceptor.  Multi-protocol adapter.  Currently supports Core, OpenWire, Stomp and AMQP. -->
+         <!-- performance tests have shown that openWire performs best with these buffer sizes -->
+         <acceptor name="artemis">tcp://0.0.0.0:61616?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576</acceptor>
+
+         <!-- AMQP Acceptor.  Listens on default AMQP port for AMQP traffic.-->
+         <acceptor name="amqp">tcp://0.0.0.0:5672?protocols=AMQP</acceptor>
+
+         <!-- STOMP Acceptor. -->
+         <acceptor name="stomp">tcp://0.0.0.0:61613?protocols=STOMP</acceptor>
+
+         <!-- HornetQ Compatibility Acceptor.  Enables ActiveMQ Artemis Core and STOMP for legacy HornetQ clients. -->
+         <acceptor name="hornetq">tcp://0.0.0.0:5445?protocols=HORNETQ,STOMP</acceptor>
+
+         <!-- MQTT Acceptor -->
+         <acceptor name="mqtt">tcp://0.0.0.0:1883?protocols=MQTT</acceptor>
+      </acceptors>
+
+      <security-settings>
+         <security-setting match="#">
+            <permission type="createNonDurableQueue" roles="amq"/>
+            <permission type="deleteNonDurableQueue" roles="amq"/>
+            <permission type="createDurableQueue" roles="amq"/>
+            <permission type="deleteDurableQueue" roles="amq"/>
+            <permission type="consume" roles="amq"/>
+            <permission type="send" roles="amq"/>
+            <!-- we need this otherwise ./artemis data imp wouldn't work -->
+            <permission type="manage" roles="amq"/>
+         </security-setting>
+      </security-settings>
+
+      <address-settings>
+         <!--default for catch all-->
+         <address-setting match="#">
+            <dead-letter-address>jms.queue.DLQ</dead-letter-address>
+            <expiry-address>jms.queue.ExpiryQueue</expiry-address>
+            <redelivery-delay>0</redelivery-delay>
+            <max-size-bytes>10485760</max-size-bytes>
+            <message-counter-history-day-limit>10</message-counter-history-day-limit>
+            <address-full-policy>BLOCK</address-full-policy>
+         </address-setting>
+      </address-settings>
+   </core>
+</configuration>

--- a/artemis-features/src/main/resources/features.xml
+++ b/artemis-features/src/main/resources/features.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one or more
   ~ contributor license agreements. See the NOTICE file distributed with
@@ -14,7 +15,6 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<?xml version="1.0" encoding="UTF-8"?>
 <features name="artemis-${pom.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.3.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
@@ -31,6 +31,9 @@
 		<feature>transaction</feature>
 		<feature>netty-core</feature>
 		<feature>scr</feature>
+		<configfile finalname="etc/org.apache.activemq.artemis.cfg">mvn:org.apache.activemq/artemis-features/${pom.version}/cfg</configfile>
+		<configfile finalname="etc/artemis.xml">mvn:org.apache.activemq/artemis-features/${pom.version}/xml/artemis</configfile>
+		
 		<bundle>mvn:org.apache.geronimo.specs/geronimo-jms_2.0_spec/${geronimo.jms.2.spec.version}</bundle>
 		<bundle>mvn:com.google.guava/guava/18.0</bundle>
 		<bundle>mvn:io.netty/netty-codec-http/${netty.version}</bundle>
@@ -38,8 +41,6 @@
 		<bundle>mvn:commons-collections/commons-collections/3.2.1</bundle>
 
 		<bundle>mvn:org.jboss.logging/jboss-logging/3.1.4.GA</bundle>
-		<!-- <bundle>wrap:mvn:org.jboss.modules/jboss-modules/1.3.1.Final</bundle> -->
-		<!-- <bundle>mvn:org.jboss.logmanager/jboss-logmanager/1.5.3.Final</bundle>-->
 		<bundle>mvn:org.jgroups/jgroups/3.6.0.Final</bundle>
 
 		<bundle>mvn:org.apache.activemq/artemis-native/${pom.version}</bundle>

--- a/artemis-features/src/main/resources/org.apache.activemq.artemis.cfg
+++ b/artemis-features/src/main/resources/org.apache.activemq.artemis.cfg
@@ -1,0 +1,3 @@
+config=file:etc/artemis.xml
+name=local
+domain=local

--- a/pom.xml
+++ b/pom.xml
@@ -1053,6 +1053,7 @@
                   <exclude>**/.checkstyle</exclude>
                   <exclude>**/.factorypath</exclude>
                   <exclude>ratReport.txt</exclude>
+                  <exclude>**/org.apache.activemq.artemis.cfg</exclude>
                   <!-- activemq5 unit tests exclude -->
                   <exclude>**/*.data</exclude>
                   <exclude>**/*.bin</exclude>


### PR DESCRIPTION
Adds default configs to the feature so a broker is created automatically when the feature is installed.
This also fixes a bug in the feature file I introduced by placing the license header in the wrong position.