### PR TITLE
ARTEMIS-1051 Make ServerSession send thread safe

### DIFF
--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile
@@ -23,7 +23,7 @@ ARTEMIS_INSTANCE='${artemis.instance}'
 
 
 # Java Opts
-JAVA_ARGS="-XX:+UseParallelGC -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -Xms512M -Xmx1024M"
+JAVA_ARGS="-XX:+PrintClassHistogram -XX:+UseG1GC -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -Xms512M -Xmx2G"
 
 #
 # There might be options that you only want to enable on specifc commands, like setting a JMX port

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile.cmd
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile.cmd
@@ -23,7 +23,7 @@ rem Cluster Properties: Used to pass arguments to ActiveMQ Artemis which can be 
 rem set ARTEMIS_CLUSTER_PROPS=-Dactivemq.remoting.default.port=61617 -Dactivemq.remoting.amqp.port=5673 -Dactivemq.remoting.stomp.port=61614 -Dactivemq.remoting.hornetq.port=5446
 
 rem Java Opts
-set JAVA_ARGS=-XX:+UseParallelGC -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -Xms512M -Xmx1024M -Xbootclasspath/a:%ARTEMIS_HOME%\lib\${logmanager} -Djava.security.auth.login.config=%ARTEMIS_INSTANCE%\etc\login.config ${java-opts} -Dartemis.instance=%ARTEMIS_INSTANCE%
+set JAVA_ARGS=-XX:+PrintClassHistogram -XX:+UseG1GC -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -Xms512M -Xmx1024M -Xbootclasspath/a:%ARTEMIS_HOME%\lib\${logmanager} -Djava.security.auth.login.config=%ARTEMIS_INSTANCE%\etc\login.config ${java-opts} -Dartemis.instance=%ARTEMIS_INSTANCE%
 
 rem There might be options that you only want to enable on specifc commands, like setting a JMX port
 rem See https://issues.apache.org/jira/browse/ARTEMIS-318

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -1285,7 +1285,7 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
    }
 
    @Override
-   public RoutingStatus send(Transaction tx,
+   public synchronized RoutingStatus send(Transaction tx,
                              final Message message,
                              final boolean direct,
                              boolean noAutoCreateQueue) throws Exception {
@@ -1616,6 +1616,7 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
                                final SimpleString originalAddress,
                                final boolean direct,
                                final boolean noAutoCreateQueue) throws Exception {
+
       RoutingStatus result = RoutingStatus.OK;
 
       RoutingType routingType = msg.getRouteType();


### PR DESCRIPTION
According to @clebertsuconic  this is a historical design decision when the CORE protocol was the main focus. With Proton and AMQP it is possible that sends are initiated from separate threads, this could cause problem when a send on a single server session is interleaved with 2 threads.