### PR TITLE
Avoid byte[] copy

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/PacketImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/PacketImpl.java
@@ -347,7 +347,7 @@ public class PacketImpl implements Packet {
    }
 
    protected ByteBuf copyMessageBuffer(ByteBuf buffer, int skipBytes) {
-      ByteBuf byteBuf = buffer.retainedSlice(PACKET_HEADERS_SIZE, buffer.capacity());
+      ByteBuf byteBuf = buffer.retainedSlice(PACKET_HEADERS_SIZE, buffer.capacity() - PACKET_HEADERS_SIZE);
       byteBuf.setIndex( 0, buffer.writerIndex() - PACKET_HEADERS_SIZE - skipBytes);
       return byteBuf;
    }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/PacketImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/PacketImpl.java
@@ -347,7 +347,9 @@ public class PacketImpl implements Packet {
    }
 
    protected ByteBuf copyMessageBuffer(ByteBuf buffer, int skipBytes) {
-      return buffer.retainedSlice(PACKET_HEADERS_SIZE, buffer.readableBytes() - skipBytes);
+      ByteBuf byteBuf = buffer.retainedSlice(PACKET_HEADERS_SIZE, buffer.capacity());
+      byteBuf.setIndex( 0, buffer.writerIndex() - PACKET_HEADERS_SIZE - skipBytes);
+      return byteBuf;
    }
 
 

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/PacketImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/PacketImpl.java
@@ -347,18 +347,7 @@ public class PacketImpl implements Packet {
    }
 
    protected ByteBuf copyMessageBuffer(ByteBuf buffer, int skipBytes) {
-
-      ByteBuf newNettyBuffer = Unpooled.buffer(buffer.capacity() - PACKET_HEADERS_SIZE - skipBytes);
-
-      int read = buffer.readerIndex();
-      int writ = buffer.writerIndex();
-      buffer.readerIndex(PACKET_HEADERS_SIZE);
-
-      newNettyBuffer.writeBytes(buffer, buffer.readableBytes() - skipBytes);
-      buffer.setIndex( read, writ );
-      newNettyBuffer.setIndex( 0, writ - PACKET_HEADERS_SIZE - skipBytes);
-
-      return newNettyBuffer;
+      return buffer.retainedSlice(PACKET_HEADERS_SIZE, buffer.readableBytes() - skipBytes);
    }
 
 


### PR DESCRIPTION
Avoid copying bytes, instead simply slice the existing buffer. This avoids if the buffer is off heap, it becoming on heap.

Need to create jira etc, but simply creating PR to pair with discussion in mail thread.
