### PR TITLE
ARTEMIS-904 - Remove cyclic dependencies from artemis-cli

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/bootstrap/ActiveMQBootstrapBundle.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/bootstrap/ActiveMQBootstrapBundle.java
@@ -14,12 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.factory;
+package org.apache.activemq.artemis.bootstrap;
 
-import org.apache.activemq.artemis.dto.SecurityDTO;
-import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager;
+import org.jboss.logging.Messages;
+import org.jboss.logging.annotations.MessageBundle;
 
-public interface SecurityHandler {
+/**
+ * Logger Code 10
+ *
+ * each message id must be 6 digits long starting with 10, the 3rd digit should be 9
+ *
+ * so 109000 to 109999
+ */
+@MessageBundle(projectCode = "AMQ")
+public interface ActiveMQBootstrapBundle {
 
-   ActiveMQSecurityManager createSecurityManager(SecurityDTO securityDTO) throws Exception;
+   ActiveMQBootstrapBundle BUNDLE = Messages.getBundle(ActiveMQBootstrapBundle.class);
+
 }

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/bootstrap/ActiveMQBootstrapLogger.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/bootstrap/ActiveMQBootstrapLogger.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.integration.bootstrap;
+package org.apache.activemq.artemis.bootstrap;
 
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/Artemis.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/Artemis.java
@@ -119,7 +119,7 @@ public class Artemis {
     * This method is used to validate exception returns.
     * Useful on test cases
     */
-   public static Object internalExecute(File artemisHome, File artemisInstance, String[] args) throws Exception {
+   private static Object internalExecute(File artemisHome, File artemisInstance, String[] args) throws Exception {
       Action action = builder(artemisInstance).build().parse(args);
       action.setHomeValues(artemisHome, artemisInstance);
 
@@ -160,19 +160,4 @@ public class Artemis {
 
       return builder;
    }
-
-   public static void printBanner() throws Exception {
-      copy(Artemis.class.getResourceAsStream("banner.txt"), System.out);
-   }
-
-   private static long copy(InputStream in, OutputStream out) throws Exception {
-      byte[] buffer = new byte[1024];
-      int len = in.read(buffer);
-      while (len != -1) {
-         out.write(buffer, 0, len);
-         len = in.read(buffer);
-      }
-      return len;
-   }
-
 }

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Configurable.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Configurable.java
@@ -29,8 +29,8 @@ import io.airlift.airline.model.GlobalMetadata;
 import org.apache.activemq.artemis.core.config.FileDeploymentManager;
 import org.apache.activemq.artemis.core.config.impl.FileConfiguration;
 import org.apache.activemq.artemis.dto.BrokerDTO;
-import org.apache.activemq.artemis.factory.BrokerFactory;
-import org.apache.activemq.artemis.integration.bootstrap.ActiveMQBootstrapLogger;
+import org.apache.activemq.artemis.cli.factory.broker.BrokerFactory;
+import org.apache.activemq.artemis.bootstrap.ActiveMQBootstrapLogger;
 import org.apache.activemq.artemis.jms.server.config.impl.FileJMSConfiguration;
 
 /**
@@ -59,7 +59,7 @@ public abstract class Configurable extends ActionAbstract {
       helpGroup(group, command);
    }
 
-   protected void helpGroup(String groupName, String commandName) {
+   private void helpGroup(String groupName, String commandName) {
       for (CommandGroupMetadata group : global.getCommandGroups()) {
          if (group.getName().equals(groupName)) {
             for (CommandMetadata command : group.getCommands()) {

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Run.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Run.java
@@ -22,16 +22,16 @@ import java.util.TimerTask;
 
 import io.airlift.airline.Command;
 import io.airlift.airline.Option;
-import org.apache.activemq.artemis.cli.Artemis;
 import org.apache.activemq.artemis.cli.commands.tools.LockAbstract;
+import org.apache.activemq.artemis.cli.commands.tools.PrintData;
 import org.apache.activemq.artemis.components.ExternalComponent;
 import org.apache.activemq.artemis.core.config.impl.FileConfiguration;
 import org.apache.activemq.artemis.dto.BrokerDTO;
 import org.apache.activemq.artemis.dto.ComponentDTO;
-import org.apache.activemq.artemis.factory.BrokerFactory;
-import org.apache.activemq.artemis.factory.SecurityManagerFactory;
-import org.apache.activemq.artemis.integration.Broker;
-import org.apache.activemq.artemis.integration.bootstrap.ActiveMQBootstrapLogger;
+import org.apache.activemq.artemis.cli.factory.broker.BrokerFactory;
+import org.apache.activemq.artemis.cli.factory.security.SecurityManagerFactory;
+import org.apache.activemq.artemis.cli.factory.broker.Broker;
+import org.apache.activemq.artemis.bootstrap.ActiveMQBootstrapLogger;
 import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager;
 import org.apache.activemq.artemis.utils.ReusableLatch;
 
@@ -63,7 +63,7 @@ public class Run extends LockAbstract {
 
       FileConfiguration fileConfiguration = getFileConfiguration();
 
-      Artemis.printBanner();
+      PrintData.printBanner();
 
       createDirectories(getFileConfiguration());
 

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/queue/QueueAbstract.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/queue/QueueAbstract.java
@@ -106,14 +106,14 @@ public class QueueAbstract extends AbstractAction {
       return this;
    }
 
-   public Integer getMaxConsumers(Integer defaultValue) {
+   Integer getMaxConsumers(Integer defaultValue) {
       if (maxConsumers == null) {
          return defaultValue;
       }
       return maxConsumers;
    }
 
-   public boolean isAutoCreateAddress() {
+   boolean isAutoCreateAddress() {
       if (autoCreateAddress == null) {
          autoCreateAddress = inputBoolean("--auto-create-address", "should auto create the address if it doesn't exist", false);
       }
@@ -219,7 +219,7 @@ public class QueueAbstract extends AbstractAction {
       return name;
    }
 
-   public String getRoutingType() {
+   String getRoutingType() {
       if (isAnycast() && isMulticast()) {
          throw new IllegalArgumentException("--multicast and --anycast are exclusive options for a Queue");
       }

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/CompactJournal.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/CompactJournal.java
@@ -44,12 +44,12 @@ public final class CompactJournal extends LockAbstract {
       return null;
    }
 
-   void compactJournal(final File directory,
-                       final String journalPrefix,
-                       final String journalSuffix,
-                       final int minFiles,
-                       final int fileSize,
-                       final IOCriticalErrorListener listener) throws Exception {
+   private void compactJournal(final File directory,
+                               final String journalPrefix,
+                               final String journalSuffix,
+                               final int minFiles,
+                               final int fileSize,
+                               final IOCriticalErrorListener listener) throws Exception {
       NIOSequentialFileFactory nio = new NIOSequentialFileFactory(directory, listener, 1);
 
       JournalImpl journal = new JournalImpl(fileSize, minFiles, minFiles, 0, 0, nio, journalPrefix, journalSuffix, 1);

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/DataAbstract.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/DataAbstract.java
@@ -39,7 +39,7 @@ public abstract class DataAbstract extends Configurable {
    @Option(name = "--large-messages", description = "The folder used for large-messages (default from broker.xml)")
    public String largeMessges;
 
-   public String getLargeMessages() throws Exception {
+   String getLargeMessages() throws Exception {
       if (largeMessges == null) {
          largeMessges = getFileConfiguration().getLargeMessagesLocation().getAbsolutePath();
       }

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/DecodeJournal.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/DecodeJournal.java
@@ -79,12 +79,12 @@ public class DecodeJournal extends LockAbstract {
 
    }
 
-   public static void importJournal(final String directory,
-                                    final String journalPrefix,
-                                    final String journalSuffix,
-                                    final int minFiles,
-                                    final int fileSize,
-                                    final InputStream stream) throws Exception {
+   private static void importJournal(final String directory,
+                                     final String journalPrefix,
+                                     final String journalSuffix,
+                                     final int minFiles,
+                                     final int fileSize,
+                                     final InputStream stream) throws Exception {
       Reader reader = new InputStreamReader(stream);
       importJournal(directory, journalPrefix, journalSuffix, minFiles, fileSize, reader);
    }
@@ -216,7 +216,7 @@ public class DecodeJournal extends LockAbstract {
       journal.stop();
    }
 
-   protected static AtomicInteger getCounter(final Long txID, final Map<Long, AtomicInteger> txCounters) {
+   private static AtomicInteger getCounter(final Long txID, final Map<Long, AtomicInteger> txCounters) {
 
       AtomicInteger counter = txCounters.get(txID);
       if (counter == null) {
@@ -227,7 +227,7 @@ public class DecodeJournal extends LockAbstract {
       return counter;
    }
 
-   protected static RecordInfo parseRecord(final Properties properties) throws Exception {
+   private static RecordInfo parseRecord(final Properties properties) throws Exception {
       long id = parseLong("id", properties);
       byte userRecordType = parseByte("userRecordType", properties);
       boolean isUpdate = parseBoolean("isUpdate", properties);
@@ -284,7 +284,7 @@ public class DecodeJournal extends LockAbstract {
       return value;
    }
 
-   protected static Properties parseLine(final String[] splitLine) {
+   private static Properties parseLine(final String[] splitLine) {
       Properties properties = new Properties();
 
       for (String el : splitLine) {

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/EncodeJournal.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/EncodeJournal.java
@@ -64,11 +64,11 @@ public class EncodeJournal extends LockAbstract {
       return null;
    }
 
-   public static void exportJournal(final String directory,
-                                    final String journalPrefix,
-                                    final String journalSuffix,
-                                    final int minFiles,
-                                    final int fileSize) throws Exception {
+   private static void exportJournal(final String directory,
+                                     final String journalPrefix,
+                                     final String journalSuffix,
+                                     final int minFiles,
+                                     final int fileSize) throws Exception {
 
       exportJournal(directory, journalPrefix, journalSuffix, minFiles, fileSize, System.out);
    }
@@ -111,9 +111,9 @@ public class EncodeJournal extends LockAbstract {
     * @param file
     * @throws Exception
     */
-   public static void exportJournalFile(final PrintStream out,
-                                        final SequentialFileFactory fileFactory,
-                                        final JournalFile file) throws Exception {
+   private static void exportJournalFile(final PrintStream out,
+                                         final SequentialFileFactory fileFactory,
+                                         final JournalFile file) throws Exception {
       JournalImpl.readJournalFile(fileFactory, file, new JournalReaderCallback() {
 
          @Override

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/LockAbstract.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/LockAbstract.java
@@ -33,7 +33,7 @@ public abstract class LockAbstract extends DataAbstract implements Action {
    private static RandomAccessFile serverLockFile = null;
    private static FileLock serverLockLock = null;
 
-   protected File getLockPlace() throws Exception {
+   private File getLockPlace() throws Exception {
       String brokerInstance = getBrokerInstance();
       if (brokerInstance != null) {
          return new File(new File(brokerInstance), "lock");

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/PrintData.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/PrintData.java
@@ -17,6 +17,8 @@
 package org.apache.activemq.artemis.cli.commands.tools;
 
 import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -74,7 +76,7 @@ public class PrintData extends OptionalLocking {
    public static void printData(File bindingsDirectory, File messagesDirectory, File pagingDirectory) throws Exception {
       // Having the version on the data report is an information very useful to understand what happened
       // When debugging stuff
-      Artemis.printBanner();
+      printBanner();
 
       File serverLockFile = new File(messagesDirectory, "server.lock");
 
@@ -221,7 +223,7 @@ public class PrintData extends OptionalLocking {
    /**
     * Calculate the acks on the page system
     */
-   protected static PageCursorsInfo calculateCursorsInfo(List<RecordInfo> records) throws Exception {
+   private static PageCursorsInfo calculateCursorsInfo(List<RecordInfo> records) throws Exception {
 
       PageCursorsInfo cursorInfo = new PageCursorsInfo();
 
@@ -272,6 +274,20 @@ public class PrintData extends OptionalLocking {
       return cursorInfo;
    }
 
+   public static void printBanner() throws Exception {
+      copy(PrintData.class.getResourceAsStream("banner.txt"), System.out);
+   }
+
+   private static long copy(InputStream in, OutputStream out) throws Exception {
+      byte[] buffer = new byte[1024];
+      int len = in.read(buffer);
+      while (len != -1) {
+         out.write(buffer, 0, len);
+         len = in.read(buffer);
+      }
+      return len;
+   }
+
    private static class PageCursorsInfo {
 
       private final Map<Long, Set<PagePosition>> cursorRecords = new HashMap<>();
@@ -286,14 +302,14 @@ public class PrintData extends OptionalLocking {
       /**
        * @return the pgTXs
        */
-      public Set<Long> getPgTXs() {
+      Set<Long> getPgTXs() {
          return pgTXs;
       }
 
       /**
        * @return the cursorRecords
        */
-      public Map<Long, Set<PagePosition>> getCursorRecords() {
+      Map<Long, Set<PagePosition>> getCursorRecords() {
          return cursorRecords;
       }
 
@@ -304,7 +320,7 @@ public class PrintData extends OptionalLocking {
          return completePages;
       }
 
-      public Set<Long> getCompletePages(Long queueID) {
+      Set<Long> getCompletePages(Long queueID) {
          Set<Long> completePagesSet = completePages.get(queueID);
 
          if (completePagesSet == null) {

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/user/AddUser.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/user/AddUser.java
@@ -20,7 +20,6 @@ import io.airlift.airline.Command;
 import io.airlift.airline.Option;
 import org.apache.activemq.artemis.cli.commands.ActionContext;
 import org.apache.activemq.artemis.cli.commands.util.HashUtil;
-import org.apache.activemq.artemis.util.FileBasedSecStoreConfig;
 import org.apache.commons.lang3.StringUtils;
 
 /**

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/user/FileBasedSecStoreConfig.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/user/FileBasedSecStoreConfig.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.util;
+package org.apache.activemq.artemis.cli.commands.user;
 
 import org.apache.activemq.artemis.api.core.Pair;
 import org.apache.activemq.artemis.utils.StringUtil;
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-public class FileBasedSecStoreConfig {
+class FileBasedSecStoreConfig {
 
    private static final String LICENSE_HEADER =
            "## ---------------------------------------------------------------------------\n" +
@@ -51,7 +51,7 @@ public class FileBasedSecStoreConfig {
    private PropertiesConfiguration userConfig;
    private PropertiesConfiguration roleConfig;
 
-   public FileBasedSecStoreConfig(File userFile, File roleFile) throws Exception {
+   FileBasedSecStoreConfig(File userFile, File roleFile) throws Exception {
       Configurations configs = new Configurations();
       userBuilder = configs.propertiesBuilder(userFile);
       roleBuilder = configs.propertiesBuilder(roleFile);
@@ -78,7 +78,7 @@ public class FileBasedSecStoreConfig {
       }
    }
 
-   public void addNewUser(String username, String hash, String... roles) throws Exception {
+   void addNewUser(String username, String hash, String... roles) throws Exception {
       if (userConfig.getString(username) != null) {
          throw new IllegalArgumentException("User already exist: " + username);
       }
@@ -86,12 +86,12 @@ public class FileBasedSecStoreConfig {
       addRoles(username, roles);
    }
 
-   public void save() throws Exception {
+   void save() throws Exception {
       userBuilder.save();
       roleBuilder.save();
    }
 
-   public void removeUser(String username) throws Exception {
+   void removeUser(String username) throws Exception {
       if (userConfig.getProperty(username) == null) {
          throw new IllegalArgumentException("user " + username + " doesn't exist.");
       }
@@ -99,7 +99,7 @@ public class FileBasedSecStoreConfig {
       removeRoles(username);
    }
 
-   public List<String> listUser(String username) {
+   List<String> listUser(String username) {
       List<String> result = new ArrayList<>();
       result.add("--- \"user\"(roles) ---\n");
 
@@ -146,7 +146,7 @@ public class FileBasedSecStoreConfig {
       return builder.toString();
    }
 
-   public void updateUser(String username, String password, String[] roles) {
+   void updateUser(String username, String password, String[] roles) {
       String oldPassword = (String) userConfig.getProperty(username);
       if (oldPassword == null) {
          throw new IllegalArgumentException("user " + username + " doesn't exist.");

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/user/ListUser.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/user/ListUser.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import io.airlift.airline.Command;
 import org.apache.activemq.artemis.cli.commands.ActionContext;
-import org.apache.activemq.artemis.util.FileBasedSecStoreConfig;
 
 /**
  * list existing users, example:

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/user/PasswordAction.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/user/PasswordAction.java
@@ -24,7 +24,7 @@ public class PasswordAction extends UserAction {
    @Option(name = "--password", description = "the password (Default: input)")
    String password;
 
-   protected void checkInputPassword() {
+   void checkInputPassword() {
       if (password == null) {
          password = inputPassword("--password", "Please provide the password:", null);
       }

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/user/RemoveUser.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/user/RemoveUser.java
@@ -18,7 +18,6 @@ package org.apache.activemq.artemis.cli.commands.user;
 
 import io.airlift.airline.Command;
 import org.apache.activemq.artemis.cli.commands.ActionContext;
-import org.apache.activemq.artemis.util.FileBasedSecStoreConfig;
 
 /**
  * Remove a user, example:

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/user/ResetUser.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/user/ResetUser.java
@@ -20,7 +20,6 @@ import io.airlift.airline.Command;
 import io.airlift.airline.Option;
 import org.apache.activemq.artemis.cli.commands.ActionContext;
 import org.apache.activemq.artemis.cli.commands.util.HashUtil;
-import org.apache.activemq.artemis.util.FileBasedSecStoreConfig;
 import org.apache.commons.lang3.StringUtils;
 
 /**

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/user/UserAction.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/user/UserAction.java
@@ -19,7 +19,6 @@ package org.apache.activemq.artemis.cli.commands.user;
 import io.airlift.airline.Option;
 import org.apache.activemq.artemis.cli.commands.InputAbstract;
 import org.apache.activemq.artemis.spi.core.security.jaas.PropertiesLoginModule;
-import org.apache.activemq.artemis.util.FileBasedSecStoreConfig;
 
 import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.Configuration;
@@ -39,7 +38,7 @@ public abstract class UserAction extends InputAbstract {
    @Option(name = "--entry", description = "The appConfigurationEntry (default: activemq)")
    String entry = "activemq";
 
-   protected void checkInputUser() {
+   void checkInputUser() {
       if (username == null) {
          username = input("--user", "Please provider the userName:", null);
       }
@@ -49,7 +48,7 @@ public abstract class UserAction extends InputAbstract {
       this.role = role;
    }
 
-   public void checkInputRole() {
+   void checkInputRole() {
       if (role == null) {
          role = input("--role", "type a comma separated list of roles", null);
       }

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/factory/broker/Broker.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/factory/broker/Broker.java
@@ -14,21 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.integration.bootstrap;
+package org.apache.activemq.artemis.cli.factory.broker;
 
-import org.jboss.logging.Messages;
-import org.jboss.logging.annotations.MessageBundle;
+import org.apache.activemq.artemis.core.server.ActiveMQComponent;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
 
 /**
- * Logger Code 10
- *
- * each message id must be 6 digits long starting with 10, the 3rd digit should be 9
- *
- * so 109000 to 109999
+ * A Broker os a set of ActiveMQComponents that create a Server, for instance core and jms.
  */
-@MessageBundle(projectCode = "AMQ")
-public interface ActiveMQBootstrapBundle {
+public interface Broker extends ActiveMQComponent {
 
-   ActiveMQBootstrapBundle BUNDLE = Messages.getBundle(ActiveMQBootstrapBundle.class);
-
+   ActiveMQServer getServer();
 }

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/factory/broker/BrokerFactory.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/factory/broker/BrokerFactory.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.factory;
+package org.apache.activemq.artemis.cli.factory.broker;
 
 import java.io.IOException;
 import java.net.URI;
@@ -22,7 +22,6 @@ import java.net.URI;
 import org.apache.activemq.artemis.cli.ConfigurationException;
 import org.apache.activemq.artemis.dto.BrokerDTO;
 import org.apache.activemq.artemis.dto.ServerDTO;
-import org.apache.activemq.artemis.integration.Broker;
 import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager;
 import org.apache.activemq.artemis.utils.FactoryFinder;
 
@@ -30,25 +29,6 @@ public class BrokerFactory {
 
    public static BrokerDTO createBrokerConfiguration(URI configURI) throws Exception {
       return createBrokerConfiguration(configURI, null, null, null);
-   }
-
-   public static BrokerDTO createBrokerConfiguration(URI configURI,
-                                                     String artemisHome,
-                                                     String artemisInstance,
-                                                     URI artemisURIInstance) throws Exception {
-      if (configURI.getScheme() == null) {
-         throw new ConfigurationException("Invalid configuration URI, no scheme specified: " + configURI);
-      }
-
-      BrokerFactoryHandler factory = null;
-      try {
-         FactoryFinder finder = new FactoryFinder("META-INF/services/org/apache/activemq/artemis/broker/");
-         factory = (BrokerFactoryHandler) finder.newInstance(configURI.getScheme());
-      } catch (IOException ioe) {
-         throw new ConfigurationException("Invalid configuration URI, can't find configuration scheme: " + configURI.getScheme());
-      }
-
-      return factory.createBroker(configURI, artemisHome, artemisInstance, artemisURIInstance);
    }
 
    public static BrokerDTO createBrokerConfiguration(String configuration) throws Exception {
@@ -70,7 +50,8 @@ public class BrokerFactory {
          try {
             FactoryFinder finder = new FactoryFinder("META-INF/services/org/apache/activemq/artemis/broker/server/");
             handler = (BrokerHandler) finder.newInstance(configURI.getScheme());
-         } catch (IOException ioe) {
+         }
+         catch (IOException ioe) {
             throw new ConfigurationException("Invalid configuration URI, can't find configuration scheme: " + configURI.getScheme());
          }
 
@@ -79,4 +60,23 @@ public class BrokerFactory {
       return null;
    }
 
+   private static BrokerDTO createBrokerConfiguration(URI configURI,
+                                                      String artemisHome,
+                                                      String artemisInstance,
+                                                      URI artemisURIInstance) throws Exception {
+      if (configURI.getScheme() == null) {
+         throw new ConfigurationException("Invalid configuration URI, no scheme specified: " + configURI);
+      }
+
+      BrokerFactoryHandler factory = null;
+      try {
+         FactoryFinder finder = new FactoryFinder("META-INF/services/org/apache/activemq/artemis/broker/");
+         factory = (BrokerFactoryHandler) finder.newInstance(configURI.getScheme());
+      }
+      catch (IOException ioe) {
+         throw new ConfigurationException("Invalid configuration URI, can't find configuration scheme: " + configURI.getScheme());
+      }
+
+      return factory.createBroker(configURI, artemisHome, artemisInstance, artemisURIInstance);
+   }
 }

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/factory/broker/BrokerFactoryHandler.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/factory/broker/BrokerFactoryHandler.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.factory;
+package org.apache.activemq.artemis.cli.factory.broker;
 
 import java.net.URI;
 

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/factory/broker/BrokerHandler.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/factory/broker/BrokerHandler.java
@@ -14,10 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.factory;
+package org.apache.activemq.artemis.cli.factory.broker;
 
 import org.apache.activemq.artemis.dto.ServerDTO;
-import org.apache.activemq.artemis.integration.Broker;
 import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager;
 
 public interface BrokerHandler {

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/factory/broker/file/FileBroker.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/factory/broker/file/FileBroker.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.integration;
+package org.apache.activemq.artemis.cli.factory.broker.file;
 
 import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
@@ -29,7 +29,8 @@ import org.apache.activemq.artemis.core.server.ActiveMQComponent;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.RoutingType;
 import org.apache.activemq.artemis.dto.ServerDTO;
-import org.apache.activemq.artemis.integration.bootstrap.ActiveMQBootstrapLogger;
+import org.apache.activemq.artemis.cli.factory.broker.Broker;
+import org.apache.activemq.artemis.bootstrap.ActiveMQBootstrapLogger;
 import org.apache.activemq.artemis.jms.server.config.JMSQueueConfiguration;
 import org.apache.activemq.artemis.jms.server.config.TopicConfiguration;
 import org.apache.activemq.artemis.jms.server.config.impl.FileJMSConfiguration;
@@ -137,7 +138,7 @@ public class FileBroker implements Broker {
    * this makes sure the components are started in the correct order. Its simple at the mo as e only have core and jms but
    * will need impproving if we get more.
    * */
-   public ArrayList<ActiveMQComponent> getComponentsByStartOrder(Map<String, ActiveMQComponent> components) {
+   private ArrayList<ActiveMQComponent> getComponentsByStartOrder(Map<String, ActiveMQComponent> components) {
       ArrayList<ActiveMQComponent> activeMQComponents = new ArrayList<>();
       ActiveMQComponent jmsComponent = components.get("jms");
       if (jmsComponent != null) {

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/factory/broker/file/FileBrokerHandler.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/factory/broker/file/FileBrokerHandler.java
@@ -14,15 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.integration;
+package org.apache.activemq.artemis.cli.factory.broker.file;
 
-import org.apache.activemq.artemis.core.server.ActiveMQComponent;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.dto.ServerDTO;
+import org.apache.activemq.artemis.cli.factory.broker.BrokerHandler;
+import org.apache.activemq.artemis.cli.factory.broker.Broker;
+import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager;
 
-/**
- * A Broker os a set of ActiveMQComponents that create a Server, for instance core and jms.
- */
-public interface Broker extends ActiveMQComponent {
+public class FileBrokerHandler implements BrokerHandler {
 
-   ActiveMQServer getServer();
+   @Override
+   public Broker createServer(ServerDTO brokerDTO, ActiveMQSecurityManager security) {
+      return new FileBroker(brokerDTO, security);
+   }
 }

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/factory/broker/xml/XmlBrokerFactoryHandler.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/factory/broker/xml/XmlBrokerFactoryHandler.java
@@ -14,12 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.factory;
+package org.apache.activemq.artemis.cli.factory.broker.xml;
 
 import java.io.File;
 import java.net.URI;
 
 import org.apache.activemq.artemis.cli.ConfigurationException;
+import org.apache.activemq.artemis.cli.factory.broker.BrokerFactoryHandler;
 import org.apache.activemq.artemis.dto.BrokerDTO;
 import org.apache.activemq.artemis.dto.XmlUtil;
 

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/factory/security/JaasSecurityHandler.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/factory/security/JaasSecurityHandler.java
@@ -14,17 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.factory;
+package org.apache.activemq.artemis.cli.factory.security;
 
-import org.apache.activemq.artemis.dto.ServerDTO;
-import org.apache.activemq.artemis.integration.Broker;
-import org.apache.activemq.artemis.integration.FileBroker;
+import org.apache.activemq.artemis.dto.JaasSecurityDTO;
+import org.apache.activemq.artemis.dto.SecurityDTO;
+import org.apache.activemq.artemis.spi.core.security.ActiveMQJAASSecurityManager;
 import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager;
 
-public class FileBrokerHandler implements BrokerHandler {
+public class JaasSecurityHandler implements SecurityHandler {
 
    @Override
-   public Broker createServer(ServerDTO brokerDTO, ActiveMQSecurityManager security) {
-      return new FileBroker(brokerDTO, security);
+   public ActiveMQSecurityManager createSecurityManager(SecurityDTO security) throws Exception {
+      JaasSecurityDTO jaasSecurity = (JaasSecurityDTO) security;
+      ActiveMQJAASSecurityManager securityManager = new ActiveMQJAASSecurityManager(jaasSecurity.domain, jaasSecurity.certificateDomain);
+      return securityManager;
    }
 }

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/factory/security/SecurityHandler.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/factory/security/SecurityHandler.java
@@ -14,19 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.factory;
+package org.apache.activemq.artemis.cli.factory.security;
 
-import org.apache.activemq.artemis.dto.JaasSecurityDTO;
 import org.apache.activemq.artemis.dto.SecurityDTO;
-import org.apache.activemq.artemis.spi.core.security.ActiveMQJAASSecurityManager;
 import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager;
 
-public class JaasSecurityHandler implements SecurityHandler {
+public interface SecurityHandler {
 
-   @Override
-   public ActiveMQSecurityManager createSecurityManager(SecurityDTO security) throws Exception {
-      JaasSecurityDTO jaasSecurity = (JaasSecurityDTO) security;
-      ActiveMQJAASSecurityManager securityManager = new ActiveMQJAASSecurityManager(jaasSecurity.domain, jaasSecurity.certificateDomain);
-      return securityManager;
-   }
+   ActiveMQSecurityManager createSecurityManager(SecurityDTO securityDTO) throws Exception;
 }

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/factory/security/SecurityManagerFactory.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/factory/security/SecurityManagerFactory.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.factory;
+package org.apache.activemq.artemis.cli.factory.security;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -25,13 +25,12 @@ import org.apache.activemq.artemis.utils.FactoryFinder;
 public class SecurityManagerFactory {
 
    public static ActiveMQSecurityManager create(SecurityDTO config) throws Exception {
-      if (config != null) {
-         FactoryFinder finder = new FactoryFinder("META-INF/services/org/apache/activemq/artemis/broker/security/");
-         SecurityHandler securityHandler = (SecurityHandler) finder.newInstance(config.getClass().getAnnotation(XmlRootElement.class).name());
-         return securityHandler.createSecurityManager(config);
-      } else {
+      if (config == null) {
          throw new Exception("No security manager configured!");
       }
+      FactoryFinder finder = new FactoryFinder("META-INF/services/org/apache/activemq/artemis/broker/security/");
+      SecurityHandler securityHandler = (SecurityHandler) finder.newInstance(config.getClass().getAnnotation(XmlRootElement.class).name());
+      return securityHandler.createSecurityManager(config);
    }
 
 }

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/process/ProcessBuilder.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/process/ProcessBuilder.java
@@ -94,7 +94,7 @@ public class ProcessBuilder {
       return process;
    }
 
-   public static String[] rebuildArgs(String[] args, String... prefixArgs) {
+   private static String[] rebuildArgs(String[] args, String... prefixArgs) {
       String[] resultArgs = new String[args.length + prefixArgs.length];
 
       int i = 0;

--- a/artemis-cli/src/main/resources/META-INF/services/org/apache/activemq/artemis/broker/security/jaas-security
+++ b/artemis-cli/src/main/resources/META-INF/services/org/apache/activemq/artemis/broker/security/jaas-security
@@ -14,4 +14,4 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
-class=org.apache.activemq.artemis.factory.JaasSecurityHandler
+class=org.apache.activemq.artemis.cli.factory.security.JaasSecurityHandler

--- a/artemis-cli/src/main/resources/META-INF/services/org/apache/activemq/artemis/broker/server/file
+++ b/artemis-cli/src/main/resources/META-INF/services/org/apache/activemq/artemis/broker/server/file
@@ -14,4 +14,4 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
-class=org.apache.activemq.artemis.factory.FileBrokerHandler
+class=org.apache.activemq.artemis.cli.factory.broker.file.FileBrokerHandler

--- a/artemis-cli/src/main/resources/META-INF/services/org/apache/activemq/artemis/broker/xml
+++ b/artemis-cli/src/main/resources/META-INF/services/org/apache/activemq/artemis/broker/xml
@@ -14,4 +14,4 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
-class=org.apache.activemq.artemis.factory.XmlBrokerFactoryHandler
+class=org.apache.activemq.artemis.cli.factory.broker.xml.XmlBrokerFactoryHandler

--- a/artemis-cli/src/test/java/org/apache/activemq/cli/ArtemisTest.java
+++ b/artemis-cli/src/test/java/org/apache/activemq/cli/ArtemisTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.cli.test;
+package org.apache.activemq.cli;
 
 import javax.jms.Connection;
 import javax.jms.MessageProducer;

--- a/artemis-cli/src/test/java/org/apache/activemq/cli/TestActionContext.java
+++ b/artemis-cli/src/test/java/org/apache/activemq/cli/TestActionContext.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.cli.test;
+package org.apache.activemq.cli;
 
 import org.apache.activemq.artemis.cli.commands.ActionContext;
 
@@ -23,11 +23,11 @@ import java.io.PrintStream;
 
 public class TestActionContext extends ActionContext {
 
-   public ByteArrayOutputStream stdout;
-   public ByteArrayOutputStream stderr;
+   private ByteArrayOutputStream stdout;
+   private ByteArrayOutputStream stderr;
    private int bufferSize;
 
-   public TestActionContext(int bufferSize) {
+   private TestActionContext(int bufferSize) {
       this.bufferSize = bufferSize;
       this.stdout = new ByteArrayOutputStream(bufferSize);
       this.stderr = new ByteArrayOutputStream(bufferSize);
@@ -36,11 +36,11 @@ public class TestActionContext extends ActionContext {
       this.err = new PrintStream(stderr);
    }
 
-   public TestActionContext() {
+   TestActionContext() {
       this(4096);
    }
 
-   public String getStdout() {
+   String getStdout() {
       return stdout.toString();
    }
 

--- a/artemis-cli/src/test/java/org/apache/activemq/cli/commands/StreamClassPathTest.java
+++ b/artemis-cli/src/test/java/org/apache/activemq/cli/commands/StreamClassPathTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.activemq.cli.test;
+package org.apache.activemq.cli.commands;
 
 import java.io.InputStream;
 

--- a/artemis-cli/src/test/java/org/apache/activemq/cli/factory/broker/file/FileBrokerTest.java
+++ b/artemis-cli/src/test/java/org/apache/activemq/cli/factory/broker/file/FileBrokerTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.cli.test;
+package org.apache.activemq.cli.factory.broker.file;
 
 import java.io.File;
 import java.io.IOException;
@@ -33,7 +33,7 @@ import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.config.impl.SecurityConfiguration;
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl;
 import org.apache.activemq.artemis.dto.ServerDTO;
-import org.apache.activemq.artemis.integration.FileBroker;
+import org.apache.activemq.artemis.cli.factory.broker.file.FileBroker;
 import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
 import org.apache.activemq.artemis.spi.core.security.ActiveMQJAASSecurityManager;
 import org.apache.activemq.artemis.spi.core.security.jaas.InVMLoginModule;

--- a/docs/user-manual/en/SUMMARY.md
+++ b/docs/user-manual/en/SUMMARY.md
@@ -61,4 +61,4 @@
 * [Unit Testing](unit-testing.md)
 * [Troubleshooting and Performance Tuning](perf-tuning.md)
 * [Configuration Reference](configuration-index.md)
-
+* [Updating Artemis](updating-artemis.md)

--- a/docs/user-manual/en/updating-artemis.md
+++ b/docs/user-manual/en/updating-artemis.md
@@ -1,0 +1,25 @@
+# Updating Artemis
+
+The standard Apache ActiveMQ is runnable out of the box. Just download it, 
+go into the unzipped ActiveMQ folder and run this command: ./bin/activemq run. 
+The ActiveMQ Artemis sub project needs an additional step to run the Message Queue.
+Before running activemq run you have to create a new message broker instance. 
+It looks like an overhead at first glance, but becomes very practically 
+when updating to a new Artemis version for example. 
+To create a artemis broker cd into the artemis folder and run: `./bin/artemis create $HOME/mybroker` on the command line.
+
+> **Note**
+>
+> We recommend choosing a folder different than the downloaded apache-artemis one to separate both from each other.
+> This separation allowes you run multiple brokers with the same artemis runtime for example. 
+> It also simplifies updating to newer versions of Artemis.
+
+Because of this separation it's very easy to update Artemis. 
+You just need to cd into the `etc` folder of your created message broker and open the `artemis.profile` file.
+It contains a property which is relevant for the update procedure:
+ 
+    ARTEMIS_HOME='/Users/.../apache-artemis-X.X.X'
+    
+The `ARTEMIS_HOME` property is used to link the broker together with the Artemis runtime. 
+In case you want to update your broker you can simply download the new version of ActiveMQ Artemis and change the `ARTEMIS_HOME` to the formerly downloaded, newer version.
+That's all. There's no need to touch your broker, copy configuration files or stuff like that.


### PR DESCRIPTION
To ensure a maintainability in future I refactored the cli project and removed all cyclic dependencies between classes and packages by moving classes and packages near to their real responsibility and reduced access modifiers after it. (I can show you a "before and after" picture of the projects architecture from a package point of view if you want.)
I tried to move classes and methods only and reduced visibility of methods. Didn't change other stuff like unused methods and so on.