### PR TITLE
ARTEMIS-311 - added broker name to jmx object name properties.

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
@@ -91,6 +91,9 @@ public class Create extends InputAbstract {
    @Option(name = "--host", description = "The host name of the broker (Default: 0.0.0.0 or input if clustered)")
    String host;
 
+   @Option(name = "--name", description = "The name of the broker (Default: same as host)")
+   String name;
+
    @Option(name = "--port-offset", description = "Off sets the default ports")
    int portOffset;
 
@@ -512,9 +515,13 @@ public class Create extends InputAbstract {
 
       if (clustered) {
          filters.put("${host}", getHostForClustered());
+         if (name == null) {
+            name = getHostForClustered();
+         }
          String connectorSettings = readTextFile(ETC_CONNECTOR_SETTINGS_TXT);
          connectorSettings = applyFilters(connectorSettings, filters);
 
+         filters.put("${name}", name);
          filters.put("${connector-config.settings}", connectorSettings);
          filters.put("${cluster-security.settings}", readTextFile(ETC_CLUSTER_SECURITY_SETTINGS_TXT));
          filters.put("${cluster.settings}", applyFilters(readTextFile(ETC_CLUSTER_SETTINGS_TXT), filters));
@@ -522,6 +529,10 @@ public class Create extends InputAbstract {
          filters.put("${cluster-password}", getClusterPassword());
       }
       else {
+         if (name == null) {
+            name = getHost();
+         }
+         filters.put("${name}", name);
          filters.put("${host}", getHost());
          filters.put("${connector-config.settings}", "");
          filters.put("${cluster-security.settings}", "");

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/broker.xml
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/broker.xml
@@ -29,6 +29,8 @@ under the License.
 
    <core xmlns="urn:activemq:core">
 
+      <name>${name}</name>
+
       <persistence-enabled>${persistence-enabled}</persistence-enabled>
 
       <!-- this could be ASYNCIO or NIO

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
@@ -175,6 +175,9 @@ public final class ActiveMQDefaultConfiguration {
    // the JMX domain used to registered ActiveMQ Artemis MBeans in the MBeanServer
    private static String DEFAULT_JMX_DOMAIN = "org.apache.activemq.artemis";
 
+   // the JMX domain used to registered ActiveMQ Artemis MBeans in the MBeanServer
+   private static boolean DEFAULT_JMX_IS_USE_BROKER_NAME = true;
+
    // true means that message counters are enabled
    private static boolean DEFAULT_MESSAGE_COUNTER_ENABLED = false;
 
@@ -517,6 +520,10 @@ public final class ActiveMQDefaultConfiguration {
     */
    public static String getDefaultJmxDomain() {
       return DEFAULT_JMX_DOMAIN;
+   }
+
+   public static boolean isDefaultJMXUseBrokerName() {
+      return DEFAULT_JMX_IS_USE_BROKER_NAME;
    }
 
    /**

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
@@ -25,6 +25,7 @@ import org.apache.activemq.artemis.api.core.BroadcastGroupConfiguration;
 import org.apache.activemq.artemis.api.core.DiscoveryGroupConfiguration;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
 import org.apache.activemq.artemis.core.security.Role;
 import org.apache.activemq.artemis.core.server.JournalType;
 import org.apache.activemq.artemis.core.server.SecuritySettingPlugin;
@@ -193,6 +194,16 @@ public interface Configuration {
     * the same JVM and all servers are using the same MBeanServer.
     */
    Configuration setJMXDomain(String domain);
+
+  /**
+   * whether or not to use the broker name in the JMX tree
+   * */
+   boolean isJMXUseBrokerName();
+
+   /**
+    * whether or not to use the broker name in the JMX tree
+    * */
+   ConfigurationImpl setJMXUseBrokerName(boolean jmxUseBrokerName);
 
    /**
     * Returns the list of interceptors classes used by this server for incoming messages (i.e. those being delivered to

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
@@ -65,7 +65,7 @@ public class ConfigurationImpl implements Configuration, Serializable {
 
    // Attributes -----------------------------------------------------------------------------
 
-   private String name = "ConfigurationImpl::" + System.identityHashCode(this);
+   private String name = "localhost";
 
    private boolean persistenceEnabled = ActiveMQDefaultConfiguration.isDefaultPersistenceEnabled();
 
@@ -88,6 +88,8 @@ public class ConfigurationImpl implements Configuration, Serializable {
    protected boolean jmxManagementEnabled = ActiveMQDefaultConfiguration.isDefaultJmxManagementEnabled();
 
    protected String jmxDomain = ActiveMQDefaultConfiguration.getDefaultJmxDomain();
+
+   protected boolean jmxUseBrokerName =  ActiveMQDefaultConfiguration.isDefaultJMXUseBrokerName();
 
    protected long connectionTTLOverride = ActiveMQDefaultConfiguration.getDefaultConnectionTtlOverride();
 
@@ -856,6 +858,17 @@ public class ConfigurationImpl implements Configuration, Serializable {
    @Override
    public ConfigurationImpl setJMXDomain(final String domain) {
       jmxDomain = domain;
+      return this;
+   }
+
+   @Override
+   public boolean isJMXUseBrokerName() {
+      return jmxUseBrokerName;
+   }
+
+   @Override
+   public ConfigurationImpl setJMXUseBrokerName(boolean jmxUseBrokerName) {
+      this.jmxUseBrokerName = jmxUseBrokerName;
       return this;
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -232,6 +232,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
       config.setJMXDomain(getString(e, "jmx-domain", config.getJMXDomain(), Validators.NOT_NULL_OR_EMPTY));
 
+      config.setJMXUseBrokerName(getBoolean(e, "jmx-use-broker-name", config.isJMXUseBrokerName()));
+
       config.setSecurityInvalidationInterval(getLong(e, "security-invalidation-interval", config.getSecurityInvalidationInterval(), Validators.GT_ZERO));
 
       config.setConnectionTTLOverride(getLong(e, "connection-ttl-override", config.getConnectionTTLOverride(), Validators.MINUS_ONE_OR_GT_ZERO));

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/impl/ManagementServiceImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/impl/ManagementServiceImpl.java
@@ -142,7 +142,7 @@ public class ManagementServiceImpl implements ManagementService {
       registry = new ConcurrentHashMap<>();
       broadcaster = new NotificationBroadcasterSupport();
       notificationsEnabled = true;
-      objectNameBuilder = ObjectNameBuilder.create(configuration.getJMXDomain());
+      objectNameBuilder = ObjectNameBuilder.create(configuration.getJMXDomain(), configuration.getName(), configuration.isJMXUseBrokerName());
    }
 
    // Public --------------------------------------------------------

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -197,6 +197,14 @@
             </xsd:annotation>
          </xsd:element>
 
+         <xsd:element name="jmx-use-broker-name" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+              <xsd:documentation>
+                 Whether or not to use the broker name in the JMX properties
+              </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
          <xsd:element name="message-counter-enabled" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
             <xsd:annotation>
                <xsd:documentation>

--- a/docs/user-manual/en/management.md
+++ b/docs/user-manual/en/management.md
@@ -25,6 +25,16 @@ JMS messages.
 This choice depends on your requirements, your application settings and
 your environment to decide which way suits you best.
 
+
+
+## Object name changes between versions 1.1 and 2
+
+In version 1.2 of Artemis new properties were added to distinguish object names when multiple brokers were deploiyed in 
+the same JVM and to be more like ActiveMQ 5. so for the server the name changed from `org.apache.activemq.artemis:module=Core,type=Server`
+to `org.apache.activemq.artemis:type=Broker,brokerName=<broker name>,module=Core,ServerType=Server`. you can configure 
+the old style by setting `<jmx-use-broker-name>false</jmx-use-broker-name>`. Note that if you do not set a broker name
+then this will default to localhost.
+
 ## The Management API
 
 Regardless of the way you *invoke* management operations, the management
@@ -66,7 +76,7 @@ full details of the API please consult the javadoc. In summary:
     Core queues can be created or destroyed using the management
     operations `createQueue()` or `deployQueue()` or `destroyQueue()`)on
     the `ActiveMQServerControl` (with the ObjectName
-    `org.apache.activemq.artemis:module=Core,type=Server` or the resource name
+    `org.apache.activemq.artemis:type=Broker,brokerName=<broker name>,module=Core,serviceType=Server` or the resource name
     `core.server`)
 
     `createQueue` will fail if the queue already exists while
@@ -133,7 +143,7 @@ full details of the API please consult the javadoc. In summary:
     any currently attached clients.
 
     to do this use the `forceFailover()` on the `ActiveMQServerControl`
-    (with the ObjectName `org.apache.activemq.artemis:module=Core,type=Server`
+    (with the ObjectName `org.apache.activemq.artemis:type=Broker,brokerName=<broker name>,module=Core,serviceType=Server`
     or the resource name `core.server`)
 
     > **Note**
@@ -145,7 +155,7 @@ full details of the API please consult the javadoc. In summary:
 #### Core Address Management
 
 Core addresses can be managed using the `AddressControl` class (with the
-ObjectName `org.apache.activemq.artemis:module=Core,type=Address,name="<the
+ObjectName `org.apache.activemq.artemis:type=Broker,brokerName=<broker name>,module=Core,serviceType=Address,name="<the
                   address name>"` or the resource name
 `core.address.<the
                   address name>`).
@@ -161,7 +171,7 @@ ObjectName `org.apache.activemq.artemis:module=Core,type=Address,name="<the
 The bulk of the core management API deals with core queues. The
 `QueueControl` class defines the Core queue management operations (with
 the ObjectName
-`org.apache.activemq.artemis:module=Core,type=Queue,address="<the bound
+`org.apache.activemq.artemis:type=Broker,brokerName=<broker name>,module=Core,serviceType=Queue,address="<the bound
                   address>",name="<the queue name>"` or the resource
 name `core.queue.<the queue name>`).
 
@@ -245,7 +255,7 @@ transactions). These resources are:
 
     They can be started or stopped using the `start()` or. `stop()`
     method on the `AcceptorControl` class (with the ObjectName
-    `org.apache.activemq.artemis:module=Core,type=Acceptor,name="<the acceptor name>"`
+    `org.apache.activemq.artemis:type=Broker,brokerName=<broker name>,module=Core,serviceType=Acceptor,name="<the acceptor name>"`
     or the resource name
     `core.acceptor.<the address name>`). The acceptors parameters
     can be retrieved using the `AcceptorControl` attributes (see [Understanding Acceptors](configuring-transports.md))
@@ -254,7 +264,7 @@ transactions). These resources are:
 
     They can be started or stopped using the `start()` or `stop()`
     method on the `DivertControl` class (with the ObjectName
-    `org.apache.activemq.artemis:module=Core,type=Divert,name=<the divert name>`
+    `org.apache.activemq.artemis:type=Broker,brokerName=<broker name>,module=Core,serviceType=Divert,name=<the divert name>`
     or the resource name `core.divert.<the divert name>`). Diverts
     parameters can be retrieved using the `DivertControl` attributes
     (see [Diverting and Splitting Message Flows)](diverts.md))
@@ -263,7 +273,7 @@ transactions). These resources are:
 
     They can be started or stopped using the `start()` (resp. `stop()`)
     method on the `BridgeControl` class (with the ObjectName
-    `org.apache.activemq.artemis:module=Core,type=Bridge,name="<the bridge name>"`
+    `org.apache.activemq.artemis:type=Broker,brokerName=<broker name>,module=Core,serviceType=Bridge,name="<the bridge name>"`
     or the resource name
     `core.bridge.<the bridge name>`). Bridges parameters can be retrieved
     using the `BridgeControl` attributes (see [Core bridges](core-bridges.md))
@@ -272,7 +282,7 @@ transactions). These resources are:
 
     They can be started or stopped using the `start()` or `stop()`
     method on the `BroadcastGroupControl` class (with the ObjectName
-    `org.apache.activemq.artemis:module=Core,type=BroadcastGroup,name="<the broadcast group name>"` or the resource name
+    `org.apache.activemq.artemis:type=Broker,brokerName=<broker name>,module=Core,serviceType=BroadcastGroup,name="<the broadcast group name>"` or the resource name
     `core.broadcastgroup.<the broadcast group name>`). Broadcast groups
     parameters can be retrieved using the `BroadcastGroupControl`
     attributes (see [Clusters](clusters.md))
@@ -281,7 +291,7 @@ transactions). These resources are:
 
     They can be started or stopped using the `start()` or `stop()`
     method on the `DiscoveryGroupControl` class (with the ObjectName
-    `org.apache.activemq.artemis:module=Core,type=DiscoveryGroup,name="<the discovery group name>"` or the resource name
+    `org.apache.activemq.artemis:type=Broker,brokerName=<broker name>,module=Core,serviceType=DiscoveryGroup,name="<the discovery group name>"` or the resource name
     `core.discovery.<the discovery group name>`). Discovery groups
     parameters can be retrieved using the `DiscoveryGroupControl`
     attributes (see [Clusters](clusters.md))
@@ -290,7 +300,7 @@ transactions). These resources are:
 
     They can be started or stopped using the `start()` or `stop()`
     method on the `ClusterConnectionControl` class (with the ObjectName
-    `org.apache.activemq.artemis:module=Core,type=ClusterConnection,name="<the cluster connection name>"` or the resource name
+    `org.apache.activemq.artemis:type=Broker,brokerName=<broker name>,module=Core,serviceType=ClusterConnection,name="<the cluster connection name>"` or the resource name
     `core.clusterconnection.<the cluster connection name>`). Cluster
     connections parameters can be retrieved using the
     `ClusterConnectionControl` attributes (see [Clusters](clusters.md))
@@ -304,7 +314,7 @@ objects* (i.e. JMS queues, topics and connection factories).
 
 JMS Resources (connection factories and destinations) can be created
 using the `JMSServerControl` class (with the ObjectName
-`org.apache.activemq.artemis:module=JMS,type=Server` or the resource name
+`org.apache.activemq.artemis:type=Broker,brokerName=<broker name>,module=JMS,serviceType=Server` or the resource name
 `jms.server`).
 
 -   Listing, creating, destroying connection factories
@@ -359,7 +369,7 @@ using the `JMSServerControl` class (with the ObjectName
 
 JMS Connection Factories can be managed using the
 `ConnectionFactoryControl` class (with the ObjectName
-`org.apache.activemq.artemis:module=JMS,type=ConnectionFactory,name="<the connection factory
+`org.apache.activemq.artemis:type=Broker,brokerName=<broker name>,module=JMS,serviceType=ConnectionFactory,name="<the connection factory
                   name>"` or the resource name
 `jms.connectionfactory.<the
                   connection factory name>`).
@@ -376,7 +386,7 @@ JMS Connection Factories can be managed using the
 #### JMS Queue Management
 
 JMS queues can be managed using the `JMSQueueControl` class (with the
-ObjectName `org.apache.activemq.artemis:module=JMS,type=Queue,name="<the queue
+ObjectName `org.apache.activemq.artemis:type=Broker,brokerName=<broker name>,module=JMS,serviceType=Queue,name="<the queue
                   name>"` or the resource name `jms.queue.<the queue
                   name>`).
 
@@ -449,7 +459,7 @@ operations on a core queue.*
 #### JMS Topic Management
 
 JMS Topics can be managed using the `TopicControl` class (with the
-ObjectName `org.apache.activemq.artemis:module=JMS,type=Topic,name="<the topic
+ObjectName `org.apache.activemq.artemis:type=Broker,brokerName=<broker name>,module=JMS,serviceType=Topic,name="<the topic
                   name>"` or the resource name `jms.topic.<the topic
                   name>`).
 
@@ -485,7 +495,7 @@ Apache ActiveMQ Artemis registers its resources with the domain `org.apache.acti
 
 For example, the `ObjectName` to manage a JMS Queue `exampleQueue` is:
 
-    org.apache.activemq.artemis:module=JMS,type=Queue,name="exampleQueue"
+    org.apache.activemq.artemis:type=Broker,brokerName=<broker name>,module=JMS,serviceType=Queue,name="exampleQueue"
 
 and the MBean is:
 
@@ -549,7 +559,7 @@ be to use a brower and go to the URL http://localhost:8161/jolokia/read/org.apac
 
 This would give you back something like the following:
 
-    {"timestamp":1422019706,"status":200,"request":{"mbean":"org.apache.activemq.artemis:module=Core,type=Server","attribute":"Version","type":"read"},"value":"1.0.0.SNAPSHOT (Active Hornet, 126)"}
+    {"timestamp":1422019706,"status":200,"request":{"mbean":"org.apache.activemq.artemis:type=Broker,brokerName=<broker name>,module=Core,serviceType=Server","attribute":"Version","type":"read"},"value":"1.0.0.SNAPSHOT (Active Hornet, 126)"}
 
 ## Using Management Via Core API
 
@@ -714,10 +724,10 @@ These notifications can be received by 3 different ways:
 If JMX is enabled (see Configuring JMX section), JMX notifications can be received by
 subscribing to 2 MBeans:
 
--   `org.apache.activemq.artemis:module=Core,type=Server` for notifications on
+-   `org.apache.activemq.artemis:type=Broker,brokerName=<broker name>,module=Core,serviceType=Server` for notifications on
     *Core* resources
 
--   `org.apache.activemq.artemis:module=JMS,type=Server` for notifications on
+-   `org.apache.activemq.artemis:type=Broker,brokerName=<broker name>,module=JMS,serviceType=Server` for notifications on
     *JMS* resources
 
 ### Core Messages Notifications

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/JMXDomainTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/JMXDomainTest.java
@@ -48,7 +48,7 @@ public class JMXDomainTest extends ManagementTestBase {
       server_1 = addServer(ActiveMQServers.newActiveMQServer(config_1, mbeanServer, false));
 
       ObjectNameBuilder builder_0 = ObjectNameBuilder.DEFAULT;
-      ObjectNameBuilder builder_1 = ObjectNameBuilder.create(jmxDomain_1);
+      ObjectNameBuilder builder_1 = ObjectNameBuilder.create(jmxDomain_1, "localhost");
 
       checkNoResource(builder_0.getActiveMQServerObjectName());
       checkNoResource(builder_1.getActiveMQServerObjectName());


### PR DESCRIPTION
Its now possible to also add the broker name to jmx tree avoiding clashes when multiple brokers are in a single vm. This is now the default but the old way can be used with some configuration

https://issues.apache.org/jira/browse/ARTEMIS-311