### PR TITLE
ARTEMIS-350 fix for potential race

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalStorageManager.java
@@ -584,7 +584,12 @@ public class JournalStorageManager extends AbstractJournalStorageManager {
          SequentialFile seqFile = largeMessagesFactory.createSequentialFile(fileName);
          if (!seqFile.exists())
             continue;
-         replicator.syncLargeMessageFile(seqFile, size, id);
+         if (replicator != null) {
+            replicator.syncLargeMessageFile(seqFile, size, id);
+         }
+         else {
+            throw ActiveMQMessageBundle.BUNDLE.replicatorIsNull();
+         }
       }
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQMessageBundle.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQMessageBundle.java
@@ -368,4 +368,7 @@ public interface ActiveMQMessageBundle {
 
    @Message(id = 119116, value = "Netty Acceptor unavailable", format = Message.Format.MESSAGE_FORMAT)
    IllegalStateException acceptorUnavailable();
+
+   @Message(id = 119117, value = "Replicator is null. Replication was likely terminated.")
+   ActiveMQIllegalStateException replicatorIsNull();
 }


### PR DESCRIPTION
It's possible for the latch used for flow control here to get out of sync. In
other words, multiple count-downs can occur between count-ups so that the latch
always has a count > 0. When this situation arises then every single packet
sent to the replica is delayed by 5 seconds.

The solution here essentially is to eliminate the latch completely and use a
condition/wait/notify pattern.