### PR TITLE
Stomp encode speedups

### DIFF
--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompFrame.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompFrame.java
@@ -91,15 +91,10 @@ public class StompFrame {
 
    public ActiveMQBuffer toActiveMQBuffer() throws Exception {
       if (buffer == null) {
-         if (bytesBody != null) {
-            buffer = ActiveMQBuffers.dynamicBuffer(bytesBody.length + 512);
-         }
-         else {
-            buffer = ActiveMQBuffers.dynamicBuffer(512);
-         }
-
          if (isPing()) {
-            buffer.writeByte((byte) 10);
+            buffer = ActiveMQBuffers.fixedBuffer(1);
+            buffer.writeByte((byte)10);
+            size = buffer.writerIndex();
             return buffer;
          }
 
@@ -117,7 +112,12 @@ public class StompFrame {
          // Add a newline to separate the headers from the content.
          head.append(Stomp.NEWLINE);
 
-         buffer.writeBytes(head.toString().getBytes(StandardCharsets.UTF_8));
+         byte[] headBytes = head.toString().getBytes(StandardCharsets.UTF_8);
+         int bodyLength = (bytesBody == null) ? 0 : bytesBody.length;
+
+         buffer = ActiveMQBuffers.fixedBuffer(headBytes.length + bodyLength + END_OF_FRAME.length);
+
+         buffer.writeBytes(headBytes);
          if (bytesBody != null) {
             buffer.writeBytes(bytesBody);
          }

--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompFrame.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompFrame.java
@@ -103,7 +103,7 @@ public class StompFrame {
             return buffer;
          }
 
-         StringBuilder head = new StringBuilder();
+         StringBuilder head = new StringBuilder(512);
          head.append(command);
          head.append(Stomp.NEWLINE);
          // Output the headers.


### PR DESCRIPTION
These translate to ~15% speedup of `toActiveMQBuffer()`, measured with JMH on my system using a frame with ~20 headers.