### PR TITLE
ARTEMIS-332 avoid shutting down the server after interrupted threads on divert (copy and rename)

### DIFF
--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/AbstractSequentialFile.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/AbstractSequentialFile.java
@@ -19,6 +19,7 @@ package org.apache.activemq.artemis.core.io;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
@@ -124,6 +125,9 @@ public abstract class AbstractSequentialFile implements SequentialFile {
          newFileName.close();
          this.close();
       }
+      catch (ClosedChannelException e) {
+         throw e;
+      }
       catch (IOException e) {
          factory.onIOError(new ActiveMQIOErrorException(e.getMessage(), e), e.getMessage(), this);
          throw e;
@@ -147,6 +151,9 @@ public abstract class AbstractSequentialFile implements SequentialFile {
    public final void renameTo(final String newFileName) throws IOException, InterruptedException, ActiveMQException {
       try {
          close();
+      }
+      catch (ClosedChannelException e) {
+         throw e;
       }
       catch (IOException e) {
          factory.onIOError(new ActiveMQIOErrorException(e.getMessage(), e), e.getMessage(), this);


### PR DESCRIPTION
Bug 1168712 – HQ222010: Critical IO Error, shutting down the server  after interrupted threads on divert (copy and rename)