### PR TITLE
ARTEMIS-596 JMS Bridge messages should be identified.

### DIFF
--- a/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/bridge/ActiveMQJMSBridgeLogger.java
+++ b/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/bridge/ActiveMQJMSBridgeLogger.java
@@ -48,58 +48,58 @@ public interface ActiveMQJMSBridgeLogger extends BasicLogger {
    ActiveMQJMSBridgeLogger LOGGER = Logger.getMessageLogger(ActiveMQJMSBridgeLogger.class, ActiveMQJMSBridgeLogger.class.getPackage().getName());
 
    @LogMessage(level = Logger.Level.INFO)
-   @Message(id = 341000, value = "Failed to set up JMS bridge connections. Most probably the source or target servers are unavailable." + " Will retry after a pause of {0} ms", format = Message.Format.MESSAGE_FORMAT)
-   void failedToSetUpBridge(long failureRetryInterval);
+   @Message(id = 341000, value = "Failed to set up JMS bridge {1} connections. Most probably the source or target servers are unavailable." + " Will retry after a pause of {0} ms", format = Message.Format.MESSAGE_FORMAT)
+   void failedToSetUpBridge(long failureRetryInterval,String bridgeName);
 
    @LogMessage(level = Logger.Level.INFO)
-   @Message(id = 341001, value = "JMS Bridge Succeeded in reconnecting to servers", format = Message.Format.MESSAGE_FORMAT)
-   void bridgeReconnected();
+   @Message(id = 341001, value = "JMS Bridge {0} succeeded in reconnecting to servers", format = Message.Format.MESSAGE_FORMAT)
+   void bridgeReconnected(String bridgeName);
 
    @LogMessage(level = Logger.Level.INFO)
-   @Message(id = 341002, value = "Succeeded in connecting to servers", format = Message.Format.MESSAGE_FORMAT)
-   void bridgeConnected();
+   @Message(id = 341002, value = "JMSBridge {0} succeeded in connecting to servers", format = Message.Format.MESSAGE_FORMAT)
+   void bridgeConnected(String bridgeName);
 
    @LogMessage(level = Logger.Level.WARN)
-   @Message(id = 342000, value = "Attempt to start JMS Bridge, but is already started", format = Message.Format.MESSAGE_FORMAT)
-   void errorBridgeAlreadyStarted();
+   @Message(id = 342000, value = "Attempt to start JMS Bridge {0}, but is already started", format = Message.Format.MESSAGE_FORMAT)
+   void errorBridgeAlreadyStarted(String bridgeName);
 
    @LogMessage(level = Logger.Level.WARN)
-   @Message(id = 342001, value = "Failed to start JMS Bridge", format = Message.Format.MESSAGE_FORMAT)
-   void errorStartingBridge();
+   @Message(id = 342001, value = "Failed to start JMS Bridge {0}", format = Message.Format.MESSAGE_FORMAT)
+   void errorStartingBridge(String bridgeName);
 
    @LogMessage(level = Logger.Level.WARN)
-   @Message(id = 342002, value = "Failed to unregisted JMS Bridge {0}", format = Message.Format.MESSAGE_FORMAT)
-   void errorUnregisteringBridge(ObjectName objectName);
+   @Message(id = 342002, value = "Failed to unregisted JMS Bridge {0} - {1}", format = Message.Format.MESSAGE_FORMAT)
+   void errorUnregisteringBridge(ObjectName objectName,String bridgeName);
 
    @LogMessage(level = Logger.Level.WARN)
-   @Message(id = 342003, value = "JMS Bridge unable to set up connections, bridge will be stopped", format = Message.Format.MESSAGE_FORMAT)
-   void errorConnectingBridge();
+   @Message(id = 342003, value = "JMS Bridge {0} unable to set up connections, bridge will be stopped", format = Message.Format.MESSAGE_FORMAT)
+   void errorConnectingBridge(String bridgeName);
 
    @LogMessage(level = Logger.Level.WARN)
-   @Message(id = 342004, value = "JMS Bridge Will retry after a pause of {0} ms", format = Message.Format.MESSAGE_FORMAT)
-   void bridgeRetry(long failureRetryInterval);
+   @Message(id = 342004, value = "JMS Bridge {1}, will retry after a pause of {0} ms", format = Message.Format.MESSAGE_FORMAT)
+   void bridgeRetry(long failureRetryInterval,String bridgeName);
 
    @LogMessage(level = Logger.Level.WARN)
-   @Message(id = 342005, value = "JMS Bridge unable to set up connections, bridge will not be started", format = Message.Format.MESSAGE_FORMAT)
-   void bridgeNotStarted();
+   @Message(id = 342005, value = "JMS Bridge {0} unable to set up connections, bridge will not be started", format = Message.Format.MESSAGE_FORMAT)
+   void bridgeNotStarted(String bridgeName);
 
    @LogMessage(level = Logger.Level.WARN)
-   @Message(id = 342006, value = "Detected failure on bridge connection", format = Message.Format.MESSAGE_FORMAT)
-   void bridgeFailure(@Cause Exception e);
+   @Message(id = 342006, value = "JMS Bridge {0}, detected failure on bridge connection", format = Message.Format.MESSAGE_FORMAT)
+   void bridgeFailure(@Cause Exception e,String bridgeName);
 
    @LogMessage(level = Logger.Level.WARN)
-   @Message(id = 342009, value = "JMS Bridge failed to send + acknowledge batch, closing JMS objects", format = Message.Format.MESSAGE_FORMAT)
-   void bridgeAckError(@Cause Exception e);
+   @Message(id = 342009, value = "JMS Bridge {0} failed to send + acknowledge batch, closing JMS objects", format = Message.Format.MESSAGE_FORMAT)
+   void bridgeAckError(@Cause Exception e,String bridgeName);
 
    @LogMessage(level = Logger.Level.WARN)
-   @Message(id = 342010, value = "Failed to connect JMS Bridge", format = Message.Format.MESSAGE_FORMAT)
-   void bridgeConnectError(@Cause Exception e);
+   @Message(id = 342010, value = "Failed to connect JMS Bridge {0}", format = Message.Format.MESSAGE_FORMAT)
+   void bridgeConnectError(@Cause Exception e,String bridgeName);
 
    @LogMessage(level = Logger.Level.ERROR)
-   @Message(id = 344001, value = "Failed to start source connection", format = Message.Format.MESSAGE_FORMAT)
-   void jmsBridgeSrcConnectError(@Cause Exception e);
+   @Message(id = 344001, value = "JMS Bridge {0}, failed to start source connection", format = Message.Format.MESSAGE_FORMAT)
+   void jmsBridgeSrcConnectError(@Cause Exception e,String bridgeName);
 
    @LogMessage(level = Logger.Level.ERROR)
-   @Message(id = 344002, value = "Failed to start JMS Bridge.  QoS Mode: {0} requires a Transaction Manager, none found", format = Message.Format.MESSAGE_FORMAT)
-   void jmsBridgeTransactionManagerMissing(QualityOfServiceMode qosMode);
+   @Message(id = 344002, value = "Failed to start JMS Bridge {1}.  QoS Mode: {0} requires a Transaction Manager, none found", format = Message.Format.MESSAGE_FORMAT)
+   void jmsBridgeTransactionManagerMissing(QualityOfServiceMode qosMode,String bridgeName);
 }

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/JMSBridgeReconnectionTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/JMSBridgeReconnectionTest.java
@@ -55,7 +55,7 @@ public class JMSBridgeReconnectionTest extends BridgeTestBase {
       activeMQServer = jmsServer1;
       ConnectionFactoryFactory factInUse0 = cff0;
       ConnectionFactoryFactory factInUse1 = cff1;
-      final JMSBridgeImpl bridge = new JMSBridgeImpl(factInUse0, factInUse1, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 1000, -1, QualityOfServiceMode.DUPLICATES_OK, 10, -1, null, null, false);
+      final JMSBridgeImpl bridge = new JMSBridgeImpl("test-bridge",factInUse0, factInUse1, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 1000, -1, QualityOfServiceMode.DUPLICATES_OK, 10, -1, null, null, false);
 
       addActiveMQComponent(bridge);
       bridge.setTransactionManager(newTransactionManager());

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/jms/bridge/JMSBridgeClusteredTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/jms/bridge/JMSBridgeClusteredTest.java
@@ -95,7 +95,7 @@ public class JMSBridgeClusteredTest extends ClusteredBridgeTestBase {
 
          //even number
          final int batchSize = 4;
-         bridge = new JMSBridgeImpl(sourceCFF, targetCFF, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 1000, -1, mode, batchSize, -1, null, null, false);
+         bridge = new JMSBridgeImpl("test-bridge",sourceCFF, targetCFF, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 1000, -1, mode, batchSize, -1, null, null, false);
 
          txMgr = newTransactionManager();
          bridge.setTransactionManager(txMgr);
@@ -154,7 +154,7 @@ public class JMSBridgeClusteredTest extends ClusteredBridgeTestBase {
          DestinationFactory sourceQueueFactory = sourceServer.getDestinationFactory(sourceQueueName);
          DestinationFactory targetQueueFactory = targetServer.getDestinationFactory(targetQueueName);
 
-         bridge = new JMSBridgeImpl(sourceCFF, targetCFF, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 1000, -1, mode, 10, 1000, null, null, false);
+         bridge = new JMSBridgeImpl("test-bridge",sourceCFF, targetCFF, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 1000, -1, mode, 10, 1000, null, null, false);
 
          txMgr = newTransactionManager();
          bridge.setTransactionManager(txMgr);

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/jms/bridge/JMSBridgeReconnectionTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/jms/bridge/JMSBridgeReconnectionTest.java
@@ -107,7 +107,7 @@ public class JMSBridgeReconnectionTest extends BridgeTestBase {
    public void testRetryConnectionOnStartup() throws Exception {
       jmsServer1.stop();
 
-      JMSBridgeImpl bridge = new JMSBridgeImpl(cff0, cff1, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 1000, -1, QualityOfServiceMode.DUPLICATES_OK, 10, -1, null, null, false);
+      JMSBridgeImpl bridge = new JMSBridgeImpl("test-bridge",cff0, cff1, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 1000, -1, QualityOfServiceMode.DUPLICATES_OK, 10, -1, null, null, false);
       bridge.setTransactionManager(newTransactionManager());
       addActiveMQComponent(bridge);
       bridge.start();
@@ -133,7 +133,7 @@ public class JMSBridgeReconnectionTest extends BridgeTestBase {
    public void testStopBridgeWithFailureWhenStarted() throws Exception {
       jmsServer1.stop();
 
-      JMSBridgeImpl bridge = new JMSBridgeImpl(cff0, cff1, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 500, -1, QualityOfServiceMode.DUPLICATES_OK, 10, -1, null, null, false);
+      JMSBridgeImpl bridge = new JMSBridgeImpl("test-bridge",cff0, cff1, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 500, -1, QualityOfServiceMode.DUPLICATES_OK, 10, -1, null, null, false);
       bridge.setTransactionManager(newTransactionManager());
 
       bridge.start();
@@ -168,7 +168,7 @@ public class JMSBridgeReconnectionTest extends BridgeTestBase {
          factInUse1 = cff1xa;
       }
 
-      bridge = new JMSBridgeImpl(factInUse0, factInUse1, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 1000, -1, qosMode, 10, -1, null, null, false);
+      bridge = new JMSBridgeImpl("test-bridge",factInUse0, factInUse1, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 1000, -1, qosMode, 10, -1, null, null, false);
       addActiveMQComponent(bridge);
       bridge.setTransactionManager(newTransactionManager());
       bridge.start();
@@ -223,7 +223,7 @@ public class JMSBridgeReconnectionTest extends BridgeTestBase {
    public void performCrashDestinationStopBridge() throws Exception {
       ConnectionFactoryFactory factInUse0 = cff0;
       ConnectionFactoryFactory factInUse1 = cff1;
-      final JMSBridgeImpl bridge = new JMSBridgeImpl(factInUse0, factInUse1, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 1000, -1, QualityOfServiceMode.DUPLICATES_OK, 10, -1, null, null, false);
+      final JMSBridgeImpl bridge = new JMSBridgeImpl("test-bridge",factInUse0, factInUse1, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 1000, -1, QualityOfServiceMode.DUPLICATES_OK, 10, -1, null, null, false);
 
       addActiveMQComponent(bridge);
       bridge.setTransactionManager(newTransactionManager());
@@ -294,7 +294,7 @@ public class JMSBridgeReconnectionTest extends BridgeTestBase {
       DummyTransaction tx = new DummyTransaction();
       tm.tx = tx;
 
-      JMSBridgeImpl bridge = new JMSBridgeImpl(cff0xa, cff1xa, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 1000, -1, QualityOfServiceMode.ONCE_AND_ONLY_ONCE, 10, 5000, null, null, false);
+      JMSBridgeImpl bridge = new JMSBridgeImpl("test-bridge",cff0xa, cff1xa, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 1000, -1, QualityOfServiceMode.ONCE_AND_ONLY_ONCE, 10, 5000, null, null, false);
       addActiveMQComponent(bridge);
       bridge.setTransactionManager(tm);
 
@@ -379,7 +379,7 @@ public class JMSBridgeReconnectionTest extends BridgeTestBase {
     * Verify all messages are received
     */
    private void performCrashAndReconnectDestCrashBeforePrepare(final boolean persistent) throws Exception {
-      JMSBridgeImpl bridge = new JMSBridgeImpl(cff0xa, cff1xa, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 1000, -1, QualityOfServiceMode.ONCE_AND_ONLY_ONCE, 10, 5000, null, null, false);
+      JMSBridgeImpl bridge = new JMSBridgeImpl("test-bridge",cff0xa, cff1xa, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 1000, -1, QualityOfServiceMode.ONCE_AND_ONLY_ONCE, 10, 5000, null, null, false);
       addActiveMQComponent(bridge);
       bridge.setTransactionManager(newTransactionManager());
 

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/jms/bridge/JMSBridgeTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/jms/bridge/JMSBridgeTest.java
@@ -335,7 +335,7 @@ public class JMSBridgeTest extends BridgeTestBase {
       try {
          final int NUM_MESSAGES = 10;
 
-         bridge = new JMSBridgeImpl(factInUse0, factInUse1, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 5000, 10, QualityOfServiceMode.AT_MOST_ONCE, NUM_MESSAGES, -1, null, null, false);
+         bridge = new JMSBridgeImpl("test-bridge",factInUse0, factInUse1, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 5000, 10, QualityOfServiceMode.AT_MOST_ONCE, NUM_MESSAGES, -1, null, null, false);
 
          bridge.start();
 
@@ -414,7 +414,7 @@ public class JMSBridgeTest extends BridgeTestBase {
       String clientID = null;
 
       try {
-         bridge = new JMSBridgeImpl(null, cff1, sourceQueueFactory, targetQueueFactory, sourceUsername, sourcePassword, destUsername, destPassword, selector, failureRetryInterval, maxRetries, qosMode, batchSize, maxBatchTime, subName, clientID, false);
+         bridge = new JMSBridgeImpl("test-bridge",null, cff1, sourceQueueFactory, targetQueueFactory, sourceUsername, sourcePassword, destUsername, destPassword, selector, failureRetryInterval, maxRetries, qosMode, batchSize, maxBatchTime, subName, clientID, false);
          fail("expected exception");
       }
       catch (IllegalArgumentException e) {
@@ -425,7 +425,7 @@ public class JMSBridgeTest extends BridgeTestBase {
       }
 
       try {
-         bridge = new JMSBridgeImpl(cff0, null, sourceQueueFactory, targetQueueFactory, sourceUsername, sourcePassword, destUsername, destPassword, selector, failureRetryInterval, maxRetries, qosMode, batchSize, maxBatchTime, subName, clientID, false);
+         bridge = new JMSBridgeImpl("test-bridge",cff0, null, sourceQueueFactory, targetQueueFactory, sourceUsername, sourcePassword, destUsername, destPassword, selector, failureRetryInterval, maxRetries, qosMode, batchSize, maxBatchTime, subName, clientID, false);
          fail("expected exception");
       }
       catch (IllegalArgumentException e) {
@@ -436,7 +436,7 @@ public class JMSBridgeTest extends BridgeTestBase {
       }
 
       try {
-         bridge = new JMSBridgeImpl(cff0, cff1, null, targetQueueFactory, sourceUsername, sourcePassword, destUsername, destPassword, selector, failureRetryInterval, maxRetries, qosMode, batchSize, maxBatchTime, subName, clientID, false);
+         bridge = new JMSBridgeImpl("test-bridge",cff0, cff1, null, targetQueueFactory, sourceUsername, sourcePassword, destUsername, destPassword, selector, failureRetryInterval, maxRetries, qosMode, batchSize, maxBatchTime, subName, clientID, false);
          fail("expected exception");
       }
       catch (IllegalArgumentException e) {
@@ -447,7 +447,7 @@ public class JMSBridgeTest extends BridgeTestBase {
       }
 
       try {
-         bridge = new JMSBridgeImpl(cff0, cff1, sourceQueueFactory, null, sourceUsername, sourcePassword, destUsername, destPassword, selector, failureRetryInterval, maxRetries, qosMode, batchSize, maxBatchTime, subName, clientID, false);
+         bridge = new JMSBridgeImpl("test-bridge",cff0, cff1, sourceQueueFactory, null, sourceUsername, sourcePassword, destUsername, destPassword, selector, failureRetryInterval, maxRetries, qosMode, batchSize, maxBatchTime, subName, clientID, false);
          fail("expected exception");
       }
       catch (IllegalArgumentException e) {
@@ -458,7 +458,7 @@ public class JMSBridgeTest extends BridgeTestBase {
       }
 
       try {
-         bridge = new JMSBridgeImpl(cff0, cff1, sourceQueueFactory, targetQueueFactory, sourceUsername, sourcePassword, destUsername, destPassword, selector, -2, maxRetries, qosMode, batchSize, maxBatchTime, subName, clientID, false);
+         bridge = new JMSBridgeImpl("test-bridge",cff0, cff1, sourceQueueFactory, targetQueueFactory, sourceUsername, sourcePassword, destUsername, destPassword, selector, -2, maxRetries, qosMode, batchSize, maxBatchTime, subName, clientID, false);
          fail("expected exception");
       }
       catch (IllegalArgumentException e) {
@@ -469,7 +469,7 @@ public class JMSBridgeTest extends BridgeTestBase {
       }
 
       try {
-         bridge = new JMSBridgeImpl(cff0, cff1, sourceQueueFactory, targetQueueFactory, sourceUsername, sourcePassword, destUsername, destPassword, selector, -1, 10, qosMode, batchSize, maxBatchTime, subName, clientID, false);
+         bridge = new JMSBridgeImpl("test-bridge",cff0, cff1, sourceQueueFactory, targetQueueFactory, sourceUsername, sourcePassword, destUsername, destPassword, selector, -1, 10, qosMode, batchSize, maxBatchTime, subName, clientID, false);
          fail("expected exception");
       }
       catch (IllegalArgumentException e) {
@@ -480,7 +480,7 @@ public class JMSBridgeTest extends BridgeTestBase {
       }
 
       try {
-         bridge = new JMSBridgeImpl(cff0, cff1, sourceQueueFactory, null, sourceUsername, sourcePassword, destUsername, destPassword, selector, failureRetryInterval, maxRetries, qosMode, 0, maxBatchTime, subName, clientID, false);
+         bridge = new JMSBridgeImpl("test-bridge",cff0, cff1, sourceQueueFactory, null, sourceUsername, sourcePassword, destUsername, destPassword, selector, failureRetryInterval, maxRetries, qosMode, 0, maxBatchTime, subName, clientID, false);
          fail("expected exception");
       }
       catch (IllegalArgumentException e) {
@@ -491,7 +491,7 @@ public class JMSBridgeTest extends BridgeTestBase {
       }
 
       try {
-         bridge = new JMSBridgeImpl(cff0, cff1, sourceQueueFactory, null, sourceUsername, sourcePassword, destUsername, destPassword, selector, failureRetryInterval, maxRetries, qosMode, batchSize, -2, subName, clientID, false);
+         bridge = new JMSBridgeImpl("test-bridge",cff0, cff1, sourceQueueFactory, null, sourceUsername, sourcePassword, destUsername, destPassword, selector, failureRetryInterval, maxRetries, qosMode, batchSize, -2, subName, clientID, false);
          fail("expected exception");
       }
       catch (IllegalArgumentException e) {
@@ -513,7 +513,7 @@ public class JMSBridgeTest extends BridgeTestBase {
       try {
          final int NUM_MESSAGES = 10;
 
-         bridge = new JMSBridgeImpl(cff0, cff1, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 5000, 10, QualityOfServiceMode.AT_MOST_ONCE, 1, -1, null, null, false);
+         bridge = new JMSBridgeImpl("test-bridge",cff0, cff1, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 5000, 10, QualityOfServiceMode.AT_MOST_ONCE, 1, -1, null, null, false);
 
          bridge.start();
 
@@ -577,7 +577,7 @@ public class JMSBridgeTest extends BridgeTestBase {
 
          String selector = "vegetable='radish'";
 
-         bridge = new JMSBridgeImpl(cff0, cff1, sourceQueueFactory, targetQueueFactory, null, null, null, null, selector, 5000, 10, QualityOfServiceMode.AT_MOST_ONCE, 1, -1, null, null, false);
+         bridge = new JMSBridgeImpl("test-bridge",cff0, cff1, sourceQueueFactory, targetQueueFactory, null, null, null, null, selector, 5000, 10, QualityOfServiceMode.AT_MOST_ONCE, 1, -1, null, null, false);
 
          bridge.start();
 
@@ -652,7 +652,7 @@ public class JMSBridgeTest extends BridgeTestBase {
       try {
          final int NUM_MESSAGES = 10;
 
-         bridge = new JMSBridgeImpl(cff0, cff1, sourceQueueFactory, targetQueueFactory, "guest", mask, "guest", mask, null, 5000, 10, QualityOfServiceMode.AT_MOST_ONCE, 1, -1, null, null, false);
+         bridge = new JMSBridgeImpl("test-bridge",cff0, cff1, sourceQueueFactory, targetQueueFactory, "guest", mask, "guest", mask, null, 5000, 10, QualityOfServiceMode.AT_MOST_ONCE, 1, -1, null, null, false);
 
          bridge.setUseMaskedPassword(true);
 
@@ -726,7 +726,7 @@ public class JMSBridgeTest extends BridgeTestBase {
       try {
          final int NUM_MESSAGES = 10;
 
-         bridge = new JMSBridgeImpl(cff0, cff1, sourceQueueFactory, targetQueueFactory, "guest", mask, "guest", mask, null, 5000, 10, QualityOfServiceMode.AT_MOST_ONCE, 1, -1, null, null, false);
+         bridge = new JMSBridgeImpl("test-bridge",cff0, cff1, sourceQueueFactory, targetQueueFactory, "guest", mask, "guest", mask, null, 5000, 10, QualityOfServiceMode.AT_MOST_ONCE, 1, -1, null, null, false);
 
          bridge.setUseMaskedPassword(true);
          bridge.setPasswordCodec(codec.getClass().getName() + ";key=bridgekey");
@@ -812,7 +812,7 @@ public class JMSBridgeTest extends BridgeTestBase {
 
          final int NUM_MESSAGES = 10;
 
-         bridge = new JMSBridgeImpl(cff0, cff1, sourceTopicFactory, targetQueueFactory, null, null, null, null, null, 5000, 10, QualityOfServiceMode.AT_MOST_ONCE, 1, -1, null, null, false);
+         bridge = new JMSBridgeImpl("test-bridge",cff0, cff1, sourceTopicFactory, targetQueueFactory, null, null, null, null, null, 5000, 10, QualityOfServiceMode.AT_MOST_ONCE, 1, -1, null, null, false);
          bridge.start();
 
          sendMessages(cf0, sourceTopic, 0, NUM_MESSAGES, false, largeMessage);
@@ -859,7 +859,7 @@ public class JMSBridgeTest extends BridgeTestBase {
       try {
          final int NUM_MESSAGES = 10;
 
-         bridge = new JMSBridgeImpl(cff0, cff1, sourceTopicFactory, targetQueueFactory, null, null, null, null, null, 5000, 10, QualityOfServiceMode.AT_MOST_ONCE, batchSize, -1, null, null, false);
+         bridge = new JMSBridgeImpl("test-bridge",cff0, cff1, sourceTopicFactory, targetQueueFactory, null, null, null, null, null, 5000, 10, QualityOfServiceMode.AT_MOST_ONCE, batchSize, -1, null, null, false);
 
          bridge.start();
 
@@ -890,7 +890,7 @@ public class JMSBridgeTest extends BridgeTestBase {
       try {
          final int NUM_MESSAGES = 10;
 
-         bridge = new JMSBridgeImpl(cff0, cff1, sourceTopicFactory, targetQueueFactory, null, null, null, null, null, 5000, 10, QualityOfServiceMode.AT_MOST_ONCE, batchSize, -1, "subTest", "clientid123", false);
+         bridge = new JMSBridgeImpl("test-bridge",cff0, cff1, sourceTopicFactory, targetQueueFactory, null, null, null, null, null, 5000, 10, QualityOfServiceMode.AT_MOST_ONCE, batchSize, -1, "subTest", "clientid123", false);
 
          bridge.start();
 
@@ -932,7 +932,7 @@ public class JMSBridgeTest extends BridgeTestBase {
       try {
          final int NUM_MESSAGES = 10;
 
-         bridge = new JMSBridgeImpl(cff0, cff1, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 5000, 10, QualityOfServiceMode.AT_MOST_ONCE, 1, -1, null, null, on);
+         bridge = new JMSBridgeImpl("test-bridge",cff0, cff1, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 5000, 10, QualityOfServiceMode.AT_MOST_ONCE, 1, -1, null, null, on);
 
          bridge.start();
 
@@ -1107,7 +1107,7 @@ public class JMSBridgeTest extends BridgeTestBase {
       try {
          final int NUM_MESSAGES = 10;
 
-         bridge = new JMSBridgeImpl(cff0, cff1, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 5000, 10, QualityOfServiceMode.AT_MOST_ONCE, 1, -1, null, null, messageIDInHeader);
+         bridge = new JMSBridgeImpl("test-bridge",cff0, cff1, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 5000, 10, QualityOfServiceMode.AT_MOST_ONCE, 1, -1, null, null, messageIDInHeader);
 
          bridge.start();
 
@@ -1255,7 +1255,7 @@ public class JMSBridgeTest extends BridgeTestBase {
       try {
          final int NUM_MESSAGES = 10;
 
-         bridge = new JMSBridgeImpl(cff0, cff1, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 5000, 10, QualityOfServiceMode.AT_MOST_ONCE, 1, -1, null, null, false);
+         bridge = new JMSBridgeImpl("test-bridge",cff0, cff1, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 5000, 10, QualityOfServiceMode.AT_MOST_ONCE, 1, -1, null, null, false);
 
          bridge.start();
 
@@ -1339,7 +1339,7 @@ public class JMSBridgeTest extends BridgeTestBase {
       }
 
       try {
-         bridge = new JMSBridgeImpl(factInUse0, factInUse1, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 5000, 10, qosMode, batchSize, -1, null, null, false);
+         bridge = new JMSBridgeImpl("test-bridge",factInUse0, factInUse1, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 5000, 10, qosMode, batchSize, -1, null, null, false);
 
          bridge.start();
 
@@ -1409,7 +1409,7 @@ public class JMSBridgeTest extends BridgeTestBase {
       }
 
       try {
-         bridge = new JMSBridgeImpl(factInUse0, factInUse1, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 5000, 10, qosMode, 2, maxBatchTime, null, null, false);
+         bridge = new JMSBridgeImpl("test-bridge",factInUse0, factInUse1, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 5000, 10, qosMode, 2, maxBatchTime, null, null, false);
 
          bridge.start();
 
@@ -1477,7 +1477,7 @@ public class JMSBridgeTest extends BridgeTestBase {
       }
 
       try {
-         bridge = new JMSBridgeImpl(factInUse0, factInUse0, sourceQueueFactory, localTargetQueueFactory, null, null, null, null, null, 5000, 10, qosMode, batchSize, -1, null, null, false);
+         bridge = new JMSBridgeImpl("test-bridge",factInUse0, factInUse0, sourceQueueFactory, localTargetQueueFactory, null, null, null, null, null, 5000, 10, qosMode, batchSize, -1, null, null, false);
 
          bridge.start();
 
@@ -1542,7 +1542,7 @@ public class JMSBridgeTest extends BridgeTestBase {
       try {
          final int NUM_MESSAGES = 10;
 
-         bridge = new JMSBridgeImpl(factInUse0, factInUse1, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 5000, 10, qosMode, NUM_MESSAGES, -1, null, null, false);
+         bridge = new JMSBridgeImpl("test-bridge",factInUse0, factInUse1, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 5000, 10, qosMode, NUM_MESSAGES, -1, null, null, false);
 
          bridge.start();
 
@@ -1599,7 +1599,7 @@ public class JMSBridgeTest extends BridgeTestBase {
       try {
          final int NUM_MESSAGES = 10;
 
-         bridge = new JMSBridgeImpl(factInUse0, factInUse0, sourceQueueFactory, localTargetQueueFactory, null, null, null, null, null, 5000, 10, qosMode, NUM_MESSAGES, -1, null, null, false);
+         bridge = new JMSBridgeImpl("test-bridge",factInUse0, factInUse0, sourceQueueFactory, localTargetQueueFactory, null, null, null, null, null, 5000, 10, qosMode, NUM_MESSAGES, -1, null, null, false);
 
          bridge.start();
 
@@ -1658,7 +1658,7 @@ public class JMSBridgeTest extends BridgeTestBase {
 
          final int MAX_BATCH_SIZE = 100000; // something big so it won't reach it
 
-         bridge = new JMSBridgeImpl(factInUse0, factInUse1, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 3000, 10, qosMode, MAX_BATCH_SIZE, MAX_BATCH_TIME, null, null, false);
+         bridge = new JMSBridgeImpl("test-bridge",factInUse0, factInUse1, sourceQueueFactory, targetQueueFactory, null, null, null, null, null, 3000, 10, qosMode, MAX_BATCH_SIZE, MAX_BATCH_TIME, null, null, false);
 
          bridge.start();
 
@@ -1698,7 +1698,7 @@ public class JMSBridgeTest extends BridgeTestBase {
 
          final int MAX_BATCH_SIZE = 100000; // something big so it won't reach it
 
-         bridge = new JMSBridgeImpl(factInUse0, factInUse0, sourceQueueFactory, localTargetQueueFactory, null, null, null, null, null, 3000, 10, qosMode, MAX_BATCH_SIZE, MAX_BATCH_TIME, null, null, false);
+         bridge = new JMSBridgeImpl("test-bridge",factInUse0, factInUse0, sourceQueueFactory, localTargetQueueFactory, null, null, null, null, null, 3000, 10, qosMode, MAX_BATCH_SIZE, MAX_BATCH_TIME, null, null, false);
 
          bridge.start();
 
@@ -1731,7 +1731,7 @@ public class JMSBridgeTest extends BridgeTestBase {
 
       JMSBridgeImpl bridge = null;
       try {
-         bridge = new JMSBridgeImpl(cff0, cff0, sourceQueueFactory, localTargetQueueFactory, null, null, null, null, null, 3000, 10, QualityOfServiceMode.ONCE_AND_ONLY_ONCE, 10000, 3000, null, null, false);
+         bridge = new JMSBridgeImpl("test-bridge",cff0, cff0, sourceQueueFactory, localTargetQueueFactory, null, null, null, null, null, 3000, 10, QualityOfServiceMode.ONCE_AND_ONLY_ONCE, 10000, 3000, null, null, false);
          bridge.start();
       }
       finally {
@@ -1747,7 +1747,7 @@ public class JMSBridgeTest extends BridgeTestBase {
       MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
       ObjectName objectName = new ObjectName("example.jmsbridge:service=JMSBridge");
 
-      JMSBridgeImpl bridge = new JMSBridgeImpl(cff0, cff0, sourceQueueFactory, localTargetQueueFactory, null, null, null, null, null, 5000, 10, QualityOfServiceMode.AT_MOST_ONCE, 1, -1, null, null, false, mbeanServer, objectName.getCanonicalName());
+      JMSBridgeImpl bridge = new JMSBridgeImpl("test-bridge",cff0, cff0, sourceQueueFactory, localTargetQueueFactory, null, null, null, null, null, 5000, 10, QualityOfServiceMode.AT_MOST_ONCE, 1, -1, null, null, false, mbeanServer, objectName.getCanonicalName());
 
       Assert.assertTrue(mbeanServer.isRegistered(objectName));
 


### PR DESCRIPTION
In cases where there are many JMS bridges defined on a broker it should
be possible to identify any error message by a bridge name.