### PR TITLE
Fix scaledownhandler lookup duplicate handling

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ScaleDownHandler.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ScaleDownHandler.java
@@ -578,7 +578,7 @@ public class ScaleDownHandler {
                   }
 
                   if (initialRef == null) {
-                     lastRef = initialRef;
+                     initialRef = lastRef;
                   }
                   else {
                      if (initialRef.equals(lastRef)) {


### PR DESCRIPTION
Just something I happened to notice when examining Eclipse's redundant null check warnings. Not tested, nor have I run into this or fully looked into what this even does. But `initialRef` was never assigned any other value than `null`, and the fix here looks kind of obvious.