### PR TITLE
[1.x] [ARTEMIS-1043] Support IPv6 in NettyConnector

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnector.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnector.java
@@ -659,9 +659,10 @@ public class NettyConnector extends AbstractConnector {
                if (sslEnabled) {
                   scheme = "https";
                }
-               URI uri = new URI(scheme, null, IPV6Util.encloseHost(host), port, null, null, null);
+               String ipv6Host = IPV6Util.encloseHost(host);
+               URI uri = new URI(scheme, null, ipv6Host, port, null, null, null);
                HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri.getRawPath());
-               request.headers().set(HttpHeaders.Names.HOST, host);
+               request.headers().set(HttpHeaders.Names.HOST, ipv6Host);
                request.headers().set(HttpHeaders.Names.UPGRADE, ACTIVEMQ_REMOTING);
                request.headers().set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.UPGRADE);
                final String serverName = ConfigurationHelper.getStringProperty(TransportConstants.ACTIVEMQ_SERVER_NAME, null, configuration);


### PR DESCRIPTION
Wrap the host added to the HTTP request headers with
IPV6Util.encloseHost to ensure that load balancers that reads the header
will have a valid IPv6 address.

JIRA: https://issues.apache.org/jira/browse/ARTEMIS-1043