### PR TITLE
Fix connection list cleanup in OpenWireProtocolManager.removeConnection

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireProtocolManager.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireProtocolManager.java
@@ -155,7 +155,7 @@ public class OpenWireProtocolManager implements ProtocolManager<Interceptor>, Cl
             if (context != null && context.decRefCount() == 0) {
                //connection is still there and need to close
                context.getConnection().disconnect(error != null);
-               this.connections.remove(this);//what's that for?
+               this.connections.remove(context.getConnection());
                this.clientIdSet.remove(clientId);
             }
          }


### PR DESCRIPTION
Issue found by FindBugs, not tested but I think this is the intended behavior.