### PR TITLE
ARTEMIS-360 - PagingTest.testSpreadMessagesWithFilterWithDeadConsumer…

### DIFF
--- a/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
@@ -1069,7 +1069,7 @@ public abstract class ActiveMQTestBase extends Assert {
    }
 
    protected void waitForNotPaging(PagingStore store) throws InterruptedException {
-      long timeout = System.currentTimeMillis() + 10000;
+      long timeout = System.currentTimeMillis() + 20000;
       while (timeout > System.currentTimeMillis() && store.isPaging()) {
          Thread.sleep(100);
       }


### PR DESCRIPTION
… fails on timeout waiting for stop paging

extended waiting time