### PR TITLE
ARTEMIS-385 clean-up factory on timeout

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorImpl.java
@@ -809,6 +809,9 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       // how the sendSubscription happens.
       // in case this ever changes.
       if (topology != null && !factory.waitForTopology(callTimeout, TimeUnit.MILLISECONDS)) {
+         if (factory != null) {
+            factory.cleanup();
+         }
          throw ActiveMQClientMessageBundle.BUNDLE.connectionTimedOutOnReceiveTopology(discoveryGroup);
       }
 


### PR DESCRIPTION
This restores a call to ClientSessionFactory#cleanup that appears to have been
mistakenly removed by a previous change related to this JIRA.