### PR TITLE
ARTEMIS-1107 test AddressControl.sendMessage

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/AddressControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/AddressControlImpl.java
@@ -291,8 +291,10 @@ public class AddressControlImpl extends AbstractControl implements AddressContro
             }
          });
          CoreMessage message = new CoreMessage(storageManager.generateID(), 50);
-         for (String header : headers.keySet()) {
-            message.putStringProperty(new SimpleString(header), new SimpleString(headers.get(header)));
+         if (headers != null) {
+            for (String header : headers.keySet()) {
+               message.putStringProperty(new SimpleString(header), new SimpleString(headers.get(header)));
+            }
          }
          message.setType((byte) type);
          message.setDurable(durable);
@@ -341,7 +343,7 @@ public class AddressControlImpl extends AbstractControl implements AddressContro
             QueueControl coreQueueControl = (QueueControl) managementService.getResource(ResourceNames.QUEUE + queue);
 
             // Ignore the "special" subscription
-            if (coreQueueControl != null && !coreQueueControl.getName().equals(getAddress())) {
+            if (coreQueueControl != null) {
                if (durability == DurabilityType.ALL || durability == DurabilityType.DURABLE && coreQueueControl.isDurable() ||
                      durability == DurabilityType.NON_DURABLE && !coreQueueControl.isDurable()) {
                   matchingQueues.add(coreQueueControl);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/ProtonTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/ProtonTestBase.java
@@ -30,7 +30,7 @@ import org.junit.Before;
 
 public class ProtonTestBase extends ActiveMQTestBase {
 
-   protected String brokerName = "my-broker";
+   protected String brokerName = "localhost";
    protected ActiveMQServer server;
 
    protected String tcpAmqpConnectionUri = "tcp://localhost:5672";


### PR DESCRIPTION
Add tests for this management operation with both core and AMQP encoded
messages. Also fix a few problems with the implementation like not
checking the passed-in headers for null and not counting messages
properly.