### PR TITLE
ARTEMIS-621 Several tests do not use getUDPDiscoveryAddress

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/connection/ConnectionFactorySerializationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/connection/ConnectionFactorySerializationTest.java
@@ -84,8 +84,8 @@ public class ConnectionFactorySerializationTest extends JMSTestBase {
       UDPBroadcastEndpointFactory befc = (UDPBroadcastEndpointFactory) dgc.getBroadcastEndpointFactory();
       Assert.assertEquals(Integer.parseInt(System.getProperty("org.apache.activemq.artemis.api.core.UDPBroadcastEndpointFactory.localBindPort", "-1")), befc.getLocalBindPort());
       Assert.assertEquals(System.getProperty("org.apache.activemq.artemis.api.core.UDPBroadcastEndpointFactory.localBindAddress"), befc.getLocalBindAddress());
-      Assert.assertEquals(1234, befc.getGroupPort());
-      Assert.assertEquals("1.2.3.4", befc.getGroupAddress());
+      Assert.assertEquals(getUDPDiscoveryPort(), befc.getGroupPort());
+      Assert.assertEquals(getUDPDiscoveryAddress(), befc.getGroupAddress());
    }
 
    @Test


### PR DESCRIPTION
Fixing the commit 8fdc7a6788797a98d3d0b3f0d79c64987f490281