### PR TITLE
Couple of fixes

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/queue/CreateQueue.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/queue/CreateQueue.java
@@ -36,7 +36,7 @@ public class CreateQueue extends QueueAbstract {
       performCoreManagement(new ManagementCallback<ClientMessage>() {
          @Override
          public void setUpInvocation(ClientMessage message) throws Exception {
-            ManagementHelper.putOperationInvocation(message, "broker", "createQueue", getAddress(true), getRoutingType(), getName(), getFilter(), isDurable(), getMaxConsumers(-1), isDeleteOnNoConsumers(true), isAutoCreateAddress());
+            ManagementHelper.putOperationInvocation(message, "broker", "createQueue", getAddress(true), getRoutingType(), getName(), getFilter(), isDurable(), getMaxConsumers(-1), isPurgeOnNoConsumers(true), isAutoCreateAddress());
          }
 
          @Override

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/queue/QueueAbstract.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/queue/QueueAbstract.java
@@ -37,11 +37,11 @@ public class QueueAbstract extends AbstractAction {
    @Option(name = "--no-durable", description = "whether the queue is durable or not (default input)")
    private Boolean noDurable;
 
-   @Option(name = "--delete-on-no-consumers", description = "whether to delete this queue when it's last consumers disconnects (default input)")
-   private Boolean deleteOnNoConsumers;
+   @Option(name = "--purge-on-no-consumers", description = "whether to delete the contents of this queue when its last consumer disconnects (default input)")
+   private Boolean purgeOnNoConsumers;
 
-   @Option(name = "--keep-on-no-consumers", description = "whether to queue this queue when it's last consumers disconnects (default input)")
-   private Boolean keepOnNoConsumers;
+   @Option(name = "--preserve-on-no-consumers", description = "whether to preserve the contents of this queue when its last consumer disconnects (default input)")
+   private Boolean preserveOnNoConsumers;
 
    @Option(name = "--max-consumers", description = "Maximum number of consumers allowed on this queue at any one time (default no limit)")
    private Integer maxConsumers;
@@ -97,12 +97,12 @@ public class QueueAbstract extends AbstractAction {
       return this;
    }
 
-   public boolean isKeepOnNoConsumers() {
-      return keepOnNoConsumers;
+   public boolean getPreserveOnNoConsumers() {
+      return preserveOnNoConsumers;
    }
 
-   public QueueAbstract setKeepOnNoConsumers(boolean keepOnNoConsumers) {
-      this.keepOnNoConsumers = keepOnNoConsumers;
+   public QueueAbstract setPreserveOnNoConsumers(boolean preserveOnNoConsumers) {
+      this.preserveOnNoConsumers = preserveOnNoConsumers;
       return this;
    }
 
@@ -165,23 +165,23 @@ public class QueueAbstract extends AbstractAction {
       return this;
    }
 
-   public Boolean isDeleteOnNoConsumers() {
-      return isDeleteOnNoConsumers(false);
+   public Boolean isPurgeOnNoConsumers() {
+      return isPurgeOnNoConsumers(false);
    }
 
-   public Boolean isDeleteOnNoConsumers(boolean useInput) {
+   public Boolean isPurgeOnNoConsumers(boolean useInput) {
 
       Boolean value = null;
 
-      if (deleteOnNoConsumers != null) {
-         value = deleteOnNoConsumers.booleanValue();
-      } else if (keepOnNoConsumers != null) {
-         value = !keepOnNoConsumers.booleanValue();
+      if (purgeOnNoConsumers != null) {
+         value = purgeOnNoConsumers.booleanValue();
+      } else if (preserveOnNoConsumers != null) {
+         value = !preserveOnNoConsumers.booleanValue();
       }
 
 
       if (value == null && useInput) {
-         value = inputBoolean("--delete-on-no-consumers", "Delete on non consumers", false);
+         value = inputBoolean("--purge-on-no-consumers", "Purge the contents of the queue once there are no consumers", false);
       }
 
       if (value == null) {
@@ -189,8 +189,8 @@ public class QueueAbstract extends AbstractAction {
          return null;
       }
 
-      deleteOnNoConsumers = value.booleanValue();
-      keepOnNoConsumers = !value.booleanValue();
+      purgeOnNoConsumers = value.booleanValue();
+      preserveOnNoConsumers = !value.booleanValue();
 
       return value;
    }
@@ -199,8 +199,8 @@ public class QueueAbstract extends AbstractAction {
       this.maxConsumers = maxConsumers;
    }
 
-   public void setDeleteOnNoConsumers(boolean deleteOnNoConsumers) {
-      this.deleteOnNoConsumers = deleteOnNoConsumers;
+   public void setPurgeOnNoConsumers(boolean purgeOnNoConsumers) {
+      this.purgeOnNoConsumers = purgeOnNoConsumers;
    }
 
    public void setAddress(String address) {

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/queue/UpdateQueue.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/queue/UpdateQueue.java
@@ -36,7 +36,7 @@ public class UpdateQueue extends QueueAbstract {
       performCoreManagement(new ManagementCallback<ClientMessage>() {
          @Override
          public void setUpInvocation(ClientMessage message) throws Exception {
-            ManagementHelper.putOperationInvocation(message, "broker", "updateQueue", getName(), getRoutingType(), getMaxConsumers(null), isDeleteOnNoConsumers());
+            ManagementHelper.putOperationInvocation(message, "broker", "updateQueue", getName(), getRoutingType(), getMaxConsumers(null), isPurgeOnNoConsumers());
          }
 
          @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
@@ -446,7 +446,7 @@ public final class ActiveMQDefaultConfiguration {
 
    public static final int DEFAULT_MAX_QUEUE_CONSUMERS = -1;
 
-   public static final boolean DEFAULT_DELETE_QUEUE_ON_NO_CONSUMERS = false;
+   public static final boolean DEFAULT_PURGE_ON_NO_CONSUMERS = false;
 
    public static final RoutingType DEFAULT_ROUTING_TYPE = RoutingType.MULTICAST;
 
@@ -1217,8 +1217,8 @@ public final class ActiveMQDefaultConfiguration {
       return DEFAULT_MAX_QUEUE_CONSUMERS;
    }
 
-   public static boolean getDefaultDeleteQueueOnNoConsumers() {
-      return DEFAULT_DELETE_QUEUE_ON_NO_CONSUMERS;
+   public static boolean getDefaultPurgeOnNoConsumers() {
+      return DEFAULT_PURGE_ON_NO_CONSUMERS;
    }
 
    public static String getInternalNamingPrefix() {

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/client/ClientSession.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/client/ClientSession.java
@@ -71,7 +71,7 @@ public interface ClientSession extends XAResource, AutoCloseable {
        */
       boolean isAutoCreateAddresses();
 
-      boolean isDefaultDeleteOnNoConsumers();
+      boolean isDefaultPurgeOnNoConsumers();
 
       int getDefaultMaxConsumers();
    }
@@ -135,7 +135,7 @@ public interface ClientSession extends XAResource, AutoCloseable {
 
       int getMaxConsumers();
 
-      boolean isDeleteOnNoConsumers();
+      boolean isPurgeOnNoConsumers();
 
       boolean isAutoCreated();
    }
@@ -524,11 +524,11 @@ public interface ClientSession extends XAResource, AutoCloseable {
     * @param durable      whether the queue is durable or not
     * @param autoCreated  whether to mark this queue as autoCreated or not
     * @param maxConsumers how many concurrent consumers will be allowed on this queue
-    * @param deleteOnNoConsumers whether to delete the queue when the last consumer disconnects
+    * @param purgeOnNoConsumers whether to delete the contents of the queue when the last consumer disconnects
     * @throws ActiveMQException
     */
    void createQueue(SimpleString address, RoutingType routingType, SimpleString queueName, SimpleString filter,
-                    boolean durable, boolean autoCreated, int maxConsumers, boolean deleteOnNoConsumers) throws ActiveMQException;
+                    boolean durable, boolean autoCreated, int maxConsumers, boolean purgeOnNoConsumers) throws ActiveMQException;
 
    /**
     * Creates a <em>non-temporary</em>queue.
@@ -553,11 +553,11 @@ public interface ClientSession extends XAResource, AutoCloseable {
     * @param durable     whether the queue is durable or not
     * @param autoCreated whether to mark this queue as autoCreated or not
     * @param maxConsumers how many concurrent consumers will be allowed on this queue
-    * @param deleteOnNoConsumers whether to delete the queue when the last consumer disconnects
+    * @param purgeOnNoConsumers whether to delete the contents of the queue when the last consumer disconnects
     * @throws ActiveMQException
     */
    void createQueue(String address, RoutingType routingType, String queueName, String filter, boolean durable, boolean autoCreated,
-                           int maxConsumers, boolean deleteOnNoConsumers) throws ActiveMQException;
+                           int maxConsumers, boolean purgeOnNoConsumers) throws ActiveMQException;
 
    /**
     * Creates a <em>temporary</em> queue.

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
@@ -565,7 +565,7 @@ public interface ActiveMQServerControl {
     * @param filterStr           filter of the queue
     * @param durable             is the queue durable?
     * @param maxConsumers        the maximum number of consumers allowed on this queue at any one time
-    * @param deleteOnNoConsumers delete this queue when the last consumer disconnects
+    * @param purgeOnNoConsumers delete this queue when the last consumer disconnects
     * @param autoCreateAddress   create an address with default values should a matching address not be found
     * @return a textual summary of the queue
     * @throws Exception
@@ -576,7 +576,7 @@ public interface ActiveMQServerControl {
                     @Parameter(name = "filter", desc = "Filter of the queue") String filterStr,
                     @Parameter(name = "durable", desc = "Is the queue durable?") boolean durable,
                     @Parameter(name = "maxConsumers", desc = "The maximum number of consumers allowed on this queue at any one time") int maxConsumers,
-                    @Parameter(name = "deleteOnNoConsumers", desc = "Delete this queue when the last consumer disconnects") boolean deleteOnNoConsumers,
+                    @Parameter(name = "purgeOnNoConsumers", desc = "Delete this queue when the last consumer disconnects") boolean purgeOnNoConsumers,
                     @Parameter(name = "autoCreateAddress", desc = "Create an address with default values should a matching address not be found") boolean autoCreateAddress) throws Exception;
 
    /**
@@ -585,14 +585,14 @@ public interface ActiveMQServerControl {
     * @param name                name of the queue
     * @param routingType         the routing type used for this address, {@code MULTICAST} or {@code ANYCAST}
     * @param maxConsumers        the maximum number of consumers allowed on this queue at any one time
-    * @param deleteOnNoConsumers delete this queue when the last consumer disconnects
+    * @param purgeOnNoConsumers delete this queue when the last consumer disconnects
     * @return a textual summary of the queue
     * @throws Exception
     */
    String updateQueue(@Parameter(name = "name", desc = "Name of the queue") String name,
                       @Parameter(name = "routingType", desc = "The routing type used for this address, MULTICAST or ANYCAST") String routingType,
                       @Parameter(name = "maxConsumers", desc = "The maximum number of consumers allowed on this queue at any one time") Integer maxConsumers,
-                      @Parameter(name = "deleteOnNoConsumers", desc = "Delete this queue when the last consumer disconnects") Boolean deleteOnNoConsumers) throws Exception;
+                      @Parameter(name = "purgeOnNoConsumers", desc = "Delete this queue when the last consumer disconnects") Boolean purgeOnNoConsumers) throws Exception;
 
 
 

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/QueueControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/QueueControl.java
@@ -150,7 +150,7 @@ public interface QueueControl {
     *
     */
    @Attribute(desc = "delete this queue when the last consumer disconnects")
-   boolean isDeleteOnNoConsumers();
+   boolean isPurgeOnNoConsumers();
 
    // Operations ----------------------------------------------------
 

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/AddressQueryImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/AddressQueryImpl.java
@@ -32,7 +32,7 @@ public class AddressQueryImpl implements ClientSession.AddressQuery {
 
    private final boolean autoCreateAddresses;
 
-   private final boolean defaultDeleteOnNoConsumers;
+   private final boolean defaultPurgeOnNoConsumers;
 
    private final int defaultMaxConsumers;
 
@@ -40,13 +40,13 @@ public class AddressQueryImpl implements ClientSession.AddressQuery {
                            final List<SimpleString> queueNames,
                            final boolean autoCreateQueues,
                            final boolean autoCreateAddresses,
-                           final boolean defaultDeleteOnNoConsumers,
+                           final boolean defaultPurgeOnNoConsumers,
                            final int defaultMaxConsumers) {
       this.exists = exists;
       this.queueNames = new ArrayList<>(queueNames);
       this.autoCreateQueues = autoCreateQueues;
       this.autoCreateAddresses = autoCreateAddresses;
-      this.defaultDeleteOnNoConsumers = defaultDeleteOnNoConsumers;
+      this.defaultPurgeOnNoConsumers = defaultPurgeOnNoConsumers;
       this.defaultMaxConsumers = defaultMaxConsumers;
    }
 
@@ -71,8 +71,8 @@ public class AddressQueryImpl implements ClientSession.AddressQuery {
    }
 
    @Override
-   public boolean isDefaultDeleteOnNoConsumers() {
-      return defaultDeleteOnNoConsumers;
+   public boolean isDefaultPurgeOnNoConsumers() {
+      return defaultPurgeOnNoConsumers;
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionImpl.java
@@ -368,7 +368,7 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
                           durable,
                           false,
                           ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers(),
-                          ActiveMQDefaultConfiguration.getDefaultDeleteQueueOnNoConsumers(),
+                          ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers(),
                           autoCreated);
    }
 
@@ -385,20 +385,20 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
 
    @Override
    public void createQueue(final SimpleString address, final RoutingType routingType, final SimpleString queueName, final SimpleString filterString,
-                           final boolean durable, final boolean autoCreated, final int maxConsumers, final boolean deleteOnNoConsumers) throws ActiveMQException {
+                           final boolean durable, final boolean autoCreated, final int maxConsumers, final boolean purgeOnNoConsumers) throws ActiveMQException {
       internalCreateQueue(address,
                           queueName, routingType,
                           filterString,
                           durable,
                           false,
                           maxConsumers,
-                          deleteOnNoConsumers,
+                          purgeOnNoConsumers,
                           autoCreated);
    }
 
    @Override
    public void createQueue(final String address, final RoutingType routingType, final String queueName, final String filterString,
-                           final boolean durable, final boolean autoCreated, final int maxConsumers, final boolean deleteOnNoConsumers) throws ActiveMQException {
+                           final boolean durable, final boolean autoCreated, final int maxConsumers, final boolean purgeOnNoConsumers) throws ActiveMQException {
       createQueue(SimpleString.toSimpleString(address),
                   routingType,
                   SimpleString.toSimpleString(queueName),
@@ -406,7 +406,7 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
                   durable,
                   autoCreated,
                   maxConsumers,
-                  deleteOnNoConsumers);
+                  purgeOnNoConsumers);
    }
 
    @Override
@@ -432,7 +432,7 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
                           false,
                           true,
                           ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers(),
-                          ActiveMQDefaultConfiguration.getDefaultDeleteQueueOnNoConsumers(),
+                          ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers(),
                           false);
    }
 
@@ -458,7 +458,7 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
                           durable,
                           false,
                           ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers(),
-                          ActiveMQDefaultConfiguration.getDefaultDeleteQueueOnNoConsumers(),
+                          ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers(),
                           false);
    }
 
@@ -533,7 +533,7 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
                           false,
                           true,
                           ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers(),
-                          ActiveMQDefaultConfiguration.getDefaultDeleteQueueOnNoConsumers(),
+                          ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers(),
                           false);
    }
 
@@ -554,7 +554,7 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
                           false,
                           false,
                           ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers(),
-                          ActiveMQDefaultConfiguration.getDefaultDeleteQueueOnNoConsumers(),
+                          ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers(),
                           false);
    }
 
@@ -578,7 +578,7 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
                           durable,
                           false,
                           ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers(),
-                          ActiveMQDefaultConfiguration.getDefaultDeleteQueueOnNoConsumers(),
+                          ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers(),
                           false);
    }
 
@@ -1823,7 +1823,7 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
                                     final boolean durable,
                                     final boolean temp,
                                     final int maxConsumers,
-                                    final boolean deleteOnNoConsumers,
+                                    final boolean purgeOnNoConsumers,
                                     final boolean autoCreated) throws ActiveMQException {
       checkClosed();
 
@@ -1840,7 +1840,7 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
                                     durable,
                                     temp,
                                     maxConsumers,
-                                    deleteOnNoConsumers,
+                                    purgeOnNoConsumers,
                                     autoCreated);
       } finally {
          endCall();

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/QueueQueryImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/QueueQueryImpl.java
@@ -44,7 +44,7 @@ public class QueueQueryImpl implements ClientSession.QueueQuery {
 
    private final RoutingType routingType;
 
-   private final boolean deleteOnNoConsumers;
+   private final boolean purgeOnNoConsumers;
 
    private final int maxConsumers;
 
@@ -82,7 +82,7 @@ public class QueueQueryImpl implements ClientSession.QueueQuery {
                          final boolean autoCreateQueues,
                          final int maxConsumers,
                          final boolean autoCreated,
-                         final boolean deleteOnNoConsumers,
+                         final boolean purgeOnNoConsumers,
                          final RoutingType routingType) {
       this.durable = durable;
       this.temporary = temporary;
@@ -95,7 +95,7 @@ public class QueueQueryImpl implements ClientSession.QueueQuery {
       this.autoCreateQueues = autoCreateQueues;
       this.maxConsumers = maxConsumers;
       this.autoCreated = autoCreated;
-      this.deleteOnNoConsumers = deleteOnNoConsumers;
+      this.purgeOnNoConsumers = purgeOnNoConsumers;
       this.routingType = routingType;
    }
 
@@ -155,8 +155,8 @@ public class QueueQueryImpl implements ClientSession.QueueQuery {
    }
 
    @Override
-   public boolean isDeleteOnNoConsumers() {
-      return deleteOnNoConsumers;
+   public boolean isPurgeOnNoConsumers() {
+      return purgeOnNoConsumers;
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ActiveMQSessionContext.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ActiveMQSessionContext.java
@@ -310,19 +310,19 @@ public class ActiveMQSessionContext extends SessionContext {
       if (sessionChannel.supports(PacketImpl.SESS_BINDINGQUERY_RESP_V4, getServerVersion())) {
          Packet packet = sessionChannel.sendBlocking(new SessionBindingQueryMessage(address), PacketImpl.SESS_BINDINGQUERY_RESP_V4);
          SessionBindingQueryResponseMessage_V4 response = (SessionBindingQueryResponseMessage_V4) packet;
-         return new AddressQueryImpl(response.isExists(), response.getQueueNames(), response.isAutoCreateQueues(), response.isAutoCreateAddresses(), response.isDefaultDeleteOnNoConsumers(), response.getDefaultMaxConsumers());
+         return new AddressQueryImpl(response.isExists(), response.getQueueNames(), response.isAutoCreateQueues(), response.isAutoCreateAddresses(), response.isDefaultPurgeOnNoConsumers(), response.getDefaultMaxConsumers());
       } else if (sessionChannel.supports(PacketImpl.SESS_BINDINGQUERY_RESP_V3, getServerVersion())) {
          Packet packet = sessionChannel.sendBlocking(new SessionBindingQueryMessage(address), PacketImpl.SESS_BINDINGQUERY_RESP_V3);
          SessionBindingQueryResponseMessage_V3 response = (SessionBindingQueryResponseMessage_V3) packet;
-         return new AddressQueryImpl(response.isExists(), response.getQueueNames(), response.isAutoCreateQueues(), response.isAutoCreateAddresses(), ActiveMQDefaultConfiguration.getDefaultDeleteQueueOnNoConsumers(), ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers());
+         return new AddressQueryImpl(response.isExists(), response.getQueueNames(), response.isAutoCreateQueues(), response.isAutoCreateAddresses(), ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers(), ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers());
       } else if (sessionChannel.supports(PacketImpl.SESS_BINDINGQUERY_RESP_V2, getServerVersion())) {
          Packet packet = sessionChannel.sendBlocking(new SessionBindingQueryMessage(address), PacketImpl.SESS_BINDINGQUERY_RESP_V2);
          SessionBindingQueryResponseMessage_V2 response = (SessionBindingQueryResponseMessage_V2) packet;
-         return new AddressQueryImpl(response.isExists(), response.getQueueNames(), response.isAutoCreateQueues(), false, ActiveMQDefaultConfiguration.getDefaultDeleteQueueOnNoConsumers(), ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers());
+         return new AddressQueryImpl(response.isExists(), response.getQueueNames(), response.isAutoCreateQueues(), false, ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers(), ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers());
       } else {
          Packet packet = sessionChannel.sendBlocking(new SessionBindingQueryMessage(address), PacketImpl.SESS_BINDINGQUERY_RESP);
          SessionBindingQueryResponseMessage response = (SessionBindingQueryResponseMessage) packet;
-         return new AddressQueryImpl(response.isExists(), response.getQueueNames(), false, false, ActiveMQDefaultConfiguration.getDefaultDeleteQueueOnNoConsumers(), ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers());
+         return new AddressQueryImpl(response.isExists(), response.getQueueNames(), false, false, ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers(), ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers());
       }
    }
 
@@ -617,7 +617,7 @@ public class ActiveMQSessionContext extends SessionContext {
                            boolean durable,
                            boolean temp,
                            boolean autoCreated) throws ActiveMQException {
-      createQueue(address, ActiveMQDefaultConfiguration.getDefaultRoutingType(), queueName, filterString, durable, temp, ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers(), ActiveMQDefaultConfiguration.getDefaultDeleteQueueOnNoConsumers(), autoCreated);
+      createQueue(address, ActiveMQDefaultConfiguration.getDefaultRoutingType(), queueName, filterString, durable, temp, ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers(), ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers(), autoCreated);
    }
 
    @Override
@@ -628,9 +628,9 @@ public class ActiveMQSessionContext extends SessionContext {
                            boolean durable,
                            boolean temp,
                            int maxConsumers,
-                           boolean deleteOnNoConsumers,
+                           boolean purgeOnNoConsumers,
                            boolean autoCreated) throws ActiveMQException {
-      CreateQueueMessage request = new CreateQueueMessage_V2(address, queueName, routingType, filterString, durable, temp, maxConsumers, deleteOnNoConsumers, autoCreated, true);
+      CreateQueueMessage request = new CreateQueueMessage_V2(address, queueName, routingType, filterString, durable, temp, maxConsumers, purgeOnNoConsumers, autoCreated, true);
       sessionChannel.sendBlocking(request, PacketImpl.NULL_RESPONSE);
    }
 
@@ -715,7 +715,7 @@ public class ActiveMQSessionContext extends SessionContext {
       // they are defined in broker.xml
       // This allows e.g. JMS non durable subs and temporary queues to continue to be used after failover
       if (!queueInfo.isDurable()) {
-         CreateQueueMessage_V2 createQueueRequest = new CreateQueueMessage_V2(queueInfo.getAddress(), queueInfo.getName(), queueInfo.getRoutingType(), queueInfo.getFilterString(), false, queueInfo.isTemporary(), queueInfo.getMaxConsumers(), queueInfo.isDeleteOnNoConsumers(), queueInfo.isAutoCreated(), false);
+         CreateQueueMessage_V2 createQueueRequest = new CreateQueueMessage_V2(queueInfo.getAddress(), queueInfo.getName(), queueInfo.getRoutingType(), queueInfo.getFilterString(), false, queueInfo.isTemporary(), queueInfo.getMaxConsumers(), queueInfo.isPurgeOnNoConsumers(), queueInfo.isAutoCreated(), false);
 
          sendPacketWithoutLock(sessionChannel, createQueueRequest);
       }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/CreateQueueMessage_V2.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/CreateQueueMessage_V2.java
@@ -28,7 +28,7 @@ public class CreateQueueMessage_V2 extends CreateQueueMessage {
 
    private int maxConsumers;
 
-   private boolean deleteOnNoConsumers;
+   private boolean purgeOnNoConsumers;
 
    public CreateQueueMessage_V2(final SimpleString address,
                                 final SimpleString queueName,
@@ -37,7 +37,7 @@ public class CreateQueueMessage_V2 extends CreateQueueMessage {
                                 final boolean durable,
                                 final boolean temporary,
                                 final int maxConsumers,
-                                final boolean deleteOnNoConsumers,
+                                final boolean purgeOnNoConsumers,
                                 final boolean autoCreated,
                                 final boolean requiresResponse) {
       this();
@@ -51,7 +51,7 @@ public class CreateQueueMessage_V2 extends CreateQueueMessage {
       this.requiresResponse = requiresResponse;
       this.routingType = routingType;
       this.maxConsumers = maxConsumers;
-      this.deleteOnNoConsumers = deleteOnNoConsumers;
+      this.purgeOnNoConsumers = purgeOnNoConsumers;
    }
 
    public CreateQueueMessage_V2() {
@@ -66,7 +66,7 @@ public class CreateQueueMessage_V2 extends CreateQueueMessage {
       buff.append(", autoCreated=" + autoCreated);
       buff.append(", routingType=" + routingType);
       buff.append(", maxConsumers=" + maxConsumers);
-      buff.append(", deleteOnNoConsumers=" + deleteOnNoConsumers);
+      buff.append(", purgeOnNoConsumers=" + purgeOnNoConsumers);
       buff.append("]");
       return buff.toString();
    }
@@ -87,12 +87,12 @@ public class CreateQueueMessage_V2 extends CreateQueueMessage {
       this.maxConsumers = maxConsumers;
    }
 
-   public boolean isDeleteOnNoConsumers() {
-      return deleteOnNoConsumers;
+   public boolean isPurgeOnNoConsumers() {
+      return purgeOnNoConsumers;
    }
 
-   public void setDeleteOnNoConsumers(boolean deleteOnNoConsumers) {
-      this.deleteOnNoConsumers = deleteOnNoConsumers;
+   public void setPurgeOnNoConsumers(boolean purgeOnNoConsumers) {
+      this.purgeOnNoConsumers = purgeOnNoConsumers;
    }
 
    public boolean isAutoCreated() {
@@ -109,7 +109,7 @@ public class CreateQueueMessage_V2 extends CreateQueueMessage {
       buffer.writeBoolean(autoCreated);
       buffer.writeByte(routingType == null ? -1 : routingType.getType());
       buffer.writeInt(maxConsumers);
-      buffer.writeBoolean(deleteOnNoConsumers);
+      buffer.writeBoolean(purgeOnNoConsumers);
    }
 
    @Override
@@ -118,7 +118,7 @@ public class CreateQueueMessage_V2 extends CreateQueueMessage {
       autoCreated = buffer.readBoolean();
       routingType = RoutingType.getType(buffer.readByte());
       maxConsumers = buffer.readInt();
-      deleteOnNoConsumers = buffer.readBoolean();
+      purgeOnNoConsumers = buffer.readBoolean();
    }
 
    @Override
@@ -128,7 +128,7 @@ public class CreateQueueMessage_V2 extends CreateQueueMessage {
       result = prime * result + (autoCreated ? 1231 : 1237);
       result = prime * result + (routingType.getType());
       result = prime * result + (maxConsumers);
-      result = prime * result + (deleteOnNoConsumers ? 1231 : 1237);
+      result = prime * result + (purgeOnNoConsumers ? 1231 : 1237);
       return result;
    }
 
@@ -145,9 +145,9 @@ public class CreateQueueMessage_V2 extends CreateQueueMessage {
          return false;
       if (maxConsumers != other.maxConsumers)
          return false;
-      if (deleteOnNoConsumers != other.deleteOnNoConsumers)
+      if (purgeOnNoConsumers != other.purgeOnNoConsumers)
          return false;
-      if (deleteOnNoConsumers != other.deleteOnNoConsumers)
+      if (purgeOnNoConsumers != other.purgeOnNoConsumers)
          return false;
       if (routingType == null) {
          if (other.routingType != null)

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/CreateSessionMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/CreateSessionMessage.java
@@ -202,7 +202,7 @@ public class CreateSessionMessage extends PacketImpl {
       buff.append(", defaultAddress=" + defaultAddress);
       buff.append(", minLargeMessageSize=" + minLargeMessageSize);
       buff.append(", name=" + name);
-      buff.append(", password=" + password);
+      buff.append(", password=****");
       buff.append(", preAcknowledge=" + preAcknowledge);
       buff.append(", sessionChannelID=" + sessionChannelID);
       buff.append(", username=" + username);

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionBindingQueryResponseMessage_V4.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionBindingQueryResponseMessage_V4.java
@@ -23,7 +23,7 @@ import org.apache.activemq.artemis.api.core.SimpleString;
 
 public class SessionBindingQueryResponseMessage_V4 extends SessionBindingQueryResponseMessage_V3 {
 
-   private boolean defaultDeleteOnNoConsumers;
+   private boolean defaultPurgeOnNoConsumers;
 
    private int defaultMaxConsumers;
 
@@ -31,7 +31,7 @@ public class SessionBindingQueryResponseMessage_V4 extends SessionBindingQueryRe
                                                 final List<SimpleString> queueNames,
                                                 final boolean autoCreateQueues,
                                                 final boolean autoCreateAddresses,
-                                                final boolean defaultDeleteOnNoConsumers,
+                                                final boolean defaultPurgeOnNoConsumers,
                                                 final int defaultMaxConsumers) {
       super(SESS_BINDINGQUERY_RESP_V4);
 
@@ -43,7 +43,7 @@ public class SessionBindingQueryResponseMessage_V4 extends SessionBindingQueryRe
 
       this.autoCreateAddresses = autoCreateAddresses;
 
-      this.defaultDeleteOnNoConsumers = defaultDeleteOnNoConsumers;
+      this.defaultPurgeOnNoConsumers = defaultPurgeOnNoConsumers;
 
       this.defaultMaxConsumers = defaultMaxConsumers;
    }
@@ -52,8 +52,8 @@ public class SessionBindingQueryResponseMessage_V4 extends SessionBindingQueryRe
       super(SESS_BINDINGQUERY_RESP_V4);
    }
 
-   public boolean isDefaultDeleteOnNoConsumers() {
-      return defaultDeleteOnNoConsumers;
+   public boolean isDefaultPurgeOnNoConsumers() {
+      return defaultPurgeOnNoConsumers;
    }
 
    public int getDefaultMaxConsumers() {
@@ -63,14 +63,14 @@ public class SessionBindingQueryResponseMessage_V4 extends SessionBindingQueryRe
    @Override
    public void encodeRest(final ActiveMQBuffer buffer) {
       super.encodeRest(buffer);
-      buffer.writeBoolean(defaultDeleteOnNoConsumers);
+      buffer.writeBoolean(defaultPurgeOnNoConsumers);
       buffer.writeInt(defaultMaxConsumers);
    }
 
    @Override
    public void decodeRest(final ActiveMQBuffer buffer) {
       super.decodeRest(buffer);
-      defaultDeleteOnNoConsumers = buffer.readBoolean();
+      defaultPurgeOnNoConsumers = buffer.readBoolean();
       defaultMaxConsumers = buffer.readInt();
    }
 
@@ -78,7 +78,7 @@ public class SessionBindingQueryResponseMessage_V4 extends SessionBindingQueryRe
    public int hashCode() {
       final int prime = 31;
       int result = super.hashCode();
-      result = prime * result + (defaultDeleteOnNoConsumers ? 1231 : 1237);
+      result = prime * result + (defaultPurgeOnNoConsumers ? 1231 : 1237);
       result = prime * result + defaultMaxConsumers;
       return result;
    }
@@ -93,7 +93,7 @@ public class SessionBindingQueryResponseMessage_V4 extends SessionBindingQueryRe
    @Override
    public String getParentString() {
       StringBuffer buff = new StringBuffer(super.getParentString());
-      buff.append(", defaultDeleteOnNoConsumers=" + defaultDeleteOnNoConsumers);
+      buff.append(", defaultPurgeOnNoConsumers=" + defaultPurgeOnNoConsumers);
       buff.append(", defaultMaxConsumers=" + defaultMaxConsumers);
       return buff.toString();
    }
@@ -107,7 +107,7 @@ public class SessionBindingQueryResponseMessage_V4 extends SessionBindingQueryRe
       if (!(obj instanceof SessionBindingQueryResponseMessage_V4))
          return false;
       SessionBindingQueryResponseMessage_V4 other = (SessionBindingQueryResponseMessage_V4) obj;
-      if (defaultDeleteOnNoConsumers != other.defaultDeleteOnNoConsumers)
+      if (defaultPurgeOnNoConsumers != other.defaultPurgeOnNoConsumers)
          return false;
       if (defaultMaxConsumers != other.defaultMaxConsumers)
          return false;

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionQueueQueryResponseMessage_V3.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionQueueQueryResponseMessage_V3.java
@@ -27,14 +27,14 @@ public class SessionQueueQueryResponseMessage_V3 extends SessionQueueQueryRespon
 
    protected boolean autoCreated;
 
-   protected boolean deleteOnNoConsumers;
+   protected boolean purgeOnNoConsumers;
 
    protected RoutingType routingType;
 
    protected int maxConsumers;
 
    public SessionQueueQueryResponseMessage_V3(final QueueQueryResult result) {
-      this(result.getName(), result.getAddress(), result.isDurable(), result.isTemporary(), result.getFilterString(), result.getConsumerCount(), result.getMessageCount(), result.isExists(), result.isAutoCreateQueues(), result.isAutoCreated(), result.isDeleteOnNoConsumers(), result.getRoutingType(), result.getMaxConsumers());
+      this(result.getName(), result.getAddress(), result.isDurable(), result.isTemporary(), result.getFilterString(), result.getConsumerCount(), result.getMessageCount(), result.isExists(), result.isAutoCreateQueues(), result.isAutoCreated(), result.isPurgeOnNoConsumers(), result.getRoutingType(), result.getMaxConsumers());
    }
 
    public SessionQueueQueryResponseMessage_V3() {
@@ -51,7 +51,7 @@ public class SessionQueueQueryResponseMessage_V3 extends SessionQueueQueryRespon
                                                final boolean exists,
                                                final boolean autoCreateQueues,
                                                final boolean autoCreated,
-                                               final boolean deleteOnNoConsumers,
+                                               final boolean purgeOnNoConsumers,
                                                final RoutingType routingType,
                                                final int maxConsumers) {
       super(SESS_QUEUEQUERY_RESP_V3);
@@ -76,7 +76,7 @@ public class SessionQueueQueryResponseMessage_V3 extends SessionQueueQueryRespon
 
       this.autoCreated = autoCreated;
 
-      this.deleteOnNoConsumers = deleteOnNoConsumers;
+      this.purgeOnNoConsumers = purgeOnNoConsumers;
 
       this.routingType = routingType;
 
@@ -91,12 +91,12 @@ public class SessionQueueQueryResponseMessage_V3 extends SessionQueueQueryRespon
       this.autoCreated = autoCreated;
    }
 
-   public boolean isDeleteOnNoConsumers() {
-      return deleteOnNoConsumers;
+   public boolean isPurgeOnNoConsumers() {
+      return purgeOnNoConsumers;
    }
 
-   public void setDeleteOnNoConsumers(boolean deleteOnNoConsumers) {
-      this.deleteOnNoConsumers = deleteOnNoConsumers;
+   public void setPurgeOnNoConsumers(boolean purgeOnNoConsumers) {
+      this.purgeOnNoConsumers = purgeOnNoConsumers;
    }
 
    public RoutingType getRoutingType() {
@@ -119,7 +119,7 @@ public class SessionQueueQueryResponseMessage_V3 extends SessionQueueQueryRespon
    public void encodeRest(final ActiveMQBuffer buffer) {
       super.encodeRest(buffer);
       buffer.writeBoolean(autoCreated);
-      buffer.writeBoolean(deleteOnNoConsumers);
+      buffer.writeBoolean(purgeOnNoConsumers);
       buffer.writeByte(routingType.getType());
       buffer.writeInt(maxConsumers);
    }
@@ -128,7 +128,7 @@ public class SessionQueueQueryResponseMessage_V3 extends SessionQueueQueryRespon
    public void decodeRest(final ActiveMQBuffer buffer) {
       super.decodeRest(buffer);
       autoCreated = buffer.readBoolean();
-      deleteOnNoConsumers = buffer.readBoolean();
+      purgeOnNoConsumers = buffer.readBoolean();
       routingType = RoutingType.getType(buffer.readByte());
       maxConsumers = buffer.readInt();
    }
@@ -138,7 +138,7 @@ public class SessionQueueQueryResponseMessage_V3 extends SessionQueueQueryRespon
       final int prime = 31;
       int result = super.hashCode();
       result = prime * result + (autoCreated ? 1231 : 1237);
-      result = prime * result + (deleteOnNoConsumers ? 1231 : 1237);
+      result = prime * result + (purgeOnNoConsumers ? 1231 : 1237);
       result = prime * result + routingType.hashCode();
       result = prime * result + maxConsumers;
       return result;
@@ -155,7 +155,7 @@ public class SessionQueueQueryResponseMessage_V3 extends SessionQueueQueryRespon
    public String getParentString() {
       StringBuffer buff = new StringBuffer(super.getParentString());
       buff.append(", autoCreated=" + autoCreated);
-      buff.append(", deleteOnNoConsumers=" + deleteOnNoConsumers);
+      buff.append(", purgeOnNoConsumers=" + purgeOnNoConsumers);
       buff.append(", routingType=" + routingType);
       buff.append(", maxConsumers=" + maxConsumers);
       return buff.toString();
@@ -163,7 +163,7 @@ public class SessionQueueQueryResponseMessage_V3 extends SessionQueueQueryRespon
 
    @Override
    public ClientSession.QueueQuery toQueueQuery() {
-      return new QueueQueryImpl(isDurable(), isTemporary(), getConsumerCount(), getMessageCount(), getFilterString(), getAddress(), getName(), isExists(), isAutoCreateQueues(), getMaxConsumers(), isAutoCreated(), isDeleteOnNoConsumers(), getRoutingType());
+      return new QueueQueryImpl(isDurable(), isTemporary(), getConsumerCount(), getMessageCount(), getFilterString(), getAddress(), getName(), isExists(), isAutoCreateQueues(), getMaxConsumers(), isAutoCreated(), isPurgeOnNoConsumers(), getRoutingType());
    }
 
    @Override
@@ -177,7 +177,7 @@ public class SessionQueueQueryResponseMessage_V3 extends SessionQueueQueryRespon
       SessionQueueQueryResponseMessage_V3 other = (SessionQueueQueryResponseMessage_V3) obj;
       if (autoCreated != other.autoCreated)
          return false;
-      if (deleteOnNoConsumers != other.deleteOnNoConsumers)
+      if (purgeOnNoConsumers != other.purgeOnNoConsumers)
          return false;
       if (routingType == null) {
          if (other.routingType != null)

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/server/AddressQueryResult.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/server/AddressQueryResult.java
@@ -28,10 +28,10 @@ public class AddressQueryResult {
    private final boolean autoCreated;
    private final boolean exists;
    private final boolean autoCreateAddresses;
-   private final boolean defaultDeleteOnNoConsumers;
+   private final boolean defaultPurgeOnNoConsumers;
    private final int defaultMaxConsumers;
 
-   public AddressQueryResult(SimpleString name, Set<RoutingType> routingTypes, long id, boolean autoCreated, boolean exists, boolean autoCreateAddresses, boolean defaultDeleteOnNoConsumers, int defaultMaxConsumers) {
+   public AddressQueryResult(SimpleString name, Set<RoutingType> routingTypes, long id, boolean autoCreated, boolean exists, boolean autoCreateAddresses, boolean defaultPurgeOnNoConsumers, int defaultMaxConsumers) {
 
       this.name = name;
       this.routingTypes = routingTypes;
@@ -40,7 +40,7 @@ public class AddressQueryResult {
       this.autoCreated = autoCreated;
       this.exists = exists;
       this.autoCreateAddresses = autoCreateAddresses;
-      this.defaultDeleteOnNoConsumers = defaultDeleteOnNoConsumers;
+      this.defaultPurgeOnNoConsumers = defaultPurgeOnNoConsumers;
       this.defaultMaxConsumers = defaultMaxConsumers;
    }
 
@@ -68,8 +68,8 @@ public class AddressQueryResult {
       return autoCreateAddresses;
    }
 
-   public boolean isDefaultDeleteOnNoConsumers() {
-      return defaultDeleteOnNoConsumers;
+   public boolean isDefaultPurgeOnNoConsumers() {
+      return defaultPurgeOnNoConsumers;
    }
 
    public int getDefaultMaxConsumers() {

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/server/QueueQueryResult.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/server/QueueQueryResult.java
@@ -40,7 +40,7 @@ public class QueueQueryResult {
 
    private boolean autoCreated;
 
-   private boolean deleteOnNoConsumers;
+   private boolean purgeOnNoConsumers;
 
    private RoutingType routingType;
 
@@ -56,7 +56,7 @@ public class QueueQueryResult {
                            final boolean autoCreateQueues,
                            final boolean exists,
                            final boolean autoCreated,
-                           final boolean deleteOnNoConsumers,
+                           final boolean purgeOnNoConsumers,
                            final RoutingType routingType,
                            final int maxConsumers) {
       this.durable = durable;
@@ -79,7 +79,7 @@ public class QueueQueryResult {
 
       this.autoCreated = autoCreated;
 
-      this.deleteOnNoConsumers = deleteOnNoConsumers;
+      this.purgeOnNoConsumers = purgeOnNoConsumers;
 
       this.routingType = routingType;
 
@@ -126,8 +126,8 @@ public class QueueQueryResult {
       return autoCreated;
    }
 
-   public boolean isDeleteOnNoConsumers() {
-      return deleteOnNoConsumers;
+   public boolean isPurgeOnNoConsumers() {
+      return purgeOnNoConsumers;
    }
 
    public RoutingType getRoutingType() {

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/SessionContext.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/SessionContext.java
@@ -203,7 +203,7 @@ public abstract class SessionContext {
                                     boolean durable,
                                     boolean temp,
                                     int maxConsumers,
-                                    boolean deleteOnNoConsumers,
+                                    boolean purgeOnNoConsumers,
                                     boolean autoCreated) throws ActiveMQException;
 
    public abstract ClientSession.QueueQuery queueQuery(SimpleString queueName) throws ActiveMQException;

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQMessageProducer.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQMessageProducer.java
@@ -412,7 +412,7 @@ public class ActiveMQMessageProducer implements MessageProducer, QueueSender, To
                         // TODO is it right to use the address for the queue name here?
                         clientSession.createTemporaryQueue(address, RoutingType.ANYCAST, address);
                      } else {
-                        clientSession.createQueue(address, RoutingType.ANYCAST, address, null, true, true, query.getDefaultMaxConsumers(), query.isDefaultDeleteOnNoConsumers());
+                        clientSession.createQueue(address, RoutingType.ANYCAST, address, null, true, true, query.getDefaultMaxConsumers(), query.isDefaultPurgeOnNoConsumers());
                      }
                   } else if (!destination.isQueue() && query.isAutoCreateAddresses()) {
                      clientSession.createAddress(address, RoutingType.MULTICAST, true);

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
@@ -303,9 +303,9 @@ public class ActiveMQSession implements QueueSession, TopicSession {
             if (!response.isExists()) {
                try {
                   if (jbd.isQueue() && response.isAutoCreateQueues()) {
-                     // perhaps just relying on the broker to do it is simplest (i.e. deleteOnNoConsumers)
+                     // perhaps just relying on the broker to do it is simplest (i.e. purgeOnNoConsumers)
                      session.createAddress(jbd.getSimpleAddress(), RoutingType.ANYCAST, true);
-                     session.createQueue(jbd.getSimpleAddress(), RoutingType.ANYCAST, jbd.getSimpleAddress(), null, true, true, response.getDefaultMaxConsumers(), response.isDefaultDeleteOnNoConsumers());
+                     session.createQueue(jbd.getSimpleAddress(), RoutingType.ANYCAST, jbd.getSimpleAddress(), null, true, true, response.getDefaultMaxConsumers(), response.isDefaultPurgeOnNoConsumers());
                   } else if (!jbd.isQueue() && response.isAutoCreateAddresses()) {
                      session.createAddress(jbd.getSimpleAddress(), RoutingType.MULTICAST, true);
                   } else {
@@ -667,7 +667,7 @@ public class ActiveMQSession implements QueueSession, TopicSession {
             if (!response.isExists() || !response.getQueueNames().contains(dest.getSimpleAddress())) {
                if (response.isAutoCreateQueues()) {
                   try {
-                     session.createQueue(dest.getSimpleAddress(), RoutingType.ANYCAST, dest.getSimpleAddress(), null, true, true, response.getDefaultMaxConsumers(), response.isDefaultDeleteOnNoConsumers());
+                     session.createQueue(dest.getSimpleAddress(), RoutingType.ANYCAST, dest.getSimpleAddress(), null, true, true, response.getDefaultMaxConsumers(), response.isDefaultPurgeOnNoConsumers());
                   } catch (ActiveMQQueueExistsException e) {
                      // The queue was created by another client/admin between the query check and send create queue packet
                   }
@@ -724,7 +724,7 @@ public class ActiveMQSession implements QueueSession, TopicSession {
 
                if (!subResponse.isExists()) {
                   // durable subscription queues are not technically considered to be auto-created
-                  session.createQueue(dest.getSimpleAddress(), RoutingType.MULTICAST, queueName, coreFilterString, true, false, response.getDefaultMaxConsumers(), response.isDefaultDeleteOnNoConsumers());
+                  session.createQueue(dest.getSimpleAddress(), RoutingType.MULTICAST, queueName, coreFilterString, true, false, response.getDefaultMaxConsumers(), response.isDefaultPurgeOnNoConsumers());
                } else {
                   // Already exists
                   if (subResponse.getConsumerCount() > 0) {
@@ -755,7 +755,7 @@ public class ActiveMQSession implements QueueSession, TopicSession {
                      session.deleteQueue(queueName);
 
                      // Create the new one
-                     session.createQueue(dest.getSimpleAddress(), RoutingType.MULTICAST, queueName, coreFilterString, true, false, response.getDefaultMaxConsumers(), response.isDefaultDeleteOnNoConsumers());
+                     session.createQueue(dest.getSimpleAddress(), RoutingType.MULTICAST, queueName, coreFilterString, true, false, response.getDefaultMaxConsumers(), response.isDefaultPurgeOnNoConsumers());
                   }
                }
 
@@ -817,7 +817,7 @@ public class ActiveMQSession implements QueueSession, TopicSession {
          AddressQuery response = session.addressQuery(new SimpleString(activeMQDestination.getAddress()));
          if (!response.isExists()) {
             if (response.isAutoCreateQueues()) {
-               session.createQueue(activeMQDestination.getSimpleAddress(), RoutingType.ANYCAST, activeMQDestination.getSimpleAddress(), null, true, true, response.getDefaultMaxConsumers(), response.isDefaultDeleteOnNoConsumers());
+               session.createQueue(activeMQDestination.getSimpleAddress(), RoutingType.ANYCAST, activeMQDestination.getSimpleAddress(), null, true, true, response.getDefaultMaxConsumers(), response.isDefaultPurgeOnNoConsumers());
             } else {
                throw new InvalidDestinationException("Destination " + activeMQDestination.getName() + " does not exist");
             }

--- a/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/impl/JMSServerManagerImpl.java
+++ b/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/impl/JMSServerManagerImpl.java
@@ -1078,7 +1078,7 @@ public class JMSServerManagerImpl implements JMSServerManager, ActivateCallback 
          server.addOrUpdateAddressInfo(new AddressInfo(SimpleString.toSimpleString(queueName)).addRoutingType(RoutingType.ANYCAST));
 
          AddressSettings as = server.getAddressSettingsRepository().getMatch(queueName);
-         server.createQueue(SimpleString.toSimpleString(queueName), RoutingType.ANYCAST, SimpleString.toSimpleString(queueName), SimpleString.toSimpleString(coreFilterString), null, durable, false, true, false, false, as.getDefaultMaxConsumers(), as.isDefaultDeleteOnNoConsumers(), as.isAutoCreateAddresses());
+         server.createQueue(SimpleString.toSimpleString(queueName), RoutingType.ANYCAST, SimpleString.toSimpleString(queueName), SimpleString.toSimpleString(coreFilterString), null, durable, false, true, false, false, as.getDefaultMaxConsumers(), as.isDefaultPurgeOnNoConsumers(), as.isAutoCreateAddresses());
 
          queues.put(queueName, ActiveMQDestination.createQueue(queueName));
 

--- a/artemis-junit/src/main/java/org/apache/activemq/artemis/junit/EmbeddedActiveMQResource.java
+++ b/artemis-junit/src/main/java/org/apache/activemq/artemis/junit/EmbeddedActiveMQResource.java
@@ -361,7 +361,7 @@ public class EmbeddedActiveMQResource extends ExternalResource {
       boolean temporary = false;
       Queue queue = null;
       try {
-         queue = server.getActiveMQServer().createQueue(address, RoutingType.MULTICAST, name, filter, isUseDurableQueue(), temporary, server.getActiveMQServer().getAddressSettingsRepository().getMatch(address.toString()).getDefaultMaxConsumers(), server.getActiveMQServer().getAddressSettingsRepository().getMatch(address.toString()).isDefaultDeleteOnNoConsumers(), true);
+         queue = server.getActiveMQServer().createQueue(address, RoutingType.MULTICAST, name, filter, isUseDurableQueue(), temporary, server.getActiveMQServer().getAddressSettingsRepository().getMatch(address.toString()).getDefaultMaxConsumers(), server.getActiveMQServer().getAddressSettingsRepository().getMatch(address.toString()).isDefaultPurgeOnNoConsumers(), true);
       } catch (Exception ex) {
          throw new EmbeddedActiveMQResourceException(String.format("Failed to create queue: queueName = %s, name = %s", address.toString(), name.toString()), ex);
       }

--- a/artemis-protocols/artemis-hqclient-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/hornetq/client/HornetQClientSessionContext.java
+++ b/artemis-protocols/artemis-hqclient-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/hornetq/client/HornetQClientSessionContext.java
@@ -72,7 +72,7 @@ public class HornetQClientSessionContext extends ActiveMQSessionContext {
    public ClientSession.AddressQuery addressQuery(final SimpleString address) throws ActiveMQException {
       SessionBindingQueryResponseMessage response = (SessionBindingQueryResponseMessage) getSessionChannel().sendBlocking(new SessionBindingQueryMessage(address), PacketImpl.SESS_BINDINGQUERY_RESP);
 
-      return new AddressQueryImpl(response.isExists(), response.getQueueNames(), false, false, ActiveMQDefaultConfiguration.getDefaultDeleteQueueOnNoConsumers(), ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers());
+      return new AddressQueryImpl(response.isExists(), response.getQueueNames(), false, false, ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers(), ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers());
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/CoreQueueConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/CoreQueueConfiguration.java
@@ -35,7 +35,7 @@ public class CoreQueueConfiguration implements Serializable {
 
    private Integer maxConsumers = ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers();
 
-   private Boolean deleteOnNoConsumers = ActiveMQDefaultConfiguration.getDefaultDeleteQueueOnNoConsumers();
+   private Boolean purgeOnNoConsumers = ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers();
 
    private RoutingType routingType = ActiveMQDefaultConfiguration.getDefaultRoutingType();
 
@@ -99,15 +99,15 @@ public class CoreQueueConfiguration implements Serializable {
    }
 
    /**
-    * @param deleteOnNoConsumers delete this queue when consumer count reaches 0, default is false
+    * @param purgeOnNoConsumers delete this queue when consumer count reaches 0, default is false
     */
-   public CoreQueueConfiguration setDeleteOnNoConsumers(Boolean deleteOnNoConsumers) {
-      this.deleteOnNoConsumers = deleteOnNoConsumers;
+   public CoreQueueConfiguration setPurgeOnNoConsumers(Boolean purgeOnNoConsumers) {
+      this.purgeOnNoConsumers = purgeOnNoConsumers;
       return this;
    }
 
-   public boolean getDeleteOnNoConsumers() {
-      return deleteOnNoConsumers;
+   public boolean getPurgeOnNoConsumers() {
+      return purgeOnNoConsumers;
    }
 
    public int getMaxConsumers() {
@@ -132,7 +132,7 @@ public class CoreQueueConfiguration implements Serializable {
       result = prime * result + ((filterString == null) ? 0 : filterString.hashCode());
       result = prime * result + ((name == null) ? 0 : name.hashCode());
       result = prime * result + ((maxConsumers == null) ? 0 : maxConsumers.hashCode());
-      result = prime * result + ((deleteOnNoConsumers == null) ? 0 : deleteOnNoConsumers.hashCode());
+      result = prime * result + ((purgeOnNoConsumers == null) ? 0 : purgeOnNoConsumers.hashCode());
       return result;
    }
 
@@ -167,10 +167,10 @@ public class CoreQueueConfiguration implements Serializable {
             return false;
       } else if (!maxConsumers.equals(other.maxConsumers))
          return false;
-      if (deleteOnNoConsumers == null) {
-         if (other.deleteOnNoConsumers != null)
+      if (purgeOnNoConsumers == null) {
+         if (other.purgeOnNoConsumers != null)
             return false;
-      } else if (!deleteOnNoConsumers.equals(other.deleteOnNoConsumers)) {
+      } else if (!purgeOnNoConsumers.equals(other.purgeOnNoConsumers)) {
          return false;
       }
       return true;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -185,7 +185,7 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
    private static final String AUTO_DELETE_ADDRESSES = "auto-delete-addresses";
 
-   private static final String DEFAULT_DELETE_ON_NO_CONSUMERS = "default-delete-on-no-consumers";
+   private static final String DEFAULT_PURGE_ON_NO_CONSUMERS = "default-purge-on-no-consumers";
 
    private static final String DEFAULT_MAX_CONSUMERS = "default-max-consumers";
 
@@ -889,8 +889,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
             addressSettings.setAutoDeleteAddresses(XMLUtil.parseBoolean(child));
          } else if (MANAGEMENT_BROWSE_PAGE_SIZE.equalsIgnoreCase(name)) {
             addressSettings.setManagementBrowsePageSize(XMLUtil.parseInt(child));
-         } else if (DEFAULT_DELETE_ON_NO_CONSUMERS.equalsIgnoreCase(name)) {
-            addressSettings.setDefaultDeleteOnNoConsumers(XMLUtil.parseBoolean(child));
+         } else if (DEFAULT_PURGE_ON_NO_CONSUMERS.equalsIgnoreCase(name)) {
+            addressSettings.setDefaultPurgeOnNoConsumers(XMLUtil.parseBoolean(child));
          } else if (DEFAULT_MAX_CONSUMERS.equalsIgnoreCase(name)) {
             addressSettings.setDefaultMaxConsumers(XMLUtil.parseInt(child));
          } else if (DEFAULT_QUEUE_ROUTING_TYPE.equalsIgnoreCase(name)) {
@@ -937,7 +937,7 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       String filterString = null;
       boolean durable = true;
       int maxConsumers = ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers();
-      boolean deleteOnNoConsumers = ActiveMQDefaultConfiguration.getDefaultDeleteQueueOnNoConsumers();
+      boolean purgeOnNoConsumers = ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers();
 
       NamedNodeMap attributes = node.getAttributes();
       for (int i = 0; i < attributes.getLength(); i++) {
@@ -945,8 +945,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
          if (item.getNodeName().equals("max-consumers")) {
             maxConsumers = Integer.parseInt(item.getNodeValue());
             Validators.MAX_QUEUE_CONSUMERS.validate(name, maxConsumers);
-         } else if (item.getNodeName().equals("delete-on-no-consumers")) {
-            deleteOnNoConsumers = Boolean.parseBoolean(item.getNodeValue());
+         } else if (item.getNodeName().equals("purge-on-no-consumers")) {
+            purgeOnNoConsumers = Boolean.parseBoolean(item.getNodeValue());
          }
       }
 
@@ -963,7 +963,7 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
          }
       }
 
-      return new CoreQueueConfiguration().setAddress(address).setName(name).setFilterString(filterString).setDurable(durable).setMaxConsumers(maxConsumers).setDeleteOnNoConsumers(deleteOnNoConsumers);
+      return new CoreQueueConfiguration().setAddress(address).setName(name).setFilterString(filterString).setDurable(durable).setMaxConsumers(maxConsumers).setPurgeOnNoConsumers(purgeOnNoConsumers);
    }
 
    protected CoreAddressConfiguration parseAddressConfiguration(final Node node) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -605,7 +605,7 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
             if (maxConsumers != Queue.MAX_CONSUMERS_UNLIMITED) {
                output.append(", maxConsumers=").append(queue.getMaxConsumers());
             }
-            output.append(", deleteOnNoConsumers=").append(queue.isDeleteOnNoConsumers());
+            output.append(", purgeOnNoConsumers=").append(queue.isPurgeOnNoConsumers());
             output.append(", autoCreateAddress=").append(queue.isAutoCreated());
             output.append(']');
             return output;
@@ -725,7 +725,7 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
    @Override
    public void createQueue(final String address, final String name, final String filterStr, final boolean durable, final String routingType) throws Exception {
       AddressSettings addressSettings = server.getAddressSettingsRepository().getMatch(address);
-      createQueue(address, routingType, name, filterStr, durable, addressSettings.getDefaultMaxConsumers(), addressSettings.isDefaultDeleteOnNoConsumers(), addressSettings.isAutoCreateAddresses());
+      createQueue(address, routingType, name, filterStr, durable, addressSettings.getDefaultMaxConsumers(), addressSettings.isDefaultPurgeOnNoConsumers(), addressSettings.isAutoCreateAddresses());
    }
 
    @Override
@@ -735,7 +735,7 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
                              String filterStr,
                              boolean durable,
                              int maxConsumers,
-                             boolean deleteOnNoConsumers,
+                             boolean purgeOnNoConsumers,
                              boolean autoCreateAddress) throws Exception {
       checkStarted();
 
@@ -747,7 +747,7 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
             filter = new SimpleString(filterStr);
          }
 
-         final Queue queue = server.createQueue(SimpleString.toSimpleString(address), RoutingType.valueOf(routingType.toUpperCase()), new SimpleString(name), filter, durable, false, maxConsumers, deleteOnNoConsumers, autoCreateAddress);
+         final Queue queue = server.createQueue(SimpleString.toSimpleString(address), RoutingType.valueOf(routingType.toUpperCase()), new SimpleString(name), filter, durable, false, maxConsumers, purgeOnNoConsumers, autoCreateAddress);
          return QueueTextFormatter.Long.format(queue, new StringBuilder()).toString();
       } finally {
          blockOnIO();
@@ -758,13 +758,13 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
    public String updateQueue(String name,
                              String routingType,
                              Integer maxConsumers,
-                             Boolean deleteOnNoConsumers) throws Exception {
+                             Boolean purgeOnNoConsumers) throws Exception {
       checkStarted();
 
       clearIO();
 
       try {
-         final Queue queue = server.updateQueue(name, routingType != null ? RoutingType.valueOf(routingType) : null, maxConsumers, deleteOnNoConsumers);
+         final Queue queue = server.updateQueue(name, routingType != null ? RoutingType.valueOf(routingType) : null, maxConsumers, purgeOnNoConsumers);
          if (queue == null) {
             throw ActiveMQMessageBundle.BUNDLE.noSuchQueue(new SimpleString(name));
          }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/QueueControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/QueueControlImpl.java
@@ -344,12 +344,12 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
    }
 
    @Override
-   public boolean isDeleteOnNoConsumers() {
+   public boolean isPurgeOnNoConsumers() {
       checkStarted();
 
       clearIO();
       try {
-         return queue.isDeleteOnNoConsumers();
+         return queue.isPurgeOnNoConsumers();
       } finally {
          blockOnIO();
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/QueueBindingInfo.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/QueueBindingInfo.java
@@ -50,9 +50,9 @@ public interface QueueBindingInfo {
 
    void setMaxConsumers(int maxConsumers);
 
-   boolean isDeleteOnNoConsumers();
+   boolean isPurgeOnNoConsumers();
 
-   void setDeleteOnNoConsumers(boolean deleteOnNoConsumers);
+   void setPurgeOnNoConsumers(boolean purgeOnNoConsumers);
 
    byte getRoutingType();
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AbstractJournalStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AbstractJournalStorageManager.java
@@ -1221,7 +1221,7 @@ public abstract class AbstractJournalStorageManager implements StorageManager {
 
       SimpleString filterString = filter == null ? null : filter.getFilterString();
 
-      PersistentQueueBindingEncoding bindingEncoding = new PersistentQueueBindingEncoding(queue.getName(), binding.getAddress(), filterString, queue.getUser(), queue.isAutoCreated(), queue.getMaxConsumers(), queue.isDeleteOnNoConsumers(), queue.getRoutingType().getType());
+      PersistentQueueBindingEncoding bindingEncoding = new PersistentQueueBindingEncoding(queue.getName(), binding.getAddress(), filterString, queue.getUser(), queue.isAutoCreated(), queue.getMaxConsumers(), queue.isPurgeOnNoConsumers(), queue.getRoutingType().getType());
 
       readLock();
       try {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/PersistentQueueBindingEncoding.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/PersistentQueueBindingEncoding.java
@@ -44,7 +44,7 @@ public class PersistentQueueBindingEncoding implements EncodingSupport, QueueBin
 
    public int maxConsumers;
 
-   public boolean deleteOnNoConsumers;
+   public boolean purgeOnNoConsumers;
 
    public byte routingType;
 
@@ -66,8 +66,8 @@ public class PersistentQueueBindingEncoding implements EncodingSupport, QueueBin
          autoCreated +
          ", maxConsumers=" +
          maxConsumers +
-         ", deleteOnNoConsumers=" +
-         deleteOnNoConsumers +
+         ", purgeOnNoConsumers=" +
+         purgeOnNoConsumers +
          ", routingType=" +
          routingType +
          "]";
@@ -79,7 +79,7 @@ public class PersistentQueueBindingEncoding implements EncodingSupport, QueueBin
                                          final SimpleString user,
                                          final boolean autoCreated,
                                          final int maxConsumers,
-                                         final boolean deleteOnNoConsumers,
+                                         final boolean purgeOnNoConsumers,
                                          final byte routingType) {
       this.name = name;
       this.address = address;
@@ -87,7 +87,7 @@ public class PersistentQueueBindingEncoding implements EncodingSupport, QueueBin
       this.user = user;
       this.autoCreated = autoCreated;
       this.maxConsumers = maxConsumers;
-      this.deleteOnNoConsumers = deleteOnNoConsumers;
+      this.purgeOnNoConsumers = purgeOnNoConsumers;
       this.routingType = routingType;
    }
 
@@ -154,13 +154,13 @@ public class PersistentQueueBindingEncoding implements EncodingSupport, QueueBin
    }
 
    @Override
-   public boolean isDeleteOnNoConsumers() {
+   public boolean isPurgeOnNoConsumers() {
       return false;
    }
 
    @Override
-   public void setDeleteOnNoConsumers(boolean deleteOnNoConsumers) {
-      this.deleteOnNoConsumers = deleteOnNoConsumers;
+   public void setPurgeOnNoConsumers(boolean purgeOnNoConsumers) {
+      this.purgeOnNoConsumers = purgeOnNoConsumers;
    }
 
    @Override
@@ -196,11 +196,11 @@ public class PersistentQueueBindingEncoding implements EncodingSupport, QueueBin
 
       if (buffer.readableBytes() > 0) {
          maxConsumers = buffer.readInt();
-         deleteOnNoConsumers = buffer.readBoolean();
+         purgeOnNoConsumers = buffer.readBoolean();
          routingType = buffer.readByte();
       } else {
          maxConsumers = ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers();
-         deleteOnNoConsumers = ActiveMQDefaultConfiguration.getDefaultDeleteQueueOnNoConsumers();
+         purgeOnNoConsumers = ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers();
          routingType = ActiveMQDefaultConfiguration.getDefaultRoutingType().getType();
       }
    }
@@ -213,7 +213,7 @@ public class PersistentQueueBindingEncoding implements EncodingSupport, QueueBin
       buffer.writeNullableSimpleString(createMetadata());
       buffer.writeBoolean(autoCreated);
       buffer.writeInt(maxConsumers);
-      buffer.writeBoolean(deleteOnNoConsumers);
+      buffer.writeBoolean(purgeOnNoConsumers);
       buffer.writeByte(routingType);
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/PostOffice.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/PostOffice.java
@@ -60,7 +60,7 @@ public interface PostOffice extends ActiveMQComponent {
    QueueBinding updateQueue(SimpleString name,
                             RoutingType routingType,
                             Integer maxConsumers,
-                            Boolean deleteOnNoConsumers) throws Exception;
+                            Boolean purgeOnNoConsumers) throws Exception;
 
    List<Queue> listQueuesForAddress(SimpleString address) throws Exception;
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -444,7 +444,7 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
    public QueueBinding updateQueue(SimpleString name,
                                    RoutingType routingType,
                                    Integer maxConsumers,
-                                   Boolean deleteOnNoConsumers) throws Exception {
+                                   Boolean purgeOnNoConsumers) throws Exception {
       synchronized (addressLock) {
          final QueueBinding queueBinding = (QueueBinding) addressManager.getBinding(name);
          if (queueBinding == null) {
@@ -474,8 +474,8 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
          if (routingType != null) {
             queue.setRoutingType(routingType);
          }
-         if (deleteOnNoConsumers != null) {
-            queue.setDeleteOnNoConsumers(deleteOnNoConsumers);
+         if (purgeOnNoConsumers != null) {
+            queue.setPurgeOnNoConsumers(purgeOnNoConsumers);
          }
          return queueBinding;
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/ServerSessionPacketHandler.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/ServerSessionPacketHandler.java
@@ -252,7 +252,7 @@ public class ServerSessionPacketHandler implements ChannelHandler {
                case CREATE_QUEUE_V2: {
                   CreateQueueMessage_V2 request = (CreateQueueMessage_V2) packet;
                   requiresResponse = request.isRequiresResponse();
-                  session.createQueue(request.getAddress(), request.getQueueName(), request.getRoutingType(), request.getFilterString(), request.isTemporary(), request.isDurable(), request.getMaxConsumers(), request.isDeleteOnNoConsumers(),
+                  session.createQueue(request.getAddress(), request.getQueueName(), request.getRoutingType(), request.getFilterString(), request.isTemporary(), request.isDurable(), request.getMaxConsumers(), request.isPurgeOnNoConsumers(),
                                       request.isAutoCreated());
                   if (requiresResponse) {
                      response = new NullResponseMessage();
@@ -302,7 +302,7 @@ public class ServerSessionPacketHandler implements ChannelHandler {
                   SessionBindingQueryMessage request = (SessionBindingQueryMessage) packet;
                   BindingQueryResult result = session.executeBindingQuery(request.getAddress(remotingConnection.getClientVersion()));
                   if (channel.supports(PacketImpl.SESS_BINDINGQUERY_RESP_V4)) {
-                     response = new SessionBindingQueryResponseMessage_V4(result.isExists(), result.getQueueNames(), result.isAutoCreateQueues(), result.isAutoCreateAddresses(), result.isDefaultDeleteOnNoConsumers(), result.getDefaultMaxConsumers());
+                     response = new SessionBindingQueryResponseMessage_V4(result.isExists(), result.getQueueNames(), result.isAutoCreateQueues(), result.isAutoCreateAddresses(), result.isDefaultPurgeOnNoConsumers(), result.getDefaultMaxConsumers());
                   } else if (channel.supports(PacketImpl.SESS_BINDINGQUERY_RESP_V3)) {
                      response = new SessionBindingQueryResponseMessage_V3(result.isExists(), result.getQueueNames(), result.isAutoCreateQueues(), result.isAutoCreateAddresses());
                   } else if (channel.supports(PacketImpl.SESS_BINDINGQUERY_RESP_V2)) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServer.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServer.java
@@ -287,16 +287,16 @@ public interface ActiveMQServer extends ActiveMQComponent {
                      boolean durable, boolean temporary) throws Exception;
 
    Queue createQueue(SimpleString address, RoutingType routingType, SimpleString queueName, SimpleString filter,
-                     boolean durable, boolean temporary, int maxConsumers, boolean deleteOnNoConsumers,
+                     boolean durable, boolean temporary, int maxConsumers, boolean purgeOnNoConsumers,
                      boolean autoCreateAddress) throws Exception;
 
    Queue createQueue(SimpleString address, RoutingType routingType, SimpleString queueName, SimpleString filter,
                      SimpleString user, boolean durable, boolean temporary, boolean autoCreated, Integer maxConsumers,
-                     Boolean deleteOnNoConsumers, boolean autoCreateAddress) throws Exception;
+                     Boolean purgeOnNoConsumers, boolean autoCreateAddress) throws Exception;
 
    Queue createQueue(SimpleString address, RoutingType routingType, SimpleString queueName, SimpleString filter,
                      SimpleString user, boolean durable, boolean temporary, boolean ignoreIfExists, boolean transientQueue,
-                     boolean autoCreated, int maxConsumers, boolean deleteOnNoConsumers, boolean autoCreateAddress) throws Exception;
+                     boolean autoCreated, int maxConsumers, boolean purgeOnNoConsumers, boolean autoCreateAddress) throws Exception;
 
    @Deprecated
    Queue createQueue(SimpleString address, SimpleString queueName, SimpleString filter, boolean durable, boolean temporary) throws Exception;
@@ -367,7 +367,7 @@ public interface ActiveMQServer extends ActiveMQComponent {
    Queue updateQueue(String name,
                      RoutingType routingType,
                      Integer maxConsumers,
-                     Boolean deleteOnNoConsumers) throws Exception;
+                     Boolean purgeOnNoConsumers) throws Exception;
 
    /*
             * add a ProtocolManagerFactory to be used. Note if @see Configuration#isResolveProtocols is tur then this factory will

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/BindingQueryResult.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/BindingQueryResult.java
@@ -30,7 +30,7 @@ public class BindingQueryResult {
 
    private boolean autoCreateAddresses;
 
-   private boolean defaultDeleteOnNoConsumers;
+   private boolean defaultPurgeOnNoConsumers;
 
    private int defaultMaxConsumers;
 
@@ -38,7 +38,7 @@ public class BindingQueryResult {
                              final List<SimpleString> queueNames,
                              final boolean autoCreateQueues,
                              final boolean autoCreateAddresses,
-                             final boolean defaultDeleteOnNoConsumers,
+                             final boolean defaultPurgeOnNoConsumers,
                              final int defaultMaxConsumers) {
       this.exists = exists;
 
@@ -48,7 +48,7 @@ public class BindingQueryResult {
 
       this.autoCreateAddresses = autoCreateAddresses;
 
-      this.defaultDeleteOnNoConsumers = defaultDeleteOnNoConsumers;
+      this.defaultPurgeOnNoConsumers = defaultPurgeOnNoConsumers;
 
       this.defaultMaxConsumers = defaultMaxConsumers;
    }
@@ -69,8 +69,8 @@ public class BindingQueryResult {
       return queueNames;
    }
 
-   public boolean isDefaultDeleteOnNoConsumers() {
-      return defaultDeleteOnNoConsumers;
+   public boolean isDefaultPurgeOnNoConsumers() {
+      return defaultPurgeOnNoConsumers;
    }
 
    public int getDefaultMaxConsumers() {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/Queue.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/Queue.java
@@ -52,9 +52,9 @@ public interface Queue extends Bindable {
 
    boolean isAutoCreated();
 
-   boolean isDeleteOnNoConsumers();
+   boolean isPurgeOnNoConsumers();
 
-   void setDeleteOnNoConsumers(boolean value);
+   void setPurgeOnNoConsumers(boolean value);
 
    int getMaxConsumers();
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/QueueConfig.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/QueueConfig.java
@@ -36,7 +36,7 @@ public final class QueueConfig {
    private final boolean autoCreated;
    private final RoutingType routingType;
    private final int maxConsumers;
-   private final boolean deleteOnNoConsumers;
+   private final boolean purgeOnNoConsumers;
 
    public static final class Builder {
 
@@ -51,7 +51,7 @@ public final class QueueConfig {
       private boolean autoCreated;
       private RoutingType routingType;
       private int maxConsumers;
-      private boolean deleteOnNoConsumers;
+      private boolean purgeOnNoConsumers;
 
       private Builder(final long id, final SimpleString name) {
          this(id, name, name);
@@ -69,7 +69,7 @@ public final class QueueConfig {
          this.autoCreated = true;
          this.routingType = ActiveMQDefaultConfiguration.getDefaultRoutingType();
          this.maxConsumers = ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers();
-         this.deleteOnNoConsumers = ActiveMQDefaultConfiguration.getDefaultDeleteQueueOnNoConsumers();
+         this.purgeOnNoConsumers = ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers();
          validateState();
       }
 
@@ -121,8 +121,8 @@ public final class QueueConfig {
          return this;
       }
 
-      public Builder deleteOnNoConsumers(final boolean deleteOnNoConsumers) {
-         this.deleteOnNoConsumers = deleteOnNoConsumers;
+      public Builder purgeOnNoConsumers(final boolean purgeOnNoConsumers) {
+         this.purgeOnNoConsumers = purgeOnNoConsumers;
          return this;
       }
 
@@ -152,7 +152,7 @@ public final class QueueConfig {
          } else {
             pageSubscription = null;
          }
-         return new QueueConfig(id, address, name, filter, pageSubscription, user, durable, temporary, autoCreated, routingType, maxConsumers, deleteOnNoConsumers);
+         return new QueueConfig(id, address, name, filter, pageSubscription, user, durable, temporary, autoCreated, routingType, maxConsumers, purgeOnNoConsumers);
       }
 
    }
@@ -196,7 +196,7 @@ public final class QueueConfig {
                        final boolean autoCreated,
                        final RoutingType routingType,
                        final int maxConsumers,
-                       final boolean deleteOnNoConsumers) {
+                       final boolean purgeOnNoConsumers) {
       this.id = id;
       this.address = address;
       this.name = name;
@@ -207,7 +207,7 @@ public final class QueueConfig {
       this.temporary = temporary;
       this.autoCreated = autoCreated;
       this.routingType = routingType;
-      this.deleteOnNoConsumers = deleteOnNoConsumers;
+      this.purgeOnNoConsumers = purgeOnNoConsumers;
       this.maxConsumers = maxConsumers;
    }
 
@@ -247,8 +247,8 @@ public final class QueueConfig {
       return autoCreated;
    }
 
-   public boolean isDeleteOnNoConsumers() {
-      return deleteOnNoConsumers;
+   public boolean isPurgeOnNoConsumers() {
+      return purgeOnNoConsumers;
    }
 
    public int maxConsumers() {
@@ -288,7 +288,7 @@ public final class QueueConfig {
          return false;
       if (maxConsumers != that.maxConsumers)
          return false;
-      if (deleteOnNoConsumers != that.deleteOnNoConsumers)
+      if (purgeOnNoConsumers != that.purgeOnNoConsumers)
          return false;
       return user != null ? user.equals(that.user) : that.user == null;
 
@@ -307,7 +307,7 @@ public final class QueueConfig {
       result = 31 * result + (autoCreated ? 1 : 0);
       result = 31 * result + routingType.getType();
       result = 31 * result + maxConsumers;
-      result = 31 * result + (deleteOnNoConsumers ? 1 : 0);
+      result = 31 * result + (purgeOnNoConsumers ? 1 : 0);
       return result;
    }
 
@@ -325,6 +325,6 @@ public final class QueueConfig {
          + ", autoCreated=" + autoCreated
          + ", routingType=" + routingType
          + ", maxConsumers=" + maxConsumers
-         + ", deleteOnNoConsumers=" + deleteOnNoConsumers + '}';
+         + ", purgeOnNoConsumers=" + purgeOnNoConsumers + '}';
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ServerSession.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ServerSession.java
@@ -134,7 +134,7 @@ public interface ServerSession extends SecurityAuth {
                      boolean temporary,
                      boolean durable,
                      int maxConsumers,
-                     boolean deleteOnNoConsumers,
+                     boolean purgeOnNoConsumers,
                      boolean autoCreated) throws Exception;
 
    Queue createQueue(SimpleString address,

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/AutoCreatedQueueManagerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/AutoCreatedQueueManagerImpl.java
@@ -39,7 +39,7 @@ public class AutoCreatedQueueManagerImpl implements AutoCreatedQueueManager {
          long consumerCount = queue.getConsumerCount();
          long messageCount = queue.getMessageCount();
 
-         if (((queue.isAutoCreated() && settings.isAutoDeleteQueues()) || queue.isDeleteOnNoConsumers()) && queue.getMessageCount() == 0) {
+         if (((queue.isAutoCreated() && settings.isAutoDeleteQueues()) || queue.isPurgeOnNoConsumers()) && queue.getMessageCount() == 0) {
             if (ActiveMQServerLogger.LOGGER.isDebugEnabled()) {
                ActiveMQServerLogger.LOGGER.debug("deleting " + (queue.isAutoCreated() ? "auto-created " : "") + "queue \"" + queueName + ".\" consumerCount = " + consumerCount + "; messageCount = " + messageCount + "; isAutoDeleteQueues = " + settings.isAutoDeleteQueues());
             }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/LastValueQueue.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/LastValueQueue.java
@@ -59,13 +59,13 @@ public class LastValueQueue extends QueueImpl {
                          final boolean autoCreated,
                          final RoutingType routingType,
                          final Integer maxConsumers,
-                         final Boolean deleteOnNoConsumers,
+                         final Boolean purgeOnNoConsumers,
                          final ScheduledExecutorService scheduledExecutor,
                          final PostOffice postOffice,
                          final StorageManager storageManager,
                          final HierarchicalRepository<AddressSettings> addressSettingsRepository,
                          final Executor executor) {
-      super(persistenceID, address, name, filter, pageSubscription, user, durable, temporary, autoCreated, routingType, maxConsumers, deleteOnNoConsumers, scheduledExecutor, postOffice, storageManager, addressSettingsRepository, executor);
+      super(persistenceID, address, name, filter, pageSubscription, user, durable, temporary, autoCreated, routingType, maxConsumers, purgeOnNoConsumers, scheduledExecutor, postOffice, storageManager, addressSettingsRepository, executor);
       new Exception("LastValueQeue " + this).toString();
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/PostOfficeJournalLoader.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/PostOfficeJournalLoader.java
@@ -149,7 +149,7 @@ public class PostOfficeJournalLoader implements JournalLoader {
             .durable(true)
             .temporary(false)
             .autoCreated(queueBindingInfo.isAutoCreated())
-            .deleteOnNoConsumers(queueBindingInfo.isDeleteOnNoConsumers())
+            .purgeOnNoConsumers(queueBindingInfo.isPurgeOnNoConsumers())
             .maxConsumers(queueBindingInfo.getMaxConsumers())
             .routingType(RoutingType.getType(queueBindingInfo.getRoutingType()));
          final Queue queue = queueFactory.createQueueWith(queueConfigBuilder.build());

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueFactoryImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueFactoryImpl.java
@@ -72,9 +72,9 @@ public class QueueFactoryImpl implements QueueFactory {
       final AddressSettings addressSettings = addressSettingsRepository.getMatch(config.address().toString());
       final Queue queue;
       if (addressSettings.isLastValueQueue()) {
-         queue = new LastValueQueue(config.id(), config.address(), config.name(), config.filter(), config.pageSubscription(), config.user(), config.isDurable(), config.isTemporary(), config.isAutoCreated(), config.deliveryMode(), config.maxConsumers(), config.isDeleteOnNoConsumers(), scheduledExecutor, postOffice, storageManager, addressSettingsRepository, executorFactory.getExecutor());
+         queue = new LastValueQueue(config.id(), config.address(), config.name(), config.filter(), config.pageSubscription(), config.user(), config.isDurable(), config.isTemporary(), config.isAutoCreated(), config.deliveryMode(), config.maxConsumers(), config.isPurgeOnNoConsumers(), scheduledExecutor, postOffice, storageManager, addressSettingsRepository, executorFactory.getExecutor());
       } else {
-         queue = new QueueImpl(config.id(), config.address(), config.name(), config.filter(), config.pageSubscription(), config.user(), config.isDurable(), config.isTemporary(), config.isAutoCreated(), config.deliveryMode(), config.maxConsumers(), config.isDeleteOnNoConsumers(), scheduledExecutor, postOffice, storageManager, addressSettingsRepository, executorFactory.getExecutor());
+         queue = new QueueImpl(config.id(), config.address(), config.name(), config.filter(), config.pageSubscription(), config.user(), config.isDurable(), config.isTemporary(), config.isAutoCreated(), config.deliveryMode(), config.maxConsumers(), config.isPurgeOnNoConsumers(), scheduledExecutor, postOffice, storageManager, addressSettingsRepository, executorFactory.getExecutor());
       }
       return queue;
    }
@@ -98,7 +98,7 @@ public class QueueFactoryImpl implements QueueFactory {
 
       Queue queue;
       if (addressSettings.isLastValueQueue()) {
-         queue = new LastValueQueue(persistenceID, address, name, filter, pageSubscription, user, durable, temporary, autoCreated, ActiveMQDefaultConfiguration.getDefaultRoutingType(), ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers(), ActiveMQDefaultConfiguration.getDefaultDeleteQueueOnNoConsumers(),  scheduledExecutor, postOffice, storageManager, addressSettingsRepository, executorFactory.getExecutor());
+         queue = new LastValueQueue(persistenceID, address, name, filter, pageSubscription, user, durable, temporary, autoCreated, ActiveMQDefaultConfiguration.getDefaultRoutingType(), ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers(), ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers(),  scheduledExecutor, postOffice, storageManager, addressSettingsRepository, executorFactory.getExecutor());
       } else {
          queue = new QueueImpl(persistenceID, address, name, filter, pageSubscription, user, durable, temporary, autoCreated, scheduledExecutor, postOffice, storageManager, addressSettingsRepository, executorFactory.getExecutor());
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
@@ -242,7 +242,7 @@ public class QueueImpl implements Queue {
 
    private volatile int maxConsumers;
 
-   private volatile boolean deleteOnNoConsumers;
+   private volatile boolean purgeOnNoConsumers;
 
    private final AddressInfo addressInfo;
 
@@ -360,7 +360,7 @@ public class QueueImpl implements Queue {
                     final boolean autoCreated,
                     final RoutingType routingType,
                     final Integer maxConsumers,
-                    final Boolean deleteOnNoConsumers,
+                    final Boolean purgeOnNoConsumers,
                     final ScheduledExecutorService scheduledExecutor,
                     final PostOffice postOffice,
                     final StorageManager storageManager,
@@ -389,7 +389,7 @@ public class QueueImpl implements Queue {
 
       this.maxConsumers = maxConsumers == null ? ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers() : maxConsumers;
 
-      this.deleteOnNoConsumers = deleteOnNoConsumers == null ? ActiveMQDefaultConfiguration.getDefaultDeleteQueueOnNoConsumers() : deleteOnNoConsumers;
+      this.purgeOnNoConsumers = purgeOnNoConsumers == null ? ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers() : purgeOnNoConsumers;
 
       this.postOffice = postOffice;
 
@@ -478,13 +478,13 @@ public class QueueImpl implements Queue {
    }
 
    @Override
-   public boolean isDeleteOnNoConsumers() {
-      return deleteOnNoConsumers;
+   public boolean isPurgeOnNoConsumers() {
+      return purgeOnNoConsumers;
    }
 
    @Override
-   public synchronized void setDeleteOnNoConsumers(boolean value) {
-      this.deleteOnNoConsumers = value;
+   public synchronized void setPurgeOnNoConsumers(boolean value) {
+      this.purgeOnNoConsumers = value;
    }
 
    @Override
@@ -851,7 +851,7 @@ public class QueueImpl implements Queue {
             refCountForConsumers.decrement();
          }
 
-         if (noConsumers.decrementAndGet() == 0 && deleteOnNoConsumers) {
+         if (noConsumers.decrementAndGet() == 0 && purgeOnNoConsumers) {
             try {
                deleteQueue();
             } catch (Exception e) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -506,7 +506,7 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
                             final boolean temporary,
                             final boolean durable) throws Exception {
       AddressSettings as = server.getAddressSettingsRepository().getMatch(address.toString());
-      return createQueue(address, name, as.getDefaultQueueRoutingType(), filterString, temporary, durable, as.getDefaultMaxConsumers(), as.isDefaultDeleteOnNoConsumers(), false);
+      return createQueue(address, name, as.getDefaultQueueRoutingType(), filterString, temporary, durable, as.getDefaultMaxConsumers(), as.isDefaultPurgeOnNoConsumers(), false);
    }
 
    @Override
@@ -517,7 +517,7 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
                             final boolean temporary,
                             final boolean durable) throws Exception {
       AddressSettings as = server.getAddressSettingsRepository().getMatch(address.toString());
-      return createQueue(address, name, routingType, filterString, temporary, durable, as.getDefaultMaxConsumers(), as.isDefaultDeleteOnNoConsumers(), false);
+      return createQueue(address, name, routingType, filterString, temporary, durable, as.getDefaultMaxConsumers(), as.isDefaultPurgeOnNoConsumers(), false);
    }
 
    @Override
@@ -528,7 +528,7 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
                             final boolean temporary,
                             final boolean durable,
                             final int maxConsumers,
-                            final boolean deleteOnNoConsumers,
+                            final boolean purgeOnNoConsumers,
                             final boolean autoCreated) throws Exception {
       final SimpleString unPrefixedName = removePrefix(name);
 
@@ -543,7 +543,7 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
 
       server.checkQueueCreationLimit(getUsername());
 
-      Queue queue = server.createQueue(art.getA(), art.getB(), unPrefixedName, filterString, SimpleString.toSimpleString(getUsername()), durable, temporary, autoCreated, maxConsumers, deleteOnNoConsumers, server.getAddressSettingsRepository().getMatch(address.toString()).isAutoCreateAddresses());
+      Queue queue = server.createQueue(art.getA(), art.getB(), unPrefixedName, filterString, SimpleString.toSimpleString(getUsername()), durable, temporary, autoCreated, maxConsumers, purgeOnNoConsumers, server.getAddressSettingsRepository().getMatch(address.toString()).isAutoCreateAddresses());
 
       if (temporary) {
          // Temporary queue in core simply means the queue will be deleted if
@@ -582,7 +582,7 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
                             boolean durable,
                             boolean autoCreated) throws Exception {
       AddressSettings as = server.getAddressSettingsRepository().getMatch(address.toString());
-      return createQueue(address, name, routingType, filterString, temporary, durable, as.getDefaultMaxConsumers(), as.isDefaultDeleteOnNoConsumers(), autoCreated);
+      return createQueue(address, name, routingType, filterString, temporary, durable, as.getDefaultMaxConsumers(), as.isDefaultPurgeOnNoConsumers(), autoCreated);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
@@ -158,7 +158,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
    private Integer defaultMaxConsumers = null;
 
-   private Boolean defaultDeleteOnNoConsumers = null;
+   private Boolean defaultPurgeOnNoConsumers = null;
 
    private RoutingType defaultQueueRoutingType = null;
 
@@ -200,7 +200,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       this.queuePrefetch = other.queuePrefetch;
       this.maxSizeBytesRejectThreshold = other.maxSizeBytesRejectThreshold;
       this.defaultMaxConsumers = other.defaultMaxConsumers;
-      this.defaultDeleteOnNoConsumers = other.defaultDeleteOnNoConsumers;
+      this.defaultPurgeOnNoConsumers = other.defaultPurgeOnNoConsumers;
       this.defaultQueueRoutingType = other.defaultQueueRoutingType;
       this.defaultAddressRoutingType = other.defaultAddressRoutingType;
    }
@@ -297,12 +297,12 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       return this;
    }
 
-   public boolean isDefaultDeleteOnNoConsumers() {
-      return defaultDeleteOnNoConsumers != null ? defaultDeleteOnNoConsumers : ActiveMQDefaultConfiguration.getDefaultDeleteQueueOnNoConsumers();
+   public boolean isDefaultPurgeOnNoConsumers() {
+      return defaultPurgeOnNoConsumers != null ? defaultPurgeOnNoConsumers : ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers();
    }
 
-   public AddressSettings setDefaultDeleteOnNoConsumers(Boolean defaultDeleteOnNoConsumers) {
-      this.defaultDeleteOnNoConsumers = defaultDeleteOnNoConsumers;
+   public AddressSettings setDefaultPurgeOnNoConsumers(Boolean defaultPurgeOnNoConsumers) {
+      this.defaultPurgeOnNoConsumers = defaultPurgeOnNoConsumers;
       return this;
    }
 
@@ -612,8 +612,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       if (defaultMaxConsumers == null) {
          defaultMaxConsumers = merged.defaultMaxConsumers;
       }
-      if (defaultDeleteOnNoConsumers == null) {
-         defaultDeleteOnNoConsumers = merged.defaultDeleteOnNoConsumers;
+      if (defaultPurgeOnNoConsumers == null) {
+         defaultPurgeOnNoConsumers = merged.defaultPurgeOnNoConsumers;
       }
       if (defaultQueueRoutingType == null) {
          defaultQueueRoutingType = merged.defaultQueueRoutingType;
@@ -697,7 +697,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
       defaultMaxConsumers = BufferHelper.readNullableInteger(buffer);
 
-      defaultDeleteOnNoConsumers = BufferHelper.readNullableBoolean(buffer);
+      defaultPurgeOnNoConsumers = BufferHelper.readNullableBoolean(buffer);
 
       defaultQueueRoutingType = RoutingType.getType(buffer.readByte());
 
@@ -737,7 +737,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
          BufferHelper.sizeOfNullableInteger(managementBrowsePageSize) +
          BufferHelper.sizeOfNullableLong(maxSizeBytesRejectThreshold) +
          BufferHelper.sizeOfNullableInteger(defaultMaxConsumers) +
-         BufferHelper.sizeOfNullableBoolean(defaultDeleteOnNoConsumers) +
+         BufferHelper.sizeOfNullableBoolean(defaultPurgeOnNoConsumers) +
          DataConstants.SIZE_BYTE +
          DataConstants.SIZE_BYTE;
    }
@@ -804,7 +804,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
       BufferHelper.writeNullableInteger(buffer, defaultMaxConsumers);
 
-      BufferHelper.writeNullableBoolean(buffer, defaultDeleteOnNoConsumers);
+      BufferHelper.writeNullableBoolean(buffer, defaultPurgeOnNoConsumers);
 
       buffer.writeByte(defaultQueueRoutingType == null ? -1 : defaultQueueRoutingType.getType());
 
@@ -849,7 +849,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       result = prime * result + ((queuePrefetch == null) ? 0 : queuePrefetch.hashCode());
       result = prime * result + ((maxSizeBytesRejectThreshold == null) ? 0 : maxSizeBytesRejectThreshold.hashCode());
       result = prime * result + ((defaultMaxConsumers == null) ? 0 : defaultMaxConsumers.hashCode());
-      result = prime * result + ((defaultDeleteOnNoConsumers == null) ? 0 : defaultDeleteOnNoConsumers.hashCode());
+      result = prime * result + ((defaultPurgeOnNoConsumers == null) ? 0 : defaultPurgeOnNoConsumers.hashCode());
       result = prime * result + ((defaultQueueRoutingType == null) ? 0 : defaultQueueRoutingType.hashCode());
       result = prime * result + ((defaultAddressRoutingType == null) ? 0 : defaultAddressRoutingType.hashCode());
       return result;
@@ -1025,10 +1025,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       } else if (!defaultMaxConsumers.equals(other.defaultMaxConsumers))
          return false;
 
-      if (defaultDeleteOnNoConsumers == null) {
-         if (other.defaultDeleteOnNoConsumers != null)
+      if (defaultPurgeOnNoConsumers == null) {
+         if (other.defaultPurgeOnNoConsumers != null)
             return false;
-      } else if (!defaultDeleteOnNoConsumers.equals(other.defaultDeleteOnNoConsumers))
+      } else if (!defaultPurgeOnNoConsumers.equals(other.defaultPurgeOnNoConsumers))
          return false;
 
       if (defaultQueueRoutingType == null) {
@@ -1109,8 +1109,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
          managementBrowsePageSize +
          ", defaultMaxConsumers=" +
          defaultMaxConsumers +
-         ", defaultDeleteOnNoConsumers=" +
-         defaultDeleteOnNoConsumers +
+         ", defaultPurgeOnNoConsumers=" +
+         defaultPurgeOnNoConsumers +
          ", defaultQueueRoutingType=" +
          defaultQueueRoutingType +
          ", defaultAddressRoutingType=" +

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -2553,10 +2553,11 @@
                </xsd:annotation>
             </xsd:element>
 
-            <xsd:element name="default-delete-on-no-consumers" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+            <xsd:element name="default-purge-on-no-consumers" type="xsd:boolean" default="false" maxOccurs="1"
+                         minOccurs="0">
                <xsd:annotation>
                   <xsd:documentation>
-                     Purge and pause this queue when the last consumer disconnects
+                     purge the contents of the queue once there are no consumers
                   </xsd:documentation>
                </xsd:annotation>
             </xsd:element>
@@ -2704,7 +2705,7 @@
       </xsd:all>
       <xsd:attribute name="name" type="xsd:ID" use="required"/>
       <xsd:attribute name="max-consumers" type="xsd:integer" use="optional"/>
-      <xsd:attribute name="delete-on-no-consumers" type="xsd:boolean" use="optional"/>
+      <xsd:attribute name="purge-on-no-consumers" type="xsd:boolean" use="optional"/>
    </xsd:complexType>
 
    <xsd:complexType name="addressType">

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
@@ -305,7 +305,7 @@ public class FileConfigurationTest extends ConfigurationImplTest {
       assertEquals(true, conf.getAddressesSettings().get("a1").isAutoDeleteJmsQueues());
       assertEquals(true, conf.getAddressesSettings().get("a1").isAutoCreateJmsTopics());
       assertEquals(true, conf.getAddressesSettings().get("a1").isAutoDeleteJmsTopics());
-      assertEquals(false, conf.getAddressesSettings().get("a1").isDefaultDeleteOnNoConsumers());
+      assertEquals(false, conf.getAddressesSettings().get("a1").isDefaultPurgeOnNoConsumers());
       assertEquals(5, conf.getAddressesSettings().get("a1").getDefaultMaxConsumers());
       assertEquals(RoutingType.ANYCAST, conf.getAddressesSettings().get("a1").getDefaultQueueRoutingType());
       assertEquals(RoutingType.MULTICAST, conf.getAddressesSettings().get("a1").getDefaultAddressRoutingType());
@@ -324,7 +324,7 @@ public class FileConfigurationTest extends ConfigurationImplTest {
       assertEquals(false, conf.getAddressesSettings().get("a2").isAutoDeleteJmsQueues());
       assertEquals(false, conf.getAddressesSettings().get("a2").isAutoCreateJmsTopics());
       assertEquals(false, conf.getAddressesSettings().get("a2").isAutoDeleteJmsTopics());
-      assertEquals(true, conf.getAddressesSettings().get("a2").isDefaultDeleteOnNoConsumers());
+      assertEquals(true, conf.getAddressesSettings().get("a2").isDefaultPurgeOnNoConsumers());
       assertEquals(15, conf.getAddressesSettings().get("a2").getDefaultMaxConsumers());
       assertEquals(RoutingType.MULTICAST, conf.getAddressesSettings().get("a2").getDefaultQueueRoutingType());
       assertEquals(RoutingType.ANYCAST, conf.getAddressesSettings().get("a2").getDefaultAddressRoutingType());
@@ -398,7 +398,7 @@ public class FileConfigurationTest extends ConfigurationImplTest {
       assertEquals("q1", queueConfiguration.getName());
       assertFalse(queueConfiguration.isDurable());
       assertEquals("color='blue'", queueConfiguration.getFilterString());
-      assertEquals(ActiveMQDefaultConfiguration.getDefaultDeleteQueueOnNoConsumers(), queueConfiguration.getDeleteOnNoConsumers());
+      assertEquals(ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers(), queueConfiguration.getPurgeOnNoConsumers());
       assertEquals("addr1", queueConfiguration.getAddress());
       assertEquals(ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers(), queueConfiguration.getMaxConsumers());
 
@@ -409,7 +409,7 @@ public class FileConfigurationTest extends ConfigurationImplTest {
       assertTrue(queueConfiguration.isDurable());
       assertEquals("color='green'", queueConfiguration.getFilterString());
       assertEquals(Queue.MAX_CONSUMERS_UNLIMITED, queueConfiguration.getMaxConsumers());
-      assertFalse(queueConfiguration.getDeleteOnNoConsumers());
+      assertFalse(queueConfiguration.getPurgeOnNoConsumers());
       assertEquals("addr1", queueConfiguration.getAddress());
 
       // Addr 2
@@ -427,7 +427,7 @@ public class FileConfigurationTest extends ConfigurationImplTest {
       assertTrue(queueConfiguration.isDurable());
       assertEquals("color='red'", queueConfiguration.getFilterString());
       assertEquals(10, queueConfiguration.getMaxConsumers());
-      assertEquals(ActiveMQDefaultConfiguration.getDefaultDeleteQueueOnNoConsumers(), queueConfiguration.getDeleteOnNoConsumers());
+      assertEquals(ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers(), queueConfiguration.getPurgeOnNoConsumers());
       assertEquals("addr2", queueConfiguration.getAddress());
 
       // Addr 2 Queue 2
@@ -437,7 +437,7 @@ public class FileConfigurationTest extends ConfigurationImplTest {
       assertTrue(queueConfiguration.isDurable());
       assertNull(queueConfiguration.getFilterString());
       assertEquals(ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers(), queueConfiguration.getMaxConsumers());
-      assertTrue(queueConfiguration.getDeleteOnNoConsumers());
+      assertTrue(queueConfiguration.getPurgeOnNoConsumers());
       assertEquals("addr2", queueConfiguration.getAddress());
 
       // Addr 3

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/ScheduledDeliveryHandlerTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/ScheduledDeliveryHandlerTest.java
@@ -838,7 +838,7 @@ public class ScheduledDeliveryHandlerTest extends Assert {
    public class FakeQueueForScheduleUnitTest implements Queue {
 
       @Override
-      public void setDeleteOnNoConsumers(boolean value) {
+      public void setPurgeOnNoConsumers(boolean value) {
 
       }
 
@@ -922,7 +922,7 @@ public class ScheduledDeliveryHandlerTest extends Assert {
       }
 
       @Override
-      public boolean isDeleteOnNoConsumers() {
+      public boolean isPurgeOnNoConsumers() {
          return false;
       }
 

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/settings/AddressSettingsTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/settings/AddressSettingsTest.java
@@ -48,7 +48,7 @@ public class AddressSettingsTest extends ActiveMQTestBase {
       Assert.assertEquals(AddressSettings.DEFAULT_AUTO_DELETE_QUEUES, addressSettings.isAutoDeleteQueues());
       Assert.assertEquals(AddressSettings.DEFAULT_AUTO_CREATE_ADDRESSES, addressSettings.isAutoCreateAddresses());
       Assert.assertEquals(AddressSettings.DEFAULT_AUTO_DELETE_ADDRESSES, addressSettings.isAutoDeleteAddresses());
-      Assert.assertEquals(ActiveMQDefaultConfiguration.getDefaultDeleteQueueOnNoConsumers(), addressSettings.isDefaultDeleteOnNoConsumers());
+      Assert.assertEquals(ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers(), addressSettings.isDefaultPurgeOnNoConsumers());
       Assert.assertEquals(ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers(), addressSettings.getDefaultMaxConsumers());
    }
 

--- a/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
@@ -272,7 +272,7 @@
             <auto-delete-queues>true</auto-delete-queues>
             <auto-create-addresses>true</auto-create-addresses>
             <auto-delete-addresses>true</auto-delete-addresses>
-            <default-delete-on-no-consumers>false</default-delete-on-no-consumers>
+            <default-purge-on-no-consumers>false</default-purge-on-no-consumers>
             <default-max-consumers>5</default-max-consumers>
             <default-queue-routing-type>ANYCAST</default-queue-routing-type>
             <default-address-routing-type>MULTICAST</default-address-routing-type>
@@ -296,7 +296,7 @@
             <auto-delete-queues>false</auto-delete-queues>
             <auto-create-addresses>false</auto-create-addresses>
             <auto-delete-addresses>false</auto-delete-addresses>
-            <default-delete-on-no-consumers>true</default-delete-on-no-consumers>
+            <default-purge-on-no-consumers>true</default-purge-on-no-consumers>
             <default-max-consumers>15</default-max-consumers>
             <default-queue-routing-type>MULTICAST</default-queue-routing-type>
             <default-address-routing-type>ANYCAST</default-address-routing-type>
@@ -321,7 +321,7 @@
                   <durable>false</durable>
                   <filter string="color='blue'"/>
                </queue>
-               <queue name="q2" max-consumers="-1" delete-on-no-consumers="false">
+               <queue name="q2" max-consumers="-1" purge-on-no-consumers="false">
                   <durable>true</durable>
                   <filter string="color='green'"/>
                </queue>
@@ -332,7 +332,7 @@
                <queue name="q3" max-consumers="10" >
                   <filter string="color='red'"/>
                </queue>
-               <queue name="q4" delete-on-no-consumers="true">
+               <queue name="q4" purge-on-no-consumers="true">
                   <durable>true</durable>
                </queue>
             </multicast>

--- a/artemis-tools/src/main/java/org/apache/activemq/artemis/tools/migrate/config/addressing/Address.java
+++ b/artemis-tools/src/main/java/org/apache/activemq/artemis/tools/migrate/config/addressing/Address.java
@@ -29,7 +29,7 @@ public class Address {
 
    private String defaultMaxConsumers = "-1";
 
-   private String defaultDeleteOnNoConsumers = "false";
+   private String defaultPurgeOnNoConsumers = "false";
 
    private List<Queue> queues = new ArrayList<>();
 

--- a/artemis-tools/src/test/resources/artemis-configuration.xsd
+++ b/artemis-tools/src/test/resources/artemis-configuration.xsd
@@ -2593,7 +2593,7 @@
       </xsd:all>
       <xsd:attribute name="name" type="xsd:ID" use="required"/>
       <xsd:attribute name="max-consumers" type="xsd:integer" use="optional"/>
-      <xsd:attribute name="delete-on-no-consumers" type="xsd:boolean" use="optional"/>
+      <xsd:attribute name="purge-on-no-consumers" type="xsd:boolean" use="optional"/>
    </xsd:complexType>
 
    <xsd:complexType name="addressType">

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/addressing/AddressingTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/addressing/AddressingTest.java
@@ -223,13 +223,13 @@ public class AddressingTest extends ActiveMQTestBase {
    }
 
    @Test
-   public void testDeleteQueueOnNoConsumersTrue() throws Exception {
+   public void testPurgeOnNoConsumersTrue() throws Exception {
 
       SimpleString address = new SimpleString("test.address");
       SimpleString queueName = SimpleString.toSimpleString(UUID.randomUUID().toString());
       // For each address, create 2 Queues with the same address, assert both queues receive message
-      boolean deleteOnNoConsumers = true;
-      Queue q1 = server.createQueue(address, RoutingType.MULTICAST, queueName, null, true, false, Queue.MAX_CONSUMERS_UNLIMITED, deleteOnNoConsumers, true);
+      boolean purgeOnNoConsumers = true;
+      Queue q1 = server.createQueue(address, RoutingType.MULTICAST, queueName, null, true, false, Queue.MAX_CONSUMERS_UNLIMITED, purgeOnNoConsumers, true);
 
       ClientSession session = sessionFactory.createSession();
       session.start();
@@ -241,12 +241,12 @@ public class AddressingTest extends ActiveMQTestBase {
    }
 
    @Test
-   public void testDeleteQueueOnNoConsumersFalse() throws Exception {
+   public void testPurgeOnNoConsumersFalse() throws Exception {
       SimpleString address = new SimpleString("test.address");
       SimpleString queueName = SimpleString.toSimpleString(UUID.randomUUID().toString());
       // For each address, create 2 Queues with the same address, assert both queues receive message
-      boolean deleteOnNoConsumers = false;
-      Queue q1 = server.createQueue(address,RoutingType.MULTICAST, queueName, null, true, false, Queue.MAX_CONSUMERS_UNLIMITED, deleteOnNoConsumers, true);
+      boolean purgeOnNoConsumers = false;
+      Queue q1 = server.createQueue(address,RoutingType.MULTICAST, queueName, null, true, false, Queue.MAX_CONSUMERS_UNLIMITED, purgeOnNoConsumers, true);
 
       ClientSession session = sessionFactory.createSession();
       session.start();
@@ -262,8 +262,8 @@ public class AddressingTest extends ActiveMQTestBase {
       SimpleString address = new SimpleString("test.address");
       SimpleString queueName = SimpleString.toSimpleString(UUID.randomUUID().toString());
       // For each address, create 2 Queues with the same address, assert both queues receive message
-      boolean deleteOnNoConsumers = false;
-      Queue q1 = server.createQueue(address, RoutingType.MULTICAST, queueName, null, true, false, 0, deleteOnNoConsumers, true);
+      boolean purgeOnNoConsumers = false;
+      Queue q1 = server.createQueue(address, RoutingType.MULTICAST, queueName, null, true, false, 0, purgeOnNoConsumers, true);
 
       Exception expectedException = null;
       String expectedMessage = "Maximum Consumer Limit Reached on Queue";
@@ -288,8 +288,8 @@ public class AddressingTest extends ActiveMQTestBase {
       SimpleString address = new SimpleString("test.address");
       SimpleString queueName = SimpleString.toSimpleString(UUID.randomUUID().toString());
       // For each address, create 2 Queues with the same address, assert both queues receive message
-      boolean deleteOnNoConsumers = false;
-      Queue q1 = server.createQueue(address, RoutingType.MULTICAST, queueName, null, true, false, Queue.MAX_CONSUMERS_UNLIMITED, deleteOnNoConsumers, true);
+      boolean purgeOnNoConsumers = false;
+      Queue q1 = server.createQueue(address, RoutingType.MULTICAST, queueName, null, true, false, Queue.MAX_CONSUMERS_UNLIMITED, purgeOnNoConsumers, true);
 
       ClientSession session = sessionFactory.createSession();
       session.start();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cli/QueueCommandTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cli/QueueCommandTest.java
@@ -76,7 +76,7 @@ public class QueueCommandTest extends JMSTestBase {
 
       Queue queue = server.locateQueue(new SimpleString(queueName));
       assertEquals(-1, queue.getMaxConsumers());
-      assertEquals(false, queue.isDeleteOnNoConsumers());
+      assertEquals(false, queue.isPurgeOnNoConsumers());
       assertTrue(server.queueQuery(new SimpleString(queueName)).isExists());
    }
 
@@ -100,7 +100,7 @@ public class QueueCommandTest extends JMSTestBase {
 
       Queue queue = server.locateQueue(new SimpleString(queueName));
       assertEquals(-1, queue.getMaxConsumers());
-      assertEquals(false, queue.isDeleteOnNoConsumers());
+      assertEquals(false, queue.isPurgeOnNoConsumers());
       assertTrue(server.queueQuery(new SimpleString(queueName)).isExists());
    }
 
@@ -245,17 +245,17 @@ public class QueueCommandTest extends JMSTestBase {
       final SimpleString addressSimpleString = new SimpleString(addressName);
       final int oldMaxConsumers = -1;
       final RoutingType oldRoutingType = RoutingType.MULTICAST;
-      final boolean oldDeleteOnNoConsumers = false;
+      final boolean oldPurgeOnNoConsumers = false;
       final AddressInfo addressInfo = new AddressInfo(addressSimpleString, EnumSet.of(RoutingType.ANYCAST, RoutingType.MULTICAST));
       server.addAddressInfo(addressInfo);
-      server.createQueue(addressSimpleString, oldRoutingType, queueNameString, null, true, false, oldMaxConsumers, oldDeleteOnNoConsumers, false);
+      server.createQueue(addressSimpleString, oldRoutingType, queueNameString, null, true, false, oldMaxConsumers, oldPurgeOnNoConsumers, false);
 
       final int newMaxConsumers = 1;
       final RoutingType newRoutingType = RoutingType.ANYCAST;
-      final boolean newDeleteOnNoConsumers = true;
+      final boolean newPurgeOnNoConsumers = true;
       final UpdateQueue updateQueue = new UpdateQueue();
       updateQueue.setName(queueName);
-      updateQueue.setDeleteOnNoConsumers(newDeleteOnNoConsumers);
+      updateQueue.setPurgeOnNoConsumers(newPurgeOnNoConsumers);
       updateQueue.setAnycast(true);
       updateQueue.setMulticast(false);
       updateQueue.setMaxConsumers(newMaxConsumers);
@@ -266,7 +266,7 @@ public class QueueCommandTest extends JMSTestBase {
       final QueueQueryResult queueQueryResult = server.queueQuery(queueNameString);
       assertEquals("maxConsumers", newMaxConsumers, queueQueryResult.getMaxConsumers());
       assertEquals("routingType", newRoutingType, queueQueryResult.getRoutingType());
-      assertTrue("deleteOnNoConsumers", newDeleteOnNoConsumers == queueQueryResult.isDeleteOnNoConsumers());
+      assertTrue("purgeOnNoConsumers", newPurgeOnNoConsumers == queueQueryResult.isPurgeOnNoConsumers());
    }
 
    @Test
@@ -277,11 +277,11 @@ public class QueueCommandTest extends JMSTestBase {
       final SimpleString addressSimpleString = new SimpleString(addressName);
       final int oldMaxConsumers = 10;
       final RoutingType oldRoutingType = RoutingType.MULTICAST;
-      final boolean oldDeleteOnNoConsumers = false;
+      final boolean oldPurgeOnNoConsumers = false;
       final Set<RoutingType> supportedRoutingTypes = EnumSet.of(oldRoutingType);
       final AddressInfo addressInfo = new AddressInfo(addressSimpleString, EnumSet.copyOf(supportedRoutingTypes));
       server.addAddressInfo(addressInfo);
-      server.createQueue(addressSimpleString, oldRoutingType, queueNameString, null, true, false, oldMaxConsumers, oldDeleteOnNoConsumers, false);
+      server.createQueue(addressSimpleString, oldRoutingType, queueNameString, null, true, false, oldMaxConsumers, oldPurgeOnNoConsumers, false);
 
       final RoutingType newRoutingType = RoutingType.ANYCAST;
       final UpdateQueue updateQueue = new UpdateQueue();
@@ -296,7 +296,7 @@ public class QueueCommandTest extends JMSTestBase {
       final QueueQueryResult queueQueryResult = server.queueQuery(queueNameString);
       assertEquals("maxConsumers", oldMaxConsumers, queueQueryResult.getMaxConsumers());
       assertEquals("routingType", oldRoutingType, queueQueryResult.getRoutingType());
-      assertTrue("deleteOnNoConsumers", oldDeleteOnNoConsumers == queueQueryResult.isDeleteOnNoConsumers());
+      assertTrue("purgeOnNoConsumers", oldPurgeOnNoConsumers == queueQueryResult.isPurgeOnNoConsumers());
    }
 
    @Test
@@ -307,10 +307,10 @@ public class QueueCommandTest extends JMSTestBase {
       final SimpleString addressSimpleString = new SimpleString(addressName);
       final int oldMaxConsumers = 2;
       final RoutingType oldRoutingType = RoutingType.MULTICAST;
-      final boolean oldDeleteOnNoConsumers = false;
+      final boolean oldPurgeOnNoConsumers = false;
       final AddressInfo addressInfo = new AddressInfo(addressSimpleString, oldRoutingType);
       server.addAddressInfo(addressInfo);
-      server.createQueue(addressSimpleString, oldRoutingType, queueNameString, null, true, false, oldMaxConsumers, oldDeleteOnNoConsumers, false);
+      server.createQueue(addressSimpleString, oldRoutingType, queueNameString, null, true, false, oldMaxConsumers, oldPurgeOnNoConsumers, false);
 
       server.locateQueue(queueNameString).addConsumer(new DummyServerConsumer());
       server.locateQueue(queueNameString).addConsumer(new DummyServerConsumer());

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/HangConsumerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/HangConsumerTest.java
@@ -228,13 +228,13 @@ public class HangConsumerTest extends ActiveMQTestBase {
                              final boolean autoCreated,
                              final RoutingType deliveryMode,
                              final Integer maxConsumers,
-                             final Boolean deleteOnNoConsumers,
+                             final Boolean purgeOnNoConsumers,
                              final ScheduledExecutorService scheduledExecutor,
                              final PostOffice postOffice,
                              final StorageManager storageManager,
                              final HierarchicalRepository<AddressSettings> addressSettingsRepository,
                              final Executor executor) {
-            super(id, address, name, filter, pageSubscription, user, durable, temporary, autoCreated, deliveryMode, maxConsumers, deleteOnNoConsumers, scheduledExecutor, postOffice, storageManager, addressSettingsRepository, executor);
+            super(id, address, name, filter, pageSubscription, user, durable, temporary, autoCreated, deliveryMode, maxConsumers, purgeOnNoConsumers, scheduledExecutor, postOffice, storageManager, addressSettingsRepository, executor);
          }
 
          @Override
@@ -261,7 +261,7 @@ public class HangConsumerTest extends ActiveMQTestBase {
 
          @Override
          public Queue createQueueWith(final QueueConfig config) {
-            queue = new MyQueueWithBlocking(config.id(), config.address(), config.name(), config.filter(), config.user(), config.pageSubscription(), config.isDurable(), config.isTemporary(), config.isAutoCreated(), config.deliveryMode(), config.maxConsumers(), config.isDeleteOnNoConsumers(), scheduledExecutor, postOffice, storageManager, addressSettingsRepository, executorFactory.getExecutor());
+            queue = new MyQueueWithBlocking(config.id(), config.address(), config.name(), config.filter(), config.user(), config.pageSubscription(), config.isDurable(), config.isTemporary(), config.isAutoCreated(), config.deliveryMode(), config.maxConsumers(), config.isPurgeOnNoConsumers(), scheduledExecutor, postOffice, storageManager, addressSettingsRepository, executorFactory.getExecutor());
             return queue;
          }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/ClusterTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/ClusterTestBase.java
@@ -544,7 +544,7 @@ public abstract class ClusterTestBase extends ActiveMQTestBase {
                                     final String address,
                                     final RoutingType routingType,
                                     final int defaulMaxConsumers,
-                                    boolean defaultDeleteOnNoConsumers) throws Exception {
+                                    boolean defaultPurgeOnNoConsumers) throws Exception {
       AddressInfo addressInfo = new AddressInfo(new SimpleString(address));
       addressInfo.addRoutingType(routingType);
       servers[node].addOrUpdateAddressInfo(addressInfo);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/JmsProducerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/JmsProducerTest.java
@@ -141,7 +141,7 @@ public class JmsProducerTest extends JMSTestBase {
    public void defaultAutoCreatedQueueConfigTest() throws Exception {
       final String queueName = "q1";
 
-      server.getAddressSettingsRepository().addMatch(queueName, new AddressSettings().setDefaultMaxConsumers(5).setDefaultDeleteOnNoConsumers(true));
+      server.getAddressSettingsRepository().addMatch(queueName, new AddressSettings().setDefaultMaxConsumers(5).setDefaultPurgeOnNoConsumers(true));
 
       Queue q1 = context.createQueue(queueName);
 
@@ -150,14 +150,14 @@ public class JmsProducerTest extends JMSTestBase {
       org.apache.activemq.artemis.core.server.Queue  queue = server.locateQueue(SimpleString.toSimpleString(queueName));
 
       assertEquals(5, queue.getMaxConsumers());
-      assertEquals(true, queue.isDeleteOnNoConsumers());
+      assertEquals(true, queue.isPurgeOnNoConsumers());
    }
 
    @Test
    public void defaultAutoCreatedQueueConfigTest2() throws Exception {
       final String queueName = "q1";
 
-      server.getAddressSettingsRepository().addMatch(queueName, new AddressSettings().setDefaultMaxConsumers(5).setDefaultDeleteOnNoConsumers(true));
+      server.getAddressSettingsRepository().addMatch(queueName, new AddressSettings().setDefaultMaxConsumers(5).setDefaultPurgeOnNoConsumers(true));
 
       Connection connection = cf.createConnection();
 
@@ -168,7 +168,7 @@ public class JmsProducerTest extends JMSTestBase {
       org.apache.activemq.artemis.core.server.Queue  queue = server.locateQueue(SimpleString.toSimpleString(queueName));
 
       assertEquals(5, queue.getMaxConsumers());
-      assertEquals(true, queue.isDeleteOnNoConsumers());
+      assertEquals(true, queue.isPurgeOnNoConsumers());
 
       connection.close();
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/consumer/JmsConsumerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/consumer/JmsConsumerTest.java
@@ -748,7 +748,7 @@ public class JmsConsumerTest extends JMSTestBase {
       server.getAddressSettingsRepository()
             .addMatch(queueName, new AddressSettings()
                .setDefaultMaxConsumers(5)
-               .setDefaultDeleteOnNoConsumers(true));
+               .setDefaultPurgeOnNoConsumers(true));
 
       Connection connection = cf.createConnection();
 
@@ -759,7 +759,7 @@ public class JmsConsumerTest extends JMSTestBase {
       org.apache.activemq.artemis.core.server.Queue  queue = server.locateQueue(SimpleString.toSimpleString(queueName));
 
       assertEquals(5, queue.getMaxConsumers());
-      assertEquals(true, queue.isDeleteOnNoConsumers());
+      assertEquals(true, queue.isPurgeOnNoConsumers());
 
       connection.close();
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
@@ -259,7 +259,7 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       SimpleString address = RandomUtil.randomSimpleString();
       SimpleString name = RandomUtil.randomSimpleString();
       boolean durable = RandomUtil.randomBoolean();
-      boolean deleteOnNoConsumers = RandomUtil.randomBoolean();
+      boolean purgeOnNoConsumers = RandomUtil.randomBoolean();
       boolean autoCreateAddress = true;
       int maxConsumers = RandomUtil.randomInt();
 
@@ -267,7 +267,7 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
 
       checkNoResource(ObjectNameBuilder.DEFAULT.getQueueObjectName(address, name, RoutingType.ANYCAST));
       serverControl.createAddress(address.toString(), "ANYCAST");
-      serverControl.createQueue(address.toString(), RoutingType.ANYCAST.toString(), name.toString(), null, durable, maxConsumers, deleteOnNoConsumers, autoCreateAddress);
+      serverControl.createQueue(address.toString(), RoutingType.ANYCAST.toString(), name.toString(), null, durable, maxConsumers, purgeOnNoConsumers, autoCreateAddress);
 
       checkResource(ObjectNameBuilder.DEFAULT.getQueueObjectName(address, name, RoutingType.ANYCAST));
       QueueControl queueControl = ManagementControlHelper.createQueueControl(address, name, RoutingType.ANYCAST, mbeanServer);
@@ -275,7 +275,7 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       Assert.assertEquals(name.toString(), queueControl.getName());
       Assert.assertNull(queueControl.getFilter());
       Assert.assertEquals(durable, queueControl.isDurable());
-      Assert.assertEquals(deleteOnNoConsumers, queueControl.isDeleteOnNoConsumers());
+      Assert.assertEquals(purgeOnNoConsumers, queueControl.isPurgeOnNoConsumers());
       Assert.assertEquals(maxConsumers, queueControl.getMaxConsumers());
       Assert.assertEquals(false, queueControl.isTemporary());
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
@@ -113,17 +113,17 @@ public class ActiveMQServerControlUsingCoreTest extends ActiveMQServerControlTes
                                    String filterStr,
                                    boolean durable,
                                    int maxConsumers,
-                                   boolean deleteOnNoConsumers,
+                                   boolean purgeOnNoConsumers,
                                    boolean autoCreateAddress) throws Exception {
-            return (String) proxy.invokeOperation("createQueue", address, routingType, name, filterStr, durable, maxConsumers, deleteOnNoConsumers, autoCreateAddress);
+            return (String) proxy.invokeOperation("createQueue", address, routingType, name, filterStr, durable, maxConsumers, purgeOnNoConsumers, autoCreateAddress);
          }
 
          @Override
          public String updateQueue(@Parameter(name = "name", desc = "Name of the queue") String name,
                                    @Parameter(name = "routingType", desc = "The routing type used for this address, MULTICAST or ANYCAST") String routingType,
                                    @Parameter(name = "maxConsumers", desc = "The maximum number of consumers allowed on this queue at any one time") Integer maxConsumers,
-                                   @Parameter(name = "deleteOnNoConsumers", desc = "Delete this queue when the last consumer disconnects") Boolean deleteOnNoConsumers) throws Exception {
-            return (String) proxy.invokeOperation("updateQueue", name, routingType, maxConsumers, deleteOnNoConsumers);
+                                   @Parameter(name = "purgeOnNoConsumers", desc = "Delete this queue when the last consumer disconnects") Boolean purgeOnNoConsumers) throws Exception {
+            return (String) proxy.invokeOperation("updateQueue", name, routingType, maxConsumers, purgeOnNoConsumers);
          }
 
          @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlUsingCoreTest.java
@@ -87,8 +87,8 @@ public class QueueControlUsingCoreTest extends QueueControlTest {
          }
 
          @Override
-         public boolean isDeleteOnNoConsumers() {
-            return (Boolean) proxy.retrieveAttributeValue("deleteOnNoConsumers");
+         public boolean isPurgeOnNoConsumers() {
+            return (Boolean) proxy.retrieveAttributeValue("purgeOnNoConsumers");
          }
 
          @Override

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/MessageHeaderTest.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/MessageHeaderTest.java
@@ -1013,7 +1013,7 @@ public class MessageHeaderTest extends MessageHeaderTestBase {
                               boolean durable,
                               boolean autoCreated,
                               int maxConsumers,
-                              boolean deleteOnNoConsumers) throws ActiveMQException {
+                              boolean purgeOnNoConsumers) throws ActiveMQException {
 
       }
 
@@ -1043,7 +1043,7 @@ public class MessageHeaderTest extends MessageHeaderTestBase {
                               boolean durable,
                               boolean autoCreated,
                               int maxConsumers,
-                              boolean deleteOnNoConsumers) throws ActiveMQException {
+                              boolean purgeOnNoConsumers) throws ActiveMQException {
 
       }
 

--- a/tests/joram-tests/src/test/java/org/apache/activemq/artemis/common/AbstractAdmin.java
+++ b/tests/joram-tests/src/test/java/org/apache/activemq/artemis/common/AbstractAdmin.java
@@ -120,7 +120,7 @@ public class AbstractAdmin implements Admin {
    public void createQueue(final String name) {
       Boolean result;
       try {
-         invokeSyncOperation(ResourceNames.BROKER, "createQueue", name, RoutingType.ANYCAST.toString(), name, null, true, ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers(), ActiveMQDefaultConfiguration.getDefaultDeleteQueueOnNoConsumers(), true);
+         invokeSyncOperation(ResourceNames.BROKER, "createQueue", name, RoutingType.ANYCAST.toString(), name, null, true, ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers(), ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers(), true);
       } catch (Exception e) {
          throw new IllegalStateException(e);
       }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/FakeQueue.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/FakeQueue.java
@@ -39,7 +39,7 @@ import org.apache.activemq.artemis.utils.ReferenceCounter;
 public class FakeQueue implements Queue {
 
    @Override
-   public void setDeleteOnNoConsumers(boolean value) {
+   public void setPurgeOnNoConsumers(boolean value) {
 
    }
 
@@ -455,7 +455,7 @@ public class FakeQueue implements Queue {
    }
 
    @Override
-   public boolean isDeleteOnNoConsumers() {
+   public boolean isPurgeOnNoConsumers() {
       return false;
    }
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/impl/fakes/FakePostOffice.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/impl/fakes/FakePostOffice.java
@@ -46,7 +46,7 @@ public class FakePostOffice implements PostOffice {
    public QueueBinding updateQueue(SimpleString name,
                                    RoutingType routingType,
                                    Integer maxConsumers,
-                                   Boolean deleteOnNoConsumers) throws Exception {
+                                   Boolean purgeOnNoConsumers) throws Exception {
       return null;
    }
 


### PR DESCRIPTION
The name "deleteOnNoConsumers" isn't a good match for the semantics underneath.
The name "purgeOnNoConsumers" (and variants) is a better fit.