### PR TITLE
ARTEMIS-1002 Use default PooledBufferAllocator in ActiveMQBuffers

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/ActiveMQBuffers.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/ActiveMQBuffers.java
@@ -28,7 +28,7 @@ import org.apache.activemq.artemis.core.buffers.impl.ChannelBufferWrapper;
 public final class ActiveMQBuffers {
 
 
-   private static final PooledByteBufAllocator ALLOCATOR = new PooledByteBufAllocator();
+   private static final PooledByteBufAllocator ALLOCATOR = PooledByteBufAllocator.DEFAULT;
 
    /**
     * Creates a <em>self-expanding</em> ActiveMQBuffer with the given initial size

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/PartialPooledByteBufAllocator.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/PartialPooledByteBufAllocator.java
@@ -28,7 +28,7 @@ import io.netty.buffer.UnpooledByteBufAllocator;
  */
 public class PartialPooledByteBufAllocator implements ByteBufAllocator {
 
-   private static final ByteBufAllocator POOLED = new PooledByteBufAllocator(false);
+   private static final ByteBufAllocator POOLED = PooledByteBufAllocator.DEFAULT;
    private static final ByteBufAllocator UNPOOLED = new UnpooledByteBufAllocator(false);
 
    public static final PartialPooledByteBufAllocator INSTANCE = new PartialPooledByteBufAllocator();

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/transport/PartialPooledByteBufAllocator.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/transport/PartialPooledByteBufAllocator.java
@@ -28,7 +28,7 @@ import io.netty.buffer.UnpooledByteBufAllocator;
  */
 public class PartialPooledByteBufAllocator implements ByteBufAllocator {
 
-   private static final ByteBufAllocator POOLED = new PooledByteBufAllocator(false);
+   private static final ByteBufAllocator POOLED = PooledByteBufAllocator.DEFAULT;
    private static final ByteBufAllocator UNPOOLED = new UnpooledByteBufAllocator(false);
 
    public static final PartialPooledByteBufAllocator INSTANCE = new PartialPooledByteBufAllocator();


### PR DESCRIPTION
I'd like feedback from @willr3 before this is merged as @willr3 did the original work around the perf gains and I don't want to reverse that good work.