### PR TITLE
ARTEMIS-585 support send on dynamic sender link

### DIFF
--- a/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/AMQPClientSenderContext.java
+++ b/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/AMQPClientSenderContext.java
@@ -21,4 +21,7 @@ import org.apache.qpid.proton.message.ProtonJMessage;
 public interface AMQPClientSenderContext {
 
    void send(ProtonJMessage message);
+
+   String getAddress();
+
 }

--- a/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/AMQPClientSessionContext.java
+++ b/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/AMQPClientSessionContext.java
@@ -22,6 +22,8 @@ public interface AMQPClientSessionContext extends AMQPSessionContext {
 
    AMQPClientSenderContext createSender(String address, boolean preSettled) throws ActiveMQAMQPException;
 
+   AMQPClientSenderContext createDynamicSender(boolean preSettled) throws ActiveMQAMQPException;
+
    AMQPClientReceiverContext createReceiver(String address) throws ActiveMQAMQPException;
 
    AMQPClientReceiverContext createReceiver(String name, String address) throws ActiveMQAMQPException;

--- a/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/context/AbstractProtonReceiverContext.java
+++ b/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/context/AbstractProtonReceiverContext.java
@@ -32,7 +32,7 @@ public abstract class AbstractProtonReceiverContext extends ProtonInitializable 
 
    protected final Receiver receiver;
 
-   protected final String address;
+   protected String address;
 
    protected final AMQPSessionCallback sessionSPI;
 
@@ -43,12 +43,6 @@ public abstract class AbstractProtonReceiverContext extends ProtonInitializable 
       this.connection = connection;
       this.protonSession = protonSession;
       this.receiver = receiver;
-      if (receiver.getRemoteTarget() != null) {
-         this.address = receiver.getRemoteTarget().getAddress();
-      }
-      else {
-         this.address = null;
-      }
       this.sessionSPI = sessionSPI;
    }
 

--- a/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/context/client/ProtonClientContext.java
+++ b/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/context/client/ProtonClientContext.java
@@ -67,7 +67,10 @@ public class ProtonClientContext extends AbstractProtonContextSender implements 
          Thread.currentThread().interrupt();
          return false;
       }
-
    }
 
+   @Override
+   public String getAddress() {
+      return sender.getRemoteTarget().getAddress();
+   }
 }

--- a/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/context/server/ProtonServerReceiverContext.java
+++ b/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/context/server/ProtonServerReceiverContext.java
@@ -61,20 +61,20 @@ public class ProtonServerReceiverContext extends AbstractProtonReceiverContext {
          if (target.getDynamic()) {
             //if dynamic we have to create the node (queue) and set the address on the target, the node is temporary and
             // will be deleted on closing of the session
-            String queue = sessionSPI.tempQueueName();
+            address = sessionSPI.tempQueueName();
 
             try {
-               sessionSPI.createTemporaryQueue(queue);
+               sessionSPI.createTemporaryQueue(address);
             }
             catch (Exception e) {
                throw new ActiveMQAMQPInternalErrorException(e.getMessage(), e);
             }
-            target.setAddress(queue);
+            target.setAddress(address);
          }
          else {
             //if not dynamic then we use the targets address as the address to forward the messages to, however there has to
             //be a queue bound to it so we nee to check this.
-            String address = target.getAddress();
+            address = target.getAddress();
             if (address == null) {
                throw ActiveMQAMQPProtocolMessageBundle.BUNDLE.targetAddressNotSet();
             }


### PR DESCRIPTION
The sender abstraction must be able to update its sender address in the
case of dynamic senders whose target address is not set until the code
initializes the link and creates a destination for it.