### PR TITLE
[ARTEMIS-397] Change mqtt connection ttl to be keepalive * 1500 from 750

### DIFF
--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTProtocolHandler.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTProtocolHandler.java
@@ -156,7 +156,7 @@ public class MQTTProtocolHandler extends ChannelInboundHandlerAdapter {
     */
    void handleConnect(MqttConnectMessage connect, ChannelHandlerContext ctx) throws Exception {
       this.ctx = ctx;
-      connectionEntry.ttl = connect.variableHeader().keepAliveTimeSeconds() * 750;
+      connectionEntry.ttl = connect.variableHeader().keepAliveTimeSeconds() * 1500;
 
       String clientId = connect.payload().clientIdentifier();
       session.getConnectionManager().connect(clientId, connect.payload().userName(), connect.payload().password(), connect.variableHeader().isWillFlag(), connect.payload().willMessage(), connect.payload().willTopic(), connect.variableHeader().isWillRetain(), connect.variableHeader().willQos(), connect.variableHeader().isCleanSession());


### PR DESCRIPTION
Fixes: ARTEMIS-397

From mqtt specs:

“If the Keep Alive value is non-zero and the Server does not receive a
Control Packet from the Client within one and a half times the Keep
Alive time period, it MUST disconnect the Network Connection to the
Client as if the network had failed [MQTT-3.1.2-24]. “