### PR TITLE
ARTEMIS-1099 Force Netty EPOLL to be available only on Linux 64bit platforms

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/Env.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/Env.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.utils;
+
+/**
+ * Utility that detects various properties specific to the current runtime
+ * environment, such as JVM bitness and OS type.
+ */
+public final class Env {
+
+   private static final String OS = System.getProperty("os.name").toLowerCase();
+   private static final boolean IS_LINUX = OS.startsWith("linux");
+   private static final boolean IS_64BIT = checkIs64bit();
+
+   private Env() {
+
+   }
+
+   public static boolean isLinuxOs() {
+      return IS_LINUX == true;
+   }
+
+   public static boolean is64BitJvm() {
+      return IS_64BIT;
+   }
+
+   private static boolean checkIs64bit() {
+      //check the more used JVMs
+      String systemProp;
+      systemProp = System.getProperty("com.ibm.vm.bitmode");
+      if (systemProp != null) {
+         return "64".equals(systemProp);
+      }
+      systemProp = System.getProperty("sun.arch.data.model");
+      if (systemProp != null) {
+         return "64".equals(systemProp);
+      }
+      systemProp = System.getProperty("java.vm.version");
+      return systemProp != null && systemProp.contains("_64");
+   }
+}

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/Epoll.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/Epoll.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.core.remoting.impl.netty;
+
+import org.apache.activemq.artemis.utils.Env;
+
+/**
+ * Tells if <a href="http://netty.io/wiki/native-transports.html">{@code netty-transport-native-epoll}</a> is supported.
+ */
+public final class Epoll {
+
+   private static final boolean IS_AVAILABLE_EPOLL;
+
+   static {
+      if (Env.is64BitJvm() && Env.isLinuxOs()) {
+         IS_AVAILABLE_EPOLL = io.netty.channel.epoll.Epoll.isAvailable();
+      } else {
+         IS_AVAILABLE_EPOLL = false;
+      }
+   }
+
+   private Epoll() {
+
+   }
+
+   public static boolean isAvailable() {
+      return IS_AVAILABLE_EPOLL;
+   }
+}

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnector.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnector.java
@@ -59,7 +59,6 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.WriteBufferWaterMark;
-import io.netty.channel.epoll.Epoll;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.epoll.EpollSocketChannel;
 import io.netty.channel.group.ChannelGroup;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptor.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptor.java
@@ -45,7 +45,6 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.WriteBufferWaterMark;
-import io.netty.channel.epoll.Epoll;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.epoll.EpollServerSocketChannel;
 import io.netty.channel.group.ChannelGroup;


### PR DESCRIPTION
It checks the compatibility of the Epoll implementation avoiding to load and link the Epoll library on 32 bit JVMs. 