### PR TITLE
ARTEMIS-1092 Validated user + AMQP fix

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/Message.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/Message.java
@@ -314,6 +314,14 @@ public interface Message {
 
    Message setUserID(Object userID);
 
+   default  String getValidatedUserID() {
+      return null;
+   }
+
+   default Message setValidatedUserID(String validatedUserID) {
+      return this;
+   }
+
    /**
     * Returns whether this message is durable or not.
     */

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessage.java
@@ -384,6 +384,17 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
    }
 
    @Override
+   public String getValidatedUserID() {
+      return getStringProperty(Message.HDR_VALIDATED_USER);
+   }
+
+   @Override
+   public CoreMessage setValidatedUserID(String validatedUserID) {
+      putStringProperty(Message.HDR_VALIDATED_USER, SimpleString.toSimpleString(validatedUserID));
+      return this;
+   }
+
+   @Override
    public CoreMessage setMessageID(long messageID) {
       this.messageID = messageID;
       if (messageIDPosition >= 0 && validBuffer) {

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQMessage.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQMessage.java
@@ -588,7 +588,7 @@ public class ActiveMQMessage implements javax.jms.Message {
          if (MessageUtil.JMSXGROUPID.equals(name)) {
             return message.getStringProperty(org.apache.activemq.artemis.api.core.Message.HDR_GROUP_ID);
          } else if (MessageUtil.JMSXUSERID.equals(name)) {
-            return message.getStringProperty(org.apache.activemq.artemis.api.core.Message.HDR_VALIDATED_USER);
+            return message.getValidatedUserID();
          } else {
             return message.getStringProperty(new SimpleString(name));
          }

--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompUtils.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompUtils.java
@@ -101,8 +101,8 @@ public class StompUtils {
       if (message.getStringProperty(Message.HDR_CONTENT_TYPE.toString()) != null) {
          command.addHeader(Stomp.Headers.CONTENT_TYPE, message.getStringProperty(Message.HDR_CONTENT_TYPE.toString()));
       }
-      if (message.getStringProperty(Message.HDR_VALIDATED_USER.toString()) != null) {
-         command.addHeader(Stomp.Headers.Message.VALIDATED_USER, message.getStringProperty(Message.HDR_VALIDATED_USER.toString()));
+      if (message.getValidatedUserID() != null) {
+         command.addHeader(Stomp.Headers.Message.VALIDATED_USER, message.getValidatedUserID());
       }
 
       // now let's add all the rest of the message headers

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -1307,7 +1307,7 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
       }
 
       if (server.getConfiguration().isPopulateValidatedUser() && validatedUser != null) {
-         message.putStringProperty(Message.HDR_VALIDATED_USER, SimpleString.toSimpleString(validatedUser));
+         message.setValidatedUserID(validatedUser);
       }
 
       SimpleString address = message.getAddressSimpleString();


### PR DESCRIPTION
When populate-validated-user = true AMQP messages can cause exceptions.
This feature isn't particularly applicable to AMQP so this commit
eliminates the exception and leaves the AMQP messages untouched
even if populate-validated-user = true. In other words,
populate-validated-user + AMQP is not supported.