### PR TITLE
ARTEMIS-581 Implement max disk usage, and global-max-size

### DIFF
--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/broker.xml
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/broker.xml
@@ -50,6 +50,17 @@ under the License.
       <journal-pool-files>-1</journal-pool-files>
 ${journal-buffer.settings}
 ${connector-config.settings}
+      <!-- how often we are looking for how many bytes are being used on the disk in ms -->
+      <disk-scan-period>5000</disk-scan-period>
+
+      <!-- once the disk hits this limit the system will block, or close the connection in certain protocols
+           that won't support flow control. -->
+      <max-disk-usage>90</max-disk-usage>
+
+      <!-- the system will enter into page mode once you hit this limit.
+           This is an estimate in bytes of how much the messages are using in memory -->
+      <global-max-size>104857600</global-max-size>
+
       <acceptors>
          <!-- Default ActiveMQ Artemis Acceptor.  Multi-protocol adapter.  Currently supports ActiveMQ Artemis Core, OpenWire, STOMP, AMQP, MQTT, and HornetQ Core. -->
          <!-- performance tests have shown that openWire performs best with these buffer sizes -->
@@ -78,9 +89,10 @@ ${cluster-security.settings}${cluster.settings}${replicated.settings}${shared-st
             <dead-letter-address>jms.queue.DLQ</dead-letter-address>
             <expiry-address>jms.queue.ExpiryQueue</expiry-address>
             <redelivery-delay>0</redelivery-delay>
-            <max-size-bytes>10485760</max-size-bytes>
+            <!-- with -1 only the global-max-size is in use for limiting -->
+            <max-size-bytes>-1</max-size-bytes>
             <message-counter-history-day-limit>10</message-counter-history-day-limit>
-            <address-full-policy>BLOCK</address-full-policy>
+            <address-full-policy>PAGE</address-full-policy>
          </address-setting>
       </address-settings>
    </core>

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
@@ -429,6 +429,12 @@ public final class ActiveMQDefaultConfiguration {
    // Default period to wait between configuration file checks
    public static final long DEFAULT_CONFIGURATION_FILE_REFRESH_PERIOD = 5000;
 
+   public static final long DEFAULT_GLOBAL_MAX_SIZE = -1;
+
+   public static final int DEFAULT_MAX_DISK_USAGE = 100;
+
+   public static final int DEFAULT_DISK_SCAN = 5000;
+
    /**
     * If true then the ActiveMQ Artemis Server will make use of any Protocol Managers that are in available on the classpath. If false then only the core protocol will be available, unless in Embedded mode where users can inject their own Protocol Managers.
     */
@@ -1143,5 +1149,18 @@ public final class ActiveMQDefaultConfiguration {
 
    public static long getDefaultConfigurationFileRefreshPeriod() {
       return DEFAULT_CONFIGURATION_FILE_REFRESH_PERIOD;
+   }
+
+   /** The default global max size. -1 = no global max size. */
+   public static long getDefaultMaxGlobalSize() {
+      return DEFAULT_GLOBAL_MAX_SIZE;
+   }
+
+   public static int getDefaultMaxDiskUsage() {
+      return DEFAULT_MAX_DISK_USAGE;
+   }
+
+   public static int getDefaultDiskScanPeriod() {
+      return DEFAULT_DISK_SCAN;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/protocol/AbstractRemotingConnection.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/protocol/AbstractRemotingConnection.java
@@ -219,4 +219,8 @@ public abstract class AbstractRemotingConnection implements RemotingConnection {
       dataReceived = true;
    }
 
+   @Override
+   public boolean isSupportsFlowControl() {
+      return true;
+   }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/protocol/RemotingConnection.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/protocol/RemotingConnection.java
@@ -196,4 +196,12 @@ public interface RemotingConnection extends BufferHandler {
     * @return
     */
    boolean isSupportReconnect();
+
+   /**
+    * Return true if the protocol supports flow control.
+    * This is because in some cases we may need to hold message producers in cases like disk full.
+    * If the protocol doesn't support it we trash the connection and throw exceptions.
+    * @return
+    */
+   boolean isSupportsFlowControl();
 }

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTConnection.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTConnection.java
@@ -221,4 +221,9 @@ public class MQTTConnection implements RemotingConnection {
    public boolean isSupportReconnect() {
       return false;
    }
+
+   @Override
+   public boolean isSupportsFlowControl() {
+      return false;
+   }
 }

--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompConnection.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompConnection.java
@@ -738,4 +738,8 @@ public final class StompConnection implements RemotingConnection {
       //unsupported
    }
 
+   @Override
+   public boolean isSupportsFlowControl() {
+      return false;
+   }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
@@ -561,10 +561,10 @@ public interface Configuration {
     */
    Configuration setJournalCompactMinFiles(int minFiles);
 
-   /** Number of files that would be acceptable to keep on a pool. Default value is {@link org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration#DEFAULT_JOURNAL_POOL_SIZE}.*/
+   /** Number of files that would be acceptable to keep on a pool. Default value is {@link org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration#DEFAULT_JOURNAL_POOL_FILES}.*/
    int getJournalPoolFiles();
 
-   /** Number of files that would be acceptable to keep on a pool. Default value is {@link org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration#DEFAULT_JOURNAL_POOL_SIZE}.*/
+   /** Number of files that would be acceptable to keep on a pool. Default value is {@link org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration#DEFAULT_JOURNAL_POOL_FILES}.*/
    Configuration setJournalPoolFiles(int poolSize);
 
 
@@ -967,5 +967,17 @@ public interface Configuration {
    long getConfigurationFileRefreshPeriod();
 
    Configuration setConfigurationFileRefreshPeriod(long configurationFileRefreshPeriod);
+
+   long getGlobalMaxSize();
+
+   Configuration setGlobalMaxSize(long globalMaxSize);
+
+   int getMaxDiskUsage();
+
+   Configuration setMaxDiskUsage(int maxDiskUsage);
+
+   Configuration setDiskScanPeriod(int diskScanPeriod);
+
+   int getDiskScanPeriod();
 
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
@@ -246,6 +246,12 @@ public class ConfigurationImpl implements Configuration, Serializable {
 
    private long configurationFileRefreshPeriod = ActiveMQDefaultConfiguration.getDefaultConfigurationFileRefreshPeriod();
 
+   private long globalMaxSize = ActiveMQDefaultConfiguration.getDefaultMaxGlobalSize();
+
+   private int maxDiskUsage = ActiveMQDefaultConfiguration.getDefaultMaxDiskUsage();
+
+   private int diskScanPeriod = ActiveMQDefaultConfiguration.getDefaultDiskScanPeriod();
+
    /**
     * Parent folder for all data folders.
     */
@@ -261,6 +267,28 @@ public class ConfigurationImpl implements Configuration, Serializable {
    @Override
    public boolean isPersistenceEnabled() {
       return persistenceEnabled;
+   }
+
+   @Override
+   public int getMaxDiskUsage() {
+      return maxDiskUsage;
+   }
+
+   @Override
+   public ConfigurationImpl setMaxDiskUsage(int maxDiskUsage) {
+      this.maxDiskUsage = maxDiskUsage;
+      return this;
+   }
+
+   @Override
+   public ConfigurationImpl setGlobalMaxSize(long maxSize) {
+      this.globalMaxSize = maxSize;
+      return this;
+   }
+
+   @Override
+   public long getGlobalMaxSize() {
+      return globalMaxSize;
    }
 
    @Override
@@ -1781,6 +1809,17 @@ public class ConfigurationImpl implements Configuration, Serializable {
    @Override
    public ConfigurationImpl setConfigurationFileRefreshPeriod(long configurationFileRefreshPeriod) {
       this.configurationFileRefreshPeriod = configurationFileRefreshPeriod;
+      return this;
+   }
+
+   @Override
+   public int getDiskScanPeriod() {
+      return diskScanPeriod;
+   }
+
+   @Override
+   public ConfigurationImpl setDiskScanPeriod(int diskScanPeriod) {
+      this.diskScanPeriod = diskScanPeriod;
       return this;
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -175,6 +175,12 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
    private static final String MAX_QUEUES_NODE_NAME = "max-queues";
 
+   private static final String GLOBAL_MAX_SIZE = "global-max-size";
+
+   private static final String MAX_DISK_USAGE = "max-disk-usage";
+
+   private static final String DISK_SCAN_PERIOD = "disk-scan-period";
+
    // Attributes ----------------------------------------------------
 
    private boolean validateAIO = false;
@@ -281,6 +287,12 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       config.setConnectionTtlCheckInterval(getLong(e, "connection-ttl-check-interval", config.getConnectionTtlCheckInterval(), Validators.GT_ZERO));
 
       config.setConfigurationFileRefreshPeriod(getLong(e, "configuration-file-refresh-period", config.getConfigurationFileRefreshPeriod(), Validators.GT_ZERO));
+
+      config.setGlobalMaxSize(getLong(e, GLOBAL_MAX_SIZE, config.getGlobalMaxSize(), Validators.MINUS_ONE_OR_GT_ZERO));
+
+      config.setMaxDiskUsage(getInteger(e, MAX_DISK_USAGE, config.getMaxDiskUsage(), Validators.PERCENTAGE));
+
+      config.setDiskScanPeriod(getInteger(e, DISK_SCAN_PERIOD, config.getDiskScanPeriod(), Validators.MINUS_ONE_OR_GT_ZERO));
 
       // parsing cluster password
       String passwordText = getString(e, "cluster-password", null, Validators.NO_CHECK);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/PagingManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/PagingManager.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.server.ActiveMQComponent;
+import org.apache.activemq.artemis.core.server.files.FileStoreMonitor;
 import org.apache.activemq.artemis.core.settings.HierarchicalRepositoryChangeListener;
 
 /**
@@ -78,6 +79,10 @@ public interface PagingManager extends ActiveMQComponent, HierarchicalRepository
 
    void resumeCleanup();
 
+   void addBlockedStore(PagingStore store);
+
+   void injectMonitor(FileStoreMonitor monitor) throws Exception;
+
    /**
     * Lock the manager. This method should not be called during normal PagingManager usage.
     */
@@ -89,4 +94,15 @@ public interface PagingManager extends ActiveMQComponent, HierarchicalRepository
     * @see #lock()
     */
    void unlock();
+
+   /** Add size at the global count level.
+    *  if totalSize > globalMaxSize it will return true */
+   PagingManager addSize(int size);
+
+   boolean isUsingGlobalSize();
+
+   boolean isGlobalFull();
+
+   boolean isDiskFull();
+
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/PagingStore.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/PagingStore.java
@@ -130,6 +130,9 @@ public interface PagingStore extends ActiveMQComponent {
 
    boolean isRejectingMessages();
 
+   /** It will return true if the destination is leaving blocking. */
+   boolean checkReleasedMemory();
+
    /**
     * Write lock the PagingStore.
     *

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/PagingStoreFactory.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/PagingStoreFactory.java
@@ -23,6 +23,7 @@ import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.io.SequentialFileFactory;
 import org.apache.activemq.artemis.core.paging.cursor.PageCursorProvider;
 import org.apache.activemq.artemis.core.persistence.StorageManager;
+import org.apache.activemq.artemis.core.server.files.FileStoreMonitor;
 import org.apache.activemq.artemis.core.settings.HierarchicalRepository;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 
@@ -42,5 +43,7 @@ public interface PagingStoreFactory {
    List<PagingStore> reloadStores(HierarchicalRepository<AddressSettings> addressSettingsRepository) throws Exception;
 
    SequentialFileFactory newFileFactory(SimpleString address) throws Exception;
+
+   void injectMonitor(FileStoreMonitor monitor) throws Exception;
 
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PageSyncTimer.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PageSyncTimer.java
@@ -67,6 +67,8 @@ final class PageSyncTimer {
       ctx.pageSyncLineUp();
       if (!pendingSync) {
          pendingSync = true;
+
+         // this is a single event
          scheduledExecutor.schedule(runnable, timeSync, TimeUnit.NANOSECONDS);
       }
       syncOperations.add(ctx);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingStoreFactoryNIO.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingStoreFactoryNIO.java
@@ -40,7 +40,8 @@ import org.apache.activemq.artemis.core.paging.cursor.PageCursorProvider;
 import org.apache.activemq.artemis.core.paging.cursor.impl.PageCursorProviderImpl;
 import org.apache.activemq.artemis.core.persistence.StorageManager;
 import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
-import org.apache.activemq.artemis.core.server.impl.FileMoveManager;
+import org.apache.activemq.artemis.core.server.files.FileMoveManager;
+import org.apache.activemq.artemis.core.server.files.FileStoreMonitor;
 import org.apache.activemq.artemis.core.settings.HierarchicalRepository;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.utils.ExecutorFactory;
@@ -93,6 +94,11 @@ public class PagingStoreFactoryNIO implements PagingStoreFactory {
 
    @Override
    public void stop() {
+   }
+
+   @Override
+   public void injectMonitor(FileStoreMonitor monitor) throws Exception {
+      monitor.addStore(this.directory);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/StorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/StorageManager.java
@@ -46,6 +46,7 @@ import org.apache.activemq.artemis.core.server.LargeServerMessage;
 import org.apache.activemq.artemis.core.server.MessageReference;
 import org.apache.activemq.artemis.core.server.RouteContextList;
 import org.apache.activemq.artemis.core.server.ServerMessage;
+import org.apache.activemq.artemis.core.server.files.FileStoreMonitor;
 import org.apache.activemq.artemis.core.server.group.impl.GroupBinding;
 import org.apache.activemq.artemis.core.server.impl.JournalLoader;
 import org.apache.activemq.artemis.core.transaction.ResourceManager;
@@ -413,4 +414,7 @@ public interface StorageManager extends IDGenerator, ActiveMQComponent {
     * {@link org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl}
     */
    void persistIdGenerator();
+
+
+   void injectMonitor(FileStoreMonitor monitor) throws Exception;
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalStorageManager.java
@@ -60,6 +60,7 @@ import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
 import org.apache.activemq.artemis.core.server.JournalType;
 import org.apache.activemq.artemis.core.server.LargeServerMessage;
 import org.apache.activemq.artemis.core.server.ServerMessage;
+import org.apache.activemq.artemis.core.server.files.FileStoreMonitor;
 import org.apache.activemq.artemis.utils.ExecutorFactory;
 import org.jboss.logging.Logger;
 
@@ -67,6 +68,8 @@ public class JournalStorageManager extends AbstractJournalStorageManager {
    private static final Logger logger = Logger.getLogger(JournalStorageManager.class);
 
    private SequentialFileFactory journalFF;
+
+   private SequentialFileFactory bindingsFF;
 
    SequentialFileFactory largeMessagesFactory;
 
@@ -95,7 +98,7 @@ public class JournalStorageManager extends AbstractJournalStorageManager {
          throw ActiveMQMessageBundle.BUNDLE.invalidJournal();
       }
 
-      SequentialFileFactory bindingsFF = new NIOSequentialFileFactory(config.getBindingsLocation(), criticalErrorListener, config.getJournalMaxIO_NIO());
+      bindingsFF = new NIOSequentialFileFactory(config.getBindingsLocation(), criticalErrorListener, config.getJournalMaxIO_NIO());
 
       Journal localBindings = new JournalImpl(1024 * 1024, 2, config.getJournalCompactMinFiles(), config.getJournalPoolFiles(), config.getJournalCompactPercentage(), bindingsFF, "activemq-bindings", "bindings", 1);
 
@@ -725,5 +728,12 @@ public class JournalStorageManager extends AbstractJournalStorageManager {
       finally {
          readUnLock();
       }
+   }
+
+   @Override
+   public void injectMonitor(FileStoreMonitor monitor) throws Exception {
+      monitor.addStore(journalFF.getDirectory());
+      monitor.addStore(largeMessagesFactory.getDirectory());
+      monitor.addStore(bindingsFF.getDirectory());
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/nullpm/NullStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/nullpm/NullStorageManager.java
@@ -52,6 +52,7 @@ import org.apache.activemq.artemis.core.server.LargeServerMessage;
 import org.apache.activemq.artemis.core.server.MessageReference;
 import org.apache.activemq.artemis.core.server.RouteContextList;
 import org.apache.activemq.artemis.core.server.ServerMessage;
+import org.apache.activemq.artemis.core.server.files.FileStoreMonitor;
 import org.apache.activemq.artemis.core.server.group.impl.GroupBinding;
 import org.apache.activemq.artemis.core.server.impl.JournalLoader;
 import org.apache.activemq.artemis.core.transaction.ResourceManager;
@@ -80,6 +81,11 @@ public class NullStorageManager implements StorageManager {
 
    @Override
    public void criticalError(Throwable error) {
+
+   }
+
+   @Override
+   public void injectMonitor(FileStoreMonitor monitor) throws Exception {
 
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQMessageBundle.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQMessageBundle.java
@@ -24,6 +24,7 @@ import org.apache.activemq.artemis.api.core.ActiveMQConnectionTimedOutException;
 import org.apache.activemq.artemis.api.core.ActiveMQDisconnectedException;
 import org.apache.activemq.artemis.api.core.ActiveMQDuplicateMetaDataException;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.ActiveMQIOErrorException;
 import org.apache.activemq.artemis.api.core.ActiveMQIllegalStateException;
 import org.apache.activemq.artemis.api.core.ActiveMQIncompatibleClientServerException;
 import org.apache.activemq.artemis.api.core.ActiveMQInternalErrorException;
@@ -370,4 +371,8 @@ public interface ActiveMQMessageBundle {
 
    @Message(id = 119118, value = "Management method not applicable for current server configuration")
    IllegalStateException methodNotApplicable();
+
+   @Message(id = 119119, value = "Disk Capacity is Low, cannot produce more messages.")
+   ActiveMQIOErrorException diskBeyondLimit();
+
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQScheduledComponent.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQScheduledComponent.java
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.core.server;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.logging.Logger;
+
+/** This is for components with a scheduled at a fixed rate. */
+public abstract class ActiveMQScheduledComponent implements ActiveMQComponent, Runnable {
+
+   private static final Logger logger = Logger.getLogger(ActiveMQScheduledComponent.class);
+   private final ScheduledExecutorService scheduledExecutorService;
+   private long period;
+   private TimeUnit timeUnit;
+   private ScheduledFuture future;
+
+   public ActiveMQScheduledComponent(ScheduledExecutorService scheduledExecutorService,
+                                     long checkPeriod,
+                                     TimeUnit timeUnit) {
+      this.scheduledExecutorService = scheduledExecutorService;
+      this.period = checkPeriod;
+      this.timeUnit = timeUnit;
+   }
+
+   @Override
+   public synchronized void start() {
+      if (future != null) {
+         return;
+      }
+      if (period >= 0) {
+         future = scheduledExecutorService.scheduleWithFixedDelay(this, period, period, timeUnit);
+      }
+      else {
+         logger.tracef("did not start scheduled executor on %s because period was configured as %d", this, period);
+      }
+   }
+
+   public long getPeriod() {
+      return period;
+   }
+
+   public synchronized ActiveMQScheduledComponent setPeriod(long period) {
+      this.period = period;
+      restartIfNeeded();
+      return this;
+   }
+
+   public TimeUnit getTimeUnit() {
+      return timeUnit;
+   }
+
+   public synchronized ActiveMQScheduledComponent setTimeUnit(TimeUnit timeUnit) {
+      this.timeUnit = timeUnit;
+      restartIfNeeded();
+      return this;
+   }
+
+   @Override
+   public synchronized void stop() {
+      if (future == null) {
+         return; // no big deal
+      }
+
+      future.cancel(false);
+      future = null;
+
+   }
+
+   @Override
+   public synchronized boolean isStarted() {
+      return future != null;
+   }
+
+
+   // this will restart the schedulped component upon changes
+   private void restartIfNeeded() {
+      if (isStarted()) {
+         stop();
+         start();
+      }
+   }
+
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1242,6 +1242,16 @@ public interface ActiveMQServerLogger extends BasicLogger {
       format = Message.Format.MESSAGE_FORMAT)
    void impossibleToRouteGrouped();
 
+   @LogMessage(level = Logger.Level.WARN)
+   @Message(id = 222210, value = "Storage usage is beyond max-disk-usage. System will start blocking producers.",
+      format = Message.Format.MESSAGE_FORMAT)
+   void diskBeyondCapacity();
+
+   @LogMessage(level = Logger.Level.WARN)
+   @Message(id = 222211, value = "Storage is back to stable now, under max-disk-usage.",
+      format = Message.Format.MESSAGE_FORMAT)
+   void diskCapacityRestored();
+
    @LogMessage(level = Logger.Level.ERROR)
    @Message(id = 224000, value = "Failure in initialisation", format = Message.Format.MESSAGE_FORMAT)
    void initializationError(@Cause Throwable e);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/files/FileMoveManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/files/FileMoveManager.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.activemq.artemis.core.server.impl;
+package org.apache.activemq.artemis.core.server.files;
 
 import java.io.File;
 import java.io.FilenameFilter;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/files/FileStoreMonitor.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/files/FileStoreMonitor.java
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.core.server.files;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.activemq.artemis.core.server.ActiveMQScheduledComponent;
+import org.jboss.logging.Logger;
+
+/** This will keep a list of fileStores. It will make a comparisson on all file stores registered. if any is over the limit,
+ *  all Callbacks will be called with over.
+ *
+ *  For instance: if Large Messages folder is registered on a different folder and it's over capacity,
+ *                the whole system will be waiting it to be released.
+ *  */
+public class FileStoreMonitor extends ActiveMQScheduledComponent {
+
+   private static final Logger logger = Logger.getLogger(FileStoreMonitor.class);
+
+   private final Set<Callback> callbackList = new HashSet<>();
+   private final Set<FileStore> stores = new HashSet<>();
+   private double maxUsage;
+
+   public FileStoreMonitor(ScheduledExecutorService scheduledExecutorService,
+                           long checkPeriod,
+                           TimeUnit timeUnit,
+                           double maxUsage) {
+      super(scheduledExecutorService, checkPeriod, timeUnit);
+      this.maxUsage = maxUsage;
+   }
+
+   public synchronized FileStoreMonitor addCallback(Callback callback) {
+      callbackList.add(callback);
+      return this;
+   }
+
+   public synchronized FileStoreMonitor addStore(File file) throws IOException {
+      if (file.exists()) {
+         addStore(Files.getFileStore(file.toPath()));
+      }
+      return this;
+   }
+
+   public synchronized FileStoreMonitor addStore(FileStore store) {
+      stores.add(store);
+      return this;
+   }
+
+
+   public void run() {
+      tick();
+   }
+
+   public synchronized void tick() {
+      boolean over = false;
+
+      FileStore lastStore = null;
+      double usage = 0;
+
+      for (FileStore store : stores) {
+         try {
+            lastStore = store;
+            usage = calculateUsage(store);
+            over = usage  > maxUsage;
+            if (over) {
+               break;
+            }
+         }
+         catch (Exception e) {
+            logger.warn(e.getMessage(), e);
+         }
+      }
+
+      for (Callback callback : callbackList) {
+         callback.tick(lastStore, usage);
+
+         if (over) {
+            callback.over(lastStore, usage);
+         }
+         else {
+            callback.under(lastStore, usage);
+         }
+      }
+   }
+
+   public double getMaxUsage() {
+      return maxUsage;
+   }
+
+   public FileStoreMonitor setMaxUsage(double maxUsage) {
+      this.maxUsage = maxUsage;
+      return this;
+   }
+
+   protected double calculateUsage(FileStore store) throws IOException {
+      return 1.0 - (double)store.getUsableSpace() / (double)store.getTotalSpace();
+   }
+
+   public interface Callback {
+      void tick(FileStore store, double usage);
+      void over(FileStore store, double usage);
+      void under(FileStore store, double usage);
+   }
+
+}

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -676,6 +676,30 @@
             </xsd:annotation>
          </xsd:element>
 
+         <xsd:element name="global-max-size" type="xsd:long" default="-1" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Global Max Size before all addresses will enter into their Full Policy configured upon messages being produced.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="max-disk-usage" type="xsd:int" default="90" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Max percentage of disk usage before the system blocks or fail clients.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="disk-scan-period" type="xsd:long" default="5000" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  how often (in ms) to scan the disks for full disks.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
          <xsd:element name="memory-warning-threshold" type="xsd:int" default="25" maxOccurs="1" minOccurs="0">
             <xsd:annotation>
                <xsd:documentation>

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
@@ -356,6 +356,9 @@ public class FileConfigurationTest extends ConfigurationImplTest {
       assertFalse(a2Role.isCreateNonDurableQueue());
       assertTrue(a2Role.isDeleteNonDurableQueue());
       assertFalse(a2Role.isManage());
+      assertEquals(1234567, conf.getGlobalMaxSize());
+      assertEquals(37, conf.getMaxDiskUsage());
+      assertEquals(123, conf.getDiskScanPeriod());
    }
 
    @Test

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/files/FileMoveManagerTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/files/FileMoveManagerTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.activemq.artemis.core.server.impl;
+package org.apache.activemq.artemis.core.server.files;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -286,7 +286,7 @@ public class FileMoveManagerTest {
                new PagingStoreFactoryNIO(storageManager, dataLocation, 100, null,
                   new OrderedExecutorFactory(threadPool), true, null);
 
-            PagingManagerImpl managerImpl = new PagingManagerImpl(storeFactory, addressSettings);
+            PagingManagerImpl managerImpl = new PagingManagerImpl(storeFactory, addressSettings, -1);
 
             managerImpl.start();
 

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/files/FileStoreMonitorTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/files/FileStoreMonitorTest.java
@@ -1,0 +1,161 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.core.server.files;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.FileStore;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.apache.activemq.artemis.utils.ReusableLatch;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FileStoreMonitorTest extends ActiveMQTestBase {
+
+   private ScheduledExecutorService scheduledExecutorService;
+
+   @Before
+   public void startScheduled() {
+      scheduledExecutorService = new ScheduledThreadPoolExecutor(5);
+   }
+
+   @After
+   public void stopScheduled() {
+      scheduledExecutorService.shutdown();
+      scheduledExecutorService = null;
+   }
+
+   @Test
+   public void testSimpleTick() throws Exception {
+      File garbageFile = new File(getTestDirfile(), "garbage.bin");
+      FileOutputStream garbage = new FileOutputStream(garbageFile);
+      BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(garbage);
+      PrintStream out = new PrintStream(bufferedOutputStream);
+
+      // This is just to make sure there is at least something on the device.
+      // If the testsuite is running with an empty tempFS, it would return 0 and the assertion would fail.
+      for (int i = 0; i < 100; i++) {
+         out.println("Garbage " + i);
+      }
+
+      bufferedOutputStream.close();
+
+      final AtomicInteger over = new AtomicInteger(0);
+      final AtomicInteger under = new AtomicInteger(0);
+      final AtomicInteger tick = new AtomicInteger(0);
+
+      FileStoreMonitor.Callback callback = new FileStoreMonitor.Callback() {
+         @Override
+         public void tick(FileStore store, double usage) {
+            tick.incrementAndGet();
+            System.out.println("tick:: " + store + " usage::" + usage);
+         }
+
+         @Override
+         public void over(FileStore store, double usage) {
+            over.incrementAndGet();
+            System.out.println("over:: " + store + " usage::" + usage);
+         }
+
+         @Override
+         public void under(FileStore store, double usage) {
+            under.incrementAndGet();
+            System.out.println("under:: " + store + " usage::" + usage);
+         }
+      };
+
+      final AtomicBoolean fakeReturn = new AtomicBoolean(false);
+      FileStoreMonitor storeMonitor = new FileStoreMonitor(scheduledExecutorService, 100, TimeUnit.MILLISECONDS, 0.999) {
+         @Override
+         protected double calculateUsage(FileStore store) throws IOException {
+            if (fakeReturn.get()) {
+               return 1f;
+            }
+            else {
+               return super.calculateUsage(store);
+            }
+         }
+      };
+      storeMonitor.addCallback(callback);
+      storeMonitor.addStore(getTestDirfile());
+
+      storeMonitor.tick();
+
+      Assert.assertEquals(0, over.get());
+      Assert.assertEquals(1, tick.get());
+      Assert.assertEquals(1, under.get());
+
+      fakeReturn.set(true);
+
+      storeMonitor.tick();
+
+      Assert.assertEquals(1, over.get());
+      Assert.assertEquals(2, tick.get());
+      Assert.assertEquals(1, under.get());
+   }
+
+   @Test
+   public void testScheduler() throws Exception {
+
+      FileStoreMonitor storeMonitor = new FileStoreMonitor(scheduledExecutorService, 20, TimeUnit.MILLISECONDS, 0.9);
+
+      final ReusableLatch latch = new ReusableLatch(5);
+      storeMonitor.addStore(getTestDirfile());
+      storeMonitor.addCallback(new FileStoreMonitor.Callback() {
+         @Override
+         public void tick(FileStore store, double usage) {
+            System.out.println("TickS::" + usage);
+            latch.countDown();
+         }
+
+         @Override
+         public void over(FileStore store, double usage) {
+
+         }
+
+         @Override
+         public void under(FileStore store, double usage) {
+
+         }
+      });
+      storeMonitor.start();
+
+
+      Assert.assertTrue(latch.await(1, TimeUnit.SECONDS));
+
+      storeMonitor.stop();
+
+      latch.setCount(1);
+
+      Assert.assertFalse(latch.await(100, TimeUnit.MILLISECONDS));
+
+//      FileStoreMonitor monitor = new FileStoreMonitor()
+
+   }
+}

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/transaction/impl/TransactionImplTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/transaction/impl/TransactionImplTest.java
@@ -52,6 +52,7 @@ import org.apache.activemq.artemis.core.server.LargeServerMessage;
 import org.apache.activemq.artemis.core.server.MessageReference;
 import org.apache.activemq.artemis.core.server.RouteContextList;
 import org.apache.activemq.artemis.core.server.ServerMessage;
+import org.apache.activemq.artemis.core.server.files.FileStoreMonitor;
 import org.apache.activemq.artemis.core.server.group.impl.GroupBinding;
 import org.apache.activemq.artemis.core.server.impl.JournalLoader;
 import org.apache.activemq.artemis.core.transaction.ResourceManager;
@@ -296,6 +297,11 @@ public class TransactionImplTest extends ActiveMQTestBase {
       public void confirmPendingLargeMessageTX(Transaction transaction,
                                                long messageID,
                                                long recordID) throws Exception {
+
+      }
+
+      @Override
+      public void injectMonitor(FileStoreMonitor monitor) throws Exception {
 
       }
 

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
@@ -1420,8 +1420,14 @@ public abstract class ActiveMQTestBase extends Assert {
          }
       }
    }
-
    protected final ActiveMQServer createServer(final boolean realFiles,
+                                               final Configuration configuration,
+                                               final long pageSize,
+                                               final long maxAddressSize) {
+      return createServer(realFiles, configuration, pageSize, maxAddressSize, (Map<String, AddressSettings>)null);
+   }
+
+   protected ActiveMQServer createServer(final boolean realFiles,
                                                final Configuration configuration,
                                                final long pageSize,
                                                final long maxAddressSize,
@@ -1458,20 +1464,20 @@ public abstract class ActiveMQTestBase extends Assert {
    }
 
    protected final ActiveMQServer createServer(final boolean realFiles, final boolean netty) throws Exception {
-      return createServer(realFiles, createDefaultConfig(netty), AddressSettings.DEFAULT_PAGE_SIZE, AddressSettings.DEFAULT_MAX_SIZE_BYTES, new HashMap<String, AddressSettings>());
+      return createServer(realFiles, createDefaultConfig(netty), AddressSettings.DEFAULT_PAGE_SIZE, AddressSettings.DEFAULT_MAX_SIZE_BYTES);
    }
 
    protected ActiveMQServer createServer(final boolean realFiles, final Configuration configuration) {
-      return createServer(realFiles, configuration, AddressSettings.DEFAULT_PAGE_SIZE, AddressSettings.DEFAULT_MAX_SIZE_BYTES, new HashMap<String, AddressSettings>());
+      return createServer(realFiles, configuration, AddressSettings.DEFAULT_PAGE_SIZE, AddressSettings.DEFAULT_MAX_SIZE_BYTES);
    }
 
    protected final ActiveMQServer createServer(final Configuration configuration) {
-      return createServer(configuration.isPersistenceEnabled(), configuration, AddressSettings.DEFAULT_PAGE_SIZE, AddressSettings.DEFAULT_MAX_SIZE_BYTES, new HashMap<String, AddressSettings>());
+      return createServer(configuration.isPersistenceEnabled(), configuration, AddressSettings.DEFAULT_PAGE_SIZE, AddressSettings.DEFAULT_MAX_SIZE_BYTES);
    }
 
    protected ActiveMQServer createServer(final boolean realFiles, boolean isNetty, StoreConfiguration.StoreType storeType) throws Exception {
       Configuration configuration = storeType == StoreConfiguration.StoreType.DATABASE ? createDefaultJDBCConfig(isNetty) : createDefaultConfig(isNetty);
-      return createServer(realFiles, configuration, AddressSettings.DEFAULT_PAGE_SIZE, AddressSettings.DEFAULT_MAX_SIZE_BYTES, new HashMap<String, AddressSettings>());
+      return createServer(realFiles, configuration, AddressSettings.DEFAULT_PAGE_SIZE, AddressSettings.DEFAULT_MAX_SIZE_BYTES);
    }
 
    protected ActiveMQServer createInVMFailoverServer(final boolean realFiles,
@@ -1559,7 +1565,7 @@ public abstract class ActiveMQTestBase extends Assert {
                                                             final boolean realFiles,
                                                             final Map<String, Object> params) throws Exception {
       String acceptor = isNetty ? NETTY_ACCEPTOR_FACTORY : INVM_ACCEPTOR_FACTORY;
-      return createServer(realFiles, createDefaultConfig(index, params, acceptor), -1, -1, new HashMap<String, AddressSettings>());
+      return createServer(realFiles, createDefaultConfig(index, params, acceptor), -1, -1);
    }
 
    protected ActiveMQServer createClusteredServerWithParams(final boolean isNetty,
@@ -1568,7 +1574,7 @@ public abstract class ActiveMQTestBase extends Assert {
                                                             final int pageSize,
                                                             final int maxAddressSize,
                                                             final Map<String, Object> params) throws Exception {
-      return createServer(realFiles, createDefaultConfig(index, params, (isNetty ? NETTY_ACCEPTOR_FACTORY : INVM_ACCEPTOR_FACTORY)), pageSize, maxAddressSize, new HashMap<String, AddressSettings>());
+      return createServer(realFiles, createDefaultConfig(index, params, (isNetty ? NETTY_ACCEPTOR_FACTORY : INVM_ACCEPTOR_FACTORY)), pageSize, maxAddressSize);
    }
 
    protected ServerLocator createFactory(final boolean isNetty) throws Exception {

--- a/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
@@ -53,6 +53,9 @@
       <populate-validated-user>true</populate-validated-user>
       <connection-ttl-check-interval>98765</connection-ttl-check-interval>
       <configuration-file-refresh-period>1234567</configuration-file-refresh-period>
+      <global-max-size>1234567</global-max-size>
+      <max-disk-usage>37</max-disk-usage>
+      <disk-scan-period>123</disk-scan-period>
       <remoting-incoming-interceptors>
          <class-name>org.apache.activemq.artemis.tests.unit.core.config.impl.TestInterceptor1</class-name>
          <class-name>org.apache.activemq.artemis.tests.unit.core.config.impl.TestInterceptor2</class-name>

--- a/docs/user-manual/en/configuration-index.md
+++ b/docs/user-manual/en/configuration-index.md
@@ -41,7 +41,9 @@ Name | Description
 [create-bindings-dir](persistence.md "Configuring the bindings journal") |  true means that the server will create the bindings directory on start up. Default=true
 [create-journal-dir](persistence.md)                                             |  true means that the journal directory will be created. Default=true
 [discovery-groups](clusters.md "Clusters")                           |  [a list of discovery-group](#discovery-group-type)
+[disk-scan-period](paging.md#max-disk-usage) | The interval where the disk is scanned for percentual usage. Default=5000 ms.
 [diverts](diverts.md "Diverting and Splitting Message Flows")        |  [a list of diverts to use](#divert-type)
+[global-max-size](paging.md#global-max-size) | The amount in bytes before all addresses are considered full
 [graceful-shutdown-enabled](graceful-shutdown.md "Graceful Server Shutdown")      |  true means that graceful shutdown is enabled. Default=true
 [graceful-shutdown-timeout](graceful-shutdown.md "Graceful Server Shutdown")      |  Timeout on waitin for clients to disconnect before server shutdown. Default=-1
 [grouping-handler](message-grouping.md "Message Grouping")             |  Message Group configuration
@@ -65,6 +67,7 @@ Name | Description
 [management-notification-address](management.md "Configuring The Core Management Notification Address") |  the name of the address that consumers bind to receive management notifications. Default=activemq.notifications
 [mask-password](configuration-index.md "Using Masked Passwords in Configuration Files")  |  This option controls whether passwords in server configuration need be masked. If set to "true" the passwords are masked. Default=false
 [max-saved-replicated-journals-size]()                                                                |    This specifies how many times a replicated backup server can restart after moving its files on start. Once there are this number of backup journal files the server will stop permanently after if fails back. Default=2
+[max-disk-usage](paging.md#max-disk-usage) | The max percentage of data we should use from disks. The System will block while the disk is full. Default=100
 [memory-measure-interval](perf-tuning.md)                                                             |  frequency to sample JVM memory in ms (or -1 to disable memory sampling). Default=-1
 [memory-warning-threshold](perf-tuning.md)                                                            |  Percentage of available memory which will trigger a warning log. Default=25
 [message-counter-enabled](management.md "Configuring Message Counters")                       |  true means that message counters are enabled. Default=false

--- a/docs/user-manual/en/paging.md
+++ b/docs/user-manual/en/paging.md
@@ -11,8 +11,7 @@ a low memory footprint.
 Apache ActiveMQ Artemis will start paging messages to disk, when the size of all
 messages in memory for an address exceeds a configured maximum size.
 
-By default, Apache ActiveMQ Artemis does not page messages - this must be explicitly
-configured to activate it.
+The default configuration from Artemis has destinations with paging.
 
 ## Page Files
 
@@ -121,6 +120,12 @@ This is the list of available parameters on the address settings.
     </tbody>
 </table>
 
+## Global Max Size
+
+Beyond the max-size-bytes on the address you can also set the global-max-size on the main configuration. If you set max-size-bytes = -1 on paging the global-max-size can still be used.
+
+When you have more messages than what is configured global-max-size any new produced message will make that destination to go through its paging policy. 
+
 ## Dropping messages
 
 Instead of paging messages when the max size is reached, an address can
@@ -180,6 +185,12 @@ For example:
 In this example all the other 9 queues will be consuming messages from
 the page system. This may cause performance issues if this is an
 undesirable state.
+
+## Max Disk Usage
+
+The System will perform scans on the disk to determine if the disk is beyond a configured limit. 
+These are configured through 'max-disk-usage' in percentage. Once that limit is reached any 
+message will be blocked. (unless the protocol doesn't support flow control on which case there will be an exception thrown and the connection for those clients dropped).
 
 ## Example
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/HangConsumerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/HangConsumerTest.java
@@ -588,7 +588,7 @@ public class HangConsumerTest extends ActiveMQTestBase {
                                                         SessionCallback callback,
                                                         OperationContext context,
                                                         boolean autoCreateQueue) throws Exception {
-         return new ServerSessionImpl(name, username, password, validatedUser, minLargeMessageSize, autoCommitSends, autoCommitAcks, preAcknowledge, getConfiguration().isPersistDeliveryCountBeforeDelivery(), xa, connection, getStorageManager(), getPostOffice(), getResourceManager(), getSecurityStore(), getManagementService(), this, getConfiguration().getManagementAddress(), defaultAddress == null ? null : new SimpleString(defaultAddress), new MyCallback(callback), context, null);
+         return new ServerSessionImpl(name, username, password, validatedUser, minLargeMessageSize, autoCommitSends, autoCommitAcks, preAcknowledge, getConfiguration().isPersistDeliveryCountBeforeDelivery(), xa, connection, getStorageManager(), getPostOffice(), getResourceManager(), getSecurityStore(), getManagementService(), this, getConfiguration().getManagementAddress(), defaultAddress == null ? null : new SimpleString(defaultAddress), new MyCallback(callback), context, null, getPagingManager());
       }
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/LargeMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/LargeMessageTest.java
@@ -57,7 +57,7 @@ import org.junit.Test;
 
 public class LargeMessageTest extends LargeMessageTestBase {
 
-   static final int RECEIVE_WAIT_TIME = 10000;
+   private static final int RECEIVE_WAIT_TIME = 10000;
 
    private final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/BackupSyncJournalTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/BackupSyncJournalTest.java
@@ -41,7 +41,7 @@ import org.apache.activemq.artemis.core.paging.PagingStore;
 import org.apache.activemq.artemis.core.persistence.impl.journal.DescribeJournal;
 import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager;
 import org.apache.activemq.artemis.core.server.Queue;
-import org.apache.activemq.artemis.core.server.impl.FileMoveManager;
+import org.apache.activemq.artemis.core.server.files.FileMoveManager;
 import org.apache.activemq.artemis.tests.integration.cluster.util.BackupSyncDelay;
 import org.apache.activemq.artemis.tests.integration.cluster.util.TestableServer;
 import org.apache.activemq.artemis.tests.util.TransportConfigurationUtils;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailoverTest.java
@@ -51,7 +51,7 @@ import org.apache.activemq.artemis.core.server.cluster.ha.ReplicaPolicy;
 import org.apache.activemq.artemis.core.server.cluster.ha.ReplicatedPolicy;
 import org.apache.activemq.artemis.core.server.cluster.ha.SharedStoreMasterPolicy;
 import org.apache.activemq.artemis.core.server.cluster.ha.SharedStoreSlavePolicy;
-import org.apache.activemq.artemis.core.server.impl.FileMoveManager;
+import org.apache.activemq.artemis.core.server.files.FileMoveManager;
 import org.apache.activemq.artemis.core.server.impl.InVMNodeManager;
 import org.apache.activemq.artemis.core.transaction.impl.XidImpl;
 import org.apache.activemq.artemis.jms.client.ActiveMQTextMessage;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/AddressFullLoggingTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/AddressFullLoggingTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.tests.integration.server;
+package org.apache.activemq.artemis.tests.integration.paging;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -49,11 +49,7 @@ public class AddressFullLoggingTest extends ActiveMQTestBase {
    }
 
    @Test
-   /**
-    * When running this test from an IDE add this to the test command line so that the AssertionLoggerHandler works properly:
-    *
-    *   -Djava.util.logging.manager=org.jboss.logmanager.LogManager  -Dlogging.configuration=file:<path_to_source>/tests/config/logging.properties
-    */ public void testBlockLogging() throws Exception {
+   public void testBlockLogging() throws Exception {
       final int MAX_MESSAGES = 200;
       final String MY_ADDRESS = "myAddress";
       final String MY_QUEUE = "myQueue";
@@ -64,6 +60,31 @@ public class AddressFullLoggingTest extends ActiveMQTestBase {
       server.getAddressSettingsRepository().addMatch("#", defaultSetting);
       server.start();
 
+      internalTest(MAX_MESSAGES, MY_ADDRESS, MY_QUEUE, server);
+   }
+
+   @Test
+   public void testGlobalBlockLogging() throws Exception {
+      final int MAX_MESSAGES = 200;
+      final String MY_ADDRESS = "myAddress";
+      final String MY_QUEUE = "myQueue";
+
+      ActiveMQServer server = createServer(false);
+
+      AddressSettings defaultSetting = new AddressSettings().setAddressFullMessagePolicy(AddressFullMessagePolicy.BLOCK);
+      server.getAddressSettingsRepository().addMatch("#", defaultSetting);
+      server.getConfiguration().setGlobalMaxSize(20 * 1024);
+
+      server.start();
+
+
+      internalTest(MAX_MESSAGES, MY_ADDRESS, MY_QUEUE, server);
+   }
+
+   private void internalTest(int MAX_MESSAGES,
+                             String MY_ADDRESS,
+                             String MY_QUEUE,
+                             ActiveMQServer server) throws Exception {
       ServerLocator locator = createInVMNonHALocator().setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setBlockOnAcknowledge(true);
 
       ClientSessionFactory factory = createSessionFactory(locator);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/GlobalPagingTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/GlobalPagingTest.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.tests.integration.paging;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.client.ClientConsumer;
+import org.apache.activemq.artemis.api.core.client.ClientMessage;
+import org.apache.activemq.artemis.api.core.client.ClientProducer;
+import org.apache.activemq.artemis.api.core.client.ClientSession;
+import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.ActiveMQServers;
+import org.apache.activemq.artemis.core.server.Queue;
+import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl;
+import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
+import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class GlobalPagingTest extends PagingTest {
+
+   @Override
+   @Before
+   public void setUp() throws Exception {
+      super.setUp();
+   }
+
+   @Override
+   protected ActiveMQServer createServer(final boolean realFiles,
+                                               final Configuration configuration,
+                                               final long pageSize,
+                                               final long maxAddressSize,
+                                               final Map<String, AddressSettings> settings) {
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(configuration, realFiles));
+
+      if (settings != null) {
+         for (Map.Entry<String, AddressSettings> setting : settings.entrySet()) {
+            server.getAddressSettingsRepository().addMatch(setting.getKey(), setting.getValue());
+         }
+      }
+
+      server.getConfiguration().setGlobalMaxSize(maxAddressSize);
+      AddressSettings defaultSetting = new AddressSettings().setPageSizeBytes(pageSize).setMaxSizeBytes(-1).setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
+
+      server.getAddressSettingsRepository().addMatch("#", defaultSetting);
+
+      return server;
+   }
+
+
+
+   @Test
+   public void testPagingOverFullDisk() throws Exception {
+      clearDataRecreateServerDirs();
+
+      Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false);
+
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
+      server.getConfiguration().setGlobalMaxSize(-1);
+
+      server.start();
+
+      ActiveMQServerImpl serverImpl = (ActiveMQServerImpl)server;
+      serverImpl.getMonitor().stop(); // stop the scheduled executor, we will do it manually only
+      serverImpl.getMonitor().tick();
+
+      final int numberOfMessages = 500;
+
+      locator = createInVMNonHALocator().setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setBlockOnAcknowledge(true);
+
+      sf = createSessionFactory(locator);
+
+      final ClientSession session = sf.createSession(false, false, false);
+
+      session.createQueue(PagingTest.ADDRESS, PagingTest.ADDRESS, null, true);
+
+      final ClientProducer producer = session.createProducer(PagingTest.ADDRESS);
+
+      ClientMessage message = null;
+
+      final byte[] body = new byte[MESSAGE_SIZE];
+
+      ByteBuffer bb = ByteBuffer.wrap(body);
+
+      for (int j = 1; j <= MESSAGE_SIZE; j++) {
+         bb.put(getSamplebyte(j));
+      }
+
+
+      Queue queue = server.locateQueue(ADDRESS);
+      queue.getPageSubscription().getPagingStore().forceAnotherPage();
+
+      sendFewMessages(numberOfMessages, session, producer, body);
+
+      serverImpl.getMonitor().setMaxUsage(0); // forcing disk full (faking it)
+
+      serverImpl.getMonitor().tick();
+
+      Thread t = new Thread() {
+         public void run() {
+            try {
+               sendFewMessages(numberOfMessages, session, producer, body);
+            }
+            catch (Exception e) {
+               e.printStackTrace();
+            }
+         }
+      };
+
+      t.start();
+
+      t.join(1000);
+      Assert.assertTrue(t.isAlive());
+
+      // releasing the disk
+      serverImpl.getMonitor().setMaxUsage(1).tick();
+      t.join(5000);
+      Assert.assertFalse(t.isAlive());
+
+
+      session.start();
+
+      assertEquals(numberOfMessages * 2, getMessageCount(queue));
+
+      // The consumer has to be created after the getMessageCount(queue) assertion
+      // otherwise delivery could alter the messagecount and give us a false failure
+      ClientConsumer consumer = session.createConsumer(PagingTest.ADDRESS);
+      ClientMessage msg = null;
+
+      for (int i = 0; i < numberOfMessages * 2; i++) {
+         msg = consumer.receive(1000);
+         assertNotNull(msg);
+         msg.acknowledge();
+         if (i % 500 == 0) {
+            session.commit();
+         }
+      }
+      session.commit();
+
+      assertEquals(0, getMessageCount(queue));
+   }
+
+   protected void sendFewMessages(int numberOfMessages,
+                                  ClientSession session,
+                                  ClientProducer producer,
+                                  byte[] body) throws ActiveMQException {
+      ClientMessage message;
+      for (int i = 0; i < numberOfMessages; i++) {
+         message = session.createMessage(true);
+
+         ActiveMQBuffer bodyLocal = message.getBodyBuffer();
+
+         bodyLocal.writeBytes(body);
+
+         producer.send(message);
+         if (i % 1000 == 0) {
+            session.commit();
+         }
+      }
+      session.commit();
+   }
+
+}

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingOrderTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingOrderTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.tests.integration.client;
+package org.apache.activemq.artemis.tests.integration.paging;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.SimpleString;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingSyncTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingSyncTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.tests.integration.client;
+package org.apache.activemq.artemis.tests.integration.paging;
 
 import java.nio.ByteBuffer;
 import java.util.HashMap;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.tests.integration.client;
+package org.apache.activemq.artemis.tests.integration.paging;
 
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
@@ -88,18 +88,18 @@ public class PagingTest extends ActiveMQTestBase {
 
    private static final Logger logger = Logger.getLogger(PagingTest.class);
 
-   private ServerLocator locator;
-   private ActiveMQServer server;
-   private ClientSessionFactory sf;
+   protected ServerLocator locator;
+   protected ActiveMQServer server;
+   protected ClientSessionFactory sf;
    static final int MESSAGE_SIZE = 1024; // 1k
 
-   private static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
+   protected static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
 
-   private static final int RECEIVE_TIMEOUT = 5000;
+   protected static final int RECEIVE_TIMEOUT = 5000;
 
-   private static final int PAGE_MAX = 100 * 1024;
+   protected static final int PAGE_MAX = 100 * 1024;
 
-   private static final int PAGE_SIZE = 10 * 1024;
+   protected static final int PAGE_SIZE = 10 * 1024;
 
    static final SimpleString ADDRESS = new SimpleString("SimpleAddress");
 
@@ -118,11 +118,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       final int PAGE_SIZE = 10 * 1024;
 
-      HashMap<String, AddressSettings> map = new HashMap<>();
-
-      AddressSettings value = new AddressSettings();
-      map.put(ADDRESS.toString(), value);
-      ActiveMQServer server = createServer(true, config, PAGE_SIZE, PAGE_MAX, map);
+      ActiveMQServer server = createServer(true, config, PAGE_SIZE, PAGE_MAX);
       server.start();
 
       final int numberOfBytes = 1024;
@@ -158,7 +154,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       server.stop();
 
-      server = createServer(true, config, PAGE_SIZE, PAGE_MAX, map);
+      server = createServer(true, config, PAGE_SIZE, PAGE_MAX);
       server.start();
 
       sf = createSessionFactory(locator);
@@ -171,7 +167,7 @@ public class PagingTest extends ActiveMQTestBase {
          session.start();
 
          for (int i = 0; i < 201; i++) {
-            ClientMessage message2 = consumer.receive(LargeMessageTest.RECEIVE_WAIT_TIME);
+            ClientMessage message2 = consumer.receive(10000);
 
             Assert.assertNotNull(message2);
 
@@ -186,7 +182,7 @@ public class PagingTest extends ActiveMQTestBase {
          else {
             session.rollback();
             for (int i = 0; i < 100; i++) {
-               ClientMessage message2 = consumer.receive(LargeMessageTest.RECEIVE_WAIT_TIME);
+               ClientMessage message2 = consumer.receive(10000);
 
                Assert.assertNotNull(message2);
 
@@ -210,7 +206,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false);
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -330,7 +326,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false);
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -435,7 +431,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false);
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -629,7 +625,7 @@ public class PagingTest extends ActiveMQTestBase {
       Configuration config = createDefaultInVMConfig().setJournalDirectory(getJournalDir()).setJournalSyncNonTransactional(false).setJournalCompactMinFiles(0) // disable compact
          .setMessageExpiryScanPeriod(500);
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       AddressSettings defaultSetting = new AddressSettings().setPageSizeBytes(PAGE_SIZE).setMaxSizeBytes(PAGE_MAX).setExpiryAddress(new SimpleString("EXP")).setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
 
@@ -743,7 +739,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig().setJournalDirectory(getJournalDir()).setJournalSyncNonTransactional(false).setJournalCompactMinFiles(0); // disable compact
 
-      ActiveMQServer server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      ActiveMQServer server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -896,7 +892,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false);
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -951,7 +947,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       server.stop();
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
       server.start();
 
       locator = createInVMNonHALocator();
@@ -1000,7 +996,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       server.stop();
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
       server.start();
 
       waitForServerToStart(server);
@@ -1075,7 +1071,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false);
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
       server.getAddressSettingsRepository().getMatch("#").setAddressFullMessagePolicy(AddressFullMessagePolicy.BLOCK);
 
       server.start();
@@ -1145,7 +1141,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false);
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -1195,7 +1191,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       server.stop();
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
       server.start();
 
       locator = createInVMNonHALocator();
@@ -1255,7 +1251,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       config.setJournalSyncNonTransactional(false);
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -1305,7 +1301,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       server.stop();
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
       server.start();
 
       locator = createInVMNonHALocator();
@@ -1358,7 +1354,7 @@ public class PagingTest extends ActiveMQTestBase {
       // a dumb user, or anything that will remove the data
       deleteDirectory(new File(getPageDir()));
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
       server.start();
 
       locator = createInVMNonHALocator().setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setBlockOnAcknowledge(true);
@@ -1391,7 +1387,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       server.stop();
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
       server.start();
 
       locator = createInVMNonHALocator();
@@ -1434,7 +1430,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false);
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -1511,7 +1507,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       jrn.stop();
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -1548,7 +1544,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false);
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -1629,7 +1625,7 @@ public class PagingTest extends ActiveMQTestBase {
          }
       }
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -1678,7 +1674,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false);
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -1774,7 +1770,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false);
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       if (divert) {
          DivertConfiguration divert1 = new DivertConfiguration().setName("dv1").setRoutingName("nm1").setAddress(PagingTest.ADDRESS.toString()).setForwardingAddress(PagingTest.ADDRESS.toString() + "-1").setExclusive(true);
@@ -1876,7 +1872,7 @@ public class PagingTest extends ActiveMQTestBase {
             locator.close();
          }
 
-         server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+         server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
          server.start();
 
          Queue queue1 = server.locateQueue(PagingTest.ADDRESS.concat("-1"));
@@ -2011,7 +2007,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false);
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -2067,7 +2063,7 @@ public class PagingTest extends ActiveMQTestBase {
          locator.close();
       }
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
       server.start();
 
       ServerLocator locator1 = createInVMNonHALocator();
@@ -2151,7 +2147,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false);
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -2199,7 +2195,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       server.stop();
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
       server.start();
 
       locator = createInVMNonHALocator();
@@ -2264,7 +2260,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig();
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -2374,7 +2370,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig();
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -2402,6 +2398,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       int numberOfMessages = 0;
       while (true) {
+         System.out.println("Sending message " + numberOfMessages);
          message = session.createMessage(IS_DURABLE_MESSAGE);
          message.getBodyBuffer().writeBytes(body);
          message.putIntProperty("id", numberOfMessages);
@@ -2485,7 +2482,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig();
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -2577,7 +2574,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false).setJournalSyncTransactional(false);
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -2668,7 +2665,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false).setJournalSyncTransactional(false);
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_SIZE * 2, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_SIZE * 2);
 
       server.getConfiguration();
       server.getConfiguration();
@@ -2777,7 +2774,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false);
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -2825,7 +2822,7 @@ public class PagingTest extends ActiveMQTestBase {
 
          server.stop();
 
-         server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+         server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
          server.start();
 
          sf = createSessionFactory(locator);
@@ -2873,7 +2870,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig();
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -2924,7 +2921,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig();
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -3167,7 +3164,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig();
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -3210,7 +3207,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       server.stop();
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -3240,7 +3237,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig();
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -3277,7 +3274,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       server.stop();
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -3305,7 +3302,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       server.stop();
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -3535,7 +3532,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       int NUMBER_OF_MESSAGES = 2;
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -3569,7 +3566,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       server.stop();
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
       server.start();
 
       sf = createSessionFactory(locator);
@@ -3610,7 +3607,7 @@ public class PagingTest extends ActiveMQTestBase {
    public void testSyncPage() throws Exception {
       Configuration config = createDefaultInVMConfig();
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -3653,7 +3650,7 @@ public class PagingTest extends ActiveMQTestBase {
    public void testSyncPageTX() throws Exception {
       Configuration config = createDefaultInVMConfig();
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -3878,7 +3875,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false).setJournalFileSize(10 * 1024 * 1024);
 
-      server = createServer(true, config, 512 * 1024, 1024 * 1024, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, 512 * 1024, 1024 * 1024);
 
       server.start();
 
@@ -3980,7 +3977,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false);
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -4062,7 +4059,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false);
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -4158,7 +4155,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false);
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -4235,7 +4232,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false);
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -4959,7 +4956,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false);
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -5020,7 +5017,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false);
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -5198,7 +5195,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false);
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -5292,7 +5289,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false);
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -5376,7 +5373,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false);
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -5460,7 +5457,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false);
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -5533,7 +5530,7 @@ public class PagingTest extends ActiveMQTestBase {
    public void testNoCursors() throws Exception {
       Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false);
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 
@@ -5570,7 +5567,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false);
 
-      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX, new HashMap<String, AddressSettings>());
+      server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 
       server.start();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/StompTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/StompTestBase.java
@@ -205,7 +205,7 @@ public abstract class StompTestBase extends ActiveMQTestBase {
       TransportConfiguration stompTransport = new TransportConfiguration(NettyAcceptorFactory.class.getName(), params);
       TransportConfiguration allTransport = new TransportConfiguration(NettyAcceptorFactory.class.getName());
 
-      Configuration config = createBasicConfig().setSecurityEnabled(isSecurityEnabled()).setPersistenceEnabled(false).addAcceptorConfiguration(stompTransport).addAcceptorConfiguration(new TransportConfiguration(InVMAcceptorFactory.class.getName()));
+      Configuration config = createBasicConfig().setSecurityEnabled(isSecurityEnabled()).setPersistenceEnabled(true).addAcceptorConfiguration(stompTransport).addAcceptorConfiguration(new TransportConfiguration(InVMAcceptorFactory.class.getName()));
       config.addAcceptorConfiguration(allTransport);
 
       ActiveMQServer activeMQServer = addServer(ActiveMQServers.newActiveMQServer(config, defUser, defPass));

--- a/tests/performance-tests/src/test/java/org/apache/activemq/artemis/tests/performance/storage/PersistMultiThreadTest.java
+++ b/tests/performance-tests/src/test/java/org/apache/activemq/artemis/tests/performance/storage/PersistMultiThreadTest.java
@@ -448,5 +448,10 @@ public class PersistMultiThreadTest extends ActiveMQTestBase {
       public boolean isStarted() {
          return false;
       }
+
+      @Override
+      public boolean checkReleasedMemory() {
+         return true;
+      }
    }
 }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/paging/impl/PagingStoreImplTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/paging/impl/PagingStoreImplTest.java
@@ -50,6 +50,7 @@ import org.apache.activemq.artemis.core.paging.impl.PagingStoreImpl;
 import org.apache.activemq.artemis.core.persistence.StorageManager;
 import org.apache.activemq.artemis.core.persistence.impl.nullpm.NullStorageManager;
 import org.apache.activemq.artemis.core.server.ServerMessage;
+import org.apache.activemq.artemis.core.server.files.FileStoreMonitor;
 import org.apache.activemq.artemis.core.server.impl.RoutingContextImpl;
 import org.apache.activemq.artemis.core.server.impl.ServerMessageImpl;
 import org.apache.activemq.artemis.core.settings.HierarchicalRepository;
@@ -824,6 +825,11 @@ public class PagingStoreImplTest extends ActiveMQTestBase {
 
       @Override
       public void stop() throws InterruptedException {
+      }
+
+      @Override
+      public void injectMonitor(FileStoreMonitor monitor) throws Exception {
+
       }
 
       public void beforePageRead() throws Exception {

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/FakePagingManager.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/FakePagingManager.java
@@ -23,37 +23,23 @@ import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.paging.PageTransactionInfo;
 import org.apache.activemq.artemis.core.paging.PagingManager;
 import org.apache.activemq.artemis.core.paging.PagingStore;
-import org.apache.activemq.artemis.core.postoffice.PostOffice;
 import org.apache.activemq.artemis.core.server.ServerMessage;
+import org.apache.activemq.artemis.core.server.files.FileStoreMonitor;
 
 public final class FakePagingManager implements PagingManager {
 
-   public void activate() {
-   }
+   @Override
+   public void addBlockedStore(PagingStore store) {
 
-   public long addSize(final long size) {
-      return 0;
    }
 
    @Override
    public void addTransaction(final PageTransactionInfo pageTransaction) {
    }
 
-   public PagingStore createPageStore(final SimpleString destination) throws Exception {
-      return null;
-   }
-
-   public long getTotalMemory() {
-      return 0;
-   }
-
    @Override
    public SimpleString[] getStoreNames() {
       return null;
-   }
-
-   public long getMaxMemory() {
-      return 0;
    }
 
    @Override
@@ -74,10 +60,6 @@ public final class FakePagingManager implements PagingManager {
       return false;
    }
 
-   public boolean isGlobalPageMode() {
-      return false;
-   }
-
    public boolean isPaging(final SimpleString destination) throws Exception {
       return false;
    }
@@ -93,6 +75,11 @@ public final class FakePagingManager implements PagingManager {
    }
 
    @Override
+   public FakePagingManager addSize(int size) {
+      return this;
+   }
+
+   @Override
    public void reloadStores() throws Exception {
    }
 
@@ -101,13 +88,9 @@ public final class FakePagingManager implements PagingManager {
 
    }
 
-   public void setGlobalPageMode(final boolean globalMode) {
-   }
-
-   public void setPostOffice(final PostOffice postOffice) {
-   }
-
-   public void resumeDepages() {
+   @Override
+   public boolean isUsingGlobalSize() {
+      return false;
    }
 
    public void sync(final Collection<SimpleString> destinationsToSync) throws Exception {
@@ -126,10 +109,15 @@ public final class FakePagingManager implements PagingManager {
    public void stop() throws Exception {
    }
 
+   @Override
+   public boolean isDiskFull() {
+      return false;
+   }
+
    /*
-    * (non-Javadoc)
-    * @see org.apache.activemq.artemis.core.paging.PagingManager#isGlobalFull()
-    */
+       * (non-Javadoc)
+       * @see org.apache.activemq.artemis.core.paging.PagingManager#isGlobalFull()
+       */
    public boolean isGlobalFull() {
       return false;
    }
@@ -177,4 +165,8 @@ public final class FakePagingManager implements PagingManager {
       // no-op
    }
 
+   @Override
+   public void injectMonitor(FileStoreMonitor monitor) throws Exception {
+
+   }
 }


### PR DESCRIPTION
max-disk-usage = how much of a disk we can use before the system blocks
global-max-size = how much bytes we can take from memory for messages before we start enter into the configured page mode

This will also change the default created configuration into page-mode as that's more reliable for systems.