### PR TITLE
ARTEMIS-607 Added interceptor support for MQTT protocol.

### DIFF
--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTInterceptor.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTInterceptor.java
@@ -1,0 +1,26 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.activemq.artemis.core.protocol.mqtt;
+
+import io.netty.handler.codec.mqtt.MqttMessage;
+import org.apache.activemq.artemis.api.core.BaseInterceptor;
+
+public interface MQTTInterceptor extends BaseInterceptor<MqttMessage> {
+}

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTProtocolManagerFactory.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTProtocolManagerFactory.java
@@ -22,12 +22,13 @@ import java.util.Map;
 
 import org.apache.activemq.artemis.api.core.BaseInterceptor;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.spi.core.protocol.AbstractProtocolManagerFactory;
 import org.apache.activemq.artemis.spi.core.protocol.ProtocolManager;
 import org.apache.activemq.artemis.spi.core.protocol.ProtocolManagerFactory;
 import org.osgi.service.component.annotations.Component;
 
 @Component(service = ProtocolManagerFactory.class)
-public class MQTTProtocolManagerFactory implements ProtocolManagerFactory<BaseInterceptor> {
+public class MQTTProtocolManagerFactory extends AbstractProtocolManagerFactory<MQTTInterceptor> {
 
    public static final String MQTT_PROTOCOL_NAME = "MQTT";
 
@@ -40,13 +41,12 @@ public class MQTTProtocolManagerFactory implements ProtocolManagerFactory<BaseIn
                                                 final Map<String, Object> parameters,
                                                 List<BaseInterceptor> incomingInterceptors,
                                                 List<BaseInterceptor> outgoingInterceptors) {
-      return new MQTTProtocolManager(server);
+      return new MQTTProtocolManager(server, incomingInterceptors, outgoingInterceptors);
    }
 
    @Override
-   public List filterInterceptors(List list) {
-      // TODO Add support for interceptors.
-      return null;
+   public List<MQTTInterceptor> filterInterceptors(List<BaseInterceptor> interceptors) {
+      return internalFilterInterceptors(MQTTInterceptor.class, interceptors);
    }
 
    @Override

--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompProtocolManager.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompProtocolManager.java
@@ -37,9 +37,9 @@ import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
 import org.apache.activemq.artemis.core.server.ServerSession;
 import org.apache.activemq.artemis.core.server.impl.ServerMessageImpl;
+import org.apache.activemq.artemis.spi.core.protocol.AbstractProtocolManager;
 import org.apache.activemq.artemis.spi.core.protocol.ConnectionEntry;
 import org.apache.activemq.artemis.spi.core.protocol.MessageConverter;
-import org.apache.activemq.artemis.spi.core.protocol.ProtocolManager;
 import org.apache.activemq.artemis.spi.core.protocol.ProtocolManagerFactory;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
 import org.apache.activemq.artemis.spi.core.remoting.Acceptor;
@@ -52,7 +52,7 @@ import static org.apache.activemq.artemis.core.protocol.stomp.ActiveMQStompProto
 /**
  * StompProtocolManager
  */
-class StompProtocolManager implements ProtocolManager<StompFrameInterceptor> {
+class StompProtocolManager extends AbstractProtocolManager<StompFrame,StompFrameInterceptor,StompConnection> {
    // Constants -----------------------------------------------------
 
    // Attributes ----------------------------------------------------
@@ -409,22 +409,5 @@ class StompProtocolManager implements ProtocolManager<StompFrameInterceptor> {
 
    public ActiveMQServer getServer() {
       return server;
-   }
-
-   private void invokeInterceptors(List<StompFrameInterceptor> interceptors,
-                                   final StompFrame frame,
-                                   final StompConnection connection) {
-      if (interceptors != null && !interceptors.isEmpty()) {
-         for (StompFrameInterceptor interceptor : interceptors) {
-            try {
-               if (!interceptor.intercept(frame, connection)) {
-                  break;
-               }
-            }
-            catch (Exception e) {
-               ActiveMQServerLogger.LOGGER.error(e);
-            }
-         }
-      }
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/protocol/AbstractProtocolManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/protocol/AbstractProtocolManager.java
@@ -1,0 +1,46 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.activemq.artemis.spi.core.protocol;
+
+import org.apache.activemq.artemis.api.core.BaseInterceptor;
+import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
+
+import java.util.List;
+
+public abstract class AbstractProtocolManager<P, I extends BaseInterceptor<P>, C extends RemotingConnection>
+      implements ProtocolManager<I> {
+
+   protected void invokeInterceptors(final List<I> interceptors,
+                                     final P message,
+                                     final C connection) {
+      if (interceptors != null && !interceptors.isEmpty()) {
+         for (I interceptor : interceptors) {
+            try {
+               if (!interceptor.intercept(message, connection)) {
+                  break;
+               }
+            }
+            catch (Exception e) {
+               ActiveMQServerLogger.LOGGER.error(e);
+            }
+         }
+      }
+   }
+}

--- a/docs/hacking-guide/en/maintainers.md
+++ b/docs/hacking-guide/en/maintainers.md
@@ -11,7 +11,7 @@ What does it mean to be reasonably confident? If the developer has run the same 
 builds are running they can be reasonably confident. Currently the [PR build](https://builds.apache.org/job/ActiveMQ-Artemis-PR-Build/)
 runs this command:
 
-    mvn compile test-compile javadoc:javadoc -Pfast-tests -Pextra-tests test
+    mvn -Pfast-tests -Pextra-tests install
 
 However, if the changes are significant, touches a wide area of code, or even if the developer just wants a second
 opinion they are encouraged to engage other members of the community to obtain an additional review prior to pushing.

--- a/docs/user-manual/en/intercepting-operations.md
+++ b/docs/user-manual/en/intercepting-operations.md
@@ -9,7 +9,9 @@ makes interceptors powerful, but also potentially dangerous.
 
 ## Implementing The Interceptors
 
-An interceptor must implement the `Interceptor interface`:
+All interceptors are protocol specific.
+
+An interceptor for the core protocol must implement the interface `Interceptor`:
 
 ``` java
 package org.apache.artemis.activemq.api.core.interceptor;
@@ -20,14 +22,25 @@ public interface Interceptor
 }
 ```
 
-For stomp protocol an interceptor must implement the `StompFrameInterceptor class`:
+For stomp protocol an interceptor must implement the interface `StompFrameInterceptor`:
 
 ``` java
 package org.apache.activemq.artemis.core.protocol.stomp;
 
-public interface StompFrameInterceptor
+public interface StompFrameInterceptor extends BaseInterceptor<StompFrame>
 {
-   public abstract boolean intercept(StompFrame stompFrame, RemotingConnection connection);
+   boolean intercept(StompFrame stompFrame, RemotingConnection connection);
+}
+```
+
+Likewise for MQTT protocol, an interceptor must implement the interface `MQTTInterceptor`:
+ 
+``` java
+package org.apache.activemq.artemis.core.protocol.mqtt;
+
+public interface MQTTInterceptor extends BaseInterceptor<MqttMessage>
+{
+    boolean intercept(MqttMessage mqttMessage, RemotingConnection connection);
 }
 ```
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/imported/MQTTTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/imported/MQTTTest.java
@@ -246,7 +246,9 @@ public class MQTTTest extends MQTTTestSupport {
    }
 
    @Test(timeout = 60 * 1000)
-   public void testSendAndReceiveExactlyOnce() throws Exception {
+   public void testSendAndReceiveExactlyOnceWithInterceptors() throws Exception {
+      MQTTIncomingInterceptor.clear();
+      MQTTOutoingInterceptor.clear();
       final MQTTClientProvider publisher = getMQTTClientProvider();
       initializeConnection(publisher);
 
@@ -263,6 +265,8 @@ public class MQTTTest extends MQTTTestSupport {
       }
       subscriber.disconnect();
       publisher.disconnect();
+      assertEquals(NUM_MESSAGES, MQTTIncomingInterceptor.getMessageCount());
+      assertEquals(NUM_MESSAGES, MQTTOutoingInterceptor.getMessageCount());
    }
 
    @Test(timeout = 60 * 1000)
@@ -380,7 +384,8 @@ public class MQTTTest extends MQTTTestSupport {
          Message msg = connection.receive(5, TimeUnit.SECONDS);
          do {
             assertNotNull("RETAINED null " + wildcard, msg);
-            assertTrue("RETAINED prefix " + wildcard, new String(msg.getPayload()).startsWith(RETAINED));
+            String msgPayload = new String(msg.getPayload());
+            assertTrue("RETAINED prefix " + wildcard + " msg " + msgPayload, msgPayload.startsWith(RETAINED));
             assertTrue("RETAINED matching " + wildcard + " " + msg.getTopic(), pattern.matcher(msg.getTopic()).matches());
             msg.ack();
             msg = connection.receive(5000, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
BTW, feel free to cry foul on things that don't look right.  I was trying to follow the patterns in Stomp, but the structure just doesn't line up.  I didn't want to duplicate the logic so I did move into a common base class.  The result though is that the protocol handler knows about its parent protocol handler manager.