### PR TITLE
POC for CDI Integration in Artemis

### DIFF
--- a/docs/user-manual/en/cdi-integration.md
+++ b/docs/user-manual/en/cdi-integration.md
@@ -1,0 +1,32 @@
+# CDI Integration
+
+Apache ActiveMQ Artemis provides a simple CDI integration.  It can either use an embedded broker or connect to a remote broker.
+
+## Configuring a connection
+
+Configuration is provided by implementing the `ArtemisClientConfiguration` interface.
+
+```java
+public interface ArtemisClientConfiguration {
+   String getHost();
+
+   Integer getPort();
+
+   String getUsername();
+
+   String getPassword();
+
+   String getUrl();
+
+   String getConnectorFactory();
+
+   boolean startEmbeddedBroker();
+
+   boolean isHa();
+
+   boolean hasAuthentication();
+}
+```
+
+There's a default configuration out of the box, if none is specified.  This will generate an embedded broker.
+

--- a/integration/artemis-cdi-integration/pom.xml
+++ b/integration/artemis-cdi-integration/pom.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements. See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership. The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>artemis-pom</artifactId>
+        <groupId>org.apache.activemq</groupId>
+        <version>1.5.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <properties>
+        <activemq.basedir>${project.basedir}/../../</activemq.basedir>
+    </properties>
+
+    <artifactId>artemis-cdi-client</artifactId>
+    <name>ActiveMQ Artemis CDI Integration</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-processor</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-jms-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-jms-server</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+    </dependencies>
+    <profiles>
+        <profile>
+            <id>Weld</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.weld.se</groupId>
+                    <artifactId>weld-se</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-weld-embedded</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>OWB</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.openwebbeans</groupId>
+                    <artifactId>openwebbeans-impl</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.openwebbeans</groupId>
+                    <artifactId>openwebbeans-spi</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.openwebbeans</groupId>
+                    <artifactId>openwebbeans-resource</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.openwebbeans.arquillian</groupId>
+                    <artifactId>owb-arquillian-standalone</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-annotation_1.2_spec</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+</project>

--- a/integration/artemis-cdi-integration/src/main/java/org/apache/artemis/client/cdi/configuration/ArtemisClientConfiguration.java
+++ b/integration/artemis-cdi-integration/src/main/java/org/apache/artemis/client/cdi/configuration/ArtemisClientConfiguration.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.artemis.client.cdi.configuration;
+
+import org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnectorFactory;
+import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory;
+
+public interface ArtemisClientConfiguration {
+
+   String IN_VM_CONNECTOR = InVMConnectorFactory.class.getName();
+   String REMOTE_CONNECTOR = NettyConnectorFactory.class.getName();
+
+   /**
+    * @return if present, sends a username for the connection
+    */
+   String getUsername();
+
+   /**
+    * @return the password for the connection.  If username is set, password must be set
+    */
+   String getPassword();
+
+   /**
+    * Either url should be set, or host, port, connector factory should be set.
+    *
+    * @return if set, will be used in the server locator to look up the server instead of the hostname/port combination
+    */
+   String getUrl();
+
+   /**
+    * @return The hostname to connect to
+    */
+   String getHost();
+
+   /**
+    * @return the port number to connect to
+    */
+   Integer getPort();
+
+   /**
+    * @return the connector factory to use for connections.
+    */
+   String getConnectorFactory();
+
+   /**
+    * @return Whether or not to start the embedded broker
+    */
+   boolean startEmbeddedBroker();
+
+   /**
+    * @return whether or not this is an HA connection
+    */
+   boolean isHa();
+
+   /**
+    * @return whether or not the authentication parameters should be used
+    */
+   boolean hasAuthentication();
+}

--- a/integration/artemis-cdi-integration/src/main/java/org/apache/artemis/client/cdi/configuration/DefaultArtemisClientConfigurationImpl.java
+++ b/integration/artemis-cdi-integration/src/main/java/org/apache/artemis/client/cdi/configuration/DefaultArtemisClientConfigurationImpl.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.artemis.client.cdi.configuration;
+
+import javax.enterprise.inject.Vetoed;
+import java.util.Map;
+
+@Vetoed
+public class DefaultArtemisClientConfigurationImpl implements ArtemisClientConfiguration {
+
+   private String host;
+   private Integer port;
+   private String url;
+   private String username;
+   private String password;
+   private boolean ha;
+
+   public DefaultArtemisClientConfigurationImpl() {
+   }
+
+   public DefaultArtemisClientConfigurationImpl(Map<String, Object> params) {
+      host = (String) params.get("host");
+      port = (Integer) params.get("port");
+      url = (String) params.get("url");
+      username = (String) params.get("username");
+      password = (String) params.get("password");
+      Boolean isHa = (Boolean) params.get("ha");
+      if (isHa == null) {
+         isHa = false;
+      }
+      ha = isHa;
+   }
+
+   @Override
+   public String getHost() {
+      return host;
+   }
+
+   @Override
+   public Integer getPort() {
+      return port;
+   }
+
+   @Override
+   public String getUsername() {
+      return username;
+   }
+
+   @Override
+   public String getPassword() {
+      return password;
+   }
+
+   @Override
+   public String getUrl() {
+      return url;
+   }
+
+   @Override
+   public String getConnectorFactory() {
+      return startEmbeddedBroker() ? IN_VM_CONNECTOR : REMOTE_CONNECTOR;
+   }
+
+   @Override
+   public boolean startEmbeddedBroker() {
+      return host == null && url == null;
+   }
+
+   @Override
+   public boolean isHa() {
+      return ha;
+   }
+
+   @Override
+   public boolean hasAuthentication() {
+      return getUsername() != null && getUsername().length() > 0;
+   }
+}

--- a/integration/artemis-cdi-integration/src/main/java/org/apache/artemis/client/cdi/extension/AnyLiteral.java
+++ b/integration/artemis-cdi-integration/src/main/java/org/apache/artemis/client/cdi/extension/AnyLiteral.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.artemis.client.cdi.extension;
+
+import javax.enterprise.inject.Any;
+import javax.enterprise.util.AnnotationLiteral;
+
+class AnyLiteral extends AnnotationLiteral<Any> implements Any {
+
+   static final Any INSTANCE = new AnyLiteral();
+}

--- a/integration/artemis-cdi-integration/src/main/java/org/apache/artemis/client/cdi/extension/ArtemisClientConfigBean.java
+++ b/integration/artemis-cdi-integration/src/main/java/org/apache/artemis/client/cdi/extension/ArtemisClientConfigBean.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.artemis.client.cdi.extension;
+
+import org.apache.artemis.client.cdi.configuration.ArtemisClientConfiguration;
+import org.apache.artemis.client.cdi.configuration.DefaultArtemisClientConfigurationImpl;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.InjectionPoint;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.util.Collections.emptySet;
+
+class ArtemisClientConfigBean implements Bean<ArtemisClientConfiguration> {
+
+   @Override
+   public Class<?> getBeanClass() {
+      return DefaultArtemisClientConfigurationImpl.class;
+   }
+
+   @Override
+   public Set<InjectionPoint> getInjectionPoints() {
+      return emptySet();
+   }
+
+   @Override
+   public boolean isNullable() {
+      return false;
+   }
+
+   @Override
+   public ArtemisClientConfiguration create(CreationalContext<ArtemisClientConfiguration> creationalContext) {
+      return new DefaultArtemisClientConfigurationImpl();
+   }
+
+   @Override
+   public void destroy(ArtemisClientConfiguration configuration,
+                       CreationalContext<ArtemisClientConfiguration> creationalContext) {
+   }
+
+   @Override
+   public Set<Type> getTypes() {
+      Set<Type> types = new HashSet<>();
+      types.add(DefaultArtemisClientConfigurationImpl.class);
+      types.add(ArtemisClientConfiguration.class);
+      return types;
+   }
+
+   @Override
+   public Set<Annotation> getQualifiers() {
+      Set<Annotation> qualifiers = new HashSet<>();
+      qualifiers.add(AnyLiteral.INSTANCE);
+      qualifiers.add(DefaultLiteral.INSTANCE);
+      return qualifiers;
+
+   }
+
+   @Override
+   public Class<? extends Annotation> getScope() {
+      return ApplicationScoped.class;
+   }
+
+   @Override
+   public String getName() {
+      return null;
+   }
+
+   @Override
+   public Set<Class<? extends Annotation>> getStereotypes() {
+      return emptySet();
+   }
+
+   @Override
+   public boolean isAlternative() {
+      return false;
+   }
+}

--- a/integration/artemis-cdi-integration/src/main/java/org/apache/artemis/client/cdi/extension/ArtemisEmbeddedServerConfigBean.java
+++ b/integration/artemis-cdi-integration/src/main/java/org/apache/artemis/client/cdi/extension/ArtemisEmbeddedServerConfigBean.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.artemis.client.cdi.extension;
+
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
+import org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.InjectionPoint;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Collections.emptySet;
+
+public class ArtemisEmbeddedServerConfigBean implements Bean<Configuration> {
+
+   @Override
+   public Class<?> getBeanClass() {
+      return ConfigurationImpl.class;
+   }
+
+   @Override
+   public Set<InjectionPoint> getInjectionPoints() {
+      return emptySet();
+   }
+
+   @Override
+   public boolean isNullable() {
+      return false;
+   }
+
+   @Override
+   public Configuration create(CreationalContext<Configuration> creationalContext) {
+      Map<String, Object> params = new HashMap<>();
+      params.put(org.apache.activemq.artemis.core.remoting.impl.invm.TransportConstants.SERVER_ID_PROP_NAME, "1");
+      return new ConfigurationImpl().setSecurityEnabled(false).setPersistenceEnabled(false).setJMXManagementEnabled(false).addAcceptorConfiguration(new TransportConfiguration(InVMAcceptorFactory.class.getName(), params));
+   }
+
+   @Override
+   public void destroy(Configuration configuration, CreationalContext<Configuration> creationalContext) {
+   }
+
+   @Override
+   public Set<Type> getTypes() {
+      Set<Type> types = new HashSet<>();
+      types.add(ConfigurationImpl.class);
+      types.add(Configuration.class);
+      return types;
+   }
+
+   @Override
+   public Set<Annotation> getQualifiers() {
+      Set<Annotation> qualifiers = new HashSet<>();
+      qualifiers.add(AnyLiteral.INSTANCE);
+      qualifiers.add(DefaultLiteral.INSTANCE);
+      return qualifiers;
+
+   }
+
+   @Override
+   public Class<? extends Annotation> getScope() {
+      return ApplicationScoped.class;
+   }
+
+   @Override
+   public String getName() {
+      return null;
+   }
+
+   @Override
+   public Set<Class<? extends Annotation>> getStereotypes() {
+      return emptySet();
+   }
+
+   @Override
+   public boolean isAlternative() {
+      return false;
+   }
+}

--- a/integration/artemis-cdi-integration/src/main/java/org/apache/artemis/client/cdi/extension/ArtemisExtension.java
+++ b/integration/artemis-cdi-integration/src/main/java/org/apache/artemis/client/cdi/extension/ArtemisExtension.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.artemis.client.cdi.extension;
+
+import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.artemis.client.cdi.configuration.ArtemisClientConfiguration;
+import org.apache.artemis.client.cdi.logger.ActiveMQCDILogger;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AfterBeanDiscovery;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.ProcessAnnotatedType;
+
+public class ArtemisExtension implements Extension {
+
+   private boolean foundEmbeddedConfig = false;
+   private boolean foundConfiguration = false;
+
+   <T extends ArtemisClientConfiguration> void foundClientConfig(@Observes ProcessAnnotatedType<T> pat) {
+      ActiveMQCDILogger.LOGGER.discoveredConfiguration(pat);
+      foundConfiguration = true;
+   }
+
+   <T extends Configuration> void foundEmbeddedConfig(@Observes ProcessAnnotatedType<T> pat) {
+      ActiveMQCDILogger.LOGGER.discoveredClientConfiguration(pat);
+      foundEmbeddedConfig = true;
+   }
+
+   void afterBeanDiscovery(@Observes AfterBeanDiscovery afterBeanDiscovery) {
+      if (!foundConfiguration) {
+         afterBeanDiscovery.addBean(new ArtemisClientConfigBean());
+      }
+      else {
+         ActiveMQCDILogger.LOGGER.notUsingDefaultConfiguration();
+      }
+      if (!foundEmbeddedConfig) {
+         afterBeanDiscovery.addBean(new ArtemisEmbeddedServerConfigBean());
+      }
+      else {
+         ActiveMQCDILogger.LOGGER.notUsingDefaultClientConfiguration();
+      }
+
+   }
+
+}

--- a/integration/artemis-cdi-integration/src/main/java/org/apache/artemis/client/cdi/extension/DefaultLiteral.java
+++ b/integration/artemis-cdi-integration/src/main/java/org/apache/artemis/client/cdi/extension/DefaultLiteral.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.artemis.client.cdi.extension;
+
+import javax.enterprise.inject.Default;
+import javax.enterprise.util.AnnotationLiteral;
+
+class DefaultLiteral extends AnnotationLiteral<Default> implements Default {
+
+   static final Default INSTANCE = new DefaultLiteral();
+}

--- a/integration/artemis-cdi-integration/src/main/java/org/apache/artemis/client/cdi/factory/ConnectionFactoryProvider.java
+++ b/integration/artemis-cdi-integration/src/main/java/org/apache/artemis/client/cdi/factory/ConnectionFactoryProvider.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.artemis.client.cdi.factory;
+
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
+import org.apache.activemq.artemis.api.jms.JMSFactoryType;
+import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.ActiveMQServers;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
+import org.apache.artemis.client.cdi.configuration.ArtemisClientConfiguration;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import javax.jms.JMSContext;
+import java.util.HashMap;
+import java.util.Map;
+
+@ApplicationScoped
+public class ConnectionFactoryProvider {
+
+   @Produces
+   @ApplicationScoped
+   private ActiveMQConnectionFactory activeMQConnectionFactory;
+
+   @Inject
+   private ArtemisClientConfiguration configuration;
+
+   @Inject
+   private Configuration embeddedConfiguration;
+
+   @PostConstruct
+   public void setupConnection() {
+      if (configuration.startEmbeddedBroker()) {
+         try {
+            ActiveMQServer activeMQServer = ActiveMQServers.newActiveMQServer(embeddedConfiguration, false);
+            JMSServerManagerImpl jmsServerManager = new JMSServerManagerImpl(activeMQServer);
+            jmsServerManager.start();
+         }
+         catch (Exception e) {
+            throw new RuntimeException("Unable to start embedded JMS", e);
+         }
+      }
+
+      try {
+         this.activeMQConnectionFactory = createConnectionFactory();
+      }
+      catch (Exception e) {
+         throw new RuntimeException("Unable to connect to remote server", e);
+      }
+   }
+
+   @Produces
+   @ApplicationScoped
+   public JMSContext createJMSContext() {
+      return this.activeMQConnectionFactory.createContext();
+   }
+
+   private ActiveMQConnectionFactory createConnectionFactory() throws Exception {
+      Map<String, Object> params = new HashMap<>();
+      params.put(org.apache.activemq.artemis.core.remoting.impl.invm.TransportConstants.SERVER_ID_PROP_NAME, "1");
+      final ActiveMQConnectionFactory activeMQConnectionFactory;
+      if (configuration.getUrl() != null) {
+         activeMQConnectionFactory = ActiveMQJMSClient.createConnectionFactory(configuration.getUrl(), null);
+      }
+      else {
+         if (configuration.getHost() != null) {
+            params.put(TransportConstants.HOST_PROP_NAME, configuration.getHost());
+            params.put(TransportConstants.PORT_PROP_NAME, configuration.getPort());
+         }
+         if (configuration.isHa()) {
+            activeMQConnectionFactory = ActiveMQJMSClient.createConnectionFactoryWithHA(JMSFactoryType.CF, new TransportConfiguration(configuration.getConnectorFactory(), params));
+         }
+         else {
+            activeMQConnectionFactory = ActiveMQJMSClient.createConnectionFactoryWithoutHA(JMSFactoryType.CF, new TransportConfiguration(configuration.getConnectorFactory(), params));
+         }
+      }
+      if (configuration.hasAuthentication()) {
+         activeMQConnectionFactory.setUser(configuration.getUsername());
+         activeMQConnectionFactory.setPassword(configuration.getPassword());
+      }
+      return activeMQConnectionFactory;
+   }
+}

--- a/integration/artemis-cdi-integration/src/main/java/org/apache/artemis/client/cdi/logger/ActiveMQCDILogger.java
+++ b/integration/artemis-cdi-integration/src/main/java/org/apache/artemis/client/cdi/logger/ActiveMQCDILogger.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.artemis.client.cdi.logger;
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
+
+import javax.enterprise.inject.spi.ProcessAnnotatedType;
+
+/**
+ * Logger code 57
+ *
+ * each message id must be 6 digits long starting with 57, the 3rd digit donates the level so
+ *
+ * INF0  1
+ * WARN  2
+ * DEBUG 3
+ * ERROR 4
+ * TRACE 5
+ * FATAL 6
+ *
+ * so an INFO message would be 571000 to 571999
+ */
+@MessageLogger(projectCode = "AMQ")
+public interface ActiveMQCDILogger extends BasicLogger {
+
+   ActiveMQCDILogger LOGGER = Logger.getMessageLogger(ActiveMQCDILogger.class,
+                                                      ActiveMQCDILogger.class.getPackage().getName());
+
+   @LogMessage
+   @Message(id = 571000, value = "Discovered configuration class {0}", format = Message.Format.MESSAGE_FORMAT)
+   void discoveredConfiguration(ProcessAnnotatedType<?> pat);
+
+   @LogMessage
+   @Message(id = 571001, value = "Discovered client configuration class {0}", format = Message.Format.MESSAGE_FORMAT)
+   void discoveredClientConfiguration(ProcessAnnotatedType<?> pat);
+
+   @LogMessage(level = Logger.Level.DEBUG)
+   @Message(id = 573000, value = "Configuration found, not using built in configuration")
+   void notUsingDefaultConfiguration();
+
+   @LogMessage(level = Logger.Level.DEBUG)
+   @Message(id = 573001, value = "Configuration found, not using built in configuration")
+   void notUsingDefaultClientConfiguration();
+}

--- a/integration/artemis-cdi-integration/src/test/java/org/apache/activemq/artemis/cdi/bootstrap/CDIBootstrapTest.java
+++ b/integration/artemis-cdi-integration/src/test/java/org/apache/activemq/artemis/cdi/bootstrap/CDIBootstrapTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.activemq.artemis.cdi.bootstrap;
+
+import org.apache.artemis.client.cdi.configuration.ArtemisClientConfiguration;
+import org.apache.artemis.client.cdi.configuration.DefaultArtemisClientConfigurationImpl;
+import org.apache.artemis.client.cdi.extension.ArtemisExtension;
+import org.apache.artemis.client.cdi.factory.ConnectionFactoryProvider;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.spi.Extension;
+import javax.inject.Inject;
+import javax.jms.JMSContext;
+import javax.jms.Queue;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Arquillian.class)
+public class CDIBootstrapTest {
+
+   @Deployment
+   public static Archive<?> createArchive() {
+      return ShrinkWrap.create(JavaArchive.class)
+         .addAsServiceProviderAndClasses(Extension.class, ArtemisExtension.class)
+         .addClasses(NativeConfig.class, ConnectionFactoryProvider.class)
+         .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+   }
+
+   @Inject
+   private JMSContext jmsContext;
+
+   @Test
+   public void shouldStartJMS() throws Exception {
+      String body = "This is a test";
+      Queue queue = jmsContext.createQueue("test");
+      jmsContext.createProducer().send(queue, body);
+      String receivedBody = jmsContext.createConsumer(queue).receiveBody(String.class, 5000);
+      Assert.assertNotNull(receivedBody);
+      assertEquals(body, receivedBody);
+   }
+
+   @ApplicationScoped
+   public static class NativeConfig extends DefaultArtemisClientConfigurationImpl {
+
+      @Override
+      public String getConnectorFactory() {
+         return ArtemisClientConfiguration.IN_VM_CONNECTOR;
+      }
+   }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
       <module>integration/activemq-spring-integration</module>
       <module>integration/activemq-aerogear-integration</module>
       <module>integration/activemq-vertx-integration</module>
+      <module>integration/artemis-cdi-integration</module>
       <module>artemis-distribution</module>
       <module>tests</module>
       <module>artemis-features</module>
@@ -96,6 +97,10 @@
       <geronimo.ejb.3.0.spec.version>1.0.1</geronimo.ejb.3.0.spec.version>
       <geronimo.jta.1.1.spec.version>1.1.1</geronimo.jta.1.1.spec.version>
       <geronimo.jms.2.spec.version>1.0-alpha-2</geronimo.jms.2.spec.version>
+      <weld.version>2.4.0.Final</weld.version>
+      <arquillian-weld-embedded.version>2.0.0.Beta3</arquillian-weld-embedded.version>
+      <owb.version>1.7.0</owb.version>
+      <arquillian.version>1.1.11.Final</arquillian.version>
 
       <owasp.version>1.4.3</owasp.version>
 
@@ -155,6 +160,8 @@
       <javac-compiler-id>javac-with-errorprone</javac-compiler-id>
 
       <directory-version>1.5.7</directory-version>
+      <cdi-api.version>1.2</cdi-api.version>
+      <geronimo-annotation_1.2_spec.version>1.0</geronimo-annotation_1.2_spec.version>
    </properties>
 
    <scm>
@@ -586,7 +593,60 @@
             <!-- License: Apache 2.0 -->
          </dependency>
 
-
+         <dependency>
+            <groupId>org.apache.openwebbeans</groupId>
+            <artifactId>openwebbeans-impl</artifactId>
+            <version>${owb.version}</version>
+            <scope>test</scope>
+         </dependency>
+         <dependency>
+            <groupId>org.apache.openwebbeans</groupId>
+            <artifactId>openwebbeans-spi</artifactId>
+            <version>${owb.version}</version>
+            <scope>test</scope>
+         </dependency>
+         <dependency>
+            <groupId>org.apache.openwebbeans</groupId>
+            <artifactId>openwebbeans-resource</artifactId>
+            <version>${owb.version}</version>
+            <scope>test</scope>
+         </dependency>
+         <dependency>
+            <groupId>org.apache.openwebbeans.arquillian</groupId>
+            <artifactId>owb-arquillian-standalone</artifactId>
+            <version>${owb.version}</version>
+            <scope>test</scope>
+         </dependency>
+         <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-annotation_1.2_spec</artifactId>
+            <version>${geronimo-annotation_1.2_spec.version}</version>
+            <scope>provided</scope>
+         </dependency>
+         <dependency>
+            <groupId>org.jboss.weld.se</groupId>
+            <artifactId>weld-se</artifactId>
+            <version>${weld.version}</version>
+            <scope>test</scope>
+         </dependency>
+         <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-weld-embedded</artifactId>
+            <version>${arquillian-weld-embedded.version}</version>
+            <scope>test</scope>
+         </dependency>
+         <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <version>${arquillian.version}</version>
+            <scope>test</scope>
+         </dependency>
+         <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <version>${cdi-api.version}</version>
+            <scope>provided</scope>
+         </dependency>
       </dependencies>
    </dependencyManagement>
 


### PR DESCRIPTION
This PR isn't ready to go.  However, two issues I'm running into.

- When running tests, it cannot locate the JBoss Log Manager.  I'm assuming theres some JVM arguments missing.
```
Could not load Logmanager "org.jboss.logmanager.LogManager"
java.lang.ClassNotFoundException: org.jboss.logmanager.LogManager
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at java.util.logging.LogManager$1.run(LogManager.java:195)
	at java.util.logging.LogManager$1.run(LogManager.java:181)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.util.logging.LogManager.<clinit>(LogManager.java:181)
	at org.jboss.logging.LoggerProviders.tryJBossLogManager(LoggerProviders.java:144)
	at org.jboss.logging.LoggerProviders.findProvider(LoggerProviders.java:85)
	at org.jboss.logging.LoggerProviders.find(LoggerProviders.java:34)
	at org.jboss.logging.LoggerProviders.<clinit>(LoggerProviders.java:31)
	at org.jboss.logging.Logger.getLogger(Logger.java:2465)
	at org.jboss.logging.Logger$1.run(Logger.java:2565)
	at java.security.AccessController.doPrivileged(Native Method)
	at org.jboss.logging.Logger.getMessageLogger(Logger.java:2529)
	at org.jboss.logging.Logger.getMessageLogger(Logger.java:2516)
	at org.jboss.weld.logging.VersionLogger.<clinit>(VersionLogger.java:35)
	at org.jboss.weld.bootstrap.WeldStartup.<clinit>(WeldStartup.java:155)
	at org.jboss.weld.bootstrap.WeldBootstrap.<init>(WeldBootstrap.java:53)
	at org.jboss.weld.environment.se.Weld.initialize(Weld.java:589)
	at org.apache.activemq.artemis.cdi.bootstrap.CDIBootstrapTest.shouldStartJMS(CDIBootstrapTest.java:50)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:283)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:173)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:128)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)
```

- Second, and I was hoping it was because I was flying and not paying attention closely, however I'm stumped.  Even though it seems like the message is being sent, I'm not able to receive it.  I also noticed the new CDI API doesn't give a good way to create a destination.