### PR TITLE
ARTEMIS-1007 Missing management annotations

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
@@ -1060,10 +1060,10 @@ public interface ActiveMQServerControl {
    String listNetworkTopology() throws Exception;
 
    @Operation(desc = "Get the selected address", impact = MBeanOperationInfo.INFO)
-   String getAddressInfo(String address) throws ActiveMQAddressDoesNotExistException;
+   String getAddressInfo(@Parameter(name = "address", desc = "The address") String address) throws ActiveMQAddressDoesNotExistException;
 
    @Operation(desc = "Get a list of bindings associated with an address", impact = MBeanOperationInfo.INFO)
-   String listBindingsForAddress(String address) throws Exception;
+   String listBindingsForAddress(@Parameter(name = "address", desc = "The address") String address) throws Exception;
 
    @Operation(desc = "List Addresses on the broker", impact = MBeanOperationInfo.INFO)
    String listAddresses(@Parameter(name = "separator", desc = "Separator used on the string listing") String separator) throws Exception;

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/AddressControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/AddressControl.java
@@ -119,7 +119,7 @@ public interface AddressControl {
     */
    @Operation(desc = "Sends a TextMessage to a password-protected address.", impact = MBeanOperationInfo.ACTION)
    String sendMessage(@Parameter(name = "headers", desc = "The headers to add to the message") Map<String, String> headers,
-                      @Parameter(name = "headers", desc = "A type for the message") final int type,
+                      @Parameter(name = "type", desc = "A type for the message") final int type,
                       @Parameter(name = "body", desc = "The body (byte[]) of the message encoded as a string using Base64") String body,
                       @Parameter(name = "durable", desc = "Whether the message is durable") boolean durable,
                       @Parameter(name = "user", desc = "The user to authenticate with") String user,


### PR DESCRIPTION
There are some operations in ActiveMQServerControl that don't have
@Parameter annotations. That will make clients like JBoss Jon failed
to invoke those operations.
Also in AddressControl there is a typo in sendMessage. The second
parameter's name should be 'type' not 'headers'.