### PR TITLE
ARTEMIS-1132 return suectiry errors instead of generic failed

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/exceptions/ActiveMQAMQPSecurityException.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/exceptions/ActiveMQAMQPSecurityException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.exceptions;
+
+import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
+import org.apache.qpid.proton.amqp.transport.AmqpError;
+
+public class ActiveMQAMQPSecurityException extends ActiveMQAMQPException {
+
+   public ActiveMQAMQPSecurityException(String message, Throwable e) {
+      super(AmqpError.UNAUTHORIZED_ACCESS, message, e, ActiveMQExceptionType.SECURITY_EXCEPTION);
+   }
+
+   public ActiveMQAMQPSecurityException(String message) {
+      super(AmqpError.UNAUTHORIZED_ACCESS, message, ActiveMQExceptionType.SECURITY_EXCEPTION);
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/logger/ActiveMQAMQPProtocolMessageBundle.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/logger/ActiveMQAMQPProtocolMessageBundle.java
@@ -20,6 +20,7 @@ import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPIllegalS
 import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPInternalErrorException;
 import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPInvalidFieldException;
 import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPNotFoundException;
+import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPSecurityException;
 import org.jboss.logging.Messages;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageBundle;
@@ -76,5 +77,11 @@ public interface ActiveMQAMQPProtocolMessageBundle {
 
    @Message(id = 219014, value = "Transaction not found: xid={0}", format = Message.Format.MESSAGE_FORMAT)
    ActiveMQAMQPIllegalStateException txNotFound(String xidToString);
+
+   @Message(id = 219015, value = "not authorized to create consumer, {0}", format = Message.Format.MESSAGE_FORMAT)
+   ActiveMQAMQPSecurityException securityErrorCreatingConsumer(String message);
+
+   @Message(id = 219016, value = "not authorized to create temporary destination, {0}", format = Message.Format.MESSAGE_FORMAT)
+   ActiveMQAMQPSecurityException securityErrorCreatingTempDestination(String message);
 
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpClientTestSupport.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpClientTestSupport.java
@@ -58,6 +58,12 @@ public class AmqpClientTestSupport extends AmqpTestSupport {
 
    protected static final String BROKER_NAME = "localhost";
 
+   protected String noprivUser = "noprivs";
+   protected String noprivPass = "noprivs";
+
+   protected String browseUser = "browser";
+   protected String browsePass = "browser";
+
    protected String guestUser = "guest";
    protected String guestPass = "guest";
 
@@ -220,6 +226,10 @@ public class AmqpClientTestSupport extends AmqpTestSupport {
          ActiveMQJAASSecurityManager securityManager = (ActiveMQJAASSecurityManager) server.getSecurityManager();
 
          // User additions
+         securityManager.getConfiguration().addUser(noprivUser, noprivPass);
+         securityManager.getConfiguration().addRole(noprivUser, "nothing");
+         securityManager.getConfiguration().addUser(browseUser, browsePass);
+         securityManager.getConfiguration().addRole(browseUser, "browser");
          securityManager.getConfiguration().addUser(guestUser, guestPass);
          securityManager.getConfiguration().addRole(guestUser, "guest");
          securityManager.getConfiguration().addUser(fullUser, fullPass);
@@ -228,7 +238,9 @@ public class AmqpClientTestSupport extends AmqpTestSupport {
          // Configure roles
          HierarchicalRepository<Set<Role>> securityRepository = server.getSecurityRepository();
          HashSet<Role> value = new HashSet<>();
-         value.add(new Role("guest", false, true, true, true, true, true, true, true));
+         value.add(new Role("nothing", false, false, false, false, false, false, false, false));
+         value.add(new Role("browser", false, false, false, false, false, false, false, true));
+         value.add(new Role("guest", false, true, false, false, false, false, false, true));
          value.add(new Role("full", true, true, true, true, true, true, true, true));
          securityRepository.addMatch(getQueueName(), value);
 


### PR DESCRIPTION
When creating some AMQP resources (senders, receivers, etc) the broker
can return an error of 'failed' instead of the security error that is
expected in these cases.  In the case of a receiver being created and
a security error happening the broker fails to send back a response
causing the client to hang waiting for an attach response.