### PR TITLE
NO-JIRA upgrade maven-surefire-plugin to 2.19.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1086,7 +1086,7 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-surefire-plugin</artifactId>
-               <version>2.18.1</version>
+               <version>2.19.1</version>
                <configuration>
                   <forkMode>once</forkMode>
                   <testFailureIgnore>true</testFailureIgnore>
@@ -1098,7 +1098,7 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-surefire-report-plugin</artifactId>
-               <version>2.18.1</version>
+               <version>2.19.1</version>
             </plugin>
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>

--- a/tests/extra-tests/pom.xml
+++ b/tests/extra-tests/pom.xml
@@ -270,7 +270,7 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>2.18.1</version>
+            <version>2.19.1</version>
             <configuration>
                <skipTests>${skipExtraTests}</skipTests>
                <!-- ensure we don't inherit a byteman jar form any env settings -->


### PR DESCRIPTION
Version 2.19 improves filtering with the `-Dtest` option and even allows exclusions, like

    mvn ... -Dtest=\!LargeMessage\*