### PR TITLE
ARTEMIS-629 Preserve the correlation ID type during conversions

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/proton/converter/message/InboundTransformer.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/proton/converter/message/InboundTransformer.java
@@ -215,7 +215,7 @@ public abstract class InboundTransformer {
             jms.setJMSReplyTo(vendor.createDestination(properties.getReplyTo()));
          }
          if (properties.getCorrelationId() != null) {
-            jms.setJMSCorrelationID(properties.getCorrelationId().toString());
+            jms.setJMSCorrelationID(AMQPMessageIdHelper.INSTANCE.toBaseMessageIdString(properties.getCorrelationId()));
          }
          if (properties.getContentType() != null) {
             jms.setStringProperty(prefixVendor + "ContentType", properties.getContentType().toString());

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/proton/converter/message/JMSMappingOutboundTransformer.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/proton/converter/message/JMSMappingOutboundTransformer.java
@@ -176,7 +176,14 @@ public class JMSMappingOutboundTransformer extends OutboundTransformer {
          maMap.put(LEGACY_JMS_REPLY_TO_TYPE_MSG_ANNOTATION, destinationAttributes(msg.getJMSReplyTo()));
       }
       if (msg.getJMSCorrelationID() != null) {
-         props.setCorrelationId(msg.getJMSCorrelationID());
+         String correlationId = msg.getJMSCorrelationID();
+
+         try {
+            props.setCorrelationId(AMQPMessageIdHelper.INSTANCE.toIdObject(correlationId));
+         }
+         catch (ActiveMQAMQPIllegalStateException e) {
+            props.setCorrelationId(correlationId);
+         }
       }
       if (msg.getJMSExpiration() != 0) {
          long ttl = msg.getJMSExpiration() - System.currentTimeMillis();


### PR DESCRIPTION
When converted to a core message type the original type of the
CorrelationId in the AMQP message is lost, we must encode the type to
prevent the loss of the original type as this value is meant to be
immutable.