### PR TITLE
ARTEMIS-943 fix queueType in import-export schema

### DIFF
--- a/artemis-cli/src/main/resources/schema/artemis-import-export.xsd
+++ b/artemis-cli/src/main/resources/schema/artemis-import-export.xsd
@@ -144,7 +144,7 @@
    </xsd:complexType>
    <xsd:complexType name="queuesType">
       <xsd:sequence>
-         <xsd:element type="queueType" name="queue"/>
+         <xsd:element type="queueType" name="queue" minOccurs="1" maxOccurs="unbounded"/>
       </xsd:sequence>
    </xsd:complexType>
    <xsd:complexType name="bodyType">


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARTEMIS-943

queueType in the artemis-import-export schema needs to be marked with
min and max occurs attributes to specify that the element can occur more than one
time.  This is important so JAXB generates the correct bindings.