### PR TITLE
ARTEMIS-318 use profile JAVA_ARGS only for 'run'

### DIFF
--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis
@@ -105,6 +105,11 @@ if $cygwin ; then
   CLASSPATH=`cygpath --windows "$CLASSPATH"`
 fi
 
+# Empty JAVA_ARGS unless the command is 'run' or 'data'. See https://issues.apache.org/jira/browse/ARTEMIS-318.
+if [ $1 != "run" -a $1 != "data" ]; then
+  JAVA_ARGS=""
+fi
+
 exec "$JAVACMD" $JAVA_ARGS $ARTEMIS_CLUSTER_PROPS \
     -classpath "$CLASSPATH" \
     -Dartemis.home="$ARTEMIS_HOME" \


### PR DESCRIPTION
I'm not sure this is the best solution, but it has the benefit of being really simple and it solves the problem outlined in ARTEMIS-318. My only other thought here would be to use a profile per command (e.g. artemis-run.profile, artemis-stop.profile, etc.).