### PR TITLE
Add forceShutdown core management operation

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
@@ -818,6 +818,9 @@ public interface ActiveMQServerControl {
    @Operation(desc = "force the server to stop and notify clients to failover", impact = MBeanOperationInfo.UNKNOWN)
    void forceFailover() throws Exception;
 
+   @Operation(desc = "force the server to stop and shutdown JVM", impact = MBeanOperationInfo.UNKNOWN)
+   void forceShutdown() throws Exception;
+
    void updateDuplicateIdCache(String address, Object[] ids) throws Exception;
 
    @Operation(desc = "force the server to stop and to scale down to another server", impact = MBeanOperationInfo.UNKNOWN)

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -1983,6 +1983,12 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
    }
 
    @Override
+   public void forceShutdown() throws Exception {
+      forceFailover();
+      System.exit(0);
+   }
+
+   @Override
    public void updateDuplicateIdCache(String address, Object[] ids) throws Exception {
       clearIO();
       try {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
@@ -612,6 +612,11 @@ public class ActiveMQServerControlUsingCoreTest extends ActiveMQServerControlTes
             proxy.invokeOperation("forceFailover");
          }
 
+         @Override
+         public void forceShutdown() throws Exception {
+            proxy.invokeOperation("forceShutdown");
+         }
+
          public String getLiveConnectorName() throws Exception {
             return (String) proxy.retrieveAttributeValue("liveConnectorName");
          }


### PR DESCRIPTION
This is a proposal of an operation to shutdown not just the artemis server but the JVM itself. This feature would allow us to avoid creating a parent process to control the JVM lifecycle. Apologies if there is already some way to do this remotely.