### PR TITLE
ARTEMIS-551 Obfuscate truststore password

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/TransportConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/TransportConfiguration.java
@@ -257,7 +257,7 @@ public class TransportConfiguration implements Serializable {
 
             // HORNETQ-1281 - don't log passwords
             String val;
-            if (key.equals(TransportConstants.KEYSTORE_PASSWORD_PROP_NAME) || key.equals(TransportConstants.DEFAULT_TRUSTSTORE_PASSWORD)) {
+            if (key.equals(TransportConstants.KEYSTORE_PASSWORD_PROP_NAME) || key.equals(TransportConstants.TRUSTSTORE_PASSWORD_PROP_NAME)) {
                val = "****";
             }
             else {

--- a/artemis-core-client/src/test/java/org/apache/activemq/artemis/api/core/TransportConfigurationTest.java
+++ b/artemis-core-client/src/test/java/org/apache/activemq/artemis/api/core/TransportConfigurationTest.java
@@ -19,8 +19,12 @@ package org.apache.activemq.artemis.api.core;
 
 import java.util.HashMap;
 
+import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
 
 public class TransportConfigurationTest {
 
@@ -61,4 +65,16 @@ public class TransportConfigurationTest {
       Assert.assertNotEquals(configuration.hashCode(), configuration2.hashCode());
 
    }
+
+   @Test
+   public void testToStringObfuscatesPasswords() {
+      HashMap<String, Object> params = new HashMap<>();
+      params.put(TransportConstants.TRUSTSTORE_PASSWORD_PROP_NAME, "secret_password");
+      params.put(TransportConstants.KEYSTORE_PASSWORD_PROP_NAME, "secret_password");
+
+      TransportConfiguration configuration = new TransportConfiguration("SomeClass", params, null);
+
+      Assert.assertThat(configuration.toString(), not(containsString("secret_password")));
+   }
+
 }


### PR DESCRIPTION
Obfuscate truststore password in TransportConfiguration.toString() in the same way as keystore. The password will not be logged in plain text when bridge is connected.