### PR TITLE
ARTEMIS-570 Fix buffer size overflow ProtonHandler

### DIFF
--- a/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/handler/impl/ProtonHandlerImpl.java
+++ b/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/handler/impl/ProtonHandlerImpl.java
@@ -259,6 +259,7 @@ public class ProtonHandlerImpl extends ProtonInitializable implements ProtonHand
          ByteBuf buffer = PooledByteBufAllocator.DEFAULT.buffer(size);
          ByteBuffer head = transport.head();
          head.position(offset);
+         head.limit(offset + size);
          buffer.writeBytes(head);
          offset += size; // incrementing offset for future calls
          return buffer;


### PR DESCRIPTION
There is a race condition in the ProtonHandlerImpl.outputBuffer()
method.  The method checks to see how many bytes (n) are pending in the
underlying ProtonJ buffer, then creates a Netty buffer of size n.  It
then writes the contents of the pending ProtonJ head.  However, ProtonJ
can still write to it's internal buffer, meaning that it's buffer.size >
n causing an illegalArgumentException.  This patch fixes it by only
writing 'n' bytes to the Netty buffer.