### PR TITLE
Add default constructor for reflection

### DIFF
--- a/artemis-protocols/artemis-hqclient-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/hornetq/HQPropertiesConversionInterceptor.java
+++ b/artemis-protocols/artemis-hqclient-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/hornetq/HQPropertiesConversionInterceptor.java
@@ -28,6 +28,10 @@ public class HQPropertiesConversionInterceptor implements Interceptor {
 
    private final boolean replaceHQ;
 
+   public HQPropertiesConversionInterceptor() {
+      this(true);
+   }
+   
    public HQPropertiesConversionInterceptor(final boolean replaceHQ) {
       this.replaceHQ = replaceHQ;
    }

--- a/artemis-protocols/artemis-hqclient-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/hornetq/HQPropertiesConversionInterceptor.java
+++ b/artemis-protocols/artemis-hqclient-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/hornetq/HQPropertiesConversionInterceptor.java
@@ -31,7 +31,7 @@ public class HQPropertiesConversionInterceptor implements Interceptor {
    public HQPropertiesConversionInterceptor() {
       this(true);
    }
-   
+
    public HQPropertiesConversionInterceptor(final boolean replaceHQ) {
       this.replaceHQ = replaceHQ;
    }


### PR DESCRIPTION
When you use `org.apache.activemq.artemis.core.protocol.hornetq.client.HornetQClientProtocolManagerFactory` as protocol-manager-factory, this class needs to be instantiated by reflection.

Caused by: java.lang.RuntimeException: Your class must have a constructor without arguments. If it is an inner class, it must be static! org.apache.activemq.artemis.core.protocol.hornetq.HQPropertiesConversionInterceptor
	at org.apache.activemq.artemis.utils.ClassloadingUtil.newInstanceFromClassLoader(ClassloadingUtil.java:50)
	at org.apache.activemq.artemis.core.client.impl.ServerLocatorImpl$6.run(ServerLocatorImpl.java:1776)
	at java.security.AccessController.doPrivileged(Native Method)
	at org.apache.activemq.artemis.core.client.impl.ServerLocatorImpl.feedInterceptors(ServerLocatorImpl.java:1771)
	at org.apache.activemq.artemis.core.client.impl.ServerLocatorImpl.setIncomingInterceptorList(ServerLocatorImpl.java:816)
	at org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory.setIncomingInterceptorList(ActiveMQConnectionFactory.java:642)
	... 27 more
Caused by: java.lang.InstantiationException: org.apache.activemq.artemis.core.protocol.hornetq.HQPropertiesConversionInterceptor
	at java.lang.Class.newInstance(Class.java:427)
	at org.apache.activemq.artemis.utils.ClassloadingUtil.newInstanceFromClassLoader(ClassloadingUtil.java:47)
	... 32 more
Caused by: java.lang.NoSuchMethodException: org.apache.activemq.artemis.core.protocol.hornetq.HQPropertiesConversionInterceptor.<init>()
	at java.lang.Class.getConstructor0(Class.java:3082)
	at java.lang.Class.newInstance(Class.java:412)
	... 33 more