### PR TITLE
ARTEMIS-938 JDBC persistence-store should use BIGINT type for IDs in database tables

### DIFF
--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/drivers/derby/DerbySQLProvider.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/drivers/derby/DerbySQLProvider.java
@@ -32,7 +32,7 @@ public class DerbySQLProvider extends GenericSQLProvider {
       super(tableName.toUpperCase());
 
       createFileTableSQL = "CREATE TABLE " + tableName +
-         "(ID INTEGER NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1)," +
+         "(ID BIGINT NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1)," +
          "FILENAME VARCHAR(255), EXTENSION VARCHAR(10), DATA BLOB, PRIMARY KEY(ID))";
 
       appendToFileSQL = "UPDATE " + tableName + " SET DATA = DATA || ? WHERE ID=?";

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/drivers/mysql/MySQLSQLProvider.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/drivers/mysql/MySQLSQLProvider.java
@@ -33,7 +33,7 @@ public class MySQLSQLProvider extends GenericSQLProvider {
       super(tName.toLowerCase());
 
       createFileTableSQL = "CREATE TABLE " + tableName +
-         "(ID INTEGER NOT NULL AUTO_INCREMENT," +
+         "(ID BIGINT NOT NULL AUTO_INCREMENT," +
          "FILENAME VARCHAR(255), EXTENSION VARCHAR(10), DATA LONGBLOB, PRIMARY KEY(ID)) ENGINE=InnoDB;";
 
       createJournalTableSQL = new String[] {

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/drivers/postgres/PostgresSQLProvider.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/drivers/postgres/PostgresSQLProvider.java
@@ -31,7 +31,7 @@ public class PostgresSQLProvider extends GenericSQLProvider {
    private PostgresSQLProvider(String tName) {
       super(tName.toLowerCase());
       createFileTableSQL = "CREATE TABLE " + tableName +
-         "(ID SERIAL, FILENAME VARCHAR(255), EXTENSION VARCHAR(10), DATA OID, PRIMARY KEY(ID))";
+         "(ID BIGSERIAL, FILENAME VARCHAR(255), EXTENSION VARCHAR(10), DATA OID, PRIMARY KEY(ID))";
 
       createJournalTableSQL = new String[] {
          "CREATE TABLE " + tableName + "(id BIGINT,recordType SMALLINT,compactCount SMALLINT,txId BIGINT,userRecordType SMALLINT,variableSize INTEGER,record BYTEA,txDataSize INTEGER,txData BYTEA,txCheckNoRecords INTEGER,seq BIGINT)",

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/file/JDBCFileUtils.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/file/JDBCFileUtils.java
@@ -29,7 +29,12 @@ class JDBCFileUtils {
    static JDBCSequentialFileFactoryDriver getDBFileDriver(String driverClass,
                                                           String jdbcConnectionUrl,
                                                           SQLProvider provider) throws SQLException {
-      JDBCSequentialFileFactoryDriver dbDriver = new JDBCSequentialFileFactoryDriver();
+      final JDBCSequentialFileFactoryDriver dbDriver;
+      if (provider instanceof PostgresSQLProvider) {
+         dbDriver = new PostgresSequentialSequentialFileDriver();
+      } else {
+         dbDriver = new JDBCSequentialFileFactoryDriver();
+      }
       dbDriver.setSqlProvider(provider);
       dbDriver.setJdbcConnectionUrl(jdbcConnectionUrl);
       dbDriver.setJdbcDriverClass(driverClass);

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/file/JDBCSequentialFile.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/file/JDBCSequentialFile.java
@@ -47,7 +47,7 @@ public class JDBCSequentialFile implements SequentialFile {
 
    private boolean isCreated = false;
 
-   private int id = -1;
+   private long id = -1;
 
    private long readPosition = 0;
 
@@ -333,11 +333,11 @@ public class JDBCSequentialFile implements SequentialFile {
       }
    }
 
-   public int getId() {
+   public long getId() {
       return id;
    }
 
-   public void setId(int id) {
+   public void setId(long id) {
       this.id = id;
    }
 

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/sql/GenericSQLProvider.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/sql/GenericSQLProvider.java
@@ -61,7 +61,7 @@ public class GenericSQLProvider implements SQLProvider {
       this.tableName = tableName;
 
       createFileTableSQL = "CREATE TABLE " + tableName +
-         "(ID INT AUTO_INCREMENT, FILENAME VARCHAR(255), EXTENSION VARCHAR(10), DATA BLOB, PRIMARY KEY(ID))";
+         "(ID BIGINT AUTO_INCREMENT, FILENAME VARCHAR(255), EXTENSION VARCHAR(10), DATA BLOB, PRIMARY KEY(ID))";
 
       insertFileSQL = "INSERT INTO " + tableName + " (FILENAME, EXTENSION, DATA) VALUES (?,?,?)";
 


### PR DESCRIPTION
Artemis creates file table with ID of type INT. This may not be enough from long term POV.