### PR TITLE
ARTEMIS-905 JCtools ConcurrentMap replacement

### DIFF
--- a/artemis-cli/pom.xml
+++ b/artemis-cli/pom.xml
@@ -83,6 +83,10 @@
          <version>${commons.lang.version}</version>
       </dependency>
       <dependency>
+         <groupId>org.jctools</groupId>
+         <artifactId>jctools-core</artifactId>
+      </dependency>
+      <dependency>
         <groupId>com.sun.winsw</groupId>
         <artifactId>winsw</artifactId>
         <version>${winsw.version}</version>

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/XmlDataExporter.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/XmlDataExporter.java
@@ -31,7 +31,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -91,6 +90,7 @@ import org.apache.activemq.artemis.utils.ActiveMQThreadFactory;
 import org.apache.activemq.artemis.utils.Base64;
 import org.apache.activemq.artemis.utils.ExecutorFactory;
 import org.apache.activemq.artemis.utils.OrderedExecutorFactory;
+import org.jctools.maps.NonBlockingHashMap;
 
 @Command(name = "exp", description = "Export all message-data using an XML that could be interpreted by any system.")
 public final class XmlDataExporter extends OptionalLocking {
@@ -115,11 +115,11 @@ public final class XmlDataExporter extends OptionalLocking {
 
    private final HashMap<Long, PersistentQueueBindingEncoding> queueBindings = new HashMap<>();
 
-   private final Map<String, PersistedConnectionFactory> jmsConnectionFactories = new ConcurrentHashMap<>();
+   private final Map<String, PersistedConnectionFactory> jmsConnectionFactories = new NonBlockingHashMap<>();
 
-   private final Map<Pair<PersistedType, String>, PersistedDestination> jmsDestinations = new ConcurrentHashMap<>();
+   private final Map<Pair<PersistedType, String>, PersistedDestination> jmsDestinations = new NonBlockingHashMap<>();
 
-   private final Map<Pair<PersistedType, String>, PersistedBindings> jmsJNDI = new ConcurrentHashMap<>();
+   private final Map<Pair<PersistedType, String>, PersistedBindings> jmsJNDI = new NonBlockingHashMap<>();
 
    long messagesPrinted = 0L;
 

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/process/ProcessBuilder.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/process/ProcessBuilder.java
@@ -21,12 +21,13 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.Set;
 
-import org.apache.activemq.artemis.utils.ConcurrentHashSet;
+import org.jctools.maps.NonBlockingHashSet;
 
 public class ProcessBuilder {
 
-   static ConcurrentHashSet<Process> processes = new ConcurrentHashSet<>();
+   static Set<Process> processes = new NonBlockingHashSet<>();
 
    static {
       Runtime.getRuntime().addShutdownHook(new Thread() {

--- a/artemis-commons/pom.xml
+++ b/artemis-commons/pom.xml
@@ -61,6 +61,10 @@
          <artifactId>guava</artifactId>
       </dependency>
       <dependency>
+         <groupId>org.jctools</groupId>
+         <artifactId>jctools-core</artifactId>
+      </dependency>
+      <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
          <scope>test</scope>

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/core/server/NetworkHealthCheck.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/core/server/NetworkHealthCheck.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.activemq.artemis.logs.ActiveMQUtilLogger;
 import org.apache.activemq.artemis.utils.ActiveMQThreadFactory;
-import org.apache.activemq.artemis.utils.ConcurrentHashSet;
+import org.jctools.maps.NonBlockingHashSet;
 import org.jboss.logging.Logger;
 
 /**
@@ -44,9 +44,9 @@ public class NetworkHealthCheck extends ActiveMQScheduledComponent {
 
    private static final Logger logger = Logger.getLogger(NetworkHealthCheck.class);
 
-   private final Set<ActiveMQComponent> componentList = new ConcurrentHashSet<>();
-   private final Set<InetAddress> addresses = new ConcurrentHashSet<>();
-   private final Set<URL> urls = new ConcurrentHashSet<>();
+   private final Set<ActiveMQComponent> componentList = new NonBlockingHashSet<>();
+   private final Set<InetAddress> addresses = new NonBlockingHashSet<>();
+   private final Set<URL> urls = new NonBlockingHashSet<>();
    private NetworkInterface networkInterface;
 
    public static final String IPV6_DEFAULT_COMMAND = "ping6 -c 1 %2$s";

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/logs/AssertionLoggerHandler.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/logs/AssertionLoggerHandler.java
@@ -17,11 +17,11 @@
 package org.apache.activemq.artemis.logs;
 
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 
 import org.jboss.logmanager.ExtHandler;
 import org.jboss.logmanager.ExtLogRecord;
+import org.jctools.maps.NonBlockingHashMap;
 
 /**
  * This class contains a tool where programs could intercept for LogMessage given an interval of time between {@link #startCapture()}
@@ -31,7 +31,7 @@ import org.jboss.logmanager.ExtLogRecord;
  */
 public class AssertionLoggerHandler extends ExtHandler {
 
-   private static final Map<String, ExtLogRecord> messages = new ConcurrentHashMap<>();
+   private static final Map<String, ExtLogRecord> messages = new NonBlockingHashMap<>();
    private static boolean capture = false;
 
    /**

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/FactoryFinder.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/FactoryFinder.java
@@ -20,7 +20,7 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 public class FactoryFinder {
@@ -52,7 +52,7 @@ public class FactoryFinder {
     */
    protected static class StandaloneObjectFactory implements ObjectFactory {
 
-      final ConcurrentMap<String, Class> classMap = new ConcurrentHashMap<>();
+      final ConcurrentMap<String, Class> classMap = new NonBlockingHashMap<>();
 
       @Override
       public Object create(final String path) throws InstantiationException, IllegalAccessException, ClassNotFoundException, IOException {

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/uri/FluentPropertyBeanIntrospectorWithIgnores.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/uri/FluentPropertyBeanIntrospectorWithIgnores.java
@@ -21,18 +21,19 @@ import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Method;
 import java.util.Locale;
+import java.util.Set;
 
 import org.apache.activemq.artemis.api.core.Pair;
-import org.apache.activemq.artemis.utils.ConcurrentHashSet;
 import org.apache.commons.beanutils.FluentPropertyBeanIntrospector;
 import org.apache.commons.beanutils.IntrospectionContext;
 import org.jboss.logging.Logger;
+import org.jctools.maps.NonBlockingHashSet;
 
 public class FluentPropertyBeanIntrospectorWithIgnores extends FluentPropertyBeanIntrospector {
 
    static Logger logger = Logger.getLogger(FluentPropertyBeanIntrospectorWithIgnores.class);
 
-   private static ConcurrentHashSet<Pair<String, String>> ignores = new ConcurrentHashSet<>();
+   private static Set<Pair<String, String>> ignores = new NonBlockingHashSet<>();
 
    public static void addIgnore(String className, String propertyName) {
       logger.trace("Adding ignore on " + className + "/" + propertyName);

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/uri/URIFactory.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/uri/URIFactory.java
@@ -20,13 +20,13 @@ package org.apache.activemq.artemis.utils.uri;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 
 public class URIFactory<T, P> {
 
    private URI defaultURI;
 
-   private final Map<String, URISchema<T, P>> schemas = new ConcurrentHashMap<>();
+   private final Map<String, URISchema<T, P>> schemas = new NonBlockingHashMap<>();
 
    public URI getDefaultURI() {
       return defaultURI;

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionFactoryImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionFactoryImpl.java
@@ -62,12 +62,12 @@ import org.apache.activemq.artemis.spi.core.remoting.ConnectorFactory;
 import org.apache.activemq.artemis.spi.core.remoting.SessionContext;
 import org.apache.activemq.artemis.spi.core.remoting.TopologyResponseHandler;
 import org.apache.activemq.artemis.utils.ClassloadingUtil;
-import org.apache.activemq.artemis.utils.ConcurrentHashSet;
 import org.apache.activemq.artemis.utils.ConfirmationWindowWarning;
 import org.apache.activemq.artemis.utils.ExecutorFactory;
 import org.apache.activemq.artemis.utils.OrderedExecutorFactory;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
 import org.jboss.logging.Logger;
+import org.jctools.maps.NonBlockingHashSet;
 
 public class ClientSessionFactoryImpl implements ClientSessionFactoryInternal, ClientConnectionLifeCycleListener {
 
@@ -93,7 +93,7 @@ public class ClientSessionFactoryImpl implements ClientSessionFactoryInternal, C
 
    private final long connectionTTL;
 
-   private final Set<ClientSessionInternal> sessions = new ConcurrentHashSet<>();
+   private final Set<ClientSessionInternal> sessions = new NonBlockingHashSet<>();
 
    private final Object createSessionLock = new Object();
 
@@ -121,9 +121,9 @@ public class ClientSessionFactoryImpl implements ClientSessionFactoryInternal, C
 
    private int reconnectAttempts;
 
-   private final Set<SessionFailureListener> listeners = new ConcurrentHashSet<>();
+   private final Set<SessionFailureListener> listeners = new NonBlockingHashSet<>();
 
-   private final Set<FailoverEventListener> failoverListeners = new ConcurrentHashSet<>();
+   private final Set<FailoverEventListener> failoverListeners = new NonBlockingHashSet<>();
 
    private Connector connector;
 

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/Topology.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/Topology.java
@@ -23,7 +23,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.Executor;
 
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
@@ -73,7 +73,7 @@ public final class Topology {
 
    public Topology(final Object owner, final Executor executor) {
       this.topologyListeners = new HashSet<>();
-      this.topology = new ConcurrentHashMap<>();
+      this.topology = new NonBlockingHashMap<>();
       if (executor == null) {
          throw new IllegalArgumentException("Executor is required");
       }
@@ -450,7 +450,7 @@ public final class Topology {
 
    private synchronized Map<String, Long> getMapDelete() {
       if (mapDelete == null) {
-         mapDelete = new ConcurrentHashMap<>();
+         mapDelete = new NonBlockingHashMap<>();
       }
       return mapDelete;
    }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/cluster/DiscoveryGroup.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/cluster/DiscoveryGroup.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
@@ -60,7 +60,7 @@ public final class DiscoveryGroup implements ActiveMQComponent {
 
    private final Object waitLock = new Object();
 
-   private final Map<String, DiscoveryEntry> connectors = new ConcurrentHashMap<>();
+   private final Map<String, DiscoveryEntry> connectors = new NonBlockingHashMap<>();
 
    private final long timeout;
 

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/RemotingConnectionImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/RemotingConnectionImpl.java
@@ -18,9 +18,7 @@ package org.apache.activemq.artemis.core.protocol.core.impl;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
@@ -41,6 +39,7 @@ import org.apache.activemq.artemis.spi.core.protocol.AbstractRemotingConnection;
 import org.apache.activemq.artemis.spi.core.remoting.Connection;
 import org.apache.activemq.artemis.utils.SimpleIDGenerator;
 import org.jboss.logging.Logger;
+import org.jctools.maps.NonBlockingHashMapLong;
 
 public class RemotingConnectionImpl extends AbstractRemotingConnection implements CoreRemotingConnection {
 
@@ -48,7 +47,7 @@ public class RemotingConnectionImpl extends AbstractRemotingConnection implement
 
    private final PacketDecoder packetDecoder;
 
-   private final Map<Long, Channel> channels = new ConcurrentHashMap<>();
+   private final NonBlockingHashMapLong<Channel> channels = new NonBlockingHashMapLong<>();
 
    private final long blockingCallTimeout;
 

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnector.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnector.java
@@ -37,7 +37,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
@@ -209,7 +209,7 @@ public class NettyConnector extends AbstractConnector {
 
    private long batchDelay;
 
-   private ConcurrentMap<Object, Connection> connections = new ConcurrentHashMap<>();
+   private ConcurrentMap<Object, Connection> connections = new NonBlockingHashMap<>();
 
    private String servletPath;
 

--- a/artemis-core-client/src/test/java/org/apache/activemq/artemis/util/TimeAndCounterIDGeneratorTest.java
+++ b/artemis-core-client/src/test/java/org/apache/activemq/artemis/util/TimeAndCounterIDGeneratorTest.java
@@ -16,11 +16,12 @@
  */
 package org.apache.activemq.artemis.util;
 
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.activemq.artemis.utils.ConcurrentHashSet;
 import org.apache.activemq.artemis.utils.TimeAndCounterIDGenerator;
+import org.jctools.maps.NonBlockingHashSet;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -73,7 +74,7 @@ public class TimeAndCounterIDGeneratorTest extends Assert {
 
    @Test
    public void testCalculationOnMultiThread() throws Throwable {
-      final ConcurrentHashSet<Long> hashSet = new ConcurrentHashSet<>();
+      final Set<Long> hashSet = new NonBlockingHashSet<>();
 
       final TimeAndCounterIDGenerator seq = new TimeAndCounterIDGenerator();
 

--- a/artemis-distribution/pom.xml
+++ b/artemis-distribution/pom.xml
@@ -201,6 +201,10 @@
            <groupId>org.apache.johnzon</groupId>
            <artifactId>johnzon-core</artifactId>
        </dependency>
+      <dependency>
+         <groupId>org.jctools</groupId>
+         <artifactId>jctools-core</artifactId>
+      </dependency>
    </dependencies>
 
    <build>

--- a/artemis-distribution/src/main/assembly/dep.xml
+++ b/artemis-distribution/src/main/assembly/dep.xml
@@ -96,6 +96,7 @@
             <include>org.jgroups:jgroups</include>
             <include>org.apache.geronimo.specs:geronimo-json_1.0_spec</include>
             <include>org.apache.johnzon:johnzon-core</include>
+            <include>org.jctools:jctools-core</include>
          </includes>
          <!--excludes>
             <exclude>org.apache.activemq:artemis-website</exclude>

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/file/JDBCSequentialFile.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/file/JDBCSequentialFile.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.sql.SQLException;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.Executor;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
@@ -62,7 +62,7 @@ public class JDBCSequentialFile implements SequentialFile {
    private final JDBCSequentialFileFactoryDriver dbDriver;
 
    // Allows DB Drivers to cache meta data.
-   private final Map<Object, Object> metaData = new ConcurrentHashMap<>();
+   private final Map<Object, Object> metaData = new NonBlockingHashMap<>();
 
    JDBCSequentialFile(final JDBCSequentialFileFactory fileFactory,
                       final String filename,

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalImpl.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalImpl.java
@@ -24,7 +24,6 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -46,6 +45,7 @@ import org.apache.activemq.artemis.jdbc.store.drivers.AbstractJDBCDriver;
 import org.apache.activemq.artemis.jdbc.store.sql.SQLProvider;
 import org.apache.activemq.artemis.journal.ActiveMQJournalLogger;
 import org.jboss.logging.Logger;
+import org.jctools.maps.NonBlockingHashMapLong;
 
 public class JDBCJournalImpl extends AbstractJDBCDriver implements Journal {
 
@@ -79,7 +79,7 @@ public class JDBCJournalImpl extends AbstractJDBCDriver implements Journal {
    private final ScheduledExecutorService scheduledExecutorService;
 
    // Track Tx Records
-   private Map<Long, TransactionHolder> transactions = new ConcurrentHashMap<>();
+   private NonBlockingHashMapLong<TransactionHolder> transactions = new NonBlockingHashMapLong<>();
 
    // Sequence ID for journal records
    private final AtomicLong seq = new AtomicLong(0);
@@ -627,7 +627,8 @@ public class JDBCJournalImpl extends AbstractJDBCDriver implements Journal {
 
          jli.setMaxID(((JDBCJournalLoaderCallback) reloadManager).getMaxId());
          jli.setNumberOfRecords(noRecords);
-         transactions = jrc.getTransactions();
+         transactions.clear();
+         transactions.putAll(jrc.getTransactions());
       }
       return jli;
    }

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
@@ -53,9 +53,9 @@ import org.apache.activemq.artemis.core.client.impl.ClientSessionInternal;
 import org.apache.activemq.artemis.core.version.Version;
 import org.apache.activemq.artemis.reader.MessageUtil;
 import org.apache.activemq.artemis.utils.ActiveMQThreadFactory;
-import org.apache.activemq.artemis.utils.ConcurrentHashSet;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
 import org.apache.activemq.artemis.utils.VersionLoader;
+import org.jctools.maps.NonBlockingHashSet;
 
 /**
  * ActiveMQ Artemis implementation of a JMS Connection.
@@ -84,11 +84,11 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
 
    private final int connectionType;
 
-   private final Set<ActiveMQSession> sessions = new ConcurrentHashSet<>();
+   private final Set<ActiveMQSession> sessions = new NonBlockingHashSet<>();
 
-   private final Set<SimpleString> tempQueues = new ConcurrentHashSet<>();
+   private final Set<SimpleString> tempQueues = new NonBlockingHashSet<>();
 
-   private final Set<SimpleString> knownDestinations = new ConcurrentHashSet<>();
+   private final Set<SimpleString> knownDestinations = new NonBlockingHashSet<>();
 
    private volatile boolean hasNoLocal;
 

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jndi/ActiveMQInitialContextFactory.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jndi/ActiveMQInitialContextFactory.java
@@ -24,7 +24,7 @@ import javax.naming.NamingException;
 import javax.naming.spi.InitialContextFactory;
 import java.util.Hashtable;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
 import org.apache.activemq.artemis.uri.ConnectionFactoryParser;
@@ -49,7 +49,7 @@ public class ActiveMQInitialContextFactory implements InitialContextFactory {
    @Override
    public Context getInitialContext(Hashtable<?, ?> environment) throws NamingException {
       // lets create a factory
-      Map<String, Object> data = new ConcurrentHashMap<>();
+      Map<String, Object> data = new NonBlockingHashMap<>();
       for (Map.Entry<?, ?> entry : environment.entrySet()) {
          String key = entry.getKey().toString();
          if (key.startsWith(connectionFactoryPrefix)) {

--- a/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/persistence/impl/journal/JMSJournalStorageManagerImpl.java
+++ b/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/persistence/impl/journal/JMSJournalStorageManagerImpl.java
@@ -20,7 +20,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
@@ -63,11 +63,11 @@ public final class JMSJournalStorageManagerImpl implements JMSStorageManager {
 
    private volatile boolean started;
 
-   private final Map<String, PersistedConnectionFactory> mapFactories = new ConcurrentHashMap<>();
+   private final Map<String, PersistedConnectionFactory> mapFactories = new NonBlockingHashMap<>();
 
-   private final Map<Pair<PersistedType, String>, PersistedDestination> destinations = new ConcurrentHashMap<>();
+   private final Map<Pair<PersistedType, String>, PersistedDestination> destinations = new NonBlockingHashMap<>();
 
-   private final Map<Pair<PersistedType, String>, PersistedBindings> mapBindings = new ConcurrentHashMap<>();
+   private final Map<Pair<PersistedType, String>, PersistedBindings> mapBindings = new NonBlockingHashMap<>();
 
    private final Configuration config;
 

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/FileWrapperJournal.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/FileWrapperJournal.java
@@ -18,8 +18,6 @@ package org.apache.activemq.artemis.core.journal.impl;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -42,6 +40,7 @@ import org.apache.activemq.artemis.core.journal.impl.dataformat.JournalDeleteRec
 import org.apache.activemq.artemis.core.journal.impl.dataformat.JournalDeleteRecordTX;
 import org.apache.activemq.artemis.core.journal.impl.dataformat.JournalInternalRecord;
 import org.apache.activemq.artemis.core.journal.impl.dataformat.JournalRollbackRecordTX;
+import org.jctools.maps.NonBlockingHashMapLong;
 
 /**
  * Journal used at a replicating backup server during the synchronization of data with the 'live'
@@ -53,7 +52,7 @@ public final class FileWrapperJournal extends JournalBase {
 
    private final ReentrantLock lockAppend = new ReentrantLock();
 
-   private final ConcurrentMap<Long, AtomicInteger> transactions = new ConcurrentHashMap<>();
+   private final NonBlockingHashMapLong<AtomicInteger> transactions = new NonBlockingHashMapLong<>();
    private final JournalImpl journal;
    protected volatile JournalFile currentFile;
 

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalCompactor.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalCompactor.java
@@ -22,7 +22,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
@@ -39,6 +38,7 @@ import org.apache.activemq.artemis.core.journal.impl.dataformat.JournalDeleteRec
 import org.apache.activemq.artemis.core.journal.impl.dataformat.JournalInternalRecord;
 import org.apache.activemq.artemis.core.journal.impl.dataformat.JournalRollbackRecordTX;
 import org.apache.activemq.artemis.journal.ActiveMQJournalLogger;
+import org.jctools.maps.NonBlockingHashMapLong;
 
 public class JournalCompactor extends AbstractJournalUpdateTask implements JournalRecordProvider {
 
@@ -48,7 +48,7 @@ public class JournalCompactor extends AbstractJournalUpdateTask implements Journ
    private static final short COMPACT_SPLIT_LINE = 2;
 
    // Snapshot of transactions that were pending when the compactor started
-   private final Map<Long, PendingTransaction> pendingTransactions = new ConcurrentHashMap<>();
+   private final NonBlockingHashMapLong<PendingTransaction> pendingTransactions = new NonBlockingHashMapLong<>();
 
    private final Map<Long, JournalRecord> newRecords = new HashMap<>();
 
@@ -127,6 +127,14 @@ public class JournalCompactor extends AbstractJournalUpdateTask implements Journ
                            final JournalImpl journal,
                            final JournalFilesRepository filesRepository,
                            final Set<Long> recordsSnapshot,
+                           final long firstFileID) {
+      super(fileFactory, journal, filesRepository, recordsSnapshot, firstFileID);
+   }
+
+   public JournalCompactor(final SequentialFileFactory fileFactory,
+                           final JournalImpl journal,
+                           final JournalFilesRepository filesRepository,
+                           final long[] recordsSnapshot,
                            final long firstFileID) {
       super(fileFactory, journal, filesRepository, recordsSnapshot, firstFileID);
    }

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalFileImpl.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalFileImpl.java
@@ -17,7 +17,7 @@
 package org.apache.activemq.artemis.core.journal.impl;
 
 import java.util.Map.Entry;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -46,7 +46,7 @@ public class JournalFileImpl implements JournalFile {
 
    private final int version;
 
-   private final ConcurrentMap<JournalFile, AtomicInteger> negCounts = new ConcurrentHashMap<>();
+   private final ConcurrentMap<JournalFile, AtomicInteger> negCounts = new NonBlockingHashMap<>();
 
    private static final Logger logger = Logger.getLogger(JournalFileImpl.class);
 

--- a/artemis-protocols/artemis-amqp-protocol/pom.xml
+++ b/artemis-protocols/artemis-amqp-protocol/pom.xml
@@ -84,6 +84,10 @@
          <scope>provided</scope>
       </dependency>
       <dependency>
+         <groupId>org.jctools</groupId>
+         <artifactId>jctools-core</artifactId>
+      </dependency>
+      <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
          <scope>test</scope>

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPConnectionCallback.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPConnectionCallback.java
@@ -18,7 +18,6 @@ package org.apache.activemq.artemis.protocol.amqp.broker;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -53,12 +52,13 @@ import org.apache.qpid.proton.amqp.Binary;
 import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.amqp.transport.AmqpError;
 import org.jboss.logging.Logger;
+import org.jctools.maps.NonBlockingHashMap;
 
 public class AMQPConnectionCallback implements FailureListener, CloseListener {
 
    private static final Logger logger = Logger.getLogger(AMQPConnectionCallback.class);
 
-   private ConcurrentMap<XidImpl, Transaction> transactions = new ConcurrentHashMap<>();
+   private ConcurrentMap<XidImpl, Transaction> transactions = new NonBlockingHashMap<>();
 
    private final ProtonProtocolManager manager;
 

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/client/ProtonClientConnectionManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/client/ProtonClientConnectionManager.java
@@ -27,16 +27,16 @@ import org.apache.activemq.artemis.spi.core.remoting.BaseConnectionLifeCycleList
 import org.apache.activemq.artemis.spi.core.remoting.BufferHandler;
 import org.apache.activemq.artemis.spi.core.remoting.Connection;
 import org.jboss.logging.Logger;
+import org.jctools.maps.NonBlockingHashMap;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Manages the lifecycle of a proton client connection.
  */
 public class ProtonClientConnectionManager implements BaseConnectionLifeCycleListener<ProtonProtocolManager>, BufferHandler {
-   private final Map<Object, ActiveMQProtonRemotingConnection> connectionMap = new ConcurrentHashMap<>();
+   private final Map<Object, ActiveMQProtonRemotingConnection> connectionMap = new NonBlockingHashMap<>();
    private static final Logger log = Logger.getLogger(ProtonClientConnectionManager.class);
    private final AMQPClientConnectionFactory connectionFactory;
    private final Optional<EventHandler> eventHandler;

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPConnectionContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPConnectionContext.java
@@ -19,7 +19,6 @@ package org.apache.activemq.artemis.protocol.amqp.proton;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -46,6 +45,7 @@ import org.apache.qpid.proton.engine.Transport;
 import org.jboss.logging.Logger;
 
 import io.netty.buffer.ByteBuf;
+import org.jctools.maps.NonBlockingHashMap;
 
 public class AMQPConnectionContext extends ProtonInitializable {
 
@@ -61,7 +61,7 @@ public class AMQPConnectionContext extends ProtonInitializable {
    private final Map<Symbol, Object> connectionProperties = new HashMap<>();
    private final ScheduledExecutorService scheduledPool;
 
-   private final Map<Session, AMQPSessionContext> sessions = new ConcurrentHashMap<>();
+   private final Map<Session, AMQPSessionContext> sessions = new NonBlockingHashMap<>();
 
    protected LocalListener listener = new LocalListener();
 

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTConnectionManager.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTConnectionManager.java
@@ -26,7 +26,7 @@ import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ServerMessage;
 import org.apache.activemq.artemis.core.server.ServerSession;
 import org.apache.activemq.artemis.core.server.impl.ServerSessionImpl;
-import org.apache.activemq.artemis.utils.ConcurrentHashSet;
+import org.jctools.maps.NonBlockingHashSet;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
 
 /**
@@ -38,7 +38,7 @@ public class MQTTConnectionManager {
    private MQTTSession session;
 
    //TODO Read in a list of existing client IDs from stored Sessions.
-   public static Set<String> CONNECTED_CLIENTS = new ConcurrentHashSet<>();
+   public static Set<String> CONNECTED_CLIENTS = new NonBlockingHashSet<>();
 
    private MQTTLogger log = MQTTLogger.LOGGER;
 

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTSession.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTSession.java
@@ -19,7 +19,7 @@ package org.apache.activemq.artemis.core.protocol.mqtt;
 
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.impl.ServerSessionImpl;
@@ -27,7 +27,7 @@ import org.apache.activemq.artemis.spi.core.protocol.SessionCallback;
 
 public class MQTTSession {
 
-   static Map<String, MQTTSessionState> SESSIONS = new ConcurrentHashMap<>();
+   static Map<String, MQTTSessionState> SESSIONS = new NonBlockingHashMap<>();
 
    private final String id = UUID.randomUUID().toString();
 

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -75,7 +75,7 @@ import org.apache.activemq.artemis.spi.core.protocol.AbstractRemotingConnection;
 import org.apache.activemq.artemis.spi.core.protocol.ConnectionEntry;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
 import org.apache.activemq.artemis.spi.core.remoting.Connection;
-import org.apache.activemq.artemis.utils.ConcurrentHashSet;
+import org.jctools.maps.NonBlockingHashSet;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
 import org.apache.activemq.command.ActiveMQDestination;
 import org.apache.activemq.command.ActiveMQMessage;
@@ -147,12 +147,12 @@ public class OpenWireConnection extends AbstractRemotingConnection implements Se
 
    private final AtomicBoolean stopping = new AtomicBoolean(false);
 
-   private final Map<String, SessionId> sessionIdMap = new ConcurrentHashMap<>();
+   private final Map<String, SessionId> sessionIdMap = new NonBlockingHashMap<>();
 
-   private final Map<ConsumerId, AMQConsumerBrokerExchange> consumerExchanges = new ConcurrentHashMap<>();
-   private final Map<ProducerId, AMQProducerBrokerExchange> producerExchanges = new ConcurrentHashMap<>();
+   private final Map<ConsumerId, AMQConsumerBrokerExchange> consumerExchanges = new NonBlockingHashMap<>();
+   private final Map<ProducerId, AMQProducerBrokerExchange> producerExchanges = new NonBlockingHashMap<>();
 
-   private final Map<SessionId, AMQSession> sessions = new ConcurrentHashMap<>();
+   private final Map<SessionId, AMQSession> sessions = new NonBlockingHashMap<>();
 
    private ConnectionState state;
 
@@ -162,7 +162,7 @@ public class OpenWireConnection extends AbstractRemotingConnection implements Se
     * But always without any association with Sessions.
     * This collection will hold nonXA transactions. Hopefully while they are in transit only.
     */
-   private final Map<TransactionId, Transaction> txMap = new ConcurrentHashMap<>();
+   private final Map<TransactionId, Transaction> txMap = new NonBlockingHashMap<>();
 
    private volatile AMQSession advisorySession;
 
@@ -181,7 +181,7 @@ public class OpenWireConnection extends AbstractRemotingConnection implements Se
    private boolean useKeepAlive;
    private long maxInactivityDuration;
 
-   private final Set<SimpleString> knownDestinations = new ConcurrentHashSet<>();
+   private final Set<SimpleString> knownDestinations = new NonBlockingHashSet<>();
 
    private AtomicBoolean disableTtl = new AtomicBoolean(false);
 

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireProtocolManager.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireProtocolManager.java
@@ -24,7 +24,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -101,7 +101,7 @@ public class OpenWireProtocolManager implements ProtocolManager<Interceptor>, Cl
 
    private String brokerName;
 
-   private final Map<String, TopologyMember> topologyMap = new ConcurrentHashMap<>();
+   private final Map<String, TopologyMember> topologyMap = new NonBlockingHashMap<>();
 
    private final LinkedList<TopologyMember> members = new LinkedList<>();
 

--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompSession.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompSession.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.BlockingDeque;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.zip.Inflater;
 
@@ -35,9 +34,9 @@ import org.apache.activemq.artemis.core.persistence.OperationContext;
 import org.apache.activemq.artemis.core.persistence.StorageManager;
 import org.apache.activemq.artemis.core.persistence.impl.journal.LargeServerMessageImpl;
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
-import org.apache.activemq.artemis.core.server.RoutingType;
 import org.apache.activemq.artemis.core.server.LargeServerMessage;
 import org.apache.activemq.artemis.core.server.MessageReference;
+import org.apache.activemq.artemis.core.server.RoutingType;
 import org.apache.activemq.artemis.core.server.ServerConsumer;
 import org.apache.activemq.artemis.core.server.ServerMessage;
 import org.apache.activemq.artemis.core.server.ServerSession;
@@ -50,6 +49,7 @@ import org.apache.activemq.artemis.utils.ByteUtil;
 import org.apache.activemq.artemis.utils.ConfigurationHelper;
 import org.apache.activemq.artemis.utils.PendingTask;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
+import org.jctools.maps.NonBlockingHashMapLong;
 
 import static org.apache.activemq.artemis.core.protocol.stomp.ActiveMQStompProtocolMessageBundle.BUNDLE;
 
@@ -65,10 +65,10 @@ public class StompSession implements SessionCallback {
 
    private final BlockingDeque<PendingTask> afterDeliveryTasks = new LinkedBlockingDeque<>();
 
-   private final Map<Long, StompSubscription> subscriptions = new ConcurrentHashMap<>();
+   private final NonBlockingHashMapLong<StompSubscription> subscriptions = new NonBlockingHashMapLong<>();
 
    // key = message ID, value = consumer ID
-   private final Map<Long, Pair<Long, Integer>> messagesToAck = new ConcurrentHashMap<>();
+   private final NonBlockingHashMapLong<Pair<Long, Integer>> messagesToAck = new NonBlockingHashMapLong<>();
 
    private volatile boolean noLocal = false;
 

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRAConnectionManager.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRAConnectionManager.java
@@ -22,7 +22,9 @@ import javax.resource.spi.ConnectionRequestInfo;
 import javax.resource.spi.ManagedConnection;
 import javax.resource.spi.ManagedConnectionFactory;
 
-import org.apache.activemq.artemis.utils.ConcurrentHashSet;
+import java.util.Set;
+
+import org.jctools.maps.NonBlockingHashSet;
 
 /**
  * The connection manager used in non-managed environments.
@@ -47,7 +49,7 @@ public class ActiveMQRAConnectionManager implements ConnectionManager {
       }
    }
 
-   ConcurrentHashSet<ManagedConnection> connections = new ConcurrentHashSet<>();
+   Set<ManagedConnection> connections = new NonBlockingHashSet<>();
 
    /**
     * Allocates a connection

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQActivation.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQActivation.java
@@ -34,7 +34,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
@@ -117,7 +117,7 @@ public class ActiveMQActivation {
 
    private final List<String> nodes = Collections.synchronizedList(new ArrayList<String>());
 
-   private final Map<String, Long> removedNodes = new ConcurrentHashMap<>();
+   private final Map<String, Long> removedNodes = new NonBlockingHashMap<>();
 
    private boolean lastReceived = false;
 

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/recovery/RecoveryManager.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/recovery/RecoveryManager.java
@@ -25,7 +25,7 @@ import org.apache.activemq.artemis.ra.ActiveMQRALogger;
 import org.apache.activemq.artemis.service.extensions.xa.recovery.ActiveMQRegistry;
 import org.apache.activemq.artemis.service.extensions.xa.recovery.ActiveMQRegistryImpl;
 import org.apache.activemq.artemis.service.extensions.xa.recovery.XARecoveryConfig;
-import org.apache.activemq.artemis.utils.ConcurrentHashSet;
+import org.jctools.maps.NonBlockingHashSet;
 
 public final class RecoveryManager {
 
@@ -33,7 +33,7 @@ public final class RecoveryManager {
 
    private static final String RESOURCE_RECOVERY_CLASS_NAMES = "org.jboss.as.messaging.jms.AS7RecoveryRegistry;" + "org.jboss.as.integration.activemq.recovery.AS5RecoveryRegistry";
 
-   private final Set<XARecoveryConfig> resources = new ConcurrentHashSet<>();
+   private final Set<XARecoveryConfig> resources = new NonBlockingHashSet<>();
 
    public void start(final boolean useAutoRecovery) {
       if (useAutoRecovery) {

--- a/artemis-rest/src/main/java/org/apache/activemq/artemis/rest/queue/ConsumersResource.java
+++ b/artemis-rest/src/main/java/org/apache/activemq/artemis/rest/queue/ConsumersResource.java
@@ -29,7 +29,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -40,7 +40,7 @@ import org.apache.activemq.artemis.rest.util.TimeoutTask;
 
 public class ConsumersResource implements TimeoutTask.Callback {
 
-   protected ConcurrentMap<String, QueueConsumer> queueConsumers = new ConcurrentHashMap<>();
+   protected ConcurrentMap<String, QueueConsumer> queueConsumers = new NonBlockingHashMap<>();
    protected ClientSessionFactory sessionFactory;
    protected String destination;
    protected final String startup = Long.toString(System.currentTimeMillis());

--- a/artemis-rest/src/main/java/org/apache/activemq/artemis/rest/queue/QueueDestinationsResource.java
+++ b/artemis-rest/src/main/java/org/apache/activemq/artemis/rest/queue/QueueDestinationsResource.java
@@ -27,7 +27,7 @@ import javax.ws.rs.core.UriInfo;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.SimpleString;
@@ -45,7 +45,7 @@ import org.w3c.dom.Document;
 @Path(Constants.PATH_FOR_QUEUES)
 public class QueueDestinationsResource {
 
-   private final Map<String, QueueResource> queues = new ConcurrentHashMap<>();
+   private final Map<String, QueueResource> queues = new NonBlockingHashMap<>();
    private final QueueServiceManager manager;
 
    public QueueDestinationsResource(QueueServiceManager manager) {

--- a/artemis-rest/src/main/java/org/apache/activemq/artemis/rest/queue/push/PushConsumerResource.java
+++ b/artemis-rest/src/main/java/org/apache/activemq/artemis/rest/queue/push/PushConsumerResource.java
@@ -29,7 +29,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
@@ -39,7 +39,7 @@ import org.apache.activemq.artemis.rest.queue.push.xml.PushRegistration;
 
 public class PushConsumerResource {
 
-   protected Map<String, PushConsumer> consumers = new ConcurrentHashMap<>();
+   protected Map<String, PushConsumer> consumers = new NonBlockingHashMap<>();
    protected ClientSessionFactory sessionFactory;
    protected String destination;
    protected final String startup = Long.toString(System.currentTimeMillis());

--- a/artemis-rest/src/main/java/org/apache/activemq/artemis/rest/topic/PushSubscriptionsResource.java
+++ b/artemis-rest/src/main/java/org/apache/activemq/artemis/rest/topic/PushSubscriptionsResource.java
@@ -28,7 +28,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
@@ -41,7 +41,7 @@ import org.apache.activemq.artemis.rest.queue.push.PushConsumer;
 
 public class PushSubscriptionsResource {
 
-   protected Map<String, PushSubscription> consumers = new ConcurrentHashMap<>();
+   protected Map<String, PushSubscription> consumers = new NonBlockingHashMap<>();
    protected ClientSessionFactory sessionFactory;
    protected String destination;
    protected final String startup = Long.toString(System.currentTimeMillis());

--- a/artemis-rest/src/main/java/org/apache/activemq/artemis/rest/topic/SubscriptionsResource.java
+++ b/artemis-rest/src/main/java/org/apache/activemq/artemis/rest/topic/SubscriptionsResource.java
@@ -29,7 +29,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -46,7 +46,7 @@ import org.apache.activemq.artemis.rest.util.TimeoutTask;
 
 public class SubscriptionsResource implements TimeoutTask.Callback {
 
-   protected ConcurrentMap<String, QueueConsumer> queueConsumers = new ConcurrentHashMap<>();
+   protected ConcurrentMap<String, QueueConsumer> queueConsumers = new NonBlockingHashMap<>();
    protected ClientSessionFactory sessionFactory;
    protected String destination;
    protected final String startup = Long.toString(System.currentTimeMillis());

--- a/artemis-rest/src/main/java/org/apache/activemq/artemis/rest/topic/TopicDestinationsResource.java
+++ b/artemis-rest/src/main/java/org/apache/activemq/artemis/rest/topic/TopicDestinationsResource.java
@@ -27,7 +27,7 @@ import javax.ws.rs.core.UriInfo;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.SimpleString;
@@ -47,7 +47,7 @@ import org.w3c.dom.Document;
 @Path("/topics")
 public class TopicDestinationsResource {
 
-   private final Map<String, TopicResource> topics = new ConcurrentHashMap<>();
+   private final Map<String, TopicResource> topics = new NonBlockingHashMap<>();
    private final TopicServiceManager manager;
 
    public TopicDestinationsResource(TopicServiceManager manager) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageCursorProviderImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageCursorProviderImpl.java
@@ -19,8 +19,6 @@ package org.apache.activemq.artemis.core.paging.cursor.impl;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -42,6 +40,7 @@ import org.apache.activemq.artemis.core.transaction.impl.TransactionImpl;
 import org.apache.activemq.artemis.utils.FutureLatch;
 import org.apache.activemq.artemis.utils.SoftValueHashMap;
 import org.jboss.logging.Logger;
+import org.jctools.maps.NonBlockingHashMapLong;
 
 /**
  * A PageProviderIMpl
@@ -72,7 +71,7 @@ public class PageCursorProviderImpl implements PageCursorProvider {
 
    private final SoftValueHashMap<Long, PageCache> softCache;
 
-   private final ConcurrentMap<Long, PageSubscription> activeCursors = new ConcurrentHashMap<>();
+   private final NonBlockingHashMapLong<PageSubscription> activeCursors = new NonBlockingHashMapLong<>();
 
    // Static --------------------------------------------------------
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageSubscriptionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageSubscriptionImpl.java
@@ -55,7 +55,7 @@ import org.apache.activemq.artemis.core.transaction.Transaction;
 import org.apache.activemq.artemis.core.transaction.TransactionOperationAbstract;
 import org.apache.activemq.artemis.core.transaction.TransactionPropertyIndexes;
 import org.apache.activemq.artemis.core.transaction.impl.TransactionImpl;
-import org.apache.activemq.artemis.utils.ConcurrentHashSet;
+import org.jctools.maps.NonBlockingHashSet;
 import org.apache.activemq.artemis.utils.FutureLatch;
 import org.jboss.logging.Logger;
 
@@ -882,7 +882,7 @@ final class PageSubscriptionImpl implements PageSubscription {
 
       private WeakReference<PageCache> cache;
 
-      private final Set<PagePosition> removedReferences = new ConcurrentHashSet<>();
+      private final Set<PagePosition> removedReferences = new NonBlockingHashSet<>();
 
       // The page was live at the time of the creation
       private final boolean wasLive;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/Page.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/Page.java
@@ -34,7 +34,7 @@ import org.apache.activemq.artemis.core.persistence.StorageManager;
 import org.apache.activemq.artemis.core.server.ActiveMQMessageBundle;
 import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
 import org.apache.activemq.artemis.core.server.LargeServerMessage;
-import org.apache.activemq.artemis.utils.ConcurrentHashSet;
+import org.jctools.maps.NonBlockingHashSet;
 import org.apache.activemq.artemis.utils.DataConstants;
 import org.jboss.logging.Logger;
 
@@ -361,7 +361,7 @@ public final class Page implements Comparable<Page> {
 
    private synchronized Set<PageSubscriptionCounter> getOrCreatePendingCounters() {
       if (pendingCounters == null) {
-         pendingCounters = new ConcurrentHashSet<>();
+         pendingCounters = new NonBlockingHashSet<>();
       }
 
       return pendingCounters;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingManagerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingManagerImpl.java
@@ -21,7 +21,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -35,8 +34,10 @@ import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
 import org.apache.activemq.artemis.core.server.files.FileStoreMonitor;
 import org.apache.activemq.artemis.core.settings.HierarchicalRepository;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
-import org.apache.activemq.artemis.utils.ConcurrentHashSet;
 import org.jboss.logging.Logger;
+import org.jctools.maps.NonBlockingHashMap;
+import org.jctools.maps.NonBlockingHashMapLong;
+import org.jctools.maps.NonBlockingHashSet;
 
 public final class PagingManagerImpl implements PagingManager {
 
@@ -52,9 +53,9 @@ public final class PagingManagerImpl implements PagingManager {
     */
    private final ReentrantReadWriteLock syncLock = new ReentrantReadWriteLock();
 
-   private final Set<PagingStore> blockedStored = new ConcurrentHashSet<>();
+   private final Set<PagingStore> blockedStored = new NonBlockingHashSet<>();
 
-   private final ConcurrentMap<SimpleString, PagingStore> stores = new ConcurrentHashMap<>();
+   private final ConcurrentMap<SimpleString, PagingStore> stores = new NonBlockingHashMap<>();
 
    private final HierarchicalRepository<AddressSettings> addressSettingsRepository;
 
@@ -68,7 +69,7 @@ public final class PagingManagerImpl implements PagingManager {
 
    private volatile boolean diskFull = false;
 
-   private final ConcurrentMap</*TransactionID*/Long, PageTransactionInfo> transactions = new ConcurrentHashMap<>();
+   private final NonBlockingHashMapLong<PageTransactionInfo> transactions = new NonBlockingHashMapLong<>();
 
    // Static
    // --------------------------------------------------------------------------------------------------------------------------

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AbstractJournalStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AbstractJournalStorageManager.java
@@ -29,7 +29,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
@@ -183,9 +183,9 @@ public abstract class AbstractJournalStorageManager implements StorageManager {
    protected final Configuration config;
 
    // Persisted core configuration
-   protected final Map<SimpleString, PersistedRoles> mapPersistedRoles = new ConcurrentHashMap<>();
+   protected final Map<SimpleString, PersistedRoles> mapPersistedRoles = new NonBlockingHashMap<>();
 
-   protected final Map<SimpleString, PersistedAddressSetting> mapPersistedAddressSettings = new ConcurrentHashMap<>();
+   protected final Map<SimpleString, PersistedAddressSetting> mapPersistedAddressSettings = new NonBlockingHashMap<>();
 
    protected final Set<Long> largeMessagesToDelete = new HashSet<>();
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/BindingsImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/BindingsImpl.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -44,6 +43,8 @@ import org.apache.activemq.artemis.core.server.group.GroupingHandler;
 import org.apache.activemq.artemis.core.server.group.impl.Proposal;
 import org.apache.activemq.artemis.core.server.group.impl.Response;
 import org.jboss.logging.Logger;
+import org.jctools.maps.NonBlockingHashMap;
+import org.jctools.maps.NonBlockingHashMapLong;
 
 public final class BindingsImpl implements Bindings {
 
@@ -52,11 +53,11 @@ public final class BindingsImpl implements Bindings {
    // This is public as we use on test assertions
    public static final int MAX_GROUP_RETRY = 10;
 
-   private final ConcurrentMap<SimpleString, List<Binding>> routingNameBindingMap = new ConcurrentHashMap<>();
+   private final ConcurrentMap<SimpleString, List<Binding>> routingNameBindingMap = new NonBlockingHashMap<>();
 
-   private final Map<SimpleString, Integer> routingNamePositions = new ConcurrentHashMap<>();
+   private final Map<SimpleString, Integer> routingNamePositions = new NonBlockingHashMap<>();
 
-   private final Map<Long, Binding> bindingsMap = new ConcurrentHashMap<>();
+   private final NonBlockingHashMapLong<Binding> bindingsMap = new NonBlockingHashMapLong<>();
 
    private final List<Binding> exclusiveBindings = new CopyOnWriteArrayList<>();
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/DuplicateIDCacheImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/DuplicateIDCacheImpl.java
@@ -19,7 +19,7 @@ package org.apache.activemq.artemis.core.postoffice.impl;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 
 import org.apache.activemq.artemis.api.core.ActiveMQDuplicateIdException;
 import org.apache.activemq.artemis.api.core.Pair;
@@ -43,7 +43,7 @@ public class DuplicateIDCacheImpl implements DuplicateIDCache {
    private static final Logger logger = Logger.getLogger(DuplicateIDCacheImpl.class);
 
    // ByteHolder, position
-   private final Map<ByteArrayHolder, Integer> cache = new ConcurrentHashMap<>();
+   private final Map<ByteArrayHolder, Integer> cache = new NonBlockingHashMap<>();
 
    private final SimpleString address;
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -26,7 +26,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
@@ -121,7 +121,7 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
 
    private final int reaperPriority;
 
-   private final ConcurrentMap<SimpleString, DuplicateIDCache> duplicateIDCaches = new ConcurrentHashMap<>();
+   private final ConcurrentMap<SimpleString, DuplicateIDCache> duplicateIDCaches = new NonBlockingHashMap<>();
 
    private final int idCacheSize;
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/SimpleAddressManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/SimpleAddressManager.java
@@ -21,7 +21,7 @@ import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
@@ -45,17 +45,17 @@ public class SimpleAddressManager implements AddressManager {
 
    private static final Logger logger = Logger.getLogger(SimpleAddressManager.class);
 
-   private final ConcurrentMap<SimpleString, AddressInfo> addressInfoMap = new ConcurrentHashMap<>();
+   private final ConcurrentMap<SimpleString, AddressInfo> addressInfoMap = new NonBlockingHashMap<>();
 
    /**
     * HashMap<Address, Binding>
     */
-   private final ConcurrentMap<SimpleString, Bindings> mappings = new ConcurrentHashMap<>();
+   private final ConcurrentMap<SimpleString, Bindings> mappings = new NonBlockingHashMap<>();
 
    /**
     * HashMap<QueueName, Binding>
     */
-   private final ConcurrentMap<SimpleString, Binding> nameMap = new ConcurrentHashMap<>();
+   private final ConcurrentMap<SimpleString, Binding> nameMap = new NonBlockingHashMap<>();
 
    private final BindingsFactory bindingsFactory;
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/WildcardAddressManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/WildcardAddressManager.java
@@ -19,7 +19,7 @@ package org.apache.activemq.artemis.core.postoffice.impl;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.config.WildcardConfiguration;
@@ -48,9 +48,9 @@ public class WildcardAddressManager extends SimpleAddressManager {
     * These are all the addresses, we use this so we can link back from the actual address to its linked wilcard addresses
     * or vice versa
     */
-   private final Map<SimpleString, Address> addresses = new ConcurrentHashMap<>();
+   private final Map<SimpleString, Address> addresses = new NonBlockingHashMap<>();
 
-   private final Map<SimpleString, Address> wildCardAddresses = new ConcurrentHashMap<>();
+   private final Map<SimpleString, Address> wildCardAddresses = new NonBlockingHashMap<>();
 
    public WildcardAddressManager(final BindingsFactory bindingsFactory, final WildcardConfiguration wildcardConfiguration) {
       super(bindingsFactory, wildcardConfiguration);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/CoreProtocolManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/CoreProtocolManager.java
@@ -20,7 +20,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 
@@ -152,7 +152,7 @@ public class CoreProtocolManager implements ProtocolManager<Interceptor> {
       return entry;
    }
 
-   private final Map<String, ServerSessionPacketHandler> sessionHandlers = new ConcurrentHashMap<>();
+   private final Map<String, ServerSessionPacketHandler> sessionHandlers = new NonBlockingHashMap<>();
 
    ServerSessionPacketHandler getSessionHandler(final String sessionName) {
       return sessionHandlers.get(sessionName);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/registry/MapBindingRegistry.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/registry/MapBindingRegistry.java
@@ -16,14 +16,14 @@
  */
 package org.apache.activemq.artemis.core.registry;
 
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import org.apache.activemq.artemis.spi.core.naming.BindingRegistry;
 
 public class MapBindingRegistry implements BindingRegistry {
 
-   protected ConcurrentMap<String, Object> registry = new ConcurrentHashMap<>();
+   protected ConcurrentMap<String, Object> registry = new NonBlockingHashMap<>();
 
    @Override
    public Object lookup(String name) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMAcceptor.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMAcceptor.java
@@ -17,7 +17,7 @@
 package org.apache.activemq.artemis.core.remoting.impl.invm;
 
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 
@@ -50,7 +50,7 @@ public final class InVMAcceptor extends AbstractAcceptor {
 
    private final ServerConnectionLifeCycleListener listener;
 
-   private final ConcurrentMap<String, Connection> connections = new ConcurrentHashMap<>();
+   private final ConcurrentMap<String, Connection> connections = new NonBlockingHashMap<>();
 
    private volatile boolean started;
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMConnector.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMConnector.java
@@ -19,7 +19,7 @@ package org.apache.activemq.artemis.core.remoting.impl.invm;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -87,7 +87,7 @@ public class InVMConnector extends AbstractConnector {
 
    private final InVMAcceptor acceptor;
 
-   private final ConcurrentMap<String, Connection> connections = new ConcurrentHashMap<>();
+   private final ConcurrentMap<String, Connection> connections = new NonBlockingHashMap<>();
 
    private volatile boolean started;
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMRegistry.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMRegistry.java
@@ -16,16 +16,14 @@
  */
 package org.apache.activemq.artemis.core.remoting.impl.invm;
 
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-
 import org.apache.activemq.artemis.core.server.ActiveMQMessageBundle;
+import org.jctools.maps.NonBlockingHashMapLong;
 
 public final class InVMRegistry {
 
    public static final InVMRegistry instance = new InVMRegistry();
 
-   private final ConcurrentMap<Integer, InVMAcceptor> acceptors = new ConcurrentHashMap<>();
+   private final NonBlockingHashMapLong<InVMAcceptor> acceptors = new NonBlockingHashMapLong<>();
 
    public void registerAcceptor(final int id, final InVMAcceptor acceptor) {
       if (acceptors.putIfAbsent(id, acceptor) != null) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptor.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptor.java
@@ -29,7 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -154,7 +154,7 @@ public class NettyAcceptor extends AbstractAcceptor {
 
    private final int nioRemotingThreads;
 
-   private final ConcurrentMap<Object, NettyServerConnection> connections = new ConcurrentHashMap<>();
+   private final ConcurrentMap<Object, NettyServerConnection> connections = new NonBlockingHashMap<>();
 
    private final Map<String, Object> configuration;
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/server/impl/RemotingServiceImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/server/impl/RemotingServiceImpl.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.ServiceLoader;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
@@ -90,7 +90,7 @@ public class RemotingServiceImpl implements RemotingService, ServerConnectionLif
 
    private final Map<String, Acceptor> acceptors = new HashMap<>();
 
-   private final Map<Object, ConnectionEntry> connections = new ConcurrentHashMap<>();
+   private final Map<Object, ConnectionEntry> connections = new NonBlockingHashMap<>();
 
    private final ReusableLatch connectionCountLatch = new ReusableLatch(0);
 
@@ -108,7 +108,7 @@ public class RemotingServiceImpl implements RemotingService, ServerConnectionLif
 
    private final ClusterManager clusterManager;
 
-   private final Map<String, ProtocolManagerFactory> protocolMap = new ConcurrentHashMap<>();
+   private final Map<String, ProtocolManagerFactory> protocolMap = new NonBlockingHashMap<>();
 
    private ActiveMQPrincipal defaultInvmSecurityPrincipal;
 
@@ -233,7 +233,7 @@ public class RemotingServiceImpl implements RemotingService, ServerConnectionLif
       try {
          AcceptorFactory factory = server.getServiceRegistry().getAcceptorFactory(info.getName(), info.getFactoryClassName());
 
-         Map<String, ProtocolManagerFactory> selectedProtocolFactories = new ConcurrentHashMap<>();
+         Map<String, ProtocolManagerFactory> selectedProtocolFactories = new NonBlockingHashMap<>();
 
          @SuppressWarnings("deprecation")
          String protocol = ConfigurationHelper.getStringProperty(TransportConstants.PROTOCOL_PROP_NAME, null, info.getParams());
@@ -255,7 +255,7 @@ public class RemotingServiceImpl implements RemotingService, ServerConnectionLif
             selectedProtocolFactories = protocolMap;
          }
 
-         Map<String, ProtocolManager> selectedProtocols = new ConcurrentHashMap<>();
+         Map<String, ProtocolManager> selectedProtocols = new NonBlockingHashMap<>();
          for (Entry<String, ProtocolManagerFactory> entry : selectedProtocolFactories.entrySet()) {
             selectedProtocols.put(entry.getKey(), entry.getValue().createProtocolManager(server, info.getExtraParams(), incomingInterceptors, outgoingInterceptors));
          }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ClusterManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ClusterManager.java
@@ -62,7 +62,7 @@ import org.apache.activemq.artemis.core.server.impl.Activation;
 import org.apache.activemq.artemis.core.server.management.ManagementService;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
 import org.apache.activemq.artemis.spi.core.remoting.Acceptor;
-import org.apache.activemq.artemis.utils.ConcurrentHashSet;
+import org.jctools.maps.NonBlockingHashSet;
 import org.apache.activemq.artemis.utils.ExecutorFactory;
 import org.apache.activemq.artemis.utils.FutureLatch;
 import org.jboss.logging.Logger;
@@ -140,7 +140,7 @@ public final class ClusterManager implements ActiveMQComponent {
    // the cluster connections which links this node to other cluster nodes
    private final Map<String, ClusterConnection> clusterConnections = new HashMap<>();
 
-   private final Set<ServerLocatorInternal> clusterLocators = new ConcurrentHashSet<>();
+   private final Set<ServerLocatorInternal> clusterLocators = new NonBlockingHashSet<>();
 
    private final Executor executor;
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/impl/ClusterConnectionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/impl/ClusterConnectionImpl.java
@@ -24,7 +24,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -130,9 +130,9 @@ public final class ClusterConnectionImpl implements ClusterConnection, AfterConn
     * however we need the guard to synchronize multiple step operations during topology updates.
     */
    private final Object recordsGuard = new Object();
-   private final Map<String, MessageFlowRecord> records = new ConcurrentHashMap<>();
+   private final Map<String, MessageFlowRecord> records = new NonBlockingHashMap<>();
 
-   private final Map<String, MessageFlowRecord> disconnectedRecords = new ConcurrentHashMap<>();
+   private final Map<String, MessageFlowRecord> disconnectedRecords = new NonBlockingHashMap<>();
 
    private final ScheduledExecutorService scheduledExecutor;
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/group/impl/LocalGroupingHandler.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/group/impl/LocalGroupingHandler.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -50,9 +50,9 @@ public final class LocalGroupingHandler extends GroupHandlingAbstract {
 
    private static final Logger logger = Logger.getLogger(LocalGroupingHandler.class);
 
-   private final ConcurrentMap<SimpleString, GroupBinding> map = new ConcurrentHashMap<>();
+   private final ConcurrentMap<SimpleString, GroupBinding> map = new NonBlockingHashMap<>();
 
-   private final ConcurrentMap<SimpleString, List<GroupBinding>> groupMap = new ConcurrentHashMap<>();
+   private final ConcurrentMap<SimpleString, List<GroupBinding>> groupMap = new NonBlockingHashMap<>();
 
    private final SimpleString name;
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/group/impl/RemoteGroupingHandler.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/group/impl/RemoteGroupingHandler.java
@@ -19,7 +19,8 @@ package org.apache.activemq.artemis.core.server.group.impl;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Set;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
@@ -34,9 +35,9 @@ import org.apache.activemq.artemis.core.server.ActiveMQMessageBundle;
 import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
 import org.apache.activemq.artemis.core.server.management.ManagementService;
 import org.apache.activemq.artemis.core.server.management.Notification;
-import org.apache.activemq.artemis.utils.ConcurrentHashSet;
 import org.apache.activemq.artemis.utils.ExecutorFactory;
 import org.apache.activemq.artemis.utils.TypedProperties;
+import org.jctools.maps.NonBlockingHashSet;
 
 /**
  * A remote Grouping handler.
@@ -48,7 +49,7 @@ public final class RemoteGroupingHandler extends GroupHandlingAbstract {
 
    private final SimpleString name;
 
-   private final Map<SimpleString, Response> responses = new ConcurrentHashMap<>();
+   private final Map<SimpleString, Response> responses = new NonBlockingHashMap<>();
 
    private final Lock lock = new ReentrantLock();
 
@@ -58,9 +59,9 @@ public final class RemoteGroupingHandler extends GroupHandlingAbstract {
 
    private final long groupTimeout;
 
-   private final ConcurrentMap<SimpleString, List<SimpleString>> groupMap = new ConcurrentHashMap<>();
+   private final ConcurrentMap<SimpleString, List<SimpleString>> groupMap = new NonBlockingHashMap<>();
 
-   private final ConcurrentHashSet<Notification> pendingNotifications = new ConcurrentHashSet<>();
+   private final Set<Notification> pendingNotifications = new NonBlockingHashSet<>();
 
    private boolean started = false;
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -158,7 +158,7 @@ import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager;
 import org.apache.activemq.artemis.utils.ActiveMQThreadFactory;
 import org.apache.activemq.artemis.utils.ActiveMQThreadPoolExecutor;
 import org.apache.activemq.artemis.utils.CertificateUtil;
-import org.apache.activemq.artemis.utils.ConcurrentHashSet;
+import org.jctools.maps.NonBlockingHashSet;
 import org.apache.activemq.artemis.utils.ExecutorFactory;
 import org.apache.activemq.artemis.utils.OrderedExecutorFactory;
 import org.apache.activemq.artemis.utils.ReusableLatch;
@@ -275,7 +275,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
 
    private FileStoreMonitor fileStoreMonitor;
 
-   private final Map<String, ServerSession> sessions = new ConcurrentHashMap<>();
+   private final Map<String, ServerSession> sessions = new NonBlockingHashMap<>();
 
    private final Semaphore activationLock = new Semaphore(1);
    /**
@@ -284,13 +284,13 @@ public class ActiveMQServerImpl implements ActiveMQServer {
     */
    private final ReusableLatch activationLatch = new ReusableLatch(0);
 
-   private final Set<ActivateCallback> activateCallbacks = new ConcurrentHashSet<>();
+   private final Set<ActivateCallback> activateCallbacks = new NonBlockingHashSet<>();
 
-   private final Set<ActivationFailureListener> activationFailureListeners = new ConcurrentHashSet<>();
+   private final Set<ActivationFailureListener> activationFailureListeners = new NonBlockingHashSet<>();
 
-   private final Set<PostQueueCreationCallback> postQueueCreationCallbacks = new ConcurrentHashSet<>();
+   private final Set<PostQueueCreationCallback> postQueueCreationCallbacks = new NonBlockingHashSet<>();
 
-   private final Set<PostQueueDeletionCallback> postQueueDeletionCallbacks = new ConcurrentHashSet<>();
+   private final Set<PostQueueDeletionCallback> postQueueDeletionCallbacks = new NonBlockingHashSet<>();
 
    private volatile GroupingHandler groupingHandler;
 
@@ -322,7 +322,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
 
    private final List<ActiveMQComponent> externalComponents = new ArrayList<>();
 
-   private final ConcurrentMap<String, AtomicInteger> connectedClientIds = new ConcurrentHashMap();
+   private final ConcurrentMap<String, AtomicInteger> connectedClientIds = new NonBlockingHashMap();
 
    private final ActiveMQComponent networkCheckMonitor = new ActiveMQComponent() {
       @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/LastValueQueue.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/LastValueQueue.java
@@ -17,7 +17,7 @@
 package org.apache.activemq.artemis.core.server.impl;
 
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -46,7 +46,7 @@ import org.apache.activemq.artemis.core.transaction.Transaction;
  */
 public class LastValueQueue extends QueueImpl {
 
-   private final Map<SimpleString, HolderReference> map = new ConcurrentHashMap<>();
+   private final Map<SimpleString, HolderReference> map = new NonBlockingHashMap<>();
 
    public LastValueQueue(final long persistenceID,
                          final SimpleString address,

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
@@ -85,7 +85,7 @@ import org.apache.activemq.artemis.core.transaction.TransactionPropertyIndexes;
 import org.apache.activemq.artemis.core.transaction.impl.BindingsTransactionImpl;
 import org.apache.activemq.artemis.core.transaction.impl.TransactionImpl;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
-import org.apache.activemq.artemis.utils.ConcurrentHashSet;
+import org.jctools.maps.NonBlockingHashSet;
 import org.apache.activemq.artemis.utils.FutureLatch;
 import org.apache.activemq.artemis.utils.LinkedListIterator;
 import org.apache.activemq.artemis.utils.PriorityLinkedList;
@@ -202,7 +202,7 @@ public class QueueImpl implements Queue {
 
    private Redistributor redistributor;
 
-   private final Set<ScheduledFuture<?>> futures = new ConcurrentHashSet<>();
+   private final Set<ScheduledFuture<?>> futures = new NonBlockingHashSet<>();
 
    private ScheduledFuture<?> redistributorFuture;
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ScheduledDeliveryHandlerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ScheduledDeliveryHandlerImpl.java
@@ -24,7 +24,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -34,6 +33,7 @@ import org.apache.activemq.artemis.core.server.MessageReference;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.server.ScheduledDeliveryHandler;
 import org.jboss.logging.Logger;
+import org.jctools.maps.NonBlockingHashMapLong;
 
 /**
  * Handles scheduling deliveries to a queue at the correct time.
@@ -44,7 +44,7 @@ public class ScheduledDeliveryHandlerImpl implements ScheduledDeliveryHandler {
 
    private final ScheduledExecutorService scheduledExecutor;
 
-   private final Map<Long, Runnable> runnables = new ConcurrentHashMap<>();
+   private final NonBlockingHashMapLong<Runnable> runnables = new NonBlockingHashMapLong<>();
 
    // This contains RefSchedules which are delegates to the real references
    // just adding some information to keep it in order accordingly to the initial operations

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -28,7 +28,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
@@ -92,6 +91,7 @@ import org.apache.activemq.artemis.utils.PrefixUtil;
 import org.apache.activemq.artemis.utils.TypedProperties;
 import org.apache.activemq.artemis.utils.UUID;
 import org.jboss.logging.Logger;
+import org.jctools.maps.NonBlockingHashMapLong;
 
 import static org.apache.activemq.artemis.api.core.JsonUtil.nullSafe;
 
@@ -127,7 +127,7 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
 
    protected final RemotingConnection remotingConnection;
 
-   protected final Map<Long, ServerConsumer> consumers = new ConcurrentHashMap<>();
+   protected final NonBlockingHashMapLong<ServerConsumer> consumers = new NonBlockingHashMapLong<>();
 
    protected Transaction tx;
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServiceRegistryImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServiceRegistryImpl.java
@@ -23,7 +23,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -63,10 +63,10 @@ public class ServiceRegistryImpl implements ServiceRegistry {
    public ServiceRegistryImpl() {
       this.incomingInterceptors = Collections.synchronizedList(new ArrayList<BaseInterceptor>());
       this.outgoingInterceptors = Collections.synchronizedList(new ArrayList<BaseInterceptor>());
-      this.connectorServices = new ConcurrentHashMap<>();
-      this.divertTransformers = new ConcurrentHashMap<>();
-      this.bridgeTransformers = new ConcurrentHashMap<>();
-      this.acceptorFactories = new ConcurrentHashMap<>();
+      this.connectorServices = new NonBlockingHashMap<>();
+      this.divertTransformers = new NonBlockingHashMap<>();
+      this.bridgeTransformers = new NonBlockingHashMap<>();
+      this.acceptorFactories = new NonBlockingHashMap<>();
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/impl/ManagementServiceImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/impl/ManagementServiceImpl.java
@@ -29,7 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.apache.activemq.artemis.api.core.BroadcastGroupConfiguration;
@@ -85,7 +85,7 @@ import org.apache.activemq.artemis.core.settings.HierarchicalRepository;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.core.transaction.ResourceManager;
 import org.apache.activemq.artemis.spi.core.remoting.Acceptor;
-import org.apache.activemq.artemis.utils.ConcurrentHashSet;
+import org.jctools.maps.NonBlockingHashSet;
 import org.apache.activemq.artemis.utils.TypedProperties;
 import org.jboss.logging.Logger;
 
@@ -130,7 +130,7 @@ public class ManagementServiceImpl implements ManagementService {
 
    private boolean notificationsEnabled;
 
-   private final Set<NotificationListener> listeners = new ConcurrentHashSet<>();
+   private final Set<NotificationListener> listeners = new NonBlockingHashSet<>();
 
    private final ObjectNameBuilder objectNameBuilder;
 
@@ -145,7 +145,7 @@ public class ManagementServiceImpl implements ManagementService {
       managementAddress = configuration.getManagementAddress();
       managementNotificationAddress = configuration.getManagementNotificationAddress();
 
-      registry = new ConcurrentHashMap<>();
+      registry = new NonBlockingHashMap<>();
       broadcaster = new NotificationBroadcasterSupport();
       notificationsEnabled = true;
       objectNameBuilder = ObjectNameBuilder.create(configuration.getJMXDomain(), configuration.getName(), configuration.isJMXUseBrokerName());

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/HierarchicalObjectRepository.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/HierarchicalObjectRepository.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
@@ -71,7 +71,7 @@ public class HierarchicalObjectRepository<T> implements HierarchicalRepository<T
    /**
     * a cache
     */
-   private final Map<String, T> cache = new ConcurrentHashMap<>();
+   private final Map<String, T> cache = new NonBlockingHashMap<>();
 
    /**
     * Need a lock instead of using multiple {@link ConcurrentHashMap}s.

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/transaction/impl/ResourceManagerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/transaction/impl/ResourceManagerImpl.java
@@ -25,7 +25,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
@@ -37,7 +37,7 @@ import org.apache.activemq.artemis.core.transaction.Transaction;
 
 public class ResourceManagerImpl implements ResourceManager {
 
-   private final ConcurrentMap<Xid, Transaction> transactions = new ConcurrentHashMap<>();
+   private final ConcurrentMap<Xid, Transaction> transactions = new NonBlockingHashMap<>();
 
    private final List<HeuristicCompletionHolder> heuristicCompletions = new ArrayList<>();
 

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/group/impl/ClusteredResetMockTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/group/impl/ClusteredResetMockTest.java
@@ -57,8 +57,8 @@ import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.core.transaction.ResourceManager;
 import org.apache.activemq.artemis.spi.core.remoting.Acceptor;
 import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
-import org.apache.activemq.artemis.utils.ConcurrentHashSet;
 import org.apache.activemq.artemis.utils.ReusableLatch;
+import org.jctools.maps.NonBlockingHashSet;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -171,7 +171,7 @@ public class ClusteredResetMockTest extends ActiveMQTestBase {
 
    class FakeManagement implements ManagementService {
 
-      public ConcurrentHashSet<Notification> pendingNotifications = new ConcurrentHashSet<>();
+      public Set<Notification> pendingNotifications = new NonBlockingHashSet<>();
 
       final ReusableLatch latch;
 

--- a/examples/features/standard/message-group/src/main/java/org/apache/activemq/artemis/jms/example/MessageGroupExample.java
+++ b/examples/features/standard/message-group/src/main/java/org/apache/activemq/artemis/jms/example/MessageGroupExample.java
@@ -26,7 +26,7 @@ import javax.jms.Queue;
 import javax.jms.Session;
 import javax.jms.TextMessage;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
@@ -37,7 +37,7 @@ import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 public class MessageGroupExample {
 
    public static void main(final String[] args) throws Exception {
-      final Map<String, String> messageReceiverMap = new ConcurrentHashMap<>();
+      final Map<String, String> messageReceiverMap = new NonBlockingHashMap<>();
       Connection connection = null;
       try {
 

--- a/examples/features/standard/message-group2/src/main/java/org/apache/activemq/artemis/jms/example/MessageGroup2Example.java
+++ b/examples/features/standard/message-group2/src/main/java/org/apache/activemq/artemis/jms/example/MessageGroup2Example.java
@@ -26,7 +26,7 @@ import javax.jms.Queue;
 import javax.jms.Session;
 import javax.jms.TextMessage;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
@@ -39,7 +39,7 @@ public class MessageGroup2Example {
    private boolean result = true;
 
    public static void main(String[] args) throws Exception {
-      final Map<String, String> messageReceiverMap = new ConcurrentHashMap<>();
+      final Map<String, String> messageReceiverMap = new NonBlockingHashMap<>();
       Connection connection = null;
       try {
          //Step 2. Perform a lookup on the queue

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,7 @@
       <arquillian-weld-embedded.version>2.0.0.Beta3</arquillian-weld-embedded.version>
       <owb.version>1.7.0</owb.version>
       <arquillian.version>1.1.11.Final</arquillian.version>
+      <jctools-core.version>2.0</jctools-core.version>
 
       <owasp.version>1.4.3</owasp.version>
 
@@ -654,6 +655,12 @@
             <artifactId>cdi-api</artifactId>
             <version>${cdi-api.version}</version>
             <scope>provided</scope>
+         </dependency>
+         <dependency>
+            <groupId>org.jctools</groupId>
+            <artifactId>jctools-core</artifactId>
+            <version>${jctools-core.version}</version>
+            <!-- License: Apache 2.0 -->
          </dependency>
       </dependencies>
    </dependencyManagement>

--- a/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/JmsRollbackRedeliveryTest.java
+++ b/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/JmsRollbackRedeliveryTest.java
@@ -26,7 +26,7 @@ import javax.jms.MessageProducer;
 import javax.jms.Session;
 import javax.jms.TextMessage;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.activemq.broker.BrokerService;
@@ -112,7 +112,7 @@ public class JmsRollbackRedeliveryTest {
       // Consume messages and rollback transactions
       {
          AtomicInteger received = new AtomicInteger();
-         Map<String, Boolean> rolledback = new ConcurrentHashMap<>();
+         Map<String, Boolean> rolledback = new NonBlockingHashMap<>();
          while (received.get() < nbMessages) {
             Session session = connection.createSession(true, Session.AUTO_ACKNOWLEDGE);
             Destination destination = session.createQueue(destinationName);
@@ -148,7 +148,7 @@ public class JmsRollbackRedeliveryTest {
       // Consume messages and rollback transactions
       {
          AtomicInteger received = new AtomicInteger();
-         Map<String, Boolean> rolledback = new ConcurrentHashMap<>();
+         Map<String, Boolean> rolledback = new NonBlockingHashMap<>();
          Session session = connection.createSession(true, Session.AUTO_ACKNOWLEDGE);
          Destination destination = session.createQueue(destinationName);
          MessageConsumer consumer = session.createConsumer(destination);
@@ -182,7 +182,7 @@ public class JmsRollbackRedeliveryTest {
       // Consume messages and rollback transactions
       {
          AtomicInteger received = new AtomicInteger();
-         Map<String, Boolean> rolledback = new ConcurrentHashMap<>();
+         Map<String, Boolean> rolledback = new NonBlockingHashMap<>();
          Session session = connection.createSession(true, Session.AUTO_ACKNOWLEDGE);
          Destination destination = session.createQueue(destinationName);
          while (received.get() < nbMessages) {

--- a/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/transport/tcp/SocketTstFactory.java
+++ b/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/transport/tcp/SocketTstFactory.java
@@ -22,7 +22,7 @@ import java.net.InetAddress;
 import java.net.Socket;
 import java.net.UnknownHostException;
 import java.util.Random;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import org.slf4j.Logger;
@@ -35,7 +35,7 @@ public class SocketTstFactory extends SocketFactory {
 
    private static final Logger LOG = LoggerFactory.getLogger(SocketTstFactory.class);
 
-   private static final ConcurrentMap<InetAddress, Integer> closeIter = new ConcurrentHashMap<>();
+   private static final ConcurrentMap<InetAddress, Integer> closeIter = new NonBlockingHashMap<>();
 
    private class SocketTst {
 

--- a/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/usecases/ConcurrentProducerDurableConsumerTest.java
+++ b/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/usecases/ConcurrentProducerDurableConsumerTest.java
@@ -36,7 +36,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -395,7 +395,7 @@ public class ConcurrentProducerDurableConsumerTest extends TestSupport {
       long batchReceiptAccumulator = 0;
       long maxReceiptTime = 0;
       AtomicLong count = new AtomicLong(0);
-      Map<Integer, MessageIdList> messageLists = new ConcurrentHashMap<>(new HashMap<Integer, MessageIdList>());
+      Map<Integer, MessageIdList> messageLists = new NonBlockingHashMap<>(new HashMap<Integer, MessageIdList>());
 
       @Override
       public void onMessage(Message message) {

--- a/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/usecases/ConcurrentProducerQueueConsumerTest.java
+++ b/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/usecases/ConcurrentProducerQueueConsumerTest.java
@@ -34,7 +34,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -349,7 +349,7 @@ public class ConcurrentProducerQueueConsumerTest extends TestSupport {
       long batchReceiptAccumulator = 0;
       long maxReceiptTime = 0;
 
-      final Map<Integer, MessageIdList> messageLists = new ConcurrentHashMap<>(new HashMap<Integer, MessageIdList>());
+      final Map<Integer, MessageIdList> messageLists = new NonBlockingHashMap<>(new HashMap<Integer, MessageIdList>());
 
       @Override
       public void onMessage(Message message) {

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/benchmarks/journal/JournalImplAppendTptBench.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/benchmarks/journal/JournalImplAppendTptBench.java
@@ -1,0 +1,111 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.tests.extras.benchmarks.journal;
+
+import java.io.File;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+
+import io.netty.util.internal.shaded.org.jctools.util.UnsafeAccess;
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.core.io.DummyCallback;
+import org.apache.activemq.artemis.core.io.SequentialFileFactory;
+import org.apache.activemq.artemis.core.io.nio.NIOSequentialFileFactory;
+import org.apache.activemq.artemis.core.journal.EncodingSupport;
+import org.apache.activemq.artemis.core.journal.impl.JournalImpl;
+
+public class JournalImplAppendTptBench {
+
+   private static final int FILE_SIZE = 1024 * 1024 * 1024;
+   private static final int ITERATIONS = 100_000;
+   private static final int WARMUP_ITERATIONS = 20_000;
+   private static final int TESTS = 10;
+   private static int TOTAL_MESSAGES = (ITERATIONS * TESTS + WARMUP_ITERATIONS);
+   private static int ENCODED_SIZE = 8;
+   private static final EncodingSupport encodingSupport = new EncodingSupport() {
+      @Override
+      public int getEncodeSize() {
+         return ENCODED_SIZE;
+      }
+
+      @Override
+      public void encode(ActiveMQBuffer buffer) {
+         buffer.writerIndex(buffer.writerIndex() + ENCODED_SIZE);
+      }
+
+      @Override
+      public void decode(ActiveMQBuffer buffer) {
+         throw new UnsupportedOperationException();
+      }
+   };
+   private static byte RECORD_TYPE = (byte) 1;
+
+   public static void main(String[] args) throws Exception {
+      int numFiles = (int) ((TOTAL_MESSAGES * 1024 + 512) / FILE_SIZE * 1.3);
+      if (numFiles < 2) {
+         numFiles = 2;
+      }
+      final File journalDir = new File(System.getProperty("java.io.tmpdir"));
+      final SequentialFileFactory sequentialFileFactory = new NIOSequentialFileFactory(journalDir, false, 0, 0, 1, false, (code, message, file) -> {
+      }) {
+
+         private final ByteBuffer buffer = ByteBuffer.allocateDirect(UnsafeAccess.UNSAFE.pageSize());
+
+         @Override
+         public ByteBuffer newBuffer(int size) {
+            //little trick to reduce GC pressure
+            if (size > buffer.capacity())
+               throw new IllegalStateException("IMPOSSIBLE!");
+            this.buffer.clear();
+            this.buffer.limit(size);
+            return this.buffer;
+         }
+
+         @Override
+         public boolean isSupportsCallbacks() {
+            return true;
+         }
+      };
+      final JournalImpl journal = new JournalImpl(() -> Runnable::run, FILE_SIZE, numFiles, numFiles, 0, 0, sequentialFileFactory, "activemq-data", "amq", 1, 0);
+      journal.start();
+      journal.load(new ArrayList<>(), null, null);
+      try {
+         long id = 0;
+         for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+            journal.appendAddRecord(id, RECORD_TYPE, encodingSupport, false, DummyCallback.getInstance());
+            id++;
+         }
+         for (int t = 0; t < TESTS; t++) {
+            System.gc();
+            final long start = System.nanoTime();
+            for (int i = 0; i < ITERATIONS; i++) {
+               journal.appendAddRecord(id, RECORD_TYPE, encodingSupport, false, DummyCallback.getInstance());
+               id++;
+            }
+            final long elapsed = System.nanoTime() - start;
+            System.out.println((ITERATIONS * 1000_000_000L) / elapsed);
+         }
+      } finally {
+         journal.stop();
+         for (File file : journalDir.listFiles()) {
+            file.deleteOnExit();
+         }
+      }
+   }
+
+}

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/jms/ra/MDBMultipleHandlersServerDisconnectTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/jms/ra/MDBMultipleHandlersServerDisconnectTest.java
@@ -31,7 +31,9 @@ import java.io.StringWriter;
 import java.lang.reflect.Method;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
+
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -64,7 +66,7 @@ import org.junit.Test;
  */
 public class MDBMultipleHandlersServerDisconnectTest extends ActiveMQRATestBase {
 
-   final ConcurrentHashMap<Integer, AtomicInteger> mapCounter = new ConcurrentHashMap<>();
+   final ConcurrentMap<Integer, AtomicInteger> mapCounter = new NonBlockingHashMap<>();
 
    volatile ActiveMQResourceAdapter resourceAdapter;
 

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/protocols/hornetq/HornetQProtocolManagerTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/protocols/hornetq/HornetQProtocolManagerTest.java
@@ -23,7 +23,7 @@ import javax.jms.MessageProducer;
 import javax.jms.Queue;
 import javax.jms.Session;
 import javax.jms.TextMessage;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
@@ -85,8 +85,8 @@ public class HornetQProtocolManagerTest extends ActiveMQTestBase {
       connectionFactory2.createConnection().close();
 
       RecoveryManager manager = new RecoveryManager();
-      manager.register(connectionFactory, null, null, new ConcurrentHashMap<String, String>());
-      manager.register(connectionFactory2, null, null, new ConcurrentHashMap<String, String>());
+      manager.register(connectionFactory, null, null, new NonBlockingHashMap<String, String>());
+      manager.register(connectionFactory2, null, null, new NonBlockingHashMap<String, String>());
 
       for (XARecoveryConfig resource : manager.getResources()) {
          try (ServerLocator locator = resource.createServerLocator();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ConsumerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ConsumerTest.java
@@ -41,7 +41,7 @@ import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
 import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
-import org.apache.activemq.artemis.utils.ConcurrentHashSet;
+import org.jctools.maps.NonBlockingHashSet;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -371,7 +371,7 @@ public class ConsumerTest extends ActiveMQTestBase {
    @Test
    public void testReceiveAndResend() throws Exception {
 
-      final Set<Object> sessions = new ConcurrentHashSet<>();
+      final Set<Object> sessions = new NonBlockingHashSet<>();
       final AtomicInteger errors = new AtomicInteger(0);
 
       final SimpleString QUEUE_RESPONSE = SimpleString.toSimpleString("QUEUE_RESPONSE");

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/QuorumFailOverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/QuorumFailOverTest.java
@@ -17,7 +17,7 @@
 package org.apache.activemq.artemis.tests.integration.cluster.failover;
 
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.activemq.artemis.api.core.Pair;
@@ -102,7 +102,7 @@ public class QuorumFailOverTest extends StaticClusterWithBackupFailoverTest {
    private static class TopologyListener implements ClusterTopologyListener {
 
       final String prefix;
-      final Map<String, Pair<TransportConfiguration, TransportConfiguration>> nodes = new ConcurrentHashMap<>();
+      final Map<String, Pair<TransportConfiguration, TransportConfiguration>> nodes = new NonBlockingHashMap<>();
 
       private TopologyListener(String string) {
          prefix = string;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/imported/MQTTTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/imported/MQTTTest.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
@@ -51,12 +51,12 @@ import org.fusesource.mqtt.client.Topic;
 import org.fusesource.mqtt.client.Tracer;
 import org.fusesource.mqtt.codec.MQTTFrame;
 import org.fusesource.mqtt.codec.PUBLISH;
+import org.jctools.maps.NonBlockingHashSet;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.vertx.java.core.impl.ConcurrentHashSet;
 
 /**
  * QT
@@ -73,11 +73,11 @@ public class MQTTTest extends MQTTTestSupport {
    public void setUp() throws Exception {
       Field sessions = MQTTSession.class.getDeclaredField("SESSIONS");
       sessions.setAccessible(true);
-      sessions.set(null, new ConcurrentHashMap<>());
+      sessions.set(null, new NonBlockingHashMap<>());
 
       Field connectedClients = MQTTConnectionManager.class.getDeclaredField("CONNECTED_CLIENTS");
       connectedClients.setAccessible(true);
-      connectedClients.set(null, new ConcurrentHashSet<>());
+      connectedClients.set(null, new NonBlockingHashSet<>());
       super.setUp();
 
    }
@@ -825,7 +825,7 @@ public class MQTTTest extends MQTTTestSupport {
       final MQTT mqtt = createMQTTConnection("nonclean-packetid", false);
       mqtt.setKeepAlive((short) 15);
 
-      final Map<Short, PUBLISH> publishMap = new ConcurrentHashMap<>();
+      final Map<Short, PUBLISH> publishMap = new NonBlockingHashMap<>();
       mqtt.setTracer(new Tracer() {
          @Override
          public void onReceive(MQTTFrame frame) {
@@ -899,7 +899,7 @@ public class MQTTTest extends MQTTTestSupport {
    // If there is a good reason for this we should follow ActiveMQ.
    public void testPacketIdGeneratorCleanSession() throws Exception {
       final String[] cleanClientIds = new String[]{"", "clean-packetid", null};
-      final Map<Short, PUBLISH> publishMap = new ConcurrentHashMap<>();
+      final Map<Short, PUBLISH> publishMap = new NonBlockingHashMap<>();
       MQTT[] mqtts = new MQTT[cleanClientIds.length];
       for (int i = 0; i < cleanClientIds.length; i++) {
          mqtts[i] = createMQTTConnection("", true);

--- a/tests/joram-tests/src/test/java/org/apache/activemq/artemis/common/testjndi/TestContextFactory.java
+++ b/tests/joram-tests/src/test/java/org/apache/activemq/artemis/common/testjndi/TestContextFactory.java
@@ -24,7 +24,7 @@ import javax.naming.NamingException;
 import javax.naming.spi.InitialContextFactory;
 import java.util.Hashtable;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
 import org.apache.activemq.artemis.jndi.LazyCreateContext;
@@ -50,7 +50,7 @@ public class TestContextFactory implements InitialContextFactory {
    @Override
    public Context getInitialContext(Hashtable<?, ?> environment) throws NamingException {
       // lets create a factory
-      Map<String, Object> data = new ConcurrentHashMap<>();
+      Map<String, Object> data = new NonBlockingHashMap<>();
       for (Map.Entry<?, ?> entry : environment.entrySet()) {
          String key = entry.getKey().toString();
          if (key.startsWith(connectionFactoryPrefix)) {

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/fakes/FakeSequentialFileFactory.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/fakes/FakeSequentialFileFactory.java
@@ -22,7 +22,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import org.jctools.maps.NonBlockingHashMap;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
@@ -35,7 +35,7 @@ import org.apache.activemq.artemis.core.journal.EncodingSupport;
 
 public class FakeSequentialFileFactory implements SequentialFileFactory {
 
-   private final Map<String, FakeSequentialFile> fileMap = new ConcurrentHashMap<>();
+   private final Map<String, FakeSequentialFile> fileMap = new NonBlockingHashMap<>();
 
    private final int alignment;
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/paging/impl/PagingStoreImplTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/paging/impl/PagingStoreImplTest.java
@@ -20,8 +20,6 @@ import java.io.File;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -62,6 +60,7 @@ import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.ActiveMQThreadFactory;
 import org.apache.activemq.artemis.utils.ExecutorFactory;
 import org.apache.activemq.artemis.utils.RandomUtil;
+import org.jctools.maps.NonBlockingHashMapLong;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -374,7 +373,7 @@ public class PagingStoreImplTest extends ActiveMQTestBase {
 
       final CountDownLatch latchStart = new CountDownLatch(numberOfThreads);
 
-      final ConcurrentHashMap<Long, ServerMessage> buffers = new ConcurrentHashMap<>();
+      final NonBlockingHashMapLong<ServerMessage> buffers = new NonBlockingHashMapLong<>();
 
       final ArrayList<Page> readPages = new ArrayList<>();
 
@@ -477,7 +476,7 @@ public class PagingStoreImplTest extends ActiveMQTestBase {
          throw consumer.e;
       }
 
-      final ConcurrentMap<Long, ServerMessage> buffers2 = new ConcurrentHashMap<>();
+      final NonBlockingHashMapLong<ServerMessage> buffers2 = new NonBlockingHashMapLong<>();
 
       for (Page page : readPages) {
          page.open();


### PR DESCRIPTION
It's a total replacement of ConcurrentHasMap and ConcurrentHashSet usage with faster and lower memory footprint versions of jctools; a high performance concurrent collections library.