### PR TITLE
ARTEMIS-342 NettySecurityClientTest fails

### DIFF
--- a/tests/integration-tests/src/test/resources/restricted-security-client.policy
+++ b/tests/integration-tests/src/test/resources/restricted-security-client.policy
@@ -55,6 +55,8 @@ grant {
         permission java.util.PropertyPermission "java.io.tmpdir", "read";
         permission java.util.PropertyPermission "sun.arch.data.model", "read";
         permission java.util.PropertyPermission "sun.nio.ch.bugLevel", "read";
+        permission java.util.PropertyPermission "io.netty.leakDetection.level", "read";
+        permission java.util.PropertyPermission "io.netty.leakDetection.maxRecords", "read";
         permission java.lang.RuntimePermission "setContextClassLoader";
         permission java.lang.RuntimePermission "accessDeclaredMembers";
         permission java.lang.RuntimePermission "accessClassInPackage.sun.misc";


### PR DESCRIPTION
Security client requires additional permissions.