### PR TITLE
Allow users to configure jdbc driver class name

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
@@ -403,7 +403,10 @@ public final class ActiveMQDefaultConfiguration {
    private static String DEFAULT_STORE_TYPE = "FILE";
 
    // Default database url.  Derby database is used by default.
-   private static String DEFAULT_DATABASE_URL = "jdbc:derby:data/derby;create=true";
+   private static String DEFAULT_DATABASE_URL = null;
+
+   // Default JDBC Driver class name
+   private static String DEFAULT_JDBC_DRIVER_CLASS_NAME = null;
 
    // Default message table name, used with Database storage type
    private static String DEFAULT_MESSAGE_TABLE_NAME = "MESSAGES";
@@ -1095,5 +1098,9 @@ public final class ActiveMQDefaultConfiguration {
 
    public static String getDefaultBindingsTableName() {
       return DEFAULT_BINDINGS_TABLE_NAME;
+   }
+
+   public static String getDefaultDriverClassName() {
+      return DEFAULT_JDBC_DRIVER_CLASS_NAME;
    }
 }

--- a/artemis-jdbc-store/pom.xml
+++ b/artemis-jdbc-store/pom.xml
@@ -56,6 +56,7 @@
       <dependency>
          <groupId>org.apache.derby</groupId>
          <artifactId>derby</artifactId>
+         <scope>test</scope>
       </dependency>
 
       <dependency>

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/storage/DatabaseStorageConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/storage/DatabaseStorageConfiguration.java
@@ -27,6 +27,7 @@ public class DatabaseStorageConfiguration implements StoreConfiguration {
 
    private String jdbcConnectionUrl = ActiveMQDefaultConfiguration.getDefaultDatabaseUrl();
 
+   private String jdbcDriverClassName = ActiveMQDefaultConfiguration.getDefaultDriverClassName();
    @Override
    public StoreType getStoreType() {
       return StoreType.DATABASE;
@@ -54,5 +55,13 @@ public class DatabaseStorageConfiguration implements StoreConfiguration {
 
    public String getJdbcConnectionUrl() {
       return jdbcConnectionUrl;
+   }
+
+   public void setJdbcDriverClassName(String jdbcDriverClassName) {
+      this.jdbcDriverClassName = jdbcDriverClassName;
+   }
+
+   public String getJdbcDriverClassName() {
+      return jdbcDriverClassName;
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -1150,6 +1150,7 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       conf.setBindingsTableName(getString(storeNode, "bindings-table-name", conf.getBindingsTableName(), Validators.NO_CHECK));
       conf.setMessageTableName(getString(storeNode, "message-table-name", conf.getMessageTableName(), Validators.NO_CHECK));
       conf.setJdbcConnectionUrl(getString(storeNode, "jdbc-connection-url", conf.getJdbcConnectionUrl(), Validators.NO_CHECK));
+      conf.setJdbcDriverClassName(getString(storeNode, "jdbc-driver-class-name", conf.getJdbcDriverClassName(), Validators.NO_CHECK));
       return conf;
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JDBCJournalStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JDBCJournalStorageManager.java
@@ -42,10 +42,10 @@ public class JDBCJournalStorageManager extends JournalStorageManager {
    protected void init(Configuration config, IOCriticalErrorListener criticalErrorListener) {
       DatabaseStorageConfiguration dbConf = (DatabaseStorageConfiguration) config.getStoreConfiguration();
 
-      Journal localBindings = new JDBCJournalImpl(dbConf.getJdbcConnectionUrl(), dbConf.getBindingsTableName());
+      Journal localBindings = new JDBCJournalImpl(dbConf.getJdbcConnectionUrl(), dbConf.getBindingsTableName(), dbConf.getJdbcDriverClassName());
       bindingsJournal = localBindings;
 
-      Journal localMessage = new JDBCJournalImpl(dbConf.getJdbcConnectionUrl(), dbConf.getMessageTableName());
+      Journal localMessage = new JDBCJournalImpl(dbConf.getJdbcConnectionUrl(), dbConf.getMessageTableName(), dbConf.getJdbcDriverClassName());
       messageJournal = localMessage;
    }
 

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -1516,6 +1516,13 @@
 
    <xsd:complexType name="databaseStoreType">
       <xsd:all>
+         <xsd:element name="jdbc-driver-class-name" type="xsd:string" minOccurs="1" maxOccurs="1">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The JDBC Driver class name
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
          <xsd:element name="jdbc-connection-url" type="xsd:string" minOccurs="1" maxOccurs="1">
             <xsd:annotation>
                <xsd:documentation>

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
@@ -395,6 +395,7 @@ public abstract class ActiveMQTestBase extends Assert {
       dbStorageConfiguration.setJdbcConnectionUrl(getTestJDBCConnectionUrl());
       dbStorageConfiguration.setBindingsTableName("BINDINGS");
       dbStorageConfiguration.setMessageTableName("MESSAGES");
+      dbStorageConfiguration.setJdbcDriverClassName("org.apache.derby.jdbc.EmbeddedDriver");
 
       configuration.setStoreConfiguration(dbStorageConfiguration);
 

--- a/artemis-server/src/test/resources/database-store-config.xml
+++ b/artemis-server/src/test/resources/database-store-config.xml
@@ -24,6 +24,7 @@
             <jdbc-connection-url>jdbc:derby:target/derby/database-store;create=true</jdbc-connection-url>
             <bindings-table-name>BINDINGS_TABLE</bindings-table-name>
             <message-table-name>MESSAGE_TABLE</message-table-name>
+            <jdbc-driver-class-name>org.apache.derby.jdbc.EmbeddedDriver</jdbc-driver-class-name>
          </database-store>
       </store>
    </core>

--- a/docs/user-manual/en/persistence.md
+++ b/docs/user-manual/en/persistence.md
@@ -376,6 +376,7 @@ To configure Apache ActiveMQ Artemis to use a database for persisting messages a
             <jdbc-connection-url>jdbc:derby:target/derby/database-store;create=true</jdbc-connection-url>
             <bindings-table-name>BINDINGS_TABLE</bindings-table-name>
             <message-table-name>MESSAGE_TABLE</message-table-name>
+            <jdbc-driver-class-name>org.apache.derby.jdbc.EmbeddedDriver</jdbc-driver-class-name>
          </database-store>
       </store>
 ```
@@ -391,6 +392,11 @@ To configure Apache ActiveMQ Artemis to use a database for persisting messages a
 -   `message-table-name`
 
     The name of the table in which messages and related data will be persisted for the ActiveMQ Artemis server.  Specifying table names allows users to share single database amongst multiple servers, without interference.
+
+-   `jdbc-driver-class-name`
+
+    The fully qualified class name of the desired database Driver.
+
 
 ## Configuring Apache ActiveMQ Artemis for Zero Persistence
 

--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,7 @@
             <groupId>org.apache.derby</groupId>
             <artifactId>derby</artifactId>
             <version>${apache.derby.version}</version>
+            <scope>test</scope>
          </dependency>
          <dependency>
             <groupId>org.eclipse.paho</groupId>

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jdbc/store/journal/JDBCJournalTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jdbc/store/journal/JDBCJournalTest.java
@@ -18,7 +18,6 @@ package org.apache.activemq.artemis.tests.integration.jdbc.store.journal;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -41,16 +40,16 @@ public class JDBCJournalTest {
 
    private static final String JOURNAL_TABLE_NAME = "MESSAGE_JOURNAL";
 
+   private static final String DRIVER_CLASS = "org.apache.derby.jdbc.EmbeddedDriver";
+
    private JDBCJournalImpl journal;
 
    private String jdbcUrl;
 
-   private Properties jdbcConnectionProperties;
-
    @Before
    public void setup() throws Exception {
       jdbcUrl = "jdbc:derby:target/data;create=true";
-      journal = new JDBCJournalImpl(jdbcUrl, JOURNAL_TABLE_NAME);
+      journal = new JDBCJournalImpl(jdbcUrl, JOURNAL_TABLE_NAME, DRIVER_CLASS);
       journal.start();
    }
 


### PR DESCRIPTION
This patch allows users to configure the Driver class that the JDBC
store and journal uses and removes Derby as a default.