### PR TITLE
Configure BROWSE permission in last-value-queue example

### DIFF
--- a/examples/features/standard/last-value-queue/src/main/resources/activemq/server0/broker.xml
+++ b/examples/features/standard/last-value-queue/src/main/resources/activemq/server0/broker.xml
@@ -53,6 +53,7 @@ under the License.
             <permission type="deleteNonDurableQueue" roles="guest"/>
             <permission type="consume" roles="guest"/>
             <permission type="send" roles="guest"/>
+            <permission type="browse" roles="guest"/>
          </security-setting>
       </security-settings>
 


### PR DESCRIPTION
PR #630 added the BROWSE role but the example was not updated. Before this change, the example would fail with exception

    javax.jms.JMSSecurityException: AMQ119032: User: null does not
     have permission='BROWSE' on address jms.queue.exampleQueue

I checked all examples included in the -Pexamples profile and nothing else is failing with this exception.