### PR TITLE
NO-JIRA update building instructions on Fedora

### DIFF
--- a/docs/hacking-guide/en/building.md
+++ b/docs/hacking-guide/en/building.md
@@ -49,7 +49,7 @@ To install it to your local maven repo:
 
 ## Build the distribution without docs
 
-It is possible to build a distribution with out the manuals and Javadocs.
+It is possible to build a distribution without the manuals and Javadocs.
 simply run
 
     $ mvn package

--- a/docs/hacking-guide/en/building.md
+++ b/docs/hacking-guide/en/building.md
@@ -23,9 +23,9 @@ Install `NPM` using the instructions below
 
 The new npm-shrinkwrap.json should be written, commit it.
 
-#### Install npm On Fedora
+#### Install npm On Fedora 24
 
-    $ yum install npm
+    $ dnf install nodejs
 
 #### Install npm On Mac-OS
 


### PR DESCRIPTION
The npm command is now provided by the package nodejs. Attempt to install the npm
package fails with the following message (if nodejs is installed)

    $ sudo dnf install npm 
    Last metadata expiration check: 3:01:30 ago on Sun Jun 26 17:00:37 2016.
    Error: installed package nodejs-1:4.4.5-1.fc24.x86_64 obsoletes npm < 3.5.4-6 provided by npm-3.5.4-5.fc24.noarch
    (try to add '--allowerasing' to command line to replace conflicting packages)

If nodejs is not installed, the message is somewhat cryptic

    $ sudo dnf install npm 
    Last metadata expiration check: 3:00:41 ago on Sun Jun 26 17:00:37 2016.
    Error: package npm-3.5.4-5.fc24.noarch requires nodejs(engine), but none of the providers can be installed
    (try to add '--allowerasing' to command line to replace conflicting packages)