### PR TITLE
ARTEMIS-1127 Match remote Sender and Receiver settle modes

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerReceiverContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerReceiverContext.java
@@ -31,6 +31,7 @@ import org.apache.qpid.proton.amqp.messaging.Rejected;
 import org.apache.qpid.proton.amqp.messaging.TerminusExpiryPolicy;
 import org.apache.qpid.proton.amqp.transaction.TransactionalState;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
+import org.apache.qpid.proton.amqp.transport.ReceiverSettleMode;
 import org.apache.qpid.proton.engine.Delivery;
 import org.apache.qpid.proton.engine.Receiver;
 import org.jboss.logging.Logger;
@@ -80,6 +81,12 @@ public class ProtonServerReceiverContext extends ProtonInitializable implements 
    public void initialise() throws Exception {
       super.initialise();
       org.apache.qpid.proton.amqp.messaging.Target target = (org.apache.qpid.proton.amqp.messaging.Target) receiver.getRemoteTarget();
+
+      // Match the settlement mode of the remote instead of relying on the default of MIXED.
+      receiver.setSenderSettleMode(receiver.getRemoteSenderSettleMode());
+
+      // We don't currently support SECOND so enforce that the answer is anlways FIRST
+      receiver.setReceiverSettleMode(ReceiverSettleMode.FIRST);
 
       if (target != null) {
          if (target.getDynamic()) {

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/AmqpSender.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/AmqpSender.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -66,7 +66,10 @@ public class AmqpSender extends AmqpAbstractResource<Sender> {
    private final AmqpSession session;
    private final String address;
    private final String senderId;
+
    private final Target userSpecifiedTarget;
+   private final SenderSettleMode userSpecifiedSenderSettlementMode;
+   private final ReceiverSettleMode userSpecifiedReceiverSettlementMode;
 
    private boolean presettle;
    private long sendTimeout = DEFAULT_SEND_TIMEOUT;
@@ -81,11 +84,32 @@ public class AmqpSender extends AmqpAbstractResource<Sender> {
    /**
     * Create a new sender instance.
     *
-    * @param session  The parent session that created the session.
-    * @param address  The address that this sender produces to.
-    * @param senderId The unique ID assigned to this sender.
+    * @param session
+    *        The parent session that created the session.
+    * @param address
+    *        The address that this sender produces to.
+    * @param senderId
+    *        The unique ID assigned to this sender.
     */
    public AmqpSender(AmqpSession session, String address, String senderId) {
+      this(session, address, senderId, null, null);
+   }
+
+   /**
+    * Create a new sender instance.
+    *
+    * @param session
+    *        The parent session that created the session.
+    * @param address
+    *        The address that this sender produces to.
+    * @param senderId
+    *        The unique ID assigned to this sender.
+    * @param senderMode
+    *        The {@link SenderSettleMode} to use on open.
+    * @param receiverMode
+    *        The {@link ReceiverSettleMode} to use on open.
+    */
+   public AmqpSender(AmqpSession session, String address, String senderId, SenderSettleMode senderMode, ReceiverSettleMode receiverMode) {
 
       if (address != null && address.isEmpty()) {
          throw new IllegalArgumentException("Address cannot be empty.");
@@ -95,6 +119,8 @@ public class AmqpSender extends AmqpAbstractResource<Sender> {
       this.address = address;
       this.senderId = senderId;
       this.userSpecifiedTarget = null;
+      this.userSpecifiedSenderSettlementMode = senderMode;
+      this.userSpecifiedReceiverSettlementMode = receiverMode;
    }
 
    /**
@@ -111,9 +137,11 @@ public class AmqpSender extends AmqpAbstractResource<Sender> {
       }
 
       this.session = session;
-      this.userSpecifiedTarget = target;
       this.address = target.getAddress();
       this.senderId = senderId;
+      this.userSpecifiedTarget = target;
+      this.userSpecifiedSenderSettlementMode = null;
+      this.userSpecifiedReceiverSettlementMode = null;
    }
 
    /**
@@ -289,12 +317,25 @@ public class AmqpSender extends AmqpAbstractResource<Sender> {
       Sender sender = session.getEndpoint().sender(senderName);
       sender.setSource(source);
       sender.setTarget(target);
-      if (presettle) {
-         sender.setSenderSettleMode(SenderSettleMode.SETTLED);
+
+      if (userSpecifiedSenderSettlementMode != null) {
+         sender.setSenderSettleMode(userSpecifiedSenderSettlementMode);
+         if (SenderSettleMode.SETTLED.equals(userSpecifiedSenderSettlementMode)) {
+            presettle = true;
+         }
       } else {
-         sender.setSenderSettleMode(SenderSettleMode.UNSETTLED);
+         if (presettle) {
+            sender.setSenderSettleMode(SenderSettleMode.SETTLED);
+         } else {
+            sender.setSenderSettleMode(SenderSettleMode.UNSETTLED);
+         }
       }
-      sender.setReceiverSettleMode(ReceiverSettleMode.FIRST);
+
+      if (userSpecifiedReceiverSettlementMode != null) {
+         sender.setReceiverSettleMode(userSpecifiedReceiverSettlementMode);
+      } else {
+         sender.setReceiverSettleMode(ReceiverSettleMode.FIRST);
+      }
 
       sender.setDesiredCapabilities(desiredCapabilities);
       sender.setOfferedCapabilities(offeredCapabilities);

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/AmqpSession.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/AmqpSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -28,6 +28,8 @@ import org.apache.activemq.transport.amqp.client.util.UnmodifiableSession;
 import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.amqp.messaging.Source;
 import org.apache.qpid.proton.amqp.messaging.Target;
+import org.apache.qpid.proton.amqp.transport.ReceiverSettleMode;
+import org.apache.qpid.proton.amqp.transport.SenderSettleMode;
 import org.apache.qpid.proton.engine.Connection;
 import org.apache.qpid.proton.engine.Session;
 
@@ -174,6 +176,42 @@ public class AmqpSession extends AmqpAbstractResource<Session> {
    }
 
    /**
+    * Create a sender instance using the given address
+    *
+    * @param address
+    *        the address to which the sender will produce its messages.
+    * @param senderSettlementMode
+    *        controls the settlement mode used by the created Sender
+    * @param receiverSettlementMode
+    *        controls the desired settlement mode used by the remote Receiver
+    *
+    * @return a newly created sender that is ready for use.
+    *
+    * @throws Exception if an error occurs while creating the sender.
+    */
+   public AmqpSender createSender(final String address, final SenderSettleMode senderMode, ReceiverSettleMode receiverMode) throws Exception {
+      checkClosed();
+
+      final AmqpSender sender = new AmqpSender(AmqpSession.this, address, getNextSenderId(), senderMode, receiverMode);
+      final ClientFuture request = new ClientFuture();
+
+      connection.getScheduler().execute(new Runnable() {
+
+         @Override
+         public void run() {
+            checkClosed();
+            sender.setStateInspector(getStateInspector());
+            sender.open(request);
+            pumpToProtonTransport(request);
+         }
+      });
+
+      request.sync();
+
+      return sender;
+   }
+
+   /**
     * Create a sender instance using the given Target
     *
     * @param target the caller created and configured Target used to create the sender link.
@@ -292,6 +330,42 @@ public class AmqpSession extends AmqpAbstractResource<Session> {
       if (selector != null && !selector.isEmpty()) {
          receiver.setSelector(selector);
       }
+
+      connection.getScheduler().execute(new Runnable() {
+
+         @Override
+         public void run() {
+            checkClosed();
+            receiver.setStateInspector(getStateInspector());
+            receiver.open(request);
+            pumpToProtonTransport(request);
+         }
+      });
+
+      request.sync();
+
+      return receiver;
+   }
+
+   /**
+    * Create a receiver instance using the given address
+    *
+    * @param address
+    *        the address to which the receiver will subscribe for its messages.
+    * @param senderSettlementMode
+    *        controls the desired settlement mode used by the remote Sender
+    * @param receiverSettlementMode
+    *        controls the settlement mode used by the created Receiver
+    *
+    * @return a newly created receiver that is ready for use.
+    *
+    * @throws Exception if an error occurs while creating the receiver.
+    */
+   public AmqpReceiver createReceiver(String address, SenderSettleMode senderMode, ReceiverSettleMode receiverMode) throws Exception {
+      checkClosed();
+
+      final ClientFuture request = new ClientFuture();
+      final AmqpReceiver receiver = new AmqpReceiver(AmqpSession.this, address, getNextReceiverId(), senderMode, receiverMode);
 
       connection.getScheduler().execute(new Runnable() {
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpReceiverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpReceiverTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.amqp;
+
+import org.apache.activemq.artemis.core.server.Queue;
+import org.apache.activemq.transport.amqp.client.AmqpClient;
+import org.apache.activemq.transport.amqp.client.AmqpConnection;
+import org.apache.activemq.transport.amqp.client.AmqpReceiver;
+import org.apache.activemq.transport.amqp.client.AmqpSession;
+import org.apache.qpid.proton.amqp.transport.ReceiverSettleMode;
+import org.apache.qpid.proton.amqp.transport.SenderSettleMode;
+import org.junit.Test;
+
+/**
+ * Test various behaviors of AMQP receivers with the broker.
+ */
+public class AmqpReceiverTest extends AmqpClientTestSupport {
+
+   @Test(timeout = 60000)
+   public void testSenderSettlementModeSettledIsHonored() throws Exception {
+      doTestSenderSettlementModeIsHonored(SenderSettleMode.SETTLED);
+   }
+
+   @Test(timeout = 60000)
+   public void testSenderSettlementModeUnsettledIsHonored() throws Exception {
+      doTestSenderSettlementModeIsHonored(SenderSettleMode.UNSETTLED);
+   }
+
+   @Test(timeout = 60000)
+   public void testSenderSettlementModeMixedIsHonored() throws Exception {
+      doTestSenderSettlementModeIsHonored(SenderSettleMode.MIXED);
+   }
+
+   public void doTestSenderSettlementModeIsHonored(SenderSettleMode settleMode) throws Exception {
+      AmqpClient client = createAmqpClient();
+      AmqpConnection connection = addConnection(client.connect());
+      AmqpSession session = connection.createSession();
+
+      AmqpReceiver receiver = session.createReceiver("queue://" + getTestName(), settleMode, ReceiverSettleMode.FIRST);
+
+      Queue queueView = getProxyToQueue(getQueueName());
+      assertNotNull(queueView);
+      assertEquals(0, queueView.getMessageCount());
+      assertEquals(1, server.getTotalConsumerCount());
+
+      assertEquals(settleMode, receiver.getEndpoint().getRemoteSenderSettleMode());
+
+      receiver.close();
+
+      connection.close();
+   }
+
+   @Test(timeout = 60000)
+   public void testReceiverSettlementModeSetToFirst() throws Exception {
+      doTestReceiverSettlementModeForcedToFirst(ReceiverSettleMode.FIRST);
+   }
+
+   @Test(timeout = 60000)
+   public void testReceiverSettlementModeSetToSecond() throws Exception {
+      doTestReceiverSettlementModeForcedToFirst(ReceiverSettleMode.SECOND);
+   }
+
+   /*
+    * The Broker does not currently support ReceiverSettleMode of SECOND so we ensure that it
+    * always drops that back to FIRST to let the client know. The client will need to check and
+    * react accordingly.
+    */
+   private void doTestReceiverSettlementModeForcedToFirst(ReceiverSettleMode modeToUse) throws Exception {
+      AmqpClient client = createAmqpClient();
+      AmqpConnection connection = addConnection(client.connect());
+      AmqpSession session = connection.createSession();
+
+      AmqpReceiver receiver = session.createReceiver("queue://" + getTestName(), SenderSettleMode.MIXED, modeToUse);
+
+      Queue queueView = getProxyToQueue(getQueueName());
+      assertNotNull(queueView);
+      assertEquals(0, queueView.getMessageCount());
+      assertEquals(1, server.getTotalConsumerCount());
+
+      assertEquals(ReceiverSettleMode.FIRST, receiver.getEndpoint().getRemoteReceiverSettleMode());
+
+      receiver.close();
+      connection.close();
+   }
+}

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpSenderTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpSenderTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.amqp;
+
+import org.apache.activemq.artemis.core.server.Queue;
+import org.apache.activemq.transport.amqp.client.AmqpClient;
+import org.apache.activemq.transport.amqp.client.AmqpConnection;
+import org.apache.activemq.transport.amqp.client.AmqpMessage;
+import org.apache.activemq.transport.amqp.client.AmqpSender;
+import org.apache.activemq.transport.amqp.client.AmqpSession;
+import org.apache.qpid.proton.amqp.transport.ReceiverSettleMode;
+import org.apache.qpid.proton.amqp.transport.SenderSettleMode;
+import org.junit.Test;
+
+/**
+ * Test broker behavior when creating AMQP senders
+ */
+public class AmqpSenderTest extends AmqpClientTestSupport {
+
+   @Test(timeout = 60000)
+   public void testSenderSettlementModeSettledIsHonored() throws Exception {
+      doTestSenderSettlementModeIsHonored(SenderSettleMode.SETTLED);
+   }
+
+   @Test(timeout = 60000)
+   public void testSenderSettlementModeUnsettledIsHonored() throws Exception {
+      doTestSenderSettlementModeIsHonored(SenderSettleMode.UNSETTLED);
+   }
+
+   @Test(timeout = 60000)
+   public void testSenderSettlementModeMixedIsHonored() throws Exception {
+      doTestSenderSettlementModeIsHonored(SenderSettleMode.MIXED);
+   }
+
+   public void doTestSenderSettlementModeIsHonored(SenderSettleMode settleMode) throws Exception {
+      AmqpClient client = createAmqpClient();
+
+      AmqpConnection connection = addConnection(client.connect());
+      AmqpSession session = connection.createSession();
+
+      AmqpSender sender = session.createSender("queue://" + getTestName(), settleMode, ReceiverSettleMode.FIRST);
+
+      Queue queueView = getProxyToQueue(getQueueName());
+      assertNotNull(queueView);
+      assertEquals(0, queueView.getMessageCount());
+
+      assertEquals(settleMode, sender.getEndpoint().getRemoteSenderSettleMode());
+
+      AmqpMessage message = new AmqpMessage();
+      message.setText("Test-Message");
+      sender.send(message);
+
+      sender.close();
+
+      connection.close();
+   }
+
+   @Test(timeout = 60000)
+   public void testReceiverSettlementModeSetToFirst() throws Exception {
+      doTestReceiverSettlementModeForcedToFirst(ReceiverSettleMode.FIRST);
+   }
+
+   @Test(timeout = 60000)
+   public void testReceiverSettlementModeSetToSecond() throws Exception {
+      doTestReceiverSettlementModeForcedToFirst(ReceiverSettleMode.SECOND);
+   }
+
+   /*
+    * The Broker does not currently support ReceiverSettleMode of SECOND so we ensure that it
+    * always drops that back to FIRST to let the client know. The client will need to check and
+    * react accordingly.
+    */
+   private void doTestReceiverSettlementModeForcedToFirst(ReceiverSettleMode modeToUse) throws Exception {
+      AmqpClient client = createAmqpClient();
+      AmqpConnection connection = addConnection(client.connect());
+      AmqpSession session = connection.createSession();
+
+      AmqpSender sender = session.createSender("queue://" + getTestName(), SenderSettleMode.UNSETTLED, modeToUse);
+
+      Queue queueView = getProxyToQueue(getQueueName());
+      assertNotNull(queueView);
+      assertEquals(0, queueView.getMessageCount());
+
+      assertEquals(ReceiverSettleMode.FIRST, sender.getEndpoint().getRemoteReceiverSettleMode());
+
+      sender.close();
+
+      connection.close();
+   }
+}


### PR DESCRIPTION
On link attach we currently default out SenderSettleMode to MIXED which
while legal doesn't truly reflect what the client asked for. We instead
now update the link to reflect the mode requested by the client

Also add some tests to ensure that we always return the
ReceiverSettleMode as FIRST since we don't support SECOND.