### PR TITLE
(1.x) [ARTEMIS-931] Improve HTTP Upgrade connection

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/ActiveMQClientLogger.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/ActiveMQClientLogger.java
@@ -433,4 +433,8 @@ public interface ActiveMQClientLogger extends BasicLogger {
       format = Message.Format.MESSAGE_FORMAT)
    void reconnectCreatingNewSession(long id);
 
+   @LogMessage(level = Logger.Level.ERROR)
+   @Message(id = 214029, value = "Unexpected response from HTTP server: %s")
+   void unexpectedResponseFromHttpServer(Object response);
+
 }


### PR DESCRIPTION
If the object received is not an expected HttpResponse, close the
ChannelHandlerContext and countdown the latch

JIRA: https://issues.apache.org/jira/browse/ARTEMIS-931