### PR TITLE
ARTEMIS-669 Do binding query on sender link attach

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/proton/plug/ProtonSessionIntegrationCallback.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/proton/plug/ProtonSessionIntegrationCallback.java
@@ -27,6 +27,7 @@ import org.apache.activemq.artemis.core.io.IOCallback;
 import org.apache.activemq.artemis.core.paging.PagingStore;
 import org.apache.activemq.artemis.core.protocol.proton.ProtonProtocolManager;
 import org.apache.activemq.artemis.core.protocol.proton.converter.message.EncodedMessage;
+import org.apache.activemq.artemis.core.server.BindingQueryResult;
 import org.apache.activemq.artemis.core.server.MessageReference;
 import org.apache.activemq.artemis.core.server.QueueQueryResult;
 import org.apache.activemq.artemis.core.server.ServerConsumer;
@@ -213,6 +214,28 @@ public class ProtonSessionIntegrationCallback implements AMQPSessionCallback, Se
       else {
          if (queueQuery.isAutoCreateJmsQueues()) {
             serverSession.createQueue(new SimpleString(queueName), new SimpleString(queueName), null, false, true);
+            queryResult = true;
+         }
+         else {
+            queryResult = false;
+         }
+      }
+
+      return queryResult;
+   }
+
+   @Override
+   public boolean bindingQuery(String address) throws Exception {
+      boolean queryResult = false;
+
+      BindingQueryResult queueQuery = serverSession.executeBindingQuery(SimpleString.toSimpleString(address));
+
+      if (queueQuery.isExists()) {
+         queryResult = true;
+      }
+      else {
+         if (queueQuery.isAutoCreateJmsQueues()) {
+            serverSession.createQueue(new SimpleString(address), new SimpleString(address), null, false, true);
             queryResult = true;
          }
          else {

--- a/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/AMQPSessionCallback.java
+++ b/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/AMQPSessionCallback.java
@@ -50,6 +50,8 @@ public interface AMQPSessionCallback {
 
    boolean queueQuery(String queueName) throws Exception;
 
+   boolean bindingQuery(String address) throws Exception;
+
    void closeSender(Object brokerConsumer) throws Exception;
 
    // This one can be a lot improved

--- a/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/context/server/ProtonServerReceiverContext.java
+++ b/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/context/server/ProtonServerReceiverContext.java
@@ -88,7 +88,7 @@ public class ProtonServerReceiverContext extends AbstractProtonReceiverContext {
             }
 
             try {
-               if (!sessionSPI.queueQuery(address)) {
+               if (!sessionSPI.bindingQuery(address)) {
                   throw ActiveMQAMQPProtocolMessageBundle.BUNDLE.addressDoesntExist();
                }
             }

--- a/artemis-protocols/artemis-proton-plug/src/test/java/org/proton/plug/test/minimalserver/MinimalSessionSPI.java
+++ b/artemis-protocols/artemis-proton-plug/src/test/java/org/proton/plug/test/minimalserver/MinimalSessionSPI.java
@@ -105,6 +105,11 @@ public class MinimalSessionSPI implements AMQPSessionCallback {
    }
 
    @Override
+   public boolean bindingQuery(String address) throws Exception {
+      return true;
+   }
+
+   @Override
    public void closeSender(Object brokerConsumer) {
       ((Consumer) brokerConsumer).close();
    }


### PR DESCRIPTION
QueueQuery was previously used instead of checking for bindings on a
particular address name.  This meant sending and receiving only worked
for those queues that happened to have the same queueName to address.
This patch replaces this with binding check.

There's also some minor ProtonTest fixes included.