### PR TITLE
ARTEMIS-777 Remove dependency on legacy Qpid AMQP 0.x JMS client

### DIFF
--- a/tests/integration-tests/pom.xml
+++ b/tests/integration-tests/pom.xml
@@ -29,7 +29,7 @@
    <properties>
       <activemq.basedir>${project.basedir}/../..</activemq.basedir>
       <karaf.version>4.0.6</karaf.version>
-	  <pax.exam.version>4.9.1</pax.exam.version>
+     <pax.exam.version>4.9.1</pax.exam.version>
       <vertx.version>2.1.6</vertx.version>
       <vertx.testtools.version>2.0.3-final</vertx.testtools.version>
    </properties>
@@ -156,12 +156,12 @@
          <artifactId>artemis-hornetq-protocol</artifactId>
          <version>${project.version}</version>
       </dependency>
-	   <dependency>
-		   <groupId>org.apache.activemq</groupId>
-		   <artifactId>artemis-features</artifactId>
-		   <version>${project.version}</version>
-		   <type>pom</type>
-	   </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-features</artifactId>
+         <version>${project.version}</version>
+         <type>pom</type>
+      </dependency>
 
       <!-- MQTT Deps -->
       <dependency>
@@ -219,11 +219,6 @@
           <groupId>org.apache.qpid</groupId>
           <artifactId>proton-j</artifactId>
        </dependency>
-      <dependency>
-         <groupId>org.apache.qpid</groupId>
-         <artifactId>qpid-client</artifactId>
-         <version>0.24</version>
-      </dependency>
       <dependency>
          <groupId>org.slf4j</groupId>
          <artifactId>slf4j-api</artifactId>
@@ -314,31 +309,31 @@
          </exclusions>
       </dependency>
 
-	  <!-- karaf test -->
+     <!-- karaf test -->
 
-	   <dependency>
-		   <groupId>org.ops4j.pax.exam</groupId>
-		   <artifactId>pax-exam-container-karaf</artifactId>
-		   <version>${pax.exam.version}</version>
-		   <scope>test</scope>
-	   </dependency>
-	   <dependency>
-		   <groupId>org.ops4j.pax.exam</groupId>
-		   <artifactId>pax-exam-junit4</artifactId>
-		   <version>${pax.exam.version}</version>
-		   <scope>test</scope>
-	   </dependency>
-	   <dependency>
-		   <groupId>org.apache.karaf</groupId>
-		   <artifactId>apache-karaf</artifactId>
-		   <version>${karaf.version}</version>
-		   <type>tar.gz</type>
-	   </dependency>
-	   <dependency>
-		   <groupId>org.apache.karaf.shell</groupId>
-		   <artifactId>org.apache.karaf.shell.console</artifactId>
-		   <version>${karaf.version}</version>
-	   </dependency>
+      <dependency>
+         <groupId>org.ops4j.pax.exam</groupId>
+         <artifactId>pax-exam-container-karaf</artifactId>
+         <version>${pax.exam.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.ops4j.pax.exam</groupId>
+         <artifactId>pax-exam-junit4</artifactId>
+         <version>${pax.exam.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.karaf</groupId>
+         <artifactId>apache-karaf</artifactId>
+         <version>${karaf.version}</version>
+         <type>tar.gz</type>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.karaf.shell</groupId>
+         <artifactId>org.apache.karaf.shell.console</artifactId>
+         <version>${karaf.version}</version>
+      </dependency>
       <dependency>
          <groupId>org.apache.activemq.tests</groupId>
          <artifactId>artemis-test-support</artifactId>
@@ -445,19 +440,19 @@
                <argLine>-Djgroups.bind_addr=::1 ${activemq-surefire-argline}</argLine>
             </configuration>
          </plugin>
-		  <plugin>
-			  <groupId>org.apache.servicemix.tooling</groupId>
-			  <artifactId>depends-maven-plugin</artifactId>
-			  <version>1.2</version>
-			  <executions>
-				  <execution>
-					  <id>generate-depends-file</id>
-					  <goals>
-						  <goal>generate-depends-file</goal>
-					  </goals>
-				  </execution>
-			  </executions>
-		  </plugin>
+        <plugin>
+           <groupId>org.apache.servicemix.tooling</groupId>
+           <artifactId>depends-maven-plugin</artifactId>
+           <version>1.2</version>
+           <executions>
+              <execution>
+                 <id>generate-depends-file</id>
+                 <goals>
+                    <goal>generate-depends-file</goal>
+                 </goals>
+              </execution>
+           </executions>
+        </plugin>
       </plugins>
    </build>
 


### PR DESCRIPTION
Remove the dependency on the qpid-client module which is an AMQP JMS
client for the 0.x AMQP protocols which Artemis does not support.