### PR TITLE
ARTEMIS-824: Add management routines for connector services

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.api.core.management;
 
 import javax.management.MBeanOperationInfo;
+import java.util.Map;
 
 /**
  * An ActiveMQServerControl is used to manage ActiveMQ Artemis servers.
@@ -849,6 +850,17 @@ public interface ActiveMQServerControl {
 
    @Operation(desc = "Destroy a bridge", impact = MBeanOperationInfo.ACTION)
    void destroyBridge(@Parameter(name = "name", desc = "Name of the bridge") String name) throws Exception;
+
+   @Operation(desc = "Create a connector service", impact = MBeanOperationInfo.ACTION)
+   void createConnectorService(@Parameter(name = "name", desc = "Name of the connector service") String name,
+                               @Parameter(name = "factoryClass", desc = "Class name of the connector service factory") String factoryClass,
+                               @Parameter(name = "parameters", desc = "Parameter specific to the connector service") Map<String, Object> parameters) throws Exception;
+
+   @Operation(desc = "Destroy a connector service", impact = MBeanOperationInfo.ACTION)
+   void destroyConnectorService(@Parameter(name = "name", desc = "Name of the connector service") String name) throws Exception;
+
+   @Attribute(desc = "names of the connector services on this server")
+   String[] getConnectorServices();
 
    @Operation(desc = "force the server to stop and notify clients to failover", impact = MBeanOperationInfo.UNKNOWN)
    void forceFailover() throws Exception;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -52,6 +52,7 @@ import org.apache.activemq.artemis.api.core.management.DivertControl;
 import org.apache.activemq.artemis.api.core.management.QueueControl;
 import org.apache.activemq.artemis.core.config.BridgeConfiguration;
 import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.config.ConnectorServiceConfiguration;
 import org.apache.activemq.artemis.core.config.DivertConfiguration;
 import org.apache.activemq.artemis.core.messagecounter.MessageCounterManager;
 import org.apache.activemq.artemis.core.messagecounter.impl.MessageCounterManagerImpl;
@@ -68,6 +69,7 @@ import org.apache.activemq.artemis.core.security.Role;
 import org.apache.activemq.artemis.core.server.ActiveMQMessageBundle;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
+import org.apache.activemq.artemis.core.server.ConnectorServiceFactory;
 import org.apache.activemq.artemis.core.server.Consumer;
 import org.apache.activemq.artemis.core.server.JournalType;
 import org.apache.activemq.artemis.core.server.Queue;
@@ -1845,6 +1847,47 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
       clearIO();
       try {
          server.destroyBridge(name);
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public void createConnectorService(final String name, final String factoryClass, final Map<String, Object> parameters) throws Exception {
+      checkStarted();
+
+      clearIO();
+
+      try {
+         final ConnectorServiceConfiguration config = new ConnectorServiceConfiguration().setName(name).setFactoryClassName(factoryClass).setParams(parameters);
+         ConnectorServiceFactory factory = server.getServiceRegistry().getConnectorService(config);
+         server.getConnectorsService().createService(config, factory);
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public void destroyConnectorService(final String name) throws Exception {
+      checkStarted();
+
+      clearIO();
+
+      try {
+         server.getConnectorsService().destroyService(name);
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public String[] getConnectorServices() {
+      checkStarted();
+
+      clearIO();
+
+      try {
+         return server.getConnectorsService().getConnectors().keySet().toArray(new String[0]);
       } finally {
          blockOnIO();
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ServiceRegistry.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ServiceRegistry.java
@@ -54,6 +54,14 @@ public interface ServiceRegistry {
     */
    Collection<Pair<ConnectorServiceFactory, ConnectorServiceConfiguration>> getConnectorServices(List<ConnectorServiceConfiguration> configs);
 
+   /**
+    * Get connector service for a given configuration.
+    *
+    * @param configuration The connector service configuration.
+    * @return an instance of the connector service factory.
+    */
+   ConnectorServiceFactory getConnectorService(ConnectorServiceConfiguration configuration);
+
    void addIncomingInterceptor(BaseInterceptor interceptor);
 
    /**

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServiceRegistryImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServiceRegistryImpl.java
@@ -103,18 +103,18 @@ public class ServiceRegistryImpl implements ServiceRegistry {
       if (configs != null) {
          for (final ConnectorServiceConfiguration config : configs) {
             if (connectorServices.get(config.getConnectorName()) == null) {
-               ConnectorServiceFactory factory = AccessController.doPrivileged(new PrivilegedAction<ConnectorServiceFactory>() {
-                  @Override
-                  public ConnectorServiceFactory run() {
-                     return (ConnectorServiceFactory) ClassloadingUtil.newInstanceFromClassLoader(config.getFactoryClassName());
-                  }
-               });
+               ConnectorServiceFactory factory = loadClass(config.getFactoryClassName());
                addConnectorService(factory, config);
             }
          }
       }
 
       return connectorServices.values();
+   }
+
+   @Override
+   public ConnectorServiceFactory getConnectorService(ConnectorServiceConfiguration configuration) {
+      return loadClass(configuration.getFactoryClassName());
    }
 
    @Override
@@ -184,13 +184,7 @@ public class ServiceRegistryImpl implements ServiceRegistry {
       AcceptorFactory factory = acceptorFactories.get(name);
 
       if (factory == null && className != null) {
-         factory = AccessController.doPrivileged(new PrivilegedAction<AcceptorFactory>() {
-            @Override
-            public AcceptorFactory run() {
-               return (AcceptorFactory) ClassloadingUtil.newInstanceFromClassLoader(className);
-            }
-         });
-
+         factory = loadClass(className);
          addAcceptorFactory(name, factory);
       }
 
@@ -202,17 +196,21 @@ public class ServiceRegistryImpl implements ServiceRegistry {
       acceptorFactories.put(name, acceptorFactory);
    }
 
+   public <T> T loadClass(final String className) {
+      return AccessController.doPrivileged(new PrivilegedAction<T>() {
+         @Override
+         public T run() {
+            return (T) ClassloadingUtil.newInstanceFromClassLoader(className);
+         }
+      });
+   }
+
    private Transformer instantiateTransformer(final String className) {
       Transformer transformer = null;
 
       if (className != null) {
          try {
-            transformer = AccessController.doPrivileged(new PrivilegedAction<Transformer>() {
-               @Override
-               public Transformer run() {
-                  return (Transformer) ClassloadingUtil.newInstanceFromClassLoader(className);
-               }
-            });
+            transformer = loadClass(className);
          } catch (Exception e) {
             throw ActiveMQMessageBundle.BUNDLE.errorCreatingTransformerClass(e, className);
          }
@@ -223,13 +221,7 @@ public class ServiceRegistryImpl implements ServiceRegistry {
    private void instantiateInterceptors(List<String> classNames, List<BaseInterceptor> interceptors) {
       if (classNames != null) {
          for (final String className : classNames) {
-            BaseInterceptor interceptor = AccessController.doPrivileged(new PrivilegedAction<BaseInterceptor>() {
-               @Override
-               public BaseInterceptor run() {
-                  return (BaseInterceptor) ClassloadingUtil.newInstanceFromClassLoader(className);
-               }
-            });
-
+            BaseInterceptor interceptor = loadClass(className);
             interceptors.add(interceptor);
          }
       }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
@@ -58,6 +58,7 @@ import org.apache.activemq.artemis.jlibaio.LibaioContext;
 import org.apache.activemq.artemis.spi.core.security.ActiveMQJAASSecurityManager;
 import org.apache.activemq.artemis.spi.core.security.jaas.InVMLoginModule;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
+import org.apache.activemq.artemis.tests.unit.core.config.impl.fakes.FakeConnectorServiceFactory;
 import org.apache.activemq.artemis.utils.RandomUtil;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
 import org.junit.Assert;
@@ -1325,6 +1326,21 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       Assert.assertEquals("myUser", second.getString("principal"));
       Assert.assertTrue(second.getJsonNumber("creationTime").longValue() > 0);
       Assert.assertEquals(1, second.getJsonNumber("consumerCount").longValue());
+   }
+
+   @Test
+   public void testConnectorServiceManagement() throws Exception {
+      ActiveMQServerControl managementControl = createManagementControl();
+      managementControl.createConnectorService("myconn", FakeConnectorServiceFactory.class.getCanonicalName(), new HashMap<String, Object>());
+
+      Assert.assertEquals(1, server.getConnectorsService().getConnectors().size());
+
+      managementControl.createConnectorService("myconn2", FakeConnectorServiceFactory.class.getCanonicalName(), new HashMap<String, Object>());
+      Assert.assertEquals(2, server.getConnectorsService().getConnectors().size());
+
+      managementControl.destroyConnectorService("myconn");
+      Assert.assertEquals(1, server.getConnectorsService().getConnectors().size());
+      Assert.assertEquals("myconn2", managementControl.getConnectorServices()[0]);
    }
 
    protected void scaleDown(ScaleDownHandler handler) throws Exception {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
@@ -20,6 +20,8 @@ import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl;
 import org.apache.activemq.artemis.api.core.management.Parameter;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
 
+import java.util.Map;
+
 public class ActiveMQServerControlUsingCoreTest extends ActiveMQServerControlTest {
 
    // Constants -----------------------------------------------------
@@ -625,6 +627,21 @@ public class ActiveMQServerControlUsingCoreTest extends ActiveMQServerControlTes
          public void destroyBridge(String name) throws Exception {
             proxy.invokeOperation("destroyBridge", name);
 
+         }
+
+         @Override
+         public void createConnectorService(String name, String factoryClass, Map<String, Object> parameters) throws Exception {
+            proxy.invokeOperation("createConnectorService", name, factoryClass, parameters);
+         }
+
+         @Override
+         public void destroyConnectorService(String name) throws Exception {
+            proxy.invokeOperation("destroyConnectorService", name);
+         }
+
+         @Override
+         public String[] getConnectorServices() {
+            return ActiveMQServerControlUsingCoreTest.toStringArray((Object[]) proxy.retrieveAttributeValue("connectorServices"));
          }
 
          @Override


### PR DESCRIPTION
This adds management operations for creating and destroying connector services at run time. This feature is needed when building a messaging service where the topology changes and the broker must be disconnected from the network.

I made the ConnectorsService class thread safe in case the management operations can be called concurrently. I'd also like to hear your thoughts on the exception handling. I've tried to do the same 'ignore and log' behavior when creating the connector services at startup. For management requests, I think the errors should be propagated to the client.