### PR TITLE
ARTEMIS-416 - Netty Acceptor allows transfer of connections when paused

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptor.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptor.java
@@ -426,6 +426,9 @@ public class NettyAcceptor extends AbstractAcceptor {
     * @param channel A Netty channel created outside this NettyAcceptor.
     */
    public void transfer(Channel channel) {
+      if (paused || eventLoopGroup == null) {
+         throw ActiveMQMessageBundle.BUNDLE.acceptorUnavailable();
+      }
       channel.pipeline().addLast(protocolHandler.getProtocolDecoder());
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQMessageBundle.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQMessageBundle.java
@@ -365,4 +365,7 @@ public interface ActiveMQMessageBundle {
 
    @Message(id = 119115, value = "Colocated Policy hasn't different type live and backup", format = Message.Format.MESSAGE_FORMAT)
    ActiveMQIllegalStateException liveBackupMismatch();
+
+   @Message(id = 119116, value = "Netty Acceptor unavailable", format = Message.Format.MESSAGE_FORMAT)
+   IllegalStateException acceptorUnavailable();
 }


### PR DESCRIPTION
Throw an exception if the acceptor is paused or not started

https://issues.apache.org/jira/browse/ARTEMIS-416