### PR TITLE
ARTEMIS-988 Regression: web tmp dir not cleaned up

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Run.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Run.java
@@ -134,7 +134,7 @@ public class Run extends LockAbstract {
             if (file.exists()) {
                try {
                   try {
-                     server.stop(true);
+                     server.exit();
                   } catch (Exception e) {
                      e.printStackTrace();
                   }
@@ -155,7 +155,7 @@ public class Run extends LockAbstract {
          @Override
          public void run() {
             try {
-               server.stop(true);
+               server.exit();
             } catch (Exception e) {
                e.printStackTrace();
             }

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/integration/FileBroker.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/integration/FileBroker.java
@@ -118,15 +118,19 @@ public class FileBroker implements Broker {
    }
 
    @Override
-   public void stop(boolean isShutdown) throws Exception {
+   public void exit() throws Exception {
+      stop(true);
+   }
+
+   private void stop(boolean isShutdown) throws Exception {
       if (!started) {
          return;
       }
       ActiveMQComponent[] mqComponents = new ActiveMQComponent[components.size()];
       components.values().toArray(mqComponents);
       for (int i = mqComponents.length - 1; i >= 0; i--) {
-         if (mqComponents[i] instanceof ServiceComponent) {
-            ((ServiceComponent)mqComponents[i]).stop(isShutdown);
+         if (mqComponents[i] instanceof ServiceComponent && isShutdown) {
+            ((ServiceComponent) mqComponents[i]).exit();
          } else {
             mqComponents[i].stop();
          }

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/core/server/ServiceComponent.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/core/server/ServiceComponent.java
@@ -21,5 +21,6 @@ package org.apache.activemq.artemis.core.server;
  */
 public interface ServiceComponent extends ActiveMQComponent {
 
-   void stop(boolean isShutdown) throws Exception;
+   //called by shutdown hooks before exit the VM
+   void exit() throws Exception;
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServer.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServer.java
@@ -64,7 +64,7 @@ import org.apache.activemq.artemis.utils.ExecutorFactory;
  * <p>
  * This is not part of our public API.
  */
-public interface ActiveMQServer extends ActiveMQComponent {
+public interface ActiveMQServer extends ServiceComponent {
 
    /**
     * Sets the server identity.

--- a/artemis-web/src/main/java/org/apache/activemq/artemis/component/WebServerComponent.java
+++ b/artemis-web/src/main/java/org/apache/activemq/artemis/component/WebServerComponent.java
@@ -150,6 +150,7 @@ public class WebServerComponent implements ExternalComponent {
                //somehow when broker is stopped and restarted quickly
                //this tmpdir won't get deleted sometimes
                boolean fileDeleted = TimeUtils.waitOnBoolean(false, 5000, tmpdir::exists);
+
                if (!fileDeleted) {
                   //because the execution order of shutdown hooks are
                   //not determined, so it's possible that the deleteOnExit
@@ -190,6 +191,10 @@ public class WebServerComponent implements ExternalComponent {
    }
 
    @Override
+   public void exit() throws Exception {
+      stop(true);
+   }
+
    public void stop(boolean isShutdown) throws Exception {
       if (isShutdown) {
          internalStop();


### PR DESCRIPTION
Due to recent changes, the web component is shutdown by the
server, but the shutdown flag is lost so the web component's
cleanup check method is not get called and the web's tmp
dir is left there after user stopped the broker (control-c).

The fix is add a suitable API to allow passing of the
flag so the web component can make sure its tmp dir gets
cleaned up properly before exiting the VM.