### PR TITLE
ARTEMIS-592 finer-grained security for queues

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -420,10 +420,20 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
       }
 
       if (browseOnly) {
-         securityCheck(binding.getAddress(), CheckType.BROWSE, this);
+         try {
+            securityCheck(binding.getAddress(), CheckType.BROWSE, this);
+         }
+         catch (Exception e) {
+            securityCheck(binding.getAddress().concat(".").concat(queueName), CheckType.BROWSE, this);
+         }
       }
       else {
-         securityCheck(binding.getAddress(), CheckType.CONSUME, this);
+         try {
+            securityCheck(binding.getAddress(), CheckType.CONSUME, this);
+         }
+         catch (Exception e) {
+            securityCheck(binding.getAddress().concat(".").concat(queueName), CheckType.CONSUME, this);
+         }
       }
 
       Filter filter = FilterImpl.createFilter(filterString);

--- a/tests/integration-tests/src/test/resources/roles.properties
+++ b/tests/integration-tests/src/test/resources/roles.properties
@@ -18,3 +18,5 @@
 programmers=first
 accounting=second
 employees=first,second
+a=a
+b=b

--- a/tests/integration-tests/src/test/resources/users.properties
+++ b/tests/integration-tests/src/test/resources/users.properties
@@ -17,3 +17,5 @@
 
 first=secret
 second=password
+a=a
+b=b


### PR DESCRIPTION
This was the simplest way I could think of to implement this feature.  It allows a security-setting to match to a particular queue by using the syntax "&lt;address&gt;.&lt;queue&gt;" in the match.  For example, if two queues  A & B each mapped to the same address Z each queue could have independent security-settings by matching "Z.A" and "Z.B".  

If people are in favor of this implementation then I will write up some documentation and squash that with this commit so don't merge this until there is a satisfactory consensus and docs are written (if necessary).