### PR TITLE
ARTEMIS-698 Remove full path + executability check of java

### DIFF
--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis
@@ -86,17 +86,8 @@ if [ -z "$JAVACMD" ] ; then
       JAVACMD="$JAVA_HOME/bin/java"
     fi
   else
-    JAVACMD=`which java 2> /dev/null `
-    if [ -z "$JAVACMD" ] ; then
-        JAVACMD=java
-    fi
+    JAVACMD=java
   fi
-fi
-
-if [ ! -x "$JAVACMD" ] ; then
-  echo "Error: JAVA_HOME is not defined correctly."
-  echo "  We cannot execute $JAVACMD"
-  exit 1
 fi
 
 if $cygwin ; then

--- a/artemis-distribution/src/main/resources/bin/artemis
+++ b/artemis-distribution/src/main/resources/bin/artemis
@@ -80,19 +80,9 @@ if [ -z "$JAVACMD" ] ; then
       JAVACMD="$JAVA_HOME/bin/java"
     fi
   else
-    JAVACMD=`which java 2> /dev/null `
-    if [ -z "$JAVACMD" ] ; then
-        JAVACMD=java
-    fi
+    JAVACMD=java
   fi
 fi
-
-if [ ! -x "$JAVACMD" ] ; then
-  echo "Error: JAVA_HOME is not defined correctly."
-  echo "  We cannot execute $JAVACMD"
-  exit 1
-fi
-
 
 if $cygwin ; then
   JAVA_HOME=`cygpath --windows "$JAVA_HOME"`


### PR DESCRIPTION
Fixes issues with systems that have no "which", as well as the fallback
to using plain "java" from PATH.

This is an alternative fix to #732, see discussion in it for more details.