### PR TITLE
ARTEMIS-980 Openwire can't send message to temp destination

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQConsumer.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQConsumer.java
@@ -215,7 +215,9 @@ public class AMQConsumer {
             return 0;
          }
 
-         if (session.getConnection().isNoLocal()) {
+         if (session.getConnection().isNoLocal() || session.isInternal()) {
+            //internal session always delivers messages to noLocal advisory consumers
+            //so we need to remove this property too.
             message.removeProperty(MessageUtil.CONNECTION_ID_PROPERTY_NAME);
          }
          dispatch = OpenWireMessageConverter.createMessageDispatch(reference, message, this);

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQSession.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQSession.java
@@ -298,8 +298,9 @@ public class AMQSession implements SessionCallback {
 
       ServerMessage originalCoreMsg = getConverter().inbound(messageSend);
 
-      if (connection.isNoLocal() || sessInfo.getSessionId().getValue() == -1) {
-         //Internal session is used to send advisory messages, which are always noLocal
+      if (connection.isNoLocal()) {
+         //Note: advisory messages are dealt with in
+         //OpenWireProtocolManager#fireAdvisory
          originalCoreMsg.putStringProperty(MessageUtil.CONNECTION_ID_PROPERTY_NAME.toString(), this.connection.getState().getInfo().getConnectionId().getValue());
       }
 
@@ -446,5 +447,9 @@ public class AMQSession implements SessionCallback {
 
    public OpenWireConnection getConnection() {
       return connection;
+   }
+
+   public boolean isInternal() {
+      return sessInfo.getSessionId().getValue() == -1;
    }
 }


### PR DESCRIPTION
When a producer sends a messages to a temp destination created from
another connection, it fails. The reason behind it is that the
producer's connection didn't receive the advisory message (notification)
from broker about this temp destination, and it will throw an exception
if it doesn't know this temp destination.

The fix is send the advisory to the client so that it knows this destination.