### PR TITLE
Remove wildcard include on geronimo specs

### DIFF
--- a/artemis-distribution/src/main/assembly/dep.xml
+++ b/artemis-distribution/src/main/assembly/dep.xml
@@ -68,8 +68,13 @@
             <include>org.apache.activemq:artemis-service-extensions</include>
             <include>org.apache.activemq:artemis-web</include>
             <include>org.apache.activemq.rest:artemis-rest</include>
+
             <!-- dependencies -->
             <include>org.apache.geronimo.specs:geronimo-jms_2.0_spec</include>
+            <include>org.apache.geronimo.specs:geronimo-annotation_1.1_spec</include>
+            <include>org.apache.geronimo.specs:geronimo-j2ee-connector_1.5_spec</include>
+            <include>org.apache.geronimo.specs:geronimo-ejb_3.0_spec</include>
+            <include>org.apache.geronimo.specs:geronimo-jta_1.1_spec</include>
             <include>org.jboss.logmanager:jboss-logmanager</include>
             <include>org.jboss.logging:jboss-logging</include>
             <include>io.netty:netty-all</include>
@@ -81,7 +86,6 @@
             <include>com.google.guava:guava</include>
             <include>javax.inject:javax.inject</include>
             <include>org.eclipse.jetty.aggregate:jetty-all</include>
-            <include>org.apache.geronimo.specs:</include>
             <include>org.apache.tomcat:tomcat-servlet-api</include>
             <include>commons-beanutils:commons-beanutils</include>
             <include>commons-logging:commons-logging</include>


### PR DESCRIPTION
The assembly currently uses wildcard to pull down the geronimo specs.
However, this also pulls down and includes extra jars that are not
required.  This patch explicitly includes each geronimo lib.