### PR TITLE
ARTEMIS-1164: NameNotFoundException java.naming.provider.url to set url via jndi

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/uri/URIFactory.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/uri/URIFactory.java
@@ -59,6 +59,16 @@ public class URIFactory<T, P> {
       return schemaFactory.newObject(uri, param);
    }
 
+   public T newObject(URI uri, Map<String, String> overrides, P param) throws Exception {
+      URISchema<T, P> schemaFactory = schemas.get(uri.getScheme());
+
+      if (schemaFactory == null) {
+         throw new NullPointerException("Schema " + uri.getScheme() + " not found");
+      }
+
+      return schemaFactory.newObject(uri, overrides, param);
+   }
+
    public T newObject(String uri, P param) throws Exception {
       return newObject(new URI(uri), param);
    }

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/api/jms/JMSFactoryType.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/api/jms/JMSFactoryType.java
@@ -26,6 +26,13 @@ import org.apache.activemq.artemis.jms.client.ActiveMQXAConnectionFactory;
 import org.apache.activemq.artemis.jms.client.ActiveMQXATopicConnectionFactory;
 import org.apache.activemq.artemis.jms.client.ActiveMQXAQueueConnectionFactory;
 
+import javax.jms.ConnectionFactory;
+import javax.jms.QueueConnectionFactory;
+import javax.jms.TopicConnectionFactory;
+import javax.jms.XAConnectionFactory;
+import javax.jms.XAQueueConnectionFactory;
+import javax.jms.XATopicConnectionFactory;
+
 // XXX no javadocs
 public enum JMSFactoryType {
    CF {
@@ -48,6 +55,11 @@ public enum JMSFactoryType {
       public ActiveMQConnectionFactory createConnectionFactoryWithoutHA(final TransportConfiguration... transportConfigurations) {
          return new ActiveMQJMSConnectionFactory(false, transportConfigurations);
       }
+
+      @Override
+      public Class connectionFactoryInterface() {
+         return ConnectionFactory.class;
+      }
    },
    QUEUE_CF {
       @Override
@@ -68,6 +80,11 @@ public enum JMSFactoryType {
       @Override
       public ActiveMQConnectionFactory createConnectionFactoryWithoutHA(final TransportConfiguration... transportConfigurations) {
          return new ActiveMQQueueConnectionFactory(false, transportConfigurations);
+      }
+
+      @Override
+      public Class connectionFactoryInterface() {
+         return QueueConnectionFactory.class;
       }
    },
    TOPIC_CF {
@@ -90,6 +107,11 @@ public enum JMSFactoryType {
       public ActiveMQConnectionFactory createConnectionFactoryWithoutHA(final TransportConfiguration... transportConfigurations) {
          return new ActiveMQTopicConnectionFactory(false, transportConfigurations);
       }
+
+      @Override
+      public Class connectionFactoryInterface() {
+         return TopicConnectionFactory.class;
+      }
    },
    XA_CF {
       @Override
@@ -110,6 +132,11 @@ public enum JMSFactoryType {
       @Override
       public ActiveMQConnectionFactory createConnectionFactoryWithoutHA(final TransportConfiguration... transportConfigurations) {
          return new ActiveMQXAConnectionFactory(false, transportConfigurations);
+      }
+
+      @Override
+      public Class connectionFactoryInterface() {
+         return XAConnectionFactory.class;
       }
    },
    QUEUE_XA_CF {
@@ -132,6 +159,11 @@ public enum JMSFactoryType {
       public ActiveMQConnectionFactory createConnectionFactoryWithoutHA(final TransportConfiguration... transportConfigurations) {
          return new ActiveMQXAQueueConnectionFactory(false, transportConfigurations);
       }
+
+      @Override
+      public Class connectionFactoryInterface() {
+         return XAQueueConnectionFactory.class;
+      }
    },
    TOPIC_XA_CF {
       @Override
@@ -152,6 +184,11 @@ public enum JMSFactoryType {
       @Override
       public ActiveMQConnectionFactory createConnectionFactoryWithoutHA(final TransportConfiguration... transportConfigurations) {
          return new ActiveMQXATopicConnectionFactory(false, transportConfigurations);
+      }
+
+      @Override
+      public Class connectionFactoryInterface() {
+         return XATopicConnectionFactory.class;
       }
    };
 
@@ -264,5 +301,11 @@ public enum JMSFactoryType {
     */
    public abstract ActiveMQConnectionFactory createConnectionFactoryWithoutHA(final TransportConfiguration... transportConfigurations);
 
+   /**
+    * Returns the connection factory interface that this JMSFactoryType creates.
+    *
+    * @return the javax.jms Class ConnectionFactory interface
+    */
+   public abstract Class connectionFactoryInterface();
 
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/SimpleJNDIClientTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/SimpleJNDIClientTest.java
@@ -35,7 +35,6 @@ import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
@@ -528,29 +527,141 @@ public class SimpleJNDIClientTest extends ActiveMQTestBase {
 
    }
 
+   public void testContext(Context ctx, String jndiName, JMSFactoryType expectedFactoryType) {
+      try {
+         ActiveMQConnectionFactory connectionFactory = (ActiveMQConnectionFactory) ctx.lookup(jndiName);
+         if (expectedFactoryType == null) {
+            Assert.fail("expected no factory, should have thrown NamingException");
+         } else {
+            Assert.assertEquals(expectedFactoryType.intValue(), connectionFactory.getFactoryType());
+         }
+      } catch (NamingException namingException) {
+         Assert.assertNull("NamingException should only occur when no ExpectedFactoryType, but one existed", expectedFactoryType);
+      }
+   }
+
+
    @Test
-   public void providerURLTest() throws NamingException {
-      String url = "(tcp://somehost:62616,tcp://somehost:62616)?ha=true";
+   public void testProviderUrlDefault() throws NamingException, JMSException {
+      Hashtable<String, String> props = new Hashtable<>();
+      props.put(Context.INITIAL_CONTEXT_FACTORY, "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory");
+      props.put(Context.PROVIDER_URL, "vm://0");
+      Context ctx = new InitialContext(props);
 
-      Properties props = new Properties();
-      props.setProperty(javax.naming.Context.INITIAL_CONTEXT_FACTORY, ActiveMQInitialContextFactory.class.getName());
-      props.setProperty(javax.naming.Context.PROVIDER_URL, url);
-
-      InitialContext context =  new InitialContext(props);
-      ConnectionFactory connectionFactory = (ConnectionFactory)context.lookup("ConnectionFactory");
+      testContext(ctx, "ConnectionFactory", JMSFactoryType.CF);
+      testContext(ctx, "QueueConnectionFactory", JMSFactoryType.QUEUE_CF);
+      testContext(ctx, "TopicConnectionFactory", JMSFactoryType.TOPIC_CF);
+      testContext(ctx, "XAConnectionFactory", JMSFactoryType.XA_CF);
+      testContext(ctx, "XAQueueConnectionFactory", JMSFactoryType.QUEUE_XA_CF);
+      testContext(ctx, "XATopicConnectionFactory", JMSFactoryType.TOPIC_XA_CF);
    }
 
    @Test
-   public void connectionFactoryProperty() throws NamingException {
-      String url = "(tcp://somehost:62616,tcp://somehost:62616)?ha=true";
+   public void testProviderUrlCF() throws NamingException, JMSException {
+      Hashtable<String, String> props = new Hashtable<>();
+      props.put(Context.INITIAL_CONTEXT_FACTORY, "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory");
+      props.put(Context.PROVIDER_URL, "vm://0?type=CF");
+      Context ctx = new InitialContext(props);
 
-      Properties props = new Properties();
-      props.setProperty(javax.naming.Context.INITIAL_CONTEXT_FACTORY, ActiveMQInitialContextFactory.class.getName());
-      props.setProperty(javax.naming.Context.PROVIDER_URL, url);
+      testContext(ctx, "ConnectionFactory", JMSFactoryType.CF);
+      testContext(ctx, "QueueConnectionFactory", null);
+      testContext(ctx, "TopicConnectionFactory", null);
+      testContext(ctx, "XAConnectionFactory", null);
+      testContext(ctx, "XAQueueConnectionFactory", null);
+      testContext(ctx, "XATopicConnectionFactory", null);
+   }
 
-      props.setProperty("connectionFactory.ConnectionFactory",url);
+   @Test
+   public void testProviderUrlXACF() throws NamingException, JMSException {
+      Hashtable<String, String> props = new Hashtable<>();
+      props.put(Context.INITIAL_CONTEXT_FACTORY, "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory");
+      props.put(Context.PROVIDER_URL, "vm://0?type=XA_CF");
+      Context ctx = new InitialContext(props);
 
-      InitialContext context =  new InitialContext(props);
-      ConnectionFactory connectionFactory = (ConnectionFactory)context.lookup("ConnectionFactory");
+      testContext(ctx, "ConnectionFactory", null);
+      testContext(ctx, "QueueConnectionFactory", null);
+      testContext(ctx, "TopicConnectionFactory", null);
+      testContext(ctx, "XAConnectionFactory", JMSFactoryType.XA_CF);
+      testContext(ctx, "XAQueueConnectionFactory", null);
+      testContext(ctx, "XATopicConnectionFactory", null);
+   }
+
+   @Test
+   public void testProviderUrlQueueCF() throws NamingException, JMSException {
+      Hashtable<String, String> props = new Hashtable<>();
+      props.put(Context.INITIAL_CONTEXT_FACTORY, "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory");
+      props.put(Context.PROVIDER_URL, "vm://0?type=QUEUE_CF");
+      Context ctx = new InitialContext(props);
+
+      testContext(ctx, "ConnectionFactory", null);
+      testContext(ctx, "QueueConnectionFactory", JMSFactoryType.QUEUE_CF);
+      testContext(ctx, "TopicConnectionFactory", null);
+      testContext(ctx, "XAConnectionFactory", null);
+      testContext(ctx, "XAQueueConnectionFactory", null);
+      testContext(ctx, "XATopicConnectionFactory", null);
+   }
+
+   @Test
+   public void testProviderUrlQueueXACF() throws NamingException, JMSException {
+      Hashtable<String, String> props = new Hashtable<>();
+      props.put(Context.INITIAL_CONTEXT_FACTORY, "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory");
+      props.put(Context.PROVIDER_URL, "vm://0?type=QUEUE_XA_CF");
+      Context ctx = new InitialContext(props);
+
+      testContext(ctx, "ConnectionFactory", null);
+      testContext(ctx, "QueueConnectionFactory", null);
+      testContext(ctx, "TopicConnectionFactory", null);
+      testContext(ctx, "XAConnectionFactory", null);
+      testContext(ctx, "XAQueueConnectionFactory", JMSFactoryType.QUEUE_XA_CF);
+      testContext(ctx, "XATopicConnectionFactory", null);
+   }
+
+   @Test
+   public void testProviderUrlTopicCF() throws NamingException, JMSException {
+      Hashtable<String, String> props = new Hashtable<>();
+      props.put(Context.INITIAL_CONTEXT_FACTORY, "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory");
+      props.put(Context.PROVIDER_URL, "vm://0?type=TOPIC_CF");
+      Context ctx = new InitialContext(props);
+
+      testContext(ctx, "ConnectionFactory", null);
+      testContext(ctx, "QueueConnectionFactory", null);
+      testContext(ctx, "TopicConnectionFactory", JMSFactoryType.TOPIC_CF);
+      testContext(ctx, "XAConnectionFactory", null);
+      testContext(ctx, "XAQueueConnectionFactory", null);
+      testContext(ctx, "XATopicConnectionFactory", null);
+   }
+
+   @Test
+   public void testProviderUrlTopicXACF() throws NamingException, JMSException {
+      Hashtable<String, String> props = new Hashtable<>();
+      props.put(Context.INITIAL_CONTEXT_FACTORY, "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory");
+      props.put(Context.PROVIDER_URL, "vm://0?type=TOPIC_XA_CF");
+      Context ctx = new InitialContext(props);
+
+      testContext(ctx, "ConnectionFactory", null);
+      testContext(ctx, "QueueConnectionFactory", null);
+      testContext(ctx, "TopicConnectionFactory", null);
+      testContext(ctx, "XAConnectionFactory", null);
+      testContext(ctx, "XAQueueConnectionFactory", null);
+      testContext(ctx, "XATopicConnectionFactory", JMSFactoryType.TOPIC_XA_CF);
+   }
+
+   @Test
+   public void testProviderUrlDefaultAndCustom() throws NamingException, JMSException {
+      Hashtable<String, String> props = new Hashtable<>();
+      props.put(Context.INITIAL_CONTEXT_FACTORY, "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory");
+      props.put(Context.PROVIDER_URL, "vm://0");
+      props.put("connectionFactory.myConnectionFactory", "vm://0");
+      Context ctx = new InitialContext(props);
+
+      testContext(ctx, "ConnectionFactory", JMSFactoryType.CF);
+      testContext(ctx, "QueueConnectionFactory", JMSFactoryType.QUEUE_CF);
+      testContext(ctx, "TopicConnectionFactory", JMSFactoryType.TOPIC_CF);
+      testContext(ctx, "XAConnectionFactory", JMSFactoryType.XA_CF);
+      testContext(ctx, "XAQueueConnectionFactory", JMSFactoryType.QUEUE_XA_CF);
+      testContext(ctx, "XATopicConnectionFactory", JMSFactoryType.TOPIC_XA_CF);
+
+      testContext(ctx, "myConnectionFactory", JMSFactoryType.CF);
+
    }
 }


### PR DESCRIPTION
Support setting PROVIDER_URL on initial context to create default connection factories.

Added additional test scenarios, and updated ActiveMQInitialContextFactory to account for these.