### PR TITLE
Put parameters into query string in a predictable order

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/uri/URISupport.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/uri/URISupport.java
@@ -463,7 +463,7 @@ public class URISupport {
 
    /**
     * Given a key / value mapping, create and return a URI formatted query string that is valid and
-    * can be appended to a URI.
+    * can be appended to a URI. Query parameters in the string are sorted by key.
     *
     * @param options The Mapping that will create the new Query string.
     * @return a URI formatted query string.
@@ -472,9 +472,12 @@ public class URISupport {
    public static String createQueryString(Map<String, ? extends Object> options) throws URISyntaxException {
       try {
          if (options.size() > 0) {
-            StringBuffer rc = new StringBuffer();
+            StringBuilder rc = new StringBuilder();
             boolean first = true;
-            for (String key : options.keySet()) {
+            List<String> keys = new ArrayList<String>();
+            keys.addAll(options.keySet());
+            Collections.sort(keys);
+            for (String key : keys) {
                if (first) {
                   first = false;
                }

--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/URIParserTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/URIParserTest.java
@@ -114,12 +114,12 @@ public class URIParserTest {
       System.out.println("queryString2: " + queryString);
       Assert.assertEquals("key1=value1", queryString);
 
-      query.put("key2", "value2");
+      query.put("key3", "value3");
       queryString = URISupport.createQueryString(query);
       System.out.println("queryString3: " + queryString);
-      Assert.assertEquals("key1=value1&key2=value2", queryString);
+      Assert.assertEquals("key1=value1&key3=value3", queryString);
 
-      query.put("key3", "value3");
+      query.put("key2", "value2");
       queryString = URISupport.createQueryString(query);
       System.out.println("queryString4: " + queryString);
       Assert.assertEquals("key1=value1&key2=value2&key3=value3", queryString);


### PR DESCRIPTION
Previously, the order of query parameters depended on the iteration order of items in a Set.
This order is undefined for some Sets. Nevertheless, unit test for createQueryString expected
that query parameters are in a particular order.

I have indeed seen a build fail because of it from time to time, for example in this build of revision ab98eb9620bb5e53abf223e622fac2919b2808a7 from two weeks ago

```
queryString1: 
queryString2: key1=value1
queryString3: key2=value2&key1=value1
Tests run: 5, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.508 sec <<< FAILURE! - in org.apache.activemq.artemis.utils.URIParserTest
testQueryConversion(org.apache.activemq.artemis.utils.URIParserTest)  Time elapsed: 0.023 sec  <<< FAILURE!
org.junit.ComparisonFailure: expected:<key[1=value1&key2=value2]> but was:<key[2=value2&key1=value1]>
	at org.junit.Assert.assertEquals(Assert.java:115)
	at org.junit.Assert.assertEquals(Assert.java:144)
	at org.apache.activemq.artemis.utils.URIParserTest.testQueryConversion(URIParserTest.java:120)


Results :

Failed tests: 
  URIParserTest.testQueryConversion:120 expected:<key[1=value1&key2=value2]> but was:<key[2=value2&key1=value1]>
```