### PR TITLE
ARTEMIS-1138 OSGI Netty Epoll Fix

### DIFF
--- a/artemis-features/src/main/resources/features.xml
+++ b/artemis-features/src/main/resources/features.xml
@@ -35,6 +35,7 @@
 		<bundle>mvn:io.netty/netty-buffer/${netty.version}</bundle>
 		<bundle>mvn:io.netty/netty-codec/${netty.version}</bundle>
 		<bundle>mvn:io.netty/netty-handler/${netty.version}</bundle>
+		<bundle>mvn:io.netty/netty-transport-native-epoll/${netty.version}</bundle>
 	</feature>
 
 	<feature name="artemis-core" version="${pom.version}" description="ActiveMQ Artemis broker libraries">

--- a/pom.xml
+++ b/pom.xml
@@ -82,11 +82,11 @@
       <jetty.version>9.4.3.v20170317</jetty.version>
       <jgroups.version>3.6.13.Final</jgroups.version>
       <maven.assembly.plugin.version>2.4</maven.assembly.plugin.version>
-      <netty.version>4.1.6.Final</netty.version>
+      <netty.version>4.1.9.Final</netty.version>
       <proton.version>0.18.0</proton.version>
       <resteasy.version>3.0.19.Final</resteasy.version>
       <slf4j.version>1.7.21</slf4j.version>
-      <qpid.jms.version>0.21.0</qpid.jms.version>
+      <qpid.jms.version>0.22.0</qpid.jms.version>
       <johnzon.version>0.9.5</johnzon.version>
       <json-p.spec.version>1.0-alpha-1</json-p.spec.version>
       <javax.inject.version>1</javax.inject.version>


### PR DESCRIPTION
* update qpid jms to 0.22 to pick up epoll change there.
* update netty to 4.1.9 to avoid version issues as qpid also uses.
* add netty-transport-native-epoll bundle to netty-core feature