### PR TITLE
Add JDBC Storage Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ ratReport.txt
 .settings
 .checkstyle
 .factorypath
+**/derby.log
 
 # for native build
 CMakeCache.txt

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/PrintData.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/PrintData.java
@@ -47,7 +47,8 @@ import org.apache.activemq.artemis.core.paging.impl.PagingStoreFactoryNIO;
 import org.apache.activemq.artemis.core.persistence.StorageManager;
 import org.apache.activemq.artemis.core.persistence.impl.journal.DescribeJournal;
 import org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds;
-import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.CursorAckRecordEncoding;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.PageUpdateTXEncoding;
 import org.apache.activemq.artemis.core.persistence.impl.nullpm.NullStorageManager;
 import org.apache.activemq.artemis.core.server.impl.FileLockNodeManager;
 import org.apache.activemq.artemis.core.settings.HierarchicalRepository;
@@ -235,7 +236,7 @@ public class PrintData extends LockAbstract {
          ActiveMQBuffer buff = ActiveMQBuffers.wrappedBuffer(data);
 
          if (record.userRecordType == JournalRecordIds.ACKNOWLEDGE_CURSOR) {
-            JournalStorageManager.CursorAckRecordEncoding encoding = new JournalStorageManager.CursorAckRecordEncoding();
+            CursorAckRecordEncoding encoding = new CursorAckRecordEncoding();
             encoding.decode(buff);
 
             Set<PagePosition> set = cursorInfo.getCursorRecords().get(encoding.queueID);
@@ -248,7 +249,7 @@ public class PrintData extends LockAbstract {
             set.add(encoding.position);
          }
          else if (record.userRecordType == JournalRecordIds.PAGE_CURSOR_COMPLETE) {
-            JournalStorageManager.CursorAckRecordEncoding encoding = new JournalStorageManager.CursorAckRecordEncoding();
+            CursorAckRecordEncoding encoding = new CursorAckRecordEncoding();
             encoding.decode(buff);
 
             Long queueID = Long.valueOf(encoding.queueID);
@@ -260,7 +261,7 @@ public class PrintData extends LockAbstract {
          }
          else if (record.userRecordType == JournalRecordIds.PAGE_TRANSACTION) {
             if (record.isUpdate) {
-               JournalStorageManager.PageUpdateTXEncoding pageUpdate = new JournalStorageManager.PageUpdateTXEncoding();
+               PageUpdateTXEncoding pageUpdate = new PageUpdateTXEncoding();
 
                pageUpdate.decode(buff);
                cursorInfo.getPgTXs().add(pageUpdate.pageTX);

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/XmlDataExporter.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/XmlDataExporter.java
@@ -71,10 +71,10 @@ import org.apache.activemq.artemis.core.persistence.impl.journal.DescribeJournal
 import org.apache.activemq.artemis.core.persistence.impl.journal.DescribeJournal.ReferenceDescribe;
 import org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds;
 import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager;
-import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager.AckDescribe;
-import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager.CursorAckRecordEncoding;
-import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager.PageUpdateTXEncoding;
-import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager.PersistentQueueBindingEncoding;
+import org.apache.activemq.artemis.core.persistence.impl.journal.AckDescribe;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.CursorAckRecordEncoding;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.PageUpdateTXEncoding;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.PersistentQueueBindingEncoding;
 import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
 import org.apache.activemq.artemis.core.server.JournalType;
 import org.apache.activemq.artemis.core.server.LargeServerMessage;

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
@@ -396,6 +396,18 @@ public final class ActiveMQDefaultConfiguration {
    // How often the reaper will be run to check for timed out group bindings. Only valid for LOCAL handlers
    private static long DEFAULT_GROUPING_HANDLER_REAPER_PERIOD = 30000;
 
+   // Which store type to use, options are FILE or DATABASE, FILE is default.
+   private static String DEFAULT_STORE_TYPE = "FILE";
+
+   // Default database url.  Derby database is used by default.
+   private static String DEFAULT_DATABASE_URL = "jdbc:derby:data/derby;create=true";
+
+   // Default message table name, used with Database storage type
+   private static String DEFAULT_MESSAGE_TABLE_NAME = "MESSAGES";
+
+   // Default bindings table name, used with Database storage type
+   private static String DEFAULT_BINDINGS_TABLE_NAME = "BINDINGS";
+
    /**
     * If true then the ActiveMQ Artemis Server will make use of any Protocol Managers that are in available on the classpath. If false then only the core protocol will be available, unless in Embedded mode where users can inject their own Protocol Managers.
     */
@@ -1052,4 +1064,28 @@ public final class ActiveMQDefaultConfiguration {
       return DEFAULT_GROUPING_HANDLER_REAPER_PERIOD;
    }
 
+   /**
+    * The default storage type.  Options are FILE and DATABASE.
+    */
+   public static String getDefaultStoreType() {
+      return DEFAULT_STORE_TYPE;
+   }
+
+   /**
+    * The default database URL, used with DATABASE store type.
+    */
+   public static String getDefaultDatabaseUrl() {
+      return DEFAULT_DATABASE_URL;
+   }
+
+   /**
+    * The default Message Journal table name, used with DATABASE store.
+    */
+   public static String getDefaultMessageTableName() {
+      return DEFAULT_MESSAGE_TABLE_NAME;
+   }
+
+   public static String getDefaultBindingsTableName() {
+      return DEFAULT_BINDINGS_TABLE_NAME;
+   }
 }

--- a/artemis-distribution/pom.xml
+++ b/artemis-distribution/pom.xml
@@ -134,6 +134,11 @@
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-jdbc-store</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-website</artifactId>
          <version>${project.version}</version>
       </dependency>

--- a/artemis-distribution/src/main/assembly/dep.xml
+++ b/artemis-distribution/src/main/assembly/dep.xml
@@ -54,6 +54,7 @@
             <include>org.apache.activemq:artemis-jms-client</include>
             <include>org.apache.activemq:artemis-jms-server</include>
             <include>org.apache.activemq:artemis-journal</include>
+            <include>org.apache.activemq:artemis-jdbc-store</include>
             <include>org.apache.activemq:artemis-native</include>
             <include>org.apache.activemq:artemis-amqp-protocol</include>
             <include>org.apache.activemq:artemis-openwire-protocol</include>
@@ -93,6 +94,7 @@
             <include>org.fusesource.hawtbuf:hawtbuf</include>
             <include>org.jgroups:jgroups</include>
             <include>io.netty:netty-codec-mqtt</include>
+            <include>org.apache.derby:derby</include>
          </includes>
          <!--excludes>
             <exclude>org.apache.activemq:artemis-website</exclude>

--- a/artemis-jdbc-store/pom.xml
+++ b/artemis-jdbc-store/pom.xml
@@ -1,0 +1,74 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+
+   <parent>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>artemis-pom</artifactId>
+      <version>1.2.1-SNAPSHOT</version>
+   </parent>
+
+   <artifactId>artemis-jdbc-store</artifactId>
+   <packaging>jar</packaging>
+   <name>ActiveMQ Artemis JDBC Store</name>
+
+   <properties>
+      <activemq.basedir>${project.basedir}/..</activemq.basedir>
+   </properties>
+
+   <dependencies>
+
+      <!-- Logging -->
+      <dependency>
+         <groupId>org.jboss.logging</groupId>
+         <artifactId>jboss-logging-processor</artifactId>
+         <scope>provided</scope>
+         <optional>true</optional>
+      </dependency>
+
+      <dependency>
+         <groupId>org.jboss.logging</groupId>
+         <artifactId>jboss-logging</artifactId>
+      </dependency>
+
+      <dependency>
+         <groupId>org.jboss.logmanager</groupId>
+         <artifactId>jboss-logmanager</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.apache.derby</groupId>
+         <artifactId>derby</artifactId>
+      </dependency>
+
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-journal</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-core-client</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+
+   </dependencies>
+</project>

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalImpl.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalImpl.java
@@ -1,0 +1,607 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.jdbc.store.journal;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Timer;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.apache.activemq.artemis.core.journal.EncodingSupport;
+import org.apache.activemq.artemis.core.journal.IOCompletion;
+import org.apache.activemq.artemis.core.journal.Journal;
+import org.apache.activemq.artemis.core.journal.JournalLoadInformation;
+import org.apache.activemq.artemis.core.journal.LoaderCallback;
+import org.apache.activemq.artemis.core.journal.PreparedTransactionInfo;
+import org.apache.activemq.artemis.core.journal.RecordInfo;
+import org.apache.activemq.artemis.core.journal.SequentialFileFactory;
+import org.apache.activemq.artemis.core.journal.TransactionFailureCallback;
+import org.apache.activemq.artemis.core.journal.impl.JournalFile;
+import org.apache.derby.jdbc.AutoloadedDriver;
+
+public class JDBCJournalImpl implements Journal {
+
+   // Sync Delay in ms
+   public static final int SYNC_DELAY = 500;
+
+   private static int USER_VERSION = 1;
+
+   private final String tableName;
+
+   private Connection connection;
+
+   private List<JDBCJournalRecord> records;
+
+   private PreparedStatement insertJournalRecords;
+
+   private PreparedStatement selectJournalRecords;
+
+   private PreparedStatement countJournalRecords;
+
+   private PreparedStatement deleteJournalRecords;
+
+   private PreparedStatement deleteTxJournalRecords;
+
+   private boolean started;
+
+   private String jdbcUrl;
+
+   private Timer syncTimer;
+
+   private Driver dbDriver;
+
+   private final ReadWriteLock journalLock = new ReentrantReadWriteLock();
+
+   private boolean isDerby = false;
+
+   public JDBCJournalImpl(String jdbcUrl, String tableName) {
+      this.tableName = tableName;
+      this.jdbcUrl = jdbcUrl;
+
+      records = new ArrayList<JDBCJournalRecord>();
+   }
+
+   @Override
+   public void start() throws Exception {
+      // Load Database driver, sets Derby Autoloaded Driver as lowest priority.
+      List<Driver> drivers = Collections.list(DriverManager.getDrivers());
+      if (drivers.size() <= 2 && drivers.size() > 0) {
+         dbDriver = drivers.get(0);
+         isDerby = dbDriver instanceof AutoloadedDriver;
+
+         if (drivers.size() > 1 && isDerby) {
+            dbDriver = drivers.get(1);
+         }
+
+         if (isDerby) {
+            Runtime.getRuntime().addShutdownHook(new Thread() {
+               @Override
+               public void run() {
+                  try {
+                     DriverManager.getConnection("jdbc:derby:;shutdown=true");
+                  }
+                  catch (Exception e) {
+                  }
+               }
+            });
+         }
+      }
+      else {
+         String error = drivers.isEmpty() ? "No DB driver found on class path" : "Too many DB drivers on class path, not sure which to use";
+         throw new RuntimeException(error);
+      }
+
+      connection = dbDriver.connect(jdbcUrl, new Properties());
+
+      // If JOURNAL table doesn't exist then create it
+      ResultSet rs = connection.getMetaData().getTables(null, null, tableName, null);
+      if (!rs.next()) {
+         Statement statement = connection.createStatement();
+         statement.executeUpdate(JDBCJournalRecord.createTableSQL(tableName));
+      }
+
+      insertJournalRecords = connection.prepareStatement(JDBCJournalRecord.insertRecordsSQL(tableName));
+      selectJournalRecords = connection.prepareStatement(JDBCJournalRecord.selectRecordsSQL(tableName));
+      countJournalRecords = connection.prepareStatement("SELECT COUNT(*) FROM " + tableName);
+      deleteJournalRecords = connection.prepareStatement(JDBCJournalRecord.deleteRecordsSQL(tableName));
+      deleteTxJournalRecords = connection.prepareStatement(JDBCJournalRecord.deleteTxRecordsSQL(tableName));
+
+      syncTimer = new Timer();
+      syncTimer.scheduleAtFixedRate(new JDBCJournalSync(this), SYNC_DELAY * 2, SYNC_DELAY);
+
+      started = true;
+   }
+
+   @Override
+   public void stop() throws Exception {
+      stop(true);
+   }
+
+   public synchronized void stop(boolean shutdownConnection) throws Exception {
+      if (started) {
+         syncTimer.cancel();
+         sync();
+         if (shutdownConnection) {
+            connection.close();
+         }
+         started = false;
+      }
+   }
+
+   public synchronized void destroy() throws Exception {
+      connection.setAutoCommit(false);
+      Statement statement = connection.createStatement();
+      statement.executeUpdate("DROP TABLE " + tableName);
+      connection.commit();
+      stop();
+   }
+
+   public int sync() throws SQLException {
+      List<JDBCJournalRecord> recordRef = records;
+      records = new ArrayList<JDBCJournalRecord>();
+
+      for (JDBCJournalRecord record : recordRef) {
+         record.storeLineUp();
+
+         switch (record.getRecordType()) {
+            case JDBCJournalRecord.DELETE_RECORD:
+               record.writeDeleteRecord(deleteJournalRecords);
+               break;
+            case JDBCJournalRecord.DELETE_RECORD_TX:
+               record.writeDeleteTxRecord(deleteTxJournalRecords);
+               break;
+            default:
+               record.writeRecord(insertJournalRecords);
+               break;
+         }
+      }
+
+      boolean success = false;
+      try {
+         connection.setAutoCommit(false);
+         insertJournalRecords.executeBatch();
+         deleteJournalRecords.executeBatch();
+         deleteTxJournalRecords.executeBatch();
+         connection.commit();
+         success = true;
+      }
+      catch (SQLException e) {
+         connection.rollback();
+         e.printStackTrace();
+      }
+      executeCallbacks(recordRef, success);
+      return recordRef.size();
+   }
+
+   // TODO Use an executor.
+   private void executeCallbacks(final List<JDBCJournalRecord> records, final boolean result) {
+      Runnable r = new Runnable() {
+         @Override
+         public void run() {
+            for (JDBCJournalRecord record : records) {
+               record.complete(result);
+            }
+         }
+      };
+      Thread t = new Thread(r);
+      t.start();
+   }
+
+   private void appendRecord(JDBCJournalRecord record) throws SQLException {
+      try {
+         journalLock.writeLock().lock();
+         records.add(record);
+      }
+      finally {
+         journalLock.writeLock().unlock();
+      }
+   }
+
+   @Override
+   public void appendAddRecord(long id, byte recordType, byte[] record, boolean sync) throws Exception {
+      JDBCJournalRecord r = new JDBCJournalRecord(id, JDBCJournalRecord.ADD_RECORD);
+      r.setUserRecordType(recordType);
+      r.setRecord(record);
+      r.setSync(sync);
+      appendRecord(r);
+   }
+
+   @Override
+   public void appendAddRecord(long id, byte recordType, EncodingSupport record, boolean sync) throws Exception {
+      JDBCJournalRecord r = new JDBCJournalRecord(id, JDBCJournalRecord.ADD_RECORD);
+      r.setUserRecordType(recordType);
+      r.setRecord(record);
+      r.setSync(sync);
+      appendRecord(r);
+   }
+
+   @Override
+   public void appendAddRecord(long id,
+                               byte recordType,
+                               EncodingSupport record,
+                               boolean sync,
+                               IOCompletion completionCallback) throws Exception {
+      JDBCJournalRecord r = new JDBCJournalRecord(id, JDBCJournalRecord.ADD_RECORD);
+      r.setUserRecordType(recordType);
+      r.setRecord(record);
+      r.setSync(sync);
+      r.setIoCompletion(completionCallback);
+      appendRecord(r);
+   }
+
+   @Override
+   public void appendUpdateRecord(long id, byte recordType, byte[] record, boolean sync) throws Exception {
+      JDBCJournalRecord r = new JDBCJournalRecord(id, JDBCJournalRecord.UPDATE_RECORD);
+      r.setUserRecordType(recordType);
+      r.setRecord(record);
+      r.setSync(sync);
+      appendRecord(r);
+   }
+
+   @Override
+   public void appendUpdateRecord(long id, byte recordType, EncodingSupport record, boolean sync) throws Exception {
+      JDBCJournalRecord r = new JDBCJournalRecord(id, JDBCJournalRecord.UPDATE_RECORD);
+      r.setUserRecordType(recordType);
+      r.setRecord(record);
+      r.setSync(sync);
+      appendRecord(r);
+   }
+
+   @Override
+   public void appendUpdateRecord(long id,
+                                  byte recordType,
+                                  EncodingSupport record,
+                                  boolean sync,
+                                  IOCompletion completionCallback) throws Exception {
+      JDBCJournalRecord r = new JDBCJournalRecord(id, JDBCJournalRecord.ADD_RECORD);
+      r.setUserRecordType(recordType);
+      r.setRecord(record);
+      r.setSync(sync);
+      r.setIoCompletion(completionCallback);
+      appendRecord(r);
+   }
+
+   @Override
+   public void appendDeleteRecord(long id, boolean sync) throws Exception {
+      JDBCJournalRecord r = new JDBCJournalRecord(id, JDBCJournalRecord.DELETE_RECORD);
+      r.setSync(sync);
+      appendRecord(r);
+   }
+
+   @Override
+   public void appendDeleteRecord(long id, boolean sync, IOCompletion completionCallback) throws Exception {
+      JDBCJournalRecord r = new JDBCJournalRecord(id, JDBCJournalRecord.DELETE_RECORD);
+      r.setSync(sync);
+      r.setIoCompletion(completionCallback);
+      appendRecord(r);
+   }
+
+   @Override
+   public void appendAddRecordTransactional(long txID, long id, byte recordType, byte[] record) throws Exception {
+      JDBCJournalRecord r = new JDBCJournalRecord(id, JDBCJournalRecord.ADD_RECORD_TX);
+      r.setUserRecordType(recordType);
+      r.setRecord(record);
+      r.setTxId(txID);
+      appendRecord(r);
+   }
+
+   @Override
+   public void appendAddRecordTransactional(long txID,
+                                            long id,
+                                            byte recordType,
+                                            EncodingSupport record) throws Exception {
+      JDBCJournalRecord r = new JDBCJournalRecord(id, JDBCJournalRecord.ADD_RECORD_TX);
+      r.setUserRecordType(recordType);
+      r.setRecord(record);
+      r.setTxId(txID);
+      appendRecord(r);
+   }
+
+   @Override
+   public void appendUpdateRecordTransactional(long txID, long id, byte recordType, byte[] record) throws Exception {
+      JDBCJournalRecord r = new JDBCJournalRecord(id, JDBCJournalRecord.UPDATE_RECORD_TX);
+      r.setUserRecordType(recordType);
+      r.setRecord(record);
+      r.setTxId(txID);
+      appendRecord(r);
+   }
+
+   @Override
+   public void appendUpdateRecordTransactional(long txID,
+                                               long id,
+                                               byte recordType,
+                                               EncodingSupport record) throws Exception {
+      JDBCJournalRecord r = new JDBCJournalRecord(id, JDBCJournalRecord.UPDATE_RECORD_TX);
+      r.setUserRecordType(recordType);
+      r.setRecord(record);
+      r.setTxId(txID);
+      appendRecord(r);
+   }
+
+   @Override
+   public void appendDeleteRecordTransactional(long txID, long id, byte[] record) throws Exception {
+      JDBCJournalRecord r = new JDBCJournalRecord(id, JDBCJournalRecord.DELETE_RECORD_TX);
+      r.setRecord(record);
+      r.setTxId(txID);
+      appendRecord(r);
+   }
+
+   @Override
+   public void appendDeleteRecordTransactional(long txID, long id, EncodingSupport record) throws Exception {
+      JDBCJournalRecord r = new JDBCJournalRecord(id, JDBCJournalRecord.DELETE_RECORD_TX);
+      r.setRecord(record);
+      r.setTxId(txID);
+      appendRecord(r);
+   }
+
+   @Override
+   public void appendDeleteRecordTransactional(long txID, long id) throws Exception {
+      JDBCJournalRecord r = new JDBCJournalRecord(id, JDBCJournalRecord.DELETE_RECORD_TX);
+      r.setTxId(txID);
+      appendRecord(r);
+   }
+
+   @Override
+   public void appendCommitRecord(long txID, boolean sync) throws Exception {
+      JDBCJournalRecord r = new JDBCJournalRecord(0, JDBCJournalRecord.COMMIT_RECORD);
+      r.setTxId(txID);
+      appendRecord(r);
+   }
+
+   @Override
+   public void appendCommitRecord(long txID, boolean sync, IOCompletion callback) throws Exception {
+      JDBCJournalRecord r = new JDBCJournalRecord(0, JDBCJournalRecord.COMMIT_RECORD);
+      r.setTxId(txID);
+      r.setIoCompletion(callback);
+      appendRecord(r);
+   }
+
+   @Override
+   public void appendCommitRecord(long txID,
+                                  boolean sync,
+                                  IOCompletion callback,
+                                  boolean lineUpContext) throws Exception {
+      JDBCJournalRecord r = new JDBCJournalRecord(0, JDBCJournalRecord.COMMIT_RECORD);
+      r.setTxId(txID);
+      r.setStoreLineUp(lineUpContext);
+      r.setIoCompletion(callback);
+      appendRecord(r);
+   }
+
+   @Override
+   public void appendPrepareRecord(long txID, EncodingSupport transactionData, boolean sync) throws Exception {
+      JDBCJournalRecord r = new JDBCJournalRecord(0, JDBCJournalRecord.PREPARE_RECORD);
+      r.setTxId(txID);
+      r.setTxData(transactionData);
+      r.setSync(sync);
+      appendRecord(r);
+   }
+
+   @Override
+   public void appendPrepareRecord(long txID,
+                                   EncodingSupport transactionData,
+                                   boolean sync,
+                                   IOCompletion callback) throws Exception {
+      JDBCJournalRecord r = new JDBCJournalRecord(0, JDBCJournalRecord.PREPARE_RECORD);
+      r.setTxId(txID);
+      r.setTxData(transactionData);
+      r.setSync(sync);
+      r.setIoCompletion(callback);
+      appendRecord(r);
+   }
+
+   @Override
+   public void appendPrepareRecord(long txID, byte[] transactionData, boolean sync) throws Exception {
+      JDBCJournalRecord r = new JDBCJournalRecord(0, JDBCJournalRecord.PREPARE_RECORD);
+      r.setTxId(txID);
+      r.setTxData(transactionData);
+      r.setSync(sync);
+      appendRecord(r);
+   }
+
+   @Override
+   public void appendRollbackRecord(long txID, boolean sync) throws Exception {
+      JDBCJournalRecord r = new JDBCJournalRecord(0, JDBCJournalRecord.ROLLBACK_RECORD);
+      r.setTxId(txID);
+      r.setSync(sync);
+      appendRecord(r);
+   }
+
+   @Override
+   public void appendRollbackRecord(long txID, boolean sync, IOCompletion callback) throws Exception {
+      JDBCJournalRecord r = new JDBCJournalRecord(0, JDBCJournalRecord.PREPARE_RECORD);
+      r.setTxId(txID);
+      r.setSync(sync);
+      r.setIoCompletion(callback);
+      appendRecord(r);
+   }
+
+   @Override
+   public JournalLoadInformation load(LoaderCallback reloadManager) throws Exception {
+      JournalLoadInformation jli = new JournalLoadInformation();
+      JDBCJournalReaderCallback jrc = new JDBCJournalReaderCallback(reloadManager);
+      JDBCJournalRecord r;
+
+      try (ResultSet rs = selectJournalRecords.executeQuery()) {
+         int noRecords = 0;
+         while (rs.next()) {
+            r = JDBCJournalRecord.readRecord(rs);
+            switch (r.getRecordType()) {
+               case JDBCJournalRecord.ADD_RECORD:
+                  jrc.onReadAddRecord(r.toRecordInfo());
+                  break;
+               case JDBCJournalRecord.UPDATE_RECORD:
+                  jrc.onReadUpdateRecord(r.toRecordInfo());
+                  break;
+               case JDBCJournalRecord.DELETE_RECORD:
+                  jrc.onReadDeleteRecord(r.getId());
+                  break;
+               case JDBCJournalRecord.ADD_RECORD_TX:
+                  jrc.onReadAddRecordTX(r.getTxId(), r.toRecordInfo());
+                  break;
+               case JDBCJournalRecord.UPDATE_RECORD_TX:
+                  jrc.onReadUpdateRecordTX(r.getTxId(), r.toRecordInfo());
+                  break;
+               case JDBCJournalRecord.DELETE_RECORD_TX:
+                  jrc.onReadDeleteRecordTX(r.getTxId(), r.toRecordInfo());
+                  break;
+               case JDBCJournalRecord.PREPARE_RECORD:
+                  jrc.onReadPrepareRecord(r.getTxId(), r.getTxDataAsByteArray(), r.getTxCheckNoRecords());
+                  break;
+               case JDBCJournalRecord.COMMIT_RECORD:
+                  jrc.onReadCommitRecord(r.getTxId(), r.getTxCheckNoRecords());
+                  break;
+               case JDBCJournalRecord.ROLLBACK_RECORD:
+                  jrc.onReadRollbackRecord(r.getTxId());
+                  break;
+               default:
+                  throw new Exception("Error Reading Journal, Unknown Record Type: " + r.getRecordType());
+            }
+            noRecords++;
+         }
+         jli.setMaxID(((JDBCJournalLoaderCallback) reloadManager).getMaxId());
+         jli.setNumberOfRecords(noRecords);
+      }
+      return jli;
+   }
+
+   @Override
+   public JournalLoadInformation loadInternalOnly() throws Exception {
+      return null;
+   }
+
+   @Override
+   public JournalLoadInformation loadSyncOnly(JournalState state) throws Exception {
+      return null;
+   }
+
+   @Override
+   public void lineUpContext(IOCompletion callback) {
+      callback.storeLineUp();
+   }
+
+   @Override
+   public JournalLoadInformation load(List<RecordInfo> committedRecords,
+                                      List<PreparedTransactionInfo> preparedTransactions,
+                                      TransactionFailureCallback transactionFailure) throws Exception {
+      return load(committedRecords, preparedTransactions, transactionFailure, true);
+   }
+
+   public synchronized JournalLoadInformation load(final List<RecordInfo> committedRecords,
+                                                   final List<PreparedTransactionInfo> preparedTransactions,
+                                                   final TransactionFailureCallback failureCallback,
+                                                   final boolean fixBadTX) throws Exception {
+      JDBCJournalLoaderCallback lc = new JDBCJournalLoaderCallback(committedRecords, preparedTransactions, failureCallback, fixBadTX);
+      return load(lc);
+   }
+
+   @Override
+   public int getAlignment() throws Exception {
+      return 0;
+   }
+
+   @Override
+   public int getNumberOfRecords() {
+      int count = 0;
+      try (ResultSet rs = countJournalRecords.executeQuery()) {
+         rs.next();
+         count = rs.getInt(1);
+      }
+      catch (SQLException e) {
+         return -1;
+      }
+      return count;
+   }
+
+   @Override
+   public int getUserVersion() {
+      return USER_VERSION;
+   }
+
+   @Override
+   public void perfBlast(int pages) {
+   }
+
+   @Override
+   public void runDirectJournalBlast() throws Exception {
+   }
+
+   @Override
+   public Map<Long, JournalFile> createFilesForBackupSync(long[] fileIds) throws Exception {
+      return null;
+   }
+
+   public final void synchronizationLock() {
+      journalLock.writeLock().lock();
+   }
+
+   public final void synchronizationUnlock() {
+      journalLock.writeLock().unlock();
+   }
+
+   @Override
+   public void forceMoveNextFile() throws Exception {
+   }
+
+   @Override
+   public JournalFile[] getDataFiles() {
+      return new JournalFile[0];
+   }
+
+   @Override
+   public SequentialFileFactory getFileFactory() {
+      return null;
+   }
+
+   @Override
+   public int getFileSize() {
+      return 0;
+   }
+
+   @Override
+   public void scheduleCompactAndBlock(int timeout) throws Exception {
+
+   }
+
+   @Override
+   public void replicationSyncPreserveOldFiles() {
+
+   }
+
+   @Override
+   public void replicationSyncFinished() {
+
+   }
+
+   @Override
+   public boolean isStarted() {
+      return started;
+   }
+
+}

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalImpl.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalImpl.java
@@ -33,6 +33,7 @@ import java.util.Timer;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import org.apache.activemq.artemis.core.io.SequentialFileFactory;
 import org.apache.activemq.artemis.core.journal.EncodingSupport;
 import org.apache.activemq.artemis.core.journal.IOCompletion;
 import org.apache.activemq.artemis.core.journal.Journal;
@@ -40,7 +41,6 @@ import org.apache.activemq.artemis.core.journal.JournalLoadInformation;
 import org.apache.activemq.artemis.core.journal.LoaderCallback;
 import org.apache.activemq.artemis.core.journal.PreparedTransactionInfo;
 import org.apache.activemq.artemis.core.journal.RecordInfo;
-import org.apache.activemq.artemis.core.journal.SequentialFileFactory;
 import org.apache.activemq.artemis.core.journal.TransactionFailureCallback;
 import org.apache.activemq.artemis.core.journal.impl.JournalFile;
 import org.apache.derby.jdbc.AutoloadedDriver;

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalLoaderCallback.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalLoaderCallback.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.jdbc.store.journal;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.activemq.artemis.core.journal.LoaderCallback;
+import org.apache.activemq.artemis.core.journal.PreparedTransactionInfo;
+import org.apache.activemq.artemis.core.journal.RecordInfo;
+import org.apache.activemq.artemis.core.journal.TransactionFailureCallback;
+
+public class JDBCJournalLoaderCallback implements LoaderCallback {
+
+   private static final int DELETE_FLUSH = 20000;
+
+   private final List<PreparedTransactionInfo> preparedTransactions;
+
+   private final TransactionFailureCallback failureCallback;
+
+   private final boolean fixBadTX;
+
+   /* We keep track of list entries for each ID.  This preserves order and allows multiple record insertions with the
+   same ID.  We use this for deleting records */
+   private final Map<Long, List<Integer>> deleteReferences = new HashMap<Long, List<Integer>>();
+
+   private Runtime runtime = Runtime.getRuntime();
+
+   private final List<RecordInfo> committedRecords;
+
+   private long maxId = -1;
+
+   public JDBCJournalLoaderCallback(final List<RecordInfo> committedRecords,
+                                    final List<PreparedTransactionInfo> preparedTransactions,
+                                    final TransactionFailureCallback failureCallback,
+                                    final boolean fixBadTX) {
+      this.committedRecords = committedRecords;
+      this.preparedTransactions = preparedTransactions;
+      this.failureCallback = failureCallback;
+      this.fixBadTX = fixBadTX;
+   }
+
+   public synchronized void checkMaxId(long id) {
+      if (maxId < id) {
+         maxId = id;
+      }
+   }
+
+   public void addPreparedTransaction(final PreparedTransactionInfo preparedTransaction) {
+      preparedTransactions.add(preparedTransaction);
+   }
+
+   public synchronized void addRecord(final RecordInfo info) {
+      int index = committedRecords.size();
+      committedRecords.add(index, info);
+
+      ArrayList<Integer> indexes = new ArrayList<Integer>();
+      indexes.add(index);
+
+      deleteReferences.put(info.id, indexes);
+      checkMaxId(info.id);
+   }
+
+   public synchronized void updateRecord(final RecordInfo info) {
+      int index = committedRecords.size();
+      committedRecords.add(index, info);
+      deleteReferences.get(info.id).add(index);
+   }
+
+   public synchronized void deleteRecord(final long id) {
+      for (Integer i : deleteReferences.get(id)) {
+         committedRecords.remove(i);
+      }
+   }
+
+   public int getNoRecords() {
+      return committedRecords.size();
+   }
+
+   @Override
+   public void failedTransaction(final long transactionID,
+                                 final List<RecordInfo> records,
+                                 final List<RecordInfo> recordsToDelete) {
+      if (failureCallback != null) {
+         failureCallback.failedTransaction(transactionID, records, recordsToDelete);
+      }
+   }
+
+   public long getMaxId() {
+      return maxId;
+   }
+
+}

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalReaderCallback.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalReaderCallback.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.jdbc.store.journal;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.apache.activemq.artemis.core.journal.LoaderCallback;
+import org.apache.activemq.artemis.core.journal.RecordInfo;
+import org.apache.activemq.artemis.core.journal.impl.JournalFile;
+import org.apache.activemq.artemis.core.journal.impl.JournalReaderCallback;
+import org.apache.activemq.artemis.core.journal.impl.JournalTransaction;
+
+public class JDBCJournalReaderCallback implements JournalReaderCallback {
+
+   private final Map<Long, TransactionHolder> loadTransactions = new LinkedHashMap<Long, TransactionHolder>();
+
+   private final LoaderCallback loadManager;
+
+   private final ConcurrentMap<Long, JournalTransaction> transactions = new ConcurrentHashMap<Long, JournalTransaction>();
+
+   public JDBCJournalReaderCallback(LoaderCallback loadManager) {
+      this.loadManager = loadManager;
+   }
+
+   public void onReadAddRecord(final RecordInfo info) throws Exception {
+      loadManager.addRecord(info);
+   }
+
+   public void onReadUpdateRecord(final RecordInfo info) throws Exception {
+      loadManager.updateRecord(info);
+   }
+
+   public void onReadDeleteRecord(final long recordID) throws Exception {
+      loadManager.deleteRecord(recordID);
+   }
+
+   public void onReadUpdateRecordTX(final long transactionID, final RecordInfo info) throws Exception {
+      onReadAddRecordTX(transactionID, info);
+   }
+
+   public void onReadAddRecordTX(final long transactionID, final RecordInfo info) throws Exception {
+      TransactionHolder tx = loadTransactions.get(transactionID);
+      if (tx == null) {
+         tx = new TransactionHolder(transactionID);
+         loadTransactions.put(transactionID, tx);
+      }
+      tx.recordInfos.add(info);
+   }
+
+   public void onReadDeleteRecordTX(final long transactionID, final RecordInfo info) throws Exception {
+      TransactionHolder tx = loadTransactions.get(transactionID);
+      if (tx == null) {
+         tx = new TransactionHolder(transactionID);
+         loadTransactions.put(transactionID, tx);
+      }
+      tx.recordsToDelete.add(info);
+   }
+
+   public void onReadPrepareRecord(final long transactionID,
+                                   final byte[] extraData,
+                                   final int numberOfRecords) throws Exception {
+      TransactionHolder tx = loadTransactions.get(transactionID);
+      if (tx == null) {
+         tx = new TransactionHolder(transactionID);
+         loadTransactions.put(transactionID, tx);
+      }
+      tx.prepared = true;
+      tx.extraData = extraData;
+   }
+
+   public void onReadCommitRecord(final long transactionID, final int numberOfRecords) throws Exception {
+      TransactionHolder tx = loadTransactions.remove(transactionID);
+      if (tx != null) {
+         //         JournalTransaction journalTransaction = transactions.remove(transactionID);
+         //         if (journalTransaction == null)
+         //         {
+         //            throw new IllegalStateException("Cannot Commit, tx not found with ID: " + transactionID);
+         //         }
+
+         for (RecordInfo txRecord : tx.recordInfos) {
+            if (txRecord.isUpdate) {
+               loadManager.updateRecord(txRecord);
+            }
+            else {
+               loadManager.addRecord(txRecord);
+            }
+         }
+
+         for (RecordInfo deleteValue : tx.recordsToDelete) {
+            loadManager.deleteRecord(deleteValue.id);
+         }
+      }
+   }
+
+   public void onReadRollbackRecord(final long transactionID) throws Exception {
+      TransactionHolder tx = loadTransactions.remove(transactionID);
+      if (tx == null) {
+         throw new IllegalStateException("Cannot rollback, tx not found with ID: " + transactionID);
+      }
+   }
+
+   @Override
+   public void markAsDataFile(JournalFile file) {
+      // Not needed for JDBC journal impl
+   }
+}

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalRecord.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalRecord.java
@@ -1,0 +1,319 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.jdbc.store.journal;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
+import org.apache.activemq.artemis.core.journal.EncodingSupport;
+import org.apache.activemq.artemis.core.journal.IOCompletion;
+import org.apache.activemq.artemis.core.journal.RecordInfo;
+import org.apache.activemq.artemis.utils.ActiveMQBufferInputStream;
+
+public class JDBCJournalRecord {
+   /*
+   Database Table Schema:
+
+   id BIGINT (long)
+   recordType SMALLINT (byte)
+   compactCount SMALLINT (byte)
+   txId BIGINT (long)
+   userRecordType SMALLINT (byte)
+   variableSize INT (int)
+   record BLOB (InputStream)
+   txDataSize INT (int)
+   txData BLOB (InputStream)
+   txCheckNoRecords INT (int)
+   */
+
+   // Record types taken from Journal Impl
+   public static final byte ADD_RECORD = 11;
+   public static final byte UPDATE_RECORD = 12;
+   public static final byte ADD_RECORD_TX = 13;
+   public static final byte UPDATE_RECORD_TX = 14;
+
+   public static final byte DELETE_RECORD_TX = 15;
+   public static final byte DELETE_RECORD = 16;
+
+   public static final byte PREPARE_RECORD = 17;
+   public static final byte COMMIT_RECORD = 18;
+   public static final byte ROLLBACK_RECORD = 19;
+
+   // Callback and sync operations
+   private IOCompletion ioCompletion = null;
+   private boolean storeLineUp = false;
+   private boolean sync = false;
+
+   // DB Fields for all records
+   private Long id;
+   private byte recordType;
+   private byte compactCount;
+   private long txId;
+
+   // DB fields for ADD_RECORD(TX), UPDATE_RECORD(TX),
+   private int variableSize;
+   protected byte userRecordType;
+   private InputStream record;
+
+   // DB Fields for PREPARE_RECORD
+   private int txDataSize;
+   private InputStream txData;
+
+   // DB Fields for COMMIT_RECORD and PREPARE_RECORD
+   private int txCheckNoRecords;
+
+   private boolean isUpdate;
+
+   public JDBCJournalRecord(long id, byte recordType) {
+      this.id = id;
+      this.recordType = recordType;
+      this.isUpdate = recordType == UPDATE_RECORD || recordType == UPDATE_RECORD_TX;
+
+      // set defaults
+      compactCount = 0;
+      txId = 0;
+      variableSize = 0;
+      userRecordType = -1;
+      record = new ByteArrayInputStream(new byte[0]);
+      txDataSize = 0;
+      txData = new ByteArrayInputStream(new byte[0]);
+      txCheckNoRecords = 0;
+   }
+
+   public static String createTableSQL(String tableName) {
+      return "CREATE TABLE " + tableName + "(id BIGINT, " + "recordType SMALLINT, " + "compactCount SMALLINT, " + "txId BIGINT, " + "userRecordType SMALLINT, " + "variableSize INTEGER, " + "record BLOB, " + "txDataSize INTEGER, " + "txData BLOB, " + "txCheckNoRecords INTEGER)";
+   }
+
+   public static String insertRecordsSQL(String tableName) {
+      return "INSERT INTO " + tableName + "(id," + "recordType," + "compactCount," + "txId," + "userRecordType," + "variableSize," + "record," + "txDataSize," + "txData," + "txCheckNoRecords) " + "VALUES (?,?,?,?,?,?,?,?,?,?)";
+   }
+
+   public static String selectRecordsSQL(String tableName) {
+      return "SELECT id," + "recordType," + "compactCount," + "txId," + "userRecordType," + "variableSize," + "record," + "txDataSize," + "txData," + "txCheckNoRecords " + "FROM " + tableName;
+   }
+
+   public static String deleteRecordsSQL(String tableName) {
+      return "DELETE FROM " + tableName + " WHERE id = ?";
+   }
+
+   public static String deleteTxRecordsSQL(String tableName) {
+      return "DELETE FROM " + tableName + " WHERE txId = ?";
+   }
+
+   public void complete(boolean success) {
+      if (ioCompletion != null) {
+         if (success) {
+            ioCompletion.done();
+         }
+         else {
+            ioCompletion.onError(1, "DATABASE INSERT FAILED");
+         }
+      }
+   }
+
+   public void storeLineUp() {
+      if (storeLineUp && ioCompletion != null) {
+         ioCompletion.storeLineUp();
+      }
+   }
+
+   protected void writeRecord(PreparedStatement statement) throws SQLException {
+      statement.setLong(1, id);
+      statement.setByte(2, recordType);
+      statement.setByte(3, compactCount);
+      statement.setLong(4, txId);
+      statement.setByte(5, userRecordType);
+      statement.setInt(6, variableSize);
+      statement.setBlob(7, record);
+      statement.setInt(8, txDataSize);
+      statement.setBlob(9, txData);
+      statement.setInt(10, txCheckNoRecords);
+      statement.addBatch();
+   }
+
+   protected void writeDeleteTxRecord(PreparedStatement deleteTxStatement) throws SQLException {
+      deleteTxStatement.setLong(1, txId);
+      deleteTxStatement.addBatch();
+   }
+
+   protected void writeDeleteRecord(PreparedStatement deleteStatement) throws SQLException {
+      deleteStatement.setLong(1, id);
+      deleteStatement.addBatch();
+   }
+
+   public static JDBCJournalRecord readRecord(ResultSet rs) throws SQLException {
+      JDBCJournalRecord record = new JDBCJournalRecord(rs.getLong(1), (byte) rs.getShort(2));
+      record.setCompactCount((byte) rs.getShort(3));
+      record.setTxId(rs.getLong(4));
+      record.setUserRecordType((byte) rs.getShort(5));
+      record.setVariableSize(rs.getInt(6));
+      record.setRecord(rs.getBytes(7));
+      record.setTxDataSize(rs.getInt(8));
+      record.setTxData(rs.getBytes(9));
+      record.setTxCheckNoRecords(rs.getInt(10));
+      return record;
+   }
+
+   public IOCompletion getIoCompletion() {
+      return ioCompletion;
+   }
+
+   public void setIoCompletion(IOCompletion ioCompletion) {
+      this.ioCompletion = ioCompletion;
+   }
+
+   public boolean isStoreLineUp() {
+      return storeLineUp;
+   }
+
+   public void setStoreLineUp(boolean storeLineUp) {
+      this.storeLineUp = storeLineUp;
+   }
+
+   public boolean isSync() {
+      return sync;
+   }
+
+   public void setSync(boolean sync) {
+      this.sync = sync;
+   }
+
+   public Long getId() {
+      return id;
+   }
+
+   public byte getRecordType() {
+      return recordType;
+   }
+
+   public byte getCompactCount() {
+      return compactCount;
+   }
+
+   public void setCompactCount(byte compactCount) {
+      this.compactCount = compactCount;
+   }
+
+   public long getTxId() {
+      return txId;
+   }
+
+   public void setTxId(long txId) {
+      this.txId = txId;
+   }
+
+   public int getVariableSize() {
+      return variableSize;
+   }
+
+   public void setVariableSize(int variableSize) {
+      this.variableSize = variableSize;
+   }
+
+   public byte getUserRecordType() {
+      return userRecordType;
+   }
+
+   public void setUserRecordType(byte userRecordType) {
+      this.userRecordType = userRecordType;
+   }
+
+   public void setRecord(byte[] record) {
+      this.variableSize = record.length;
+      this.record = new ByteArrayInputStream(record);
+   }
+
+   public void setRecord(InputStream record) {
+      this.record = record;
+   }
+
+   public void setRecord(EncodingSupport record) {
+      this.variableSize = record.getEncodeSize();
+
+      ActiveMQBuffer encodedBuffer = ActiveMQBuffers.fixedBuffer(variableSize);
+      record.encode(encodedBuffer);
+      this.record = new ActiveMQBufferInputStream(encodedBuffer);
+   }
+
+   public InputStream getRecord() {
+      return record;
+   }
+
+   public int getTxCheckNoRecords() {
+      return txCheckNoRecords;
+   }
+
+   public void setTxCheckNoRecords(int txCheckNoRecords) {
+      this.txCheckNoRecords = txCheckNoRecords;
+   }
+
+   public void setTxDataSize(int txDataSize) {
+      this.txDataSize = txDataSize;
+   }
+
+   public int getTxDataSize() {
+      return txDataSize;
+   }
+
+   public InputStream getTxData() {
+      return txData;
+   }
+
+   public void setTxData(InputStream record) {
+      this.record = record;
+   }
+
+   public void setTxData(EncodingSupport txData) {
+      this.txDataSize = txData.getEncodeSize();
+
+      ActiveMQBuffer encodedBuffer = ActiveMQBuffers.fixedBuffer(variableSize);
+      txData.encode(encodedBuffer);
+      this.txData = new ActiveMQBufferInputStream(encodedBuffer);
+   }
+
+   public void setTxData(byte[] txData) {
+      this.txDataSize = txData.length;
+      this.txData = new ByteArrayInputStream(txData);
+   }
+
+   public boolean isUpdate() {
+      return isUpdate;
+   }
+
+   public byte[] getRecordData() throws IOException {
+      byte[] data = new byte[variableSize];
+      record.read(data);
+      return data;
+   }
+
+   public byte[] getTxDataAsByteArray() throws IOException {
+      byte[] data = new byte[txDataSize];
+      txData.read(data);
+      return data;
+   }
+
+   public RecordInfo toRecordInfo() throws IOException {
+      return new RecordInfo(getId(), getUserRecordType(), getRecordData(), isUpdate(), getCompactCount());
+   }
+}

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalSync.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalSync.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.jdbc.store.journal;
+
+import java.sql.SQLException;
+import java.util.TimerTask;
+
+public class JDBCJournalSync extends TimerTask {
+
+   private final JDBCJournalImpl journal;
+
+   public JDBCJournalSync(JDBCJournalImpl journal) {
+      this.journal = journal;
+   }
+
+   @Override
+   public void run() {
+      try {
+         journal.sync();
+      }
+      catch (SQLException e) {
+         e.printStackTrace();
+      }
+   }
+}

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/TransactionHolder.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/TransactionHolder.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.jdbc.store.journal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.activemq.artemis.core.journal.RecordInfo;
+
+final class TransactionHolder {
+
+   public TransactionHolder(final long id) {
+      transactionID = id;
+   }
+
+   public final long transactionID;
+
+   public final List<RecordInfo> recordInfos = new ArrayList<RecordInfo>();
+
+   public final List<RecordInfo> recordsToDelete = new ArrayList<RecordInfo>();
+
+   public boolean prepared;
+
+   public boolean invalid;
+
+   public byte[] extraData;
+}

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalImpl.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalImpl.java
@@ -1786,9 +1786,9 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
 
             PreparedTransactionInfo info = new PreparedTransactionInfo(transaction.transactionID, transaction.extraData);
 
-            info.records.addAll(transaction.recordInfos);
+            info.getRecords().addAll(transaction.recordInfos);
 
-            info.recordsToDelete.addAll(transaction.recordsToDelete);
+            info.getRecordsToDelete().addAll(transaction.recordsToDelete);
 
             loadManager.addPreparedTransaction(info);
          }

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/dataformat/JournalAddRecord.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/dataformat/JournalAddRecord.java
@@ -22,13 +22,13 @@ import org.apache.activemq.artemis.core.journal.impl.JournalImpl;
 
 public class JournalAddRecord extends JournalInternalRecord {
 
-   private final long id;
+   protected final long id;
 
-   private final EncodingSupport record;
+   protected final EncodingSupport record;
 
-   private final byte recordType;
+   protected final byte recordType;
 
-   private final boolean add;
+   protected final boolean add;
 
    /**
     * @param id

--- a/artemis-server/pom.xml
+++ b/artemis-server/pom.xml
@@ -68,6 +68,11 @@
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-jdbc-store</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-core-client</artifactId>
          <version>${project.version}</version>
       </dependency>

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
@@ -271,8 +271,9 @@ public interface Configuration {
 
    /**
     * Add an acceptor to the config
+    *
     * @param name the name of the acceptor
-    * @param uri the URI of the acceptor
+    * @param uri  the URI of the acceptor
     * @return this
     * @throws Exception in case of Parsing errors on the URI
     */
@@ -935,4 +936,7 @@ public interface Configuration {
     */
    File getBrokerInstance();
 
+   StoreConfiguration getStoreConfiguration();
+
+   Configuration setStoreConfiguration(StoreConfiguration storeConfiguration);
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/StoreConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/StoreConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,16 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.activemq.artemis.core.config;
 
-package org.apache.activemq.artemis.core.security;
+import java.io.Serializable;
 
-import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
+public interface StoreConfiguration extends Serializable {
 
-public interface SecurityAuth {
+   public enum StoreType {
+      FILE,
+      DATABASE
+   }
 
-   String getUsername();
-
-   String getPassword();
-
-   RemotingConnection getRemotingConnection();
+   StoreType getStoreType();
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
@@ -44,6 +44,7 @@ import org.apache.activemq.artemis.core.config.ConnectorServiceConfiguration;
 import org.apache.activemq.artemis.core.config.CoreQueueConfiguration;
 import org.apache.activemq.artemis.core.config.DivertConfiguration;
 import org.apache.activemq.artemis.core.config.HAPolicyConfiguration;
+import org.apache.activemq.artemis.core.config.StoreConfiguration;
 import org.apache.activemq.artemis.core.config.ha.ReplicaPolicyConfiguration;
 import org.apache.activemq.artemis.core.config.ha.ReplicatedPolicyConfiguration;
 import org.apache.activemq.artemis.core.security.Role;
@@ -228,6 +229,8 @@ public class ConfigurationImpl implements Configuration, Serializable {
 
    private HAPolicyConfiguration haPolicyConfiguration;
 
+   private StoreConfiguration storeConfiguration;
+
    /**
     * Parent folder for all data folders.
     */
@@ -407,7 +410,6 @@ public class ConfigurationImpl implements Configuration, Serializable {
       return this;
    }
 
-
    @Override
    public ConfigurationImpl addConnectorConfiguration(final String name, final String uri) throws Exception {
 
@@ -421,7 +423,6 @@ public class ConfigurationImpl implements Configuration, Serializable {
 
       return this;
    }
-
 
    @Override
    public ConfigurationImpl clearConnectorConfigurations() {
@@ -1276,6 +1277,17 @@ public class ConfigurationImpl implements Configuration, Serializable {
    @Override
    public boolean isResolveProtocols() {
       return resolveProtocols;
+   }
+
+   @Override
+   public StoreConfiguration getStoreConfiguration() {
+      return storeConfiguration;
+   }
+
+   @Override
+   public ConfigurationImpl setStoreConfiguration(StoreConfiguration storeConfiguration) {
+      this.storeConfiguration = storeConfiguration;
+      return this;
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/storage/DatabaseStorageConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/storage/DatabaseStorageConfiguration.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.config.storage;
+
+import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
+import org.apache.activemq.artemis.core.config.StoreConfiguration;
+
+public class DatabaseStorageConfiguration implements StoreConfiguration {
+
+   private String messageTableName = ActiveMQDefaultConfiguration.getDefaultMessageTableName();
+
+   private String bindingsTableName = ActiveMQDefaultConfiguration.getDefaultBindingsTableName();
+
+   private String jdbcConnectionUrl = ActiveMQDefaultConfiguration.getDefaultDatabaseUrl();
+
+   @Override
+   public StoreType getStoreType() {
+      return StoreType.DATABASE;
+   }
+
+   public String getMessageTableName() {
+      return messageTableName;
+   }
+
+   public void setMessageTableName(String messageTableName) {
+      this.messageTableName = messageTableName;
+   }
+
+   public String getBindingsTableName() {
+      return bindingsTableName;
+   }
+
+   public void setBindingsTableName(String bindingsTableName) {
+      this.bindingsTableName = bindingsTableName;
+   }
+
+   public void setJdbcConnectionUrl(String jdbcConnectionUrl) {
+      this.jdbcConnectionUrl = jdbcConnectionUrl;
+   }
+
+   public String getJdbcConnectionUrl() {
+      return jdbcConnectionUrl;
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/storage/FileStorageConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/storage/FileStorageConfiguration.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.config.storage;
+
+import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
+import org.apache.activemq.artemis.core.config.StoreConfiguration;
+
+public class FileStorageConfiguration implements StoreConfiguration {
+
+   private String messageTableName = ActiveMQDefaultConfiguration.getDefaultMessageTableName();
+
+   private String bindingsTableName = ActiveMQDefaultConfiguration.getDefaultBindingsTableName();
+
+   private String jdbcConnectionUrl = ActiveMQDefaultConfiguration.getDefaultDatabaseUrl();
+
+   @Override
+   public StoreType getStoreType() {
+      return StoreType.DATABASE;
+   }
+
+   public String getMessageTableName() {
+      return messageTableName;
+   }
+
+   public void setMessageTableName(String messageTableName) {
+      this.messageTableName = messageTableName;
+   }
+
+   public String getBindingsTableName() {
+      return bindingsTableName;
+   }
+
+   public void setBindingsTableName(String bindingsTableName) {
+      this.bindingsTableName = bindingsTableName;
+   }
+
+   public void setJdbcConnectionUrl(String jdbcConnectionUrl) {
+      this.jdbcConnectionUrl = jdbcConnectionUrl;
+   }
+
+   public String getJdbcConnectionUrl() {
+      return jdbcConnectionUrl;
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AbstractJournalStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AbstractJournalStorageManager.java
@@ -1,0 +1,1828 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.persistence.impl.journal;
+
+import javax.transaction.xa.Xid;
+import java.io.File;
+import java.io.FileInputStream;
+import java.security.AccessController;
+import java.security.DigestInputStream;
+import java.security.InvalidParameterException;
+import java.security.MessageDigest;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
+import org.apache.activemq.artemis.api.core.Pair;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.filter.Filter;
+import org.apache.activemq.artemis.core.io.IOCallback;
+import org.apache.activemq.artemis.core.io.IOCriticalErrorListener;
+import org.apache.activemq.artemis.core.journal.Journal;
+import org.apache.activemq.artemis.core.journal.JournalLoadInformation;
+import org.apache.activemq.artemis.core.journal.PreparedTransactionInfo;
+import org.apache.activemq.artemis.core.journal.RecordInfo;
+import org.apache.activemq.artemis.core.paging.PageTransactionInfo;
+import org.apache.activemq.artemis.core.paging.PagingManager;
+import org.apache.activemq.artemis.core.paging.PagingStore;
+import org.apache.activemq.artemis.core.paging.cursor.PagePosition;
+import org.apache.activemq.artemis.core.paging.cursor.PageSubscription;
+import org.apache.activemq.artemis.core.paging.cursor.PagedReferenceImpl;
+import org.apache.activemq.artemis.core.paging.impl.PageTransactionInfoImpl;
+import org.apache.activemq.artemis.core.persistence.GroupingInfo;
+import org.apache.activemq.artemis.core.persistence.OperationContext;
+import org.apache.activemq.artemis.core.persistence.QueueBindingInfo;
+import org.apache.activemq.artemis.core.persistence.StorageManager;
+import org.apache.activemq.artemis.core.persistence.config.PersistedAddressSetting;
+import org.apache.activemq.artemis.core.persistence.config.PersistedRoles;
+import org.apache.activemq.artemis.core.persistence.impl.PageCountPending;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.CursorAckRecordEncoding;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.DeleteEncoding;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.DeliveryCountUpdateEncoding;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.DuplicateIDEncoding;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.FinishPageMessageOperation;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.GroupingEncoding;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.HeuristicCompletionEncoding;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.LargeMessageEncoding;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.PageCountPendingImpl;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.PageCountRecord;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.PageCountRecordInc;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.PageUpdateTXEncoding;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.PendingLargeMessageEncoding;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.PersistentQueueBindingEncoding;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.RefEncoding;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.ScheduledDeliveryEncoding;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.XidEncoding;
+import org.apache.activemq.artemis.core.postoffice.Binding;
+import org.apache.activemq.artemis.core.postoffice.DuplicateIDCache;
+import org.apache.activemq.artemis.core.postoffice.PostOffice;
+import org.apache.activemq.artemis.core.server.ActiveMQMessageBundle;
+import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
+import org.apache.activemq.artemis.core.server.LargeServerMessage;
+import org.apache.activemq.artemis.core.server.MessageReference;
+import org.apache.activemq.artemis.core.server.Queue;
+import org.apache.activemq.artemis.core.server.RouteContextList;
+import org.apache.activemq.artemis.core.server.ServerMessage;
+import org.apache.activemq.artemis.core.server.group.impl.GroupBinding;
+import org.apache.activemq.artemis.core.server.impl.JournalLoader;
+import org.apache.activemq.artemis.core.server.impl.ServerMessageImpl;
+import org.apache.activemq.artemis.core.transaction.ResourceManager;
+import org.apache.activemq.artemis.core.transaction.Transaction;
+import org.apache.activemq.artemis.core.transaction.TransactionPropertyIndexes;
+import org.apache.activemq.artemis.core.transaction.impl.TransactionImpl;
+import org.apache.activemq.artemis.utils.ActiveMQThreadFactory;
+import org.apache.activemq.artemis.utils.Base64;
+import org.apache.activemq.artemis.utils.ExecutorFactory;
+import org.apache.activemq.artemis.utils.IDGenerator;
+
+import static org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds.ACKNOWLEDGE_CURSOR;
+import static org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds.ADD_LARGE_MESSAGE_PENDING;
+import static org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds.DUPLICATE_ID;
+import static org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds.PAGE_CURSOR_COUNTER_INC;
+import static org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds.PAGE_CURSOR_COUNTER_VALUE;
+import static org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds.SET_SCHEDULED_DELIVERY_TIME;
+
+/**
+ * Controls access to the journals and other storage files such as the ones used to store pages and
+ * large messages.  This class must control writing of any non-transient data, as it is the key point
+ * for synchronizing any replicating backup server.
+ * <p>
+ * Using this class also ensures that locks are acquired in the right order, avoiding dead-locks.
+ */
+public abstract class AbstractJournalStorageManager implements StorageManager {
+
+   public enum JournalContent {
+      BINDINGS((byte) 0), MESSAGES((byte) 1);
+
+      public final byte typeByte;
+
+      JournalContent(byte b) {
+         typeByte = b;
+      }
+
+      public static JournalContent getType(byte type) {
+         if (MESSAGES.typeByte == type)
+            return MESSAGES;
+         if (BINDINGS.typeByte == type)
+            return BINDINGS;
+         throw new InvalidParameterException("invalid byte: " + type);
+      }
+   }
+
+   private static final long CHECKPOINT_BATCH_SIZE = Integer.MAX_VALUE;
+
+   protected Semaphore pageMaxConcurrentIO;
+
+   protected BatchingIDGenerator idGenerator;
+
+   protected final ReentrantReadWriteLock storageManagerLock = new ReentrantReadWriteLock(true);
+
+   protected Journal messageJournal;
+
+   protected Journal bindingsJournal;
+
+   protected volatile boolean started;
+
+   /**
+    * Used to create Operation Contexts
+    */
+   private final ExecutorFactory executorFactory;
+
+   final Executor executor;
+
+   ExecutorService singleThreadExecutor;
+
+   private final boolean syncTransactional;
+
+   private final boolean syncNonTransactional;
+
+   protected int perfBlastPages = -1;
+
+   protected boolean journalLoaded = false;
+
+   private final IOCriticalErrorListener ioCriticalErrorListener;
+
+   protected final Configuration config;
+
+   // Persisted core configuration
+   protected final Map<SimpleString, PersistedRoles> mapPersistedRoles = new ConcurrentHashMap<>();
+
+   protected final Map<SimpleString, PersistedAddressSetting> mapPersistedAddressSettings = new ConcurrentHashMap<>();
+
+   protected final Set<Long> largeMessagesToDelete = new HashSet<>();
+
+   public AbstractJournalStorageManager(final Configuration config, final ExecutorFactory executorFactory) {
+      this(config, executorFactory, null);
+   }
+
+   public AbstractJournalStorageManager(Configuration config,
+                                        ExecutorFactory executorFactory,
+                                        IOCriticalErrorListener criticalErrorListener) {
+      this.executorFactory = executorFactory;
+
+      this.ioCriticalErrorListener = criticalErrorListener;
+
+      this.config = config;
+
+      executor = executorFactory.getExecutor();
+
+      syncNonTransactional = config.isJournalSyncNonTransactional();
+      syncTransactional = config.isJournalSyncTransactional();
+
+      init(config, criticalErrorListener);
+
+      idGenerator = new BatchingIDGenerator(0, CHECKPOINT_BATCH_SIZE, this);
+   }
+
+   /**
+    * Called during initialization.  Used by implementations to setup Journals, Stores etc...
+    * @param config
+    * @param criticalErrorListener
+    */
+   protected abstract void init(Configuration config, IOCriticalErrorListener criticalErrorListener);
+
+   @Override
+   public void criticalError(Throwable error) {
+      ioCriticalErrorListener.onIOException(error, error.getMessage(), null);
+   }
+
+   @Override
+   public void clearContext() {
+      OperationContextImpl.clearContext();
+   }
+
+   public static String md5(File file) {
+      try {
+         byte[] buffer = new byte[1 << 4];
+         MessageDigest md = MessageDigest.getInstance("MD5");
+
+         FileInputStream is = new FileInputStream(file);
+         DigestInputStream is2 = new DigestInputStream(is, md);
+         while (is2.read(buffer) > 0) {
+            continue;
+         }
+         byte[] digest = md.digest();
+         is.close();
+         is2.close();
+         return Base64.encodeBytes(digest);
+      }
+      catch (Exception e) {
+         throw new RuntimeException(e);
+      }
+   }
+
+   public IDGenerator getIDGenerator() {
+      return idGenerator;
+   }
+
+   @Override
+   public final void waitOnOperations() throws Exception {
+      if (!started) {
+         ActiveMQServerLogger.LOGGER.serverIsStopped();
+         throw new IllegalStateException("Server is stopped");
+      }
+      waitOnOperations(0);
+   }
+
+   @Override
+   public final boolean waitOnOperations(final long timeout) throws Exception {
+      if (!started) {
+         ActiveMQServerLogger.LOGGER.serverIsStopped();
+         throw new IllegalStateException("Server is stopped");
+      }
+      return getContext().waitCompletion(timeout);
+   }
+
+   public OperationContext getContext() {
+      return OperationContextImpl.getContext(executorFactory);
+   }
+
+   public void setContext(final OperationContext context) {
+      OperationContextImpl.setContext(context);
+   }
+
+   public Executor getSingleThreadExecutor() {
+      return singleThreadExecutor;
+   }
+
+   public OperationContext newSingleThreadContext() {
+      return newContext(singleThreadExecutor);
+   }
+
+   public OperationContext newContext(final Executor executor1) {
+      return new OperationContextImpl(executor1);
+   }
+
+   public void afterCompleteOperations(final IOCallback run) {
+      getContext().executeOnCompletion(run);
+   }
+
+   public long generateID() {
+      return idGenerator.generateID();
+   }
+
+   public long getCurrentID() {
+      return idGenerator.getCurrentID();
+   }
+
+   // Non transactional operations
+
+
+   public void confirmPendingLargeMessageTX(final Transaction tx, long messageID, long recordID) throws Exception {
+      readLock();
+      try {
+         installLargeMessageConfirmationOnTX(tx, recordID);
+         messageJournal.appendDeleteRecordTransactional(tx.getID(), recordID, new DeleteEncoding(JournalRecordIds.ADD_LARGE_MESSAGE_PENDING, messageID));
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   /**
+    * We don't need messageID now but we are likely to need it we ever decide to support a database
+    */
+   public void confirmPendingLargeMessage(long recordID) throws Exception {
+      readLock();
+      try {
+         messageJournal.appendDeleteRecord(recordID, true, getContext());
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void storeMessage(final ServerMessage message) throws Exception {
+      if (message.getMessageID() <= 0) {
+         // Sanity check only... this shouldn't happen unless there is a bug
+         throw ActiveMQMessageBundle.BUNDLE.messageIdNotAssigned();
+      }
+
+      readLock();
+      try {
+         // Note that we don't sync, the add reference that comes immediately after will sync if
+         // appropriate
+
+         if (message.isLargeMessage()) {
+            messageJournal.appendAddRecord(message.getMessageID(), JournalRecordIds.ADD_LARGE_MESSAGE, new LargeMessageEncoding((LargeServerMessage) message), false, getContext(false));
+         }
+         else {
+            messageJournal.appendAddRecord(message.getMessageID(), JournalRecordIds.ADD_MESSAGE, message, false, getContext(false));
+         }
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void storeReference(final long queueID, final long messageID, final boolean last) throws Exception {
+      readLock();
+      try {
+         messageJournal.appendUpdateRecord(messageID, JournalRecordIds.ADD_REF, new RefEncoding(queueID), last && syncNonTransactional, getContext(last && syncNonTransactional));
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   @Override
+   public void readLock() {
+      storageManagerLock.readLock().lock();
+   }
+
+   @Override
+   public void readUnLock() {
+      storageManagerLock.readLock().unlock();
+   }
+
+   public void storeAcknowledge(final long queueID, final long messageID) throws Exception {
+      readLock();
+      try {
+         messageJournal.appendUpdateRecord(messageID, JournalRecordIds.ACKNOWLEDGE_REF, new RefEncoding(queueID), syncNonTransactional, getContext(syncNonTransactional));
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void storeCursorAcknowledge(long queueID, PagePosition position) throws Exception {
+      readLock();
+      try {
+         long ackID = idGenerator.generateID();
+         position.setRecordID(ackID);
+         messageJournal.appendAddRecord(ackID, JournalRecordIds.ACKNOWLEDGE_CURSOR, new CursorAckRecordEncoding(queueID, position), syncNonTransactional, getContext(syncNonTransactional));
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void deleteMessage(final long messageID) throws Exception {
+      readLock();
+      try {
+         // Messages are deleted on postACK, one after another.
+         // If these deletes are synchronized, we would build up messages on the Executor
+         // increasing chances of losing deletes.
+         // The StorageManager should verify messages without references
+         messageJournal.appendDeleteRecord(messageID, false, getContext(false));
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void updateScheduledDeliveryTime(final MessageReference ref) throws Exception {
+      ScheduledDeliveryEncoding encoding = new ScheduledDeliveryEncoding(ref.getScheduledDeliveryTime(), ref.getQueue().getID());
+      readLock();
+      try {
+         messageJournal.appendUpdateRecord(ref.getMessage().getMessageID(), JournalRecordIds.SET_SCHEDULED_DELIVERY_TIME, encoding, syncNonTransactional, getContext(syncNonTransactional));
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void storeDuplicateID(final SimpleString address, final byte[] duplID, final long recordID) throws Exception {
+      readLock();
+      try {
+         DuplicateIDEncoding encoding = new DuplicateIDEncoding(address, duplID);
+
+         messageJournal.appendAddRecord(recordID, JournalRecordIds.DUPLICATE_ID, encoding, syncNonTransactional, getContext(syncNonTransactional));
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void deleteDuplicateID(final long recordID) throws Exception {
+      readLock();
+      try {
+         messageJournal.appendDeleteRecord(recordID, syncNonTransactional, getContext(syncNonTransactional));
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   // Transactional operations
+
+   public void storeMessageTransactional(final long txID, final ServerMessage message) throws Exception {
+      if (message.getMessageID() <= 0) {
+         throw ActiveMQMessageBundle.BUNDLE.messageIdNotAssigned();
+      }
+
+      readLock();
+      try {
+         if (message.isLargeMessage()) {
+            messageJournal.appendAddRecordTransactional(txID, message.getMessageID(), JournalRecordIds.ADD_LARGE_MESSAGE, new LargeMessageEncoding(((LargeServerMessage) message)));
+         }
+         else {
+            messageJournal.appendAddRecordTransactional(txID, message.getMessageID(), JournalRecordIds.ADD_MESSAGE, message);
+         }
+
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void storePageTransaction(final long txID, final PageTransactionInfo pageTransaction) throws Exception {
+      readLock();
+      try {
+         pageTransaction.setRecordID(generateID());
+         messageJournal.appendAddRecordTransactional(txID, pageTransaction.getRecordID(), JournalRecordIds.PAGE_TRANSACTION, pageTransaction);
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void updatePageTransaction(final long txID,
+                                     final PageTransactionInfo pageTransaction,
+                                     final int depages) throws Exception {
+      readLock();
+      try {
+         messageJournal.appendUpdateRecordTransactional(txID, pageTransaction.getRecordID(), JournalRecordIds.PAGE_TRANSACTION, new PageUpdateTXEncoding(pageTransaction.getTransactionID(), depages));
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void updatePageTransaction(final PageTransactionInfo pageTransaction, final int depages) throws Exception {
+      readLock();
+      try {
+         messageJournal.appendUpdateRecord(pageTransaction.getRecordID(), JournalRecordIds.PAGE_TRANSACTION, new PageUpdateTXEncoding(pageTransaction.getTransactionID(), depages), syncNonTransactional, getContext(syncNonTransactional));
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void storeReferenceTransactional(final long txID, final long queueID, final long messageID) throws Exception {
+      readLock();
+      try {
+         messageJournal.appendUpdateRecordTransactional(txID, messageID, JournalRecordIds.ADD_REF, new RefEncoding(queueID));
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void storeAcknowledgeTransactional(final long txID,
+                                             final long queueID,
+                                             final long messageID) throws Exception {
+      readLock();
+      try {
+         messageJournal.appendUpdateRecordTransactional(txID, messageID, JournalRecordIds.ACKNOWLEDGE_REF, new RefEncoding(queueID));
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void storeCursorAcknowledgeTransactional(long txID, long queueID, PagePosition position) throws Exception {
+      readLock();
+      try {
+         long ackID = idGenerator.generateID();
+         position.setRecordID(ackID);
+         messageJournal.appendAddRecordTransactional(txID, ackID, JournalRecordIds.ACKNOWLEDGE_CURSOR, new CursorAckRecordEncoding(queueID, position));
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void storePageCompleteTransactional(long txID, long queueID, PagePosition position) throws Exception {
+      long recordID = idGenerator.generateID();
+      position.setRecordID(recordID);
+      messageJournal.appendAddRecordTransactional(txID, recordID, JournalRecordIds.PAGE_CURSOR_COMPLETE, new CursorAckRecordEncoding(queueID, position));
+   }
+
+   public void deletePageComplete(long ackID) throws Exception {
+      messageJournal.appendDeleteRecord(ackID, false);
+   }
+
+   public void deleteCursorAcknowledgeTransactional(long txID, long ackID) throws Exception {
+      readLock();
+      try {
+         messageJournal.appendDeleteRecordTransactional(txID, ackID);
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void deleteCursorAcknowledge(long ackID) throws Exception {
+      messageJournal.appendDeleteRecord(ackID, false);
+   }
+
+   public long storeHeuristicCompletion(final Xid xid, final boolean isCommit) throws Exception {
+      readLock();
+      try {
+         long id = generateID();
+
+         messageJournal.appendAddRecord(id, JournalRecordIds.HEURISTIC_COMPLETION, new HeuristicCompletionEncoding(xid, isCommit), true, getContext(true));
+         return id;
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void deleteHeuristicCompletion(final long id) throws Exception {
+      readLock();
+      try {
+
+         messageJournal.appendDeleteRecord(id, true, getContext(true));
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void deletePageTransactional(final long recordID) throws Exception {
+      readLock();
+      try {
+         messageJournal.appendDeleteRecord(recordID, false);
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void updateScheduledDeliveryTimeTransactional(final long txID, final MessageReference ref) throws Exception {
+      ScheduledDeliveryEncoding encoding = new ScheduledDeliveryEncoding(ref.getScheduledDeliveryTime(), ref.getQueue().getID());
+      readLock();
+      try {
+
+         messageJournal.appendUpdateRecordTransactional(txID, ref.getMessage().getMessageID(), JournalRecordIds.SET_SCHEDULED_DELIVERY_TIME, encoding);
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void prepare(final long txID, final Xid xid) throws Exception {
+      readLock();
+      try {
+         messageJournal.appendPrepareRecord(txID, new XidEncoding(xid), syncTransactional, getContext(syncTransactional));
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void commit(final long txID) throws Exception {
+      commit(txID, true);
+   }
+
+   public void commitBindings(final long txID) throws Exception {
+      bindingsJournal.appendCommitRecord(txID, true);
+   }
+
+   public void rollbackBindings(final long txID) throws Exception {
+      // no need to sync, it's going away anyways
+      bindingsJournal.appendRollbackRecord(txID, false);
+   }
+
+   public void commit(final long txID, final boolean lineUpContext) throws Exception {
+      readLock();
+      try {
+         messageJournal.appendCommitRecord(txID, syncTransactional, getContext(syncTransactional), lineUpContext);
+         if (!lineUpContext && !syncTransactional) {
+            /**
+             * If {@code lineUpContext == false}, it means that we have previously lined up a
+             * context somewhere else (specifically see @{link TransactionImpl#asyncAppendCommit}),
+             * hence we need to mark it as done even if {@code syncTransactional = false} as in this
+             * case {@code getContext(syncTransactional=false)} would pass a dummy context to the
+             * {@code messageJournal.appendCommitRecord(...)} call above.
+             */
+            getContext(true).done();
+         }
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void rollback(final long txID) throws Exception {
+      readLock();
+      try {
+         messageJournal.appendRollbackRecord(txID, syncTransactional, getContext(syncTransactional));
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void storeDuplicateIDTransactional(final long txID,
+                                             final SimpleString address,
+                                             final byte[] duplID,
+                                             final long recordID) throws Exception {
+      DuplicateIDEncoding encoding = new DuplicateIDEncoding(address, duplID);
+
+      readLock();
+      try {
+         messageJournal.appendAddRecordTransactional(txID, recordID, JournalRecordIds.DUPLICATE_ID, encoding);
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void updateDuplicateIDTransactional(final long txID,
+                                              final SimpleString address,
+                                              final byte[] duplID,
+                                              final long recordID) throws Exception {
+      DuplicateIDEncoding encoding = new DuplicateIDEncoding(address, duplID);
+
+      readLock();
+      try {
+         messageJournal.appendUpdateRecordTransactional(txID, recordID, JournalRecordIds.DUPLICATE_ID, encoding);
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void deleteDuplicateIDTransactional(final long txID, final long recordID) throws Exception {
+      readLock();
+      try {
+         messageJournal.appendDeleteRecordTransactional(txID, recordID);
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   // Other operations
+
+   public void updateDeliveryCount(final MessageReference ref) throws Exception {
+      // no need to store if it's the same value
+      // otherwise the journal will get OME in case of lots of redeliveries
+      if (ref.getDeliveryCount() == ref.getPersistedCount()) {
+         return;
+      }
+
+      ref.setPersistedCount(ref.getDeliveryCount());
+      DeliveryCountUpdateEncoding updateInfo = new DeliveryCountUpdateEncoding(ref.getQueue().getID(), ref.getDeliveryCount());
+
+      readLock();
+      try {
+         messageJournal.appendUpdateRecord(ref.getMessage().getMessageID(), JournalRecordIds.UPDATE_DELIVERY_COUNT, updateInfo, syncNonTransactional, getContext(syncNonTransactional));
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void storeAddressSetting(PersistedAddressSetting addressSetting) throws Exception {
+      deleteAddressSetting(addressSetting.getAddressMatch());
+      readLock();
+      try {
+         long id = idGenerator.generateID();
+         addressSetting.setStoreId(id);
+         bindingsJournal.appendAddRecord(id, JournalRecordIds.ADDRESS_SETTING_RECORD, addressSetting, true);
+         mapPersistedAddressSettings.put(addressSetting.getAddressMatch(), addressSetting);
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public List<PersistedAddressSetting> recoverAddressSettings() throws Exception {
+      return new ArrayList<>(mapPersistedAddressSettings.values());
+   }
+
+   public List<PersistedRoles> recoverPersistedRoles() throws Exception {
+      return new ArrayList<>(mapPersistedRoles.values());
+   }
+
+   public void storeSecurityRoles(PersistedRoles persistedRoles) throws Exception {
+
+      deleteSecurityRoles(persistedRoles.getAddressMatch());
+      readLock();
+      try {
+         final long id = idGenerator.generateID();
+         persistedRoles.setStoreId(id);
+         bindingsJournal.appendAddRecord(id, JournalRecordIds.SECURITY_RECORD, persistedRoles, true);
+         mapPersistedRoles.put(persistedRoles.getAddressMatch(), persistedRoles);
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   @Override
+   public void storeID(final long journalID, final long id) throws Exception {
+      readLock();
+      try {
+         bindingsJournal.appendAddRecord(journalID, JournalRecordIds.ID_COUNTER_RECORD, BatchingIDGenerator.createIDEncodingSupport(id), true);
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   @Override
+   public void deleteID(long journalD) throws Exception {
+      readLock();
+      try {
+         bindingsJournal.appendDeleteRecord(journalD, false);
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void deleteAddressSetting(SimpleString addressMatch) throws Exception {
+      PersistedAddressSetting oldSetting = mapPersistedAddressSettings.remove(addressMatch);
+      if (oldSetting != null) {
+         readLock();
+         try {
+            bindingsJournal.appendDeleteRecord(oldSetting.getStoreId(), false);
+         }
+         finally {
+            readUnLock();
+         }
+      }
+   }
+
+   public void deleteSecurityRoles(SimpleString addressMatch) throws Exception {
+      PersistedRoles oldRoles = mapPersistedRoles.remove(addressMatch);
+      if (oldRoles != null) {
+         readLock();
+         try {
+            bindingsJournal.appendDeleteRecord(oldRoles.getStoreId(), false);
+         }
+         finally {
+            readUnLock();
+         }
+      }
+   }
+
+   @Override
+   public JournalLoadInformation loadMessageJournal(final PostOffice postOffice,
+                                                    final PagingManager pagingManager,
+                                                    final ResourceManager resourceManager,
+                                                    Map<Long, QueueBindingInfo> queueInfos,
+                                                    final Map<SimpleString, List<Pair<byte[], Long>>> duplicateIDMap,
+                                                    final Set<Pair<Long, Long>> pendingLargeMessages,
+                                                    List<PageCountPending> pendingNonTXPageCounter,
+                                                    final JournalLoader journalLoader) throws Exception {
+      List<RecordInfo> records = new ArrayList<>();
+
+      List<PreparedTransactionInfo> preparedTransactions = new ArrayList<>();
+
+      Map<Long, ServerMessage> messages = new HashMap<>();
+      readLock();
+      try {
+
+         JournalLoadInformation info = messageJournal.load(records, preparedTransactions, new LargeMessageTXFailureCallback(this, messages));
+
+         ArrayList<LargeServerMessage> largeMessages = new ArrayList<>();
+
+         Map<Long, Map<Long, AddMessageRecord>> queueMap = new HashMap<>();
+
+         Map<Long, PageSubscription> pageSubscriptions = new HashMap<>();
+
+         final int totalSize = records.size();
+
+         for (int reccount = 0; reccount < totalSize; reccount++) {
+            // It will show log.info only with large journals (more than 1 million records)
+            if (reccount > 0 && reccount % 1000000 == 0) {
+               long percent = (long) ((((double) reccount) / ((double) totalSize)) * 100f);
+
+               ActiveMQServerLogger.LOGGER.percentLoaded(percent);
+            }
+
+            RecordInfo record = records.get(reccount);
+            byte[] data = record.data;
+
+            ActiveMQBuffer buff = ActiveMQBuffers.wrappedBuffer(data);
+
+            byte recordType = record.getUserRecordType();
+
+            switch (recordType) {
+               case JournalRecordIds.ADD_LARGE_MESSAGE_PENDING: {
+                  PendingLargeMessageEncoding pending = new PendingLargeMessageEncoding();
+
+                  pending.decode(buff);
+
+                  if (pendingLargeMessages != null) {
+                     // it could be null on tests, and we don't need anything on that case
+                     pendingLargeMessages.add(new Pair<>(record.id, pending.largeMessageID));
+                  }
+                  break;
+               }
+               case JournalRecordIds.ADD_LARGE_MESSAGE: {
+                  LargeServerMessage largeMessage = parseLargeMessage(messages, buff);
+
+                  messages.put(record.id, largeMessage);
+
+                  largeMessages.add(largeMessage);
+
+                  break;
+               }
+               case JournalRecordIds.ADD_MESSAGE: {
+                  ServerMessage message = new ServerMessageImpl(record.id, 50);
+
+                  message.decode(buff);
+
+                  messages.put(record.id, message);
+
+                  break;
+               }
+               case JournalRecordIds.ADD_REF: {
+                  long messageID = record.id;
+
+                  RefEncoding encoding = new RefEncoding();
+
+                  encoding.decode(buff);
+
+                  Map<Long, AddMessageRecord> queueMessages = queueMap.get(encoding.queueID);
+
+                  if (queueMessages == null) {
+                     queueMessages = new LinkedHashMap<>();
+
+                     queueMap.put(encoding.queueID, queueMessages);
+                  }
+
+                  ServerMessage message = messages.get(messageID);
+
+                  if (message == null) {
+                     ActiveMQServerLogger.LOGGER.cannotFindMessage(record.id);
+                  }
+                  else {
+                     queueMessages.put(messageID, new AddMessageRecord(message));
+                  }
+
+                  break;
+               }
+               case JournalRecordIds.ACKNOWLEDGE_REF: {
+                  long messageID = record.id;
+
+                  RefEncoding encoding = new RefEncoding();
+
+                  encoding.decode(buff);
+
+                  Map<Long, AddMessageRecord> queueMessages = queueMap.get(encoding.queueID);
+
+                  if (queueMessages == null) {
+                     ActiveMQServerLogger.LOGGER.journalCannotFindQueue(encoding.queueID, messageID);
+                  }
+                  else {
+                     AddMessageRecord rec = queueMessages.remove(messageID);
+
+                     if (rec == null) {
+                        ActiveMQServerLogger.LOGGER.cannotFindMessage(messageID);
+                     }
+                  }
+
+                  break;
+               }
+               case JournalRecordIds.UPDATE_DELIVERY_COUNT: {
+                  long messageID = record.id;
+
+                  DeliveryCountUpdateEncoding encoding = new DeliveryCountUpdateEncoding();
+
+                  encoding.decode(buff);
+
+                  Map<Long, AddMessageRecord> queueMessages = queueMap.get(encoding.queueID);
+
+                  if (queueMessages == null) {
+                     ActiveMQServerLogger.LOGGER.journalCannotFindQueueDelCount(encoding.queueID);
+                  }
+                  else {
+                     AddMessageRecord rec = queueMessages.get(messageID);
+
+                     if (rec == null) {
+                        ActiveMQServerLogger.LOGGER.journalCannotFindMessageDelCount(messageID);
+                     }
+                     else {
+                        rec.setDeliveryCount(encoding.count);
+                     }
+                  }
+
+                  break;
+               }
+               case JournalRecordIds.PAGE_TRANSACTION: {
+                  if (record.isUpdate) {
+                     PageUpdateTXEncoding pageUpdate = new PageUpdateTXEncoding();
+
+                     pageUpdate.decode(buff);
+
+                     PageTransactionInfo pageTX = pagingManager.getTransaction(pageUpdate.pageTX);
+
+                     pageTX.onUpdate(pageUpdate.recods, null, null);
+                  }
+                  else {
+                     PageTransactionInfoImpl pageTransactionInfo = new PageTransactionInfoImpl();
+
+                     pageTransactionInfo.decode(buff);
+
+                     pageTransactionInfo.setRecordID(record.id);
+
+                     pagingManager.addTransaction(pageTransactionInfo);
+                  }
+
+                  break;
+               }
+               case JournalRecordIds.SET_SCHEDULED_DELIVERY_TIME: {
+                  long messageID = record.id;
+
+                  ScheduledDeliveryEncoding encoding = new ScheduledDeliveryEncoding();
+
+                  encoding.decode(buff);
+
+                  Map<Long, AddMessageRecord> queueMessages = queueMap.get(encoding.queueID);
+
+                  if (queueMessages == null) {
+                     ActiveMQServerLogger.LOGGER.journalCannotFindQueueScheduled(encoding.queueID, messageID);
+                  }
+                  else {
+
+                     AddMessageRecord rec = queueMessages.get(messageID);
+
+                     if (rec == null) {
+                        ActiveMQServerLogger.LOGGER.cannotFindMessage(messageID);
+                     }
+                     else {
+                        rec.setScheduledDeliveryTime(encoding.scheduledDeliveryTime);
+                     }
+                  }
+
+                  break;
+               }
+               case JournalRecordIds.DUPLICATE_ID: {
+                  DuplicateIDEncoding encoding = new DuplicateIDEncoding();
+
+                  encoding.decode(buff);
+
+                  List<Pair<byte[], Long>> ids = duplicateIDMap.get(encoding.address);
+
+                  if (ids == null) {
+                     ids = new ArrayList<>();
+
+                     duplicateIDMap.put(encoding.address, ids);
+                  }
+
+                  ids.add(new Pair<>(encoding.duplID, record.id));
+
+                  break;
+               }
+               case JournalRecordIds.HEURISTIC_COMPLETION: {
+                  HeuristicCompletionEncoding encoding = new HeuristicCompletionEncoding();
+                  encoding.decode(buff);
+                  resourceManager.putHeuristicCompletion(record.id, encoding.xid, encoding.isCommit);
+                  break;
+               }
+               case JournalRecordIds.ACKNOWLEDGE_CURSOR: {
+                  CursorAckRecordEncoding encoding = new CursorAckRecordEncoding();
+                  encoding.decode(buff);
+
+                  encoding.position.setRecordID(record.id);
+
+                  PageSubscription sub = locateSubscription(encoding.queueID, pageSubscriptions, queueInfos, pagingManager);
+
+                  if (sub != null) {
+                     sub.reloadACK(encoding.position);
+                  }
+                  else {
+                     ActiveMQServerLogger.LOGGER.journalCannotFindQueueReloading(encoding.queueID);
+                     messageJournal.appendDeleteRecord(record.id, false);
+
+                  }
+
+                  break;
+               }
+               case JournalRecordIds.PAGE_CURSOR_COUNTER_VALUE: {
+                  PageCountRecord encoding = new PageCountRecord();
+
+                  encoding.decode(buff);
+
+                  PageSubscription sub = locateSubscription(encoding.getQueueID(), pageSubscriptions, queueInfos, pagingManager);
+
+                  if (sub != null) {
+                     sub.getCounter().loadValue(record.id, encoding.getValue());
+                  }
+                  else {
+                     ActiveMQServerLogger.LOGGER.journalCannotFindQueueReloadingPage(encoding.getQueueID());
+                     messageJournal.appendDeleteRecord(record.id, false);
+                  }
+
+                  break;
+               }
+
+               case JournalRecordIds.PAGE_CURSOR_COUNTER_INC: {
+                  PageCountRecordInc encoding = new PageCountRecordInc();
+
+                  encoding.decode(buff);
+
+                  PageSubscription sub = locateSubscription(encoding.getQueueID(), pageSubscriptions, queueInfos, pagingManager);
+
+                  if (sub != null) {
+                     sub.getCounter().loadInc(record.id, encoding.getValue());
+                  }
+                  else {
+                     ActiveMQServerLogger.LOGGER.journalCannotFindQueueReloadingPageCursor(encoding.getQueueID());
+                     messageJournal.appendDeleteRecord(record.id, false);
+                  }
+
+                  break;
+               }
+
+               case JournalRecordIds.PAGE_CURSOR_COMPLETE: {
+                  CursorAckRecordEncoding encoding = new CursorAckRecordEncoding();
+                  encoding.decode(buff);
+
+                  encoding.position.setRecordID(record.id);
+
+                  PageSubscription sub = locateSubscription(encoding.queueID, pageSubscriptions, queueInfos, pagingManager);
+
+                  if (sub != null) {
+                     sub.reloadPageCompletion(encoding.position);
+                  }
+                  else {
+                     ActiveMQServerLogger.LOGGER.cantFindQueueOnPageComplete(encoding.queueID);
+                     messageJournal.appendDeleteRecord(record.id, false);
+                  }
+
+                  break;
+               }
+
+               case JournalRecordIds.PAGE_CURSOR_PENDING_COUNTER: {
+
+                  PageCountPendingImpl pendingCountEncoding = new PageCountPendingImpl();
+                  pendingCountEncoding.decode(buff);
+                  pendingCountEncoding.setID(record.id);
+
+                  // This can be null on testcases not interested on this outcome
+                  if (pendingNonTXPageCounter != null) {
+                     pendingNonTXPageCounter.add(pendingCountEncoding);
+                  }
+                  break;
+               }
+
+               default: {
+                  throw new IllegalStateException("Invalid record type " + recordType);
+               }
+            }
+
+            // This will free up memory sooner. The record is not needed any more
+            // and its byte array would consume memory during the load process even though it's not necessary any longer
+            // what would delay processing time during load
+            records.set(reccount, null);
+         }
+
+         // Release the memory as soon as not needed any longer
+         records.clear();
+         records = null;
+
+         journalLoader.handleAddMessage(queueMap);
+
+         loadPreparedTransactions(postOffice, pagingManager, resourceManager, queueInfos, preparedTransactions, duplicateIDMap, pageSubscriptions, pendingLargeMessages, journalLoader);
+
+         for (PageSubscription sub : pageSubscriptions.values()) {
+            sub.getCounter().processReload();
+         }
+
+         for (LargeServerMessage msg : largeMessages) {
+            if (msg.getRefCount() == 0) {
+               ActiveMQServerLogger.LOGGER.largeMessageWithNoRef(msg.getMessageID());
+               msg.decrementDelayDeletionCount();
+            }
+         }
+
+         journalLoader.handleNoMessageReferences(messages);
+
+         // To recover positions on Iterators
+         if (pagingManager != null) {
+            // it could be null on certain tests that are not dealing with paging
+            // This could also be the case in certain embedded conditions
+            pagingManager.processReload();
+         }
+
+         if (perfBlastPages != -1) {
+            messageJournal.perfBlast(perfBlastPages);
+         }
+
+         journalLoader.postLoad(messageJournal, resourceManager, duplicateIDMap);
+         journalLoaded = true;
+         return info;
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   /**
+    * @param queueID
+    * @param pageSubscriptions
+    * @param queueInfos
+    * @return
+    */
+   private static PageSubscription locateSubscription(final long queueID,
+                                                      final Map<Long, PageSubscription> pageSubscriptions,
+                                                      final Map<Long, QueueBindingInfo> queueInfos,
+                                                      final PagingManager pagingManager) throws Exception {
+
+      PageSubscription subs = pageSubscriptions.get(queueID);
+      if (subs == null) {
+         QueueBindingInfo queueInfo = queueInfos.get(queueID);
+
+         if (queueInfo != null) {
+            SimpleString address = queueInfo.getAddress();
+            PagingStore store = pagingManager.getPageStore(address);
+            subs = store.getCursorProvider().getSubscription(queueID);
+            pageSubscriptions.put(queueID, subs);
+         }
+      }
+
+      return subs;
+   }
+
+   // grouping handler operations
+   public void addGrouping(final GroupBinding groupBinding) throws Exception {
+      GroupingEncoding groupingEncoding = new GroupingEncoding(groupBinding.getId(), groupBinding.getGroupId(), groupBinding.getClusterName());
+      readLock();
+      try {
+         bindingsJournal.appendAddRecord(groupBinding.getId(), JournalRecordIds.GROUP_RECORD, groupingEncoding, true);
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void deleteGrouping(long tx, final GroupBinding groupBinding) throws Exception {
+      readLock();
+      try {
+         bindingsJournal.appendDeleteRecordTransactional(tx, groupBinding.getId());
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   // BindingsImpl operations
+
+   public void addQueueBinding(final long tx, final Binding binding) throws Exception {
+      Queue queue = (Queue) binding.getBindable();
+
+      Filter filter = queue.getFilter();
+
+      SimpleString filterString = filter == null ? null : filter.getFilterString();
+
+      PersistentQueueBindingEncoding bindingEncoding = new PersistentQueueBindingEncoding(queue.getName(), binding.getAddress(), filterString, queue.getUser(), queue.isAutoCreated());
+
+      readLock();
+      try {
+         bindingsJournal.appendAddRecordTransactional(tx, binding.getID(), JournalRecordIds.QUEUE_BINDING_RECORD, bindingEncoding);
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void deleteQueueBinding(long tx, final long queueBindingID) throws Exception {
+      readLock();
+      try {
+         bindingsJournal.appendDeleteRecordTransactional(tx, queueBindingID);
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public long storePageCounterInc(long txID, long queueID, int value) throws Exception {
+      readLock();
+      try {
+         long recordID = idGenerator.generateID();
+         messageJournal.appendAddRecordTransactional(txID, recordID, JournalRecordIds.PAGE_CURSOR_COUNTER_INC, new PageCountRecordInc(queueID, value));
+         return recordID;
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public long storePageCounterInc(long queueID, int value) throws Exception {
+      readLock();
+      try {
+         final long recordID = idGenerator.generateID();
+         messageJournal.appendAddRecord(recordID, JournalRecordIds.PAGE_CURSOR_COUNTER_INC, new PageCountRecordInc(queueID, value), true, getContext());
+         return recordID;
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   @Override
+   public long storePageCounter(long txID, long queueID, long value) throws Exception {
+      readLock();
+      try {
+         final long recordID = idGenerator.generateID();
+         messageJournal.appendAddRecordTransactional(txID, recordID, JournalRecordIds.PAGE_CURSOR_COUNTER_VALUE, new PageCountRecord(queueID, value));
+         return recordID;
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   @Override
+   public long storePendingCounter(final long queueID, final long pageID, final int inc) throws Exception {
+      readLock();
+      try {
+         final long recordID = idGenerator.generateID();
+         PageCountPendingImpl pendingInc = new PageCountPendingImpl(queueID, pageID, inc);
+         // We must guarantee the record sync before we actually write on the page otherwise we may get out of sync
+         // on the counter
+         messageJournal.appendAddRecord(recordID, JournalRecordIds.PAGE_CURSOR_PENDING_COUNTER, pendingInc, true);
+         return recordID;
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void deleteIncrementRecord(long txID, long recordID) throws Exception {
+      readLock();
+      try {
+         messageJournal.appendDeleteRecordTransactional(txID, recordID);
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void deletePageCounter(long txID, long recordID) throws Exception {
+      readLock();
+      try {
+         messageJournal.appendDeleteRecordTransactional(txID, recordID);
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void deletePendingPageCounter(long txID, long recordID) throws Exception {
+      readLock();
+      try {
+         messageJournal.appendDeleteRecordTransactional(txID, recordID);
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public JournalLoadInformation loadBindingJournal(final List<QueueBindingInfo> queueBindingInfos,
+                                                    final List<GroupingInfo> groupingInfos) throws Exception {
+      List<RecordInfo> records = new ArrayList<RecordInfo>();
+
+      List<PreparedTransactionInfo> preparedTransactions = new ArrayList<PreparedTransactionInfo>();
+
+      JournalLoadInformation bindingsInfo = bindingsJournal.load(records, preparedTransactions, null);
+
+      for (RecordInfo record : records) {
+         long id = record.id;
+
+         ActiveMQBuffer buffer = ActiveMQBuffers.wrappedBuffer(record.data);
+
+         byte rec = record.getUserRecordType();
+
+         if (rec == JournalRecordIds.QUEUE_BINDING_RECORD) {
+            PersistentQueueBindingEncoding bindingEncoding = newBindingEncoding(id, buffer);
+
+            queueBindingInfos.add(bindingEncoding);
+         }
+         else if (rec == JournalRecordIds.ID_COUNTER_RECORD) {
+            idGenerator.loadState(record.id, buffer);
+         }
+         else if (rec == JournalRecordIds.GROUP_RECORD) {
+            GroupingEncoding encoding = newGroupEncoding(id, buffer);
+            groupingInfos.add(encoding);
+         }
+         else if (rec == JournalRecordIds.ADDRESS_SETTING_RECORD) {
+            PersistedAddressSetting setting = newAddressEncoding(id, buffer);
+            mapPersistedAddressSettings.put(setting.getAddressMatch(), setting);
+         }
+         else if (rec == JournalRecordIds.SECURITY_RECORD) {
+            PersistedRoles roles = newSecurityRecord(id, buffer);
+            mapPersistedRoles.put(roles.getAddressMatch(), roles);
+         }
+         else {
+            throw new IllegalStateException("Invalid record type " + rec);
+         }
+      }
+
+      // This will instruct the IDGenerator to beforeStop old records
+      idGenerator.cleanup();
+
+      return bindingsInfo;
+   }
+
+   public void lineUpContext() {
+      readLock();
+      try {
+         messageJournal.lineUpContext(getContext());
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   // ActiveMQComponent implementation
+   // ------------------------------------------------------
+
+   protected abstract void beforeStart() throws Exception;
+
+   public synchronized void start() throws Exception {
+      if (started) {
+         return;
+      }
+
+      beforeStart();
+
+      singleThreadExecutor = Executors.newSingleThreadExecutor(AccessController.doPrivileged(new PrivilegedAction<ActiveMQThreadFactory>() {
+         @Override
+         public ActiveMQThreadFactory run() {
+            return new ActiveMQThreadFactory("ActiveMQ-IO-SingleThread", true, JournalStorageManager.class.getClassLoader());
+         }
+      }));
+
+      bindingsJournal.start();
+
+      messageJournal.start();
+
+      started = true;
+   }
+
+   public void stop() throws Exception {
+      stop(false);
+   }
+
+   @Override
+   public synchronized void persistIdGenerator() {
+      if (journalLoaded && idGenerator != null) {
+         // Must call close to make sure last id is persisted
+         idGenerator.persistCurrentID();
+      }
+   }
+
+   /**
+    * Assumption is that this is only called with a writeLock on the StorageManager.
+    */
+   protected abstract void performCachedLargeMessageDeletes();
+
+   public synchronized void stop(boolean ioCriticalError) throws Exception {
+      if (!started) {
+         return;
+      }
+
+      if (!ioCriticalError) {
+         performCachedLargeMessageDeletes();
+         // Must call close to make sure last id is persisted
+         if (journalLoaded && idGenerator != null)
+            idGenerator.persistCurrentID();
+      }
+
+      final CountDownLatch latch = new CountDownLatch(1);
+      executor.execute(new Runnable() {
+         @Override
+         public void run() {
+            latch.countDown();
+         }
+      });
+
+      latch.await(30, TimeUnit.SECONDS);
+
+      beforeStop();
+
+      bindingsJournal.stop();
+
+      messageJournal.stop();
+
+      singleThreadExecutor.shutdown();
+
+      journalLoaded = false;
+
+      started = false;
+   }
+
+   protected abstract void beforeStop() throws Exception;
+
+   public synchronized boolean isStarted() {
+      return started;
+   }
+
+   /**
+    * TODO: Is this still being used ?
+    */
+   public JournalLoadInformation[] loadInternalOnly() throws Exception {
+      readLock();
+      try {
+         JournalLoadInformation[] info = new JournalLoadInformation[2];
+         info[0] = bindingsJournal.loadInternalOnly();
+         info[1] = messageJournal.loadInternalOnly();
+
+         return info;
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   public void beforePageRead() throws Exception {
+      if (pageMaxConcurrentIO != null) {
+         pageMaxConcurrentIO.acquire();
+      }
+   }
+
+   public void afterPageRead() throws Exception {
+      if (pageMaxConcurrentIO != null) {
+         pageMaxConcurrentIO.release();
+      }
+   }
+
+   // Public -----------------------------------------------------------------------------------
+
+   public Journal getMessageJournal() {
+      return messageJournal;
+   }
+
+   public Journal getBindingsJournal() {
+      return bindingsJournal;
+   }
+
+   // Package protected ---------------------------------------------
+
+   protected void confirmLargeMessage(final LargeServerMessage largeServerMessage) {
+      if (largeServerMessage.getPendingRecordID() >= 0) {
+         try {
+            confirmPendingLargeMessage(largeServerMessage.getPendingRecordID());
+            largeServerMessage.setPendingRecordID(-1);
+         }
+         catch (Exception e) {
+            ActiveMQServerLogger.LOGGER.warn(e.getMessage(), e);
+         }
+      }
+   }
+
+   protected abstract LargeServerMessage parseLargeMessage(Map<Long, ServerMessage> messages,
+                                                           ActiveMQBuffer buff) throws Exception;
+
+   private void loadPreparedTransactions(final PostOffice postOffice,
+                                         final PagingManager pagingManager,
+                                         final ResourceManager resourceManager,
+                                         final Map<Long, QueueBindingInfo> queueInfos,
+                                         final List<PreparedTransactionInfo> preparedTransactions,
+                                         final Map<SimpleString, List<Pair<byte[], Long>>> duplicateIDMap,
+                                         final Map<Long, PageSubscription> pageSubscriptions,
+                                         final Set<Pair<Long, Long>> pendingLargeMessages,
+                                         JournalLoader journalLoader) throws Exception {
+      // recover prepared transactions
+      for (PreparedTransactionInfo preparedTransaction : preparedTransactions) {
+         XidEncoding encodingXid = new XidEncoding(preparedTransaction.getExtraData());
+
+         Xid xid = encodingXid.xid;
+
+         Transaction tx = new TransactionImpl(preparedTransaction.getId(), xid, this);
+
+         List<MessageReference> referencesToAck = new ArrayList<MessageReference>();
+
+         Map<Long, ServerMessage> messages = new HashMap<Long, ServerMessage>();
+
+         // Use same method as load message journal to prune out acks, so they don't get added.
+         // Then have reacknowledge(tx) methods on queue, which needs to add the page size
+
+         // first get any sent messages for this tx and recreate
+         for (RecordInfo record : preparedTransaction.getRecords()) {
+            byte[] data = record.data;
+
+            ActiveMQBuffer buff = ActiveMQBuffers.wrappedBuffer(data);
+
+            byte recordType = record.getUserRecordType();
+
+            switch (recordType) {
+               case JournalRecordIds.ADD_LARGE_MESSAGE: {
+                  messages.put(record.id, parseLargeMessage(messages, buff));
+
+                  break;
+               }
+               case JournalRecordIds.ADD_MESSAGE: {
+                  ServerMessage message = new ServerMessageImpl(record.id, 50);
+
+                  message.decode(buff);
+
+                  messages.put(record.id, message);
+
+                  break;
+               }
+               case JournalRecordIds.ADD_REF: {
+                  long messageID = record.id;
+
+                  RefEncoding encoding = new RefEncoding();
+
+                  encoding.decode(buff);
+
+                  ServerMessage message = messages.get(messageID);
+
+                  if (message == null) {
+                     throw new IllegalStateException("Cannot find message with id " + messageID);
+                  }
+
+                  journalLoader.handlePreparedSendMessage(message, tx, encoding.queueID);
+
+                  break;
+               }
+               case JournalRecordIds.ACKNOWLEDGE_REF: {
+                  long messageID = record.id;
+
+                  RefEncoding encoding = new RefEncoding();
+
+                  encoding.decode(buff);
+
+                  journalLoader.handlePreparedAcknowledge(messageID, referencesToAck, encoding.queueID);
+
+                  break;
+               }
+               case JournalRecordIds.PAGE_TRANSACTION: {
+
+                  PageTransactionInfo pageTransactionInfo = new PageTransactionInfoImpl();
+
+                  pageTransactionInfo.decode(buff);
+
+                  if (record.isUpdate) {
+                     PageTransactionInfo pgTX = pagingManager.getTransaction(pageTransactionInfo.getTransactionID());
+                     pgTX.reloadUpdate(this, pagingManager, tx, pageTransactionInfo.getNumberOfMessages());
+                  }
+                  else {
+                     pageTransactionInfo.setCommitted(false);
+
+                     tx.putProperty(TransactionPropertyIndexes.PAGE_TRANSACTION, pageTransactionInfo);
+
+                     pagingManager.addTransaction(pageTransactionInfo);
+
+                     tx.addOperation(new FinishPageMessageOperation());
+                  }
+
+                  break;
+               }
+               case SET_SCHEDULED_DELIVERY_TIME: {
+                  // Do nothing - for prepared txs, the set scheduled delivery time will only occur in a send in which
+                  // case the message will already have the header for the scheduled delivery time, so no need to do
+                  // anything.
+
+                  break;
+               }
+               case DUPLICATE_ID: {
+                  // We need load the duplicate ids at prepare time too
+                  DuplicateIDEncoding encoding = new DuplicateIDEncoding();
+
+                  encoding.decode(buff);
+
+                  DuplicateIDCache cache = postOffice.getDuplicateIDCache(encoding.address);
+
+                  cache.load(tx, encoding.duplID);
+
+                  break;
+               }
+               case ACKNOWLEDGE_CURSOR: {
+                  CursorAckRecordEncoding encoding = new CursorAckRecordEncoding();
+                  encoding.decode(buff);
+
+                  encoding.position.setRecordID(record.id);
+
+                  PageSubscription sub = locateSubscription(encoding.queueID, pageSubscriptions, queueInfos, pagingManager);
+
+                  if (sub != null) {
+                     sub.reloadPreparedACK(tx, encoding.position);
+                     referencesToAck.add(new PagedReferenceImpl(encoding.position, null, sub));
+                  }
+                  else {
+                     ActiveMQServerLogger.LOGGER.journalCannotFindQueueReloadingACK(encoding.queueID);
+                  }
+                  break;
+               }
+               case PAGE_CURSOR_COUNTER_VALUE: {
+                  ActiveMQServerLogger.LOGGER.journalPAGEOnPrepared();
+
+                  break;
+               }
+
+               case PAGE_CURSOR_COUNTER_INC: {
+                  PageCountRecordInc encoding = new PageCountRecordInc();
+
+                  encoding.decode(buff);
+
+                  PageSubscription sub = locateSubscription(encoding.getQueueID(), pageSubscriptions, queueInfos, pagingManager);
+
+                  if (sub != null) {
+                     sub.getCounter().applyIncrementOnTX(tx, record.id, encoding.getValue());
+                     sub.notEmpty();
+                  }
+                  else {
+                     ActiveMQServerLogger.LOGGER.journalCannotFindQueueReloadingACK(encoding.getQueueID());
+                  }
+
+                  break;
+               }
+
+               default: {
+                  ActiveMQServerLogger.LOGGER.journalInvalidRecordType(recordType);
+               }
+            }
+         }
+
+         for (RecordInfo recordDeleted : preparedTransaction.getRecordsToDelete()) {
+            byte[] data = recordDeleted.data;
+
+            if (data.length > 0) {
+               ActiveMQBuffer buff = ActiveMQBuffers.wrappedBuffer(data);
+               byte b = buff.readByte();
+
+               switch (b) {
+                  case ADD_LARGE_MESSAGE_PENDING: {
+                     long messageID = buff.readLong();
+                     if (!pendingLargeMessages.remove(new Pair<Long, Long>(recordDeleted.id, messageID))) {
+                        ActiveMQServerLogger.LOGGER.largeMessageNotFound(recordDeleted.id);
+                     }
+                     installLargeMessageConfirmationOnTX(tx, recordDeleted.id);
+                     break;
+                  }
+                  default:
+                     ActiveMQServerLogger.LOGGER.journalInvalidRecordTypeOnPreparedTX(b);
+               }
+            }
+
+         }
+
+         journalLoader.handlePreparedTransaction(tx, referencesToAck, xid, resourceManager);
+      }
+   }
+
+   OperationContext getContext(final boolean sync) {
+      if (sync) {
+         return getContext();
+      }
+      else {
+         return DummyOperationContext.getInstance();
+      }
+   }
+
+   // Inner Classes
+   // ----------------------------------------------------------------------------
+
+   private static final class DummyOperationContext implements OperationContext {
+
+      private static DummyOperationContext instance = new DummyOperationContext();
+
+      public static OperationContext getInstance() {
+         return DummyOperationContext.instance;
+      }
+
+      public void executeOnCompletion(final IOCallback runnable) {
+         // There are no executeOnCompletion calls while using the DummyOperationContext
+         // However we keep the code here for correctness
+         runnable.done();
+      }
+
+      public void replicationDone() {
+      }
+
+      public void replicationLineUp() {
+      }
+
+      public void storeLineUp() {
+      }
+
+      public void done() {
+      }
+
+      public void onError(final int errorCode, final String errorMessage) {
+      }
+
+      public void waitCompletion() {
+      }
+
+      public boolean waitCompletion(final long timeout) {
+         return true;
+      }
+
+      public void pageSyncLineUp() {
+      }
+
+      public void pageSyncDone() {
+      }
+   }
+
+   /**
+    * @param id
+    * @param buffer
+    * @return
+    */
+   protected static PersistedRoles newSecurityRecord(long id, ActiveMQBuffer buffer) {
+      PersistedRoles roles = new PersistedRoles();
+      roles.decode(buffer);
+      roles.setStoreId(id);
+      return roles;
+   }
+
+   /**
+    * @param id
+    * @param buffer
+    * @return
+    */
+   static PersistedAddressSetting newAddressEncoding(long id, ActiveMQBuffer buffer) {
+      PersistedAddressSetting setting = new PersistedAddressSetting();
+      setting.decode(buffer);
+      setting.setStoreId(id);
+      return setting;
+   }
+
+   /**
+    * @param id
+    * @param buffer
+    * @return
+    */
+   static GroupingEncoding newGroupEncoding(long id, ActiveMQBuffer buffer) {
+      GroupingEncoding encoding = new GroupingEncoding();
+      encoding.decode(buffer);
+      encoding.setId(id);
+      return encoding;
+   }
+
+   /**
+    * @param id
+    * @param buffer
+    * @return
+    */
+   protected static PersistentQueueBindingEncoding newBindingEncoding(long id, ActiveMQBuffer buffer) {
+      PersistentQueueBindingEncoding bindingEncoding = new PersistentQueueBindingEncoding();
+
+      bindingEncoding.decode(buffer);
+
+      bindingEncoding.setId(id);
+      return bindingEncoding;
+   }
+
+   @Override
+   public boolean addToPage(PagingStore store,
+                            ServerMessage msg,
+                            Transaction tx,
+                            RouteContextList listCtx) throws Exception {
+      /**
+       * Exposing the read-lock here is an encapsulation violation done in order to keep the code
+       * simpler. The alternative would be to add a second method, say 'verifyPaging', to
+       * PagingStore.
+       * <p>
+       * Adding this second method would also be more surprise prone as it would require a certain
+       * calling order.
+       * <p>
+       * The reasoning is that exposing the lock is more explicit and therefore `less bad`.
+       */
+      return store.page(msg, tx, listCtx, storageManagerLock.readLock());
+   }
+
+   private void installLargeMessageConfirmationOnTX(Transaction tx, long recordID) {
+      TXLargeMessageConfirmationOperation txoper = (TXLargeMessageConfirmationOperation) tx.getProperty(TransactionPropertyIndexes.LARGE_MESSAGE_CONFIRMATIONS);
+      if (txoper == null) {
+         txoper = new TXLargeMessageConfirmationOperation(this);
+         tx.putProperty(TransactionPropertyIndexes.LARGE_MESSAGE_CONFIRMATIONS, txoper);
+      }
+      txoper.confirmedMessages.add(recordID);
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AckDescribe.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AckDescribe.java
@@ -14,40 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.core.journal;
+package org.apache.activemq.artemis.core.persistence.impl.journal;
 
-import java.util.ArrayList;
-import java.util.List;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.RefEncoding;
 
-public class PreparedTransactionInfo {
+public final class AckDescribe {
 
-   private final long id;
+   public RefEncoding refEncoding;
 
-   private final byte[] extraData;
-
-   private final List<RecordInfo> records = new ArrayList<RecordInfo>();
-
-   private final List<RecordInfo> recordsToDelete = new ArrayList<RecordInfo>();
-
-   public PreparedTransactionInfo(final long id, final byte[] extraData) {
-      this.id = id;
-
-      this.extraData = extraData;
+   public AckDescribe(RefEncoding refEncoding) {
+      this.refEncoding = refEncoding;
    }
 
-   public long getId() {
-      return id;
+   @Override
+   public String toString() {
+      return "ACK;" + refEncoding;
    }
 
-   public byte[] getExtraData() {
-      return extraData;
-   }
-
-   public List<RecordInfo> getRecords() {
-      return records;
-   }
-
-   public List<RecordInfo> getRecordsToDelete() {
-      return recordsToDelete;
-   }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AddMessageRecord.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AddMessageRecord.java
@@ -26,11 +26,9 @@ public final class AddMessageRecord {
 
    final ServerMessage message;
 
-   // mtaylor (Added to compile)
-   public long scheduledDeliveryTime;
+   private long scheduledDeliveryTime;
 
-   // mtaylor (Added to compile)
-   public int deliveryCount;
+   private int deliveryCount;
 
    public ServerMessage getMessage() {
       return message;
@@ -44,4 +42,11 @@ public final class AddMessageRecord {
       return deliveryCount;
    }
 
+   public void setScheduledDeliveryTime(long scheduledDeliveryTime) {
+      this.scheduledDeliveryTime = scheduledDeliveryTime;
+   }
+
+   public void setDeliveryCount(int deliveryCount) {
+      this.deliveryCount = deliveryCount;
+   }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AddMessageRecord.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AddMessageRecord.java
@@ -26,9 +26,11 @@ public final class AddMessageRecord {
 
    final ServerMessage message;
 
-   long scheduledDeliveryTime;
+   // mtaylor (Added to compile)
+   public long scheduledDeliveryTime;
 
-   int deliveryCount;
+   // mtaylor (Added to compile)
+   public int deliveryCount;
 
    public ServerMessage getMessage() {
       return message;
@@ -41,4 +43,5 @@ public final class AddMessageRecord {
    public int getDeliveryCount() {
       return deliveryCount;
    }
+
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/DescribeJournal.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/DescribeJournal.java
@@ -28,31 +28,30 @@ import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
+import org.apache.activemq.artemis.core.io.SequentialFileFactory;
+import org.apache.activemq.artemis.core.io.nio.NIOSequentialFileFactory;
 import org.apache.activemq.artemis.core.journal.EncodingSupport;
 import org.apache.activemq.artemis.core.journal.PreparedTransactionInfo;
 import org.apache.activemq.artemis.core.journal.RecordInfo;
-import org.apache.activemq.artemis.core.io.SequentialFileFactory;
 import org.apache.activemq.artemis.core.journal.TransactionFailureCallback;
 import org.apache.activemq.artemis.core.journal.impl.JournalFile;
 import org.apache.activemq.artemis.core.journal.impl.JournalImpl;
 import org.apache.activemq.artemis.core.journal.impl.JournalReaderCallback;
-import org.apache.activemq.artemis.core.io.nio.NIOSequentialFileFactory;
 import org.apache.activemq.artemis.core.paging.cursor.impl.PageSubscriptionCounterImpl;
 import org.apache.activemq.artemis.core.paging.impl.PageTransactionInfoImpl;
 import org.apache.activemq.artemis.core.persistence.impl.journal.BatchingIDGenerator.IDCounterEncoding;
-import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager.AckDescribe;
-import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager.CursorAckRecordEncoding;
-import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager.DeliveryCountUpdateEncoding;
-import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager.DuplicateIDEncoding;
-import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager.HeuristicCompletionEncoding;
-import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager.LargeMessageEncoding;
-import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager.PageCountPendingImpl;
-import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager.PageCountRecord;
-import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager.PageCountRecordInc;
-import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager.PageUpdateTXEncoding;
-import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager.PendingLargeMessageEncoding;
-import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager.RefEncoding;
-import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager.ScheduledDeliveryEncoding;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.CursorAckRecordEncoding;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.DeliveryCountUpdateEncoding;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.DuplicateIDEncoding;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.HeuristicCompletionEncoding;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.LargeMessageEncoding;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.PageCountPendingImpl;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.PageCountRecord;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.PageCountRecordInc;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.PageUpdateTXEncoding;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.PendingLargeMessageEncoding;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.RefEncoding;
+import org.apache.activemq.artemis.core.persistence.impl.journal.codec.ScheduledDeliveryEncoding;
 import org.apache.activemq.artemis.core.server.LargeServerMessage;
 import org.apache.activemq.artemis.core.server.ServerMessage;
 import org.apache.activemq.artemis.core.server.impl.ServerMessageImpl;
@@ -200,15 +199,15 @@ public final class DescribeJournal {
             public void checkRecordCounter(RecordInfo info) {
                if (info.getUserRecordType() == JournalRecordIds.PAGE_CURSOR_COUNTER_VALUE) {
                   PageCountRecord encoding = (PageCountRecord) newObjectEncoding(info);
-                  long queueIDForCounter = encoding.queueID;
+                  long queueIDForCounter = encoding.getQueueID();
 
                   PageSubscriptionCounterImpl subsCounter = lookupCounter(counters, queueIDForCounter);
 
-                  if (subsCounter.getValue() != 0 && subsCounter.getValue() != encoding.value) {
-                     out.println("####### Counter replace wrongly on queue " + queueIDForCounter + " oldValue=" + subsCounter.getValue() + " newValue=" + encoding.value);
+                  if (subsCounter.getValue() != 0 && subsCounter.getValue() != encoding.getValue()) {
+                     out.println("####### Counter replace wrongly on queue " + queueIDForCounter + " oldValue=" + subsCounter.getValue() + " newValue=" + encoding.getValue());
                   }
 
-                  subsCounter.loadValue(info.id, encoding.value);
+                  subsCounter.loadValue(info.id, encoding.getValue());
                   subsCounter.processReload();
                   out.print("#Counter queue " + queueIDForCounter + " value=" + subsCounter.getValue() + ", result=" + subsCounter.getValue());
                   if (subsCounter.getValue() < 0) {
@@ -221,13 +220,13 @@ public final class DescribeJournal {
                }
                else if (info.getUserRecordType() == JournalRecordIds.PAGE_CURSOR_COUNTER_INC) {
                   PageCountRecordInc encoding = (PageCountRecordInc) newObjectEncoding(info);
-                  long queueIDForCounter = encoding.queueID;
+                  long queueIDForCounter = encoding.getQueueID();
 
                   PageSubscriptionCounterImpl subsCounter = lookupCounter(counters, queueIDForCounter);
 
-                  subsCounter.loadInc(info.id, encoding.value);
+                  subsCounter.loadInc(info.id, encoding.getValue());
                   subsCounter.processReload();
-                  out.print("#Counter queue " + queueIDForCounter + " value=" + subsCounter.getValue() + " increased by " + encoding.value);
+                  out.print("#Counter queue " + queueIDForCounter + " value=" + subsCounter.getValue() + " increased by " + encoding.getValue());
                   if (subsCounter.getValue() < 0) {
                      out.println(" #NegativeCounter!!!!");
                   }
@@ -311,20 +310,20 @@ public final class DescribeJournal {
          }
          else if (info.getUserRecordType() == JournalRecordIds.PAGE_CURSOR_COUNTER_VALUE) {
             PageCountRecord encoding = (PageCountRecord) o;
-            queueIDForCounter = encoding.queueID;
+            queueIDForCounter = encoding.getQueueID();
 
             subsCounter = lookupCounter(counters, queueIDForCounter);
 
-            subsCounter.loadValue(info.id, encoding.value);
+            subsCounter.loadValue(info.id, encoding.getValue());
             subsCounter.processReload();
          }
          else if (info.getUserRecordType() == JournalRecordIds.PAGE_CURSOR_COUNTER_INC) {
             PageCountRecordInc encoding = (PageCountRecordInc) o;
-            queueIDForCounter = encoding.queueID;
+            queueIDForCounter = encoding.getQueueID();
 
             subsCounter = lookupCounter(counters, queueIDForCounter);
 
-            subsCounter.loadInc(info.id, encoding.value);
+            subsCounter.loadInc(info.id, encoding.getValue());
             subsCounter.processReload();
          }
 
@@ -345,8 +344,8 @@ public final class DescribeJournal {
       out.println("### Prepared TX ###");
 
       for (PreparedTransactionInfo tx : preparedTransactions) {
-         out.println(tx.id);
-         for (RecordInfo info : tx.records) {
+         out.println(tx.getId());
+         for (RecordInfo info : tx.getRecords()) {
             Object o = newObjectEncoding(info);
             out.println("- " + describeRecord(info, o));
             if (info.getUserRecordType() == 31) {
@@ -365,7 +364,7 @@ public final class DescribeJournal {
             }
          }
 
-         for (RecordInfo info : tx.recordsToDelete) {
+         for (RecordInfo info : tx.getRecordsToDelete()) {
             out.println("- " + describeRecord(info) + " <marked to delete>");
          }
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/DummyOperationContext.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/DummyOperationContext.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.persistence.impl.journal;
+
+import org.apache.activemq.artemis.core.io.IOCallback;
+import org.apache.activemq.artemis.core.persistence.OperationContext;
+
+final class DummyOperationContext implements OperationContext {
+
+   private static DummyOperationContext instance = new DummyOperationContext();
+
+   public static OperationContext getInstance() {
+      return DummyOperationContext.instance;
+   }
+
+   public void executeOnCompletion(final IOCallback runnable) {
+      // There are no executeOnCompletion calls while using the DummyOperationContext
+      // However we keep the code here for correctness
+      runnable.done();
+   }
+
+   public void replicationDone() {
+   }
+
+   public void replicationLineUp() {
+   }
+
+   public void storeLineUp() {
+   }
+
+   public void done() {
+   }
+
+   public void onError(final int errorCode, final String errorMessage) {
+   }
+
+   public void waitCompletion() {
+   }
+
+   public boolean waitCompletion(final long timeout) {
+      return true;
+   }
+
+   public void pageSyncLineUp() {
+   }
+
+   public void pageSyncDone() {
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JDBCJournalStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JDBCJournalStorageManager.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.persistence.impl.journal;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.config.storage.DatabaseStorageConfiguration;
+import org.apache.activemq.artemis.core.io.IOCriticalErrorListener;
+import org.apache.activemq.artemis.core.journal.Journal;
+import org.apache.activemq.artemis.jdbc.store.journal.JDBCJournalImpl;
+import org.apache.activemq.artemis.utils.ExecutorFactory;
+
+public class JDBCJournalStorageManager extends JournalStorageManager {
+
+   public JDBCJournalStorageManager(Configuration config, ExecutorFactory executorFactory) {
+      super(config, executorFactory);
+   }
+
+   public JDBCJournalStorageManager(final Configuration config,
+                                final ExecutorFactory executorFactory,
+                                final IOCriticalErrorListener criticalErrorListener) {
+      super(config, executorFactory, criticalErrorListener);
+   }
+
+   @Override
+   protected void init(Configuration config, IOCriticalErrorListener criticalErrorListener) {
+      DatabaseStorageConfiguration dbConf = (DatabaseStorageConfiguration) config.getStoreConfiguration();
+
+      Journal localBindings = new JDBCJournalImpl(dbConf.getJdbcConnectionUrl(), dbConf.getBindingsTableName());
+      bindingsJournal = localBindings;
+
+      Journal localMessage = new JDBCJournalImpl(dbConf.getJdbcConnectionUrl(), dbConf.getMessageTableName());
+      messageJournal = localMessage;
+   }
+
+   @Override
+   public synchronized void stop(boolean ioCriticalError) throws Exception {
+      if (!started) {
+         return;
+      }
+
+      if (!ioCriticalError) {
+         performCachedLargeMessageDeletes();
+         // Must call close to make sure last id is persisted
+         if (journalLoaded && idGenerator != null)
+            idGenerator.persistCurrentID();
+      }
+
+      final CountDownLatch latch = new CountDownLatch(1);
+      executor.execute(new Runnable() {
+         @Override
+         public void run() {
+            latch.countDown();
+         }
+      });
+
+      latch.await(30, TimeUnit.SECONDS);
+
+      beforeStop();
+
+      ((JDBCJournalImpl) bindingsJournal).stop(false);
+
+      messageJournal.stop();
+
+      singleThreadExecutor.shutdown();
+
+      journalLoaded = false;
+
+      started = false;
+   }
+
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalRecordIds.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalRecordIds.java
@@ -26,7 +26,9 @@ package org.apache.activemq.artemis.core.persistence.impl.journal;
 public final class JournalRecordIds {
 
    // grouping journal record type
-   static final byte GROUP_RECORD = 20;
+
+   // mtaylor Added to compile
+   public static final byte GROUP_RECORD = 20;
 
    // BindingsImpl journal record type
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalRecordIds.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalRecordIds.java
@@ -27,7 +27,6 @@ public final class JournalRecordIds {
 
    // grouping journal record type
 
-   // mtaylor Added to compile
    public static final byte GROUP_RECORD = 20;
 
    // BindingsImpl journal record type

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalStorageManager.java
@@ -14,38 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.activemq.artemis.core.persistence.impl.journal;
 
-import javax.transaction.xa.Xid;
 import java.io.File;
-import java.io.FileInputStream;
 import java.nio.ByteBuffer;
-import java.security.AccessController;
-import java.security.DigestInputStream;
-import java.security.InvalidParameterException;
-import java.security.MessageDigest;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
-import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.ActiveMQIllegalStateException;
 import org.apache.activemq.artemis.api.core.ActiveMQInternalErrorException;
@@ -53,171 +37,44 @@ import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.Pair;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.config.Configuration;
-import org.apache.activemq.artemis.core.filter.Filter;
-import org.apache.activemq.artemis.core.io.IOCallback;
 import org.apache.activemq.artemis.core.io.IOCriticalErrorListener;
 import org.apache.activemq.artemis.core.io.SequentialFile;
 import org.apache.activemq.artemis.core.io.SequentialFileFactory;
 import org.apache.activemq.artemis.core.io.aio.AIOSequentialFileFactory;
 import org.apache.activemq.artemis.core.io.nio.NIOSequentialFileFactory;
 import org.apache.activemq.artemis.core.journal.Journal;
-import org.apache.activemq.artemis.core.journal.JournalLoadInformation;
-import org.apache.activemq.artemis.core.journal.PreparedTransactionInfo;
-import org.apache.activemq.artemis.core.journal.RecordInfo;
 import org.apache.activemq.artemis.core.journal.impl.JournalFile;
 import org.apache.activemq.artemis.core.journal.impl.JournalImpl;
 import org.apache.activemq.artemis.core.message.impl.MessageInternal;
-import org.apache.activemq.artemis.core.paging.PageTransactionInfo;
 import org.apache.activemq.artemis.core.paging.PagedMessage;
 import org.apache.activemq.artemis.core.paging.PagingManager;
 import org.apache.activemq.artemis.core.paging.PagingStore;
-import org.apache.activemq.artemis.core.paging.cursor.PagePosition;
-import org.apache.activemq.artemis.core.paging.cursor.PageSubscription;
-import org.apache.activemq.artemis.core.paging.cursor.PagedReferenceImpl;
-import org.apache.activemq.artemis.core.paging.impl.PageTransactionInfoImpl;
-import org.apache.activemq.artemis.core.persistence.GroupingInfo;
 import org.apache.activemq.artemis.core.persistence.OperationContext;
-import org.apache.activemq.artemis.core.persistence.QueueBindingInfo;
-import org.apache.activemq.artemis.core.persistence.StorageManager;
-import org.apache.activemq.artemis.core.persistence.config.PersistedAddressSetting;
-import org.apache.activemq.artemis.core.persistence.config.PersistedRoles;
-import org.apache.activemq.artemis.core.persistence.impl.PageCountPending;
-import org.apache.activemq.artemis.core.persistence.impl.journal.codec.CursorAckRecordEncoding;
-import org.apache.activemq.artemis.core.persistence.impl.journal.codec.DeleteEncoding;
-import org.apache.activemq.artemis.core.persistence.impl.journal.codec.DeliveryCountUpdateEncoding;
-import org.apache.activemq.artemis.core.persistence.impl.journal.codec.DuplicateIDEncoding;
-import org.apache.activemq.artemis.core.persistence.impl.journal.codec.FinishPageMessageOperation;
-import org.apache.activemq.artemis.core.persistence.impl.journal.codec.GroupingEncoding;
-import org.apache.activemq.artemis.core.persistence.impl.journal.codec.HeuristicCompletionEncoding;
 import org.apache.activemq.artemis.core.persistence.impl.journal.codec.LargeMessageEncoding;
-import org.apache.activemq.artemis.core.persistence.impl.journal.codec.PageCountPendingImpl;
-import org.apache.activemq.artemis.core.persistence.impl.journal.codec.PageCountRecord;
-import org.apache.activemq.artemis.core.persistence.impl.journal.codec.PageCountRecordInc;
-import org.apache.activemq.artemis.core.persistence.impl.journal.codec.PageUpdateTXEncoding;
 import org.apache.activemq.artemis.core.persistence.impl.journal.codec.PendingLargeMessageEncoding;
-import org.apache.activemq.artemis.core.persistence.impl.journal.codec.PersistentQueueBindingEncoding;
-import org.apache.activemq.artemis.core.persistence.impl.journal.codec.RefEncoding;
-import org.apache.activemq.artemis.core.persistence.impl.journal.codec.ScheduledDeliveryEncoding;
-import org.apache.activemq.artemis.core.persistence.impl.journal.codec.XidEncoding;
-import org.apache.activemq.artemis.core.postoffice.Binding;
-import org.apache.activemq.artemis.core.postoffice.DuplicateIDCache;
-import org.apache.activemq.artemis.core.postoffice.PostOffice;
-import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.ReplicationLiveIsStoppingMessage.LiveStopping;
+import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.ReplicationLiveIsStoppingMessage;
 import org.apache.activemq.artemis.core.replication.ReplicatedJournal;
 import org.apache.activemq.artemis.core.replication.ReplicationManager;
 import org.apache.activemq.artemis.core.server.ActiveMQMessageBundle;
 import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
 import org.apache.activemq.artemis.core.server.JournalType;
 import org.apache.activemq.artemis.core.server.LargeServerMessage;
-import org.apache.activemq.artemis.core.server.MessageReference;
-import org.apache.activemq.artemis.core.server.Queue;
-import org.apache.activemq.artemis.core.server.RouteContextList;
 import org.apache.activemq.artemis.core.server.ServerMessage;
-import org.apache.activemq.artemis.core.server.group.impl.GroupBinding;
-import org.apache.activemq.artemis.core.server.impl.JournalLoader;
-import org.apache.activemq.artemis.core.server.impl.ServerMessageImpl;
-import org.apache.activemq.artemis.core.transaction.ResourceManager;
-import org.apache.activemq.artemis.core.transaction.Transaction;
-import org.apache.activemq.artemis.core.transaction.TransactionPropertyIndexes;
-import org.apache.activemq.artemis.core.transaction.impl.TransactionImpl;
-import org.apache.activemq.artemis.utils.ActiveMQThreadFactory;
-import org.apache.activemq.artemis.utils.Base64;
 import org.apache.activemq.artemis.utils.ExecutorFactory;
-import org.apache.activemq.artemis.utils.IDGenerator;
 
-import static org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds.ACKNOWLEDGE_CURSOR;
-import static org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds.ADD_LARGE_MESSAGE_PENDING;
-import static org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds.DUPLICATE_ID;
-import static org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds.PAGE_CURSOR_COUNTER_INC;
-import static org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds.PAGE_CURSOR_COUNTER_VALUE;
-import static org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds.SET_SCHEDULED_DELIVERY_TIME;
+public class JournalStorageManager extends AbstractJournalStorageManager {
 
-/**
- * Controls access to the journals and other storage files such as the ones used to store pages and
- * large messages. This class must control writing of any non-transient data, as it is the key point
- * for synchronizing a replicating backup server.
- * <p>
- * Using this class also ensures that locks are acquired in the right order, avoiding dead-locks.
- * <p>
- * Notice that, turning on and off replication (on the live server side) is _mostly_ a matter of
- * using {@link ReplicatedJournal}s instead of regular {@link JournalImpl}, and sync the existing
- * data. For details see the Javadoc of
- * {@link #startReplication(ReplicationManager, PagingManager, String, boolean)}.
- * <p>
- */
-public class JournalStorageManager implements StorageManager {
+   private SequentialFileFactory journalFF;
 
-   public enum JournalContent {
-      BINDINGS((byte) 0), MESSAGES((byte) 1);
+   private SequentialFileFactory largeMessagesFactory;
 
-      public final byte typeByte;
+   private Journal originalMessageJournal;
 
-      JournalContent(byte b) {
-         typeByte = b;
-      }
+   private Journal originalBindingsJournal;
 
-      public static JournalContent getType(byte type) {
-         if (MESSAGES.typeByte == type)
-            return MESSAGES;
-         if (BINDINGS.typeByte == type)
-            return BINDINGS;
-         throw new InvalidParameterException("invalid byte: " + type);
-      }
-   }
-
-   private static final long CHECKPOINT_BATCH_SIZE = Integer.MAX_VALUE;
-
-   private final Semaphore pageMaxConcurrentIO;
-
-   private final BatchingIDGenerator idGenerator;
-
-   private final ReentrantReadWriteLock storageManagerLock = new ReentrantReadWriteLock(true);
+   private String largeMessagesDirectory;
 
    private ReplicationManager replicator;
-
-   private final SequentialFileFactory journalFF;
-
-   private Journal messageJournal;
-
-   private Journal bindingsJournal;
-
-   private final Journal originalMessageJournal;
-
-   private final Journal originalBindingsJournal;
-
-   private final SequentialFileFactory largeMessagesFactory;
-
-   private volatile boolean started;
-
-   /**
-    * Used to create Operation Contexts
-    */
-   private final ExecutorFactory executorFactory;
-
-   private final Executor executor;
-
-   private ExecutorService singleThreadExecutor;
-
-   private final boolean syncTransactional;
-
-   private final boolean syncNonTransactional;
-
-   private final int perfBlastPages;
-
-   private final String largeMessagesDirectory;
-
-   private boolean journalLoaded = false;
-
-   private final IOCriticalErrorListener ioCriticalErrorListener;
-
-   private final Configuration config;
-
-   // Persisted core configuration
-   private final Map<SimpleString, PersistedRoles> mapPersistedRoles = new ConcurrentHashMap<>();
-
-   private final Map<SimpleString, PersistedAddressSetting> mapPersistedAddressSettings = new ConcurrentHashMap<>();
-
-   private final Set<Long> largeMessagesToDelete = new HashSet<>();
 
    public JournalStorageManager(final Configuration config, final ExecutorFactory executorFactory) {
       this(config, executorFactory, null);
@@ -226,13 +83,11 @@ public class JournalStorageManager implements StorageManager {
    public JournalStorageManager(final Configuration config,
                                 final ExecutorFactory executorFactory,
                                 final IOCriticalErrorListener criticalErrorListener) {
-      this.executorFactory = executorFactory;
+      super(config, executorFactory, criticalErrorListener);
+   }
 
-      this.ioCriticalErrorListener = criticalErrorListener;
-
-      this.config = config;
-
-      executor = executorFactory.getExecutor();
+   @Override
+   protected void init(Configuration config, IOCriticalErrorListener criticalErrorListener) {
 
       if (config.getJournalType() != JournalType.NIO && config.getJournalType() != JournalType.ASYNCIO) {
          throw ActiveMQMessageBundle.BUNDLE.invalidJournal();
@@ -244,10 +99,6 @@ public class JournalStorageManager implements StorageManager {
 
       bindingsJournal = localBindings;
       originalBindingsJournal = localBindings;
-
-      syncNonTransactional = config.isJournalSyncNonTransactional();
-
-      syncTransactional = config.isJournalSyncTransactional();
 
       if (config.getJournalType() == JournalType.ASYNCIO) {
          ActiveMQServerLogger.LOGGER.journalUseAIO();
@@ -262,10 +113,7 @@ public class JournalStorageManager implements StorageManager {
          throw ActiveMQMessageBundle.BUNDLE.invalidJournalType2(config.getJournalType());
       }
 
-      idGenerator = new BatchingIDGenerator(0, JournalStorageManager.CHECKPOINT_BATCH_SIZE, this);
-
       Journal localMessage = new JournalImpl(config.getJournalFileSize(), config.getJournalMinFiles(), config.getJournalPoolFiles(), config.getJournalCompactMinFiles(), config.getJournalCompactPercentage(), journalFF, "activemq-data", "amq", config.getJournalType() == JournalType.ASYNCIO ? config.getJournalMaxIO_AIO() : config.getJournalMaxIO_NIO());
-
       messageJournal = localMessage;
       originalMessageJournal = localMessage;
 
@@ -283,39 +131,353 @@ public class JournalStorageManager implements StorageManager {
       }
    }
 
+   // Life Cycle Handlers
    @Override
-   public void criticalError(Throwable error) {
-      ioCriticalErrorListener.onIOException(error, error.getMessage(), null);
+   protected void beforeStart() throws Exception {
+      checkAndCreateDir(config.getBindingsLocation(), config.isCreateBindingsDir());
+      checkAndCreateDir(config.getJournalLocation(), config.isCreateJournalDir());
+      checkAndCreateDir(config.getLargeMessagesLocation(), config.isCreateJournalDir());
+      cleanupIncompleteFiles();
    }
 
    @Override
-   public void clearContext() {
-      OperationContextImpl.clearContext();
+   protected void beforeStop() throws Exception {
+      if (replicator != null) {
+         replicator.stop();
+      }
+   }
+
+   @Override
+   public void stop() throws Exception {
+      stop(false);
    }
 
    public boolean isReplicated() {
       return replicator != null;
    }
 
+   private void cleanupIncompleteFiles() throws Exception {
+      if (largeMessagesFactory != null) {
+         List<String> tmpFiles = largeMessagesFactory.listFiles("tmp");
+         for (String tmpFile : tmpFiles) {
+            SequentialFile file = largeMessagesFactory.createSequentialFile(tmpFile);
+            file.delete();
+         }
+      }
+   }
+
+   @Override
+   public synchronized void stop(boolean ioCriticalError) throws Exception {
+      if (!started) {
+         return;
+      }
+
+      if (!ioCriticalError) {
+         performCachedLargeMessageDeletes();
+         // Must call close to make sure last id is persisted
+         if (journalLoaded && idGenerator != null)
+            idGenerator.persistCurrentID();
+      }
+
+      final CountDownLatch latch = new CountDownLatch(1);
+      executor.execute(new Runnable() {
+         @Override
+         public void run() {
+            latch.countDown();
+         }
+      });
+
+      latch.await(30, TimeUnit.SECONDS);
+
+      // We cache the variable as the replicator could be changed between here and the time we call stop
+      // since sendLiveIsStoping my issue a close back from the channel
+      // and we want to ensure a stop here just in case
+      ReplicationManager replicatorInUse = replicator;
+      if (replicatorInUse != null) {
+         final OperationContext token = replicator.sendLiveIsStopping(ReplicationLiveIsStoppingMessage.LiveStopping.FAIL_OVER);
+         if (token != null) {
+            try {
+               token.waitCompletion(5000);
+            }
+            catch (Exception e) {
+               // ignore it
+            }
+         }
+         replicatorInUse.stop();
+      }
+      bindingsJournal.stop();
+
+      messageJournal.stop();
+
+      singleThreadExecutor.shutdown();
+
+      journalLoaded = false;
+
+      started = false;
+   }
+
    /**
-    * Starts replication at the live-server side.
-    * <p>
-    * In practice that means 2 things:<br>
-    * (1) all currently existing data must be sent to the backup.<br>
-    * (2) every new persistent information is replicated (sent) to the backup.
-    * <p>
-    * To achieve (1), we lock the entire journal while collecting the list of files to send to the
-    * backup. The journal does not remain locked during actual synchronization.
-    * <p>
-    * To achieve (2), instead of writing directly to instances of {@link JournalImpl}, we write to
-    * instances of {@link ReplicatedJournal}.
-    * <p>
-    * At the backup-side replication is handled by {@link org.apache.activemq.artemis.core.replication.ReplicationEndpoint}.
-    *
-    * @param replicationManager
-    * @param pagingManager
-    * @throws ActiveMQException
+    * Assumption is that this is only called with a writeLock on the StorageManager.
     */
+   @Override
+   protected void performCachedLargeMessageDeletes() {
+      for (Long largeMsgId : largeMessagesToDelete) {
+         SequentialFile msg = createFileForLargeMessage(largeMsgId, LargeMessageExtension.DURABLE);
+         try {
+            msg.delete();
+         }
+         catch (Exception e) {
+            ActiveMQServerLogger.LOGGER.journalErrorDeletingMessage(e, largeMsgId);
+         }
+         if (replicator != null) {
+            replicator.largeMessageDelete(largeMsgId);
+         }
+      }
+      largeMessagesToDelete.clear();
+   }
+
+   protected SequentialFile createFileForLargeMessage(final long messageID, final boolean durable) {
+      if (durable) {
+         return createFileForLargeMessage(messageID, LargeMessageExtension.DURABLE);
+      }
+      else {
+         return createFileForLargeMessage(messageID, LargeMessageExtension.TEMPORARY);
+      }
+   }
+
+   @Override
+   /**
+    * @param messages
+    * @param buff
+    * @return
+    * @throws Exception
+    */
+   protected LargeServerMessage parseLargeMessage(final Map<Long, ServerMessage> messages,
+                                                  final ActiveMQBuffer buff) throws Exception {
+      LargeServerMessage largeMessage = createLargeMessage();
+
+      LargeMessageEncoding messageEncoding = new LargeMessageEncoding(largeMessage);
+
+      messageEncoding.decode(buff);
+
+      if (largeMessage.containsProperty(Message.HDR_ORIG_MESSAGE_ID)) {
+         // for compatibility: couple with old behaviour, copying the old file to avoid message loss
+         long originalMessageID = largeMessage.getLongProperty(Message.HDR_ORIG_MESSAGE_ID);
+
+         SequentialFile currentFile = createFileForLargeMessage(largeMessage.getMessageID(), true);
+
+         if (!currentFile.exists()) {
+            SequentialFile linkedFile = createFileForLargeMessage(originalMessageID, true);
+            if (linkedFile.exists()) {
+               linkedFile.copyTo(currentFile);
+               linkedFile.close();
+            }
+         }
+
+         currentFile.close();
+      }
+
+      return largeMessage;
+   }
+
+   @Override
+   public void pageClosed(final SimpleString storeName, final int pageNumber) {
+      if (isReplicated()) {
+         readLock();
+         try {
+            if (isReplicated())
+               replicator.pageClosed(storeName, pageNumber);
+         }
+         finally {
+            readUnLock();
+         }
+      }
+   }
+
+   @Override
+   public void pageDeleted(final SimpleString storeName, final int pageNumber) {
+      if (isReplicated()) {
+         readLock();
+         try {
+            if (isReplicated())
+               replicator.pageDeleted(storeName, pageNumber);
+         }
+         finally {
+            readUnLock();
+         }
+      }
+   }
+
+   @Override
+   public void pageWrite(final PagedMessage message, final int pageNumber) {
+      if (isReplicated()) {
+         // Note: (https://issues.jboss.org/browse/HORNETQ-1059)
+         // We have to replicate durable and non-durable messages on paging
+         // since acknowledgments are written using the page-position.
+         // Say you are sending durable and non-durable messages to a page
+         // The ACKs would be done to wrong positions, and the backup would be a mess
+
+         readLock();
+         try {
+            if (isReplicated())
+               replicator.pageWrite(message, pageNumber);
+         }
+         finally {
+            readUnLock();
+         }
+      }
+   }
+
+   @Override
+   public ByteBuffer allocateDirectBuffer(int size) {
+      return journalFF.allocateDirectBuffer(size);
+   }
+
+   @Override
+   public void freeDirectBuffer(ByteBuffer buffer) {
+      journalFF.releaseBuffer(buffer);
+   }
+
+   public long storePendingLargeMessage(final long messageID) throws Exception {
+      readLock();
+      try {
+         long recordID = generateID();
+
+         messageJournal.appendAddRecord(recordID, JournalRecordIds.ADD_LARGE_MESSAGE_PENDING, new PendingLargeMessageEncoding(messageID), true, getContext(true));
+
+         return recordID;
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   // This should be accessed from this package only
+   void deleteLargeMessageFile(final LargeServerMessage largeServerMessage) throws ActiveMQException {
+      if (largeServerMessage.getPendingRecordID() < 0) {
+         try {
+            // The delete file happens asynchronously
+            // And the client won't be waiting for the actual file to be deleted.
+            // We set a temporary record (short lived) on the journal
+            // to avoid a situation where the server is restarted and pending large message stays on forever
+            largeServerMessage.setPendingRecordID(storePendingLargeMessage(largeServerMessage.getMessageID()));
+         }
+         catch (Exception e) {
+            throw new ActiveMQInternalErrorException(e.getMessage(), e);
+         }
+      }
+      final SequentialFile file = largeServerMessage.getFile();
+      if (file == null) {
+         return;
+      }
+
+      if (largeServerMessage.isDurable() && isReplicated()) {
+         readLock();
+         try {
+            if (isReplicated() && replicator.isSynchronizing()) {
+               synchronized (largeMessagesToDelete) {
+                  largeMessagesToDelete.add(Long.valueOf(largeServerMessage.getMessageID()));
+                  confirmLargeMessage(largeServerMessage);
+               }
+               return;
+            }
+         }
+         finally {
+            readUnLock();
+         }
+      }
+      Runnable deleteAction = new Runnable() {
+         @Override
+         public void run() {
+            try {
+               readLock();
+               try {
+                  if (replicator != null) {
+                     replicator.largeMessageDelete(largeServerMessage.getMessageID());
+                  }
+                  file.delete();
+
+                  // The confirm could only be done after the actual delete is done
+                  confirmLargeMessage(largeServerMessage);
+               }
+               finally {
+                  readUnLock();
+               }
+            }
+            catch (Exception e) {
+               ActiveMQServerLogger.LOGGER.journalErrorDeletingMessage(e, largeServerMessage.getMessageID());
+            }
+         }
+
+      };
+
+      if (executor == null) {
+         deleteAction.run();
+      }
+      else {
+         executor.execute(deleteAction);
+      }
+   }
+
+   @Override
+   public LargeServerMessage createLargeMessage() {
+      return new LargeServerMessageImpl(this);
+   }
+
+   @Override
+   public LargeServerMessage createLargeMessage(final long id, final MessageInternal message) throws Exception {
+      readLock();
+      try {
+         if (isReplicated()) {
+            replicator.largeMessageBegin(id);
+         }
+
+         LargeServerMessageImpl largeMessage = (LargeServerMessageImpl) createLargeMessage();
+
+         largeMessage.copyHeadersAndProperties(message);
+
+         largeMessage.setMessageID(id);
+
+         if (largeMessage.isDurable()) {
+            // We store a marker on the journal that the large file is pending
+            long pendingRecordID = storePendingLargeMessage(id);
+
+            largeMessage.setPendingRecordID(pendingRecordID);
+         }
+
+         return largeMessage;
+      }
+      finally {
+         readUnLock();
+      }
+   }
+
+   @Override
+   public SequentialFile createFileForLargeMessage(final long messageID, LargeMessageExtension extension) {
+      return largeMessagesFactory.createSequentialFile(messageID + extension.getExtension());
+   }
+
+   /**
+    * Send an entire journal file to a replicating backup server.
+    */
+   private void sendJournalFile(JournalFile[] journalFiles, JournalContent type) throws Exception {
+      for (JournalFile jf : journalFiles) {
+         if (!started)
+            return;
+         replicator.syncJournalFile(jf, type);
+      }
+   }
+
+   private JournalFile[] prepareJournalForCopy(Journal journal,
+                                               JournalContent contentType,
+                                               String nodeID,
+                                               boolean autoFailBack) throws Exception {
+      journal.forceMoveNextFile();
+      JournalFile[] datafiles = journal.getDataFiles();
+      replicator.sendStartSyncMessage(datafiles, contentType, nodeID, autoFailBack);
+      return datafiles;
+   }
+
    @Override
    public void startReplication(ReplicationManager replicationManager,
                                 PagingManager pagingManager,
@@ -412,88 +574,17 @@ public class JournalStorageManager implements StorageManager {
       }
    }
 
-   public static String md5(File file) {
-      try {
-         byte[] buffer = new byte[1 << 4];
-         MessageDigest md = MessageDigest.getInstance("MD5");
-
-         FileInputStream is = new FileInputStream(file);
-         DigestInputStream is2 = new DigestInputStream(is, md);
-         while (is2.read(buffer) > 0) {
+   private void sendLargeMessageFiles(final Map<Long, Pair<String, Long>> pendingLargeMessages) throws Exception {
+      Iterator<Map.Entry<Long, Pair<String, Long>>> iter = pendingLargeMessages.entrySet().iterator();
+      while (started && iter.hasNext()) {
+         Map.Entry<Long, Pair<String, Long>> entry = iter.next();
+         String fileName = entry.getValue().getA();
+         final long id = entry.getKey();
+         long size = entry.getValue().getB();
+         SequentialFile seqFile = largeMessagesFactory.createSequentialFile(fileName);
+         if (!seqFile.exists())
             continue;
-         }
-         byte[] digest = md.digest();
-         is.close();
-         is2.close();
-         return Base64.encodeBytes(digest);
-      }
-      catch (Exception e) {
-         throw new RuntimeException(e);
-      }
-   }
-
-   /**
-    * Stops replication by resetting replication-related fields to their 'unreplicated' state.
-    */
-   @Override
-   public void stopReplication() {
-      storageManagerLock.writeLock().lock();
-      try {
-         if (replicator == null)
-            return;
-         bindingsJournal = originalBindingsJournal;
-         messageJournal = originalMessageJournal;
-         try {
-            replicator.stop();
-         }
-         catch (Exception e) {
-            ActiveMQServerLogger.LOGGER.errorStoppingReplicationManager(e);
-         }
-         replicator = null;
-         // delete inside the writeLock. Avoids a lot of state checking and races with
-         // startReplication.
-         // This method should not be called under normal circumstances
-         performCachedLargeMessageDeletes();
-      }
-      finally {
-         storageManagerLock.writeLock().unlock();
-      }
-   }
-
-   /**
-    * Assumption is that this is only called with a writeLock on the StorageManager.
-    */
-   private void performCachedLargeMessageDeletes() {
-      for (Long largeMsgId : largeMessagesToDelete) {
-         SequentialFile msg = createFileForLargeMessage(largeMsgId, LargeMessageExtension.DURABLE);
-         try {
-            msg.delete();
-         }
-         catch (Exception e) {
-            ActiveMQServerLogger.LOGGER.journalErrorDeletingMessage(e, largeMsgId);
-         }
-         if (replicator != null) {
-            replicator.largeMessageDelete(largeMsgId);
-         }
-      }
-      largeMessagesToDelete.clear();
-   }
-
-   public IDGenerator getIDGenerator() {
-      return idGenerator;
-   }
-
-   /**
-    * @param pageFilesToSync
-    * @throws Exception
-    */
-   private void sendPagesToBackup(Map<SimpleString, Collection<Integer>> pageFilesToSync,
-                                  PagingManager manager) throws Exception {
-      for (Entry<SimpleString, Collection<Integer>> entry : pageFilesToSync.entrySet()) {
-         if (!started)
-            return;
-         PagingStore store = manager.getPageStore(entry.getKey());
-         store.sendPages(replicator, entry.getValue());
+         replicator.syncLargeMessageFile(seqFile, size, id);
       }
    }
 
@@ -512,22 +603,18 @@ public class JournalStorageManager implements StorageManager {
       return info;
    }
 
-   private void sendLargeMessageFiles(final Map<Long, Pair<String, Long>> pendingLargeMessages) throws Exception {
-      Iterator<Entry<Long, Pair<String, Long>>> iter = pendingLargeMessages.entrySet().iterator();
-      while (started && iter.hasNext()) {
-         Map.Entry<Long, Pair<String, Long>> entry = iter.next();
-         String fileName = entry.getValue().getA();
-         final long id = entry.getKey();
-         long size = entry.getValue().getB();
-         SequentialFile seqFile = largeMessagesFactory.createSequentialFile(fileName);
-         if (!seqFile.exists())
-            continue;
-         replicator.syncLargeMessageFile(seqFile, size, id);
-      }
-   }
 
-   private long getLargeMessageIdFromFilename(String filename) {
-      return Long.parseLong(filename.split("\\.")[0]);
+   private void checkAndCreateDir(final File dir, final boolean create) {
+      if (!dir.exists()) {
+         if (create) {
+            if (!dir.mkdirs()) {
+               throw new IllegalStateException("Failed to create directory " + dir);
+            }
+         }
+         else {
+            throw ActiveMQMessageBundle.BUNDLE.cannotCreateDir(dir.getAbsolutePath());
+         }
+      }
    }
 
    /**
@@ -561,134 +648,49 @@ public class JournalStorageManager implements StorageManager {
    }
 
    /**
-    * Send an entire journal file to a replicating backup server.
+    * @param pageFilesToSync
+    * @throws Exception
     */
-   private void sendJournalFile(JournalFile[] journalFiles, JournalContent type) throws Exception {
-      for (JournalFile jf : journalFiles) {
+   private void sendPagesToBackup(Map<SimpleString, Collection<Integer>> pageFilesToSync,
+                                  PagingManager manager) throws Exception {
+      for (Map.Entry<SimpleString, Collection<Integer>> entry : pageFilesToSync.entrySet()) {
          if (!started)
             return;
-         replicator.syncJournalFile(jf, type);
+         PagingStore store = manager.getPageStore(entry.getKey());
+         store.sendPages(replicator, entry.getValue());
       }
    }
 
-   private JournalFile[] prepareJournalForCopy(Journal journal,
-                                               JournalContent contentType,
-                                               String nodeID,
-                                               boolean autoFailBack) throws Exception {
-      journal.forceMoveNextFile();
-      JournalFile[] datafiles = journal.getDataFiles();
-      replicator.sendStartSyncMessage(datafiles, contentType, nodeID, autoFailBack);
-      return datafiles;
+   private long getLargeMessageIdFromFilename(String filename) {
+      return Long.parseLong(filename.split("\\.")[0]);
    }
 
+   /**
+    * Stops replication by resetting replication-related fields to their 'unreplicated' state.
+    */
    @Override
-   public final void waitOnOperations() throws Exception {
-      if (!started) {
-         ActiveMQServerLogger.LOGGER.serverIsStopped();
-         throw new IllegalStateException("Server is stopped");
-      }
-      waitOnOperations(0);
-   }
-
-   @Override
-   public final boolean waitOnOperations(final long timeout) throws Exception {
-      if (!started) {
-         ActiveMQServerLogger.LOGGER.serverIsStopped();
-         throw new IllegalStateException("Server is stopped");
-      }
-      return getContext().waitCompletion(timeout);
-   }
-
-   @Override
-   public void pageClosed(final SimpleString storeName, final int pageNumber) {
-      if (isReplicated()) {
-         readLock();
+   public void stopReplication() {
+      storageManagerLock.writeLock().lock();
+      try {
+         if (replicator == null)
+            return;
+         bindingsJournal = originalBindingsJournal;
+         messageJournal = originalMessageJournal;
          try {
-            if (isReplicated())
-               replicator.pageClosed(storeName, pageNumber);
+            replicator.stop();
          }
-         finally {
-            readUnLock();
+         catch (Exception e) {
+            ActiveMQServerLogger.LOGGER.errorStoppingReplicationManager(e);
          }
+         replicator = null;
+         // delete inside the writeLock. Avoids a lot of state checking and races with
+         // startReplication.
+         // This method should not be called under normal circumstances
+         performCachedLargeMessageDeletes();
       }
-   }
-
-   @Override
-   public void pageDeleted(final SimpleString storeName, final int pageNumber) {
-      if (isReplicated()) {
-         readLock();
-         try {
-            if (isReplicated())
-               replicator.pageDeleted(storeName, pageNumber);
-         }
-         finally {
-            readUnLock();
-         }
+      finally {
+         storageManagerLock.writeLock().unlock();
       }
-   }
-
-   @Override
-   public void pageWrite(final PagedMessage message, final int pageNumber) {
-      if (isReplicated()) {
-         // Note: (https://issues.jboss.org/browse/HORNETQ-1059)
-         // We have to replicate durable and non-durable messages on paging
-         // since acknowledgments are written using the page-position.
-         // Say you are sending durable and non-durable messages to a page
-         // The ACKs would be done to wrong positions, and the backup would be a mess
-
-         readLock();
-         try {
-            if (isReplicated())
-               replicator.pageWrite(message, pageNumber);
-         }
-         finally {
-            readUnLock();
-         }
-      }
-   }
-
-   @Override
-   public OperationContext getContext() {
-      return OperationContextImpl.getContext(executorFactory);
-   }
-
-   @Override
-   public void setContext(final OperationContext context) {
-      OperationContextImpl.setContext(context);
-   }
-
-   public Executor getSingleThreadExecutor() {
-      return singleThreadExecutor;
-   }
-
-   @Override
-   public OperationContext newSingleThreadContext() {
-      return newContext(singleThreadExecutor);
-   }
-
-   @Override
-   public OperationContext newContext(final Executor executor1) {
-      return new OperationContextImpl(executor1);
-   }
-
-   @Override
-   public void afterCompleteOperations(final IOCallback run) {
-      getContext().executeOnCompletion(run);
-   }
-
-   @Override
-   public long generateID() {
-      return idGenerator.generateID();
-   }
-
-   @Override
-   public long getCurrentID() {
-      return idGenerator.getCurrentID();
-   }
-
-   @Override
-   public LargeServerMessage createLargeMessage() {
-      return new LargeServerMessageImpl(this);
    }
 
    @Override
@@ -708,1807 +710,5 @@ public class JournalStorageManager implements StorageManager {
       finally {
          readUnLock();
       }
-   }
-
-   @Override
-   public LargeServerMessage createLargeMessage(final long id, final MessageInternal message) throws Exception {
-      readLock();
-      try {
-         if (isReplicated()) {
-            replicator.largeMessageBegin(id);
-         }
-
-         LargeServerMessageImpl largeMessage = (LargeServerMessageImpl) createLargeMessage();
-
-         largeMessage.copyHeadersAndProperties(message);
-
-         largeMessage.setMessageID(id);
-
-         if (largeMessage.isDurable()) {
-            // We store a marker on the journal that the large file is pending
-            long pendingRecordID = storePendingLargeMessage(id);
-
-            largeMessage.setPendingRecordID(pendingRecordID);
-         }
-
-         return largeMessage;
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   // Non transactional operations
-
-   public long storePendingLargeMessage(final long messageID) throws Exception {
-      readLock();
-      try {
-         long recordID = generateID();
-
-         messageJournal.appendAddRecord(recordID, JournalRecordIds.ADD_LARGE_MESSAGE_PENDING, new PendingLargeMessageEncoding(messageID), true, getContext(true));
-
-         return recordID;
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void confirmPendingLargeMessageTX(final Transaction tx, long messageID, long recordID) throws Exception {
-      readLock();
-      try {
-         installLargeMessageConfirmationOnTX(tx, recordID);
-         messageJournal.appendDeleteRecordTransactional(tx.getID(), recordID, new DeleteEncoding(JournalRecordIds.ADD_LARGE_MESSAGE_PENDING, messageID));
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   /**
-    * We don't need messageID now but we are likely to need it we ever decide to support a database
-    */
-   @Override
-   public void confirmPendingLargeMessage(long recordID) throws Exception {
-      readLock();
-      try {
-         messageJournal.appendDeleteRecord(recordID, true, getContext());
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void storeMessage(final ServerMessage message) throws Exception {
-      if (message.getMessageID() <= 0) {
-         // Sanity check only... this shouldn't happen unless there is a bug
-         throw ActiveMQMessageBundle.BUNDLE.messageIdNotAssigned();
-      }
-
-      readLock();
-      try {
-         // Note that we don't sync, the add reference that comes immediately after will sync if
-         // appropriate
-
-         if (message.isLargeMessage()) {
-            messageJournal.appendAddRecord(message.getMessageID(), JournalRecordIds.ADD_LARGE_MESSAGE, new LargeMessageEncoding((LargeServerMessage) message), false, getContext(false));
-         }
-         else {
-            messageJournal.appendAddRecord(message.getMessageID(), JournalRecordIds.ADD_MESSAGE, message, false, getContext(false));
-         }
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void storeReference(final long queueID, final long messageID, final boolean last) throws Exception {
-      readLock();
-      try {
-         messageJournal.appendUpdateRecord(messageID, JournalRecordIds.ADD_REF, new RefEncoding(queueID), last && syncNonTransactional, getContext(last && syncNonTransactional));
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void readLock() {
-      storageManagerLock.readLock().lock();
-   }
-
-   @Override
-   public void readUnLock() {
-      storageManagerLock.readLock().unlock();
-   }
-
-   @Override
-   public void storeAcknowledge(final long queueID, final long messageID) throws Exception {
-      readLock();
-      try {
-         messageJournal.appendUpdateRecord(messageID, JournalRecordIds.ACKNOWLEDGE_REF, new RefEncoding(queueID), syncNonTransactional, getContext(syncNonTransactional));
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void storeCursorAcknowledge(long queueID, PagePosition position) throws Exception {
-      readLock();
-      try {
-         long ackID = idGenerator.generateID();
-         position.setRecordID(ackID);
-         messageJournal.appendAddRecord(ackID, JournalRecordIds.ACKNOWLEDGE_CURSOR, new CursorAckRecordEncoding(queueID, position), syncNonTransactional, getContext(syncNonTransactional));
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void deleteMessage(final long messageID) throws Exception {
-      readLock();
-      try {
-         // Messages are deleted on postACK, one after another.
-         // If these deletes are synchronized, we would build up messages on the Executor
-         // increasing chances of losing deletes.
-         // The StorageManager should verify messages without references
-         messageJournal.appendDeleteRecord(messageID, false, getContext(false));
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void updateScheduledDeliveryTime(final MessageReference ref) throws Exception {
-      ScheduledDeliveryEncoding encoding = new ScheduledDeliveryEncoding(ref.getScheduledDeliveryTime(), ref.getQueue().getID());
-      readLock();
-      try {
-         messageJournal.appendUpdateRecord(ref.getMessage().getMessageID(), JournalRecordIds.SET_SCHEDULED_DELIVERY_TIME, encoding, syncNonTransactional, getContext(syncNonTransactional));
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void storeDuplicateID(final SimpleString address, final byte[] duplID, final long recordID) throws Exception {
-      readLock();
-      try {
-         DuplicateIDEncoding encoding = new DuplicateIDEncoding(address, duplID);
-
-         messageJournal.appendAddRecord(recordID, JournalRecordIds.DUPLICATE_ID, encoding, syncNonTransactional, getContext(syncNonTransactional));
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void deleteDuplicateID(final long recordID) throws Exception {
-      readLock();
-      try {
-         messageJournal.appendDeleteRecord(recordID, syncNonTransactional, getContext(syncNonTransactional));
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   // Transactional operations
-
-   @Override
-   public void storeMessageTransactional(final long txID, final ServerMessage message) throws Exception {
-      if (message.getMessageID() <= 0) {
-         throw ActiveMQMessageBundle.BUNDLE.messageIdNotAssigned();
-      }
-
-      readLock();
-      try {
-         if (message.isLargeMessage()) {
-            messageJournal.appendAddRecordTransactional(txID, message.getMessageID(), JournalRecordIds.ADD_LARGE_MESSAGE, new LargeMessageEncoding(((LargeServerMessage) message)));
-         }
-         else {
-            messageJournal.appendAddRecordTransactional(txID, message.getMessageID(), JournalRecordIds.ADD_MESSAGE, message);
-         }
-
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void storePageTransaction(final long txID, final PageTransactionInfo pageTransaction) throws Exception {
-      readLock();
-      try {
-         pageTransaction.setRecordID(generateID());
-         messageJournal.appendAddRecordTransactional(txID, pageTransaction.getRecordID(), JournalRecordIds.PAGE_TRANSACTION, pageTransaction);
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void updatePageTransaction(final long txID,
-                                     final PageTransactionInfo pageTransaction,
-                                     final int depages) throws Exception {
-      readLock();
-      try {
-         messageJournal.appendUpdateRecordTransactional(txID, pageTransaction.getRecordID(), JournalRecordIds.PAGE_TRANSACTION, new PageUpdateTXEncoding(pageTransaction.getTransactionID(), depages));
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void updatePageTransaction(final PageTransactionInfo pageTransaction, final int depages) throws Exception {
-      readLock();
-      try {
-         messageJournal.appendUpdateRecord(pageTransaction.getRecordID(), JournalRecordIds.PAGE_TRANSACTION, new PageUpdateTXEncoding(pageTransaction.getTransactionID(), depages), syncNonTransactional, getContext(syncNonTransactional));
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void storeReferenceTransactional(final long txID, final long queueID, final long messageID) throws Exception {
-      readLock();
-      try {
-         messageJournal.appendUpdateRecordTransactional(txID, messageID, JournalRecordIds.ADD_REF, new RefEncoding(queueID));
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void storeAcknowledgeTransactional(final long txID,
-                                             final long queueID,
-                                             final long messageID) throws Exception {
-      readLock();
-      try {
-         messageJournal.appendUpdateRecordTransactional(txID, messageID, JournalRecordIds.ACKNOWLEDGE_REF, new RefEncoding(queueID));
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void storeCursorAcknowledgeTransactional(long txID, long queueID, PagePosition position) throws Exception {
-      readLock();
-      try {
-         long ackID = idGenerator.generateID();
-         position.setRecordID(ackID);
-         messageJournal.appendAddRecordTransactional(txID, ackID, JournalRecordIds.ACKNOWLEDGE_CURSOR, new CursorAckRecordEncoding(queueID, position));
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void storePageCompleteTransactional(long txID, long queueID, PagePosition position) throws Exception {
-      long recordID = idGenerator.generateID();
-      position.setRecordID(recordID);
-      messageJournal.appendAddRecordTransactional(txID, recordID, JournalRecordIds.PAGE_CURSOR_COMPLETE, new CursorAckRecordEncoding(queueID, position));
-   }
-
-   @Override
-   public void deletePageComplete(long ackID) throws Exception {
-      messageJournal.appendDeleteRecord(ackID, false);
-   }
-
-   @Override
-   public void deleteCursorAcknowledgeTransactional(long txID, long ackID) throws Exception {
-      readLock();
-      try {
-         messageJournal.appendDeleteRecordTransactional(txID, ackID);
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void deleteCursorAcknowledge(long ackID) throws Exception {
-      messageJournal.appendDeleteRecord(ackID, false);
-   }
-
-   @Override
-   public long storeHeuristicCompletion(final Xid xid, final boolean isCommit) throws Exception {
-      readLock();
-      try {
-         long id = generateID();
-
-         messageJournal.appendAddRecord(id, JournalRecordIds.HEURISTIC_COMPLETION, new HeuristicCompletionEncoding(xid, isCommit), true, getContext(true));
-         return id;
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void deleteHeuristicCompletion(final long id) throws Exception {
-      readLock();
-      try {
-
-         messageJournal.appendDeleteRecord(id, true, getContext(true));
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void deletePageTransactional(final long recordID) throws Exception {
-      readLock();
-      try {
-         messageJournal.appendDeleteRecord(recordID, false);
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void updateScheduledDeliveryTimeTransactional(final long txID, final MessageReference ref) throws Exception {
-      ScheduledDeliveryEncoding encoding = new ScheduledDeliveryEncoding(ref.getScheduledDeliveryTime(), ref.getQueue().getID());
-      readLock();
-      try {
-
-         messageJournal.appendUpdateRecordTransactional(txID, ref.getMessage().getMessageID(), JournalRecordIds.SET_SCHEDULED_DELIVERY_TIME, encoding);
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void prepare(final long txID, final Xid xid) throws Exception {
-      readLock();
-      try {
-         messageJournal.appendPrepareRecord(txID, new XidEncoding(xid), syncTransactional, getContext(syncTransactional));
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void commit(final long txID) throws Exception {
-      commit(txID, true);
-   }
-
-   @Override
-   public void commitBindings(final long txID) throws Exception {
-      bindingsJournal.appendCommitRecord(txID, true);
-   }
-
-   @Override
-   public void rollbackBindings(final long txID) throws Exception {
-      // no need to sync, it's going away anyways
-      bindingsJournal.appendRollbackRecord(txID, false);
-   }
-
-   @Override
-   public void commit(final long txID, final boolean lineUpContext) throws Exception {
-      readLock();
-      try {
-         messageJournal.appendCommitRecord(txID, syncTransactional, getContext(syncTransactional), lineUpContext);
-         if (!lineUpContext && !syncTransactional) {
-            /**
-             * If {@code lineUpContext == false}, it means that we have previously lined up a
-             * context somewhere else (specifically see @{link TransactionImpl#asyncAppendCommit}),
-             * hence we need to mark it as done even if {@code syncTransactional = false} as in this
-             * case {@code getContext(syncTransactional=false)} would pass a dummy context to the
-             * {@code messageJournal.appendCommitRecord(...)} call above.
-             */
-            getContext(true).done();
-         }
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void rollback(final long txID) throws Exception {
-      readLock();
-      try {
-         messageJournal.appendRollbackRecord(txID, syncTransactional, getContext(syncTransactional));
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void storeDuplicateIDTransactional(final long txID,
-                                             final SimpleString address,
-                                             final byte[] duplID,
-                                             final long recordID) throws Exception {
-      DuplicateIDEncoding encoding = new DuplicateIDEncoding(address, duplID);
-
-      readLock();
-      try {
-         messageJournal.appendAddRecordTransactional(txID, recordID, JournalRecordIds.DUPLICATE_ID, encoding);
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void updateDuplicateIDTransactional(final long txID,
-                                              final SimpleString address,
-                                              final byte[] duplID,
-                                              final long recordID) throws Exception {
-      DuplicateIDEncoding encoding = new DuplicateIDEncoding(address, duplID);
-
-      readLock();
-      try {
-         messageJournal.appendUpdateRecordTransactional(txID, recordID, JournalRecordIds.DUPLICATE_ID, encoding);
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void deleteDuplicateIDTransactional(final long txID, final long recordID) throws Exception {
-      readLock();
-      try {
-         messageJournal.appendDeleteRecordTransactional(txID, recordID);
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   // Other operations
-
-   @Override
-   public void updateDeliveryCount(final MessageReference ref) throws Exception {
-      // no need to store if it's the same value
-      // otherwise the journal will get OME in case of lots of redeliveries
-      if (ref.getDeliveryCount() == ref.getPersistedCount()) {
-         return;
-      }
-
-      ref.setPersistedCount(ref.getDeliveryCount());
-      DeliveryCountUpdateEncoding updateInfo = new DeliveryCountUpdateEncoding(ref.getQueue().getID(), ref.getDeliveryCount());
-
-      readLock();
-      try {
-         messageJournal.appendUpdateRecord(ref.getMessage().getMessageID(), JournalRecordIds.UPDATE_DELIVERY_COUNT, updateInfo, syncNonTransactional, getContext(syncNonTransactional));
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void storeAddressSetting(PersistedAddressSetting addressSetting) throws Exception {
-      deleteAddressSetting(addressSetting.getAddressMatch());
-      readLock();
-      try {
-         long id = idGenerator.generateID();
-         addressSetting.setStoreId(id);
-         bindingsJournal.appendAddRecord(id, JournalRecordIds.ADDRESS_SETTING_RECORD, addressSetting, true);
-         mapPersistedAddressSettings.put(addressSetting.getAddressMatch(), addressSetting);
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public List<PersistedAddressSetting> recoverAddressSettings() throws Exception {
-      ArrayList<PersistedAddressSetting> list = new ArrayList<>(mapPersistedAddressSettings.values());
-      return list;
-   }
-
-   @Override
-   public List<PersistedRoles> recoverPersistedRoles() throws Exception {
-      ArrayList<PersistedRoles> list = new ArrayList<>(mapPersistedRoles.values());
-      return list;
-   }
-
-   @Override
-   public void storeSecurityRoles(PersistedRoles persistedRoles) throws Exception {
-
-      deleteSecurityRoles(persistedRoles.getAddressMatch());
-      readLock();
-      try {
-         final long id = idGenerator.generateID();
-         persistedRoles.setStoreId(id);
-         bindingsJournal.appendAddRecord(id, JournalRecordIds.SECURITY_RECORD, persistedRoles, true);
-         mapPersistedRoles.put(persistedRoles.getAddressMatch(), persistedRoles);
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public final void storeID(final long journalID, final long id) throws Exception {
-      readLock();
-      try {
-         bindingsJournal.appendAddRecord(journalID, JournalRecordIds.ID_COUNTER_RECORD, BatchingIDGenerator.createIDEncodingSupport(id), true);
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void deleteID(long journalD) throws Exception {
-      readLock();
-      try {
-         bindingsJournal.appendDeleteRecord(journalD, false);
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void deleteAddressSetting(SimpleString addressMatch) throws Exception {
-      PersistedAddressSetting oldSetting = mapPersistedAddressSettings.remove(addressMatch);
-      if (oldSetting != null) {
-         readLock();
-         try {
-            bindingsJournal.appendDeleteRecord(oldSetting.getStoreId(), false);
-         }
-         finally {
-            readUnLock();
-         }
-      }
-   }
-
-   @Override
-   public void deleteSecurityRoles(SimpleString addressMatch) throws Exception {
-      PersistedRoles oldRoles = mapPersistedRoles.remove(addressMatch);
-      if (oldRoles != null) {
-         readLock();
-         try {
-            bindingsJournal.appendDeleteRecord(oldRoles.getStoreId(), false);
-         }
-         finally {
-            readUnLock();
-         }
-      }
-   }
-
-   @Override
-   public JournalLoadInformation loadMessageJournal(final PostOffice postOffice,
-                                                    final PagingManager pagingManager,
-                                                    final ResourceManager resourceManager,
-                                                    Map<Long, QueueBindingInfo> queueInfos,
-                                                    final Map<SimpleString, List<Pair<byte[], Long>>> duplicateIDMap,
-                                                    final Set<Pair<Long, Long>> pendingLargeMessages,
-                                                    List<PageCountPending> pendingNonTXPageCounter,
-                                                    final JournalLoader journalLoader) throws Exception {
-      List<RecordInfo> records = new ArrayList<>();
-
-      List<PreparedTransactionInfo> preparedTransactions = new ArrayList<>();
-
-      Map<Long, ServerMessage> messages = new HashMap<>();
-      readLock();
-      try {
-
-         JournalLoadInformation info = messageJournal.load(records, preparedTransactions, new LargeMessageTXFailureCallback(messages));
-
-         ArrayList<LargeServerMessage> largeMessages = new ArrayList<>();
-
-         Map<Long, Map<Long, AddMessageRecord>> queueMap = new HashMap<>();
-
-         Map<Long, PageSubscription> pageSubscriptions = new HashMap<>();
-
-         final int totalSize = records.size();
-
-         for (int reccount = 0; reccount < totalSize; reccount++) {
-            // It will show log.info only with large journals (more than 1 million records)
-            if (reccount > 0 && reccount % 1000000 == 0) {
-               long percent = (long) ((((double) reccount) / ((double) totalSize)) * 100f);
-
-               ActiveMQServerLogger.LOGGER.percentLoaded(percent);
-            }
-
-            RecordInfo record = records.get(reccount);
-            byte[] data = record.data;
-
-            ActiveMQBuffer buff = ActiveMQBuffers.wrappedBuffer(data);
-
-            byte recordType = record.getUserRecordType();
-
-            switch (recordType) {
-               case JournalRecordIds.ADD_LARGE_MESSAGE_PENDING: {
-                  PendingLargeMessageEncoding pending = new PendingLargeMessageEncoding();
-
-                  pending.decode(buff);
-
-                  if (pendingLargeMessages != null) {
-                     // it could be null on tests, and we don't need anything on that case
-                     pendingLargeMessages.add(new Pair<>(record.id, pending.largeMessageID));
-                  }
-                  break;
-               }
-               case JournalRecordIds.ADD_LARGE_MESSAGE: {
-                  LargeServerMessage largeMessage = parseLargeMessage(messages, buff);
-
-                  messages.put(record.id, largeMessage);
-
-                  largeMessages.add(largeMessage);
-
-                  break;
-               }
-               case JournalRecordIds.ADD_MESSAGE: {
-                  ServerMessage message = new ServerMessageImpl(record.id, 50);
-
-                  message.decode(buff);
-
-                  messages.put(record.id, message);
-
-                  break;
-               }
-               case JournalRecordIds.ADD_REF: {
-                  long messageID = record.id;
-
-                  RefEncoding encoding = new RefEncoding();
-
-                  encoding.decode(buff);
-
-                  Map<Long, AddMessageRecord> queueMessages = queueMap.get(encoding.queueID);
-
-                  if (queueMessages == null) {
-                     queueMessages = new LinkedHashMap<>();
-
-                     queueMap.put(encoding.queueID, queueMessages);
-                  }
-
-                  ServerMessage message = messages.get(messageID);
-
-                  if (message == null) {
-                     ActiveMQServerLogger.LOGGER.cannotFindMessage(record.id);
-                  }
-                  else {
-                     queueMessages.put(messageID, new AddMessageRecord(message));
-                  }
-
-                  break;
-               }
-               case JournalRecordIds.ACKNOWLEDGE_REF: {
-                  long messageID = record.id;
-
-                  RefEncoding encoding = new RefEncoding();
-
-                  encoding.decode(buff);
-
-                  Map<Long, AddMessageRecord> queueMessages = queueMap.get(encoding.queueID);
-
-                  if (queueMessages == null) {
-                     ActiveMQServerLogger.LOGGER.journalCannotFindQueue(encoding.queueID, messageID);
-                  }
-                  else {
-                     AddMessageRecord rec = queueMessages.remove(messageID);
-
-                     if (rec == null) {
-                        ActiveMQServerLogger.LOGGER.cannotFindMessage(messageID);
-                     }
-                  }
-
-                  break;
-               }
-               case JournalRecordIds.UPDATE_DELIVERY_COUNT: {
-                  long messageID = record.id;
-
-                  DeliveryCountUpdateEncoding encoding = new DeliveryCountUpdateEncoding();
-
-                  encoding.decode(buff);
-
-                  Map<Long, AddMessageRecord> queueMessages = queueMap.get(encoding.queueID);
-
-                  if (queueMessages == null) {
-                     ActiveMQServerLogger.LOGGER.journalCannotFindQueueDelCount(encoding.queueID);
-                  }
-                  else {
-                     AddMessageRecord rec = queueMessages.get(messageID);
-
-                     if (rec == null) {
-                        ActiveMQServerLogger.LOGGER.journalCannotFindMessageDelCount(messageID);
-                     }
-                     else {
-                        rec.deliveryCount = encoding.count;
-                     }
-                  }
-
-                  break;
-               }
-               case JournalRecordIds.PAGE_TRANSACTION: {
-                  if (record.isUpdate) {
-                     PageUpdateTXEncoding pageUpdate = new PageUpdateTXEncoding();
-
-                     pageUpdate.decode(buff);
-
-                     PageTransactionInfo pageTX = pagingManager.getTransaction(pageUpdate.pageTX);
-
-                     pageTX.onUpdate(pageUpdate.recods, null, null);
-                  }
-                  else {
-                     PageTransactionInfoImpl pageTransactionInfo = new PageTransactionInfoImpl();
-
-                     pageTransactionInfo.decode(buff);
-
-                     pageTransactionInfo.setRecordID(record.id);
-
-                     pagingManager.addTransaction(pageTransactionInfo);
-                  }
-
-                  break;
-               }
-               case JournalRecordIds.SET_SCHEDULED_DELIVERY_TIME: {
-                  long messageID = record.id;
-
-                  ScheduledDeliveryEncoding encoding = new ScheduledDeliveryEncoding();
-
-                  encoding.decode(buff);
-
-                  Map<Long, AddMessageRecord> queueMessages = queueMap.get(encoding.queueID);
-
-                  if (queueMessages == null) {
-                     ActiveMQServerLogger.LOGGER.journalCannotFindQueueScheduled(encoding.queueID, messageID);
-                  }
-                  else {
-
-                     AddMessageRecord rec = queueMessages.get(messageID);
-
-                     if (rec == null) {
-                        ActiveMQServerLogger.LOGGER.cannotFindMessage(messageID);
-                     }
-                     else {
-                        rec.scheduledDeliveryTime = encoding.scheduledDeliveryTime;
-                     }
-                  }
-
-                  break;
-               }
-               case JournalRecordIds.DUPLICATE_ID: {
-                  DuplicateIDEncoding encoding = new DuplicateIDEncoding();
-
-                  encoding.decode(buff);
-
-                  List<Pair<byte[], Long>> ids = duplicateIDMap.get(encoding.address);
-
-                  if (ids == null) {
-                     ids = new ArrayList<>();
-
-                     duplicateIDMap.put(encoding.address, ids);
-                  }
-
-                  ids.add(new Pair<>(encoding.duplID, record.id));
-
-                  break;
-               }
-               case JournalRecordIds.HEURISTIC_COMPLETION: {
-                  HeuristicCompletionEncoding encoding = new HeuristicCompletionEncoding();
-                  encoding.decode(buff);
-                  resourceManager.putHeuristicCompletion(record.id, encoding.xid, encoding.isCommit);
-                  break;
-               }
-               case JournalRecordIds.ACKNOWLEDGE_CURSOR: {
-                  CursorAckRecordEncoding encoding = new CursorAckRecordEncoding();
-                  encoding.decode(buff);
-
-                  encoding.position.setRecordID(record.id);
-
-                  PageSubscription sub = locateSubscription(encoding.queueID, pageSubscriptions, queueInfos, pagingManager);
-
-                  if (sub != null) {
-                     sub.reloadACK(encoding.position);
-                  }
-                  else {
-                     ActiveMQServerLogger.LOGGER.journalCannotFindQueueReloading(encoding.queueID);
-                     messageJournal.appendDeleteRecord(record.id, false);
-
-                  }
-
-                  break;
-               }
-               case JournalRecordIds.PAGE_CURSOR_COUNTER_VALUE: {
-                  PageCountRecord encoding = new PageCountRecord();
-
-                  encoding.decode(buff);
-
-                  PageSubscription sub = locateSubscription(encoding.getQueueID(), pageSubscriptions, queueInfos, pagingManager);
-
-                  if (sub != null) {
-                     sub.getCounter().loadValue(record.id, encoding.getValue());
-                  }
-                  else {
-                     ActiveMQServerLogger.LOGGER.journalCannotFindQueueReloadingPage(encoding.getQueueID());
-                     messageJournal.appendDeleteRecord(record.id, false);
-                  }
-
-                  break;
-               }
-
-               case JournalRecordIds.PAGE_CURSOR_COUNTER_INC: {
-                  PageCountRecordInc encoding = new PageCountRecordInc();
-
-                  encoding.decode(buff);
-
-                  PageSubscription sub = locateSubscription(encoding.getQueueID(), pageSubscriptions, queueInfos, pagingManager);
-
-                  if (sub != null) {
-                     sub.getCounter().loadInc(record.id, encoding.getValue());
-                  }
-                  else {
-                     ActiveMQServerLogger.LOGGER.journalCannotFindQueueReloadingPageCursor(encoding.getQueueID());
-                     messageJournal.appendDeleteRecord(record.id, false);
-                  }
-
-                  break;
-               }
-
-               case JournalRecordIds.PAGE_CURSOR_COMPLETE: {
-                  CursorAckRecordEncoding encoding = new CursorAckRecordEncoding();
-                  encoding.decode(buff);
-
-                  encoding.position.setRecordID(record.id);
-
-                  PageSubscription sub = locateSubscription(encoding.queueID, pageSubscriptions, queueInfos, pagingManager);
-
-                  if (sub != null) {
-                     sub.reloadPageCompletion(encoding.position);
-                  }
-                  else {
-                     ActiveMQServerLogger.LOGGER.cantFindQueueOnPageComplete(encoding.queueID);
-                     messageJournal.appendDeleteRecord(record.id, false);
-                  }
-
-                  break;
-               }
-
-               case JournalRecordIds.PAGE_CURSOR_PENDING_COUNTER: {
-
-                  PageCountPendingImpl pendingCountEncoding = new PageCountPendingImpl();
-                  pendingCountEncoding.decode(buff);
-                  pendingCountEncoding.setID(record.id);
-
-                  // This can be null on testcases not interested on this outcome
-                  if (pendingNonTXPageCounter != null) {
-                     pendingNonTXPageCounter.add(pendingCountEncoding);
-                  }
-                  break;
-               }
-
-               default: {
-                  throw new IllegalStateException("Invalid record type " + recordType);
-               }
-            }
-
-            // This will free up memory sooner. The record is not needed any more
-            // and its byte array would consume memory during the load process even though it's not necessary any longer
-            // what would delay processing time during load
-            records.set(reccount, null);
-         }
-
-         // Release the memory as soon as not needed any longer
-         records.clear();
-         records = null;
-
-         journalLoader.handleAddMessage(queueMap);
-
-         loadPreparedTransactions(postOffice, pagingManager, resourceManager, queueInfos, preparedTransactions, duplicateIDMap, pageSubscriptions, pendingLargeMessages, journalLoader);
-
-         for (PageSubscription sub : pageSubscriptions.values()) {
-            sub.getCounter().processReload();
-         }
-
-         for (LargeServerMessage msg : largeMessages) {
-            if (msg.getRefCount() == 0) {
-               ActiveMQServerLogger.LOGGER.largeMessageWithNoRef(msg.getMessageID());
-               msg.decrementDelayDeletionCount();
-            }
-         }
-
-         journalLoader.handleNoMessageReferences(messages);
-
-         // To recover positions on Iterators
-         if (pagingManager != null) {
-            // it could be null on certain tests that are not dealing with paging
-            // This could also be the case in certain embedded conditions
-            pagingManager.processReload();
-         }
-
-         if (perfBlastPages != -1) {
-            messageJournal.perfBlast(perfBlastPages);
-         }
-
-         journalLoader.postLoad(messageJournal, resourceManager, duplicateIDMap);
-         journalLoaded = true;
-         return info;
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   /**
-    * @param queueID
-    * @param pageSubscriptions
-    * @param queueInfos
-    * @return
-    */
-   private static PageSubscription locateSubscription(final long queueID,
-                                                      final Map<Long, PageSubscription> pageSubscriptions,
-                                                      final Map<Long, QueueBindingInfo> queueInfos,
-                                                      final PagingManager pagingManager) throws Exception {
-
-      PageSubscription subs = pageSubscriptions.get(queueID);
-      if (subs == null) {
-         QueueBindingInfo queueInfo = queueInfos.get(queueID);
-
-         if (queueInfo != null) {
-            SimpleString address = queueInfo.getAddress();
-            PagingStore store = pagingManager.getPageStore(address);
-            subs = store.getCursorProvider().getSubscription(queueID);
-            pageSubscriptions.put(queueID, subs);
-         }
-      }
-
-      return subs;
-   }
-
-   // grouping handler operations
-   @Override
-   public void addGrouping(final GroupBinding groupBinding) throws Exception {
-      GroupingEncoding groupingEncoding = new GroupingEncoding(groupBinding.getId(), groupBinding.getGroupId(), groupBinding.getClusterName());
-      readLock();
-      try {
-         bindingsJournal.appendAddRecord(groupBinding.getId(), JournalRecordIds.GROUP_RECORD, groupingEncoding, true);
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void deleteGrouping(long tx, final GroupBinding groupBinding) throws Exception {
-      readLock();
-      try {
-         bindingsJournal.appendDeleteRecordTransactional(tx, groupBinding.getId());
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   // BindingsImpl operations
-
-   @Override
-   public void addQueueBinding(final long tx, final Binding binding) throws Exception {
-      Queue queue = (Queue) binding.getBindable();
-
-      Filter filter = queue.getFilter();
-
-      SimpleString filterString = filter == null ? null : filter.getFilterString();
-
-      PersistentQueueBindingEncoding bindingEncoding = new PersistentQueueBindingEncoding(queue.getName(), binding.getAddress(), filterString, queue.getUser(), queue.isAutoCreated());
-
-      readLock();
-      try {
-         bindingsJournal.appendAddRecordTransactional(tx, binding.getID(), JournalRecordIds.QUEUE_BINDING_RECORD, bindingEncoding);
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void deleteQueueBinding(long tx, final long queueBindingID) throws Exception {
-      readLock();
-      try {
-         bindingsJournal.appendDeleteRecordTransactional(tx, queueBindingID);
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public long storePageCounterInc(long txID, long queueID, int value) throws Exception {
-      readLock();
-      try {
-         long recordID = idGenerator.generateID();
-         messageJournal.appendAddRecordTransactional(txID, recordID, JournalRecordIds.PAGE_CURSOR_COUNTER_INC, new PageCountRecordInc(queueID, value));
-         return recordID;
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public long storePageCounterInc(long queueID, int value) throws Exception {
-      readLock();
-      try {
-         final long recordID = idGenerator.generateID();
-         messageJournal.appendAddRecord(recordID, JournalRecordIds.PAGE_CURSOR_COUNTER_INC, new PageCountRecordInc(queueID, value), true, getContext());
-         return recordID;
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public long storePageCounter(long txID, long queueID, long value) throws Exception {
-      readLock();
-      try {
-         final long recordID = idGenerator.generateID();
-         messageJournal.appendAddRecordTransactional(txID, recordID, JournalRecordIds.PAGE_CURSOR_COUNTER_VALUE, new PageCountRecord(queueID, value));
-         return recordID;
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public long storePendingCounter(final long queueID, final long pageID, final int inc) throws Exception {
-      readLock();
-      try {
-         final long recordID = idGenerator.generateID();
-         PageCountPendingImpl pendingInc = new PageCountPendingImpl(queueID, pageID, inc);
-         // We must guarantee the record sync before we actually write on the page otherwise we may get out of sync
-         // on the counter
-         messageJournal.appendAddRecord(recordID, JournalRecordIds.PAGE_CURSOR_PENDING_COUNTER, pendingInc, true);
-         return recordID;
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void deleteIncrementRecord(long txID, long recordID) throws Exception {
-      readLock();
-      try {
-         messageJournal.appendDeleteRecordTransactional(txID, recordID);
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void deletePageCounter(long txID, long recordID) throws Exception {
-      readLock();
-      try {
-         messageJournal.appendDeleteRecordTransactional(txID, recordID);
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void deletePendingPageCounter(long txID, long recordID) throws Exception {
-      readLock();
-      try {
-         messageJournal.appendDeleteRecordTransactional(txID, recordID);
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public JournalLoadInformation loadBindingJournal(final List<QueueBindingInfo> queueBindingInfos,
-                                                    final List<GroupingInfo> groupingInfos) throws Exception {
-      List<RecordInfo> records = new ArrayList<>();
-
-      List<PreparedTransactionInfo> preparedTransactions = new ArrayList<>();
-
-      JournalLoadInformation bindingsInfo = bindingsJournal.load(records, preparedTransactions, null);
-
-      for (RecordInfo record : records) {
-         long id = record.id;
-
-         ActiveMQBuffer buffer = ActiveMQBuffers.wrappedBuffer(record.data);
-
-         byte rec = record.getUserRecordType();
-
-         if (rec == JournalRecordIds.QUEUE_BINDING_RECORD) {
-            PersistentQueueBindingEncoding bindingEncoding = newBindingEncoding(id, buffer);
-
-            queueBindingInfos.add(bindingEncoding);
-         }
-         else if (rec == JournalRecordIds.ID_COUNTER_RECORD) {
-            idGenerator.loadState(record.id, buffer);
-         }
-         else if (rec == JournalRecordIds.GROUP_RECORD) {
-            GroupingEncoding encoding = newGroupEncoding(id, buffer);
-            groupingInfos.add(encoding);
-         }
-         else if (rec == JournalRecordIds.ADDRESS_SETTING_RECORD) {
-            PersistedAddressSetting setting = newAddressEncoding(id, buffer);
-            mapPersistedAddressSettings.put(setting.getAddressMatch(), setting);
-         }
-         else if (rec == JournalRecordIds.SECURITY_RECORD) {
-            PersistedRoles roles = newSecurityRecord(id, buffer);
-            mapPersistedRoles.put(roles.getAddressMatch(), roles);
-         }
-         else {
-            throw new IllegalStateException("Invalid record type " + rec);
-         }
-      }
-
-      // This will instruct the IDGenerator to cleanup old records
-      idGenerator.cleanup();
-
-      return bindingsInfo;
-   }
-
-   @Override
-   public void lineUpContext() {
-      readLock();
-      try {
-         messageJournal.lineUpContext(getContext());
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   // ActiveMQComponent implementation
-   // ------------------------------------------------------
-
-   @Override
-   public synchronized void start() throws Exception {
-      if (started) {
-         return;
-      }
-
-      checkAndCreateDir(config.getBindingsLocation(), config.isCreateBindingsDir());
-
-      checkAndCreateDir(config.getJournalLocation(), config.isCreateJournalDir());
-
-      checkAndCreateDir(config.getLargeMessagesLocation(), config.isCreateJournalDir());
-
-      cleanupIncompleteFiles();
-
-      singleThreadExecutor = Executors.newSingleThreadExecutor(AccessController.doPrivileged(new PrivilegedAction<ActiveMQThreadFactory>() {
-         @Override
-         public ActiveMQThreadFactory run() {
-            return new ActiveMQThreadFactory("ActiveMQ-IO-SingleThread", true, JournalStorageManager.class.getClassLoader());
-         }
-      }));
-
-      bindingsJournal.start();
-
-      messageJournal.start();
-
-      started = true;
-   }
-
-   @Override
-   public void stop() throws Exception {
-      stop(false);
-   }
-
-   @Override
-   public synchronized void persistIdGenerator() {
-      if (journalLoaded && idGenerator != null) {
-         // Must call close to make sure last id is persisted
-         idGenerator.persistCurrentID();
-      }
-   }
-
-   @Override
-   public synchronized void stop(boolean ioCriticalError) throws Exception {
-      if (!started) {
-         return;
-      }
-
-      if (!ioCriticalError) {
-         performCachedLargeMessageDeletes();
-         // Must call close to make sure last id is persisted
-         if (journalLoaded && idGenerator != null)
-            idGenerator.persistCurrentID();
-      }
-
-      final CountDownLatch latch = new CountDownLatch(1);
-      executor.execute(new Runnable() {
-         @Override
-         public void run() {
-            latch.countDown();
-         }
-      });
-
-      latch.await(30, TimeUnit.SECONDS);
-
-      // We cache the variable as the replicator could be changed between here and the time we call stop
-      // since sendLiveIsStoping my issue a close back from the channel
-      // and we want to ensure a stop here just in case
-      ReplicationManager replicatorInUse = replicator;
-      if (replicatorInUse != null) {
-         final OperationContext token = replicator.sendLiveIsStopping(LiveStopping.FAIL_OVER);
-         if (token != null) {
-            try {
-               token.waitCompletion(5000);
-            }
-            catch (Exception e) {
-               // ignore it
-            }
-         }
-         replicatorInUse.stop();
-      }
-      bindingsJournal.stop();
-
-      messageJournal.stop();
-
-      singleThreadExecutor.shutdown();
-
-      journalLoaded = false;
-
-      started = false;
-   }
-
-   @Override
-   public synchronized boolean isStarted() {
-      return started;
-   }
-
-   /**
-    * TODO: Is this still being used ?
-    */
-   public JournalLoadInformation[] loadInternalOnly() throws Exception {
-      readLock();
-      try {
-         JournalLoadInformation[] info = new JournalLoadInformation[2];
-         info[0] = bindingsJournal.loadInternalOnly();
-         info[1] = messageJournal.loadInternalOnly();
-
-         return info;
-      }
-      finally {
-         readUnLock();
-      }
-   }
-
-   @Override
-   public void beforePageRead() throws Exception {
-      if (pageMaxConcurrentIO != null) {
-         pageMaxConcurrentIO.acquire();
-      }
-   }
-
-   @Override
-   public void afterPageRead() throws Exception {
-      if (pageMaxConcurrentIO != null) {
-         pageMaxConcurrentIO.release();
-      }
-   }
-
-   @Override
-   public ByteBuffer allocateDirectBuffer(int size) {
-      return journalFF.allocateDirectBuffer(size);
-   }
-
-   @Override
-   public void freeDirectBuffer(ByteBuffer buffer) {
-      journalFF.releaseBuffer(buffer);
-   }
-
-   // Public -----------------------------------------------------------------------------------
-
-   @Override
-   public Journal getMessageJournal() {
-      return messageJournal;
-   }
-
-   @Override
-   public Journal getBindingsJournal() {
-      return bindingsJournal;
-   }
-
-   // Package protected ---------------------------------------------
-
-   protected void confirmLargeMessage(final LargeServerMessage largeServerMessage) {
-      if (largeServerMessage.getPendingRecordID() >= 0) {
-         try {
-            confirmPendingLargeMessage(largeServerMessage.getPendingRecordID());
-            largeServerMessage.setPendingRecordID(-1);
-         }
-         catch (Exception e) {
-            ActiveMQServerLogger.LOGGER.warn(e.getMessage(), e);
-         }
-      }
-   }
-
-   // This should be accessed from this package only
-   void deleteLargeMessageFile(final LargeServerMessage largeServerMessage) throws ActiveMQException {
-      if (largeServerMessage.getPendingRecordID() < 0) {
-         try {
-            // The delete file happens asynchronously
-            // And the client won't be waiting for the actual file to be deleted.
-            // We set a temporary record (short lived) on the journal
-            // to avoid a situation where the server is restarted and pending large message stays on forever
-            largeServerMessage.setPendingRecordID(storePendingLargeMessage(largeServerMessage.getMessageID()));
-         }
-         catch (Exception e) {
-            throw new ActiveMQInternalErrorException(e.getMessage(), e);
-         }
-      }
-      final SequentialFile file = largeServerMessage.getFile();
-      if (file == null) {
-         return;
-      }
-
-      if (largeServerMessage.isDurable() && isReplicated()) {
-         readLock();
-         try {
-            if (isReplicated() && replicator.isSynchronizing()) {
-               synchronized (largeMessagesToDelete) {
-                  largeMessagesToDelete.add(Long.valueOf(largeServerMessage.getMessageID()));
-                  confirmLargeMessage(largeServerMessage);
-               }
-               return;
-            }
-         }
-         finally {
-            readUnLock();
-         }
-      }
-      Runnable deleteAction = new Runnable() {
-         @Override
-         public void run() {
-            try {
-               readLock();
-               try {
-                  if (replicator != null) {
-                     replicator.largeMessageDelete(largeServerMessage.getMessageID());
-                  }
-                  file.delete();
-
-                  // The confirm could only be done after the actual delete is done
-                  confirmLargeMessage(largeServerMessage);
-               }
-               finally {
-                  readUnLock();
-               }
-            }
-            catch (Exception e) {
-               ActiveMQServerLogger.LOGGER.journalErrorDeletingMessage(e, largeServerMessage.getMessageID());
-            }
-         }
-
-      };
-
-      if (executor == null) {
-         deleteAction.run();
-      }
-      else {
-         executor.execute(deleteAction);
-      }
-   }
-
-   SequentialFile createFileForLargeMessage(final long messageID, final boolean durable) {
-      if (durable) {
-         return createFileForLargeMessage(messageID, LargeMessageExtension.DURABLE);
-      }
-      else {
-         return createFileForLargeMessage(messageID, LargeMessageExtension.TEMPORARY);
-      }
-   }
-
-   @Override
-   public SequentialFile createFileForLargeMessage(final long messageID, LargeMessageExtension extension) {
-      return largeMessagesFactory.createSequentialFile(messageID + extension.getExtension());
-   }
-
-   // Private ----------------------------------------------------------------------------------
-
-   private void checkAndCreateDir(final File dir, final boolean create) {
-      if (!dir.exists()) {
-         if (create) {
-            if (!dir.mkdirs()) {
-               throw new IllegalStateException("Failed to create directory " + dir);
-            }
-         }
-         else {
-            throw ActiveMQMessageBundle.BUNDLE.cannotCreateDir(dir.getAbsolutePath());
-         }
-      }
-   }
-
-   /**
-    * @param messages
-    * @param buff
-    * @return
-    * @throws Exception
-    */
-   protected LargeServerMessage parseLargeMessage(final Map<Long, ServerMessage> messages,
-                                                final ActiveMQBuffer buff) throws Exception {
-      LargeServerMessage largeMessage = createLargeMessage();
-
-      LargeMessageEncoding messageEncoding = new LargeMessageEncoding(largeMessage);
-
-      messageEncoding.decode(buff);
-
-      if (largeMessage.containsProperty(Message.HDR_ORIG_MESSAGE_ID)) {
-         // for compatibility: couple with old behaviour, copying the old file to avoid message loss
-         long originalMessageID = largeMessage.getLongProperty(Message.HDR_ORIG_MESSAGE_ID);
-
-         SequentialFile currentFile = createFileForLargeMessage(largeMessage.getMessageID(), true);
-
-         if (!currentFile.exists()) {
-            SequentialFile linkedFile = createFileForLargeMessage(originalMessageID, true);
-            if (linkedFile.exists()) {
-               linkedFile.copyTo(currentFile);
-               linkedFile.close();
-            }
-         }
-
-         currentFile.close();
-      }
-
-      return largeMessage;
-   }
-
-   private void loadPreparedTransactions(final PostOffice postOffice,
-                                         final PagingManager pagingManager,
-                                         final ResourceManager resourceManager,
-                                         final Map<Long, QueueBindingInfo> queueInfos,
-                                         final List<PreparedTransactionInfo> preparedTransactions,
-                                         final Map<SimpleString, List<Pair<byte[], Long>>> duplicateIDMap,
-                                         final Map<Long, PageSubscription> pageSubscriptions,
-                                         final Set<Pair<Long, Long>> pendingLargeMessages,
-                                         JournalLoader journalLoader) throws Exception {
-      // recover prepared transactions
-      for (PreparedTransactionInfo preparedTransaction : preparedTransactions) {
-         XidEncoding encodingXid = new XidEncoding(preparedTransaction.getExtraData());
-
-         Xid xid = encodingXid.xid;
-
-         Transaction tx = new TransactionImpl(preparedTransaction.getId(), xid, this);
-
-         List<MessageReference> referencesToAck = new ArrayList<>();
-
-         Map<Long, ServerMessage> messages = new HashMap<>();
-
-         // Use same method as load message journal to prune out acks, so they don't get added.
-         // Then have reacknowledge(tx) methods on queue, which needs to add the page size
-
-         // first get any sent messages for this tx and recreate
-         for (RecordInfo record : preparedTransaction.getRecords()) {
-            byte[] data = record.data;
-
-            ActiveMQBuffer buff = ActiveMQBuffers.wrappedBuffer(data);
-
-            byte recordType = record.getUserRecordType();
-
-            switch (recordType) {
-               case JournalRecordIds.ADD_LARGE_MESSAGE: {
-                  messages.put(record.id, parseLargeMessage(messages, buff));
-
-                  break;
-               }
-               case JournalRecordIds.ADD_MESSAGE: {
-                  ServerMessage message = new ServerMessageImpl(record.id, 50);
-
-                  message.decode(buff);
-
-                  messages.put(record.id, message);
-
-                  break;
-               }
-               case JournalRecordIds.ADD_REF: {
-                  long messageID = record.id;
-
-                  RefEncoding encoding = new RefEncoding();
-
-                  encoding.decode(buff);
-
-                  ServerMessage message = messages.get(messageID);
-
-                  if (message == null) {
-                     throw new IllegalStateException("Cannot find message with id " + messageID);
-                  }
-
-                  journalLoader.handlePreparedSendMessage(message, tx, encoding.queueID);
-
-                  break;
-               }
-               case JournalRecordIds.ACKNOWLEDGE_REF: {
-                  long messageID = record.id;
-
-                  RefEncoding encoding = new RefEncoding();
-
-                  encoding.decode(buff);
-
-                  journalLoader.handlePreparedAcknowledge(messageID, referencesToAck, encoding.queueID);
-
-                  break;
-               }
-               case JournalRecordIds.PAGE_TRANSACTION: {
-
-                  PageTransactionInfo pageTransactionInfo = new PageTransactionInfoImpl();
-
-                  pageTransactionInfo.decode(buff);
-
-                  if (record.isUpdate) {
-                     PageTransactionInfo pgTX = pagingManager.getTransaction(pageTransactionInfo.getTransactionID());
-                     pgTX.reloadUpdate(this, pagingManager, tx, pageTransactionInfo.getNumberOfMessages());
-                  }
-                  else {
-                     pageTransactionInfo.setCommitted(false);
-
-                     tx.putProperty(TransactionPropertyIndexes.PAGE_TRANSACTION, pageTransactionInfo);
-
-                     pagingManager.addTransaction(pageTransactionInfo);
-
-                     tx.addOperation(new FinishPageMessageOperation());
-                  }
-
-                  break;
-               }
-               case SET_SCHEDULED_DELIVERY_TIME: {
-                  // Do nothing - for prepared txs, the set scheduled delivery time will only occur in a send in which
-                  // case the message will already have the header for the scheduled delivery time, so no need to do
-                  // anything.
-
-                  break;
-               }
-               case DUPLICATE_ID: {
-                  // We need load the duplicate ids at prepare time too
-                  DuplicateIDEncoding encoding = new DuplicateIDEncoding();
-
-                  encoding.decode(buff);
-
-                  DuplicateIDCache cache = postOffice.getDuplicateIDCache(encoding.address);
-
-                  cache.load(tx, encoding.duplID);
-
-                  break;
-               }
-               case ACKNOWLEDGE_CURSOR: {
-                  CursorAckRecordEncoding encoding = new CursorAckRecordEncoding();
-                  encoding.decode(buff);
-
-                  encoding.position.setRecordID(record.id);
-
-                  PageSubscription sub = locateSubscription(encoding.queueID, pageSubscriptions, queueInfos, pagingManager);
-
-                  if (sub != null) {
-                     sub.reloadPreparedACK(tx, encoding.position);
-                     referencesToAck.add(new PagedReferenceImpl(encoding.position, null, sub));
-                  }
-                  else {
-                     ActiveMQServerLogger.LOGGER.journalCannotFindQueueReloadingACK(encoding.queueID);
-                  }
-                  break;
-               }
-               case PAGE_CURSOR_COUNTER_VALUE: {
-                  ActiveMQServerLogger.LOGGER.journalPAGEOnPrepared();
-
-                  break;
-               }
-
-               case PAGE_CURSOR_COUNTER_INC: {
-                  PageCountRecordInc encoding = new PageCountRecordInc();
-
-                  encoding.decode(buff);
-
-                  PageSubscription sub = locateSubscription(encoding.getQueueID(), pageSubscriptions, queueInfos, pagingManager);
-
-                  if (sub != null) {
-                     sub.getCounter().applyIncrementOnTX(tx, record.id, encoding.getValue());
-                     sub.notEmpty();
-                  }
-                  else {
-                     ActiveMQServerLogger.LOGGER.journalCannotFindQueueReloadingACK(encoding.getQueueID());
-                  }
-
-                  break;
-               }
-
-               default: {
-                  ActiveMQServerLogger.LOGGER.journalInvalidRecordType(recordType);
-               }
-            }
-         }
-
-         for (RecordInfo recordDeleted : preparedTransaction.getRecordsToDelete()) {
-            byte[] data = recordDeleted.data;
-
-            if (data.length > 0) {
-               ActiveMQBuffer buff = ActiveMQBuffers.wrappedBuffer(data);
-               byte b = buff.readByte();
-
-               switch (b) {
-                  case ADD_LARGE_MESSAGE_PENDING: {
-                     long messageID = buff.readLong();
-                     if (!pendingLargeMessages.remove(new Pair<>(recordDeleted.id, messageID))) {
-                        ActiveMQServerLogger.LOGGER.largeMessageNotFound(recordDeleted.id);
-                     }
-                     installLargeMessageConfirmationOnTX(tx, recordDeleted.id);
-                     break;
-                  }
-                  default:
-                     ActiveMQServerLogger.LOGGER.journalInvalidRecordTypeOnPreparedTX(b);
-               }
-            }
-
-         }
-
-         journalLoader.handlePreparedTransaction(tx, referencesToAck, xid, resourceManager);
-      }
-   }
-
-   private void cleanupIncompleteFiles() throws Exception {
-      if (largeMessagesFactory != null) {
-         List<String> tmpFiles = largeMessagesFactory.listFiles("tmp");
-         for (String tmpFile : tmpFiles) {
-            SequentialFile file = largeMessagesFactory.createSequentialFile(tmpFile);
-            file.delete();
-         }
-      }
-   }
-
-   private OperationContext getContext(final boolean sync) {
-      if (sync) {
-         return getContext();
-      }
-      else {
-         return DummyOperationContext.getInstance();
-      }
-   }
-
-   // Inner Classes
-   // ----------------------------------------------------------------------------
-
-   private static final class DummyOperationContext implements OperationContext {
-
-      private static DummyOperationContext instance = new DummyOperationContext();
-
-      public static OperationContext getInstance() {
-         return DummyOperationContext.instance;
-      }
-
-      @Override
-      public void executeOnCompletion(final IOCallback runnable) {
-         // There are no executeOnCompletion calls while using the DummyOperationContext
-         // However we keep the code here for correctness
-         runnable.done();
-      }
-
-      @Override
-      public void replicationDone() {
-      }
-
-      @Override
-      public void replicationLineUp() {
-      }
-
-      @Override
-      public void storeLineUp() {
-      }
-
-      @Override
-      public void done() {
-      }
-
-      @Override
-      public void onError(final int errorCode, final String errorMessage) {
-      }
-
-      @Override
-      public void waitCompletion() {
-      }
-
-      @Override
-      public boolean waitCompletion(final long timeout) {
-         return true;
-      }
-
-      @Override
-      public void pageSyncLineUp() {
-      }
-
-      @Override
-      public void pageSyncDone() {
-      }
-   }
-
-   /*
-    * @param id
-    * @param buffer
-    * @return
-    */
-   protected static PersistedRoles newSecurityRecord(long id, ActiveMQBuffer buffer) {
-      PersistedRoles roles = new PersistedRoles();
-      roles.decode(buffer);
-      roles.setStoreId(id);
-      return roles;
-   }
-
-   /**
-    * @param id
-    * @param buffer
-    * @return
-    */
-   static PersistedAddressSetting newAddressEncoding(long id, ActiveMQBuffer buffer) {
-      PersistedAddressSetting setting = new PersistedAddressSetting();
-      setting.decode(buffer);
-      setting.setStoreId(id);
-      return setting;
-   }
-
-   /**
-    * @param id
-    * @param buffer
-    * @return
-    */
-   static GroupingEncoding newGroupEncoding(long id, ActiveMQBuffer buffer) {
-      GroupingEncoding encoding = new GroupingEncoding();
-      encoding.decode(buffer);
-      encoding.setId(id);
-      return encoding;
-   }
-
-   /**
-    * @param id
-    * @param buffer
-    * @return
-    */
-   protected static PersistentQueueBindingEncoding newBindingEncoding(long id, ActiveMQBuffer buffer) {
-      PersistentQueueBindingEncoding bindingEncoding = new PersistentQueueBindingEncoding();
-
-      bindingEncoding.decode(buffer);
-
-      bindingEncoding.setId(id);
-      return bindingEncoding;
-   }
-
-   @Override
-   public boolean addToPage(PagingStore store,
-                            ServerMessage msg,
-                            Transaction tx,
-                            RouteContextList listCtx) throws Exception {
-      /**
-       * Exposing the read-lock here is an encapsulation violation done in order to keep the code
-       * simpler. The alternative would be to add a second method, say 'verifyPaging', to
-       * PagingStore.
-       * <p>
-       * Adding this second method would also be more surprise prone as it would require a certain
-       * calling order.
-       * <p>
-       * The reasoning is that exposing the lock is more explicit and therefore `less bad`.
-       */
-      return store.page(msg, tx, listCtx, storageManagerLock.readLock());
-   }
-
-   private void installLargeMessageConfirmationOnTX(Transaction tx, long recordID) {
-      TXLargeMessageConfirmationOperation txoper = (TXLargeMessageConfirmationOperation) tx.getProperty(TransactionPropertyIndexes.LARGE_MESSAGE_CONFIRMATIONS);
-      if (txoper == null) {
-         txoper = new TXLargeMessageConfirmationOperation();
-         tx.putProperty(TransactionPropertyIndexes.LARGE_MESSAGE_CONFIRMATIONS, txoper);
-      }
-      txoper.confirmedMessages.add(recordID);
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/LargeMessageTXFailureCallback.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/LargeMessageTXFailureCallback.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.persistence.impl.journal;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
+import org.apache.activemq.artemis.core.journal.RecordInfo;
+import org.apache.activemq.artemis.core.journal.TransactionFailureCallback;
+import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
+import org.apache.activemq.artemis.core.server.LargeServerMessage;
+import org.apache.activemq.artemis.core.server.ServerMessage;
+
+import static org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds.ADD_LARGE_MESSAGE;
+
+public class LargeMessageTXFailureCallback implements TransactionFailureCallback {
+
+   private AbstractJournalStorageManager journalStorageManager;
+   private final Map<Long, ServerMessage> messages;
+
+   public LargeMessageTXFailureCallback(AbstractJournalStorageManager journalStorageManager,
+                                        final Map<Long, ServerMessage> messages) {
+      super();
+      this.journalStorageManager = journalStorageManager;
+      this.messages = messages;
+   }
+
+   public void failedTransaction(final long transactionID,
+                                 final List<RecordInfo> records,
+                                 final List<RecordInfo> recordsToDelete) {
+      for (RecordInfo record : records) {
+         if (record.userRecordType == ADD_LARGE_MESSAGE) {
+            byte[] data = record.data;
+
+            ActiveMQBuffer buff = ActiveMQBuffers.wrappedBuffer(data);
+
+            try {
+               LargeServerMessage serverMessage = journalStorageManager.parseLargeMessage(messages, buff);
+               serverMessage.decrementDelayDeletionCount();
+            }
+            catch (Exception e) {
+               ActiveMQServerLogger.LOGGER.journalError(e);
+            }
+         }
+      }
+   }
+
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/TXLargeMessageConfirmationOperation.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/TXLargeMessageConfirmationOperation.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.persistence.impl.journal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
+import org.apache.activemq.artemis.core.transaction.Transaction;
+import org.apache.activemq.artemis.core.transaction.TransactionOperationAbstract;
+
+public final class TXLargeMessageConfirmationOperation extends TransactionOperationAbstract {
+
+   private AbstractJournalStorageManager journalStorageManager;
+   public List<Long> confirmedMessages = new LinkedList<Long>();
+
+   public TXLargeMessageConfirmationOperation(AbstractJournalStorageManager journalStorageManager) {
+      this.journalStorageManager = journalStorageManager;
+   }
+
+   @Override
+   public void afterRollback(Transaction tx) {
+      for (Long msg : confirmedMessages) {
+         try {
+            journalStorageManager.confirmPendingLargeMessage(msg);
+         }
+         catch (Throwable e) {
+            ActiveMQServerLogger.LOGGER.journalErrorConfirmingLargeMessage(e, msg);
+         }
+      }
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/CursorAckRecordEncoding.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/CursorAckRecordEncoding.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.persistence.impl.journal.codec;
+
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.core.journal.EncodingSupport;
+import org.apache.activemq.artemis.core.paging.cursor.PagePosition;
+import org.apache.activemq.artemis.core.paging.cursor.impl.PagePositionImpl;
+import org.apache.activemq.artemis.utils.DataConstants;
+
+public class CursorAckRecordEncoding implements EncodingSupport {
+
+   public CursorAckRecordEncoding(final long queueID, final PagePosition position) {
+      this.queueID = queueID;
+      this.position = position;
+   }
+
+   public CursorAckRecordEncoding() {
+      this.position = new PagePositionImpl();
+   }
+
+   @Override
+   public String toString() {
+      return "CursorAckRecordEncoding [queueID=" + queueID + ", position=" + position + "]";
+   }
+
+   public long queueID;
+
+   public PagePosition position;
+
+   public int getEncodeSize() {
+      return DataConstants.SIZE_LONG + DataConstants.SIZE_LONG + DataConstants.SIZE_INT;
+   }
+
+   public void encode(ActiveMQBuffer buffer) {
+      buffer.writeLong(queueID);
+      buffer.writeLong(position.getPageNr());
+      buffer.writeInt(position.getMessageNr());
+   }
+
+   public void decode(ActiveMQBuffer buffer) {
+      queueID = buffer.readLong();
+      long pageNR = buffer.readLong();
+      int messageNR = buffer.readInt();
+      this.position = new PagePositionImpl(pageNR, messageNR);
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/DeleteEncoding.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/DeleteEncoding.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.persistence.impl.journal.codec;
+
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.core.journal.EncodingSupport;
+import org.apache.activemq.artemis.utils.DataConstants;
+
+public class DeleteEncoding implements EncodingSupport {
+
+   public byte recordType;
+
+   public long id;
+
+   public DeleteEncoding(final byte recordType, final long id) {
+      this.recordType = recordType;
+      this.id = id;
+   }
+
+   /* (non-Javadoc)
+    * @see org.apache.activemq.artemis.core.journal.EncodingSupport#getEncodeSize()
+    */
+   @Override
+   public int getEncodeSize() {
+      return DataConstants.SIZE_BYTE + DataConstants.SIZE_LONG;
+   }
+
+   /* (non-Javadoc)
+    * @see org.apache.activemq.artemis.core.journal.EncodingSupport#encode(org.apache.activemq.artemis.api.core.ActiveMQBuffer)
+    */
+   @Override
+   public void encode(ActiveMQBuffer buffer) {
+      buffer.writeByte(recordType);
+      buffer.writeLong(id);
+   }
+
+   /* (non-Javadoc)
+    * @see org.apache.activemq.artemis.core.journal.EncodingSupport#decode(org.apache.activemq.artemis.api.core.ActiveMQBuffer)
+    */
+   @Override
+   public void decode(ActiveMQBuffer buffer) {
+      recordType = buffer.readByte();
+      id = buffer.readLong();
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/DeliveryCountUpdateEncoding.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/DeliveryCountUpdateEncoding.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.persistence.impl.journal.codec;
+
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.core.journal.EncodingSupport;
+
+public class DeliveryCountUpdateEncoding implements EncodingSupport {
+
+   public long queueID;
+
+   public int count;
+
+   public DeliveryCountUpdateEncoding() {
+      super();
+   }
+
+   public DeliveryCountUpdateEncoding(final long queueID, final int count) {
+      super();
+      this.queueID = queueID;
+      this.count = count;
+   }
+
+   public void decode(final ActiveMQBuffer buffer) {
+      queueID = buffer.readLong();
+      count = buffer.readInt();
+   }
+
+   public void encode(final ActiveMQBuffer buffer) {
+      buffer.writeLong(queueID);
+      buffer.writeInt(count);
+   }
+
+   public int getEncodeSize() {
+      return 8 + 4;
+   }
+
+   @Override
+   public String toString() {
+      return "DeliveryCountUpdateEncoding [queueID=" + queueID + ", count=" + count + "]";
+   }
+
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/DuplicateIDEncoding.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/DuplicateIDEncoding.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.persistence.impl.journal.codec;
+
+import java.nio.ByteBuffer;
+
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.journal.EncodingSupport;
+import org.apache.activemq.artemis.utils.ByteUtil;
+import org.apache.activemq.artemis.utils.DataConstants;
+import org.apache.activemq.artemis.utils.UUID;
+
+public class DuplicateIDEncoding implements EncodingSupport {
+
+   public SimpleString address;
+
+   public byte[] duplID;
+
+   public DuplicateIDEncoding(final SimpleString address, final byte[] duplID) {
+      this.address = address;
+
+      this.duplID = duplID;
+   }
+
+   public DuplicateIDEncoding() {
+   }
+
+   public void decode(final ActiveMQBuffer buffer) {
+      address = buffer.readSimpleString();
+
+      int size = buffer.readInt();
+
+      duplID = new byte[size];
+
+      buffer.readBytes(duplID);
+   }
+
+   public void encode(final ActiveMQBuffer buffer) {
+      buffer.writeSimpleString(address);
+
+      buffer.writeInt(duplID.length);
+
+      buffer.writeBytes(duplID);
+   }
+
+   public int getEncodeSize() {
+      return SimpleString.sizeofString(address) + DataConstants.SIZE_INT + duplID.length;
+   }
+
+   @Override
+   public String toString() {
+      // this would be useful when testing. Most tests on the testsuite will use a SimpleString on the duplicate ID
+      // and this may be useful to validate the journal on those tests
+      // You may uncomment these two lines on that case and replcate the toString for the PrintData
+
+      // SimpleString simpleStr = new SimpleString(duplID);
+      // return "DuplicateIDEncoding [address=" + address + ", duplID=" + simpleStr + "]";
+
+      String bridgeRepresentation = null;
+
+      // The bridge will generate IDs on these terms:
+      // This will make them easier to read
+      if (address.toString().startsWith("BRIDGE") && duplID.length == 24) {
+         try {
+            ByteBuffer buff = ByteBuffer.wrap(duplID);
+
+            // 16 for UUID
+            byte[] bytesUUID = new byte[16];
+
+            buff.get(bytesUUID);
+
+            UUID uuid = new UUID(UUID.TYPE_TIME_BASED, bytesUUID);
+
+            long id = buff.getLong();
+            bridgeRepresentation = "nodeUUID=" + uuid.toString() + " messageID=" + id;
+         }
+         catch (Throwable ignored) {
+            bridgeRepresentation = null;
+         }
+      }
+
+      if (bridgeRepresentation != null) {
+         return "DuplicateIDEncoding [address=" + address + ", duplID=" + ByteUtil.bytesToHex(duplID, 2) + " / " +
+            bridgeRepresentation + "]";
+      }
+      else {
+         return "DuplicateIDEncoding [address=" + address + ", duplID=" + ByteUtil.bytesToHex(duplID, 2) + "]";
+      }
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/FinishPageMessageOperation.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/FinishPageMessageOperation.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.persistence.impl.journal.codec;
+
+import org.apache.activemq.artemis.core.paging.PageTransactionInfo;
+import org.apache.activemq.artemis.core.transaction.Transaction;
+import org.apache.activemq.artemis.core.transaction.TransactionOperation;
+import org.apache.activemq.artemis.core.transaction.TransactionOperationAbstract;
+import org.apache.activemq.artemis.core.transaction.TransactionPropertyIndexes;
+
+/**
+ * This is only used when loading a transaction.
+ * <p>
+ * it might be possible to merge the functionality of this class with
+ * {@link FinishPageMessageOperation}
+ */
+// TODO: merge this class with the one on the PagingStoreImpl
+public class FinishPageMessageOperation extends TransactionOperationAbstract implements TransactionOperation {
+
+   @Override
+   public void afterCommit(final Transaction tx) {
+      // If part of the transaction goes to the queue, and part goes to paging, we can't let depage start for the
+      // transaction until all the messages were added to the queue
+      // or else we could deliver the messages out of order
+
+      PageTransactionInfo pageTransaction = (PageTransactionInfo) tx.getProperty(TransactionPropertyIndexes.PAGE_TRANSACTION);
+
+      if (pageTransaction != null) {
+         pageTransaction.commit();
+      }
+   }
+
+   @Override
+   public void afterRollback(final Transaction tx) {
+      PageTransactionInfo pageTransaction = (PageTransactionInfo) tx.getProperty(TransactionPropertyIndexes.PAGE_TRANSACTION);
+
+      if (tx.getState() == Transaction.State.PREPARED && pageTransaction != null) {
+         pageTransaction.rollback();
+      }
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/GroupingEncoding.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/GroupingEncoding.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.persistence.impl.journal.codec;
+
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.journal.EncodingSupport;
+import org.apache.activemq.artemis.core.persistence.GroupingInfo;
+
+public class GroupingEncoding implements EncodingSupport, GroupingInfo {
+
+   public long id;
+
+   public SimpleString groupId;
+
+   public SimpleString clusterName;
+
+   public GroupingEncoding(final long id, final SimpleString groupId, final SimpleString clusterName) {
+      this.id = id;
+      this.groupId = groupId;
+      this.clusterName = clusterName;
+   }
+
+   public GroupingEncoding() {
+   }
+
+   public int getEncodeSize() {
+      return SimpleString.sizeofString(groupId) + SimpleString.sizeofString(clusterName);
+   }
+
+   public void encode(final ActiveMQBuffer buffer) {
+      buffer.writeSimpleString(groupId);
+      buffer.writeSimpleString(clusterName);
+   }
+
+   public void decode(final ActiveMQBuffer buffer) {
+      groupId = buffer.readSimpleString();
+      clusterName = buffer.readSimpleString();
+   }
+
+   public long getId() {
+      return id;
+   }
+
+   public void setId(final long id) {
+      this.id = id;
+   }
+
+   public SimpleString getGroupId() {
+      return groupId;
+   }
+
+   public SimpleString getClusterName() {
+      return clusterName;
+   }
+
+   @Override
+   public String toString() {
+      return "GroupingEncoding [id=" + id + ", groupId=" + groupId + ", clusterName=" + clusterName + "]";
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/HeuristicCompletionEncoding.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/HeuristicCompletionEncoding.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.persistence.impl.journal.codec;
+
+import javax.transaction.xa.Xid;
+
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.core.journal.EncodingSupport;
+import org.apache.activemq.artemis.utils.DataConstants;
+import org.apache.activemq.artemis.utils.XidCodecSupport;
+
+public class HeuristicCompletionEncoding implements EncodingSupport {
+
+   public Xid xid;
+
+   public boolean isCommit;
+
+   @Override
+   public String toString() {
+      return "HeuristicCompletionEncoding [xid=" + xid + ", isCommit=" + isCommit + "]";
+   }
+
+   public HeuristicCompletionEncoding(final Xid xid, final boolean isCommit) {
+      this.xid = xid;
+      this.isCommit = isCommit;
+   }
+
+   public HeuristicCompletionEncoding() {
+   }
+
+   public void decode(final ActiveMQBuffer buffer) {
+      xid = XidCodecSupport.decodeXid(buffer);
+      isCommit = buffer.readBoolean();
+   }
+
+   public void encode(final ActiveMQBuffer buffer) {
+      XidCodecSupport.encodeXid(xid, buffer);
+      buffer.writeBoolean(isCommit);
+   }
+
+   public int getEncodeSize() {
+      return XidCodecSupport.getXidEncodeLength(xid) + DataConstants.SIZE_BOOLEAN;
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/LargeMessageEncoding.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/LargeMessageEncoding.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.persistence.impl.journal.codec;
+
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.core.journal.EncodingSupport;
+import org.apache.activemq.artemis.core.server.LargeServerMessage;
+
+public class LargeMessageEncoding implements EncodingSupport {
+
+   public final LargeServerMessage message;
+
+   public LargeMessageEncoding(final LargeServerMessage message) {
+      this.message = message;
+   }
+
+   /* (non-Javadoc)
+    * @see org.apache.activemq.artemis.core.journal.EncodingSupport#decode(org.apache.activemq.artemis.spi.core.remoting.ActiveMQBuffer)
+    */
+   public void decode(final ActiveMQBuffer buffer) {
+      message.decodeHeadersAndProperties(buffer);
+   }
+
+   /* (non-Javadoc)
+    * @see org.apache.activemq.artemis.core.journal.EncodingSupport#encode(org.apache.activemq.artemis.spi.core.remoting.ActiveMQBuffer)
+    */
+   public void encode(final ActiveMQBuffer buffer) {
+      message.encode(buffer);
+   }
+
+   /* (non-Javadoc)
+    * @see org.apache.activemq.artemis.core.journal.EncodingSupport#getEncodeSize()
+    */
+   public int getEncodeSize() {
+      return message.getEncodeSize();
+   }
+
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/PageCountPendingImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/PageCountPendingImpl.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.persistence.impl.journal.codec;
+
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.core.journal.EncodingSupport;
+import org.apache.activemq.artemis.core.persistence.impl.PageCountPending;
+import org.apache.activemq.artemis.utils.DataConstants;
+
+public class PageCountPendingImpl implements EncodingSupport, PageCountPending {
+
+   @Override
+   public String toString() {
+      return "PageCountPending [queueID=" + queueID + ", pageID=" + pageID + "]";
+   }
+
+   public PageCountPendingImpl() {
+
+   }
+
+   public PageCountPendingImpl(long queueID, long pageID, int inc) {
+      this.queueID = queueID;
+      this.pageID = pageID;
+   }
+
+   long id;
+
+   long queueID;
+
+   long pageID;
+
+   public void setID(long id) {
+      this.id = id;
+   }
+
+   public long getID() {
+      return id;
+   }
+
+   public long getQueueID() {
+      return queueID;
+   }
+
+   public long getPageID() {
+      return pageID;
+   }
+
+   @Override
+   public int getEncodeSize() {
+      return DataConstants.SIZE_LONG * 2;
+   }
+
+   @Override
+   public void encode(ActiveMQBuffer buffer) {
+      buffer.writeLong(queueID);
+      buffer.writeLong(pageID);
+   }
+
+   @Override
+   public void decode(ActiveMQBuffer buffer) {
+      queueID = buffer.readLong();
+      pageID = buffer.readLong();
+   }
+
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/PageCountRecord.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/PageCountRecord.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.persistence.impl.journal.codec;
+
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.core.journal.EncodingSupport;
+import org.apache.activemq.artemis.utils.DataConstants;
+
+public class PageCountRecord implements EncodingSupport {
+
+   private long queueID;
+
+   private long value;
+
+   @Override
+   public String toString() {
+      return "PageCountRecord [queueID=" + queueID + ", value=" + value + "]";
+   }
+
+   public PageCountRecord() {
+
+   }
+
+   public PageCountRecord(long queueID, long value) {
+      this.queueID = queueID;
+      this.value = value;
+   }
+
+   public long getQueueID() {
+      return queueID;
+   }
+
+   public long getValue() {
+      return value;
+   }
+
+   @Override
+   public int getEncodeSize() {
+      return DataConstants.SIZE_LONG * 2;
+   }
+
+   @Override
+   public void encode(ActiveMQBuffer buffer) {
+      buffer.writeLong(queueID);
+      buffer.writeLong(value);
+   }
+
+   @Override
+   public void decode(ActiveMQBuffer buffer) {
+      queueID = buffer.readLong();
+      value = buffer.readLong();
+   }
+
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/PageCountRecordInc.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/PageCountRecordInc.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.persistence.impl.journal.codec;
+
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.core.journal.EncodingSupport;
+import org.apache.activemq.artemis.utils.DataConstants;
+
+public class PageCountRecordInc implements EncodingSupport {
+
+   private long queueID;
+
+   private int value;
+
+   @Override
+   public String toString() {
+      return "PageCountRecordInc [queueID=" + queueID + ", value=" + value + "]";
+   }
+
+   public PageCountRecordInc() {
+   }
+
+   public PageCountRecordInc(long queueID, int value) {
+      this.queueID = queueID;
+      this.value = value;
+   }
+
+   public long getQueueID() {
+      return queueID;
+   }
+
+   public int getValue() {
+      return value;
+   }
+
+   public int getEncodeSize() {
+      return DataConstants.SIZE_LONG + DataConstants.SIZE_INT;
+   }
+
+   public void encode(ActiveMQBuffer buffer) {
+      buffer.writeLong(queueID);
+      buffer.writeInt(value);
+   }
+
+   public void decode(ActiveMQBuffer buffer) {
+      queueID = buffer.readLong();
+      value = buffer.readInt();
+   }
+
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/PageUpdateTXEncoding.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/PageUpdateTXEncoding.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.persistence.impl.journal.codec;
+
+import java.util.List;
+
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.core.journal.EncodingSupport;
+import org.apache.activemq.artemis.core.server.MessageReference;
+import org.apache.activemq.artemis.utils.DataConstants;
+
+public class PageUpdateTXEncoding implements EncodingSupport {
+
+   public long pageTX;
+
+   public int recods;
+
+   @Override
+   public String toString() {
+      return "PageUpdateTXEncoding [pageTX=" + pageTX + ", recods=" + recods + "]";
+   }
+
+   public PageUpdateTXEncoding() {
+   }
+
+   public PageUpdateTXEncoding(final long pageTX, final int records) {
+      this.pageTX = pageTX;
+      this.recods = records;
+   }
+
+   public void decode(ActiveMQBuffer buffer) {
+      this.pageTX = buffer.readLong();
+      this.recods = buffer.readInt();
+   }
+
+   @Override
+   public void encode(ActiveMQBuffer buffer) {
+      buffer.writeLong(pageTX);
+      buffer.writeInt(recods);
+   }
+
+   @Override
+   public int getEncodeSize() {
+      return DataConstants.SIZE_LONG + DataConstants.SIZE_INT;
+   }
+
+   public List<MessageReference> getRelatedMessageReferences() {
+      return null;
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/PendingLargeMessageEncoding.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/PendingLargeMessageEncoding.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.persistence.impl.journal.codec;
+
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.core.journal.EncodingSupport;
+import org.apache.activemq.artemis.utils.DataConstants;
+
+public class PendingLargeMessageEncoding implements EncodingSupport {
+
+   public long largeMessageID;
+
+   public PendingLargeMessageEncoding(final long pendingLargeMessageID) {
+      this.largeMessageID = pendingLargeMessageID;
+   }
+
+   public PendingLargeMessageEncoding() {
+   }
+
+   /* (non-Javadoc)
+    * @see org.apache.activemq.artemis.core.journal.EncodingSupport#decode(org.apache.activemq.artemis.spi.core.remoting.ActiveMQBuffer)
+    */
+   public void decode(final ActiveMQBuffer buffer) {
+      largeMessageID = buffer.readLong();
+   }
+
+   /* (non-Javadoc)
+    * @see org.apache.activemq.artemis.core.journal.EncodingSupport#encode(org.apache.activemq.artemis.spi.core.remoting.ActiveMQBuffer)
+    */
+   public void encode(final ActiveMQBuffer buffer) {
+      buffer.writeLong(largeMessageID);
+   }
+
+   /* (non-Javadoc)
+    * @see org.apache.activemq.artemis.core.journal.EncodingSupport#getEncodeSize()
+    */
+   public int getEncodeSize() {
+      return DataConstants.SIZE_LONG;
+   }
+
+   @Override
+   public String toString() {
+      return "PendingLargeMessageEncoding::MessageID=" + largeMessageID;
+   }
+
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/PersistentQueueBindingEncoding.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/PersistentQueueBindingEncoding.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.persistence.impl.journal.codec;
+
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.journal.EncodingSupport;
+import org.apache.activemq.artemis.core.persistence.QueueBindingInfo;
+import org.apache.activemq.artemis.utils.DataConstants;
+
+public class PersistentQueueBindingEncoding implements EncodingSupport, QueueBindingInfo {
+
+   public long id;
+
+   public SimpleString name;
+
+   public SimpleString address;
+
+   public SimpleString filterString;
+
+   public boolean autoCreated;
+
+   public SimpleString user;
+
+   public PersistentQueueBindingEncoding() {
+   }
+
+   @Override
+   public String toString() {
+      return "PersistentQueueBindingEncoding [id=" + id +
+         ", name=" +
+         name +
+         ", address=" +
+         address +
+         ", filterString=" +
+         filterString +
+         ", user=" +
+         user +
+         ", autoCreated=" +
+         autoCreated +
+         "]";
+   }
+
+   public PersistentQueueBindingEncoding(final SimpleString name,
+                                         final SimpleString address,
+                                         final SimpleString filterString,
+                                         final SimpleString user,
+                                         final boolean autoCreated) {
+      this.name = name;
+      this.address = address;
+      this.filterString = filterString;
+      this.user = user;
+      this.autoCreated = autoCreated;
+   }
+
+   public long getId() {
+      return id;
+   }
+
+   public void setId(final long id) {
+      this.id = id;
+   }
+
+   public SimpleString getAddress() {
+      return address;
+   }
+
+   public void replaceQueueName(SimpleString newName) {
+      this.name = newName;
+   }
+
+   public SimpleString getFilterString() {
+      return filterString;
+   }
+
+   public SimpleString getQueueName() {
+      return name;
+   }
+
+   public SimpleString getUser() {
+      return user;
+   }
+
+   public boolean isAutoCreated() {
+      return autoCreated;
+   }
+
+   public void decode(final ActiveMQBuffer buffer) {
+      name = buffer.readSimpleString();
+      address = buffer.readSimpleString();
+      filterString = buffer.readNullableSimpleString();
+
+      String metadata = buffer.readNullableSimpleString().toString();
+      if (metadata != null) {
+         String[] elements = metadata.split(";");
+         for (String element : elements) {
+            String[] keyValuePair = element.split("=");
+            if (keyValuePair.length == 2) {
+               if (keyValuePair[0].equals("user")) {
+                  user = SimpleString.toSimpleString(keyValuePair[1]);
+               }
+            }
+         }
+      }
+
+      autoCreated = buffer.readBoolean();
+   }
+
+   public void encode(final ActiveMQBuffer buffer) {
+      buffer.writeSimpleString(name);
+      buffer.writeSimpleString(address);
+      buffer.writeNullableSimpleString(filterString);
+      buffer.writeNullableSimpleString(createMetadata());
+      buffer.writeBoolean(autoCreated);
+   }
+
+   public int getEncodeSize() {
+      return SimpleString.sizeofString(name) + SimpleString.sizeofString(address) +
+         SimpleString.sizeofNullableString(filterString) + DataConstants.SIZE_BOOLEAN +
+         SimpleString.sizeofNullableString(createMetadata());
+   }
+
+   private SimpleString createMetadata() {
+      StringBuilder metadata = new StringBuilder();
+      metadata.append("user=").append(user).append(";");
+      return SimpleString.toSimpleString(metadata.toString());
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/QueueEncoding.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/QueueEncoding.java
@@ -14,40 +14,39 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.core.journal;
+package org.apache.activemq.artemis.core.persistence.impl.journal.codec;
 
-import java.util.ArrayList;
-import java.util.List;
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.core.journal.EncodingSupport;
 
-public class PreparedTransactionInfo {
+public class QueueEncoding implements EncodingSupport {
 
-   private final long id;
+   public long queueID;
 
-   private final byte[] extraData;
-
-   private final List<RecordInfo> records = new ArrayList<RecordInfo>();
-
-   private final List<RecordInfo> recordsToDelete = new ArrayList<RecordInfo>();
-
-   public PreparedTransactionInfo(final long id, final byte[] extraData) {
-      this.id = id;
-
-      this.extraData = extraData;
+   public QueueEncoding(final long queueID) {
+      super();
+      this.queueID = queueID;
    }
 
-   public long getId() {
-      return id;
+   public QueueEncoding() {
+      super();
    }
 
-   public byte[] getExtraData() {
-      return extraData;
+   public void decode(final ActiveMQBuffer buffer) {
+      queueID = buffer.readLong();
    }
 
-   public List<RecordInfo> getRecords() {
-      return records;
+   public void encode(final ActiveMQBuffer buffer) {
+      buffer.writeLong(queueID);
    }
 
-   public List<RecordInfo> getRecordsToDelete() {
-      return recordsToDelete;
+   public int getEncodeSize() {
+      return 8;
    }
+
+   @Override
+   public String toString() {
+      return "QueueEncoding [queueID=" + queueID + "]";
+   }
+
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/RefEncoding.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/RefEncoding.java
@@ -14,40 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.core.journal;
+package org.apache.activemq.artemis.core.persistence.impl.journal.codec;
 
-import java.util.ArrayList;
-import java.util.List;
+public class RefEncoding extends QueueEncoding {
 
-public class PreparedTransactionInfo {
-
-   private final long id;
-
-   private final byte[] extraData;
-
-   private final List<RecordInfo> records = new ArrayList<RecordInfo>();
-
-   private final List<RecordInfo> recordsToDelete = new ArrayList<RecordInfo>();
-
-   public PreparedTransactionInfo(final long id, final byte[] extraData) {
-      this.id = id;
-
-      this.extraData = extraData;
+   public RefEncoding() {
+      super();
    }
 
-   public long getId() {
-      return id;
-   }
-
-   public byte[] getExtraData() {
-      return extraData;
-   }
-
-   public List<RecordInfo> getRecords() {
-      return records;
-   }
-
-   public List<RecordInfo> getRecordsToDelete() {
-      return recordsToDelete;
+   public RefEncoding(final long queueID) {
+      super(queueID);
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/ScheduledDeliveryEncoding.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/ScheduledDeliveryEncoding.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.persistence.impl.journal.codec;
+
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+
+public class ScheduledDeliveryEncoding extends QueueEncoding {
+
+   public long scheduledDeliveryTime;
+
+   @Override
+   public String toString() {
+      return "ScheduledDeliveryEncoding [scheduledDeliveryTime=" + scheduledDeliveryTime + "]";
+   }
+
+   public ScheduledDeliveryEncoding(final long scheduledDeliveryTime, final long queueID) {
+      super(queueID);
+      this.scheduledDeliveryTime = scheduledDeliveryTime;
+   }
+
+   public ScheduledDeliveryEncoding() {
+   }
+
+   @Override
+   public int getEncodeSize() {
+      return super.getEncodeSize() + 8;
+   }
+
+   @Override
+   public void encode(final ActiveMQBuffer buffer) {
+      super.encode(buffer);
+      buffer.writeLong(scheduledDeliveryTime);
+   }
+
+   @Override
+   public void decode(final ActiveMQBuffer buffer) {
+      super.decode(buffer);
+      scheduledDeliveryTime = buffer.readLong();
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/XidEncoding.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/XidEncoding.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.persistence.impl.journal.codec;
+
+import javax.transaction.xa.Xid;
+
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
+import org.apache.activemq.artemis.core.journal.EncodingSupport;
+import org.apache.activemq.artemis.utils.XidCodecSupport;
+
+/**
+ * It's public as other classes may want to unparse data on tools
+ */
+public class XidEncoding implements EncodingSupport {
+
+   public final Xid xid;
+
+   public XidEncoding(final Xid xid) {
+      this.xid = xid;
+   }
+
+   public XidEncoding(final byte[] data) {
+      xid = XidCodecSupport.decodeXid(ActiveMQBuffers.wrappedBuffer(data));
+   }
+
+   public void decode(final ActiveMQBuffer buffer) {
+      throw new IllegalStateException("Non Supported Operation");
+   }
+
+   public void encode(final ActiveMQBuffer buffer) {
+      XidCodecSupport.encodeXid(xid, buffer);
+   }
+
+   public int getEncodeSize() {
+      return XidCodecSupport.getXidEncodeLength(xid);
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationStartSyncMessage.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationStartSyncMessage.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.core.journal.impl.JournalFile;
-import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager.JournalContent;
+import org.apache.activemq.artemis.core.persistence.impl.journal.AbstractJournalStorageManager;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
 
 /**
@@ -40,8 +40,8 @@ public class ReplicationStartSyncMessage extends PacketImpl {
    private boolean allowsAutoFailBack;
 
    public enum SyncDataType {
-      JournalBindings(JournalContent.BINDINGS.typeByte),
-      JournalMessages(JournalContent.MESSAGES.typeByte),
+      JournalBindings(AbstractJournalStorageManager.JournalContent.BINDINGS.typeByte),
+      JournalMessages(AbstractJournalStorageManager.JournalContent.MESSAGES.typeByte),
       LargeMessages((byte) 2);
 
       private byte code;
@@ -50,8 +50,8 @@ public class ReplicationStartSyncMessage extends PacketImpl {
          this.code = code;
       }
 
-      public static JournalContent getJournalContentType(SyncDataType dataType) {
-         return JournalContent.getType(dataType.code);
+      public static AbstractJournalStorageManager.JournalContent getJournalContentType(SyncDataType dataType) {
+         return AbstractJournalStorageManager.JournalContent.getType(dataType.code);
       }
 
       public static SyncDataType getDataType(byte code) {
@@ -86,7 +86,7 @@ public class ReplicationStartSyncMessage extends PacketImpl {
    }
 
    public ReplicationStartSyncMessage(JournalFile[] datafiles,
-                                      JournalContent contentType,
+                                      AbstractJournalStorageManager.JournalContent contentType,
                                       String nodeID,
                                       boolean allowsAutoFailBack) {
       this();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationSyncFileMessage.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationSyncFileMessage.java
@@ -23,7 +23,7 @@ import java.util.Set;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager.JournalContent;
+import org.apache.activemq.artemis.core.persistence.impl.journal.AbstractJournalStorageManager;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
 
 /**
@@ -35,7 +35,7 @@ public final class ReplicationSyncFileMessage extends PacketImpl {
    /**
     * The JournalType or {@code null} if sync'ing large-messages.
     */
-   private JournalContent journalType;
+   private AbstractJournalStorageManager.JournalContent journalType;
    /**
     * This value refers to {@link org.apache.activemq.artemis.core.journal.impl.JournalFile#getFileID()}, or the
     * message id if we are sync'ing a large-message.
@@ -74,7 +74,7 @@ public final class ReplicationSyncFileMessage extends PacketImpl {
       super(REPLICATION_SYNC_FILE);
    }
 
-   public ReplicationSyncFileMessage(JournalContent content,
+   public ReplicationSyncFileMessage(AbstractJournalStorageManager.JournalContent content,
                                      SimpleString storeName,
                                      long id,
                                      int size,
@@ -135,7 +135,7 @@ public final class ReplicationSyncFileMessage extends PacketImpl {
       fileId = buffer.readLong();
       switch (FileType.getFileType(buffer.readByte())) {
          case JOURNAL: {
-            journalType = JournalContent.getType(buffer.readByte());
+            journalType = AbstractJournalStorageManager.JournalContent.getType(buffer.readByte());
             fileType = FileType.JOURNAL;
             break;
          }
@@ -160,7 +160,7 @@ public final class ReplicationSyncFileMessage extends PacketImpl {
       return fileId;
    }
 
-   public JournalContent getJournalContent() {
+   public AbstractJournalStorageManager.JournalContent getJournalContent() {
       return journalType;
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/replication/ReplicationEndpoint.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/replication/ReplicationEndpoint.java
@@ -47,7 +47,7 @@ import org.apache.activemq.artemis.core.paging.impl.Page;
 import org.apache.activemq.artemis.core.paging.impl.PagingManagerImpl;
 import org.apache.activemq.artemis.core.paging.impl.PagingStoreFactoryNIO;
 import org.apache.activemq.artemis.core.persistence.StorageManager;
-import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager.JournalContent;
+import org.apache.activemq.artemis.core.persistence.impl.journal.AbstractJournalStorageManager.JournalContent;
 import org.apache.activemq.artemis.core.persistence.impl.journal.LargeServerMessageInSync;
 import org.apache.activemq.artemis.core.protocol.core.Channel;
 import org.apache.activemq.artemis.core.protocol.core.ChannelHandler;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/replication/ReplicationManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/replication/ReplicationManager.java
@@ -32,12 +32,12 @@ import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
 import org.apache.activemq.artemis.api.core.Pair;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.client.SessionFailureListener;
-import org.apache.activemq.artemis.core.journal.EncodingSupport;
 import org.apache.activemq.artemis.core.io.SequentialFile;
+import org.apache.activemq.artemis.core.journal.EncodingSupport;
 import org.apache.activemq.artemis.core.journal.impl.JournalFile;
 import org.apache.activemq.artemis.core.paging.PagedMessage;
 import org.apache.activemq.artemis.core.persistence.OperationContext;
-import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager.JournalContent;
+import org.apache.activemq.artemis.core.persistence.impl.journal.AbstractJournalStorageManager;
 import org.apache.activemq.artemis.core.persistence.impl.journal.OperationContextImpl;
 import org.apache.activemq.artemis.core.protocol.core.Channel;
 import org.apache.activemq.artemis.core.protocol.core.ChannelHandler;
@@ -437,7 +437,7 @@ public final class ReplicationManager implements ActiveMQComponent {
     * @throws ActiveMQException
     * @throws Exception
     */
-   public void syncJournalFile(JournalFile jf, JournalContent content) throws Exception {
+   public void syncJournalFile(JournalFile jf, AbstractJournalStorageManager.JournalContent content) throws Exception {
       if (!enabled) {
          return;
       }
@@ -473,7 +473,7 @@ public final class ReplicationManager implements ActiveMQComponent {
     * @param maxBytesToSend maximum number of bytes to read and send from the file
     * @throws Exception
     */
-   private void sendLargeFile(JournalContent content,
+   private void sendLargeFile(AbstractJournalStorageManager.JournalContent content,
                               SimpleString pageStore,
                               final long id,
                               SequentialFile file,
@@ -536,7 +536,7 @@ public final class ReplicationManager implements ActiveMQComponent {
     * @throws ActiveMQException
     */
    public void sendStartSyncMessage(JournalFile[] datafiles,
-                                    JournalContent contentType,
+                                    AbstractJournalStorageManager.JournalContent contentType,
                                     String nodeID,
                                     boolean allowsAutoFailBack) throws ActiveMQException {
       if (enabled)

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -51,6 +51,7 @@ import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.ConfigurationUtils;
 import org.apache.activemq.artemis.core.config.CoreQueueConfiguration;
 import org.apache.activemq.artemis.core.config.DivertConfiguration;
+import org.apache.activemq.artemis.core.config.StoreConfiguration;
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
 import org.apache.activemq.artemis.core.filter.Filter;
 import org.apache.activemq.artemis.core.filter.impl.FilterImpl;
@@ -70,6 +71,7 @@ import org.apache.activemq.artemis.core.persistence.StorageManager;
 import org.apache.activemq.artemis.core.persistence.config.PersistedAddressSetting;
 import org.apache.activemq.artemis.core.persistence.config.PersistedRoles;
 import org.apache.activemq.artemis.core.persistence.impl.PageCountPending;
+import org.apache.activemq.artemis.core.persistence.impl.journal.JDBCJournalStorageManager;
 import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager;
 import org.apache.activemq.artemis.core.persistence.impl.journal.OperationContextImpl;
 import org.apache.activemq.artemis.core.persistence.impl.nullpm.NullStorageManager;
@@ -1479,7 +1481,13 @@ public class ActiveMQServerImpl implements ActiveMQServer {
     */
    private StorageManager createStorageManager() {
       if (configuration.isPersistenceEnabled()) {
-         return new JournalStorageManager(configuration, executorFactory, shutdownOnCriticalIO);
+         if (configuration.getStoreConfiguration() != null && configuration.getStoreConfiguration().getStoreType() == StoreConfiguration.StoreType.DATABASE) {
+            return new JDBCJournalStorageManager(configuration, executorFactory, shutdownOnCriticalIO);
+         }
+         // Default to File Based Storage Manager, (Legacy default configuration).
+         else {
+            return new JournalStorageManager(configuration, executorFactory, shutdownOnCriticalIO);
+         }
       }
       return new NullStorageManager();
    }

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -683,6 +683,14 @@
             </xsd:annotation>
          </xsd:element>
 
+         <xsd:element name="store" type="storeType" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The Store Type used by the server
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
          <xsd:element name="security-settings" maxOccurs="1" minOccurs="0">
             <xsd:annotation>
                <xsd:documentation>
@@ -1437,6 +1445,55 @@
       </xsd:attribute>
 
    </xsd:complexType>
+
+   <xsd:complexType name="storeType">
+      <xsd:choice>
+         <xsd:element name="file-store" type="fileStoreType" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Use a file based store for peristing journal, paging and large messages
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="database-store" type="databaseStoreType" minOccurs="0" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Use a database for persisting journal, paging and large messages
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:choice>
+   </xsd:complexType>
+
+   <xsd:complexType name="fileStoreType">
+   </xsd:complexType>
+
+   <xsd:complexType name="databaseStoreType">
+      <xsd:all>
+         <xsd:element name="jdbc-connection-url" type="xsd:string" minOccurs="1" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The JDBC Connection URL e.g. jdbc:mysql://localhost:3306/
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="message-table-name" type="xsd:string" minOccurs="1" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The table name used to store message journal entries
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="bindings-table-name" type="xsd:string" minOccurs="1" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The table name used to store bindings journal entries
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+      </xsd:all>
+   </xsd:complexType>
+
    <xsd:complexType name="haPolicyType">
       <xsd:choice>
          <xsd:element name="live-only" type="haLiveOnlyPolicyType" minOccurs="0" maxOccurs="1">
@@ -1488,6 +1545,7 @@
          </xsd:element>
       </xsd:choice>
    </xsd:complexType>
+
 
    <xsd:complexType name="haColocationReplicationType">
       <xsd:all>

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/DatabaseStoreConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/DatabaseStoreConfigurationTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.config.impl;
+
+import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.config.FileDeploymentManager;
+import org.apache.activemq.artemis.core.config.StoreConfiguration;
+import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.junit.Test;
+
+public class DatabaseStoreConfigurationTest extends ActiveMQTestBase {
+
+   @Test
+   public void databaseStoreConfigTest() throws Exception {
+      Configuration configuration = createConfiguration("database-store-config.xml");
+      ActiveMQServerImpl server = new ActiveMQServerImpl(configuration);
+      assertEquals(StoreConfiguration.StoreType.DATABASE, server.getConfiguration().getStoreConfiguration().getStoreType());
+   }
+
+   protected Configuration createConfiguration(String fileName) throws Exception {
+      FileConfiguration fc = new FileConfiguration();
+      FileDeploymentManager deploymentManager = new FileDeploymentManager(fileName);
+      deploymentManager.addDeployable(fc);
+
+      deploymentManager.readConfiguration();
+
+      // we need this otherwise the data folder will be located under activemq-server and not on the temporary directory
+      fc.setPagingDirectory(getTestDir() + "/" + fc.getPagingDirectory());
+      fc.setLargeMessagesDirectory(getTestDir() + "/" + fc.getLargeMessagesDirectory());
+      fc.setJournalDirectory(getTestDir() + "/" + fc.getJournalDirectory());
+      fc.setBindingsDirectory(getTestDir() + "/" + fc.getBindingsDirectory());
+
+      return fc;
+   }
+}

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
@@ -80,6 +80,7 @@ import org.apache.activemq.artemis.core.config.ClusterConnectionConfiguration;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
 import org.apache.activemq.artemis.core.config.impl.SecurityConfiguration;
+import org.apache.activemq.artemis.core.config.storage.DatabaseStorageConfiguration;
 import org.apache.activemq.artemis.core.io.SequentialFileFactory;
 import org.apache.activemq.artemis.core.io.nio.NIOSequentialFileFactory;
 import org.apache.activemq.artemis.core.journal.PreparedTransactionInfo;
@@ -385,6 +386,19 @@ public abstract class ActiveMQTestBase extends Assert {
 
    protected Configuration createDefaultConfig(final boolean netty) throws Exception {
       return createDefaultConfig(0, netty);
+   }
+
+   protected Configuration createDefaultJDBCConfig() throws Exception {
+      Configuration configuration = createDefaultConfig(true);
+
+      DatabaseStorageConfiguration dbStorageConfiguration = new DatabaseStorageConfiguration();
+      dbStorageConfiguration.setJdbcConnectionUrl(getTestJDBCConnectionUrl());
+      dbStorageConfiguration.setBindingsTableName("BINDINGS");
+      dbStorageConfiguration.setMessageTableName("MESSAGES");
+
+      configuration.setStoreConfiguration(dbStorageConfiguration);
+
+      return configuration;
    }
 
    protected Configuration createDefaultConfig(final int serverID, final boolean netty) throws Exception {
@@ -747,6 +761,10 @@ public abstract class ActiveMQTestBase extends Assert {
     */
    protected final String getTestDir() {
       return testDir;
+   }
+
+   protected final String getTestJDBCConnectionUrl() {
+      return "jdbc:derby:" + getTestDir() + File.separator + "derby;create=true";
    }
 
    protected final File getTestDirfile() {

--- a/artemis-server/src/test/resources/database-store-config.xml
+++ b/artemis-server/src/test/resources/database-store-config.xml
@@ -1,0 +1,30 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<configuration
+      xmlns="urn:activemq"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="urn:activemq ../../main/resources/schema/artemis-server.xsd">
+   <core xmlns="urn:activemq:core">
+      <store>
+         <database-store>
+            <jdbc-connection-url>jdbc:derby:target/derby/database-store;create=true</jdbc-connection-url>
+            <bindings-table-name>BINDINGS_TABLE</bindings-table-name>
+            <message-table-name>MESSAGE_TABLE</message-table-name>
+         </database-store>
+      </store>
+   </core>
+</configuration>

--- a/docs/user-manual/en/persistence.md
+++ b/docs/user-manual/en/persistence.md
@@ -3,12 +3,14 @@
 In this chapter we will describe how persistence works with Apache ActiveMQ Artemis and
 how to configure it.
 
-Apache ActiveMQ Artemis ships with a high performance journal. Since Apache ActiveMQ Artemis handles
-its own persistence, rather than relying on a database or other 3rd
-party persistence engine it is very highly optimised for the specific
-messaging use cases.
+Apache ActiveMQ Artemis ships with two persistence options.  The Apache ActiveMQ Artemis File journal
+which is highly optimized for the messaging use case and gives great performance, and also Apache Artemis
+JDBC Store, which uses JDBC to connect to a database of your choice.  The JDBC Store is still under development,
+but it is possible to use it's journal features, (essentially everything except for paging and large messages).
 
-An Apache ActiveMQ Artemis journal is an *append only* journal. It consists of a set of
+## Apache ActiveMQ Artemis File Journal (Default)
+
+An Apache ActiveMQ Artemis file journal is an *append only* journal. It consists of a set of
 files on disk. Each file is pre-created to a fixed size and initially
 filled with padding. As operations are performed on the server, e.g. add
 message, update message, delete message, records are appended to the
@@ -126,7 +128,7 @@ If no persistence is required at all, Apache ActiveMQ Artemis can also be config
 not to persist any data at all to storage as discussed in the Configuring
 the broker for Zero Persistence section.
 
-## Configuring the bindings journal
+### Configuring the bindings journal
 
 The bindings journal is configured using the following attributes in
 `broker.xml`
@@ -143,11 +145,11 @@ The bindings journal is configured using the following attributes in
     `bindings-directory` if it does not already exist. The default value
     is `true`
 
-## Configuring the jms journal
+### Configuring the jms journal
 
 The jms config shares its configuration with the bindings journal.
 
-## Configuring the message journal
+### Configuring the message journal
 
 The message journal is configured using the following attributes in
 `broker.xml`
@@ -297,7 +299,7 @@ The message journal is configured using the following attributes in
 
     The default for this parameter is `30`
 
-## An important note on disabling disk write cache.
+### An important note on disabling disk write cache.
 
 > **Warning**
 >
@@ -336,7 +338,7 @@ The message journal is configured using the following attributes in
 > On Windows you can check / change the setting by right clicking on the
 > disk and clicking properties.
 
-## Installing AIO
+### Installing AIO
 
 The Java NIO journal gives great performance, but If you are running
 Apache ActiveMQ Artemis using Linux Kernel 2.6 or later, we highly recommend you use
@@ -356,6 +358,40 @@ Using aptitude, (e.g. on Ubuntu or Debian system):
 
     apt-get install libaio
 
+## Apache ActiveMQ Artemis JDBC Persistence
+
+The Apache ActiveMQ Artemis JDBC persistence store is still under development and only supports persistence of standard messages and bindings (this is everything except large messages and paging).  The JDBC store uses a JDBC connection to store messages and bindings data in records in database tables.  The data stored in the database tables is encoded using Apache ActiveMQ Artemis journal encoding.
+
+### Configuring JDBC Persistence
+
+To configure Apache ActiveMQ Artemis to use a database for persisting messages and bindings data you must do two things.
+
+1. Add the appropriate JDBC client libraries to the Artemis runtime.  You can do this by dropping the relevant jars in the lib folder of the ActiveMQ Artemis distribution.
+
+2. create a store element in your broker.xml config file under the <core> element.  For example:
+
+```xml
+      <store>
+         <database-store>
+            <jdbc-connection-url>jdbc:derby:target/derby/database-store;create=true</jdbc-connection-url>
+            <bindings-table-name>BINDINGS_TABLE</bindings-table-name>
+            <message-table-name>MESSAGE_TABLE</message-table-name>
+         </database-store>
+      </store>
+```
+
+-   `jdbc-connection-url`
+
+    The full JDBC connection URL for your database server.  The connection url should include all configuration parameters and database name.
+    
+-   `bindings-table-name`
+
+    The name of the table in which bindings data will be persisted for the ActiveMQ Artemis server.  Specifying table names allows users to share single database amongst multiple servers, without interference.
+    
+-   `message-table-name`
+
+    The name of the table in which messages and related data will be persisted for the ActiveMQ Artemis server.  Specifying table names allows users to share single database amongst multiple servers, without interference.
+
 ## Configuring Apache ActiveMQ Artemis for Zero Persistence
 
 In some situations, zero persistence is sometimes required for a
@@ -366,3 +402,5 @@ straightforward. Simply set the parameter `persistence-enabled` in
 Please note that if you set this parameter to false, then *zero*
 persistence will occur. That means no bindings data, message data, large
 message data, duplicate id caches or paging data will be persisted.
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
       <module>artemis-ra</module>
       <module>artemis-rest</module>
       <module>artemis-service-extensions</module>
+      <module>artemis-jdbc-store</module>
       <module>artemis-maven-plugin</module>
       <module>artemis-server-osgi</module>
       <module>integration/activemq-spring-integration</module>
@@ -82,6 +83,7 @@
       <resteasy.version>3.0.13.Final</resteasy.version>
       <proton.version>0.10</proton.version>
       <fuse.mqtt.client.version>1.10</fuse.mqtt.client.version>
+      <apache.derby.version>10.11.1.1</apache.derby.version>
       <skipUnitTests>true</skipUnitTests>
       <skipJmsTests>true</skipJmsTests>
       <skipExtraTests>true</skipExtraTests>
@@ -201,6 +203,11 @@
             <artifactId>mqtt-client</artifactId>
             <version>${fuse.mqtt.client.version}</version>
             <!-- Apache v2.0 License -->
+         </dependency>
+         <dependency>
+            <groupId>org.apache.derby</groupId>
+            <artifactId>derby</artifactId>
+            <version>${apache.derby.version}</version>
          </dependency>
          <dependency>
             <groupId>org.eclipse.paho</groupId>
@@ -588,10 +595,12 @@
             <module>artemis-native</module>
             <module>artemis-protocols</module>
             <module>artemis-journal</module>
+            <module>artemis-jdbc-store</module>
             <module>artemis-ra</module>
             <module>artemis-rest</module>
             <module>artemis-service-extensions</module>
             <module>artemis-maven-plugin</module>
+            <module>artemis-jdbc-store</module>
             <module>integration/activemq-spring-integration</module>
             <module>integration/activemq-aerogear-integration</module>
             <module>integration/activemq-vertx-integration</module>
@@ -623,6 +632,7 @@
             <module>artemis-jms-server</module>
             <module>artemis-native</module>
             <module>artemis-journal</module>
+            <module>artemis-jdbc-store</module>
             <module>artemis-ra</module>
             <module>artemis-rest</module>
             <module>artemis-service-extensions</module>
@@ -681,6 +691,7 @@
             <module>artemis-jms-server</module>
             <module>artemis-native</module>
             <module>artemis-journal</module>
+            <module>artemis-jdbc-store</module>
             <module>artemis-ra</module>
             <module>artemis-rest</module>
             <module>artemis-service-extensions</module>
@@ -723,6 +734,7 @@
             <module>artemis-jms-server</module>
             <module>artemis-native</module>
             <module>artemis-journal</module>
+            <module>artemis-jdbc-store</module>
             <module>artemis-ra</module>
             <module>artemis-rest</module>
             <module>artemis-service-extensions</module>
@@ -757,6 +769,7 @@
             <module>artemis-jms-server</module>
             <module>artemis-native</module>
             <module>artemis-journal</module>
+            <module>artemis-jdbc-store</module>
             <module>artemis-ra</module>
             <module>artemis-rest</module>
             <module>artemis-service-extensions</module>

--- a/tests/integration-tests/pom.xml
+++ b/tests/integration-tests/pom.xml
@@ -119,6 +119,11 @@
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-jdbc-store</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-amqp-protocol</artifactId>
          <version>${project.version}</version>
       </dependency>

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/PagingTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/PagingTest.java
@@ -65,7 +65,7 @@ import org.apache.activemq.artemis.core.persistence.OperationContext;
 import org.apache.activemq.artemis.core.persistence.impl.journal.DescribeJournal;
 import org.apache.activemq.artemis.core.persistence.impl.journal.DescribeJournal.ReferenceDescribe;
 import org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds;
-import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager.AckDescribe;
+import org.apache.activemq.artemis.core.persistence.impl.journal.AckDescribe;
 import org.apache.activemq.artemis.core.persistence.impl.journal.OperationContextImpl;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.Queue;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jdbc/store/journal/FakeEncodingSupportImpl.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jdbc/store/journal/FakeEncodingSupportImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,15 +15,32 @@
  * limitations under the License.
  */
 
-package org.apache.activemq.artemis.core.security;
+package org.apache.activemq.artemis.tests.integration.jdbc.store.journal;
 
-import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.core.journal.EncodingSupport;
 
-public interface SecurityAuth {
+public class FakeEncodingSupportImpl implements EncodingSupport {
 
-   String getUsername();
+   private byte[] data;
 
-   String getPassword();
+   public FakeEncodingSupportImpl(byte[] data) {
+      this.data = data;
+   }
 
-   RemotingConnection getRemotingConnection();
+   @Override
+   public int getEncodeSize() {
+      return data.length;
+   }
+
+   @Override
+   public void encode(ActiveMQBuffer buffer) {
+      buffer.writeBytes(data);
+   }
+
+   @Override
+   public void decode(ActiveMQBuffer buffer) {
+      data = new byte[buffer.readableBytes()];
+      buffer.readBytes(data);
+   }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jdbc/store/journal/JDBCJournalTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jdbc/store/journal/JDBCJournalTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.jdbc.store.journal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.activemq.artemis.core.journal.IOCompletion;
+import org.apache.activemq.artemis.core.journal.PreparedTransactionInfo;
+import org.apache.activemq.artemis.core.journal.RecordInfo;
+import org.apache.activemq.artemis.jdbc.store.journal.JDBCJournalImpl;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class JDBCJournalTest {
+
+   private static final String JOURNAL_TABLE_NAME = "MESSAGE_JOURNAL";
+
+   private JDBCJournalImpl journal;
+
+   private String jdbcUrl;
+
+   private Properties jdbcConnectionProperties;
+
+   @Before
+   public void setup() throws Exception {
+      jdbcUrl = "jdbc:derby:target/data;create=true";
+      journal = new JDBCJournalImpl(jdbcUrl, JOURNAL_TABLE_NAME);
+      journal.start();
+   }
+
+   @Test
+   public void testInsertRecords() throws Exception {
+      int noRecords = 10;
+      for (int i = 0; i < noRecords; i++) {
+         journal.appendAddRecord(1, (byte) 1, new byte[0], true);
+      }
+
+      Thread.sleep(3000);
+      assertEquals(noRecords, journal.getNumberOfRecords());
+
+   }
+
+   @Test
+   public void testCallbacks() throws Exception {
+      final int noRecords = 10;
+      final CountDownLatch done = new CountDownLatch(noRecords);
+
+      IOCompletion completion = new IOCompletion() {
+         @Override
+         public void storeLineUp() {
+         }
+
+         @Override
+         public void done() {
+            done.countDown();
+         }
+
+         @Override
+         public void onError(int errorCode, String errorMessage) {
+
+         }
+      };
+
+      for (int i = 0; i < noRecords; i++) {
+         journal.appendAddRecord(1, (byte) 1, new FakeEncodingSupportImpl(new byte[0]), true, completion);
+      }
+      journal.sync();
+
+      done.await(5, TimeUnit.SECONDS);
+      assertEquals(done.getCount(), 0);
+   }
+
+   @Test
+   public void testReadJournal() throws Exception {
+      int noRecords = 100;
+
+      // Standard Add Records
+      for (int i = 0; i < noRecords; i++) {
+         journal.appendAddRecord(i, (byte) i, new byte[i], true);
+      }
+
+      // TX Records
+      int noTx = 10;
+      int noTxRecords = 100;
+      for (int i = 1000; i < 1000 + noTx; i++) {
+         for (int j = 0; j < noTxRecords; j++) {
+            journal.appendAddRecordTransactional(i, Long.valueOf(i + "" + j), (byte) 1, new byte[0]);
+         }
+         journal.appendPrepareRecord(i, new byte[0], true);
+         journal.appendCommitRecord(i, true);
+      }
+
+      Thread.sleep(2000);
+      List<RecordInfo> recordInfos = new ArrayList<>();
+      List<PreparedTransactionInfo> txInfos = new ArrayList<>();
+
+      journal.load(recordInfos, txInfos, null);
+
+      assertEquals(noRecords + (noTxRecords * noTx), recordInfos.size());
+   }
+
+   @After
+   public void tearDown() throws Exception {
+      journal.destroy();
+   }
+}

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/AddressSettingsConfigurationStorageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/AddressSettingsConfigurationStorageTest.java
@@ -16,21 +16,29 @@
  */
 package org.apache.activemq.artemis.tests.integration.persistence;
 
-import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.core.persistence.config.PersistedAddressSetting;
-import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager;
-import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
-import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.config.StoreConfiguration;
+import org.apache.activemq.artemis.core.persistence.StorageManager;
+import org.apache.activemq.artemis.core.persistence.config.PersistedAddressSetting;
+import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
+import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
 public class AddressSettingsConfigurationStorageTest extends StorageManagerTestBase {
 
    private Map<SimpleString, PersistedAddressSetting> mapExpectedAddresses;
+
+   public AddressSettingsConfigurationStorageTest(StoreConfiguration.StoreType storeType) {
+      super(storeType);
+   }
 
    @Override
    @Before
@@ -40,7 +48,7 @@ public class AddressSettingsConfigurationStorageTest extends StorageManagerTestB
       mapExpectedAddresses = new HashMap<>();
    }
 
-   protected void addAddress(JournalStorageManager journal1, String address, AddressSettings setting) throws Exception {
+   protected void addAddress(StorageManager journal1, String address, AddressSettings setting) throws Exception {
       SimpleString str = new SimpleString(address);
       PersistedAddressSetting persistedSetting = new PersistedAddressSetting(str, setting);
       mapExpectedAddresses.put(str, persistedSetting);
@@ -84,7 +92,7 @@ public class AddressSettingsConfigurationStorageTest extends StorageManagerTestB
     * @param journal1
     * @throws Exception
     */
-   private void checkAddresses(JournalStorageManager journal1) throws Exception {
+   private void checkAddresses(StorageManager journal1) throws Exception {
       List<PersistedAddressSetting> listSetting = journal1.recoverAddressSettings();
 
       assertEquals(mapExpectedAddresses.size(), listSetting.size());

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/DeleteMessagesOnStartupTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/DeleteMessagesOnStartupTest.java
@@ -17,12 +17,13 @@
 package org.apache.activemq.artemis.tests.integration.persistence;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.tests.unit.core.postoffice.impl.FakeQueue;
-import org.apache.activemq.artemis.tests.unit.core.server.impl.fakes.FakePostOffice;
 import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.config.StoreConfiguration;
 import org.apache.activemq.artemis.core.persistence.GroupingInfo;
 import org.apache.activemq.artemis.core.persistence.QueueBindingInfo;
 import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager;
@@ -30,14 +31,28 @@ import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.server.ServerMessage;
 import org.apache.activemq.artemis.core.server.impl.PostOfficeJournalLoader;
 import org.apache.activemq.artemis.core.server.impl.ServerMessageImpl;
+import org.apache.activemq.artemis.tests.unit.core.postoffice.impl.FakeQueue;
+import org.apache.activemq.artemis.tests.unit.core.server.impl.fakes.FakePostOffice;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runners.Parameterized;
 
 public class DeleteMessagesOnStartupTest extends StorageManagerTestBase {
 
    volatile boolean deleteMessages = false;
 
    ArrayList<Long> deletedMessage = new ArrayList<>();
+
+   public DeleteMessagesOnStartupTest(StoreConfiguration.StoreType storeType) {
+      super(storeType);
+   }
+
+   // This is only applicable for FILE based store, as the database storage manager will automatically delete records.
+   @Parameterized.Parameters(name = "storeType")
+   public static Collection<Object[]> data() {
+      Object[][] params = new Object[][] {{StoreConfiguration.StoreType.FILE}};
+      return Arrays.asList(params);
+   }
 
    @Test
    public void testDeleteMessagesOnStartup() throws Exception {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/DuplicateCacheTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/DuplicateCacheTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.config.StoreConfiguration;
 import org.apache.activemq.artemis.core.io.IOCallback;
 import org.apache.activemq.artemis.core.persistence.impl.journal.OperationContextImpl;
 import org.apache.activemq.artemis.core.postoffice.DuplicateIDCache;
@@ -31,6 +32,10 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class DuplicateCacheTest extends StorageManagerTestBase {
+
+   public DuplicateCacheTest(StoreConfiguration.StoreType storeType) {
+      super(storeType);
+   }
 
    @After
    @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/JMSConnectionFactoryConfigurationStorageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/JMSConnectionFactoryConfigurationStorageTest.java
@@ -19,6 +19,7 @@ package org.apache.activemq.artemis.tests.integration.persistence;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
 import org.apache.activemq.artemis.api.core.Pair;
+import org.apache.activemq.artemis.core.config.StoreConfiguration;
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.jms.persistence.config.PersistedConnectionFactory;
 import org.apache.activemq.artemis.jms.server.config.ConnectionFactoryConfiguration;
@@ -35,6 +36,10 @@ import java.util.Map;
 public class JMSConnectionFactoryConfigurationStorageTest extends StorageManagerTestBase {
 
    private Map<String, PersistedConnectionFactory> mapExpectedCFs;
+
+   public JMSConnectionFactoryConfigurationStorageTest(StoreConfiguration.StoreType storeType) {
+      super(storeType);
+   }
 
    @Override
    @Before

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/JMSStorageManagerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/JMSStorageManagerTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.activemq.artemis.tests.integration.persistence;
 
+import org.apache.activemq.artemis.core.config.StoreConfiguration;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -26,6 +27,10 @@ import org.apache.activemq.artemis.jms.persistence.config.PersistedBindings;
 import org.apache.activemq.artemis.jms.persistence.config.PersistedType;
 
 public class JMSStorageManagerTest extends StorageManagerTestBase {
+
+   public JMSStorageManagerTest(StoreConfiguration.StoreType storeType) {
+      super(storeType);
+   }
 
    //https://issues.jboss.org/browse/HORNETQ-812
    @Test

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/RolesConfigurationStorageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/RolesConfigurationStorageTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.activemq.artemis.tests.integration.persistence;
 
+import org.apache.activemq.artemis.core.config.StoreConfiguration;
 import org.junit.Before;
 
 import org.junit.Test;
@@ -30,6 +31,10 @@ import org.apache.activemq.artemis.core.persistence.config.PersistedRoles;
 public class RolesConfigurationStorageTest extends StorageManagerTestBase {
 
    private Map<SimpleString, PersistedRoles> mapExpectedSets;
+
+   public RolesConfigurationStorageTest(StoreConfiguration.StoreType storeType) {
+      super(storeType);
+   }
 
    @Override
    @Before

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/AlignedJournalImplTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/AlignedJournalImplTest.java
@@ -839,10 +839,10 @@ public class AlignedJournalImplTest extends ActiveMQTestBase {
       setupAndLoadJournal(JOURNAL_SIZE, 1);
 
       Assert.assertEquals(1, transactions.size());
-      Assert.assertEquals(1, transactions.get(0).recordsToDelete.size());
+      Assert.assertEquals(1, transactions.get(0).getRecordsToDelete().size());
       Assert.assertEquals(1, records.size());
 
-      for (RecordInfo record : transactions.get(0).recordsToDelete) {
+      for (RecordInfo record : transactions.get(0).getRecordsToDelete()) {
          byte[] data = record.data;
          Assert.assertEquals(100, data.length);
          for (byte element : data) {
@@ -850,10 +850,10 @@ public class AlignedJournalImplTest extends ActiveMQTestBase {
          }
       }
 
-      Assert.assertEquals(10, transactions.get(0).extraData.length);
+      Assert.assertEquals(10, transactions.get(0).getExtraData().length);
 
       for (int i = 0; i < 10; i++) {
-         Assert.assertEquals((byte) 1, transactions.get(0).extraData[i]);
+         Assert.assertEquals((byte) 1, transactions.get(0).getExtraData()[i]);
       }
 
       journalImpl.appendCommitRecord(1L, false);
@@ -894,9 +894,9 @@ public class AlignedJournalImplTest extends ActiveMQTestBase {
       Assert.assertEquals(0, records.size());
       Assert.assertEquals(1, transactions.size());
 
-      Assert.assertEquals(10, transactions.get(0).extraData.length);
+      Assert.assertEquals(10, transactions.get(0).getExtraData().length);
       for (int i = 0; i < 10; i++) {
-         Assert.assertEquals((byte) 1, transactions.get(0).extraData[i]);
+         Assert.assertEquals((byte) 1, transactions.get(0).getExtraData()[i]);
       }
 
       journalImpl.checkReclaimStatus();
@@ -925,9 +925,9 @@ public class AlignedJournalImplTest extends ActiveMQTestBase {
 
       Assert.assertEquals(1, transactions.size());
 
-      Assert.assertEquals(15, transactions.get(0).extraData.length);
+      Assert.assertEquals(15, transactions.get(0).getExtraData().length);
 
-      for (byte element : transactions.get(0).extraData) {
+      for (byte element : transactions.get(0).getExtraData()) {
          Assert.assertEquals(2, element);
       }
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/JournalImplTestBase.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/JournalImplTestBase.java
@@ -265,9 +265,9 @@ public abstract class JournalImplTestBase extends ActiveMQTestBase {
          if (entry.getValue().prepared) {
             PreparedTransactionInfo info = new PreparedTransactionInfo(entry.getKey(), null);
 
-            info.records.addAll(entry.getValue().records);
+            info.getRecords().addAll(entry.getValue().records);
 
-            info.recordsToDelete.addAll(entry.getValue().deletes);
+            info.getRecordsToDelete().addAll(entry.getValue().deletes);
 
             prepared.add(info);
          }
@@ -465,15 +465,15 @@ public abstract class JournalImplTestBase extends ActiveMQTestBase {
 
          PreparedTransactionInfo ractual = iterActual.next();
 
-         Assert.assertEquals("ids not same", rexpected.id, ractual.id);
+         Assert.assertEquals("ids not same", rexpected.getId(), ractual.getId());
 
-         checkRecordsEquivalent(rexpected.records, ractual.records);
+         checkRecordsEquivalent(rexpected.getRecords(), ractual.getRecords());
 
-         Assert.assertEquals("deletes size not same", rexpected.recordsToDelete.size(), ractual.recordsToDelete.size());
+         Assert.assertEquals("deletes size not same", rexpected.getRecordsToDelete().size(), ractual.getRecordsToDelete().size());
 
-         Iterator<RecordInfo> iterDeletesExpected = rexpected.recordsToDelete.iterator();
+         Iterator<RecordInfo> iterDeletesExpected = rexpected.getRecordsToDelete().iterator();
 
-         Iterator<RecordInfo> iterDeletesActual = ractual.recordsToDelete.iterator();
+         Iterator<RecordInfo> iterDeletesActual = ractual.getRecordsToDelete().iterator();
 
          while (iterDeletesExpected.hasNext()) {
             long lexpected = iterDeletesExpected.next().id;


### PR DESCRIPTION
This is the inital work towards ARTEMIS-27, adding Database storage support in Artemis.

This is not yet finished, I'm opening this PR so people can start looking at the solution.

There are still several areas that need to be completed (firstly this patch needs rebasing on top of master), I'll also split this up into functional commits.  This patch currently only adds support for journal persistence in JDBC, Paging and Large Messages still use regular files.

So far, only Derby embedded DB has been tested.  See /home/mtaylor/dev/activemq-artemis/artemis-server/src/test/resources/database-store-config.xml for an example of how to configure the database store.

Also, look at the /home/mtaylor/dev/activemq-artemis/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence tests for lower level examples.