### PR TITLE
ARTEMIS-801 Decode URL paths

### DIFF
--- a/artemis-cli/src/test/java/org/apache/activemq/cli/test/FileBrokerTest.java
+++ b/artemis-cli/src/test/java/org/apache/activemq/cli/test/FileBrokerTest.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.cli.test;
 
 import java.io.IOException;
+import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -105,6 +106,7 @@ public class FileBrokerTest {
          Assert.assertTrue(activeMQServer.isStarted());
          Assert.assertTrue(broker.isStarted());
          path = activeMQServer.getConfiguration().getConfigurationUrl().getPath();
+         path = URLDecoder.decode(path, StandardCharsets.UTF_8.name());
          Assert.assertNotNull(activeMQServer.getConfiguration().getConfigurationUrl());
 
          Thread.sleep(activeMQServer.getConfiguration().getConfigurationFileRefreshPeriod() * 2);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/reload/ReloadManagerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/reload/ReloadManagerImpl.java
@@ -18,7 +18,10 @@
 package org.apache.activemq.artemis.core.server.reload;
 
 import java.io.File;
+import java.io.UnsupportedEncodingException;
 import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -92,7 +95,17 @@ public class ReloadManagerImpl extends ActiveMQScheduledComponent implements Rel
       private final List<ReloadCallback> callbacks = new LinkedList<>();
 
       ReloadRegistry(URL uri) {
-         this.file = new File(uri.getPath());
+         String filePath = null;
+         try {
+            filePath = URLDecoder.decode(uri.getPath(), StandardCharsets.UTF_8.name());
+         } catch (UnsupportedEncodingException e) {
+            logger.error(e.getMessage(), e);
+         }
+         if (filePath != null) {
+            this.file = new File(filePath);
+         } else {
+            this.file = new File(uri.getPath());
+         }
          this.lastModified = file.lastModified();
          this.uri = uri;
       }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/security/jaas/GuestLoginModuleTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/security/jaas/GuestLoginModuleTest.java
@@ -23,22 +23,33 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal;
 import org.apache.activemq.artemis.spi.core.security.jaas.UserPrincipal;
+import org.jboss.logging.Logger;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class GuestLoginModuleTest extends Assert {
+
+   private static final Logger logger = Logger.getLogger(GuestLoginModuleTest.class);
 
    static {
       String path = System.getProperty("java.security.auth.login.config");
       if (path == null) {
          URL resource = GuestLoginModuleTest.class.getClassLoader().getResource("login.config");
          if (resource != null) {
-            path = resource.getFile();
-            System.setProperty("java.security.auth.login.config", path);
+            try {
+               path = URLDecoder.decode(resource.getFile(), StandardCharsets.UTF_8.name());
+               System.setProperty("java.security.auth.login.config", path);
+            } catch (UnsupportedEncodingException e) {
+               logger.error(e.getMessage(), e);
+               throw new RuntimeException(e);
+            }
          }
       }
    }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/security/jaas/PropertiesLoginModuleTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/security/jaas/PropertiesLoginModuleTest.java
@@ -27,23 +27,34 @@ import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
 import java.io.File;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal;
 import org.apache.activemq.artemis.spi.core.security.jaas.UserPrincipal;
 import org.apache.commons.io.FileUtils;
+import org.jboss.logging.Logger;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class PropertiesLoginModuleTest extends Assert {
+
+   private static final Logger logger = Logger.getLogger(PropertiesLoginModuleTest.class);
 
    static {
       String path = System.getProperty("java.security.auth.login.config");
       if (path == null) {
          URL resource = PropertiesLoginModuleTest.class.getClassLoader().getResource("login.config");
          if (resource != null) {
-            path = resource.getFile();
-            System.setProperty("java.security.auth.login.config", path);
+            try {
+               path = URLDecoder.decode(resource.getFile(), StandardCharsets.UTF_8.name());
+               System.setProperty("java.security.auth.login.config", path);
+            } catch (UnsupportedEncodingException e) {
+               logger.error(e.getMessage(), e);
+               throw new RuntimeException(e);
+            }
          }
       }
    }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/security/jaas/TextFileCertificateLoginModuleTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/security/jaas/TextFileCertificateLoginModuleTest.java
@@ -20,7 +20,10 @@ import javax.management.remote.JMXPrincipal;
 import javax.security.auth.Subject;
 import javax.security.auth.login.LoginException;
 import javax.security.cert.X509Certificate;
+import java.io.UnsupportedEncodingException;
 import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
 import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
@@ -28,11 +31,14 @@ import org.apache.activemq.artemis.spi.core.security.jaas.CertificateLoginModule
 import org.apache.activemq.artemis.spi.core.security.jaas.JaasCallbackHandler;
 import org.apache.activemq.artemis.spi.core.security.jaas.PropertiesLoader;
 import org.apache.activemq.artemis.spi.core.security.jaas.TextFileCertificateLoginModule;
+import org.jboss.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 public class TextFileCertificateLoginModuleTest {
+
+   private static final Logger logger = Logger.getLogger(TextFileCertificateLoginModuleTest.class);
 
    private static final String CERT_USERS_FILE_SMALL = "cert-users-SMALL.properties";
    private static final String CERT_USERS_FILE_LARGE = "cert-users-LARGE.properties";
@@ -45,8 +51,13 @@ public class TextFileCertificateLoginModuleTest {
       if (path == null) {
          URL resource = TextFileCertificateLoginModuleTest.class.getClassLoader().getResource("login.config");
          if (resource != null) {
-            path = resource.getFile();
-            System.setProperty("java.security.auth.login.config", path);
+            try {
+               path = URLDecoder.decode(resource.getFile(), StandardCharsets.UTF_8.name());
+               System.setProperty("java.security.auth.login.config", path);
+            } catch (UnsupportedEncodingException e) {
+               logger.error(e.getMessage(), e);
+               throw new RuntimeException(e);
+            }
          }
       }
    }


### PR DESCRIPTION
If the path to file contains some special characters, they are encoded
in URL form using %<hex> syntax. We should decode such path when it
is used as path to file on local filesystem.