### PR TITLE
ARTEMIS-554 include additional examples in `mvn -Pexamples verify`

### DIFF
--- a/examples/features/standard/pom.xml
+++ b/examples/features/standard/pom.xml
@@ -146,12 +146,7 @@ under the License.
             <module>security-ldap</module>
             <module>send-acknowledgements</module>
             <module>spring-integration</module>
-
-            <!-- ARTEMIS-197 FIX ME
-                 this one could be the case of leaving it out for good
-                 as it may require to be run manually
-            <module>ssl-enabled</module> -->
-
+            <module>ssl-enabled</module>
             <module>static-selector</module>
 
             <!--this needs to be run standalone as it needs manual intervention-->

--- a/examples/protocols/pom.xml
+++ b/examples/protocols/pom.xml
@@ -50,6 +50,7 @@ under the License.
             <module>amqp</module>
             <module>mqtt</module>
             <module>stomp</module>
+            <module>openwire</module>
          </modules>
       </profile>
       <profile>


### PR DESCRIPTION
The following examples run without user intervention and can be added to the `examples` maven profile, so that they are all executed by a simple `mvn -Pexamples verify` command.

* all {{protocols/openwire}} examples except {{chat}}
* {{features/standard/ssl-enabled}}, because ARTEMIS-197 mentioned in comment is already fixed
* possibly also the vertx example, but that is currently failing to run for me

This PR is adding the first two to corresponding `pom.xmls`, so that they get executed.