### PR TITLE
ARTEMIS-917 Only return body of retained message after reboot

### DIFF
--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTPublishManager.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTPublishManager.java
@@ -22,6 +22,7 @@ import java.io.UnsupportedEncodingException;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.EmptyByteBuf;
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQIllegalStateException;
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.Pair;
@@ -227,7 +228,9 @@ public class MQTTPublishManager {
                log.warn("Unable to send message: " + message.getMessageID() + " Cause: " + e.getMessage());
             }
          default:
-            payload = message.getBodyBufferDuplicate().byteBuf();
+            int endOfBodyPosition = message.getWholeBuffer().getInt(ServerMessageImpl.BUFFER_HEADER_SPACE);
+            ActiveMQBuffer bodyBufferDuplicate = message.getBodyBufferDuplicate();
+            payload = bodyBufferDuplicate.readBytes(endOfBodyPosition - bodyBufferDuplicate.readerIndex()).byteBuf();
             break;
       }
       session.getProtocolHandler().send(messageId, address, qos, payload, deliveryCount);


### PR DESCRIPTION
The endOfBodyPosition pointer is not getting properly set for retained messages after reboot.  MessageImpl copy message does not set this.  This patch fixes the issue by getting the message body directly out of the message buffer.