### PR TITLE
ARTEMIS-488 Fix OpenWire Test (Temp Queue removal and others)

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQSession.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQSession.java
@@ -16,6 +16,7 @@
  */
 package org.apache.activemq.artemis.core.protocol.openwire.amq;
 
+import javax.jms.InvalidDestinationException;
 import javax.jms.ResourceAllocationException;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
@@ -24,6 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.paging.PagingStore;
+import org.apache.activemq.artemis.core.postoffice.RoutingStatus;
 import org.apache.activemq.artemis.core.protocol.openwire.OpenWireConnection;
 import org.apache.activemq.artemis.core.protocol.openwire.OpenWireMessageConverter;
 import org.apache.activemq.artemis.core.protocol.openwire.util.OpenWireUtil;
@@ -361,7 +363,11 @@ public class AMQSession implements SessionCallback {
             connection.getTransportConnection().setAutoRead(false);
          }
 
-         getCoreSession().send(coreMsg, false);
+         RoutingStatus result = getCoreSession().send(coreMsg, false, actualDestinations[i].isTemporary());
+
+         if (result == RoutingStatus.NO_BINDINGS && actualDestinations[i].isQueue()) {
+            throw new InvalidDestinationException("Cannot publish to a non-existent Destination: " + actualDestinations[i]);
+         }
 
          if (runToUse != null) {
             // if the timeout is >0, it will wait this much milliseconds

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/PostOffice.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/PostOffice.java
@@ -68,26 +68,26 @@ public interface PostOffice extends ActiveMQComponent {
 
    Map<SimpleString, Binding> getAllBindings();
 
-   void route(ServerMessage message, QueueCreator queueCreator, boolean direct) throws Exception;
+   RoutingStatus route(ServerMessage message, QueueCreator queueCreator, boolean direct) throws Exception;
 
-   void route(ServerMessage message, QueueCreator queueCreator, Transaction tx, boolean direct) throws Exception;
+   RoutingStatus route(ServerMessage message, QueueCreator queueCreator, Transaction tx, boolean direct) throws Exception;
 
-   void route(ServerMessage message,
+   RoutingStatus route(ServerMessage message,
               QueueCreator queueCreator,
               Transaction tx,
               boolean direct,
               boolean rejectDuplicates) throws Exception;
 
-   void route(ServerMessage message,
-              QueueCreator queueCreator,
-              RoutingContext context,
-              boolean direct) throws Exception;
+   RoutingStatus route(ServerMessage message,
+                    QueueCreator queueCreator,
+                    RoutingContext context,
+                    boolean direct) throws Exception;
 
-   void route(ServerMessage message,
-              QueueCreator queueCreator,
-              RoutingContext context,
-              boolean direct,
-              boolean rejectDuplicates) throws Exception;
+   RoutingStatus route(ServerMessage message,
+                    QueueCreator queueCreator,
+                    RoutingContext context,
+                    boolean direct,
+                    boolean rejectDuplicates) throws Exception;
 
    MessageReference reroute(ServerMessage message, Queue queue, Transaction tx) throws Exception;
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/RoutingStatus.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/RoutingStatus.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.postoffice;
+
+/**
+ * Used to indicate the result of a server send
+ */
+public enum RoutingStatus {
+   OK,
+   NO_BINDINGS,
+   NO_BINDINGS_DLA,
+   DUPLICATED_ID;
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -55,6 +55,7 @@ import org.apache.activemq.artemis.core.postoffice.BindingsFactory;
 import org.apache.activemq.artemis.core.postoffice.DuplicateIDCache;
 import org.apache.activemq.artemis.core.postoffice.PostOffice;
 import org.apache.activemq.artemis.core.postoffice.QueueInfo;
+import org.apache.activemq.artemis.core.postoffice.RoutingStatus;
 import org.apache.activemq.artemis.core.server.ActiveMQMessageBundle;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
@@ -570,41 +571,42 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
    }
 
    @Override
-   public void route(final ServerMessage message, QueueCreator queueCreator, final boolean direct) throws Exception {
-      route(message, queueCreator, (Transaction) null, direct);
+   public RoutingStatus route(final ServerMessage message, QueueCreator queueCreator, final boolean direct) throws Exception {
+      return route(message, queueCreator, (Transaction) null, direct);
    }
 
    @Override
-   public void route(final ServerMessage message,
+   public RoutingStatus route(final ServerMessage message,
                      QueueCreator queueCreator,
                      final Transaction tx,
                      final boolean direct) throws Exception {
-      route(message, queueCreator, new RoutingContextImpl(tx), direct);
+      return route(message, queueCreator, new RoutingContextImpl(tx), direct);
    }
 
    @Override
-   public void route(final ServerMessage message,
+   public RoutingStatus route(final ServerMessage message,
                      final QueueCreator queueCreator,
                      final Transaction tx,
                      final boolean direct,
                      final boolean rejectDuplicates) throws Exception {
-      route(message, queueCreator, new RoutingContextImpl(tx), direct, rejectDuplicates);
+      return route(message, queueCreator, new RoutingContextImpl(tx), direct, rejectDuplicates);
    }
 
    @Override
-   public void route(final ServerMessage message,
-                     final QueueCreator queueCreator,
-                     final RoutingContext context,
-                     final boolean direct) throws Exception {
-      route(message, queueCreator, context, direct, true);
+   public RoutingStatus route(final ServerMessage message,
+                           final QueueCreator queueCreator,
+                           final RoutingContext context,
+                           final boolean direct) throws Exception {
+      return route(message, queueCreator, context, direct, true);
    }
 
    @Override
-   public void route(final ServerMessage message,
-                     final QueueCreator queueCreator,
-                     final RoutingContext context,
-                     final boolean direct,
-                     boolean rejectDuplicates) throws Exception {
+   public RoutingStatus route(final ServerMessage message,
+                              final QueueCreator queueCreator,
+                              final RoutingContext context,
+                              final boolean direct,
+                              boolean rejectDuplicates) throws Exception {
+      RoutingStatus result = RoutingStatus.OK;
       // Sanity check
       if (message.getRefCount() > 0) {
          throw new IllegalStateException("Message cannot be routed more than once");
@@ -619,7 +621,7 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
       applyExpiryDelay(message, address);
 
       if (!checkDuplicateID(message, context, rejectDuplicates, startedTX)) {
-         return;
+         return RoutingStatus.DUPLICATED_ID;
       }
 
       if (message.hasInternalProperties()) {
@@ -671,6 +673,7 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
             }
 
             if (dlaAddress == null) {
+               result = RoutingStatus.NO_BINDINGS;
                ActiveMQServerLogger.LOGGER.noDLA(address);
             }
             else {
@@ -679,9 +682,12 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
                message.setAddress(dlaAddress);
 
                route(message, null, context.getTransaction(), false);
+               result = RoutingStatus.NO_BINDINGS_DLA;
             }
          }
          else {
+            result = RoutingStatus.NO_BINDINGS;
+
             if (ActiveMQServerLogger.LOGGER.isDebugEnabled()) {
                ActiveMQServerLogger.LOGGER.debug("Message " + message + " is not going anywhere as it didn't have a binding on address:" + address);
             }
@@ -709,6 +715,7 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
       if (startedTX.get()) {
          context.getTransaction().commit();
       }
+      return result;
    }
 
    // HORNETQ-1029

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ServerSession.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ServerSession.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.message.impl.MessageInternal;
 import org.apache.activemq.artemis.core.persistence.OperationContext;
+import org.apache.activemq.artemis.core.postoffice.RoutingStatus;
 import org.apache.activemq.artemis.core.security.SecurityAuth;
 import org.apache.activemq.artemis.core.transaction.Transaction;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
@@ -132,7 +133,9 @@ public interface ServerSession extends SecurityAuth {
 
    void sendContinuations(int packetSize, long totalBodySize, byte[] body, boolean continues) throws Exception;
 
-   void send(ServerMessage message, boolean direct) throws Exception;
+   RoutingStatus send(ServerMessage message, boolean direct, boolean noAutoCreateQueue) throws Exception;
+
+   RoutingStatus send(ServerMessage message, boolean direct) throws Exception;
 
    void sendLarge(MessageInternal msg) throws Exception;
 

--- a/tests/activemq5-unit-tests/pom.xml
+++ b/tests/activemq5-unit-tests/pom.xml
@@ -315,6 +315,19 @@
          <artifactId>artemis-openwire-protocol</artifactId>
          <version>${project.version}</version>
       </dependency>
+
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-stomp-protocol</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-stomp-protocol</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+
       <dependency>
          <groupId>org.jboss.byteman</groupId>
          <artifactId>byteman</artifactId>
@@ -424,6 +437,11 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
                <skipTests>${skipActiveMQ5Tests}</skipTests>
+<!--
+               <additionalClasspathElements>
+                  <additionalClasspathElement>src/main/resources/stomp</additionalClasspathElement>
+               </additionalClasspathElements>
+-->
                <includes>
                   <!-- included packages -->
                   <include>**/org/apache/activemq/*Test.java</include>

--- a/tests/activemq5-unit-tests/src/main/java/org/apache/activemq/broker/SslBrokerService.java
+++ b/tests/activemq5-unit-tests/src/main/java/org/apache/activemq/broker/SslBrokerService.java
@@ -56,11 +56,4 @@ public class SslBrokerService extends BrokerService {
                                                       SecureRandom random) throws IOException, KeyManagementException {
       return null;
    }
-
-   //one way
-   public void setupSsl(String keystoreType, String password, String serverKeystore) {
-      this.SERVER_SIDE_KEYSTORE = serverKeystore;
-      this.KEYSTORE_PASSWORD = password;
-      this.storeType = keystoreType;
-   }
 }

--- a/tests/activemq5-unit-tests/src/main/java/org/apache/activemq/broker/artemiswrapper/ArtemisBrokerWrapper.java
+++ b/tests/activemq5-unit-tests/src/main/java/org/apache/activemq/broker/artemiswrapper/ArtemisBrokerWrapper.java
@@ -90,11 +90,7 @@ public class ArtemisBrokerWrapper extends ArtemisBrokerBase {
       commonSettings.setAutoCreateJmsQueues(true);
 
       if (bservice.extraConnectors.size() == 0) {
-         serverConfig.addAcceptorConfiguration("home", "tcp://localhost:61616?protocols=OPENWIRE,CORE");
-      }
-      if (this.bservice.enableSsl()) {
-         //default
-         addServerAcceptor(serverConfig, new BrokerService.ConnectorInfo(61611, true));
+         serverConfig.addAcceptorConfiguration("home", "tcp://localhost:61616");
       }
 
       for (BrokerService.ConnectorInfo info : bservice.extraConnectors) {

--- a/tests/activemq5-unit-tests/src/main/java/org/apache/activemq/transport/tcp/TcpTransportFactory.java
+++ b/tests/activemq5-unit-tests/src/main/java/org/apache/activemq/transport/tcp/TcpTransportFactory.java
@@ -78,6 +78,7 @@ public class TcpTransportFactory extends TransportFactory {
       params.remove("broker.useJmx");
       params.remove("marshal");
       params.remove("create");
+      params.remove("asyncQueueDepth");
       URI location2 = URISupport.createRemainingURI(location, params);
       return super.doConnect(location2);
    }

--- a/tests/activemq5-unit-tests/src/main/resources/META-INF/services/org.apache.activemq.artemis.spi.core.protocol.ProtocolManagerFactory
+++ b/tests/activemq5-unit-tests/src/main/resources/META-INF/services/org.apache.activemq.artemis.spi.core.protocol.ProtocolManagerFactory
@@ -1,2 +1,0 @@
-org.apache.activemq.artemis.core.protocol.openwire.OpenWireProtocolManagerFactory
-

--- a/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/ActiveMQSslConnectionFactoryTest.java
+++ b/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/ActiveMQSslConnectionFactoryTest.java
@@ -204,7 +204,7 @@ public class ActiveMQSslConnectionFactoryTest extends CombinationTestSupport {
       SslBrokerService service = new SslBrokerService();
       service.setPersistent(false);
 
-      service.setupSsl(KEYSTORE_TYPE, PASSWORD, SERVER_KEYSTORE);
+      service.addConnector(uri);
 
       service.start();
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/impl/fakes/FakePostOffice.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/impl/fakes/FakePostOffice.java
@@ -26,6 +26,7 @@ import org.apache.activemq.artemis.core.postoffice.Binding;
 import org.apache.activemq.artemis.core.postoffice.Bindings;
 import org.apache.activemq.artemis.core.postoffice.DuplicateIDCache;
 import org.apache.activemq.artemis.core.postoffice.PostOffice;
+import org.apache.activemq.artemis.core.postoffice.RoutingStatus;
 import org.apache.activemq.artemis.core.postoffice.impl.DuplicateIDCacheImpl;
 import org.apache.activemq.artemis.core.server.MessageReference;
 import org.apache.activemq.artemis.core.server.Queue;
@@ -138,34 +139,36 @@ public class FakePostOffice implements PostOffice {
    }
 
    @Override
-   public void route(ServerMessage message,
-                     QueueCreator creator,
-                     RoutingContext context,
-                     boolean direct) throws Exception {
+   public RoutingStatus route(ServerMessage message,
+                              QueueCreator creator,
+                              RoutingContext context,
+                              boolean direct) throws Exception {
+      return RoutingStatus.OK;
 
    }
 
    @Override
-   public void route(ServerMessage message, QueueCreator creator, Transaction tx, boolean direct) throws Exception {
+   public RoutingStatus route(ServerMessage message, QueueCreator creator, Transaction tx, boolean direct) throws Exception {
+      return RoutingStatus.OK;
+   }
+
+   @Override
+   public RoutingStatus route(ServerMessage message,
+                           QueueCreator creator,
+                           RoutingContext context,
+                           boolean direct,
+                           boolean rejectDuplicates) throws Exception {
+      return RoutingStatus.OK;
 
    }
 
    @Override
-   public void route(ServerMessage message,
-                     QueueCreator creator,
-                     RoutingContext context,
-                     boolean direct,
-                     boolean rejectDuplicates) throws Exception {
-
-   }
-
-   @Override
-   public void route(ServerMessage message,
+   public RoutingStatus route(ServerMessage message,
                      QueueCreator creator,
                      Transaction tx,
                      boolean direct,
                      boolean rejectDuplicates) throws Exception {
-
+      return RoutingStatus.OK;
    }
 
    @Override
@@ -173,7 +176,7 @@ public class FakePostOffice implements PostOffice {
    }
 
    @Override
-   public void route(ServerMessage message, QueueCreator queueCreator, boolean direct) throws Exception {
-
+   public RoutingStatus route(ServerMessage message, QueueCreator queueCreator, boolean direct) throws Exception {
+      return RoutingStatus.OK;
    }
 }


### PR DESCRIPTION
Temp Queue not deleted when connection is closed.
Enable Stomp in openwire test because some test uses it.
Remove unused code in opwnwire
Wrong XA error code returned when xid is missing
(ActiveMQXAConnectionFactory.testRollbackXaErrorCode)
regression in ActiveMQSslConnectionFactoryTest (SSL related)