### PR TITLE
Add license comment to OSGI deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -516,12 +516,14 @@
             <artifactId>org.osgi.core</artifactId>
             <version>6.0.0</version>
             <scope>provided</scope>
+            <!-- License: Apache 2.0 -->
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>osgi.cmpn</artifactId>
             <version>6.0.0</version>
             <scope>provided</scope>
+            <!-- License: Apache 2.0 -->
         </dependency>
 
    </dependencies>


### PR DESCRIPTION
Although the scope is "provided" we still aim to track the licenses in
the pom.xml, to avoid mistakes going forward.