### PR TITLE
ARTEMIS-659 Remove unneeded CDI dependency.  Switch to geronimo atinj…

### DIFF
--- a/artemis-jms-client/pom.xml
+++ b/artemis-jms-client/pom.xml
@@ -59,10 +59,6 @@
          <groupId>org.apache.geronimo.specs</groupId>
          <artifactId>geronimo-jms_2.0_spec</artifactId>
       </dependency>
-      <dependency>
-         <groupId>javax.inject</groupId>
-         <artifactId>javax.inject</artifactId>
-      </dependency>
 
       <dependency>
          <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -349,16 +349,9 @@
 
          <!-- Required for: JMS Injection -->
          <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
-            <version>1.2</version>
-            <!-- License: Apache 2.0 -->
-         </dependency>
-         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-            <version>1</version>
-            <!-- License: Apache 2.0 -->
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-atinject_1.0_spec</artifactId>
+            <version>1.0</version>
          </dependency>
          <!-- End JMS Injection -->
 

--- a/tests/integration-tests/pom.xml
+++ b/tests/integration-tests/pom.xml
@@ -336,8 +336,6 @@
 	   <dependency>
 		   <groupId>org.apache.geronimo.specs</groupId>
 		   <artifactId>geronimo-atinject_1.0_spec</artifactId>
-		   <version>1.0</version>
-		   <scope>provided</scope>
 	   </dependency>
 	   <dependency>
 		   <groupId>org.apache.karaf</groupId>


### PR DESCRIPTION
…ect JAR in all uses.

It turned out the client wasn't even using the dependency and the JARs were duplicated.  So more than anything this is clean up of unnecessary dependencies.