### PR TITLE
ARTEMIS-1135: Fix lgtm.com alerts - overflows in integer addition or multiplication

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/DayCounterInfo.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/DayCounterInfo.java
@@ -32,7 +32,7 @@ public final class DayCounterInfo {
 
    private final String date;
 
-   private final int[] counters;
+   private final long[] counters;
 
    // Static --------------------------------------------------------
 
@@ -41,7 +41,7 @@ public final class DayCounterInfo {
       JsonArrayBuilder counters = JsonLoader.createArrayBuilder();
       for (DayCounterInfo info : infos) {
          JsonArrayBuilder counter = JsonLoader.createArrayBuilder();
-         for (int c : info.getCounters()) {
+         for (long c : info.getCounters()) {
             counter.add(c);
          }
          JsonObjectBuilder dci = JsonLoader.createObjectBuilder().add("date", info.getDate()).add("counters", counter);
@@ -63,7 +63,7 @@ public final class DayCounterInfo {
 
          JsonObject counter = (JsonObject) dayCounters.get(i);
          JsonArray hour = counter.getJsonArray("counters");
-         int[] hourCounters = new int[24];
+         long[] hourCounters = new long[24];
          for (int j = 0; j < 24; j++) {
             hourCounters[j] = hour.getInt(j);
          }
@@ -75,7 +75,7 @@ public final class DayCounterInfo {
 
    // Constructors --------------------------------------------------
 
-   public DayCounterInfo(final String date, final int[] counters) {
+   public DayCounterInfo(final String date, final long[] counters) {
       this.date = date;
       this.counters = counters;
    }
@@ -93,7 +93,7 @@ public final class DayCounterInfo {
     * Returns a 24-length array corresponding to the number of messages added to the queue
     * for the given hour of the day.
     */
-   public int[] getCounters() {
+   public long[] getCounters() {
       return counters;
    }
 }

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/drivers/mysql/MySQLSQLProvider.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/drivers/mysql/MySQLSQLProvider.java
@@ -21,7 +21,7 @@ import org.apache.activemq.artemis.jdbc.store.sql.SQLProvider;
 
 public class MySQLSQLProvider extends GenericSQLProvider {
 
-   private static final long MAX_BLOB_SIZE = 4 * 1024 * 1024 * 1024; // 4GB
+   private static final long MAX_BLOB_SIZE = 4L * 1024 * 1024 * 1024; // 4GB
 
    private final String createFileTableSQL;
 

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTProtocolHandler.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTProtocolHandler.java
@@ -165,7 +165,7 @@ public class MQTTProtocolHandler extends ChannelInboundHandlerAdapter {
     */
    void handleConnect(MqttConnectMessage connect, ChannelHandlerContext ctx) throws Exception {
       this.ctx = ctx;
-      connectionEntry.ttl = connect.variableHeader().keepAliveTimeSeconds() * 1500;
+      connectionEntry.ttl = connect.variableHeader().keepAliveTimeSeconds() * 1500L;
 
       String clientId = connect.payload().clientIdentifier();
       session.getConnectionManager().connect(clientId, connect.payload().userName(), connect.payload().password(), connect.variableHeader().isWillFlag(), connect.payload().willMessage(), connect.payload().willTopic(), connect.variableHeader().isWillRetain(), connect.variableHeader().willQos(), connect.variableHeader().isCleanSession());

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/AddressControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/AddressControlImpl.java
@@ -331,9 +331,9 @@ public class AddressControlImpl extends AbstractControl implements AddressContro
 
    // Private -------------------------------------------------------
 
-   private int getMessageCount(final DurabilityType durability) {
+   private long getMessageCount(final DurabilityType durability) {
       List<QueueControl> queues = getQueues(durability);
-      int count = 0;
+      long count = 0;
       for (QueueControl queue : queues) {
          count += queue.getMessageCount();
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/messagecounter/MessageCounter.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/messagecounter/MessageCounter.java
@@ -395,7 +395,7 @@ public class MessageCounter {
 
       GregorianCalendar date = null;
 
-      int[] counters = new int[DayCounter.HOURS];
+      long[] counters = new long[DayCounter.HOURS];
 
       /**
        * Constructor
@@ -415,17 +415,17 @@ public class MessageCounter {
          for (int i = 0; i < DayCounter.HOURS; i++) {
             if (i < hour) {
                if (isStartDay) {
-                  counters[i] = -1;
+                  counters[i] = -1L;
                } else {
-                  counters[i] = 0;
+                  counters[i] = 0L;
                }
             } else {
-               counters[i] = -1;
+               counters[i] = -1L;
             }
          }
 
          // set the array element of the current hour to '0'
-         counters[hour] = 0;
+         counters[hour] = 0L;
       }
 
       /**
@@ -437,7 +437,7 @@ public class MessageCounter {
          return (GregorianCalendar) date.clone();
       }
 
-      public int[] getCounters() {
+      public long[] getCounters() {
          return counters;
       }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/messagecounter/impl/MessageCounterHelper.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/messagecounter/impl/MessageCounterHelper.java
@@ -38,7 +38,7 @@ public class MessageCounterHelper {
       DayCounterInfo[] infos = new DayCounterInfo[history.size()];
       for (int i = 0; i < infos.length; i++) {
          DayCounter dayCounter = history.get(i);
-         int[] counters = dayCounter.getCounters();
+         long[] counters = dayCounter.getCounters();
          GregorianCalendar date = dayCounter.getDate();
 
          DateFormat dateFormat = DateFormat.getDateInstance(DateFormat.SHORT);


### PR DESCRIPTION
This PR addresses ARTEMIS-1135, issued based on the alerts found by the "Result of integer multiplication cast to long" and "Implicit narrowing conversion in compound assignment" rules at https://lgtm.com/projects/g/apache/activemq-artemis/alerts/. 

In `MySQLSQLProvider`, overflow occurs when setting the max blob size, which overflows to zero at runtime rather than the intended 4GB
In `MQTTProtocolHandler`, overflow occurs when determining the time to keep the connection alive.
These are both fixed by casting the operands to `long` first.

In `AddressControlImpl`, queue message counts are `long`s but added up in an `int`.
In `MessageCounter.DayCounter`, the `counters` array holds `int`s but its elements will have `long` message counts added to them.
These are both fixed by changing the counter variables and relevant return types to `long`.