### PR TITLE
ARTEMIS-979 OpenWire "no-Local" consumer not working

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
@@ -156,6 +156,8 @@ public class OpenWireConnection extends AbstractRemotingConnection implements Se
 
    private ConnectionState state;
 
+   private volatile boolean noLocal;
+
    /**
     * Openwire doesn't sen transactions associated with any sessions.
     * It will however send beingTX / endTX as it would be doing it with XA Transactions.
@@ -834,6 +836,14 @@ public class OpenWireConnection extends AbstractRemotingConnection implements Se
 
    public void enableTtl() {
       disableTtl.set(false);
+   }
+
+   public boolean isNoLocal() {
+      return noLocal;
+   }
+
+   public void setNoLocal(boolean noLocal) {
+      this.noLocal = noLocal;
    }
 
    class SlowConsumerDetection implements SlowConsumerDetectionListener {

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQSession.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQSession.java
@@ -39,6 +39,7 @@ import org.apache.activemq.artemis.core.server.ServerConsumer;
 import org.apache.activemq.artemis.core.server.ServerMessage;
 import org.apache.activemq.artemis.core.server.ServerSession;
 import org.apache.activemq.artemis.core.server.SlowConsumerDetectionListener;
+import org.apache.activemq.artemis.reader.MessageUtil;
 import org.apache.activemq.artemis.spi.core.protocol.SessionCallback;
 import org.apache.activemq.artemis.spi.core.remoting.ReadyListener;
 import org.apache.activemq.artemis.utils.IDGenerator;
@@ -296,6 +297,11 @@ public class AMQSession implements SessionCallback {
       }
 
       ServerMessage originalCoreMsg = getConverter().inbound(messageSend);
+
+      if (connection.isNoLocal() || sessInfo.getSessionId().getValue() == -1) {
+         //Internal session is used to send advisory messages, which are always noLocal
+         originalCoreMsg.putStringProperty(MessageUtil.CONNECTION_ID_PROPERTY_NAME.toString(), this.connection.getState().getInfo().getConnectionId().getValue());
+      }
 
       /* ActiveMQ failover transport will attempt to reconnect after connection failure.  Any sent messages that did
       * not receive acks will be resent.  (ActiveMQ broker handles this by returning a last sequence id received to


### PR DESCRIPTION
When creating a 'no-local' openwire consumer, it doesn't work,
meaning it can still receive messages from the same connection.
The fix is similar to what Artemis client does, which is adding
a 'filter' to the consumer/subscription.
The difference is that with OpeinWire we have to do it on the
broker side.