### PR TITLE
Don't send jgroup messages to self

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/jgroups/JChannelManager.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/jgroups/JChannelManager.java
@@ -34,7 +34,7 @@ public class JChannelManager {
 
    private static final Logger logger = Logger.getLogger(JChannelManager.class);
 
-   private Map<String, JChannelWrapper> channels;
+   private static Map<String, JChannelWrapper> channels;
 
    public synchronized JChannelWrapper getJChannel(String channelName,
                                                    JGroupsBroadcastEndpoint endpoint) throws Exception {

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/jgroups/JChannelWrapper.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/jgroups/JChannelWrapper.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.jboss.logging.Logger;
 import org.jgroups.JChannel;
+import org.jgroups.Message;
 import org.jgroups.ReceiverAdapter;
 
 /**
@@ -127,6 +128,7 @@ public class JChannelWrapper {
 
    public void send(org.jgroups.Message msg) throws Exception {
       if (logger.isTraceEnabled()) logger.trace(this + "::Sending JGroups Message: Open=" + channel.isOpen() + " on channel " + channelName + " msg=" + msg);
+      msg.setTransientFlag(Message.TransientFlag.DONT_LOOPBACK);
       channel.send(msg);
    }
 


### PR DESCRIPTION
In our broker.xml we have a broadcast group, a discovery group and a core bridge referring to the discovery group to discover other brokers. It appears, however, that the discovery mechanism discovers itself even when only 1 broker is running.

In DiscoveryGroup.java, it compares the node id of the broadcaster with the node id of the discoverygroup, but these id's appears to be generated randomly for both the broadcast and discovery group. The proper fix might be to ensure that the node id is the same for both of these, but I am not sure if it is intentional that they don't have the same id or not.

This PR is an attempted fix of an issue at the jgroups level, by ignoring jgroups messages coming from oneself. Feel free to close the PR if this should be fixed elsewhere.

