### PR TITLE
ARTEMIS-1024 Management operation causes ClassNotFoundException

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -47,6 +47,7 @@ import java.util.stream.Collectors;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.ActiveMQAddressDoesNotExistException;
+import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl;
@@ -669,6 +670,8 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
       clearIO();
       try {
          server.removeAddressInfo(new SimpleString(name), null);
+      } catch (ActiveMQException e) {
+         throw new IllegalStateException(e.getMessage());
       } finally {
          blockOnIO();
       }
@@ -738,6 +741,7 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
                              int maxConsumers,
                              boolean purgeOnNoConsumers,
                              boolean autoCreateAddress) throws Exception {
+      System.out.println("Target===================================called!");
       checkStarted();
 
       clearIO();
@@ -750,6 +754,8 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
          final Queue queue = server.createQueue(SimpleString.toSimpleString(address), RoutingType.valueOf(routingType.toUpperCase()), new SimpleString(name), filter, durable, false, maxConsumers, purgeOnNoConsumers, autoCreateAddress);
          return QueueTextFormatter.Long.format(queue, new StringBuilder()).toString();
+      } catch (ActiveMQException e) {
+         throw new IllegalStateException(e.getMessage());
       } finally {
          blockOnIO();
       }

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/ManagementExceptionHandlingTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/ManagementExceptionHandlingTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.extras.byteman;
+
+import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.jboss.byteman.contrib.bmunit.BMRules;
+import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import javax.management.RuntimeMBeanException;
+import java.lang.management.ManagementFactory;
+import java.util.HashMap;
+
+@RunWith(BMUnitRunner.class)
+public class ManagementExceptionHandlingTest extends ActiveMQTestBase {
+
+   protected ActiveMQServer server = null;
+
+   @Override
+   @Before
+   public void setUp() throws Exception {
+      super.setUp();
+      server = createServer(createDefaultNettyConfig());
+      server.getConfiguration().setJMXManagementEnabled(true);
+
+      server.start();
+   }
+
+   @Override
+   @After
+   public void tearDown() throws Exception {
+      if (server != null) {
+         server.stop();
+      }
+      super.tearDown();
+   }
+
+   @Test
+   @BMRules(
+           rules = {@BMRule(
+                   name = "checking ActiveMQServerControl methods",
+                   targetClass = "org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl",
+                   targetMethod = "createQueue(org.apache.activemq.artemis.api.core.SimpleString, org.apache.activemq.artemis.api.core.RoutingType, org.apache.activemq.artemis.api.core.SimpleString, org.apache.activemq.artemis.api.core.SimpleString, boolean, boolean, int, boolean, boolean)",
+                   targetLocation = "EXIT",
+                   action = "throw new org.apache.activemq.artemis.api.core.ActiveMQException(\"gotcha\")")})
+   public void testActiveMQServerControl() throws Exception {
+      try {
+         server.getActiveMQServerControl().createQueue("some.address", "ANYCAST", "some.queue", "filter", true, -1, false, true);
+         fail("test should have gotten an exception!");
+      } catch (ActiveMQException e) {
+         fail("Wrong exception got!");
+      } catch (IllegalStateException e) {
+         assertEquals("gotcha", e.getMessage());
+      }
+   }
+
+   @Test
+   @BMRules(
+           rules = {@BMRule(
+                   name = "checking ActiveMQServerControl methods",
+                   targetClass = "org.apache.activemq.artemis.core.postoffice.impl.PostOfficeImpl",
+                   targetMethod = "route(org.apache.activemq.artemis.api.core.Message, boolean)",
+                   targetLocation = "ENTRY",
+                   action = "throw new org.apache.activemq.artemis.api.core.ActiveMQException(\"gotcha\")")})
+   public void testAddressControl() throws Exception {
+      server.getActiveMQServerControl().createAddress("test.address", "ANYCAST");
+      MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+      System.out.println("server is " + mbs);
+      ObjectName objectName = new ObjectName("org.apache.activemq.artemis:broker=\"localhost\",component=addresses,address=\"test.address\"");
+      Object[] params = new Object[] {new HashMap(), 3, "aGVsbG8=", true, null, null};
+      String[] signature = new String[] {"java.util.Map", "int", "java.lang.String", "boolean", "java.lang.String", "java.lang.String"};
+      try {
+         mbs.invoke(objectName, "sendMessage", params, signature);
+         fail("test should have gotten an exception!");
+      } catch (RuntimeMBeanException ex) {
+         assertTrue(ex.getCause() instanceof IllegalStateException);
+         IllegalStateException e = (IllegalStateException) ex.getCause();
+         assertEquals("gotcha", e.getMessage());
+      }
+   }
+}


### PR DESCRIPTION
Artemis expose createQueue() method to management console like Jon.
If the queue to be created already exists it throws an ActiveMQException
back to the console, which will get a ClassNotFoundException when
deserializing the exception.

To fix that it should throw a common java exception like IllegalStateException.