### PR TITLE
Use the org.jboss.slf4j:slf4j-jboss-logmanager binding to allow slf4j…

### DIFF
--- a/artemis-distribution/pom.xml
+++ b/artemis-distribution/pom.xml
@@ -142,6 +142,10 @@
          <groupId>org.jboss.logmanager</groupId>
          <artifactId>jboss-logmanager</artifactId>
       </dependency>
+         <dependency>
+            <groupId>org.jboss.slf4j</groupId>
+            <artifactId>slf4j-jboss-logmanager</artifactId>
+         </dependency>
        <dependency>
            <groupId>io.airlift</groupId>
            <artifactId>airline</artifactId>

--- a/artemis-distribution/src/main/assembly/dep.xml
+++ b/artemis-distribution/src/main/assembly/dep.xml
@@ -78,6 +78,7 @@
             <include>org.apache.geronimo.specs:geronimo-jta_1.1_spec</include>
             <include>org.jboss.logmanager:jboss-logmanager</include>
             <include>org.jboss.logging:jboss-logging</include>
+            <include>org.jboss.slf4j:slf4j-jboss-logmanager</include>
             <include>io.netty:netty-all</include>
             <include>org.apache.qpid:proton-j</include>
             <include>org.apache.activemq:activemq-client</include>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
       <javax.inject.version>1</javax.inject.version>
       <hawtbuff.version>1.11</hawtbuff.version>
       <jb.logmanager.version>2.0.3.Final</jb.logmanager.version>
+      <jb.slf4j-jboss-logmanager.version>1.0.3.GA</jb.slf4j-jboss-logmanager.version>
       <airlift.version>0.7</airlift.version>
       <geronimo.annotation.1.1.spec.version>1.0.1</geronimo.annotation.1.1.spec.version>
       <geronimo.ejb.3.0.spec.version>1.0.1</geronimo.ejb.3.0.spec.version>
@@ -363,6 +364,12 @@
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>jboss-logmanager</artifactId>
             <version>${jb.logmanager.version}</version>
+            <!-- License: Apache 2.0 -->
+         </dependency>
+         <dependency>
+            <groupId>org.jboss.slf4j</groupId>
+            <artifactId>slf4j-jboss-logmanager</artifactId>
+            <version>${jb.slf4j-jboss-logmanager.version}</version>
             <!-- License: Apache 2.0 -->
          </dependency>
          <dependency>


### PR DESCRIPTION
… to bind to the jboss-logmanager

It looks like the Artemis server uses the JBoss Log Manager as it's log manager. Added a dependency to the slf4j binding to avoid the slf4j binding error.
```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```

The `org.jboss.slf4j:slf4j-jboss-logmanager` library is under the Apache license.

The dependency may also be needed by any other executable that uses jboss-logmanager, including tests. I only added it to the distribution however for simplicity and to keep the change at a minimal.