### PR TITLE
ARTEMIS-715 messages could be sent to wrong queue

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientProducerImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientProducerImpl.java
@@ -267,7 +267,6 @@ public class ClientProducerImpl implements ClientProducerInternal {
          }
          else {
             sendRegularMessage(msgI, sendBlocking, theCredits, handler);
-            session.checkDefaultAddress(sendingAddress);
          }
       }
       finally {
@@ -290,6 +289,8 @@ public class ClientProducerImpl implements ClientProducerInternal {
       int creditSize = sessionContext.getCreditsOnSendingFull(msgI);
 
       theCredits.acquireCredits(creditSize);
+
+      session.checkDefaultAddress(address);
 
       sessionContext.sendFullMessage(msgI, sendBlocking, handler, address);
    }


### PR DESCRIPTION
 In rare circumstances MessageProducer can send a message  to wrong queue

JIRA: https://issues.apache.org/jira/browse/ARTEMIS-715
backport from : hornetq/hornetq@f1b3aa4