### PR TITLE
ARTEMIS-606 JMSServerControl2Test#testCloseConsumerConnectionsForAddr…

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/management/JMSServerControl2Test.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/management/JMSServerControl2Test.java
@@ -986,6 +986,7 @@ public class JMSServerControl2Test extends ManagementTestBase {
          Assert.assertEquals(0, queueControl.getConsumerCount());
          Assert.assertEquals(1, queueControl2.getConsumerCount());
 
+         connection.close();
          connection2.close();
       }
       finally {
@@ -1148,6 +1149,7 @@ public class JMSServerControl2Test extends ManagementTestBase {
          Assert.assertEquals(0, queueControl.getConsumerCount());
          Assert.assertEquals(1, queueControl2.getConsumerCount());
 
+         connection.close();
          connection2.close();
       }
       finally {


### PR DESCRIPTION
…essForInVM fails

Based on log it is clear that the connection was closed by Finalizer before the failure
was caused by the test itself. Since the connection variable is not referenced in the
code anymore, JVM concludes it can destroy the object. Especially IBM JDK does it very
fast.