### PR TITLE
Fix allowable property check on add in AeroGearConnectorService.handle

### DIFF
--- a/integration/activemq-aerogear-integration/src/main/java/org/apache/activemq/artemis/integration/aerogear/AeroGearConnectorService.java
+++ b/integration/activemq-aerogear-integration/src/main/java/org/apache/activemq/artemis/integration/aerogear/AeroGearConnectorService.java
@@ -258,9 +258,10 @@ public class AeroGearConnectorService implements ConnectorService, Consumer, Mes
       Set<SimpleString> propertyNames = message.getPropertyNames();
 
       for (SimpleString propertyName : propertyNames) {
-         if (propertyName.toString().startsWith("AEROGEAR_") && !AeroGearConstants.ALLOWABLE_PROPERTIES.contains(propertyName)) {
+         String nameString = propertyName.toString();
+         if (nameString.startsWith("AEROGEAR_") && !AeroGearConstants.ALLOWABLE_PROPERTIES.contains(nameString)) {
             Object property = message.getTypedProperties().getProperty(propertyName);
-            builder.attribute(propertyName.toString(), property.toString());
+            builder.attribute(nameString, property.toString());
          }
       }
 


### PR DESCRIPTION
Issue found by FindBugs. Not tested, nor really understood, but the code was using  a SimpleString to look up things in a String keyed map which won't return anything useful..

Anyway TBH the code looks suspicious to me as AeroGearConstants.ALLOWABLE_PROPERTIES does not contain any properties that start with AEROGEAR_ in the first place, so even though this fix would be correct, it wouldn't probably change anything as the `contains` in the 2nd condition will continue to return false for everything the `startsWith` in the first returns true... maybe there's a further flaw in the logic, but I can't tell as I'm not sure what the specific intent of this block is.