### PR TITLE
ARTEMIS-322 auto-create/delete JMS topic

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/client/ClientSession.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/client/ClientSession.java
@@ -64,6 +64,12 @@ public interface ClientSession extends XAResource, AutoCloseable {
        * queue, <code>false</code> else.
        */
       boolean isAutoCreateJmsQueues();
+
+      /**
+       * Returns <code>true</code> if auto-creation for this address is enabled and if the address queried is for a JMS
+       * topic, <code>false</code> else.
+       */
+      boolean isAutoCreateJmsTopics();
    }
 
    /**

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
@@ -656,7 +656,9 @@ public interface ActiveMQServerControl {
                            @Parameter(desc = "how often (in seconds) to check for slow consumers", name = "slowConsumerCheckPeriod") long slowConsumerCheckPeriod,
                            @Parameter(desc = "the policy to use when a slow consumer is detected", name = "slowConsumerPolicy") String slowConsumerPolicy,
                            @Parameter(desc = "allow queues to be created automatically", name = "autoCreateJmsQueues") boolean autoCreateJmsQueues,
-                           @Parameter(desc = "allow auto-created queues to be deleted automatically", name = "autoDeleteJmsQueues") boolean autoDeleteJmsQueues) throws Exception;
+                           @Parameter(desc = "allow auto-created queues to be deleted automatically", name = "autoDeleteJmsQueues") boolean autoDeleteJmsQueues,
+                           @Parameter(desc = "allow topics to be created automatically", name = "autoCreateJmsTopics")  boolean autoCreateJmsTopics,
+                           @Parameter(desc = "allow auto-created topics to be deleted automatically", name = "autoDeleteJmsTopics") boolean autoDeleteJmsTopics) throws Exception;
 
    void removeAddressSettings(String addressMatch) throws Exception;
 

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/AddressSettingsInfo.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/AddressSettingsInfo.java
@@ -57,11 +57,15 @@ public final class AddressSettingsInfo {
 
    private final boolean autoDeleteJmsQueues;
 
+   private final boolean autoCreateJmsTopics;
+
+   private final boolean autoDeleteJmsTopics;
+
    // Static --------------------------------------------------------
 
    public static AddressSettingsInfo from(final String jsonString) throws Exception {
       JSONObject object = new JSONObject(jsonString);
-      return new AddressSettingsInfo(object.getString("addressFullMessagePolicy"), object.getLong("maxSizeBytes"), object.getInt("pageSizeBytes"), object.getInt("pageCacheMaxSize"), object.getInt("maxDeliveryAttempts"), object.getLong("redeliveryDelay"), object.getDouble("redeliveryMultiplier"), object.getLong("maxRedeliveryDelay"), object.getString("DLA"), object.getString("expiryAddress"), object.getBoolean("lastValueQueue"), object.getLong("redistributionDelay"), object.getBoolean("sendToDLAOnNoRoute"), object.getLong("slowConsumerThreshold"), object.getLong("slowConsumerCheckPeriod"), object.getString("slowConsumerPolicy"), object.getBoolean("autoCreateJmsQueues"), object.getBoolean("autoDeleteJmsQueues"));
+      return new AddressSettingsInfo(object.getString("addressFullMessagePolicy"), object.getLong("maxSizeBytes"), object.getInt("pageSizeBytes"), object.getInt("pageCacheMaxSize"), object.getInt("maxDeliveryAttempts"), object.getLong("redeliveryDelay"), object.getDouble("redeliveryMultiplier"), object.getLong("maxRedeliveryDelay"), object.getString("DLA"), object.getString("expiryAddress"), object.getBoolean("lastValueQueue"), object.getLong("redistributionDelay"), object.getBoolean("sendToDLAOnNoRoute"), object.getLong("slowConsumerThreshold"), object.getLong("slowConsumerCheckPeriod"), object.getString("slowConsumerPolicy"), object.getBoolean("autoCreateJmsQueues"), object.getBoolean("autoDeleteJmsQueues"), object.getBoolean("autoCreateJmsTopics"), object.getBoolean("autoDeleteJmsTopics"));
    }
 
    // Constructors --------------------------------------------------
@@ -83,7 +87,9 @@ public final class AddressSettingsInfo {
                               long slowConsumerCheckPeriod,
                               String slowConsumerPolicy,
                               boolean autoCreateJmsQueues,
-                              boolean autoDeleteJmsQueues) {
+                              boolean autoDeleteJmsQueues,
+                              boolean autoCreateJmsTopics,
+                              boolean autoDeleteJmsTopics) {
       this.addressFullMessagePolicy = addressFullMessagePolicy;
       this.maxSizeBytes = maxSizeBytes;
       this.pageSizeBytes = pageSizeBytes;
@@ -102,6 +108,8 @@ public final class AddressSettingsInfo {
       this.slowConsumerPolicy = slowConsumerPolicy;
       this.autoCreateJmsQueues = autoCreateJmsQueues;
       this.autoDeleteJmsQueues = autoDeleteJmsQueues;
+      this.autoCreateJmsTopics = autoCreateJmsTopics;
+      this.autoDeleteJmsTopics = autoDeleteJmsTopics;
    }
 
    // Public --------------------------------------------------------
@@ -180,6 +188,14 @@ public final class AddressSettingsInfo {
 
    public boolean isAutoDeleteJmsQueues() {
       return autoDeleteJmsQueues;
+   }
+
+   public boolean isAutoCreateJmsTopics() {
+      return autoCreateJmsTopics;
+   }
+
+   public boolean isAutoDeleteJmsTopics() {
+      return autoDeleteJmsTopics;
    }
 }
 

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/AddressQueryImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/AddressQueryImpl.java
@@ -30,12 +30,16 @@ public class AddressQueryImpl implements ClientSession.AddressQuery {
 
    private final boolean autoCreateJmsQueues;
 
+   private final boolean autoCreateJmsTopics;
+
    public AddressQueryImpl(final boolean exists,
                            final List<SimpleString> queueNames,
-                           final boolean autoCreateJmsQueues) {
+                           final boolean autoCreateJmsQueues,
+                           final boolean autoCreateJmsTopics) {
       this.exists = exists;
       this.queueNames = new ArrayList<>(queueNames);
       this.autoCreateJmsQueues = autoCreateJmsQueues;
+      this.autoCreateJmsTopics = autoCreateJmsTopics;
    }
 
    @Override
@@ -51,5 +55,10 @@ public class AddressQueryImpl implements ClientSession.AddressQuery {
    @Override
    public boolean isAutoCreateJmsQueues() {
       return autoCreateJmsQueues;
+   }
+
+   @Override
+   public boolean isAutoCreateJmsTopics() {
+      return autoCreateJmsTopics;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ActiveMQSessionContext.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ActiveMQSessionContext.java
@@ -49,18 +49,18 @@ import org.apache.activemq.artemis.core.protocol.core.ChannelHandler;
 import org.apache.activemq.artemis.core.protocol.core.CommandConfirmationHandler;
 import org.apache.activemq.artemis.core.protocol.core.CoreRemotingConnection;
 import org.apache.activemq.artemis.core.protocol.core.Packet;
+import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.ActiveMQExceptionMessage;
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.CreateQueueMessage;
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.CreateSessionMessage;
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.CreateSharedQueueMessage;
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.DisconnectConsumerMessage;
-import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.ActiveMQExceptionMessage;
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.ReattachSessionMessage;
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.ReattachSessionResponseMessage;
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.RollbackMessage;
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionAcknowledgeMessage;
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionAddMetaDataMessageV2;
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionBindingQueryMessage;
-import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionBindingQueryResponseMessage_V2;
+import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionBindingQueryResponseMessage_V3;
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionCloseMessage;
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionConsumerCloseMessage;
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionConsumerFlowCreditMessage;
@@ -283,9 +283,9 @@ public class ActiveMQSessionContext extends SessionContext {
 
    @Override
    public ClientSession.AddressQuery addressQuery(final SimpleString address) throws ActiveMQException {
-      SessionBindingQueryResponseMessage_V2 response = (SessionBindingQueryResponseMessage_V2) sessionChannel.sendBlocking(new SessionBindingQueryMessage(address), PacketImpl.SESS_BINDINGQUERY_RESP_V2);
+      SessionBindingQueryResponseMessage_V3 response = (SessionBindingQueryResponseMessage_V3) sessionChannel.sendBlocking(new SessionBindingQueryMessage(address), PacketImpl.SESS_BINDINGQUERY_RESP_V3);
 
-      return new AddressQueryImpl(response.isExists(), response.getQueueNames(), response.isAutoCreateJmsQueues());
+      return new AddressQueryImpl(response.isExists(), response.getQueueNames(), response.isAutoCreateJmsQueues(), response.isAutoCreateJmsTopics());
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ChannelImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ChannelImpl.java
@@ -164,6 +164,8 @@ public final class ChannelImpl implements Channel {
             return version >= 126;
          case PacketImpl.SESS_BINDINGQUERY_RESP_V2:
             return version >= 126;
+         case PacketImpl.SESS_BINDINGQUERY_RESP_V3:
+            return version >= 127;
          default:
             return true;
       }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/PacketDecoder.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/PacketDecoder.java
@@ -40,6 +40,7 @@ import static org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl.SES
 import static org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl.SESS_BINDINGQUERY;
 import static org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl.SESS_BINDINGQUERY_RESP;
 import static org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl.SESS_BINDINGQUERY_RESP_V2;
+import static org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl.SESS_BINDINGQUERY_RESP_V3;
 import static org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl.SESS_CLOSE;
 import static org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl.SESS_COMMIT;
 import static org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl.SESS_CONSUMER_CLOSE;
@@ -110,6 +111,7 @@ import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionAdd
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionBindingQueryMessage;
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionBindingQueryResponseMessage;
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionBindingQueryResponseMessage_V2;
+import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionBindingQueryResponseMessage_V3;
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionCloseMessage;
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionCommitMessage;
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionConsumerCloseMessage;
@@ -255,6 +257,10 @@ public abstract class PacketDecoder implements Serializable {
          }
          case SESS_BINDINGQUERY_RESP_V2: {
             packet = new SessionBindingQueryResponseMessage_V2();
+            break;
+         }
+         case SESS_BINDINGQUERY_RESP_V3: {
+            packet = new SessionBindingQueryResponseMessage_V3();
             break;
          }
          case SESS_XA_START: {

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/PacketImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/PacketImpl.java
@@ -245,6 +245,8 @@ public class PacketImpl implements Packet {
 
    public static final byte REPLICATION_RESPONSE_V2 = -9;
 
+   public static final byte SESS_BINDINGQUERY_RESP_V3 = -10;
+
    // Static --------------------------------------------------------
 
    public PacketImpl(final byte type) {

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionBindingQueryResponseMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionBindingQueryResponseMessage.java
@@ -44,8 +44,8 @@ public class SessionBindingQueryResponseMessage extends PacketImpl {
       super(SESS_BINDINGQUERY_RESP);
    }
 
-   public SessionBindingQueryResponseMessage(byte v2) {
-      super(v2);
+   public SessionBindingQueryResponseMessage(byte v) {
+      super(v);
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionBindingQueryResponseMessage_V3.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionBindingQueryResponseMessage_V3.java
@@ -21,51 +21,50 @@ import java.util.List;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.SimpleString;
 
-public class SessionBindingQueryResponseMessage_V2 extends SessionBindingQueryResponseMessage {
+public class SessionBindingQueryResponseMessage_V3 extends SessionBindingQueryResponseMessage_V2 {
 
-   protected boolean autoCreateJmsQueues;
+   private boolean autoCreateJmsTopics;
 
-   public SessionBindingQueryResponseMessage_V2(final boolean exists,
+   public SessionBindingQueryResponseMessage_V3(final boolean exists,
                                                 final List<SimpleString> queueNames,
-                                                final boolean autoCreateJmsQueues) {
-      super(SESS_BINDINGQUERY_RESP_V2);
+                                                final boolean autoCreateJmsQueues,
+                                                final boolean autoCreateJmsTopics) {
+      super(SESS_BINDINGQUERY_RESP_V3);
 
       this.exists = exists;
 
       this.queueNames = queueNames;
 
       this.autoCreateJmsQueues = autoCreateJmsQueues;
+
+      this.autoCreateJmsTopics = autoCreateJmsTopics;
    }
 
-   public SessionBindingQueryResponseMessage_V2() {
-      super(SESS_BINDINGQUERY_RESP_V2);
+   public SessionBindingQueryResponseMessage_V3() {
+      super(SESS_BINDINGQUERY_RESP_V3);
    }
 
-   public SessionBindingQueryResponseMessage_V2(byte v) {
-      super(v);
-   }
-
-   public boolean isAutoCreateJmsQueues() {
-      return autoCreateJmsQueues;
+   public boolean isAutoCreateJmsTopics() {
+      return autoCreateJmsTopics;
    }
 
    @Override
    public void encodeRest(final ActiveMQBuffer buffer) {
       super.encodeRest(buffer);
-      buffer.writeBoolean(autoCreateJmsQueues);
+      buffer.writeBoolean(autoCreateJmsTopics);
    }
 
    @Override
    public void decodeRest(final ActiveMQBuffer buffer) {
       super.decodeRest(buffer);
-      autoCreateJmsQueues = buffer.readBoolean();
+      autoCreateJmsTopics = buffer.readBoolean();
    }
 
    @Override
    public int hashCode() {
       final int prime = 31;
       int result = super.hashCode();
-      result = prime * result + (autoCreateJmsQueues ? 1231 : 1237);
+      result = prime * result + (autoCreateJmsTopics ? 1231 : 1237);
       return result;
    }
 
@@ -75,6 +74,7 @@ public class SessionBindingQueryResponseMessage_V2 extends SessionBindingQueryRe
       buff.append(", exists=" + exists);
       buff.append(", queueNames=" + queueNames);
       buff.append(", autoCreateJmsQueues=" + autoCreateJmsQueues);
+      buff.append(", autoCreateJmsTopics=" + autoCreateJmsTopics);
       buff.append("]");
       return buff.toString();
    }
@@ -85,10 +85,10 @@ public class SessionBindingQueryResponseMessage_V2 extends SessionBindingQueryRe
          return true;
       if (!super.equals(obj))
          return false;
-      if (!(obj instanceof SessionBindingQueryResponseMessage_V2))
+      if (!(obj instanceof SessionBindingQueryResponseMessage_V3))
          return false;
-      SessionBindingQueryResponseMessage_V2 other = (SessionBindingQueryResponseMessage_V2) obj;
-      if (autoCreateJmsQueues != other.autoCreateJmsQueues)
+      SessionBindingQueryResponseMessage_V3 other = (SessionBindingQueryResponseMessage_V3) obj;
+      if (autoCreateJmsTopics != other.autoCreateJmsTopics)
          return false;
       return true;
    }

--- a/artemis-core-client/src/main/resources/activemq-version.properties
+++ b/artemis-core-client/src/main/resources/activemq-version.properties
@@ -20,4 +20,4 @@ activemq.version.minorVersion=${activemq.version.minorVersion}
 activemq.version.microVersion=${activemq.version.microVersion}
 activemq.version.incrementingVersion=${activemq.version.incrementingVersion}
 activemq.version.versionTag=${activemq.version.versionTag}
-activemq.version.compatibleVersionList=121,122,123,124,125,126
+activemq.version.compatibleVersionList=121,122,123,124,125,126,127

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQMessageProducer.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQMessageProducer.java
@@ -405,7 +405,7 @@ public class ActiveMQMessageProducer implements MessageProducer, QueueSender, To
 
                // if it's autoCreateJMSQueue we will let the PostOffice.route to execute the creation at the server's side
                // as that's a more efficient path for such operation
-               if (!query.isExists() && !query.isAutoCreateJmsQueues()) {
+               if (!query.isExists() && ((address.toString().startsWith(ActiveMQDestination.JMS_QUEUE_ADDRESS_PREFIX) && !query.isAutoCreateJmsQueues()) || (address.toString().startsWith(ActiveMQDestination.JMS_TOPIC_ADDRESS_PREFIX) && !query.isAutoCreateJmsTopics()))) {
                   throw new InvalidDestinationException("Destination " + address + " does not exist");
                }
                else {

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
@@ -299,7 +299,7 @@ public class ActiveMQSession implements QueueSession, TopicSession {
          if (jbd != null) {
             ClientSession.AddressQuery response = session.addressQuery(jbd.getSimpleAddress());
 
-            if (!response.isExists() && !response.isAutoCreateJmsQueues()) {
+            if (!response.isExists() && ((jbd.getAddress().startsWith(ActiveMQDestination.JMS_QUEUE_ADDRESS_PREFIX) && !response.isAutoCreateJmsQueues()) || (jbd.getAddress().startsWith(ActiveMQDestination.JMS_TOPIC_ADDRESS_PREFIX) && !response.isAutoCreateJmsTopics()))) {
                throw new InvalidDestinationException("Destination " + jbd.getName() + " does not exist");
             }
 
@@ -659,7 +659,7 @@ public class ActiveMQSession implements QueueSession, TopicSession {
          else {
             AddressQuery response = session.addressQuery(dest.getSimpleAddress());
 
-            if (!response.isExists()) {
+            if (!response.isExists() && !response.isAutoCreateJmsTopics()) {
                throw new InvalidDestinationException("Topic " + dest.getName() + " does not exist");
             }
 
@@ -1106,7 +1106,7 @@ public class ActiveMQSession implements QueueSession, TopicSession {
 
       AddressQuery query = session.addressQuery(topic.getSimpleAddress());
 
-      if (!query.isExists()) {
+      if (!query.isExists() && !query.isAutoCreateJmsTopics()) {
          return null;
       }
       else {

--- a/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/JMSServerManager.java
+++ b/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/JMSServerManager.java
@@ -77,6 +77,17 @@ public interface JMSServerManager extends ActiveMQComponent {
    boolean createTopic(boolean storeConfig, String topicName, String... bindings) throws Exception;
 
    /**
+    *
+    * @param storeConfig
+    * @param topicName
+    * @param autoCreated
+    * @param bindings
+    * @return
+    * @throws Exception
+    */
+   boolean createTopic(boolean storeConfig, String topicName, boolean autoCreated, String... bindings) throws Exception;
+
+   /**
     * Remove the topic from the Binding Registry or BindingRegistry.
     * Calling this method does <em>not</em> destroy the destination.
     *

--- a/artemis-protocols/artemis-hqclient-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/hornetq/client/HornetQClientSessionContext.java
+++ b/artemis-protocols/artemis-hqclient-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/hornetq/client/HornetQClientSessionContext.java
@@ -74,7 +74,7 @@ public class HornetQClientSessionContext extends ActiveMQSessionContext {
    public ClientSession.AddressQuery addressQuery(final SimpleString address) throws ActiveMQException {
       SessionBindingQueryResponseMessage response = (SessionBindingQueryResponseMessage) getSessionChannel().sendBlocking(new SessionBindingQueryMessage(address), PacketImpl.SESS_BINDINGQUERY_RESP);
 
-      return new AddressQueryImpl(response.isExists(), response.getQueueNames(), false);
+      return new AddressQueryImpl(response.isExists(), response.getQueueNames(), false, false);
    }
 
    @Override

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
@@ -801,11 +801,10 @@ public class OpenWireConnection extends AbstractRemotingConnection implements Se
 
    public void removeDestination(ActiveMQDestination dest) throws Exception {
       if (dest.isQueue()) {
-         SimpleString qName = new SimpleString("jms.queue." + dest.getPhysicalName());
-         server.destroyQueue(qName);
+         server.destroyQueue(OpenWireUtil.toCoreAddress(dest));
       }
       else {
-         Bindings bindings = server.getPostOffice().getBindingsForAddress(SimpleString.toSimpleString("jms.topic." + dest.getPhysicalName()));
+         Bindings bindings = server.getPostOffice().getBindingsForAddress(OpenWireUtil.toCoreAddress(dest));
          Iterator<Binding> iterator = bindings.getBindings().iterator();
 
          while (iterator.hasNext()) {

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQConsumer.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQConsumer.java
@@ -81,7 +81,12 @@ public class AMQConsumer {
       SimpleString address;
 
       if (openwireDestination.isTopic()) {
-         address = new SimpleString("jms.topic." + physicalName);
+         if (openwireDestination.isTemporary()) {
+            address = new SimpleString("jms.temptopic." + physicalName);
+         }
+         else {
+            address = new SimpleString("jms.topic." + physicalName);
+         }
 
          SimpleString queueName = createTopicSubscription(info.isDurable(), info.getClientId(), physicalName, info.getSubscriptionName(), selector, address);
 
@@ -90,7 +95,7 @@ public class AMQConsumer {
       }
       else {
          SimpleString queueName = OpenWireUtil.toCoreAddress(openwireDestination);
-         session.getCoreServer().getJMSQueueCreator().create(queueName);
+         session.getCoreServer().getJMSDestinationCreator().create(queueName);
          serverConsumer = session.getCoreSession().createConsumer(nativeId, queueName, selector, info.isBrowser(), false, -1);
          serverConsumer.setlowConsumerDetection(slowConsumerDetectionListener);
          AddressSettings addrSettings = session.getCoreServer().getAddressSettingsRepository().getMatch(queueName.toString());

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQSession.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQSession.java
@@ -149,7 +149,7 @@ public class AMQSession implements SessionCallback {
       for (ActiveMQDestination openWireDest : dests) {
          if (openWireDest.isQueue()) {
             SimpleString queueName = OpenWireUtil.toCoreAddress(openWireDest);
-            getCoreServer().getJMSQueueCreator().create(queueName);
+            getCoreServer().getJMSDestinationCreator().create(queueName);
          }
          AMQConsumer consumer = new AMQConsumer(this, openWireDest, info, scheduledPool);
 

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/util/OpenWireUtil.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/util/OpenWireUtil.java
@@ -28,6 +28,11 @@ import org.apache.activemq.command.TransactionId;
 import org.apache.activemq.command.XATransactionId;
 import org.apache.activemq.util.ByteSequence;
 
+import static org.apache.activemq.artemis.jms.client.ActiveMQDestination.JMS_QUEUE_ADDRESS_PREFIX;
+import static org.apache.activemq.artemis.jms.client.ActiveMQDestination.JMS_TEMP_QUEUE_ADDRESS_PREFIX;
+import static org.apache.activemq.artemis.jms.client.ActiveMQDestination.JMS_TEMP_TOPIC_ADDRESS_PREFIX;
+import static org.apache.activemq.artemis.jms.client.ActiveMQDestination.JMS_TOPIC_ADDRESS_PREFIX;
+
 public class OpenWireUtil {
 
    public static ActiveMQBuffer toActiveMQBuffer(ByteSequence bytes) {
@@ -39,10 +44,20 @@ public class OpenWireUtil {
 
    public static SimpleString toCoreAddress(ActiveMQDestination dest) {
       if (dest.isQueue()) {
-         return new SimpleString("jms.queue." + dest.getPhysicalName());
+         if (dest.isTemporary()) {
+            return new SimpleString(JMS_TEMP_QUEUE_ADDRESS_PREFIX + dest.getPhysicalName());
+         }
+         else {
+            return new SimpleString(JMS_QUEUE_ADDRESS_PREFIX + dest.getPhysicalName());
+         }
       }
       else {
-         return new SimpleString("jms.topic." + dest.getPhysicalName());
+         if (dest.isTemporary()) {
+            return new SimpleString(JMS_TEMP_TOPIC_ADDRESS_PREFIX + dest.getPhysicalName());
+         }
+         else {
+            return new SimpleString(JMS_TOPIC_ADDRESS_PREFIX + dest.getPhysicalName());
+         }
       }
    }
 
@@ -54,7 +69,7 @@ public class OpenWireUtil {
     */
    public static ActiveMQDestination toAMQAddress(ServerMessage message, ActiveMQDestination actualDestination) {
       String address = message.getAddress().toString();
-      String strippedAddress = address.replace("jms.queue.", "").replace("jms.topic.", "");
+      String strippedAddress = address.replace(JMS_QUEUE_ADDRESS_PREFIX, "").replace(JMS_TEMP_QUEUE_ADDRESS_PREFIX, "").replace(JMS_TOPIC_ADDRESS_PREFIX, "").replace(JMS_TEMP_TOPIC_ADDRESS_PREFIX, "");
       if (actualDestination.isQueue()) {
          return new ActiveMQQueue(strippedAddress);
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -163,6 +163,10 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
    private static final String AUTO_DELETE_JMS_QUEUES = "auto-delete-jms-queues";
 
+   private static final String AUTO_CREATE_JMS_TOPICS = "auto-create-jms-topics";
+
+   private static final String AUTO_DELETE_JMS_TOPICS = "auto-delete-jms-topics";
+
    private static final String MANAGEMENT_BROWSE_PAGE_SIZE = "management-browse-page-size";
 
    private static final String MAX_CONNECTIONS_NODE_NAME = "max-connections";
@@ -795,6 +799,12 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
          }
          else if (AUTO_DELETE_JMS_QUEUES.equalsIgnoreCase(name)) {
             addressSettings.setAutoDeleteJmsQueues(XMLUtil.parseBoolean(child));
+         }
+         else if (AUTO_CREATE_JMS_TOPICS.equalsIgnoreCase(name)) {
+            addressSettings.setAutoCreateJmsTopics(XMLUtil.parseBoolean(child));
+         }
+         else if (AUTO_DELETE_JMS_TOPICS.equalsIgnoreCase(name)) {
+            addressSettings.setAutoDeleteJmsTopics(XMLUtil.parseBoolean(child));
          }
          else if (MANAGEMENT_BROWSE_PAGE_SIZE.equalsIgnoreCase(name)) {
             addressSettings.setManagementBrowsePageSize(XMLUtil.parseInt(child));

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -1519,6 +1519,8 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
       settings.put("slowConsumerPolicy", policy);
       settings.put("autoCreateJmsQueues", addressSettings.isAutoCreateJmsQueues());
       settings.put("autoDeleteJmsQueues", addressSettings.isAutoDeleteJmsQueues());
+      settings.put("autoCreateJmsTopics", addressSettings.isAutoCreateJmsTopics());
+      settings.put("autoDeleteJmsTopics", addressSettings.isAutoDeleteJmsTopics());
 
       JSONObject jsonObject = new JSONObject(settings);
       return jsonObject.toString();
@@ -1544,7 +1546,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
                                   final long slowConsumerCheckPeriod,
                                   final String slowConsumerPolicy,
                                   final boolean autoCreateJmsQueues,
-                                  final boolean autoDeleteJmsQueues) throws Exception {
+                                  final boolean autoDeleteJmsQueues,
+                                  final boolean autoCreateJmsTopics,
+                                  final boolean autoDeleteJmsTopics) throws Exception {
       checkStarted();
 
       // JBPAPP-6334 requested this to be pageSizeBytes > maxSizeBytes
@@ -1598,6 +1602,8 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
       }
       addressSettings.setAutoCreateJmsQueues(autoCreateJmsQueues);
       addressSettings.setAutoDeleteJmsQueues(autoDeleteJmsQueues);
+      addressSettings.setAutoCreateJmsTopics(autoCreateJmsTopics);
+      addressSettings.setAutoDeleteJmsTopics(autoDeleteJmsTopics);
       server.getAddressSettingsRepository().addMatch(address, addressSettings);
 
       storageManager.storeAddressSetting(new PersistedAddressSetting(new SimpleString(address), addressSettings));

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/ServerSessionPacketHandler.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/ServerSessionPacketHandler.java
@@ -39,6 +39,7 @@ import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionAdd
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionBindingQueryMessage;
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionBindingQueryResponseMessage;
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionBindingQueryResponseMessage_V2;
+import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionBindingQueryResponseMessage_V3;
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionConsumerCloseMessage;
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionConsumerFlowCreditMessage;
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionCreateConsumerMessage;
@@ -263,7 +264,10 @@ public class ServerSessionPacketHandler implements ChannelHandler {
                   requiresResponse = true;
                   SessionBindingQueryMessage request = (SessionBindingQueryMessage) packet;
                   BindingQueryResult result = session.executeBindingQuery(request.getAddress());
-                  if (channel.supports(PacketImpl.SESS_BINDINGQUERY_RESP_V2)) {
+                  if (channel.supports(PacketImpl.SESS_BINDINGQUERY_RESP_V3)) {
+                     response = new SessionBindingQueryResponseMessage_V3(result.isExists(), result.getQueueNames(), result.isAutoCreateJmsQueues(), result.isAutoCreateJmsTopics());
+                  }
+                  else if (channel.supports(PacketImpl.SESS_BINDINGQUERY_RESP_V2)) {
                      response = new SessionBindingQueryResponseMessage_V2(result.isExists(), result.getQueueNames(), result.isAutoCreateJmsQueues());
                   }
                   else {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServer.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServer.java
@@ -126,6 +126,36 @@ public interface ActiveMQServer extends ActiveMQComponent {
     */
    void callActivationFailureListeners(Exception e);
 
+   /**
+    * @param callback {@link org.apache.activemq.artemis.core.server.PostQueueCreationCallback}
+    */
+   void registerPostQueueCreationCallback(PostQueueCreationCallback callback);
+
+   /**
+    * @param callback {@link org.apache.activemq.artemis.core.server.PostQueueCreationCallback}
+    */
+   void unregisterPostQueueCreationCallback(PostQueueCreationCallback callback);
+
+   /**
+    * @param queueName
+    */
+   void callPostQueueCreationCallbacks(SimpleString queueName) throws Exception;
+
+   /**
+    * @param callback {@link org.apache.activemq.artemis.core.server.PostQueueDeletionCallback}
+    */
+   void registerPostQueueDeletionCallback(PostQueueDeletionCallback callback);
+
+   /**
+    * @param callback {@link org.apache.activemq.artemis.core.server.PostQueueDeletionCallback}
+    */
+   void unregisterPostQueueDeletionCallback(PostQueueDeletionCallback callback);
+
+   /**
+    * @param queueName
+    */
+   void callPostQueueDeletionCallbacks(SimpleString address, SimpleString queueName) throws Exception;
+
    void checkQueueCreationLimit(String username) throws Exception;
 
    ServerSession createSession(String name,
@@ -196,7 +226,7 @@ public interface ActiveMQServer extends ActiveMQComponent {
    /**
     * @see org.apache.activemq.artemis.core.server.ActiveMQServer#setJMSQueueCreator(QueueCreator)
     */
-   QueueCreator getJMSQueueCreator();
+   QueueCreator getJMSDestinationCreator();
 
    /**
     * This is the queue deleter responsible for automatic JMS Queue deletions.

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/BindingQueryResult.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/BindingQueryResult.java
@@ -28,14 +28,19 @@ public class BindingQueryResult {
 
    private boolean autoCreateJmsQueues;
 
+   private boolean autoCreateJmsTopics;
+
    public BindingQueryResult(final boolean exists,
                              final List<SimpleString> queueNames,
-                             final boolean autoCreateJmsQueues) {
+                             final boolean autoCreateJmsQueues,
+                             final boolean autoCreateJmsTopics) {
       this.exists = exists;
 
       this.queueNames = queueNames;
 
       this.autoCreateJmsQueues = autoCreateJmsQueues;
+
+      this.autoCreateJmsTopics = autoCreateJmsTopics;
    }
 
    public boolean isExists() {
@@ -44,6 +49,10 @@ public class BindingQueryResult {
 
    public boolean isAutoCreateJmsQueues() {
       return autoCreateJmsQueues;
+   }
+
+   public boolean isAutoCreateJmsTopics() {
+      return autoCreateJmsTopics;
    }
 
    public List<SimpleString> getQueueNames() {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/PostQueueCreationCallback.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/PostQueueCreationCallback.java
@@ -14,15 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.activemq.artemis.core.server;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
 
-public interface QueueDeleter {
+/**
+ * When a "core" queue is created this callback will be invoked
+ */
+public interface PostQueueCreationCallback {
 
-   /**
-    * @return True if a queue was deleted.
-    */
-   boolean delete(SimpleString queueName) throws Exception;
+   void callback(SimpleString queueName) throws Exception;
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/PostQueueDeletionCallback.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/PostQueueDeletionCallback.java
@@ -14,15 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.activemq.artemis.core.server;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
 
-public interface QueueDeleter {
+/**
+ * When a "core" queue is deleted this callback will be invoked
+ */
+public interface PostQueueDeletionCallback {
 
-   /**
-    * @return True if a queue was deleted.
-    */
-   boolean delete(SimpleString queueName) throws Exception;
+   void callback(SimpleString address, SimpleString queueName) throws Exception;
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/AutoCreatedQueueManagerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/AutoCreatedQueueManagerImpl.java
@@ -17,41 +17,23 @@
 package org.apache.activemq.artemis.core.server.impl;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
 import org.apache.activemq.artemis.core.server.AutoCreatedQueueManager;
-import org.apache.activemq.artemis.core.server.Queue;
+import org.apache.activemq.artemis.core.server.QueueDeleter;
 import org.apache.activemq.artemis.utils.ReferenceCounterUtil;
-import org.jboss.logging.Logger;
 
 public class AutoCreatedQueueManagerImpl implements AutoCreatedQueueManager {
 
-   private static final Logger logger = Logger.getLogger(AutoCreatedQueueManagerImpl.class);
-
    private final SimpleString queueName;
 
-   private final ActiveMQServer server;
+   private final QueueDeleter deleter;
 
    private final Runnable runnable = new Runnable() {
       @Override
       public void run() {
          try {
-            Queue queue = server.locateQueue(queueName);
-            long consumerCount = queue.getConsumerCount();
-            long messageCount = queue.getMessageCount();
-            boolean isAutoDeleteJmsQueues = server.getAddressSettingsRepository().getMatch(queueName.toString()).isAutoDeleteJmsQueues();
-
-            if (server.locateQueue(queueName).getMessageCount() == 0 && isAutoDeleteJmsQueues) {
-               if (logger.isDebugEnabled()) {
-                  logger.debug("deleting auto-created queue \"" + queueName + ".\" consumerCount = " + consumerCount + "; messageCount = " + messageCount + "; isAutoDeleteJmsQueues = " + isAutoDeleteJmsQueues);
-               }
-
-               if (server.getJMSQueueDeleter() != null) {
-                  server.getJMSQueueDeleter().delete(queueName);
-               }
-            }
-            else if (logger.isDebugEnabled()) {
-               logger.debug("NOT deleting auto-created queue \"" + queueName + ".\" consumerCount = " + consumerCount + "; messageCount = " + messageCount + "; isAutoDeleteJmsQueues = " + isAutoDeleteJmsQueues);
+            if (deleter != null) {
+               deleter.delete(queueName);
             }
          }
          catch (Exception e) {
@@ -62,9 +44,8 @@ public class AutoCreatedQueueManagerImpl implements AutoCreatedQueueManager {
 
    private final ReferenceCounterUtil referenceCounterUtil = new ReferenceCounterUtil(runnable);
 
-   public AutoCreatedQueueManagerImpl(ActiveMQServer server, SimpleString queueName) {
-      this.server = server;
-
+   public AutoCreatedQueueManagerImpl(QueueDeleter deleter, SimpleString queueName) {
+      this.deleter = deleter;
       this.queueName = queueName;
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/PostOfficeJournalLoader.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/PostOfficeJournalLoader.java
@@ -146,7 +146,7 @@ public class PostOfficeJournalLoader implements JournalLoader {
          Queue queue = queueFactory.createQueue(queueBindingInfo.getId(), queueBindingInfo.getAddress(), queueBindingInfo.getQueueName(), filter, subscription, queueBindingInfo.getUser(), true, false, queueBindingInfo.isAutoCreated());
 
          if (queueBindingInfo.isAutoCreated()) {
-            queue.setConsumersRefCount(new AutoCreatedQueueManagerImpl(((PostOfficeImpl) postOffice).getServer(), queueBindingInfo.getQueueName()));
+            queue.setConsumersRefCount(new AutoCreatedQueueManagerImpl(((PostOfficeImpl) postOffice).getServer().getJMSQueueDeleter(), queueBindingInfo.getQueueName()));
          }
 
          Binding binding = new LocalQueueBinding(queueBindingInfo.getAddress(), queue, nodeManager.getNodeId());

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -487,8 +487,8 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
 
       Queue queue;
 
-      // any non-temporary JMS queue created via this method should be marked as auto-created
-      if (!temporary && address.toString().startsWith(ResourceNames.JMS_QUEUE) && address.equals(name)) {
+      // any non-temporary JMS destination created via this method should be marked as auto-created
+      if (!temporary && ((address.toString().startsWith(ResourceNames.JMS_QUEUE) && address.equals(name)) || address.toString().startsWith(ResourceNames.JMS_TOPIC)) ) {
          queue = server.createQueue(address, name, filterString, SimpleString.toSimpleString(getUsername()), durable, temporary, true);
       }
       else {
@@ -1463,7 +1463,7 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
    }
 
    private void installJMSHooks() {
-      this.queueCreator = server.getJMSQueueCreator();
+      this.queueCreator = server.getJMSDestinationCreator();
    }
 
    private Map<SimpleString, Pair<UUID, AtomicLong>> cloneTargetAddresses() {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
@@ -56,6 +56,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
    public static final boolean DEFAULT_AUTO_DELETE_QUEUES = true;
 
+   public static final boolean DEFAULT_AUTO_CREATE_TOPICS = true;
+
+   public static final boolean DEFAULT_AUTO_DELETE_TOPICS = true;
+
    public static final long DEFAULT_REDISTRIBUTION_DELAY = -1;
 
    public static final long DEFAULT_EXPIRY_DELAY = -1;
@@ -114,6 +118,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
    private Boolean autoDeleteJmsQueues = null;
 
+   private Boolean autoCreateJmsTopics = null;
+
+   private Boolean autoDeleteJmsTopics = null;
+
    private Integer managementBrowsePageSize = AddressSettings.MANAGEMENT_BROWSE_PAGE_SIZE;
 
    //from amq5
@@ -142,6 +150,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       this.slowConsumerPolicy = other.slowConsumerPolicy;
       this.autoCreateJmsQueues = other.autoCreateJmsQueues;
       this.autoDeleteJmsQueues = other.autoDeleteJmsQueues;
+      this.autoCreateJmsTopics = other.autoCreateJmsTopics;
+      this.autoDeleteJmsTopics = other.autoDeleteJmsTopics;
       this.managementBrowsePageSize = other.managementBrowsePageSize;
       this.queuePrefetch = other.queuePrefetch;
    }
@@ -164,6 +174,24 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
    public AddressSettings setAutoDeleteJmsQueues(final boolean autoDeleteJmsQueues) {
       this.autoDeleteJmsQueues = autoDeleteJmsQueues;
+      return this;
+   }
+
+   public boolean isAutoCreateJmsTopics() {
+      return autoCreateJmsTopics != null ? autoCreateJmsTopics : AddressSettings.DEFAULT_AUTO_CREATE_TOPICS;
+   }
+
+   public AddressSettings setAutoCreateJmsTopics(final boolean autoCreateJmsTopics) {
+      this.autoCreateJmsTopics = autoCreateJmsTopics;
+      return this;
+   }
+
+   public boolean isAutoDeleteJmsTopics() {
+      return autoDeleteJmsTopics != null ? autoDeleteJmsTopics : AddressSettings.DEFAULT_AUTO_DELETE_QUEUES;
+   }
+
+   public AddressSettings setAutoDeleteJmsTopics(final boolean autoDeleteJmsTopics) {
+      this.autoDeleteJmsTopics = autoDeleteJmsTopics;
       return this;
    }
 
@@ -416,6 +444,12 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       if (autoDeleteJmsQueues == null) {
          autoDeleteJmsQueues = merged.autoDeleteJmsQueues;
       }
+      if (autoCreateJmsTopics == null) {
+         autoCreateJmsTopics = merged.autoCreateJmsTopics;
+      }
+      if (autoDeleteJmsTopics == null) {
+         autoDeleteJmsTopics = merged.autoDeleteJmsTopics;
+      }
       if (managementBrowsePageSize == null) {
          managementBrowsePageSize = merged.managementBrowsePageSize;
       }
@@ -482,6 +516,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
       autoDeleteJmsQueues = BufferHelper.readNullableBoolean(buffer);
 
+      autoCreateJmsTopics = BufferHelper.readNullableBoolean(buffer);
+
+      autoDeleteJmsTopics = BufferHelper.readNullableBoolean(buffer);
+
       managementBrowsePageSize = BufferHelper.readNullableInteger(buffer);
    }
 
@@ -509,6 +547,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
          BufferHelper.sizeOfNullableSimpleString(slowConsumerPolicy != null ? slowConsumerPolicy.toString() : null) +
          BufferHelper.sizeOfNullableBoolean(autoCreateJmsQueues) +
          BufferHelper.sizeOfNullableBoolean(autoDeleteJmsQueues) +
+         BufferHelper.sizeOfNullableBoolean(autoCreateJmsTopics) +
+         BufferHelper.sizeOfNullableBoolean(autoDeleteJmsTopics) +
          BufferHelper.sizeOfNullableInteger(managementBrowsePageSize);
    }
 
@@ -556,6 +596,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
       BufferHelper.writeNullableBoolean(buffer, autoDeleteJmsQueues);
 
+      BufferHelper.writeNullableBoolean(buffer, autoCreateJmsTopics);
+
+      BufferHelper.writeNullableBoolean(buffer, autoDeleteJmsTopics);
+
       BufferHelper.writeNullableInteger(buffer, managementBrowsePageSize);
    }
 
@@ -587,6 +631,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       result = prime * result + ((slowConsumerPolicy == null) ? 0 : slowConsumerPolicy.hashCode());
       result = prime * result + ((autoCreateJmsQueues == null) ? 0 : autoCreateJmsQueues.hashCode());
       result = prime * result + ((autoDeleteJmsQueues == null) ? 0 : autoDeleteJmsQueues.hashCode());
+      result = prime * result + ((autoCreateJmsTopics == null) ? 0 : autoCreateJmsTopics.hashCode());
+      result = prime * result + ((autoDeleteJmsTopics == null) ? 0 : autoDeleteJmsTopics.hashCode());
       result = prime * result + ((managementBrowsePageSize == null) ? 0 : managementBrowsePageSize.hashCode());
       result = prime * result + ((queuePrefetch == null) ? 0 : queuePrefetch.hashCode());
       return result;
@@ -730,8 +776,20 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       }
       else if (!autoDeleteJmsQueues.equals(other.autoDeleteJmsQueues))
          return false;
-      else if (!managementBrowsePageSize.equals(other.managementBrowsePageSize))
+
+      if (autoCreateJmsTopics == null) {
+         if (other.autoCreateJmsTopics != null)
+            return false;
+      }
+      else if (!autoCreateJmsTopics.equals(other.autoCreateJmsTopics))
          return false;
+      if (autoDeleteJmsTopics == null) {
+         if (other.autoDeleteJmsTopics != null)
+            return false;
+      }
+      else if (!autoDeleteJmsTopics.equals(other.autoDeleteJmsTopics))
+         return false;
+
       if (managementBrowsePageSize == null) {
          if (other.managementBrowsePageSize != null)
             return false;
@@ -793,6 +851,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
          autoCreateJmsQueues +
          ", autoDeleteJmsQueues=" +
          autoDeleteJmsQueues +
+         ", autoCreateJmsTopics=" +
+         autoCreateJmsTopics +
+         ", autoDeleteJmsTopics=" +
+         autoDeleteJmsTopics +
          ", managementBrowsePageSize=" +
          managementBrowsePageSize +
          "]";

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -2308,6 +2308,23 @@
                </xsd:annotation>
             </xsd:element>
 
+            <xsd:element name="auto-create-jms-topics" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     whether or not to automatically create JMS topics when a producer sends or a consumer subscribes to
+                     a topic
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
+            <xsd:element name="auto-delete-jms-topics" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     whether or not to delete auto-created JMS topics when the last subscription is closed
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
             <xsd:element name="management-browse-page-size" type="xsd:int" default="200" maxOccurs="1"
                          minOccurs="0">
                <xsd:annotation>

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
@@ -288,6 +288,8 @@ public class FileConfigurationTest extends ConfigurationImplTest {
       assertEquals(SlowConsumerPolicy.NOTIFY, conf.getAddressesSettings().get("a1").getSlowConsumerPolicy());
       assertEquals(true, conf.getAddressesSettings().get("a1").isAutoCreateJmsQueues());
       assertEquals(true, conf.getAddressesSettings().get("a1").isAutoDeleteJmsQueues());
+      assertEquals(true, conf.getAddressesSettings().get("a1").isAutoCreateJmsTopics());
+      assertEquals(true, conf.getAddressesSettings().get("a1").isAutoDeleteJmsTopics());
 
       assertEquals("a2.1", conf.getAddressesSettings().get("a2").getDeadLetterAddress().toString());
       assertEquals("a2.2", conf.getAddressesSettings().get("a2").getExpiryAddress().toString());
@@ -301,6 +303,8 @@ public class FileConfigurationTest extends ConfigurationImplTest {
       assertEquals(SlowConsumerPolicy.KILL, conf.getAddressesSettings().get("a2").getSlowConsumerPolicy());
       assertEquals(false, conf.getAddressesSettings().get("a2").isAutoCreateJmsQueues());
       assertEquals(false, conf.getAddressesSettings().get("a2").isAutoDeleteJmsQueues());
+      assertEquals(false, conf.getAddressesSettings().get("a2").isAutoCreateJmsTopics());
+      assertEquals(false, conf.getAddressesSettings().get("a2").isAutoDeleteJmsTopics());
 
       assertTrue(conf.getResourceLimitSettings().containsKey("myUser"));
       assertEquals(104, conf.getResourceLimitSettings().get("myUser").getMaxConnections());

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/settings/AddressSettingsTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/settings/AddressSettingsTest.java
@@ -41,6 +41,8 @@ public class AddressSettingsTest extends ActiveMQTestBase {
       Assert.assertEquals(AddressSettings.DEFAULT_SLOW_CONSUMER_POLICY, addressSettings.getSlowConsumerPolicy());
       Assert.assertEquals(AddressSettings.DEFAULT_AUTO_CREATE_QUEUES, addressSettings.isAutoCreateJmsQueues());
       Assert.assertEquals(AddressSettings.DEFAULT_AUTO_DELETE_QUEUES, addressSettings.isAutoDeleteJmsQueues());
+      Assert.assertEquals(AddressSettings.DEFAULT_AUTO_CREATE_TOPICS, addressSettings.isAutoCreateJmsTopics());
+      Assert.assertEquals(AddressSettings.DEFAULT_AUTO_DELETE_TOPICS, addressSettings.isAutoDeleteJmsTopics());
    }
 
    @Test

--- a/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
@@ -248,6 +248,8 @@
             <slow-consumer-policy>NOTIFY</slow-consumer-policy>
             <auto-create-jms-queues>true</auto-create-jms-queues>
             <auto-delete-jms-queues>true</auto-delete-jms-queues>
+            <auto-create-jms-topics>true</auto-create-jms-topics>
+            <auto-delete-jms-topics>true</auto-delete-jms-topics>
          </address-setting>
          <address-setting match="a2">
             <dead-letter-address>a2.1</dead-letter-address>
@@ -262,6 +264,8 @@
             <slow-consumer-policy>KILL</slow-consumer-policy>
             <auto-create-jms-queues>false</auto-create-jms-queues>
             <auto-delete-jms-queues>false</auto-delete-jms-queues>
+            <auto-create-jms-topics>false</auto-create-jms-topics>
+            <auto-delete-jms-topics>false</auto-delete-jms-topics>
          </address-setting>
       </address-settings>
       <resource-limit-settings>

--- a/docs/user-manual/en/queue-attributes.md
+++ b/docs/user-manual/en/queue-attributes.md
@@ -90,6 +90,8 @@ entry that would be found in the `broker.xml` file.
           <slow-consumer-check-period>5</slow-consumer-check-period>
           <auto-create-jms-queues>true</auto-create-jms-queues>
           <auto-delete-jms-queues>true</auto-delete-jms-queues>
+          <auto-create-jms-topics>true</auto-create-jms-topics>
+          <auto-delete-jms-topics>true</auto-delete-jms-topics>
        </address-setting>
     </address-settings>
 
@@ -177,7 +179,18 @@ create a JMS queue when a JMS message is sent to a queue whose name fits
 the address `match` (remember, a JMS queue is just a core queue which has
 the same address and queue name) or a JMS consumer tries to connect to a
 queue whose name fits the address `match`. Queues which are auto-created
-are durable, non-temporary, and non-transient.
+are durable, non-temporary, and non-transient. Default is `true`.
 
-`auto-delete-jms-queues`. Whether or not to the broker should automatically
+`auto-delete-jms-queues`. Whether or not the broker should automatically
 delete auto-created JMS queues when they have both 0 consumers and 0 messages.
+Default is `true`.
+
+`auto-create-jms-topics`. Whether or not the broker should automatically
+create a JMS topic when a JMS message is sent to a topic whose name fits
+the address `match` (remember, a JMS topic is just a core address which has 
+one or more core queues mapped to it) or a JMS consumer tries to subscribe
+to a topic whose name fits the address `match`. Default is `true`.
+
+`auto-delete-jms-topics`. Whether or not the broker should automatically
+delete auto-created JMS topics once the last subscription on the topic has
+been closed. Default is `true`.

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
       <activemq.version.majorVersion>1</activemq.version.majorVersion>
       <activemq.version.minorVersion>0</activemq.version.minorVersion>
       <activemq.version.microVersion>0</activemq.version.microVersion>
-      <activemq.version.incrementingVersion>126,125,124,123,122</activemq.version.incrementingVersion>
+      <activemq.version.incrementingVersion>127,126,125,124,123,122</activemq.version.incrementingVersion>
       <activemq.version.versionTag>${project.version}</activemq.version.versionTag>
       <ActiveMQ-Version>
          ${project.version}(${activemq.version.incrementingVersion})
@@ -236,7 +236,7 @@
             <scope>provided</scope>
             <!-- postgresql license -->
          </dependency>
-         
+
          <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections-testframework</artifactId>

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/PagingOrderTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/PagingOrderTest.java
@@ -607,7 +607,7 @@ public class PagingOrderTest extends ActiveMQTestBase {
 
       jmsServer.createTopic(true, "tt", "/topic/TT");
 
-      server.getActiveMQServerControl().addAddressSettings("jms.topic.TT", "DLQ", "DLQ", -1, false, 5, 1024 * 1024, 1024 * 10, 5, 5, 1, 1000, 0, false, "PAGE", -1, 10, "KILL", true, true);
+      server.getActiveMQServerControl().addAddressSettings("jms.topic.TT", "DLQ", "DLQ", -1, false, 5, 1024 * 1024, 1024 * 10, 5, 5, 1, 1000, 0, false, "PAGE", -1, 10, "KILL", true, true, true, true);
 
       ActiveMQJMSConnectionFactory cf = (ActiveMQJMSConnectionFactory) ActiveMQJMSClient.createConnectionFactoryWithoutHA(JMSFactoryType.CF, new TransportConfiguration(INVM_CONNECTOR_FACTORY));
 
@@ -663,7 +663,7 @@ public class PagingOrderTest extends ActiveMQTestBase {
       jmsServer.setRegistry(new JndiBindingRegistry(context));
       jmsServer.start();
 
-      server.getActiveMQServerControl().addAddressSettings("jms.queue.Q1", "DLQ", "DLQ", -1, false, 5, 100 * 1024, 10 * 1024, 5, 5, 1, 1000, 0, false, "PAGE", -1, 10, "KILL", true, true);
+      server.getActiveMQServerControl().addAddressSettings("jms.queue.Q1", "DLQ", "DLQ", -1, false, 5, 100 * 1024, 10 * 1024, 5, 5, 1, 1000, 0, false, "PAGE", -1, 10, "KILL", true, true, true, true);
 
       jmsServer.createQueue(true, "Q1", null, true, "/queue/Q1");
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/jms2client/NonExistentQueueTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/jms2client/NonExistentQueueTest.java
@@ -32,6 +32,7 @@ import java.util.Random;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
 import org.apache.activemq.artemis.api.jms.JMSFactoryType;
+import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.tests.util.JMSTestBase;
 import org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnectorFactory;
 import org.junit.Assert;
@@ -54,6 +55,7 @@ public class NonExistentQueueTest extends JMSTestBase {
 
    @Test
    public void sendToNonExistentDestination() throws Exception {
+      server.getAddressSettingsRepository().addMatch("#", new AddressSettings().setAutoCreateJmsTopics(false));
       Destination destination = ActiveMQJMSClient.createTopic("DoesNotExist");
       TransportConfiguration transportConfiguration = new TransportConfiguration(InVMConnectorFactory.class.getName());
       ConnectionFactory localConnectionFactory = ActiveMQJMSClient.createConnectionFactoryWithoutHA(JMSFactoryType.CF, transportConfiguration);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
@@ -468,12 +468,14 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       String slowConsumerPolicy = SlowConsumerPolicy.KILL.toString();
       boolean autoCreateJmsQueues = false;
       boolean autoDeleteJmsQueues = false;
+      boolean autoCreateJmsTopics = false;
+      boolean autoDeleteJmsTopics = false;
 
-      serverControl.addAddressSettings(addressMatch, DLA, expiryAddress, expiryDelay, lastValueQueue, deliveryAttempts, maxSizeBytes, pageSizeBytes, pageMaxCacheSize, redeliveryDelay, redeliveryMultiplier, maxRedeliveryDelay, redistributionDelay, sendToDLAOnNoRoute, addressFullMessagePolicy, slowConsumerThreshold, slowConsumerCheckPeriod, slowConsumerPolicy, autoCreateJmsQueues, autoDeleteJmsQueues);
+      serverControl.addAddressSettings(addressMatch, DLA, expiryAddress, expiryDelay, lastValueQueue, deliveryAttempts, maxSizeBytes, pageSizeBytes, pageMaxCacheSize, redeliveryDelay, redeliveryMultiplier, maxRedeliveryDelay, redistributionDelay, sendToDLAOnNoRoute, addressFullMessagePolicy, slowConsumerThreshold, slowConsumerCheckPeriod, slowConsumerPolicy, autoCreateJmsQueues, autoDeleteJmsQueues, autoCreateJmsTopics, autoDeleteJmsTopics);
 
       boolean ex = false;
       try {
-         serverControl.addAddressSettings(addressMatch, DLA, expiryAddress, expiryDelay, lastValueQueue, deliveryAttempts, 100, 1000, pageMaxCacheSize, redeliveryDelay, redeliveryMultiplier, maxRedeliveryDelay, redistributionDelay, sendToDLAOnNoRoute, addressFullMessagePolicy, slowConsumerThreshold, slowConsumerCheckPeriod, slowConsumerPolicy, autoCreateJmsQueues, autoDeleteJmsQueues);
+         serverControl.addAddressSettings(addressMatch, DLA, expiryAddress, expiryDelay, lastValueQueue, deliveryAttempts, 100, 1000, pageMaxCacheSize, redeliveryDelay, redeliveryMultiplier, maxRedeliveryDelay, redistributionDelay, sendToDLAOnNoRoute, addressFullMessagePolicy, slowConsumerThreshold, slowConsumerCheckPeriod, slowConsumerPolicy, autoCreateJmsQueues, autoDeleteJmsQueues, autoCreateJmsTopics, autoDeleteJmsTopics);
       }
       catch (Exception expected) {
          ex = true;
@@ -504,8 +506,10 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       assertEquals(slowConsumerPolicy, info.getSlowConsumerPolicy());
       assertEquals(autoCreateJmsQueues, info.isAutoCreateJmsQueues());
       assertEquals(autoDeleteJmsQueues, info.isAutoDeleteJmsQueues());
+      assertEquals(autoCreateJmsTopics, info.isAutoCreateJmsTopics());
+      assertEquals(autoDeleteJmsTopics, info.isAutoDeleteJmsTopics());
 
-      serverControl.addAddressSettings(addressMatch, DLA, expiryAddress, expiryDelay, lastValueQueue, deliveryAttempts, -1, 1000, pageMaxCacheSize, redeliveryDelay, redeliveryMultiplier, maxRedeliveryDelay, redistributionDelay, sendToDLAOnNoRoute, addressFullMessagePolicy, slowConsumerThreshold, slowConsumerCheckPeriod, slowConsumerPolicy, autoCreateJmsQueues, autoDeleteJmsQueues);
+      serverControl.addAddressSettings(addressMatch, DLA, expiryAddress, expiryDelay, lastValueQueue, deliveryAttempts, -1, 1000, pageMaxCacheSize, redeliveryDelay, redeliveryMultiplier, maxRedeliveryDelay, redistributionDelay, sendToDLAOnNoRoute, addressFullMessagePolicy, slowConsumerThreshold, slowConsumerCheckPeriod, slowConsumerPolicy, autoCreateJmsQueues, autoDeleteJmsQueues, autoCreateJmsTopics, autoDeleteJmsTopics);
 
       jsonString = serverControl.getAddressSettingsAsJSON(exactAddress);
       info = AddressSettingsInfo.from(jsonString);
@@ -528,10 +532,12 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       assertEquals(slowConsumerPolicy, info.getSlowConsumerPolicy());
       assertEquals(autoCreateJmsQueues, info.isAutoCreateJmsQueues());
       assertEquals(autoDeleteJmsQueues, info.isAutoDeleteJmsQueues());
+      assertEquals(autoCreateJmsTopics, info.isAutoCreateJmsTopics());
+      assertEquals(autoDeleteJmsTopics, info.isAutoDeleteJmsTopics());
 
       ex = false;
       try {
-         serverControl.addAddressSettings(addressMatch, DLA, expiryAddress, expiryDelay, lastValueQueue, deliveryAttempts, -2, 1000, pageMaxCacheSize, redeliveryDelay, redeliveryMultiplier, maxRedeliveryDelay, redistributionDelay, sendToDLAOnNoRoute, addressFullMessagePolicy, slowConsumerThreshold, slowConsumerCheckPeriod, slowConsumerPolicy, autoCreateJmsQueues, autoDeleteJmsQueues);
+         serverControl.addAddressSettings(addressMatch, DLA, expiryAddress, expiryDelay, lastValueQueue, deliveryAttempts, -2, 1000, pageMaxCacheSize, redeliveryDelay, redeliveryMultiplier, maxRedeliveryDelay, redistributionDelay, sendToDLAOnNoRoute, addressFullMessagePolicy, slowConsumerThreshold, slowConsumerCheckPeriod, slowConsumerPolicy, autoCreateJmsQueues, autoDeleteJmsQueues, autoCreateJmsTopics, autoDeleteJmsTopics);
       }
       catch (Exception e) {
          ex = true;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
@@ -587,8 +587,10 @@ public class ActiveMQServerControlUsingCoreTest extends ActiveMQServerControlTes
                                         @Parameter(desc = "how often (in seconds) to check for slow consumers", name = "slowConsumerCheckPeriod") long slowConsumerCheckPeriod,
                                         @Parameter(desc = "the policy to use when a slow consumer is detected", name = "slowConsumerPolicy") String slowConsumerPolicy,
                                         @Parameter(desc = "allow queues to be created automatically", name = "autoCreateJmsQueues") boolean autoCreateJmsQueues,
-                                        @Parameter(desc = "allow auto-created queues to be deleted automatically", name = "autoDeleteJmsQueues") boolean autoDeleteJmsQueues) throws Exception {
-            proxy.invokeOperation("addAddressSettings", addressMatch, DLA, expiryAddress, expiryDelay, lastValueQueue, deliveryAttempts, maxSizeBytes, pageSizeBytes, pageMaxCacheSize, redeliveryDelay, redeliveryMultiplier, maxRedeliveryDelay, redistributionDelay, sendToDLAOnNoRoute, addressFullMessagePolicy, slowConsumerThreshold, slowConsumerCheckPeriod, slowConsumerPolicy, autoCreateJmsQueues, autoDeleteJmsQueues);
+                                        @Parameter(desc = "allow auto-created queues to be deleted automatically", name = "autoDeleteJmsQueues") boolean autoDeleteJmsQueues,
+                                        @Parameter(desc = "allow topics to be created automatically", name = "autoCreateJmsTopics") boolean autoCreateJmsTopics,
+                                        @Parameter(desc = "allow auto-created topics to be deleted automatically", name = "autoDeleteJmsTopics") boolean autoDeleteJmsTopics) throws Exception {
+            proxy.invokeOperation("addAddressSettings", addressMatch, DLA, expiryAddress, expiryDelay, lastValueQueue, deliveryAttempts, maxSizeBytes, pageSizeBytes, pageMaxCacheSize, redeliveryDelay, redeliveryMultiplier, maxRedeliveryDelay, redistributionDelay, sendToDLAOnNoRoute, addressFullMessagePolicy, slowConsumerThreshold, slowConsumerCheckPeriod, slowConsumerPolicy, autoCreateJmsQueues, autoDeleteJmsQueues, autoCreateJmsTopics, autoDeleteJmsTopics);
          }
 
          @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ManagementWithStompTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ManagementWithStompTest.java
@@ -30,6 +30,8 @@ import org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptorFactory
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
+import org.apache.activemq.artemis.jms.server.JMSServerManager;
+import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
 import org.apache.activemq.artemis.utils.RandomUtil;
 import org.junit.Assert;
 import org.junit.Before;
@@ -51,6 +53,8 @@ public class ManagementWithStompTest extends ManagementTestBase {
    // Attributes ----------------------------------------------------
 
    protected ActiveMQServer server;
+
+   protected JMSServerManager jmsServer;
 
    protected ClientSession session;
 
@@ -169,7 +173,9 @@ public class ManagementWithStompTest extends ManagementTestBase {
 
       server = addServer(ActiveMQServers.newActiveMQServer(config, mbeanServer, false, "brianm", "wombats"));
 
-      server.start();
+      jmsServer = new JMSServerManagerImpl(server);
+
+      jmsServer.start();
 
       locator = createInVMNonHALocator().setBlockOnNonDurableSend(true);
       ClientSessionFactory sf = createSessionFactory(locator);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/amq/JmsTopicRequestReplyTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/amq/JmsTopicRequestReplyTest.java
@@ -57,11 +57,16 @@ public class JmsTopicRequestReplyTest extends BasicOpenWireTest implements Messa
       clientConnection = createConnection();
       clientConnection.setClientID("ClientConnection:" + name.getMethodName());
 
+      System.out.println("Creating session.");
       Session session = clientConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
 
       clientConnection.start();
 
       Destination replyDestination = createTemporaryDestination(session);
+      System.out.println("Created temporary topic " + replyDestination);
+
+      System.out.println("Creating consumer on: " + replyDestination);
+      MessageConsumer replyConsumer = session.createConsumer(replyDestination);
 
       // lets test the destination
       clientSideClientID = clientConnection.getClientID();
@@ -74,12 +79,15 @@ public class JmsTopicRequestReplyTest extends BasicOpenWireTest implements Messa
       System.out.println("Both the clientID and destination clientID match properly: " + clientSideClientID);
 
       /* build queues */
-      MessageProducer requestProducer = session.createProducer(requestDestination);
-      MessageConsumer replyConsumer = session.createConsumer(replyDestination);
 
       /* build requestmessage */
       TextMessage requestMessage = session.createTextMessage("Olivier");
       requestMessage.setJMSReplyTo(replyDestination);
+
+      System.out.println("Creating producer on " + requestDestination);
+      MessageProducer requestProducer = session.createProducer(requestDestination);
+
+      System.out.println("Sending message to " + requestDestination);
       requestProducer.send(requestMessage);
 
       System.out.println("Sent request.");
@@ -116,7 +124,7 @@ public class JmsTopicRequestReplyTest extends BasicOpenWireTest implements Messa
       try {
          TextMessage requestMessage = (TextMessage) message;
 
-         System.out.println("Received request.");
+         System.out.println("Received request from " + requestDestination);
          System.out.println(requestMessage.toString());
 
          Destination replyDestination = requestMessage.getJMSReplyTo();
@@ -140,7 +148,7 @@ public class JmsTopicRequestReplyTest extends BasicOpenWireTest implements Messa
             replyProducer.send(replyDestination, replyMessage);
          }
 
-         System.out.println("Sent reply.");
+         System.out.println("Sent reply to " + replyDestination);
          System.out.println(replyMessage.toString());
       }
       catch (JMSException e) {
@@ -180,6 +188,7 @@ public class JmsTopicRequestReplyTest extends BasicOpenWireTest implements Messa
       requestDestination = createDestination(serverSession);
 
       /* build queues */
+      System.out.println("Creating consumer on: " + requestDestination);
       final MessageConsumer requestConsumer = serverSession.createConsumer(requestDestination);
       if (useAsyncConsume) {
          requestConsumer.setMessageListener(this);
@@ -232,6 +241,7 @@ public class JmsTopicRequestReplyTest extends BasicOpenWireTest implements Messa
          ((TemporaryTopic) dest).delete();
       }
       else {
+         System.out.println("Deleting: " + dest);
          ((TemporaryQueue) dest).delete();
       }
    }

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/MessageProducerTest.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/MessageProducerTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
+import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.jms.tests.message.SimpleJMSMessage;
 import org.apache.activemq.artemis.jms.tests.message.SimpleJMSTextMessage;
 import org.apache.activemq.artemis.jms.tests.util.ProxyAssertSupport;
@@ -348,6 +349,7 @@ public class MessageProducerTest extends JMSTestCase {
 
    @Test
    public void testCreateProducerOnInexistentDestination() throws Exception {
+      getJmsServer().getAddressSettingsRepository().addMatch("#", new AddressSettings().setAutoCreateJmsTopics(false));
       Connection pconn = createConnection();
       try {
          Session ps = pconn.createSession(false, Session.AUTO_ACKNOWLEDGE);

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/SessionTest.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/SessionTest.java
@@ -172,6 +172,7 @@ public class SessionTest extends ActiveMQServerTestCase {
 
    @Test
    public void testCreateNonExistentTopic() throws Exception {
+      getJmsServer().getAddressSettingsRepository().addMatch("#", new AddressSettings().setAutoCreateJmsTopics(false));
       Connection conn = getConnectionFactory().createConnection();
       Session sess = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
       try {
@@ -201,6 +202,7 @@ public class SessionTest extends ActiveMQServerTestCase {
 
    @Test
    public void testCreateTopicWhileQueueWithSameNameExists() throws Exception {
+      getJmsServer().getAddressSettingsRepository().addMatch("#", new AddressSettings().setAutoCreateJmsTopics(false));
       Connection conn = getConnectionFactory().createConnection();
       Session sess = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
       try {


### PR DESCRIPTION
Implements a new feature for the broker whereby it may automatically create and
delete JMS topics which are not explicitly defined through the management API
or file-based configuration. A JMS topic is created in response to a sent
message or connected subscriber. The topic may subsequently be deleted when it
no longer has any subscribers. Auto-creation and auto-deletion can both be
turned on/off via address-setting.