### PR TITLE
ARTEMIS-584 add validated user to msg

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
@@ -390,6 +390,9 @@ public final class ActiveMQDefaultConfiguration {
    // Will this backup server come live on a normal server shutdown
    private static boolean DEFAULT_FAILOVER_ON_SERVER_SHUTDOWN = false;
 
+   // Will the broker populate the message with the name of the validated user
+   private static boolean DEFAULT_POPULATE_VALIDATED_USER = false;
+
    // its possible that you only want a server to partake in scale down as a receiver, via a group. In this case set scale-down to false
    private static boolean DEFAULT_SCALE_DOWN_ENABLED = true;
 
@@ -1058,6 +1061,13 @@ public final class ActiveMQDefaultConfiguration {
     */
    public static boolean isDefaultFailoverOnServerShutdown() {
       return DEFAULT_FAILOVER_ON_SERVER_SHUTDOWN;
+   }
+
+   /**
+    * Will the broker populate the message with the name of the validated user
+    */
+   public static boolean isDefaultPopulateValidatedUser() {
+      return DEFAULT_POPULATE_VALIDATED_USER;
    }
 
    /**

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/Message.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/Message.java
@@ -106,6 +106,11 @@ public interface Message {
     */
    SimpleString HDR_CONTENT_TYPE = new SimpleString("_AMQ_CONTENT_TYPE");
 
+   /**
+    * The name of the validated user who sent the message. Useful for auditing.
+    */
+   SimpleString HDR_VALIDATED_USER = new SimpleString("_AMQ_VALIDATED_USER");
+
    byte DEFAULT_TYPE = 0;
 
    byte OBJECT_TYPE = 2;

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/reader/MessageUtil.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/reader/MessageUtil.java
@@ -49,6 +49,8 @@ public class MessageUtil {
 
    public static final String JMSXGROUPID = "JMSXGroupID";
 
+   public static final String JMSXUSERID = "JMSXUserID";
+
    public static final SimpleString CONNECTION_ID_PROPERTY_NAME = new SimpleString("__AMQ_CID");
 
 //   public static ActiveMQBuffer getBodyBuffer(Message message) {
@@ -155,6 +157,7 @@ public class MessageUtil {
 
    public static boolean propertyExists(Message message, String name) {
       return message.containsProperty(new SimpleString(name)) || name.equals(MessageUtil.JMSXDELIVERYCOUNT) ||
-         MessageUtil.JMSXGROUPID.equals(name) && message.containsProperty(Message.HDR_GROUP_ID);
+         (MessageUtil.JMSXGROUPID.equals(name) && message.containsProperty(Message.HDR_GROUP_ID)) ||
+         (MessageUtil.JMSXUSERID.equals(name) && message.containsProperty(Message.HDR_VALIDATED_USER));
    }
 }

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQMessage.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQMessage.java
@@ -581,6 +581,9 @@ public class ActiveMQMessage implements javax.jms.Message {
          if (MessageUtil.JMSXGROUPID.equals(name)) {
             return message.getStringProperty(org.apache.activemq.artemis.api.core.Message.HDR_GROUP_ID);
          }
+         else if (MessageUtil.JMSXUSERID.equals(name)) {
+            return message.getStringProperty(org.apache.activemq.artemis.api.core.Message.HDR_VALIDATED_USER);
+         }
          else {
             return message.getStringProperty(new SimpleString(name));
          }
@@ -656,7 +659,10 @@ public class ActiveMQMessage implements javax.jms.Message {
    public void setStringProperty(final String name, final String value) throws JMSException {
       checkProperty(name);
 
-      if (handleGroupID(name, value)) {
+      if (handleCoreProperty(name, value, MessageUtil.JMSXGROUPID, org.apache.activemq.artemis.api.core.Message.HDR_GROUP_ID)) {
+         return;
+      }
+      else if (handleCoreProperty(name, value, MessageUtil.JMSXUSERID, org.apache.activemq.artemis.api.core.Message.HDR_VALIDATED_USER)) {
          return;
       }
       else {
@@ -666,7 +672,11 @@ public class ActiveMQMessage implements javax.jms.Message {
 
    @Override
    public void setObjectProperty(final String name, final Object value) throws JMSException {
-      if (handleGroupID(name, value)) {
+      if (handleCoreProperty(name, value, MessageUtil.JMSXGROUPID, org.apache.activemq.artemis.api.core.Message.HDR_GROUP_ID)) {
+         return;
+      }
+
+      if (handleCoreProperty(name, value, MessageUtil.JMSXUSERID, org.apache.activemq.artemis.api.core.Message.HDR_VALIDATED_USER)) {
          return;
       }
 
@@ -954,11 +964,11 @@ public class ActiveMQMessage implements javax.jms.Message {
       }
    }
 
-   private boolean handleGroupID(final String name, final Object value) {
+   private boolean handleCoreProperty(final String name, final Object value, String jmsPropertyName, SimpleString corePropertyName) {
       boolean result = false;
 
-      if (MessageUtil.JMSXGROUPID.equals(name)) {
-         message.putStringProperty(org.apache.activemq.artemis.api.core.Message.HDR_GROUP_ID, SimpleString.toSimpleString(value.toString()));
+      if (jmsPropertyName.equals(name)) {
+         message.putStringProperty(corePropertyName, SimpleString.toSimpleString(value.toString()));
 
          result = true;
       }

--- a/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/management/impl/openmbean/JMSOpenTypeSupport.java
+++ b/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/management/impl/openmbean/JMSOpenTypeSupport.java
@@ -166,7 +166,7 @@ public final class JMSOpenTypeSupport {
          rc.put(JMSCompositeDataConstants.JMS_REDELIVERED, data.get(CompositeDataConstants.REDELIVERED));
          putStringProperty(rc, data, JMSCompositeDataConstants.JMSXGROUP_ID, Message.HDR_GROUP_ID.toString());
          putIntProperty(rc, data, JMSCompositeDataConstants.JMSXGROUP_SEQ, JMSCompositeDataConstants.JMSXGROUP_SEQ);
-         putStringProperty(rc, data, JMSCompositeDataConstants.JMSXUSER_ID, JMSCompositeDataConstants.JMSXUSER_ID);
+         putStringProperty(rc, data, JMSCompositeDataConstants.JMSXUSER_ID, Message.HDR_VALIDATED_USER.toString());
          putStringProperty(rc, data, JMSCompositeDataConstants.ORIGINAL_DESTINATION, Message.HDR_ORIGINAL_ADDRESS.toString());
 
          rc.put(CompositeDataConstants.PROPERTIES, "" + data.get(CompositeDataConstants.PROPERTIES));

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireProtocolManager.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireProtocolManager.java
@@ -50,6 +50,7 @@ import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
 import org.apache.activemq.artemis.spi.core.remoting.Acceptor;
 import org.apache.activemq.artemis.spi.core.remoting.Connection;
 import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager;
+import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager3;
 import org.apache.activemq.artemis.utils.DataConstants;
 import org.apache.activemq.command.ActiveMQMessage;
 import org.apache.activemq.command.ActiveMQTopic;
@@ -442,7 +443,12 @@ public class OpenWireProtocolManager implements ProtocolManager<Interceptor>, Cl
       ActiveMQSecurityManager sm = server.getSecurityManager();
 
       if (sm != null && server.getConfiguration().isSecurityEnabled()) {
-         validated = sm.validateUser(login, passcode);
+         if (sm instanceof ActiveMQSecurityManager3) {
+            validated = ((ActiveMQSecurityManager3) sm).validateUser(login, passcode, null) != null;
+         }
+         else {
+            validated = sm.validateUser(login, passcode);
+         }
       }
 
       return validated;

--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/Stomp.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/Stomp.java
@@ -125,6 +125,8 @@ public interface Stomp {
          String ACK = "ack";
 
          String PERSISTENT = "persistent";
+
+         String VALIDATED_USER = "JMSXUserID";
       }
 
       public interface Subscribe {

--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompProtocolManager.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompProtocolManager.java
@@ -45,6 +45,7 @@ import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
 import org.apache.activemq.artemis.spi.core.remoting.Acceptor;
 import org.apache.activemq.artemis.spi.core.remoting.Connection;
 import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager;
+import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager3;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
 
 import static org.apache.activemq.artemis.core.protocol.stomp.ActiveMQStompProtocolMessageBundle.BUNDLE;
@@ -331,7 +332,12 @@ class StompProtocolManager extends AbstractProtocolManager<StompFrame,StompFrame
       ActiveMQSecurityManager sm = server.getSecurityManager();
 
       if (sm != null && server.getConfiguration().isSecurityEnabled()) {
-         validated = sm.validateUser(login, passcode);
+         if (sm instanceof ActiveMQSecurityManager3) {
+            validated = ((ActiveMQSecurityManager3) sm).validateUser(login, passcode, null) != null;
+         }
+         else {
+            validated = sm.validateUser(login, passcode);
+         }
       }
 
       return validated;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
@@ -948,6 +948,10 @@ public interface Configuration {
 
    Configuration setStoreConfiguration(StoreConfiguration storeConfiguration);
 
+   boolean isPopulateValidatedUser();
+
+   Configuration setPopulateValidatedUser(boolean populateValidatedUser);
+
    /** It will return all the connectors in a toString manner for debug purposes. */
    String debugConnectors();
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
@@ -237,6 +237,8 @@ public class ConfigurationImpl implements Configuration, Serializable {
 
    private StoreConfiguration storeConfiguration;
 
+   protected boolean populateValidatedUser = ActiveMQDefaultConfiguration.isDefaultPopulateValidatedUser();
+
    /**
     * Parent folder for all data folders.
     */
@@ -1353,6 +1355,17 @@ public class ConfigurationImpl implements Configuration, Serializable {
    }
 
    @Override
+   public boolean isPopulateValidatedUser() {
+      return populateValidatedUser;
+   }
+
+   @Override
+   public ConfigurationImpl setPopulateValidatedUser(boolean populateValidatedUser) {
+      this.populateValidatedUser = populateValidatedUser;
+      return this;
+   }
+
+   @Override
    public int hashCode() {
       final int prime = 31;
       int result = 1;
@@ -1417,6 +1430,7 @@ public class ConfigurationImpl implements Configuration, Serializable {
       result = prime * result + (runSyncSpeedTest ? 1231 : 1237);
       result = prime * result + scheduledThreadPoolMaxSize;
       result = prime * result + (securityEnabled ? 1231 : 1237);
+      result = prime * result + (populateValidatedUser ? 1231 : 1237);
       result = prime * result + (int) (securityInvalidationInterval ^ (securityInvalidationInterval >>> 32));
       result = prime * result + ((securitySettings == null) ? 0 : securitySettings.hashCode());
       result = prime * result + (int) (serverDumpInterval ^ (serverDumpInterval >>> 32));
@@ -1653,6 +1667,8 @@ public class ConfigurationImpl implements Configuration, Serializable {
       if (scheduledThreadPoolMaxSize != other.scheduledThreadPoolMaxSize)
          return false;
       if (securityEnabled != other.securityEnabled)
+         return false;
+      if (populateValidatedUser != other.populateValidatedUser)
          return false;
       if (securityInvalidationInterval != other.securityInvalidationInterval)
          return false;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -274,6 +274,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
       config.setPasswordCodec(getString(e, "password-codec", DefaultSensitiveStringCodec.class.getName(), Validators.NOT_NULL_OR_EMPTY));
 
+      config.setPopulateValidatedUser(getBoolean(e, "populate-validated-user", config.isPopulateValidatedUser()));
+
       // parsing cluster password
       String passwordText = getString(e, "cluster-password", null, Validators.NO_CHECK);
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/security/SecurityStore.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/security/SecurityStore.java
@@ -22,7 +22,7 @@ import org.apache.activemq.artemis.api.core.SimpleString;
 
 public interface SecurityStore {
 
-   void authenticate(String user, String password, X509Certificate[] certificates) throws Exception;
+   String authenticate(String user, String password, X509Certificate[] certificates) throws Exception;
 
    void check(SimpleString address, CheckType checkType, SecurityAuth session) throws Exception;
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -1161,19 +1161,20 @@ public class ActiveMQServerImpl implements ActiveMQServer {
                                       final String defaultAddress,
                                       final SessionCallback callback,
                                       final boolean autoCreateQueues) throws Exception {
+      String validatedUser = "";
 
       if (securityStore != null) {
          X509Certificate[] certificates = null;
          if (connection.getTransportConnection() instanceof NettyConnection) {
             certificates = CertificateUtil.getCertsFromChannel(((NettyConnection) connection.getTransportConnection()).getChannel());
          }
-         securityStore.authenticate(username, password, certificates);
+         validatedUser = securityStore.authenticate(username, password, certificates);
       }
 
-      checkSessionLimit(username);
+      checkSessionLimit(validatedUser);
 
       final OperationContext context = storageManager.newContext(getExecutorFactory().getExecutor());
-      final ServerSessionImpl session = internalCreateSession(name, username, password, minLargeMessageSize, connection, autoCommitSends, autoCommitAcks, preAcknowledge, xa, defaultAddress, callback, context, autoCreateQueues);
+      final ServerSessionImpl session = internalCreateSession(name, username, password, validatedUser, minLargeMessageSize, connection, autoCommitSends, autoCommitAcks, preAcknowledge, xa, defaultAddress, callback, context, autoCreateQueues);
 
       sessions.put(name, session);
 
@@ -1237,6 +1238,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
    protected ServerSessionImpl internalCreateSession(String name,
                                                      String username,
                                                      String password,
+                                                     String validatedUser,
                                                      int minLargeMessageSize,
                                                      RemotingConnection connection,
                                                      boolean autoCommitSends,
@@ -1247,7 +1249,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
                                                      SessionCallback callback,
                                                      OperationContext context,
                                                      boolean autoCreateJMSQueues) throws Exception {
-      return new ServerSessionImpl(name, username, password, minLargeMessageSize, autoCommitSends, autoCommitAcks, preAcknowledge, configuration.isPersistDeliveryCountBeforeDelivery(), xa, connection, storageManager, postOffice, resourceManager, securityStore, managementService, this, configuration.getManagementAddress(), defaultAddress == null ? null : new SimpleString(defaultAddress), callback, context, autoCreateJMSQueues ? jmsQueueCreator : null);
+      return new ServerSessionImpl(name, username, password, validatedUser, minLargeMessageSize, autoCommitSends, autoCommitAcks, preAcknowledge, configuration.isPersistDeliveryCountBeforeDelivery(), xa, connection, storageManager, postOffice, resourceManager, securityStore, managementService, this, configuration.getManagementAddress(), defaultAddress == null ? null : new SimpleString(defaultAddress), callback, context, autoCreateJMSQueues ? jmsQueueCreator : null);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -105,6 +105,8 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
 
    protected final String password;
 
+   protected final String validatedUser;
+
    private final int minLargeMessageSize;
 
    protected boolean autoCommitSends;
@@ -176,6 +178,7 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
    public ServerSessionImpl(final String name,
                             final String username,
                             final String password,
+                            final String validatedUser,
                             final int minLargeMessageSize,
                             final boolean autoCommitSends,
                             final boolean autoCommitAcks,
@@ -197,6 +200,8 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
       this.username = username;
 
       this.password = password;
+
+      this.validatedUser = validatedUser;
 
       this.minLargeMessageSize = minLargeMessageSize;
 
@@ -1228,6 +1233,10 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
 
          message.setMessageID(id);
          message.encodeMessageIDToBuffer();
+      }
+
+      if (server.getConfiguration().isPopulateValidatedUser() && validatedUser != null) {
+         message.putStringProperty(Message.HDR_VALIDATED_USER, SimpleString.toSimpleString(validatedUser));
       }
 
       SimpleString address = message.getAddress();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/ActiveMQSecurityManager3.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/ActiveMQSecurityManager3.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.spi.core.security;
+
+import javax.security.cert.X509Certificate;
+import java.util.Set;
+
+import org.apache.activemq.artemis.core.security.CheckType;
+import org.apache.activemq.artemis.core.security.Role;
+import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
+
+/**
+ * Used to validate whether a user is authorized to connect to the
+ * server and perform certain functions on certain destinations.
+ *
+ * This is an evolution of {@link ActiveMQSecurityManager} and
+ * {@link ActiveMQSecurityManager2} that adds the ability to determine
+ * the identity of the validated user.
+ */
+public interface ActiveMQSecurityManager3 extends ActiveMQSecurityManager {
+
+   /**
+    * is this a valid user.
+    *
+    * This method is called instead of
+    * {@link ActiveMQSecurityManager#validateUser(String, String)}.
+    *
+    * @param user     the user
+    * @param password the users password
+    * @return the name of the validated user or null if the user isn't validated
+    */
+   String validateUser(String user, String password, X509Certificate[] certificates);
+
+   /**
+    * Determine whether the given user is valid and whether they have
+    * the correct role for the given destination address.
+    *
+    * This method is called instead of
+    * {@link ActiveMQSecurityManager#validateUserAndRole(String, String, Set, CheckType)}.
+    *
+    * @param user      the user
+    * @param password  the user's password
+    * @param roles     the user's roles
+    * @param checkType which permission to validate
+    * @param address   the address for which to perform authorization
+    * @param connection   the user's connection
+    * @return the name of the validated user or null if the user isn't validated
+    */
+   String validateUserAndRole(String user, String password, Set<Role> roles, CheckType checkType, String address, RemotingConnection connection);
+}

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -324,6 +324,14 @@
             </xsd:annotation>
          </xsd:element>
 
+         <xsd:element name="populate-validated-user" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  true means that the server will add the name of the validated user to messages it sends
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
          <xsd:element name="connectors" maxOccurs="1" minOccurs="0">
             <xsd:annotation>
                <xsd:documentation>

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
@@ -102,6 +102,7 @@ public class FileConfigurationTest extends ConfigurationImplTest {
       Assert.assertEquals(33, conf.getJournalCompactPercentage());
       Assert.assertEquals(true, conf.isGracefulShutdownEnabled());
       Assert.assertEquals(12345, conf.getGracefulShutdownTimeout());
+      Assert.assertEquals(true, conf.isPopulateValidatedUser());
 
       Assert.assertEquals("largemessagesdir", conf.getLargeMessagesDirectory());
       Assert.assertEquals(95, conf.getMemoryWarningThreshold());

--- a/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
@@ -50,6 +50,7 @@
       <message-expiry-thread-priority>8</message-expiry-thread-priority>
       <id-cache-size>127</id-cache-size>
       <persist-id-cache>true</persist-id-cache>
+      <populate-validated-user>true</populate-validated-user>
       <remoting-incoming-interceptors>
          <class-name>org.apache.activemq.artemis.tests.unit.core.config.impl.TestInterceptor1</class-name>
          <class-name>org.apache.activemq.artemis.tests.unit.core.config.impl.TestInterceptor2</class-name>

--- a/docs/user-manual/en/configuration-index.md
+++ b/docs/user-manual/en/configuration-index.md
@@ -81,6 +81,7 @@ Name | Description
 [scheduled-thread-pool-max-size](thread-pooling.md#server.scheduled.thread.pool "Server Scheduled Thread Pool")|  Maximum number of threads to use for the scheduled thread pool. Default=5
 [security-enabled](security.md "Security")  |  true means that security is enabled. Default=true
 [security-invalidation-interval](security.md "Security")                                   |  how long (in ms) to wait before invalidating the security cache. Default=10000
+[populate-validated-user](security.md "Security")                                          |  whether or not to add the name of the validated user to the messages that user sends. Default=false
 [security-settings](security.md "Role based security for addresses")                             |  [a list of security-setting](#security-setting-type)
 [thread-pool-max-size](thread-pooling.md "Server Scheduled Thread Pool")                       |  Maximum number of threads to use for the thread pool. -1 means 'no limits'.. Default=30
 [transaction-timeout](transaction-config.md "Resource Manager Configuration")              |  how long (in ms) before a transaction can be removed from the resource manager after create time. Default=300000

--- a/docs/user-manual/en/security.md
+++ b/docs/user-manual/en/security.md
@@ -10,6 +10,13 @@ long. To change this period set the property
 `security-invalidation-interval`, which is in milliseconds. The default
 is `10000` ms.
 
+To assist in security auditing the `populate-validated-user` option exists. If this is `true` then
+the server will add the name of the validated user to the message using the key `_AMQ_VALIDATED_USER`.
+For JMS and Stomp clients this is mapped to the key `JMSXUserID`. For users authenticated based on
+their SSL certificate this name is the name to which their certificate's DN maps. If `security-enabled`
+is `false` and `populate-validated-user` is `true` then the server will simply use whatever user name
+(if any) the client provides. This option is `false` by default.
+
 ## Role based security for addresses
 
 Apache ActiveMQ Artemis contains a flexible role-based security model for applying

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/HangConsumerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/HangConsumerTest.java
@@ -577,6 +577,7 @@ public class HangConsumerTest extends ActiveMQTestBase {
       protected ServerSessionImpl internalCreateSession(String name,
                                                         String username,
                                                         String password,
+                                                        String validatedUser,
                                                         int minLargeMessageSize,
                                                         RemotingConnection connection,
                                                         boolean autoCommitSends,
@@ -587,7 +588,7 @@ public class HangConsumerTest extends ActiveMQTestBase {
                                                         SessionCallback callback,
                                                         OperationContext context,
                                                         boolean autoCreateQueue) throws Exception {
-         return new ServerSessionImpl(name, username, password, minLargeMessageSize, autoCommitSends, autoCommitAcks, preAcknowledge, getConfiguration().isPersistDeliveryCountBeforeDelivery(), xa, connection, getStorageManager(), getPostOffice(), getResourceManager(), getSecurityStore(), getManagementService(), this, getConfiguration().getManagementAddress(), defaultAddress == null ? null : new SimpleString(defaultAddress), new MyCallback(callback), context, null);
+         return new ServerSessionImpl(name, username, password, validatedUser, minLargeMessageSize, autoCommitSends, autoCommitAcks, preAcknowledge, getConfiguration().isPersistDeliveryCountBeforeDelivery(), xa, connection, getStorageManager(), getPostOffice(), getResourceManager(), getSecurityStore(), getManagementService(), this, getConfiguration().getManagementAddress(), defaultAddress == null ? null : new SimpleString(defaultAddress), new MyCallback(callback), context, null);
       }
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/management/JMSQueueControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/management/JMSQueueControlTest.java
@@ -236,8 +236,8 @@ public class JMSQueueControlTest extends ManagementTestBase {
 
       CompositeData[] data = queueControl.browse();
       Assert.assertEquals(1, data.length);
-      Assert.assertNotNull(data[0].get("JMSCorrelationID"));
-      Assert.assertEquals("foo", data[0].get("JMSCorrelationID"));
+      Assert.assertNotNull(data[0].get(MessageUtil.CORRELATIONID_HEADER_NAME.toString()));
+      Assert.assertEquals("foo", data[0].get(MessageUtil.CORRELATIONID_HEADER_NAME.toString()));
       System.out.println(data[0]);
 
       JMSUtil.consumeMessages(1, queue);
@@ -248,8 +248,8 @@ public class JMSQueueControlTest extends ManagementTestBase {
 
       data = queueControl.browse();
       Assert.assertEquals(1, data.length);
-      Assert.assertNotNull(data[0].get("JMSXGroupID"));
-      Assert.assertEquals("myGroupID", data[0].get("JMSXGroupID"));
+      Assert.assertNotNull(data[0].get(MessageUtil.JMSXGROUPID.toString()));
+      Assert.assertEquals("myGroupID", data[0].get(MessageUtil.JMSXGROUPID.toString()));
       System.out.println(data[0]);
 
       JMSUtil.consumeMessages(1, queue);
@@ -266,14 +266,14 @@ public class JMSQueueControlTest extends ManagementTestBase {
 
       JMSUtil.consumeMessages(1, queue);
 
-      JMSUtil.sendMessageWithProperty(session, queue, "JMSXUserID", "theheadhonch");
+      JMSUtil.sendMessageWithProperty(session, queue, MessageUtil.JMSXUSERID.toString(), "theheadhonch");
 
       Assert.assertEquals(1, getMessageCount(queueControl));
 
       data = queueControl.browse();
       Assert.assertEquals(1, data.length);
-      Assert.assertNotNull(data[0].get("JMSXUserID"));
-      Assert.assertEquals("theheadhonch", data[0].get("JMSXUserID"));
+      Assert.assertNotNull(data[0].get(MessageUtil.JMSXUSERID.toString()));
+      Assert.assertEquals("theheadhonch", data[0].get(MessageUtil.JMSXUSERID.toString()));
       System.out.println(data[0]);
 
       JMSUtil.consumeMessages(1, queue);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/StompTestWithSecurity.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/StompTestWithSecurity.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.stomp;
+
+import javax.jms.MessageConsumer;
+import javax.jms.TextMessage;
+
+import org.apache.activemq.artemis.core.protocol.stomp.Stomp;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StompTestWithSecurity extends StompTestBase {
+
+   @Test
+   public void testJMSXUserID() throws Exception {
+      server.getActiveMQServer().getConfiguration().setPopulateValidatedUser(true);
+
+      MessageConsumer consumer = session.createConsumer(queue);
+
+      String frame = "CONNECT\n" + "login: brianm\n" + "passcode: wombats\n\n" + Stomp.NULL;
+      sendFrame(frame);
+
+      frame = receiveFrame(10000);
+      Assert.assertTrue(frame.startsWith("CONNECTED"));
+
+      frame = "SEND\n" + "destination:" + getQueuePrefix() + getQueueName() + "\n\n" + "Hello World" + Stomp.NULL;
+
+      sendFrame(frame);
+
+      TextMessage message = (TextMessage) consumer.receive(1000);
+      Assert.assertNotNull(message);
+      Assert.assertEquals("Hello World", message.getText());
+      // Assert default priority 4 is used when priority header is not set
+      Assert.assertEquals("getJMSPriority", 4, message.getJMSPriority());
+      Assert.assertEquals("JMSXUserID", "brianm", message.getStringProperty("JMSXUserID"));
+
+      // Make sure that the timestamp is valid - should
+      // be very close to the current time.
+      long tnow = System.currentTimeMillis();
+      long tmsg = message.getJMSTimestamp();
+      Assert.assertTrue(Math.abs(tnow - tmsg) < 1000);
+   }
+
+   public boolean isSecurityEnabled() {
+      return true;
+   }
+}


### PR DESCRIPTION
Implements a new feature to aid in security auditing by adding the name
of the validated user to the messages it sends.