### PR TITLE
ARTEMIS-504 Inconsistent time unit on scheduling slow consumer reaper…

### DIFF
--- a/docs/user-manual/en/queue-attributes.md
+++ b/docs/user-manual/en/queue-attributes.md
@@ -169,7 +169,7 @@ application could receive and take action with. See [slow consumers](slow-consum
 on this notification.
 
 `slow-consumer-check-period`. How often to check for slow consumers on a
-particular queue. Measured in minutes. Default is 5. See [slow consumers](slow-consumers.md)
+particular queue. Measured in seconds. Default is 5. See [slow consumers](slow-consumers.md)
 for more information about slow consumer detection.
 
 `auto-create-jms-queues`. Whether or not the broker should automatically


### PR DESCRIPTION
… thread between documentation and source code

slow-consumer-check-period represents seconds between slow consumer reaper thread execution, fixed documentation to reflect this

Related Artemis Jira : https://issues.apache.org/jira/browse/ARTEMIS-504