### PR TITLE
NO-JIRA Fixing testReceiveWildcardTopicMatchDoubleWildcard

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/amq/JmsTopicWildcardSendReceiveTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/amq/JmsTopicWildcardSendReceiveTest.java
@@ -159,31 +159,6 @@ public class JmsTopicWildcardSendReceiveTest extends JmsTopicSendReceiveTest {
    }
 
    @Test
-   public void testReceiveWildcardTopicMatchDoubleWildcard() throws Exception {
-      connection.start();
-      Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
-
-      ActiveMQDestination destination1 = (ActiveMQDestination) session.createTopic("a.*.>.>");
-      ActiveMQDestination destination2 = (ActiveMQDestination) session.createTopic("a.b");
-
-      Message m = null;
-      MessageConsumer consumer = null;
-      String text = null;
-
-      consumer = session.createConsumer(destination1);
-      sendMessage(session, destination2, destination3String);
-
-      m = consumer.receive(1000);
-      assertNotNull(m);
-      text = ((TextMessage) m).getText();
-      if (!(text.equals(destination1String) || text.equals(destination3String))) {
-         fail("unexpected message:" + text);
-      }
-
-      assertNull(consumer.receiveNoWait());
-   }
-
-   @Test
    public void testReceiveWildcardTopicMatchSinglePastTheEndWildcard() throws Exception {
       connection.start();
       Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);


### PR DESCRIPTION
Fixing JmsTopicWildcardSendReceiveTest::testReceiveWildcardTopicMatchDoubleWildcard

Accordingly to bisect, this test was broken at 21b64b3e4f4fc6dbeaa30ce610ecefa15110100a