### PR TITLE
ARTEMIS-505 Fix OptimizedAckTest and testCloseConsumer

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQConsumer.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQConsumer.java
@@ -167,6 +167,10 @@ public class AMQConsumer {
    }
 
    public void acquireCredit(int n) throws Exception {
+      if (messagePullHandler != null) {
+         //don't acquire any credits when the pull handler controls it!!
+         return;
+      }
       int oldwindow = currentWindow.getAndAdd(n);
 
       boolean promptDelivery = oldwindow < prefetchSize;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerConsumerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerConsumerImpl.java
@@ -65,7 +65,6 @@ import org.apache.activemq.artemis.utils.TypedProperties;
  * Concrete implementation of a ClientConsumer.
  */
 public class ServerConsumerImpl implements ServerConsumer, ReadyListener {
-   //private static final DebugLogger logger = DebugLogger.getLogger("redelivery.log");
    // Constants ------------------------------------------------------------------------------------
 
    private static boolean isTrace = ActiveMQServerLogger.LOGGER.isTraceEnabled();

--- a/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/transport/failover/InitalReconnectDelayTest.java
+++ b/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/transport/failover/InitalReconnectDelayTest.java
@@ -47,9 +47,6 @@ public class InitalReconnectDelayTest extends OpenwireArtemisBaseTest {
    protected EmbeddedJMS server1;
    protected EmbeddedJMS server2;
 
-//   protected BrokerService broker1;
-//   protected BrokerService broker2;
-
    @Test
    public void testInitialReconnectDelay() throws Exception {
 
@@ -82,6 +79,7 @@ public class InitalReconnectDelayTest extends OpenwireArtemisBaseTest {
       //Inital reconnection should kick in and be darned close to what we expected
       LOG.info("Failover took " + (end - start) + " ms.");
       assertTrue("Failover took " + (end - start) + " ms and should be > 14000.", (end - start) > 14000);
+      connection.close();
    }
 
    @Test


### PR DESCRIPTION
OptimizedAckTest: Using core api to replace old activemq
broker API to checking message count.
JmsQueueTransactionTest#testCloseConsumer: a bug in
delivery when prefetchSize is 0.
(InitalReconnectDelayTest)close connection after test.