### PR TITLE
ARTEMIS-1111 Avoid deadlock on AMQP delivery during close

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPSessionContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPSessionContext.java
@@ -147,9 +147,12 @@ public class AMQPSessionContext extends ProtonInitializable {
       coordinator.setCapabilities(Symbol.getSymbol("amqp:local-transactions"), Symbol.getSymbol("amqp:multi-txns-per-ssn"), Symbol.getSymbol("amqp:multi-ssns-per-txn"));
 
       receiver.setContext(transactionHandler);
-      synchronized (connection.getLock()) {
+      connection.lock();
+      try {
          receiver.open();
          receiver.flow(connection.getAmqpCredits());
+      } finally {
+         connection.unlock();
       }
    }
 
@@ -161,18 +164,25 @@ public class AMQPSessionContext extends ProtonInitializable {
       try {
          protonSender.initialise();
          senders.put(sender, protonSender);
-         serverSenders.put(protonSender.getBrokerConsumer(), protonSender);
+         ser\nverSenders.put(protonSender.getBrokerConsumer(), protonSender);
          sender.setContext(protonSender);
-         synchronized (connection.getLock()) {
+         connection.lock();
+         try {
             sender.open();
+         } finally {
+            connection.unlock();
          }
+
          protonSender.start();
       } catch (ActiveMQAMQPException e) {
          senders.remove(sender);
          sender.setSource(null);
          sender.setCondition(new ErrorCondition(e.getAmqpError(), e.getMessage()));
-         synchronized (connection.getLock()) {
+         connection.lock();
+         try {
             sender.close();
+         } finally {
+            connection.unlock();
          }
       }
    }
@@ -191,15 +201,21 @@ public class AMQPSessionContext extends ProtonInitializable {
          protonReceiver.initialise();
          receivers.put(receiver, protonReceiver);
          receiver.setContext(protonReceiver);
-         synchronized (connection.getLock()) {
+         connection.lock();
+         try {
             receiver.open();
+         } finally {
+            connection.unlock();
          }
       } catch (ActiveMQAMQPException e) {
          receivers.remove(receiver);
          receiver.setTarget(null);
          receiver.setCondition(new ErrorCondition(e.getAmqpError(), e.getMessage()));
-         synchronized (connection.getLock()) {
+         connection.lock();
+         try {
             receiver.close();
+         } finally {
+            connection.unlock();
          }
       }
    }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
@@ -95,7 +96,10 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
    private boolean isVolatile = false;
    private String tempQueueName;
 
-   public ProtonServerSenderContext(AMQPConnectionContext connection, Sender sender, AMQPSessionContext protonSession, AMQPSessionCallback server) {
+   public ProtonServerSenderContext(AMQPConnectionContext connection,
+                                    Sender sender,
+                                    AMQPSessionContext protonSession,
+                                    AMQPSessionCallback server) {
       super();
       this.connection = connection;
       this.sender = sender;
@@ -246,7 +250,7 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
          }
          //check to see if the client has defined how we act
          boolean clientDefined = hasCapabilities(TOPIC, source) || hasCapabilities(QUEUE, source);
-         if (clientDefined)  {
+         if (clientDefined) {
             multicast = hasCapabilities(TOPIC, source);
             AddressQueryResult addressQueryResult = sessionSPI.addressQuery(addressToUse.toString(), multicast ? RoutingType.MULTICAST : RoutingType.ANYCAST, true);
             if (!addressQueryResult.isExists()) {
@@ -293,9 +297,8 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
                supportedFilters.put(filter.getKey(), filter.getValue());
             }
 
-
             if (queueNameToUse != null) {
-               SimpleString matchingAnycastQueue = sessionSPI.getMatchingQueue(addressToUse, queueNameToUse, RoutingType.MULTICAST  );
+               SimpleString matchingAnycastQueue = sessionSPI.getMatchingQueue(addressToUse, queueNameToUse, RoutingType.MULTICAST);
                queue = matchingAnycastQueue.toString();
             }
             //if the address specifies a broker configured queue then we always use this, treat it as a queue
@@ -313,8 +316,7 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
                if (result.isExists()) {
                   // If a client reattaches to a durable subscription with a different no-local
                   // filter value, selector or address then we must recreate the queue (JMS semantics).
-                  if (!Objects.equals(result.getFilterString(), SimpleString.toSimpleString(selector)) ||
-                     (sender.getSource() != null && !sender.getSource().getAddress().equals(result.getAddress().toString()))) {
+                  if (!Objects.equals(result.getFilterString(), SimpleString.toSimpleString(selector)) || (sender.getSource() != null && !sender.getSource().getAddress().equals(result.getAddress().toString()))) {
 
                      if (result.getConsumerCount() == 0) {
                         sessionSPI.deleteQueue(queue);
@@ -392,7 +394,7 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
 
       boolean browseOnly = !multicast && source.getDistributionMode() != null && source.getDistributionMode().equals(COPY);
       try {
-         brokerConsumer = (Consumer)sessionSPI.createSender(this, queue, multicast ? null : selector, browseOnly);
+         brokerConsumer = (Consumer) sessionSPI.createSender(this, queue, multicast ? null : selector, browseOnly);
       } catch (ActiveMQAMQPResourceLimitExceededException e1) {
          throw new ActiveMQAMQPResourceLimitExceededException(e1.getMessage());
       } catch (Exception e) {
@@ -404,7 +406,6 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
       return connection.getRemoteContainer();
    }
 
-
    /*
     * close the session
     */
@@ -415,8 +416,11 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
          sender.setCondition(condition);
       }
       protonSession.removeSender(sender);
-      synchronized (connection.getLock()) {
+      connection.lock();
+      try {
          sender.close();
+      } finally {
+         connection.unlock();
       }
       connection.flush();
 
@@ -442,7 +446,7 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
             Source source = (Source) sender.getSource();
             if (source != null && source.getAddress() != null && multicast) {
                String queueName = source.getAddress();
-               QueueQueryResult result = sessionSPI.queueQuery(queueName, routingTypeToUse,  false);
+               QueueQueryResult result = sessionSPI.queueQuery(queueName, routingTypeToUse, false);
                if (result.isExists() && source.getDynamic()) {
                   sessionSPI.deleteQueue(queueName);
                } else {
@@ -489,8 +493,11 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
 
          DeliveryState remoteState;
 
-         synchronized (connection.getLock()) {
+         connection.lock();
+         try {
             remoteState = delivery.getRemoteState();
+         } finally {
+            connection.unlock();
          }
 
          boolean settleImmediate = true;
@@ -509,8 +516,11 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
                         TransactionalState txAccepted = new TransactionalState();
                         txAccepted.setOutcome(Accepted.getInstance());
                         txAccepted.setTxnId(txState.getTxnId());
-                        synchronized (connection.getLock()) {
+                        connection.lock();
+                        try {
                            delivery.disposition(txAccepted);
+                        } finally {
+                           connection.unlock();
                         }
                      }
                      // we have to individual ack as we can't guarantee we will get the delivery
@@ -556,7 +566,7 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
                   Modified modification = (Modified) remoteState;
 
                   if (Boolean.TRUE.equals(modification.getUndeliverableHere())) {
-                     message.rejectConsumer(((Consumer)brokerConsumer).sequentialID());
+                     message.rejectConsumer(((Consumer) brokerConsumer).sequentialID());
                   }
 
                   if (Boolean.TRUE.equals(modification.getDeliveryFailed())) {
@@ -585,8 +595,11 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
    }
 
    public void settle(Delivery delivery) {
-      synchronized (connection.getLock()) {
+      connection.lock();
+      try {
          delivery.settle();
+      } finally {
+         connection.unlock();
       }
    }
 
@@ -617,10 +630,15 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
 
          int size = nettyBuffer.writerIndex();
 
-         synchronized (connection.getLock()) {
-            if (sender.getLocalState() == EndpointState.CLOSED) {
+         while (!connection.getLock().tryLock(1, TimeUnit.SECONDS)) {
+            if (closed || sender.getLocalState() == EndpointState.CLOSED) {
+               // If we're waiting on the connection lock, the link might be in the process of closing.  If this happens
+               // we return.
                return 0;
             }
+         }
+
+         try {
             final Delivery delivery;
             delivery = sender.delivery(tag, 0, tag.length);
             delivery.setMessageFormat((int) message.getMessageFormat());
@@ -636,9 +654,10 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
             } else {
                sender.advance();
             }
+            connection.flush();
+         } finally {
+            connection.unlock();
          }
-
-         connection.flush();
 
          return size;
       } finally {
@@ -659,7 +678,11 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
       return false;
    }
 
-   private static String createQueueName(String clientId, String pubId, boolean shared, boolean global, boolean isVolatile) {
+   private static String createQueueName(String clientId,
+                                         String pubId,
+                                         boolean shared,
+                                         boolean global,
+                                         boolean isVolatile) {
       String queue = clientId == null || clientId.isEmpty() ? pubId : clientId + "." + pubId;
       if (shared) {
          if (queue.contains("|")) {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/ProtonTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/ProtonTest.java
@@ -1583,6 +1583,45 @@ public class ProtonTest extends ProtonTestBase {
    }
 
    @Test
+   public void testTimedOutWaitingForWriteLogOnConsumer() throws Throwable {
+      String name = "exampleQueue1";
+
+      int numMessages = 50;
+
+      System.out.println("1. Send messages into queue");
+      Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+      javax.jms.Queue queue = session.createQueue(name);
+      MessageProducer p = session.createProducer(queue);
+      for (int i = 0; i < numMessages; i++) {
+         TextMessage message = session.createTextMessage();
+         message.setText("Message temporary");
+         p.send(message);
+      }
+      p.close();
+      session.close();
+
+      System.out.println("2. Receive one by one, each in its own session");
+      for (int i = 0; i < numMessages; i++) {
+         session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+         queue = session.createQueue(name);
+         MessageConsumer c = session.createConsumer(queue);
+         Message m = c.receive(1000);
+         p.close();
+         session.close();
+      }
+
+      System.out.println("3. Try to receive 10 in the same session");
+      session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+      queue = session.createQueue(name);
+      MessageConsumer c = session.createConsumer(queue);
+      for (int i = 0; i < numMessages; i++) {
+         Message m = c.receive(1000);
+      }
+      p.close();
+      session.close();
+   }
+
+   @Test
    public void testSimpleObject() throws Throwable {
       final int numMessages = 1;
       long time = System.currentTimeMillis();


### PR DESCRIPTION
I wanted to avoid the possibility of adding more race/lock conditions by introducing new Executors/Threads when dealing with the situation described by ARTEMIS-1111.  Instead I've upgraded the connection lock to a re-entrant lock.  Instead of the consumer delivery thread blocking forever when the ProtonHandler lock is held by the close() event, it does a tryLock(), then checks to see if the link is closed.  If so it will exit.  If not it will retry.