### PR TITLE
ARTEMIS-908: Replace lock by CAS to avoid potential deadlock

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingStoreImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingStoreImpl.java
@@ -637,7 +637,7 @@ public class PagingStoreImpl implements PagingStore {
    // To be used when the memory is oversized either by local settings or global settings on blocking addresses
    private static final class OverSizedRunnable implements Runnable {
 
-      private boolean ran;
+      private final AtomicBoolean ran = new AtomicBoolean(false);
 
       private final Runnable runnable;
 
@@ -646,11 +646,9 @@ public class PagingStoreImpl implements PagingStore {
       }
 
       @Override
-      public synchronized void run() {
-         if (!ran) {
+      public void run() {
+         if (ran.compareAndSet(false, true)) {
             runnable.run();
-
-            ran = true;
          }
       }
    }


### PR DESCRIPTION
The deadlock can happen if the wrapped Runnable acquires a lock. See https://github.com/lulf/activemq-artemis/blob/4c1bec7f9caed6a7fd9c9f64b31b3ae6ebfd57c7/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingStoreImpl.java#L665 and the lines below where the condition on line 673 is true in the deadlock case. 