### PR TITLE
Fix ByteBuffer regression from Netty upgrade

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/ByteUtil.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/ByteUtil.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.utils;
 
+import java.nio.ByteBuffer;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
@@ -88,6 +90,18 @@ public class ByteUtil {
          c = buffer.readChar();
       }
       return sb.toString();
+   }
+
+   public static byte[] getActiveArray(ByteBuffer buffer) {
+      byte[] ret = new byte[buffer.remaining()];
+      if (buffer.hasArray()) {
+         byte[] array = buffer.array();
+         System.arraycopy(array, buffer.arrayOffset() + buffer.position(), ret, 0, ret.length);
+      }
+      else {
+         buffer.slice().get(ret);
+      }
+      return ret;
    }
 
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientConsumerImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientConsumerImpl.java
@@ -38,6 +38,7 @@ import org.apache.activemq.artemis.core.client.ActiveMQClientLogger;
 import org.apache.activemq.artemis.core.client.ActiveMQClientMessageBundle;
 import org.apache.activemq.artemis.spi.core.remoting.ConsumerContext;
 import org.apache.activemq.artemis.spi.core.remoting.SessionContext;
+import org.apache.activemq.artemis.utils.ByteUtil;
 import org.apache.activemq.artemis.utils.FutureLatch;
 import org.apache.activemq.artemis.utils.PriorityLinkedList;
 import org.apache.activemq.artemis.utils.PriorityLinkedListImpl;
@@ -640,7 +641,7 @@ public final class ClientConsumerImpl implements ClientConsumerInternal {
       //sets the packet
       ActiveMQBuffer qbuff = clMessage.getBodyBuffer();
       int bytesToRead = qbuff.writerIndex() - qbuff.readerIndex();
-      final byte[] body = qbuff.readBytes(bytesToRead).toByteBuffer().array();
+      final byte[] body = ByteUtil.getActiveArray(qbuff.readBytes(bytesToRead).toByteBuffer());
 
       largeMessage.setLargeMessageController(new CompressedLargeMessageControllerImpl(currentLargeMessageController));
       currentLargeMessageController.addPacket(body, body.length, false);


### PR DESCRIPTION
Using array() is a bit dangerous as it's an optional part of any
ByteBuffer implementation. This new method will deal with various
ByteBuffer implementations appropriately.