### PR TITLE
NO-JIRA Clean up pom.xml files

### DIFF
--- a/tests/activemq5-unit-tests/pom.xml
+++ b/tests/activemq5-unit-tests/pom.xml
@@ -321,12 +321,6 @@
       </dependency>
 
       <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-stomp-protocol</artifactId>
-         <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
          <groupId>org.jboss.byteman</groupId>
          <artifactId>byteman</artifactId>
          <version>${byteman.version}</version>

--- a/tests/config/server-start-stop-backup-jms-config1.xml
+++ b/tests/config/server-start-stop-backup-jms-config1.xml
@@ -17,7 +17,7 @@
 <configuration xmlns="urn:activemq"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="urn:activemq /schema/artemis-jms.xsd">
-   
-   <queue name="myJMSQueue/>
+
+   <queue name="myJMSQueue"/>
 
 </configuration>

--- a/tests/integration-tests/pom.xml
+++ b/tests/integration-tests/pom.xml
@@ -126,12 +126,6 @@
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-proton-plug</artifactId>
-         <version>${project.version}</version>
-         <type>test-jar</type>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-stomp-protocol</artifactId>
          <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
Duplicated dependency declarations were causing the following Maven warning.  These duplicated dependencies were removed.

    [INFO] Scanning for projects...
    [WARNING]
    [WARNING] Some problems were encountered while building the effective model for org.apache.activemq.tests:integration-tests:jar:1.4.0-SNAPSHOT
    [WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.apache.activemq:artemis-proton-plug:test-jar -> duplicate declaration of version ${project.version} @ org.apache.activemq.tests:integration-tests:[unknown-version], /x1/jenkins/jenkins-slave/workspace/ActiveMQ-Artemis-Nightly-Regression-Test/tests/integration-tests/pom.xml, line 148, column 19
    [WARNING]
    [WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
    [WARNING]
    [WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
    [WARNING]

 File `server-start-stop-backup-jms-config1.xml` was malformed. A missing quotation mark was added.