### PR TITLE
ARTEMIS-805 old JMS clients failing on new broker

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/Channel.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/Channel.java
@@ -53,6 +53,11 @@ public interface Channel {
    boolean supports(byte packetID);
 
    /**
+    * For protocol check
+    */
+   boolean supports(byte packetID, int version);
+
+   /**
     * Sends a packet on this channel.
     *
     * @param packet the packet to send

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ChannelImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ChannelImpl.java
@@ -152,8 +152,11 @@ public final class ChannelImpl implements Channel {
 
    @Override
    public boolean supports(final byte packetType) {
-      int version = connection.getClientVersion();
+      return supports(packetType, connection.getClientVersion());
+   }
 
+   @Override
+   public boolean supports(final byte packetType, int version) {
       switch (packetType) {
          case PacketImpl.CLUSTER_TOPOLOGY_V2:
             return version >= 122;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/util/BackupSyncDelay.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/util/BackupSyncDelay.java
@@ -345,5 +345,10 @@ public class BackupSyncDelay implements Interceptor {
          return true;
       }
 
+      @Override
+      public boolean supports(byte packetID, int version) {
+         return true;
+      }
+
    }
 }


### PR DESCRIPTION
Old JMS clients are getting a CCE related to SessionBindingQueryResponseMessage