### PR TITLE
ARTEMIS-632 JMSServerControlUsingJMSTest fails

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/management/JMSServerControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/management/JMSServerControlTest.java
@@ -947,6 +947,12 @@ public class JMSServerControlTest extends ManagementTestBase {
       }
 
       Assert.assertTrue(failed);
+
+      // If these objects are not referenced at the end of the test, they can be destroyed by garbage collector
+      // during the test, what can lead to test failure.
+      connection.close();
+      connection2.close();
+      connection3.close();
    }
 
    // Package protected ---------------------------------------------


### PR DESCRIPTION
The testRemoteClientIDConnection fails. The failure occurs when
connection objects are destroyed by garbage collector before time.