### PR TITLE
Include key name in property conversion exception messages

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/TypedProperties.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/TypedProperties.java
@@ -161,9 +161,7 @@ public final class TypedProperties {
       else if (value instanceof SimpleString) {
          return Boolean.valueOf(((SimpleString) value).toString());
       }
-      else {
-         throw new ActiveMQPropertyConversionException("Invalid conversion");
-      }
+      throw new ActiveMQPropertyConversionException("Invalid conversion: " + key);
    }
 
    public Byte getByteProperty(final SimpleString key) throws ActiveMQPropertyConversionException {
@@ -177,23 +175,19 @@ public final class TypedProperties {
       else if (value instanceof SimpleString) {
          return Byte.parseByte(((SimpleString) value).toString());
       }
-      else {
-         throw new ActiveMQPropertyConversionException("Invalid conversion");
-      }
+      throw new ActiveMQPropertyConversionException("Invalid conversion: " + key);
    }
 
    public Character getCharProperty(final SimpleString key) throws ActiveMQPropertyConversionException {
       Object value = doGetProperty(key);
       if (value == null) {
-         throw new NullPointerException("Invalid conversion");
+         throw new NullPointerException("Invalid conversion: " + key);
       }
 
       if (value instanceof Character) {
          return ((Character) value);
       }
-      else {
-         throw new ActiveMQPropertyConversionException("Invalid conversion");
-      }
+      throw new ActiveMQPropertyConversionException("Invalid conversion: " + key);
    }
 
    public byte[] getBytesProperty(final SimpleString key) throws ActiveMQPropertyConversionException {
@@ -204,9 +198,7 @@ public final class TypedProperties {
       else if (value instanceof byte[]) {
          return (byte[]) value;
       }
-      else {
-         throw new ActiveMQPropertyConversionException("Invalid conversion");
-      }
+      throw new ActiveMQPropertyConversionException("Invalid conversion: " + key);
    }
 
    public Double getDoubleProperty(final SimpleString key) throws ActiveMQPropertyConversionException {
@@ -223,9 +215,7 @@ public final class TypedProperties {
       else if (value instanceof SimpleString) {
          return Double.parseDouble(((SimpleString) value).toString());
       }
-      else {
-         throw new ActiveMQPropertyConversionException("Invalid conversion");
-      }
+      throw new ActiveMQPropertyConversionException("Invalid conversion: " + key);
    }
 
    public Integer getIntProperty(final SimpleString key) throws ActiveMQPropertyConversionException {
@@ -245,9 +235,7 @@ public final class TypedProperties {
       else if (value instanceof SimpleString) {
          return Integer.parseInt(((SimpleString) value).toString());
       }
-      else {
-         throw new ActiveMQPropertyConversionException("Invalid conversion");
-      }
+      throw new ActiveMQPropertyConversionException("Invalid conversion: " + key);
    }
 
    public Long getLongProperty(final SimpleString key) throws ActiveMQPropertyConversionException {
@@ -270,9 +258,7 @@ public final class TypedProperties {
       else if (value instanceof SimpleString) {
          return Long.parseLong(((SimpleString) value).toString());
       }
-      else {
-         throw new ActiveMQPropertyConversionException("Invalid conversion");
-      }
+      throw new ActiveMQPropertyConversionException("Invalid conversion: " + key);
    }
 
    public Short getShortProperty(final SimpleString key) throws ActiveMQPropertyConversionException {
@@ -289,9 +275,7 @@ public final class TypedProperties {
       else if (value instanceof SimpleString) {
          return Short.parseShort(((SimpleString) value).toString());
       }
-      else {
-         throw new ActiveMQPropertyConversionException("Invalid Conversion.");
-      }
+      throw new ActiveMQPropertyConversionException("Invalid conversion: " + key);
    }
 
    public Float getFloatProperty(final SimpleString key) throws ActiveMQPropertyConversionException {
@@ -341,7 +325,7 @@ public final class TypedProperties {
       else if (value instanceof Double) {
          return new SimpleString(value.toString());
       }
-      throw new ActiveMQPropertyConversionException("Invalid conversion");
+      throw new ActiveMQPropertyConversionException("Invalid conversion: " + key);
    }
 
    public Object removeProperty(final SimpleString key) {

--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/ConcurrentHashSetTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/ConcurrentHashSetTest.java
@@ -14,11 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.util;
+package org.apache.activemq.artemis.utils;
 
-import org.apache.activemq.artemis.utils.ConcurrentHashSet;
-import org.apache.activemq.artemis.utils.ConcurrentSet;
-import org.apache.activemq.artemis.utils.RandomUtil;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/TypedPropertiesConversionTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/TypedPropertiesConversionTest.java
@@ -14,12 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.util;
+package org.apache.activemq.artemis.utils;
 
 import org.apache.activemq.artemis.api.core.ActiveMQPropertyConversionException;
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.utils.RandomUtil;
-import org.apache.activemq.artemis.utils.TypedProperties;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/TypedPropertiesTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/TypedPropertiesTest.java
@@ -14,15 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.util;
+package org.apache.activemq.artemis.utils;
 
 import java.util.Iterator;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.utils.RandomUtil;
-import org.apache.activemq.artemis.utils.TypedProperties;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
Was previously included only in getFloatProperty 