### PR TITLE
[ARTEMIS-803] Fix colocated backups with http-upgrade acceptor

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnector.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnector.java
@@ -653,6 +653,10 @@ public class NettyConnector extends AbstractConnector {
                request.headers().set(HttpHeaders.Names.HOST, host);
                request.headers().set(HttpHeaders.Names.UPGRADE, ACTIVEMQ_REMOTING);
                request.headers().set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.UPGRADE);
+               final String serverName = ConfigurationHelper.getStringProperty(TransportConstants.ACTIVEMQ_SERVER_NAME, null, configuration);
+               if (serverName != null) {
+                  request.headers().set(TransportConstants.ACTIVEMQ_SERVER_NAME, serverName);
+               }
 
                final String endpoint = ConfigurationHelper.getStringProperty(TransportConstants.HTTP_UPGRADE_ENDPOINT_PROP_NAME, null, configuration);
                if (endpoint != null) {

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/TransportConstants.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/TransportConstants.java
@@ -53,6 +53,8 @@ public class TransportConstants {
 
    public static final String USE_INVM_PROP_NAME = "useInvm";
 
+   public static final String ACTIVEMQ_SERVER_NAME = "activemqServerName";
+
    /**
     * @deprecated use PROTOCOLS_PROP_NAME
     */
@@ -252,6 +254,7 @@ public class TransportConstants {
       ALLOWABLE_ACCEPTOR_KEYS = Collections.unmodifiableSet(allowableAcceptorKeys);
 
       Set<String> allowableConnectorKeys = new HashSet<>();
+      allowableConnectorKeys.add(TransportConstants.ACTIVEMQ_SERVER_NAME);
       allowableConnectorKeys.add(TransportConstants.SSL_ENABLED_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.HTTP_ENABLED_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.HTTP_CLIENT_IDLE_PROP_NAME);


### PR DESCRIPTION
*  Do not offset ports for Netty connector/acceptor with http-upgrade
enabled.
* Pass the name of the ActiveMQ server to the HTTP request to initiate
the Upgrade so that the HTTP endpoint on the app server can find the
correct ActiveMQ broker that must handle the upgrade.

JIRA: https://issues.apache.org/jira/browse/ARTEMIS-803