### PR TITLE
Fix Delete TX on JDBCJournalImpl

### DIFF
--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalImpl.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalImpl.java
@@ -301,7 +301,7 @@ public class JDBCJournalImpl implements Journal {
 
       // We actually only need the record ID in this instance.
       if (record.isTransactional()) {
-         RecordInfo info = new RecordInfo(record.getTxId(), record.getRecordType(), new byte[0], record.isUpdate(), record.getCompactCount());
+         RecordInfo info = new RecordInfo(record.getId(), record.getRecordType(), new byte[0], record.isUpdate(), record.getCompactCount());
          if (record.getRecordType() == JDBCJournalRecord.DELETE_RECORD_TX) {
             txHolder.recordsToDelete.add(info);
          }

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalRecord.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalRecord.java
@@ -63,7 +63,7 @@ public class JDBCJournalRecord {
 
    // Callback and sync operations
    private IOCompletion ioCompletion = null;
-   private boolean storeLineUp = false;
+   private boolean storeLineUp = true;
    private boolean sync = false;
 
    // DB Fields for all records


### PR DESCRIPTION
The JDBC in memory Tx representation was using the Tx ID instead of the
Record ID which was causing deletes to fail.  Also the Store line up
should be set to true as default.