### PR TITLE
ARTEMIS-1039 Transaction Coordinator credit refill

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPSessionContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPSessionContext.java
@@ -148,7 +148,7 @@ public class AMQPSessionContext extends ProtonInitializable {
 
       receiver.setContext(transactionHandler);
       receiver.open();
-      receiver.flow(100);
+      receiver.flow(ProtonTransactionHandler.DEFAULT_COORDINATOR_CREDIT);
    }
 
    public void addSender(Sender sender) throws Exception {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpTransactionTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpTransactionTest.java
@@ -49,6 +49,22 @@ public class AmqpTransactionTest extends AmqpClientTestSupport {
    }
 
    @Test(timeout = 30000)
+   public void testCoordinatorReplenishesCredit() throws Exception {
+      AmqpClient client = createAmqpClient();
+      AmqpConnection connection = addConnection(client.connect());
+      AmqpSession session = connection.createSession();
+      assertNotNull(session);
+
+      for (int i = 0; i < 1000; ++i) {
+         session.begin();
+         assertTrue(session.isInTransaction());
+         session.commit();
+      }
+
+      connection.close();
+   }
+
+   @Test(timeout = 30000)
    public void testBeginAndRollbackTransaction() throws Exception {
       AmqpClient client = createAmqpClient();
       AmqpConnection connection = addConnection(client.connect());


### PR DESCRIPTION
The coordinator needs to refill credit on the receiver once it has been
exhausted, otherwise the remote cannot send additional declare or
discharge commands to the broker.