### PR TITLE
ARTEMIS-722 Add DELAYED_DELIVERY capability to server connection open

### DIFF
--- a/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/AMQPConnectionContext.java
+++ b/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/AMQPConnectionContext.java
@@ -16,6 +16,8 @@
  */
 package org.proton.plug;
 
+import org.apache.qpid.proton.amqp.Symbol;
+
 import io.netty.buffer.ByteBuf;
 
 public interface AMQPConnectionContext {
@@ -29,6 +31,14 @@ public interface AMQPConnectionContext {
    long getCreationTime();
 
    SASLResult getSASLResult();
+
+   /**
+    * Load and return a <code>[]Symbol</code> that contains the connection capabilities
+    * offered to new connections
+    *
+    * @return the capabilities that are offered to new remote peers on connect.
+    */
+   Symbol[] getConnectionCapabilitiesOffered();
 
    /**
     * Even though we are currently always sending packets asynchronsouly

--- a/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/AmqpSupport.java
+++ b/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/AmqpSupport.java
@@ -46,6 +46,7 @@ public class AmqpSupport {
 
    // Symbols used to announce connection information to remote peer.
    public static final Symbol ANONYMOUS_RELAY = Symbol.valueOf("ANONYMOUS-RELAY");
+   public static final Symbol DELAYED_DELIVERY = Symbol.valueOf("DELAYED_DELIVERY");
    public static final Symbol QUEUE_PREFIX = Symbol.valueOf("queue-prefix");
    public static final Symbol TOPIC_PREFIX = Symbol.valueOf("topic-prefix");
    public static final Symbol CONNECTION_OPEN_FAILED = Symbol.valueOf("amqp:connection-establishment-failed");

--- a/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/context/AbstractConnectionContext.java
+++ b/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/context/AbstractConnectionContext.java
@@ -16,6 +16,9 @@
  */
 package org.proton.plug.context;
 
+import static org.proton.plug.AmqpSupport.PRODUCT;
+import static org.proton.plug.AmqpSupport.VERSION;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -76,11 +79,13 @@ public abstract class AbstractConnectionContext extends ProtonInitializable impl
                                     ScheduledExecutorService scheduledPool) {
       this.connectionCallback = connectionCallback;
       this.containerId = (containerId != null) ? containerId : UUID.randomUUID().toString();
-      connectionProperties.put(Symbol.valueOf("product"), "apache-activemq-artemis");
-      connectionProperties.put(Symbol.valueOf("version"), VersionLoader.getVersion().getFullVersion());
+
+      connectionProperties.put(PRODUCT, "apache-activemq-artemis");
+      connectionProperties.put(VERSION, VersionLoader.getVersion().getFullVersion());
+
       this.scheduledPool = scheduledPool;
       connectionCallback.setConnection(this);
-      this.handler =   ProtonHandler.Factory.create(dispatchExecutor);
+      this.handler = ProtonHandler.Factory.create(dispatchExecutor);
       Transport transport = handler.getTransport();
       transport.setEmitFlowEventOnSend(false);
       if (idleTimeout > 0) {
@@ -211,6 +216,7 @@ public abstract class AbstractConnectionContext extends ProtonInitializable impl
             connection.setContext(AbstractConnectionContext.this);
             connection.setContainer(containerId);
             connection.setProperties(connectionProperties);
+            connection.setOfferedCapabilities(getConnectionCapabilitiesOffered());
             connection.open();
          }
          initialise();
@@ -326,9 +332,10 @@ public abstract class AbstractConnectionContext extends ProtonInitializable impl
             System.err.println("Handler is null, can't delivery " + delivery);
          }
       }
-
    }
 
-
-
+   @Override
+   public Symbol[] getConnectionCapabilitiesOffered() {
+      return null;
+   }
 }

--- a/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/context/server/ProtonServerConnectionContext.java
+++ b/artemis-protocols/artemis-proton-plug/src/main/java/org/proton/plug/context/server/ProtonServerConnectionContext.java
@@ -16,6 +16,9 @@
  */
 package org.proton.plug.context.server;
 
+import static org.proton.plug.AmqpSupport.DELAYED_DELIVERY;
+
+import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.amqp.transaction.Coordinator;
 import org.apache.qpid.proton.engine.Link;
 import org.apache.qpid.proton.engine.Receiver;
@@ -79,4 +82,7 @@ public class ProtonServerConnectionContext extends AbstractConnectionContext imp
       }
    }
 
+   public Symbol[] getConnectionCapabilitiesOffered() {
+      return new Symbol[]{DELAYED_DELIVERY};
+   }
 }


### PR DESCRIPTION
The server should indicate to clients that it supports the message
annotation that allows message delivery to be delayed
'x-opt-delivery-time'