### PR TITLE
ARTEMIS-568 Catch broken JMS selector expressions

### DIFF
--- a/artemis-selector/src/main/javacc/HyphenatedParser.jj
+++ b/artemis-selector/src/main/javacc/HyphenatedParser.jj
@@ -142,7 +142,7 @@ BooleanExpression JmsSelector() :
 }
 {
     (
-        left = orExpression()
+        left = orExpression() <EOF>
     )
     {
         return asBooleanExpression(left);

--- a/artemis-selector/src/main/javacc/StrictParser.jj
+++ b/artemis-selector/src/main/javacc/StrictParser.jj
@@ -142,7 +142,7 @@ BooleanExpression JmsSelector() :
 }
 {
     (
-        left = orExpression()
+        left = orExpression() <EOF>
     )
     {
         return asBooleanExpression(left);

--- a/artemis-selector/src/test/java/org/apache/activemq/artemis/selector/SelectorTest.java
+++ b/artemis-selector/src/test/java/org/apache/activemq/artemis/selector/SelectorTest.java
@@ -470,6 +470,8 @@ public class SelectorTest {
       assertInvalidSelector(message, "3+5");
       assertInvalidSelector(message, "True AND 3+5");
       assertInvalidSelector(message, "=TEST 'test'");
+      assertInvalidSelector(message, "prop1 = prop2 foo AND string = 'Test'");
+      assertInvalidSelector(message, "a = 1 AMD  b = 2");
    }
 
    protected MockMessage createMessage() {


### PR DESCRIPTION
Enforce an EOF on the expression so the selector parser keeps going and
catches the broken selector statement.