### PR TITLE
ARTEMIS-465 Create LM on write packet in ReplicationEndpoint

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalStorageManager.java
@@ -434,6 +434,10 @@ public class JournalStorageManager extends AbstractJournalStorageManager {
 
          LargeServerMessageImpl largeMessage = (LargeServerMessageImpl) createLargeMessage();
 
+         // We do this here to avoid a case where the replication gets a list without this file
+         // to avoid a race
+         largeMessage.validateFile();
+
          largeMessage.copyHeadersAndProperties(message);
 
          largeMessage.setMessageID(id);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/LargeServerMessageImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/LargeServerMessageImpl.java
@@ -341,7 +341,7 @@ public final class LargeServerMessageImpl extends ServerMessageImpl implements L
 
    // Private -------------------------------------------------------
 
-   private synchronized void validateFile() throws ActiveMQException {
+   public synchronized void validateFile() throws ActiveMQException {
       try {
          if (file == null) {
             if (messageID <= 0) {


### PR DESCRIPTION
If a LM write packet is received from the live assume that the large
message exists and create a local reference.

Old behavour would reject the packet which could lead to loss of data on
failover see JIRA.