### PR TITLE
Update error prone, flag missing @Override as error

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/ConcurrentUtil.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/ConcurrentUtil.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.utils;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+
+public class ConcurrentUtil {
+
+   /**
+    * Await for condition, handling
+    * <a href="http://errorprone.info/bugpattern/WaitNotInLoop">spurious wakeups</a>.
+    * @param condition condition to await for
+    * @param timeout the maximum time to wait in milliseconds
+    * @return value from {@link Condition#await(long, TimeUnit)}
+    */
+   public static boolean await(final Condition condition, final long timeout) throws InterruptedException {
+      boolean awaited = false;
+      long timeoutRemaining = timeout;
+      long awaitStarted = System.currentTimeMillis();
+      while (!awaited && timeoutRemaining > 0) {
+         awaited = condition.await(timeoutRemaining, TimeUnit.MILLISECONDS);
+         timeoutRemaining -= System.currentTimeMillis() - awaitStarted;
+      }
+      return awaited;
+   }
+}

--- a/artemis-junit/src/main/java/org/apache/activemq/artemis/junit/ActiveMQConsumerResource.java
+++ b/artemis-junit/src/main/java/org/apache/activemq/artemis/junit/ActiveMQConsumerResource.java
@@ -109,6 +109,7 @@ public class ActiveMQConsumerResource extends AbstractActiveMQClientResource {
       }
    }
 
+   @Override
    public boolean isAutoCreateQueue() {
       return autoCreateQueue;
    }
@@ -118,6 +119,7 @@ public class ActiveMQConsumerResource extends AbstractActiveMQClientResource {
     *
     * @param autoCreateQueue
     */
+   @Override
    public void setAutoCreateQueue(boolean autoCreateQueue) {
       this.autoCreateQueue = autoCreateQueue;
    }

--- a/artemis-selector/pom.xml
+++ b/artemis-selector/pom.xml
@@ -56,6 +56,16 @@
       </resources>
       <plugins>
          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+               <compilerArgs>
+                  <!-- TODO: do this only for generated-sources -->
+                  <arg>-Xep:MissingOverride:WARN</arg>
+               </compilerArgs>
+            </configuration>
+         </plugin>
+         <plugin>
            <groupId>org.codehaus.mojo</groupId>
            <artifactId>javacc-maven-plugin</artifactId>
            <version>2.6</version>

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/group/impl/LocalGroupingHandler.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/group/impl/LocalGroupingHandler.java
@@ -38,6 +38,7 @@ import org.apache.activemq.artemis.core.postoffice.BindingType;
 import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
 import org.apache.activemq.artemis.core.server.management.ManagementService;
 import org.apache.activemq.artemis.core.server.management.Notification;
+import org.apache.activemq.artemis.utils.ConcurrentUtil;
 import org.apache.activemq.artemis.utils.ExecutorFactory;
 import org.apache.activemq.artemis.utils.TypedProperties;
 import org.jboss.logging.Logger;
@@ -267,11 +268,10 @@ public final class LocalGroupingHandler extends GroupHandlingAbstract {
             if (expectedBindings.size() > 0) {
                logger.debug("Waiting remote group bindings to arrive before starting the server. timeout=" + timeout + " milliseconds");
                //now we wait here for the rest to be received in onNotification, it will signal once all have been received.
-               //if we arent signaled then bindingsAdded still has some groupids we need to remove.
-               if (!awaitCondition.await(timeout, TimeUnit.MILLISECONDS)) {
+               //if we aren't signaled then bindingsAdded still has some groupids we need to remove.
+               if (!ConcurrentUtil.await(awaitCondition, timeout)) {
                   ActiveMQServerLogger.LOGGER.remoteGroupCoordinatorsNotStarted();
                }
-
             }
          }
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/AnyLiveNodeLocatorForScaleDown.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/AnyLiveNodeLocatorForScaleDown.java
@@ -19,7 +19,6 @@ package org.apache.activemq.artemis.core.server.impl;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -29,6 +28,7 @@ import org.apache.activemq.artemis.api.core.Pair;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.TopologyMember;
 import org.apache.activemq.artemis.core.server.LiveNodeLocator;
+import org.apache.activemq.artemis.utils.ConcurrentUtil;
 import org.jboss.logging.Logger;
 
 /**
@@ -65,12 +65,14 @@ public class AnyLiveNodeLocatorForScaleDown extends LiveNodeLocator {
          if (connectors.isEmpty()) {
             try {
                if (timeout != -1L) {
-                  if (!condition.await(timeout, TimeUnit.MILLISECONDS)) {
+                  if (!ConcurrentUtil.await(condition, timeout)) {
                      throw new ActiveMQException("Timeout elapsed while waiting for cluster node");
                   }
                }
                else {
-                  condition.await();
+                  while (connectors.isEmpty()) {
+                     condition.await();
+                  }
                }
             }
             catch (InterruptedException e) {
@@ -153,4 +155,3 @@ public class AnyLiveNodeLocatorForScaleDown extends LiveNodeLocator {
       }
    }
 }
-

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/NamedLiveNodeLocatorForReplication.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/NamedLiveNodeLocatorForReplication.java
@@ -16,7 +16,6 @@
  */
 package org.apache.activemq.artemis.core.server.impl;
 
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -27,6 +26,7 @@ import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.TopologyMember;
 import org.apache.activemq.artemis.core.server.LiveNodeLocator;
 import org.apache.activemq.artemis.core.server.cluster.qourum.SharedNothingBackupQuorum;
+import org.apache.activemq.artemis.utils.ConcurrentUtil;
 
 /**
  * NamedLiveNodeLocatorForReplication looks for a live server in the cluster with a specific backupGroupName
@@ -59,10 +59,12 @@ public class NamedLiveNodeLocatorForReplication extends LiveNodeLocator {
          if (liveConfiguration == null) {
             try {
                if (timeout != -1L) {
-                  condition.await(timeout, TimeUnit.MILLISECONDS);
+                  ConcurrentUtil.await(condition, timeout);
                }
                else {
-                  condition.await();
+                  while (liveConfiguration == null) {
+                     condition.await();
+                  }
                }
             }
             catch (InterruptedException e) {
@@ -117,4 +119,3 @@ public class NamedLiveNodeLocatorForReplication extends LiveNodeLocator {
       }
    }
 }
-

--- a/pom.xml
+++ b/pom.xml
@@ -941,7 +941,12 @@
                  <dependency>
                    <groupId>org.codehaus.plexus</groupId>
                    <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                   <version>2.5</version>
+                   <version>2.8</version>
+                 </dependency>
+                 <dependency>
+                   <groupId>com.google.errorprone</groupId>
+                   <artifactId>error_prone_core</artifactId>
+                   <version>2.0.9</version>
                  </dependency>
                </dependencies>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -930,6 +930,7 @@
                  <forceJavacCompilerUse>true</forceJavacCompilerUse>
                  <compilerId>${javac-compiler-id}</compilerId>
                  <compilerArgs>
+                    <arg>-Xep:MissingOverride:ERROR</arg>
                     <arg>-Xep:NonAtomicVolatileUpdate:ERROR</arg>
                     <arg>-Xep:SynchronizeOnNonFinalField:ERROR</arg>
                     <arg>-Xep:StaticAccessedFromInstance:ERROR</arg>

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/util/UnmodifiableLink.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/util/UnmodifiableLink.java
@@ -255,6 +255,7 @@ public class UnmodifiableLink implements Link {
       return link.detached();
    }
 
+   @Override
    public Record attachments() {
       return link.attachments();
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpClientTestSupport.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpClientTestSupport.java
@@ -48,6 +48,7 @@ public class AmqpClientTestSupport extends ActiveMQTestBase {
 
 
    @Before
+   @Override
    public void setUp() throws Exception {
       super.setUp();
       server = createServer(true, true);
@@ -55,6 +56,7 @@ public class AmqpClientTestSupport extends ActiveMQTestBase {
    }
 
    @After
+   @Override
    public void tearDown() throws Exception {
       super.tearDown();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cli/DestinationCommandTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cli/DestinationCommandTest.java
@@ -38,6 +38,7 @@ public class DestinationCommandTest extends JMSTestBase {
    private ByteArrayOutputStream error;
 
    @Before
+   @Override
    public void setUp() throws Exception {
       super.setUp();
       this.output = new ByteArrayOutputStream(1024);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/ExpireWhileLoadBalanceTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/ExpireWhileLoadBalanceTest.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 public class ExpireWhileLoadBalanceTest extends ClusterTestBase {
 
    @Before
+   @Override
    public void setUp() throws Exception {
       super.setUp();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/GlobalPagingTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/GlobalPagingTest.java
@@ -117,6 +117,7 @@ public class GlobalPagingTest extends PagingTest {
       serverImpl.getMonitor().tick();
 
       Thread t = new Thread() {
+         @Override
          public void run() {
             try {
                sendFewMessages(numberOfMessages, session, producer, body);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/proton/ProtonMaxFrameSizeTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/proton/ProtonMaxFrameSizeTest.java
@@ -34,6 +34,7 @@ public class ProtonMaxFrameSizeTest extends ProtonTestBase {
 
    private static final int FRAME_SIZE = 512;
 
+   @Override
    protected void configureAmqp(Map<String, Object> params) {
       params.put("maxFrameSize", FRAME_SIZE);
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/proton/ProtonPubSubTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/proton/ProtonPubSubTest.java
@@ -54,6 +54,7 @@ public class ProtonPubSubTest extends ProtonTestBase {
    private Connection connection;
    private JmsConnectionFactory factory;
 
+   @Override
    protected void configureAmqp(Map<String, Object> params) {
       params.put("pubSubPrefix", prefix);
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/rest/RestDeserializationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/rest/RestDeserializationTest.java
@@ -44,12 +44,14 @@ public class RestDeserializationTest extends RestTestBase {
    private RestAMQConnection restConnection;
 
    @Before
+   @Override
    public void setUp() throws Exception {
       super.setUp();
       createJettyServer("localhost", 12345);
    }
 
    @After
+   @Override
    public void tearDown() throws Exception {
       if (restConnection != null) {
          restConnection.close();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/rest/RestTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/rest/RestTestBase.java
@@ -42,12 +42,14 @@ public class RestTestBase extends JMSTestBase {
    protected HandlerList handlers;
 
    @Before
+   @Override
    public void setUp() throws Exception {
       super.setUp();
       webAppDir = testFolder.newFolder("test-apps");
    }
 
    @After
+   @Override
    public void tearDown() throws Exception {
       if (server != null) {
          try {


### PR DESCRIPTION
This updates error prone to 2.0.9. It is not the latest version at the moment (2.0.13 is), but later versions than that introduce new errors that are unrelated to the missing Overrides I'm doing this for, so I suggest tackling them separately sometime. The `Condition.await` WaitNotInLoop fixes are necessary, can't have a new enough error prone without them (or without dialing WaitNotInLoop back from error). Review for these appreciated.

artemis-selectors' generated code doesn't pass the missing overrides check, so for the moment this downgrades that check to warnings for the submodule. I don't know if this could be done only for the `generated-sources` dir therein.