### PR TITLE
DOCS: Fixing apparent typo on Connectors and using sh on markdown

### DIFF
--- a/docs/migration-guide/en/authentication.md
+++ b/docs/migration-guide/en/authentication.md
@@ -5,15 +5,19 @@ Now that we have our acceptors and addresses ready, it's time to deal with broke
  
  Both ActiveMQ and Artemis use JAAS to define authentication credentials. In ActiveMQ, that's configured through the appropriate broker plugin in `conf/activemq.xml`
 
-    <plugins>
-      <jaasAuthenticationPlugin configuration="activemq" />
-    </plugins>
+```xml
+<plugins>
+  <jaasAuthenticationPlugin configuration="activemq" />
+</plugins>
+```
     
 The name of the JAAS domain is specified as a configuration parameter.    
     
 In Artemis, the same thing is achieved by defining `<jaas-security>` configuration in `etc/bootstrap.xml`
 
-    <jaas-security domain="activemq"/>
+```xml
+<jaas-security domain="activemq"/>
+```
     
 From this point on, you can go and define your users and their roles in appropriate files, like `conf/users.properties` and `conf/groups.properties` in ActiveMQ. Similarly, `etc/artemis-users.properties` and `etc/artemis-roles.properties` files are used in Artemis. These files are intechangable, so you should be able to just copy your existing configuration over to the new broker. 
 

--- a/docs/migration-guide/en/configuration.md
+++ b/docs/migration-guide/en/configuration.md
@@ -28,31 +28,40 @@ Finally, we have JAAS configuration files (`login.config`, `artemis-users.proper
 
 After this brief walk through the location of different configuration aspects of Artemis, we're ready to start the broker. If you wish to start the broker in the foreground, you should execute
 
-	$ bin/artemis run
+```sh
+$ bin/artemis run
+```
 
 This is the same as
 
-	$ bin/activemq console
-
+```sh
+$ bin/activemq console
+```
 command in ActiveMQ.
 
 For running the broker as a service, Artemis provides a separate shell script `bin/artemis-service`. So you can run the broker in the background like
-
-	$ bin/artemis-service start
+```sh
+$ bin/artemis-service start
+```
 
 This is the same as running ActiveMQ with
-
- 	$ bin/activemq start
+```sh
+$ bin/activemq start
+```
 
 After the start, you can check the broker status in `logs/artemis.log` file.
 
 Congratulations, you have your Artemis broker up and running. By default, Artemis starts *Openwire* connector on the same port as ActiveMQ, so clients can connect. To test this you can go to your existing ActiveMQ instance and run the following commands.
 
-	$ bin/activemq producer
-	$ bin/activemq consumer
+````sh
+$ bin/activemq producer
+$ bin/activemq consumer
+````
 
 You should see the messages flowing through the broker. Finally, we can stop the broker with
 
-	$ bin/artemis-service stop
+```sh
+$ bin/artemis-service stop
+```
 
 With this, our orienteering session around Artemis is finished. In the following articles we'll start digging deeper into the configuration details and differences between two brokers and see how that can affect your messaging applications.

--- a/docs/migration-guide/en/connectors.md
+++ b/docs/migration-guide/en/connectors.md
@@ -3,24 +3,26 @@ Connectors
 
 After broker is started, you'll want to connect your clients to it. So, let's start with comparing ActiveMQ and Artemis configurations in area of client connectors. In ActiveMQ terminology, they are called *transport connectors*, and the default configuration looks something like this (in `conf/activemq.xml`).
 
-	<transportConnectors>
-        <transportConnector name="openwire" uri="tcp://0.0.0.0:61616?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
-        <transportConnector name="amqp" uri="amqp://0.0.0.0:5672?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
-        <transportConnector name="stomp" uri="stomp://0.0.0.0:61613?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
-        <transportConnector name="mqtt" uri="mqtt://0.0.0.0:1883?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
-        <transportConnector name="ws" uri="ws://0.0.0.0:61614?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
-	</transportConnectors>
+```xml
+<transportConnectors>
+    <transportConnector name="openwire" uri="tcp://0.0.0.0:61616?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+    <transportConnector name="amqp" uri="amqp://0.0.0.0:5672?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+    <transportConnector name="stomp" uri="stomp://0.0.0.0:61613?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+    <transportConnector name="mqtt" uri="mqtt://0.0.0.0:1883?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+    <transportConnector name="ws" uri="ws://0.0.0.0:61614?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+</transportConnectors>
+```
         
 In Artemis, client connectors are called *acceptors* and they are configured in `etc/broker.xml` like this
-        
-	<acceptors>
-		<acceptor name="artemis">tcp://0.0.0.0:61616?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=CORE,AMQP,STOMP,HORNETQ,MQTT,OPENWIRE</acceptor>
-		<acceptor name="amqp">tcp://0.0.0.0:5672?protocols=AMQP</acceptor>
-		<acceptor name="stomp">tcp://0.0.0.0:61613?protocols=STOMP</acceptor>
-		<acceptor name="hornetq">tcp://0.0.0.0:5445?protocols=HORNETQ,STOMP</acceptor>
-		<acceptor name="mqtt">tcp://0.0.0.0:1883?protocols=MQTT</acceptor>
-	</acceptors>        
-	
+```xml
+<acceptors>
+    <acceptor name="artemis">tcp://0.0.0.0:61616?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=CORE,AMQP,STOMP,HORNETQ,MQTT,OPENWIRE</acceptor>
+    <acceptor name="amqp">tcp://0.0.0.0:5672?protocols=AMQP</acceptor>
+    <acceptor name="stomp">tcp://0.0.0.0:61613?protocols=STOMP</acceptor>
+    <acceptor name="hornetq">tcp://0.0.0.0:5445?protocols=HORNETQ,STOMP</acceptor>
+    <acceptor name="mqtt">tcp://0.0.0.0:1883?protocols=MQTT</acceptor>
+</acceptors>        
+```	
 As you can notice the syntax is very similar, but there are still some differences that we need to understand. First, as we said earlier, there's no notion of blocking	and non-blocking (nio) transport in Artemis, so you should treat everything as non-blocking. Also, in Artemis the low level transport is distinct from the actual messaging protocol (like AMQP or MQTT) used on top of it. One acceptor can handle multiple messaging protocols on the same port. By default, all protocols are accepted on the single port, but you can restrict this using the `protocols=X,Y` uri attribute pattern as shown in the example above.
   
 Besides *tcp* network protocol, Artemis support *InVm* and *Web Socket* transports. The *InVm* transport is similar to ActiveMQ's *vm* transport and is used to connect clients to the embedded broker. The difference is that you can use any messaging protocol on top of *InVm* transport in Artemis, while *vm* transport in ActiveMQ is tied to OpenWire.
@@ -29,7 +31,7 @@ One of the advantages of using Netty for IO layer, is that Web Sockets are suppo
 
 To summarize this topic, here's a table that shows you how to migrate your ActiveMQ transport connectors to the Artemis acceptors 
 
-| ActiveMQ  | Artemis (p[tions in the acceptor URL) |
+| ActiveMQ  | Artemis (options in the acceptor URL) |
 |---|---|
 | OpenWire  | protocols=OpenWire (version 10+)  |
 | NIO  | -  |

--- a/docs/migration-guide/en/destinations.md
+++ b/docs/migration-guide/en/destinations.md
@@ -5,26 +5,29 @@ We already talked about addressing differences between ActiveMQ and Artemis in t
  
 In ActiveMQ, destinations are pre-defined in the `<destinations>` section of the `conf/activemq.xml` configuration file.
 
-    <destinations>
-         <queue physicalName="my-queue" />
-         <topic physicalName="my-topic" />
-	</destinations>	
+```xml
+<destinations>
+     <queue physicalName="my-queue" />
+     <topic physicalName="my-topic" />
+</destinations>	
+```
 
 Things looks a bit different in Artemis. We already explained that queues are `anycast` addresses and topics are `muticast` ones. We're not gonna go deep into the address settings details here and you're advised to look at the user manual for that. Let's just see what we need to do in order to replicate ActiveMQ configuration. 
 
 Addresses are defined in `<addresses>` section of the `etc/broker.xml` configuration file. So the corresponding Artemis configuration for the ActiveMQ example above, looks like this:
 
-    <addresses>    
-        <address name="my-queue">
-            <anycast>
-                <queue name="my-queue"/>
-            </anycast>
-        </address>
+```xml
+<addresses>    
+    <address name="my-queue">
+        <anycast>
+            <queue name="my-queue"/>
+        </anycast>
+    </address>
 
-        <address name="my-topic">
-            <multicast></multicast>
-        </address>
-    </adresses>
+    <address name="my-topic">
+        <multicast></multicast>
+    </address>
+</adresses>
+```
     
-After this step we have our destinations ready in the new broker.    
-        
+After this step we have our destinations ready in the new broker.


### PR DESCRIPTION
I fixed a typo on an apparent typo on a table here.

I'm also using a different MD for XML and sh

example:

```xml
<something>
   <nice> 
    <!-- markdown can be nice on xml -->
   </nice>
</something>
```