### PR TITLE
ARTEMIS-866 - quorum fixes

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/qourum/QuorumVoteServerConnect.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/qourum/QuorumVoteServerConnect.java
@@ -111,7 +111,7 @@ public class QuorumVoteServerConnect extends QuorumVote<BooleanVote, Boolean> {
 
    @Override
    public void allVotesCast(Topology voteTopology) {
-
+      latch.countDown();
    }
 
    @Override


### PR DESCRIPTION
remove reconnect attempt as it serves no purposes as replication has stopped anyway.

Ensure if vote fails thatthe latch is counted down to avoid delay.

If we can't detect live has failed signal failure in replicating.

https://issues.apache.org/jira/browse/ARTEMIS-866