### PR TITLE
ARTEMIS-1101 Read the correct values for timestamp and user-id

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/message/AMQPMessageTest.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/message/AMQPMessageTest.java
@@ -17,8 +17,14 @@
 
 package org.apache.activemq.artemis.protocol.amqp.message;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
 import org.apache.activemq.artemis.protocol.amqp.broker.AMQPMessage;
 import org.apache.activemq.artemis.protocol.amqp.util.NettyWritable;
 import org.apache.commons.collections.map.HashedMap;
@@ -28,8 +34,10 @@ import org.apache.qpid.proton.amqp.messaging.Header;
 import org.apache.qpid.proton.amqp.messaging.Properties;
 import org.apache.qpid.proton.message.Message;
 import org.apache.qpid.proton.message.impl.MessageImpl;
-import org.junit.Assert;
 import org.junit.Test;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 public class AMQPMessageTest {
 
@@ -44,20 +52,168 @@ public class AMQPMessageTest {
       protonMessage.getHeader().setDurable(Boolean.TRUE);
       protonMessage.setApplicationProperties(new ApplicationProperties(new HashedMap()));
 
+      AMQPMessage decoded = encodeAndDecodeMessage(protonMessage);
+
+      assertEquals(7, decoded.getHeader().getDeliveryCount().intValue());
+      assertEquals(true, decoded.getHeader().getDurable());
+      assertEquals("someNiceLocal", decoded.getAddress());
+   }
+
+   @Test
+   public void testGetAddressFromMessage() {
+      final String ADDRESS = "myQueue";
+
+      MessageImpl protonMessage = (MessageImpl) Message.Factory.create();
+      protonMessage.setHeader(new Header());
+      protonMessage.setAddress(ADDRESS);
+
+      AMQPMessage decoded = encodeAndDecodeMessage(protonMessage);
+
+      assertEquals(ADDRESS, decoded.getAddress());
+   }
+
+   @Test
+   public void testGetAddressSimpleStringFromMessage() {
+      final String ADDRESS = "myQueue";
+
+      MessageImpl protonMessage = (MessageImpl) Message.Factory.create();
+      protonMessage.setHeader(new Header());
+      protonMessage.setAddress(ADDRESS);
+
+      AMQPMessage decoded = encodeAndDecodeMessage(protonMessage);
+
+      assertEquals(ADDRESS, decoded.getAddressSimpleString().toString());
+   }
+
+   @Test
+   public void testGetAddressFromMessageWithNoValueSet() {
+      MessageImpl protonMessage = (MessageImpl) Message.Factory.create();
+
+      AMQPMessage decoded = encodeAndDecodeMessage(protonMessage);
+
+      assertNull(decoded.getAddress());
+      assertNull(decoded.getAddressSimpleString());
+   }
+
+   @Test
+   public void testIsDurableFromMessage() {
+      MessageImpl protonMessage = (MessageImpl) Message.Factory.create();
+      protonMessage.setHeader(new Header());
+      protonMessage.setDurable(true);
+
+      AMQPMessage decoded = encodeAndDecodeMessage(protonMessage);
+
+      assertTrue(decoded.isDurable());
+   }
+
+   @Test
+   public void testIsDurableFromMessageWithNoValueSet() {
+      MessageImpl protonMessage = (MessageImpl) Message.Factory.create();
+
+      AMQPMessage decoded = encodeAndDecodeMessage(protonMessage);
+
+      assertFalse(decoded.isDurable());
+   }
+
+   @Test
+   public void testGetGroupIDFromMessage() {
+      final String GROUP_ID = "group-1";
+
+      MessageImpl protonMessage = (MessageImpl) Message.Factory.create();
+      protonMessage.setHeader(new Header());
+      protonMessage.setGroupId(GROUP_ID);
+
+      AMQPMessage decoded = encodeAndDecodeMessage(protonMessage);
+
+      assertEquals(GROUP_ID, decoded.getGroupID().toString());
+   }
+
+   @Test
+   public void testGetGroupIDFromMessageWithNoGroupId() {
+      MessageImpl protonMessage = (MessageImpl) Message.Factory.create();
+
+      AMQPMessage decoded = encodeAndDecodeMessage(protonMessage);
+
+      assertNull(decoded.getUserID());
+   }
+
+   @Test
+   public void testGetUserIDFromMessage() {
+      final String USER_NAME = "foo";
+
+      MessageImpl protonMessage = (MessageImpl) Message.Factory.create();
+      protonMessage.setHeader(new Header());
+      protonMessage.setUserId(USER_NAME.getBytes(StandardCharsets.UTF_8));
+
+      AMQPMessage decoded = encodeAndDecodeMessage(protonMessage);
+
+      assertEquals(USER_NAME, decoded.getUserID());
+   }
+
+   @Test
+   public void testGetUserIDFromMessageWithNoUserID() {
+      MessageImpl protonMessage = (MessageImpl) Message.Factory.create();
+
+      AMQPMessage decoded = encodeAndDecodeMessage(protonMessage);
+
+      assertNull(decoded.getUserID());
+   }
+
+   @Test
+   public void testGetPriorityFromMessage() {
+      final short PRIORITY = 7;
+
+      MessageImpl protonMessage = (MessageImpl) Message.Factory.create();
+      protonMessage.setHeader(new Header());
+      protonMessage.setPriority(PRIORITY);
+
+      AMQPMessage decoded = encodeAndDecodeMessage(protonMessage);
+
+      assertEquals(PRIORITY, decoded.getPriority());
+   }
+
+   @Test
+   public void testGetPriorityFromMessageWithNoPrioritySet() {
+      MessageImpl protonMessage = (MessageImpl) Message.Factory.create();
+
+      AMQPMessage decoded = encodeAndDecodeMessage(protonMessage);
+
+      assertEquals(AMQPMessage.DEFAULT_MESSAGE_PRIORITY, decoded.getPriority());
+   }
+
+   @Test
+   public void testGetTimestampFromMessage() {
+      Date timestamp = new Date(System.currentTimeMillis());
+
+      MessageImpl protonMessage = (MessageImpl) Message.Factory.create();
+      protonMessage.setHeader( new Header());
+      Properties properties = new Properties();
+      properties.setCreationTime(timestamp);
+
+      protonMessage.setProperties(properties);
+
+      AMQPMessage decoded = encodeAndDecodeMessage(protonMessage);
+
+      assertEquals(timestamp.getTime(), decoded.getTimestamp());
+   }
+
+   @Test
+   public void testGetTimestampFromMessageWithNoCreateTimeSet() {
+      MessageImpl protonMessage = (MessageImpl) Message.Factory.create();
+      protonMessage.setHeader( new Header());
+
+      AMQPMessage decoded = encodeAndDecodeMessage(protonMessage);
+
+      assertEquals(0L, decoded.getTimestamp());
+   }
+
+   private AMQPMessage encodeAndDecodeMessage(MessageImpl message) {
       ByteBuf nettyBuffer = Unpooled.buffer(1500);
 
-      protonMessage.encode(new NettyWritable(nettyBuffer));
-
+      message.encode(new NettyWritable(nettyBuffer));
       byte[] bytes = new byte[nettyBuffer.writerIndex()];
-
       nettyBuffer.readBytes(bytes);
 
-      AMQPMessage encode = new AMQPMessage(0, bytes);
-
-      Assert.assertEquals(7, encode.getHeader().getDeliveryCount().intValue());
-      Assert.assertEquals(true, encode.getHeader().getDurable());
-      Assert.assertEquals("someNiceLocal", encode.getAddress());
-
-
+      return new AMQPMessage(0, bytes);
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpMessagePriorityTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpMessagePriorityTest.java
@@ -67,9 +67,8 @@ public class AmqpMessagePriorityTest extends AmqpClientTestSupport {
       connection.close();
    }
 
-
    @Test(timeout = 60000)
-   public void testRestartServer() throws Exception {
+   public void testMessagePriorityPreservedAfterServerRestart() throws Exception {
       AmqpClient client = createAmqpClient();
       AmqpConnection connection = addConnection(client.connect());
       AmqpSession session = connection.createSession();
@@ -80,7 +79,6 @@ public class AmqpMessagePriorityTest extends AmqpClientTestSupport {
       message.setDurable(true);
       message.setMessageId("MessageID:1");
       message.setPriority((short) 7);
-
 
       sender.send(message);
       sender.close();


### PR DESCRIPTION
Fix the getUserID and getTimestamp methods in AMQPMessage to read and
return the correct values.  Adds some tests to cover these cases and
cleans up some others.