### PR TITLE
Remove duplicate references to artemis-cli in pom.xml in tests.

### DIFF
--- a/tests/integration-tests/pom.xml
+++ b/tests/integration-tests/pom.xml
@@ -99,11 +99,6 @@
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-cli</artifactId>
-         <version>${project.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-spring-integration</artifactId>
          <version>${project.version}</version>
       </dependency>

--- a/tests/unit-tests/pom.xml
+++ b/tests/unit-tests/pom.xml
@@ -66,11 +66,6 @@
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-cli</artifactId>
-         <version>${project.version}</version>
-      </dependency>
-      <dependency>
          <groupId>org.apache.geronimo.specs</groupId>
          <artifactId>geronimo-j2ee-connector_1.5_spec</artifactId>
       </dependency>


### PR DESCRIPTION
Fixed pom.xml in integration-tests and unit-tests
Fixes warnings from Maven 3