### PR TITLE
ARTEMIS-833 maxHops defaults to 0 when creating artemis cluster confi

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
@@ -136,7 +136,7 @@ public class Create extends InputAbstract {
    boolean clustered = false;
 
    @Option(name = "--max-hops", description = "Number of hops on the cluster configuration")
-   int maxHops = 0;
+   int maxHops = 1;
 
    @Option(name = "--message-load-balancing", description = "Load balancing policy on cluster. [ON_DEMAND (default) | STRICT | OFF]")
    MessageLoadBalancingType messageLoadBalancing = MessageLoadBalancingType.ON_DEMAND;


### PR DESCRIPTION
through cli

https://issues.apache.org/jira/browse/ARTEMIS-833

The generated broker.xml configuration file has the <max-hops/> element
set to 0. This is very confusing since it effectively disables message
load balancing and stop cluster from forwarding messages to other nodes
in hte cluster. This should be set to at least 1.