### PR TITLE
Remove dead code

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -623,11 +623,11 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
 
    @Override
    public QueueQueryResult executeQueueQuery(final SimpleString name) throws Exception {
-      boolean autoCreateJmsQueues = name.toString().startsWith(ResourceNames.JMS_QUEUE) && server.getAddressSettingsRepository().getMatch(name.toString()).isAutoCreateJmsQueues();
-
       if (name == null) {
          throw ActiveMQMessageBundle.BUNDLE.queueNameIsNull();
       }
+
+      boolean autoCreateJmsQueues = name.toString().startsWith(ResourceNames.JMS_QUEUE) && server.getAddressSettingsRepository().getMatch(name.toString()).isAutoCreateJmsQueues();
 
       QueueQueryResult response;
 
@@ -658,11 +658,11 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
 
    @Override
    public BindingQueryResult executeBindingQuery(final SimpleString address) throws Exception {
-      boolean autoCreateJmsQueues = address.toString().startsWith(ResourceNames.JMS_QUEUE) && server.getAddressSettingsRepository().getMatch(address.toString()).isAutoCreateJmsQueues();
-
       if (address == null) {
          throw ActiveMQMessageBundle.BUNDLE.addressIsNull();
       }
+
+      boolean autoCreateJmsQueues = address.toString().startsWith(ResourceNames.JMS_QUEUE) && server.getAddressSettingsRepository().getMatch(address.toString()).isAutoCreateJmsQueues();
 
       List<SimpleString> names = new ArrayList<>();
 

--- a/examples/features/clustered/clustered-topic/src/main/java/org/apache/activemq/artemis/jms/example/ClusteredTopicExample.java
+++ b/examples/features/clustered/clustered-topic/src/main/java/org/apache/activemq/artemis/jms/example/ClusteredTopicExample.java
@@ -23,7 +23,6 @@ import javax.jms.MessageProducer;
 import javax.jms.Session;
 import javax.jms.TextMessage;
 import javax.jms.Topic;
-import javax.naming.InitialContext;
 
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
@@ -38,10 +37,6 @@ public class ClusteredTopicExample {
       Connection connection0 = null;
 
       Connection connection1 = null;
-
-      InitialContext ic0 = null;
-
-      InitialContext ic1 = null;
 
       try {
 
@@ -115,14 +110,6 @@ public class ClusteredTopicExample {
 
          if (connection1 != null) {
             connection1.close();
-         }
-
-         if (ic0 != null) {
-            ic0.close();
-         }
-
-         if (ic1 != null) {
-            ic1.close();
          }
       }
    }

--- a/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ2401Test.java
+++ b/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ2401Test.java
@@ -90,33 +90,20 @@ public class AMQ2401Test extends TestCase implements MessageListener {
 
    public void testDupsOk() throws Exception {
 
-      TestProducer p = null;
-      TestConsumer c = null;
-      try {
-         latch = new CountDownLatch(SEND_COUNT);
+      latch = new CountDownLatch(SEND_COUNT);
 
-         for (int i = 0; i < CONSUMER_COUNT; i++) {
-            TestConsumer consumer = new TestConsumer();
-            consumer.start();
-            services.add(consumer);
-         }
-         for (int i = 0; i < PRODUCER_COUNT; i++) {
-            TestProducer producer = new TestProducer();
-            producer.start();
-            services.add(producer);
-         }
-
-         waitForMessageReceipt(TimeUnit.SECONDS.toMillis(30));
+      for (int i = 0; i < CONSUMER_COUNT; i++) {
+         TestConsumer consumer = new TestConsumer();
+         consumer.start();
+         services.add(consumer);
       }
-      finally {
-         if (p != null) {
-            p.close();
-         }
-
-         if (c != null) {
-            c.close();
-         }
+      for (int i = 0; i < PRODUCER_COUNT; i++) {
+         TestProducer producer = new TestProducer();
+         producer.start();
+         services.add(producer);
       }
+
+      waitForMessageReceipt(TimeUnit.SECONDS.toMillis(30));
    }
 
    @Override

--- a/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ2413Test.java
+++ b/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ2413Test.java
@@ -128,33 +128,19 @@ public class AMQ2413Test extends CombinationTestSupport implements MessageListen
    public void testReceipt() throws Exception {
 
       running.set(true);
-      TestProducer p = null;
-      TestConsumer c = null;
-      try {
 
-         for (int i = 0; i < CONSUMER_COUNT; i++) {
-            TestConsumer consumer = new TestConsumer();
-            consumer.start();
-            services.add(consumer);
-         }
-         for (int i = 0; i < PRODUCER_COUNT; i++) {
-            TestProducer producer = new TestProducer(i);
-            producer.start();
-            services.add(producer);
-         }
-         waitForMessageReceipt();
-
+      for (int i = 0; i < CONSUMER_COUNT; i++) {
+         TestConsumer consumer = new TestConsumer();
+         consumer.start();
+         services.add(consumer);
       }
-      finally {
-         if (p != null) {
-            p.close();
-         }
-
-         if (c != null) {
-            c.close();
-         }
+      for (int i = 0; i < PRODUCER_COUNT; i++) {
+         TestProducer producer = new TestProducer(i);
+         producer.start();
+         services.add(producer);
       }
 
+      waitForMessageReceipt();
    }
 
    /*

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/BridgeServerLocatorConfigurationTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/BridgeServerLocatorConfigurationTest.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
-import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.config.BridgeConfiguration;
 import org.apache.activemq.artemis.core.config.CoreQueueConfiguration;
 import org.apache.activemq.artemis.core.remoting.impl.invm.TransportConstants;
@@ -75,7 +74,6 @@ public class BridgeServerLocatorConfigurationTest extends ActiveMQTestBase {
          server1Params.put(TransportConstants.SERVER_ID_PROP_NAME, 1);
       }
       ActiveMQServer server1 = createClusteredServerWithParams(isNetty(), 1, true, server1Params);
-      ServerLocator locator = null;
       try {
          final String testAddress = "testAddress";
          final String queueName0 = "queue0";
@@ -118,10 +116,6 @@ public class BridgeServerLocatorConfigurationTest extends ActiveMQTestBase {
          assertEquals(BRIDGE_TTL, bridgeTTL);
       }
       finally {
-         if (locator != null) {
-            locator.close();
-         }
-
          serverWithBridge.stop();
 
          server1.stop();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/FlowControlOnIgnoreLargeMessageBodyTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/FlowControlOnIgnoreLargeMessageBodyTest.java
@@ -31,8 +31,6 @@ import javax.jms.MessageProducer;
 import javax.jms.Session;
 import javax.jms.Topic;
 import javax.jms.TopicSubscriber;
-import javax.naming.Context;
-import javax.naming.NamingException;
 
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
 import org.apache.activemq.artemis.tests.util.JMSTestBase;
@@ -290,7 +288,6 @@ public class FlowControlOnIgnoreLargeMessageBodyTest extends JMSTestBase {
 
    @Test
    public void testFlowControl() {
-      Context context = null;
       try {
          LoadProducer producer = new LoadProducer("producer", topic, cf, FlowControlOnIgnoreLargeMessageBodyTest.TOTAL_MESSAGES_COUNT);
 
@@ -340,16 +337,6 @@ public class FlowControlOnIgnoreLargeMessageBodyTest extends JMSTestBase {
       }
       catch (Exception e) {
          log.warn(e.getMessage(), e);
-      }
-      finally {
-         if (context != null) {
-            try {
-               context.close();
-            }
-            catch (NamingException ex) {
-               log.warn(ex.getMessage(), ex);
-            }
-         }
       }
    }
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/jms/misc/ManifestTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/jms/misc/ManifestTest.java
@@ -25,7 +25,6 @@ import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 
-import javax.jms.Connection;
 import javax.jms.ConnectionMetaData;
 
 import org.junit.Assert;
@@ -61,24 +60,14 @@ public class ManifestTest extends ActiveMQTestBase {
       JarFile jar = new JarFile(file);
       Manifest manifest = jar.getManifest();
 
-      // Open a connection and get ConnectionMetaData
-      Connection conn = null;
+      ActiveMQServer server = ActiveMQServers.newActiveMQServer(createBasicConfig());
 
-      try {
-         ActiveMQServer server = ActiveMQServers.newActiveMQServer(createBasicConfig());
+      ConnectionMetaData meta = new ActiveMQConnectionMetaData(server.getVersion());
 
-         ConnectionMetaData meta = new ActiveMQConnectionMetaData(server.getVersion());
+      // Compare the value from ConnectionMetaData and MANIFEST.MF
+      Attributes attrs = manifest.getMainAttributes();
 
-         // Compare the value from ConnectionMetaData and MANIFEST.MF
-         Attributes attrs = manifest.getMainAttributes();
-
-         Assert.assertEquals(meta.getProviderVersion(), attrs.getValue("ActiveMQ-Version"));
-      }
-      finally {
-         if (conn != null) {
-            conn.close();
-         }
-      }
+      Assert.assertEquals(meta.getProviderVersion(), attrs.getValue("ActiveMQ-Version"));
    }
 
    // Package protected ---------------------------------------------


### PR DESCRIPTION
ServerSessionImpl changes are actually NPE avoiding ones, but similar as the other ones (were unnecessary null checks) so I left them here. See also ARTEMIS-335 for one more related one (which is not included in this PR).