### PR TITLE
ARTEMIS-714 Improve JDBC Store

### DIFF
--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/drivers/derby/DerbySQLProvider.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/drivers/derby/DerbySQLProvider.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.jdbc.store.drivers.derby;
 
 import org.apache.activemq.artemis.jdbc.store.sql.GenericSQLProvider;
+import org.apache.activemq.artemis.jdbc.store.sql.SQLProvider;
 
 public class DerbySQLProvider extends GenericSQLProvider {
 
@@ -27,7 +28,7 @@ public class DerbySQLProvider extends GenericSQLProvider {
 
    private final String appendToFileSQL;
 
-   public DerbySQLProvider(String tableName) {
+   private DerbySQLProvider(String tableName) {
       super(tableName);
 
       createFileTableSQL = "CREATE TABLE " + tableName +
@@ -55,5 +56,13 @@ public class DerbySQLProvider extends GenericSQLProvider {
    @Override
    public boolean closeConnectionOnShutdown() {
       return false;
+   }
+
+   public static class Factory implements SQLProvider.Factory {
+
+      @Override
+      public SQLProvider create(String tableName) {
+         return new DerbySQLProvider(tableName);
+      }
    }
 }

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/drivers/mysql/MySQLSQLProvider.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/drivers/mysql/MySQLSQLProvider.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.jdbc.store.drivers.mysql;
 
 import org.apache.activemq.artemis.jdbc.store.sql.GenericSQLProvider;
+import org.apache.activemq.artemis.jdbc.store.sql.SQLProvider;
 
 public class MySQLSQLProvider extends GenericSQLProvider {
 
@@ -28,7 +29,7 @@ public class MySQLSQLProvider extends GenericSQLProvider {
 
    private final String copyFileRecordByIdSQL;
 
-   public MySQLSQLProvider(String tName) {
+   private MySQLSQLProvider(String tName) {
       super(tName.toLowerCase());
 
       createFileTableSQL = "CREATE TABLE " + tableName +
@@ -60,5 +61,12 @@ public class MySQLSQLProvider extends GenericSQLProvider {
    @Override
    public String getCopyFileRecordByIdSQL() {
       return copyFileRecordByIdSQL;
+   }
+
+   public static class Factory implements SQLProvider.Factory {
+      @Override
+      public SQLProvider create(String tableName) {
+         return new MySQLSQLProvider(tableName);
+      }
    }
 }

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/drivers/postgres/PostgresSQLProvider.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/drivers/postgres/PostgresSQLProvider.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.jdbc.store.drivers.postgres;
 
 import org.apache.activemq.artemis.jdbc.store.sql.GenericSQLProvider;
+import org.apache.activemq.artemis.jdbc.store.sql.SQLProvider;
 
 public class PostgresSQLProvider extends GenericSQLProvider {
 
@@ -27,7 +28,7 @@ public class PostgresSQLProvider extends GenericSQLProvider {
 
    private final String createJournalTableSQL;
 
-   public PostgresSQLProvider(String tName) {
+   private PostgresSQLProvider(String tName) {
       super(tName.toLowerCase());
       createFileTableSQL = "CREATE TABLE " + tableName +
          "(ID SERIAL, FILENAME VARCHAR(255), EXTENSION VARCHAR(10), DATA OID, PRIMARY KEY(ID))";
@@ -48,6 +49,15 @@ public class PostgresSQLProvider extends GenericSQLProvider {
    @Override
    public int getMaxBlobSize() {
       return MAX_BLOB_SIZE;
+   }
+
+   public static class Factory implements SQLProvider.Factory {
+
+
+      @Override
+      public SQLProvider create(String tableName) {
+         return new PostgresSQLProvider(tableName);
+      }
    }
 }
 

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/file/JDBCSequentialFileFactory.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/file/JDBCSequentialFileFactory.java
@@ -25,11 +25,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
 
+import javax.sql.DataSource;
+
 import org.apache.activemq.artemis.core.io.SequentialFile;
 import org.apache.activemq.artemis.core.io.SequentialFileFactory;
 import org.apache.activemq.artemis.core.io.nio.NIOSequentialFileFactory;
 import org.apache.activemq.artemis.core.server.ActiveMQComponent;
 import org.apache.activemq.artemis.jdbc.store.JDBCUtils;
+import org.apache.activemq.artemis.jdbc.store.sql.SQLProvider;
 import org.apache.activemq.artemis.journal.ActiveMQJournalLogger;
 
 public class JDBCSequentialFileFactory implements SequentialFileFactory, ActiveMQComponent {
@@ -44,13 +47,22 @@ public class JDBCSequentialFileFactory implements SequentialFileFactory, ActiveM
 
    private final JDBCSequentialFileFactoryDriver dbDriver;
 
-   public JDBCSequentialFileFactory(final String connectionUrl,
+   public JDBCSequentialFileFactory(final DataSource dataSource,
+                                    final SQLProvider sqlProvider,
                                     final String tableName,
-                                    final String className,
                                     Executor executor) throws Exception {
       this.executor = executor;
       files = new ArrayList<>();
-      dbDriver = JDBCUtils.getDBFileDriver(className, tableName, connectionUrl);
+      dbDriver = JDBCUtils.getDBFileDriver(dataSource, tableName, sqlProvider);
+   }
+
+   public JDBCSequentialFileFactory(final String connectionUrl,
+                                    final String className,
+                                    final SQLProvider sqlProvider,
+                                    Executor executor) throws Exception {
+      this.executor = executor;
+      files = new ArrayList<>();
+      dbDriver = JDBCUtils.getDBFileDriver(className, connectionUrl, sqlProvider);
    }
 
    @Override

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/file/JDBCSequentialFileFactoryDriver.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/file/JDBCSequentialFileFactoryDriver.java
@@ -25,7 +25,10 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.sql.DataSource;
+
 import org.apache.activemq.artemis.jdbc.store.drivers.AbstractJDBCDriver;
+import org.apache.activemq.artemis.jdbc.store.sql.SQLProvider;
 
 public class JDBCSequentialFileFactoryDriver extends AbstractJDBCDriver {
 
@@ -49,8 +52,8 @@ public class JDBCSequentialFileFactoryDriver extends AbstractJDBCDriver {
       super();
    }
 
-   public JDBCSequentialFileFactoryDriver(String tableName, String jdbcConnectionUrl, String jdbcDriverClass) {
-      super(tableName, jdbcConnectionUrl, jdbcDriverClass);
+   public JDBCSequentialFileFactoryDriver(String tableName, DataSource dataSource, SQLProvider provider) {
+      super(dataSource, provider);
    }
 
    @Override

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalImpl.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalImpl.java
@@ -29,6 +29,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import javax.sql.DataSource;
+
 import org.apache.activemq.artemis.core.io.SequentialFileFactory;
 import org.apache.activemq.artemis.core.journal.EncodingSupport;
 import org.apache.activemq.artemis.core.journal.IOCompletion;
@@ -41,6 +43,7 @@ import org.apache.activemq.artemis.core.journal.TransactionFailureCallback;
 import org.apache.activemq.artemis.core.journal.impl.JournalFile;
 import org.apache.activemq.artemis.core.journal.impl.SimpleWaitIOCallback;
 import org.apache.activemq.artemis.jdbc.store.drivers.AbstractJDBCDriver;
+import org.apache.activemq.artemis.jdbc.store.sql.SQLProvider;
 import org.apache.activemq.artemis.journal.ActiveMQJournalLogger;
 import org.jboss.logging.Logger;
 
@@ -82,8 +85,15 @@ public class JDBCJournalImpl extends AbstractJDBCDriver implements Journal {
    // Sequence ID for journal records
    private AtomicLong seq = new AtomicLong(0);
 
-   public JDBCJournalImpl(String jdbcUrl, String tableName, String jdbcDriverClass, ScheduledExecutorService scheduledExecutorService, Executor completeExecutor) {
-      super(tableName, jdbcUrl, jdbcDriverClass);
+   public JDBCJournalImpl(DataSource dataSource, SQLProvider provider, String tableName, ScheduledExecutorService scheduledExecutorService, Executor completeExecutor) {
+      super(dataSource, provider);
+      records = new ArrayList<>();
+      this.scheduledExecutorService = scheduledExecutorService;
+      this.completeExecutor = completeExecutor;
+   }
+
+   public JDBCJournalImpl(String jdbcUrl, String jdbcDriverClass, SQLProvider sqlProvider, ScheduledExecutorService scheduledExecutorService, Executor completeExecutor) {
+      super(sqlProvider, jdbcUrl, jdbcDriverClass);
       records = new ArrayList<>();
       this.scheduledExecutorService = scheduledExecutorService;
       this.completeExecutor = completeExecutor;

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/sql/GenericSQLProvider.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/sql/GenericSQLProvider.java
@@ -57,7 +57,7 @@ public class GenericSQLProvider implements SQLProvider {
 
    private final String countJournalRecordsSQL;
 
-   public GenericSQLProvider(String tableName) {
+   protected GenericSQLProvider(String tableName) {
       this.tableName = tableName;
 
       createFileTableSQL = "CREATE TABLE " + tableName +
@@ -197,5 +197,12 @@ public class GenericSQLProvider implements SQLProvider {
    @Override
    public boolean closeConnectionOnShutdown() {
       return true;
+   }
+
+   public static class Factory implements SQLProvider.Factory {
+
+      public SQLProvider create(String tableName) {
+         return new GenericSQLProvider(tableName);
+      }
    }
 }

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/sql/SQLProvider.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/sql/SQLProvider.java
@@ -57,4 +57,8 @@ public interface SQLProvider {
    String getCountJournalRecordsSQL();
 
    boolean closeConnectionOnShutdown();
+
+   interface Factory {
+      SQLProvider create(String tableName);
+   }
 }

--- a/artemis-jdbc-store/src/test/java/org/apache/activemq/artemis/jdbc/file/JDBCSequentialFileFactoryTest.java
+++ b/artemis-jdbc-store/src/test/java/org/apache/activemq/artemis/jdbc/file/JDBCSequentialFileFactoryTest.java
@@ -32,6 +32,7 @@ import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
 import org.apache.activemq.artemis.core.io.IOCallback;
 import org.apache.activemq.artemis.core.io.SequentialFile;
+import org.apache.activemq.artemis.jdbc.store.JDBCUtils;
 import org.apache.activemq.artemis.jdbc.store.file.JDBCSequentialFile;
 import org.apache.activemq.artemis.jdbc.store.file.JDBCSequentialFileFactory;
 import org.apache.activemq.artemis.utils.ActiveMQThreadFactory;
@@ -64,7 +65,7 @@ public class JDBCSequentialFileFactoryTest {
    public void setup() throws Exception {
       Executor executor = Executors.newSingleThreadExecutor(ActiveMQThreadFactory.defaultThreadFactory());
 
-      factory = new JDBCSequentialFileFactory(connectionUrl, tableName, className, executor);
+      factory = new JDBCSequentialFileFactory(connectionUrl, className, JDBCUtils.getSQLProvider(className, tableName), executor);
       factory.start();
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/storage/DatabaseStorageConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/storage/DatabaseStorageConfiguration.java
@@ -16,8 +16,11 @@
  */
 package org.apache.activemq.artemis.core.config.storage;
 
+import javax.sql.DataSource;
+
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.core.config.StoreConfiguration;
+import org.apache.activemq.artemis.jdbc.store.sql.SQLProvider;
 
 public class DatabaseStorageConfiguration implements StoreConfiguration {
 
@@ -30,6 +33,11 @@ public class DatabaseStorageConfiguration implements StoreConfiguration {
    private String jdbcConnectionUrl = ActiveMQDefaultConfiguration.getDefaultDatabaseUrl();
 
    private String jdbcDriverClassName = ActiveMQDefaultConfiguration.getDefaultDriverClassName();
+
+   private DataSource dataSource;
+
+   private SQLProvider.Factory sqlProviderFactory;
+
    @Override
    public StoreType getStoreType() {
       return StoreType.DATABASE;
@@ -73,5 +81,38 @@ public class DatabaseStorageConfiguration implements StoreConfiguration {
 
    public String getJdbcDriverClassName() {
       return jdbcDriverClassName;
+   }
+
+   /**
+    * The DataSource to use to store Artemis data in the data store (can be {@code null} if {@code jdbcConnectionUrl} and {@code jdbcDriverClassName} are used instead).
+    *
+    * @return the DataSource used to store Artemis data in the JDBC data store.
+    */
+   public DataSource getDataSource() {
+      return dataSource;
+   }
+
+   /**
+    * Configure the DataSource to use to store Artemis data in the data store.
+    *
+    * @param dataSource
+    */
+   public void setDataSource(DataSource dataSource) {
+      this.dataSource = dataSource;
+   }
+
+   /**
+    * The {@link SQLProvider.Factory} used to communicate with the JDBC data store.
+    * It can be {@code null}. If the value is {@code null} and {@code dataSource} is set, the {@code {@link org.apache.activemq.artemis.jdbc.store.sql.GenericSQLProvider.Factory} will be user,
+    * else the type of the factory will be determined based on the {@code jdbcDriverClassName).
+    *
+    * @return the factory used to communicate with the JDBC data store.
+    */
+   public SQLProvider.Factory getSqlProviderFactory() {
+      return sqlProviderFactory;
+   }
+
+   public void setSqlProvider(SQLProvider.Factory sqlProviderFactory) {
+      this.sqlProviderFactory = sqlProviderFactory;
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jdbc/store/journal/JDBCJournalTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jdbc/store/journal/JDBCJournalTest.java
@@ -29,7 +29,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.activemq.artemis.core.journal.IOCompletion;
 import org.apache.activemq.artemis.core.journal.PreparedTransactionInfo;
 import org.apache.activemq.artemis.core.journal.RecordInfo;
+import org.apache.activemq.artemis.jdbc.store.drivers.derby.DerbySQLProvider;
 import org.apache.activemq.artemis.jdbc.store.journal.JDBCJournalImpl;
+import org.apache.activemq.artemis.jdbc.store.sql.SQLProvider;
 import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.ThreadLeakCheckRule;
 import org.junit.After;
@@ -75,7 +77,9 @@ public class JDBCJournalTest extends ActiveMQTestBase {
       scheduledExecutorService = new ScheduledThreadPoolExecutor(5);
       executorService = Executors.newSingleThreadExecutor();
       jdbcUrl = "jdbc:derby:target/data;create=true";
-      journal = new JDBCJournalImpl(jdbcUrl, JOURNAL_TABLE_NAME, DRIVER_CLASS, scheduledExecutorService, executorService);
+      SQLProvider.Factory factory = new DerbySQLProvider.Factory();
+      journal = new JDBCJournalImpl(jdbcUrl, DRIVER_CLASS, factory.create(JOURNAL_TABLE_NAME),
+              scheduledExecutorService, executorService);
       journal.start();
    }
 


### PR DESCRIPTION
add DataSource and SQLProvider.Factory properties to DataStorageConfiguration to externalize the configuration of the communication with the JDBC data store instead of relying on global class path to load the SQL connection and hard-coded values for the SQL provider choice

JIRA: https://issues.apache.org/jira/browse/ARTEMIS-714