### PR TITLE
(1.x) [ARTEMIS-1043] Support IPv6 in NettyConnector

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnector.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnector.java
@@ -103,6 +103,7 @@ import org.apache.activemq.artemis.spi.core.remoting.ClientProtocolManager;
 import org.apache.activemq.artemis.spi.core.remoting.Connection;
 import org.apache.activemq.artemis.utils.ConfigurationHelper;
 import org.apache.activemq.artemis.utils.FutureLatch;
+import org.apache.activemq.artemis.utils.IPV6Util;
 import org.jboss.logging.Logger;
 
 import static org.apache.activemq.artemis.utils.Base64.encodeBytes;
@@ -658,7 +659,7 @@ public class NettyConnector extends AbstractConnector {
                if (sslEnabled) {
                   scheme = "https";
                }
-               URI uri = new URI(scheme, null, host, port, null, null, null);
+               URI uri = new URI(scheme, null, IPV6Util.encloseHost(host), port, null, null, null);
                HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri.getRawPath());
                request.headers().set(HttpHeaders.Names.HOST, host);
                request.headers().set(HttpHeaders.Names.UPGRADE, ACTIVEMQ_REMOTING);


### PR DESCRIPTION
Call IPV6Util.encloseHost when creating the uri used to send the HTTP
ugrade request to ensure that IPv6 address are properly enclosed.

JIRA: https://issues.apache.org/jira/browse/ARTEMIS-1043