### PR TITLE
ARTEMIS-466 Fix java-opts handling in maven-cli

### DIFF
--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis
@@ -105,7 +105,8 @@ if $cygwin ; then
   CLASSPATH=`cygpath --windows "$CLASSPATH"`
 fi
 
-exec "$JAVACMD" $JAVA_ARGS \
+exec "$JAVACMD" ${java-opts} \
+    $JAVA_ARGS \
     -Xbootclasspath/a:"$ARTEMIS_HOME/lib/${logmanager}" \
     -Djava.security.auth.login.config="$ARTEMIS_INSTANCE/etc/login.config" \
     $ARTEMIS_CLUSTER_PROPS \


### PR DESCRIPTION
Previously, java-opts (--java-options argument on the command line)
were not passed on to Artemis broker. This broke the client-kickoff
example, which relies on this to configure JMX.