### PR TITLE
ARTEMIS-647 track 'killed' msg count on queue

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/QueueControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/QueueControl.java
@@ -105,6 +105,12 @@ public interface QueueControl {
    long getMessagesExpired();
 
    /**
+    * Returns the number of messages removed from this queue since it was created due to exceeding the max delivery attempts.
+    */
+   @Attribute(desc = "number of messages removed from this queue since it was created due to exceeding the max delivery attempts")
+   long getMessagesKilled();
+
+   /**
     * Returns the first message on the queue as JSON
     */
    @Attribute(desc = "first message on the queue as JSON")
@@ -445,6 +451,12 @@ public interface QueueControl {
     */
    @Operation(desc = "Resets the MessagesExpired property", impact = MBeanOperationInfo.ACTION)
    void resetMessagesExpired() throws Exception;
+
+   /**
+    * Resets the MessagesExpired property
+    */
+   @Operation(desc = "Resets the MessagesKilled property", impact = MBeanOperationInfo.ACTION)
+   void resetMessagesKilled() throws Exception;
 
    /**
     * it will flush one cycle on internal executors, so you would be sure that any pending tasks are done before you call

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/api/jms/management/JMSQueueControl.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/api/jms/management/JMSQueueControl.java
@@ -62,6 +62,12 @@ public interface JMSQueueControl extends DestinationControl {
    long getMessagesExpired();
 
    /**
+    * Returns the number of messages removed from this queue since it was created due to exceeding the max delivery attempts.
+    */
+   @Attribute(desc = "number of messages removed from this queue since it was created due to exceeding the max delivery attempts")
+   long getMessagesKilled();
+
+   /**
     * returns the selector for the queue
     */
    @Attribute(desc = "selector for the queue")

--- a/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/management/impl/JMSQueueControlImpl.java
+++ b/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/management/impl/JMSQueueControlImpl.java
@@ -130,6 +130,11 @@ public class JMSQueueControlImpl extends StandardMBean implements JMSQueueContro
    }
 
    @Override
+   public long getMessagesKilled() {
+      return coreQueueControl.getMessagesKilled();
+   }
+
+   @Override
    public int getConsumerCount() {
       return coreQueueControl.getConsumerCount();
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/QueueControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/QueueControlImpl.java
@@ -270,6 +270,19 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
    }
 
    @Override
+   public long getMessagesKilled() {
+      checkStarted();
+
+      clearIO();
+      try {
+         return queue.getMessagesKilled();
+      }
+      finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
    public long getID() {
       checkStarted();
 
@@ -1031,6 +1044,20 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
       clearIO();
       try {
          queue.resetMessagesExpired();
+      }
+      finally {
+         blockOnIO();
+      }
+
+   }
+
+   @Override
+   public void resetMessagesKilled() throws Exception {
+      checkStarted();
+
+      clearIO();
+      try {
+         queue.resetMessagesKilled();
       }
       finally {
          blockOnIO();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/PagedReferenceImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/PagedReferenceImpl.java
@@ -25,6 +25,7 @@ import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
 import org.apache.activemq.artemis.core.server.MessageReference;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.server.ServerMessage;
+import org.apache.activemq.artemis.core.server.impl.AckReason;
 import org.apache.activemq.artemis.core.transaction.Transaction;
 import org.jboss.logging.Logger;
 
@@ -215,11 +216,16 @@ public class PagedReferenceImpl implements PagedReference {
 
    @Override
    public void acknowledge(Transaction tx) throws Exception {
+      acknowledge(tx, AckReason.NORMAL);
+   }
+
+   @Override
+   public void acknowledge(Transaction tx, AckReason reason) throws Exception {
       if (tx == null) {
-         getQueue().acknowledge(this);
+         getQueue().acknowledge(this, reason);
       }
       else {
-         getQueue().acknowledge(tx, this);
+         getQueue().acknowledge(tx, this, reason);
       }
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/MessageReference.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/MessageReference.java
@@ -16,6 +16,7 @@
  */
 package org.apache.activemq.artemis.core.server;
 
+import org.apache.activemq.artemis.core.server.impl.AckReason;
 import org.apache.activemq.artemis.core.transaction.Transaction;
 
 /**
@@ -72,6 +73,8 @@ public interface MessageReference {
    void acknowledge() throws Exception;
 
    void acknowledge(Transaction tx) throws Exception;
+
+   void acknowledge(Transaction tx, AckReason reason) throws Exception;
 
    void setConsumerId(Long consumerID);
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/Queue.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/Queue.java
@@ -25,6 +25,7 @@ import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.filter.Filter;
 import org.apache.activemq.artemis.core.paging.cursor.PageSubscription;
+import org.apache.activemq.artemis.core.server.impl.AckReason;
 import org.apache.activemq.artemis.core.transaction.Transaction;
 import org.apache.activemq.artemis.utils.LinkedListIterator;
 import org.apache.activemq.artemis.utils.ReferenceCounter;
@@ -74,7 +75,11 @@ public interface Queue extends Bindable {
 
    void acknowledge(MessageReference ref) throws Exception;
 
+   void acknowledge(final MessageReference ref, AckReason reason) throws Exception;
+
    void acknowledge(Transaction tx, MessageReference ref) throws Exception;
+
+   void acknowledge(final Transaction tx, final MessageReference ref, AckReason reason) throws Exception;
 
    void reacknowledge(Transaction tx, MessageReference ref) throws Exception;
 
@@ -122,6 +127,8 @@ public interface Queue extends Bindable {
    long getMessagesAcknowledged();
 
    long getMessagesExpired();
+
+   long getMessagesKilled();
 
    MessageReference removeReferenceWithID(long id) throws Exception;
 
@@ -237,6 +244,8 @@ public interface Queue extends Bindable {
    void resetMessagesAcknowledged();
 
    void resetMessagesExpired();
+
+   void resetMessagesKilled();
 
    void incrementMesssagesAdded();
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/AckReason.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/AckReason.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.core.server.impl;
+
+public enum AckReason {
+   KILLED, EXPIRED, NORMAL
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/LastValueQueue.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/LastValueQueue.java
@@ -263,6 +263,11 @@ public class LastValueQueue extends QueueImpl {
       }
 
       @Override
+      public void acknowledge(Transaction tx, AckReason reason) throws Exception {
+         ref.acknowledge(tx, reason);
+      }
+
+      @Override
       public void setPersistedCount(int count) {
          ref.setPersistedCount(count);
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/MessageReferenceImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/MessageReferenceImpl.java
@@ -192,11 +192,16 @@ public class MessageReferenceImpl implements MessageReference {
 
    @Override
    public void acknowledge(Transaction tx) throws Exception {
+      acknowledge(tx, AckReason.NORMAL);
+   }
+
+   @Override
+   public void acknowledge(Transaction tx, AckReason reason) throws Exception {
       if (tx == null) {
-         getQueue().acknowledge(this);
+         getQueue().acknowledge(this, reason);
       }
       else {
-         getQueue().acknowledge(tx, this);
+         getQueue().acknowledge(tx, this, reason);
       }
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
@@ -169,6 +169,8 @@ public class QueueImpl implements Queue {
 
    private long messagesExpired;
 
+   private long messagesKilled;
+
    protected final AtomicInteger deliveringCount = new AtomicInteger(0);
 
    private boolean paused;
@@ -964,10 +966,11 @@ public class QueueImpl implements Queue {
 
    @Override
    public void acknowledge(final MessageReference ref) throws Exception {
-      acknowledge(ref, OperationType.NORMAL);
+      acknowledge(ref, AckReason.NORMAL);
    }
 
-   private void acknowledge(final MessageReference ref, OperationType type) throws Exception {
+   @Override
+   public void acknowledge(final MessageReference ref, AckReason reason) throws Exception {
       if (ref.isPaged()) {
          pageSubscription.ack((PagedReference) ref);
          postAcknowledge(ref);
@@ -983,8 +986,11 @@ public class QueueImpl implements Queue {
          postAcknowledge(ref);
       }
 
-      if (type == OperationType.EXPIRED) {
+      if (reason == AckReason.EXPIRED) {
          messagesExpired++;
+      }
+      else if (reason == AckReason.KILLED) {
+         messagesKilled++;
       }
       else {
          messagesAcknowledged++;
@@ -994,10 +1000,11 @@ public class QueueImpl implements Queue {
 
    @Override
    public void acknowledge(final Transaction tx, final MessageReference ref) throws Exception {
-      acknowledge(tx, ref, OperationType.NORMAL);
+      acknowledge(tx, ref, AckReason.NORMAL);
    }
 
-   private void acknowledge(final Transaction tx, final MessageReference ref, OperationType type) throws Exception {
+   @Override
+   public void acknowledge(final Transaction tx, final MessageReference ref, AckReason reason) throws Exception {
       if (ref.isPaged()) {
          pageSubscription.ackTx(tx, (PagedReference) ref);
 
@@ -1017,8 +1024,11 @@ public class QueueImpl implements Queue {
          getRefsOperation(tx).addAck(ref);
       }
 
-      if (type == OperationType.EXPIRED) {
+      if (reason == AckReason.EXPIRED) {
          messagesExpired++;
+      }
+      else if (reason == AckReason.KILLED) {
+         messagesKilled++;
       }
       else {
          messagesAcknowledged++;
@@ -1095,13 +1105,13 @@ public class QueueImpl implements Queue {
          if (logger.isTraceEnabled()) {
             logger.trace("moving expired reference " + ref + " to address = " + expiryAddress + " from queue=" + this.getName());
          }
-         move(null, expiryAddress, ref, true, false, OperationType.EXPIRED);
+         move(null, expiryAddress, ref, false, AckReason.EXPIRED);
       }
       else {
          if (logger.isTraceEnabled()) {
             logger.trace("expiry is null, just acking expired message for reference " + ref + " from queue=" + this.getName());
          }
-         acknowledge(ref, OperationType.EXPIRED);
+         acknowledge(ref, AckReason.EXPIRED);
       }
    }
 
@@ -1150,6 +1160,11 @@ public class QueueImpl implements Queue {
    @Override
    public long getMessagesExpired() {
       return messagesExpired;
+   }
+
+   @Override
+   public long getMessagesKilled() {
+      return messagesKilled;
    }
 
    @Override
@@ -1533,7 +1548,7 @@ public class QueueImpl implements Queue {
                refRemoved(ref);
                incDelivering();
                try {
-                  move(null, toAddress, ref, false, rejectDuplicate, OperationType.NORMAL);
+                  move(null, toAddress, ref, rejectDuplicate, AckReason.NORMAL);
                }
                catch (Exception e) {
                   decDelivering();
@@ -2374,26 +2389,25 @@ public class QueueImpl implements Queue {
 
          if (bindingList.getBindings().isEmpty()) {
             ActiveMQServerLogger.LOGGER.messageExceededMaxDelivery(ref, deadLetterAddress);
-            ref.acknowledge(tx);
+            ref.acknowledge(tx, AckReason.KILLED);
          }
          else {
             ActiveMQServerLogger.LOGGER.messageExceededMaxDeliverySendtoDLA(ref, deadLetterAddress, name);
-            move(tx, deadLetterAddress, ref, false, false, OperationType.NORMAL);
+            move(tx, deadLetterAddress, ref, false, AckReason.KILLED);
          }
       }
       else {
          ActiveMQServerLogger.LOGGER.messageExceededMaxDeliveryNoDLA(name);
 
-         ref.acknowledge(tx);
+         ref.acknowledge(tx, AckReason.KILLED);
       }
    }
 
    private void move(final Transaction originalTX,
                      final SimpleString address,
                      final MessageReference ref,
-                     final boolean expiry,
                      final boolean rejectDuplicate,
-                     final OperationType type) throws Exception {
+                     final AckReason reason) throws Exception {
       Transaction tx;
 
       if (originalTX != null) {
@@ -2404,13 +2418,13 @@ public class QueueImpl implements Queue {
          tx = new TransactionImpl(storageManager);
       }
 
-      ServerMessage copyMessage = makeCopy(ref, expiry);
+      ServerMessage copyMessage = makeCopy(ref, reason == AckReason.EXPIRED);
 
       copyMessage.setAddress(address);
 
       postOffice.route(copyMessage, null, tx, false, rejectDuplicate);
 
-      acknowledge(tx, ref, type);
+      acknowledge(tx, ref, reason);
 
       if (originalTX == null) {
          tx.commit();
@@ -2662,6 +2676,11 @@ public class QueueImpl implements Queue {
    @Override
    public synchronized void resetMessagesExpired() {
       messagesExpired = 0;
+   }
+
+   @Override
+   public synchronized void resetMessagesKilled() {
+      messagesKilled = 0;
    }
 
    @Override
@@ -3018,10 +3037,6 @@ public class QueueImpl implements Queue {
             }
          }
       }
-   }
-
-   private enum OperationType {
-      EXPIRED, NORMAL
    }
 }
 

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/ScheduledDeliveryHandlerTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/ScheduledDeliveryHandlerTest.java
@@ -957,7 +957,17 @@ public class ScheduledDeliveryHandlerTest extends Assert {
       }
 
       @Override
+      public void acknowledge(MessageReference ref, AckReason reason) throws Exception {
+
+      }
+
+      @Override
       public void acknowledge(Transaction tx, MessageReference ref) throws Exception {
+
+      }
+
+      @Override
+      public void acknowledge(Transaction tx, MessageReference ref, AckReason reason) throws Exception {
 
       }
 
@@ -1048,6 +1058,11 @@ public class ScheduledDeliveryHandlerTest extends Assert {
 
       @Override
       public long getMessagesExpired() {
+         return 0;
+      }
+
+      @Override
+      public long getMessagesKilled() {
          return 0;
       }
 
@@ -1262,6 +1277,11 @@ public class ScheduledDeliveryHandlerTest extends Assert {
 
       @Override
       public void resetMessagesExpired() {
+
+      }
+
+      @Override
+      public void resetMessagesKilled() {
 
       }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/management/JMSQueueControlUsingJMSTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/management/JMSQueueControlUsingJMSTest.java
@@ -125,6 +125,11 @@ public class JMSQueueControlUsingJMSTest extends JMSQueueControlTest {
          }
 
          @Override
+         public long getMessagesKilled() {
+            return ((Number) proxy.retrieveAttributeValue("messagesKilled")).longValue();
+         }
+
+         @Override
          public String getDeadLetterAddress() {
             return (String) proxy.retrieveAttributeValue("deadLetterAddress");
          }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlUsingCoreTest.java
@@ -126,6 +126,11 @@ public class QueueControlUsingCoreTest extends QueueControlTest {
          }
 
          @Override
+         public long getMessagesKilled() {
+            return ((Number) proxy.retrieveAttributeValue("messagesKilled")).longValue();
+         }
+
+         @Override
          public void resetMessagesAdded() throws Exception {
             proxy.invokeOperation("resetMessagesAdded");
          }
@@ -138,6 +143,11 @@ public class QueueControlUsingCoreTest extends QueueControlTest {
          @Override
          public void resetMessagesExpired() throws Exception {
             proxy.invokeOperation("resetMessagesExpired");
+         }
+
+         @Override
+         public void resetMessagesKilled() throws Exception {
+            proxy.invokeOperation("resetMessagesKilled");
          }
 
          @Override

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/FakeQueue.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/FakeQueue.java
@@ -29,6 +29,7 @@ import org.apache.activemq.artemis.core.server.MessageReference;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.server.RoutingContext;
 import org.apache.activemq.artemis.core.server.ServerMessage;
+import org.apache.activemq.artemis.core.server.impl.AckReason;
 import org.apache.activemq.artemis.core.transaction.Transaction;
 import org.apache.activemq.artemis.utils.LinkedListIterator;
 import org.apache.activemq.artemis.utils.ReferenceCounter;
@@ -158,7 +159,19 @@ public class FakeQueue implements Queue {
    }
 
    @Override
+   public void acknowledge(MessageReference ref, AckReason reason) throws Exception {
+      // no-op
+
+   }
+
+   @Override
    public void acknowledge(final Transaction tx, final MessageReference ref) throws Exception {
+      // no-op
+
+   }
+
+   @Override
+   public void acknowledge(Transaction tx, MessageReference ref, AckReason reason) throws Exception {
       // no-op
 
    }
@@ -318,6 +331,12 @@ public class FakeQueue implements Queue {
    }
 
    @Override
+   public long getMessagesKilled() {
+      // no-op
+      return 0;
+   }
+
+   @Override
    public void resetMessagesAdded() {
       // no-op
 
@@ -331,6 +350,12 @@ public class FakeQueue implements Queue {
 
    @Override
    public void resetMessagesExpired() {
+      // no-op
+
+   }
+
+   @Override
+   public void resetMessagesKilled() {
       // no-op
 
    }


### PR DESCRIPTION
A 'killed' message is one that has been sent to a dead-letter address
or otherwise removed from the queue due to exceeding the max delivery
attempts.