### PR TITLE
ARTEMIS-1172 - Update beforeDeliver and afterDeliver method arguments

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerConsumerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerConsumerImpl.java
@@ -416,7 +416,7 @@ public class ServerConsumerImpl implements ServerConsumer, ReadyListener {
       try {
          Message message = reference.getMessage();
 
-         server.callBrokerPlugins(server.hasBrokerPlugins() ? plugin -> plugin.beforeDeliver(reference) : null);
+         server.callBrokerPlugins(server.hasBrokerPlugins() ? plugin -> plugin.beforeDeliver(this, reference) : null);
 
          if (message.isLargeMessage() && supportLargeMessage) {
             if (largeMessageDeliverer == null) {
@@ -434,7 +434,7 @@ public class ServerConsumerImpl implements ServerConsumer, ReadyListener {
       } finally {
          lockDelivery.readLock().unlock();
          callback.afterDelivery();
-         server.callBrokerPlugins(server.hasBrokerPlugins() ? plugin -> plugin.afterDeliver(reference) : null);
+         server.callBrokerPlugins(server.hasBrokerPlugins() ? plugin -> plugin.afterDeliver(this, reference) : null);
       }
 
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/plugin/ActiveMQServerPlugin.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/plugin/ActiveMQServerPlugin.java
@@ -280,8 +280,33 @@ public interface ActiveMQServerPlugin {
    /**
     * Before a message is delivered to a client consumer
     *
-    * @param reference
+    * @param consumer the consumer the message will be delivered to
+    * @param reference message reference
     */
+   default void beforeDeliver(ServerConsumer consumer, MessageReference reference) {
+      //by default call the old method for backwards compatibility
+      this.beforeDeliver(reference);
+   }
+
+   /**
+    * After a message is delivered to a client consumer
+    *
+    * @param consumer the consumer the message was delivered to
+    * @param reference message reference
+    */
+   default void afterDeliver(ServerConsumer consumer, MessageReference reference) {
+      //by default call the old method for backwards compatibility
+      this.afterDeliver(reference);
+   }
+
+   /**
+    * Before a message is delivered to a client consumer
+    *
+    * @param reference
+    *
+    * @deprecated use {@link #beforeDeliver(ServerConsumer, MessageReference)}
+    */
+   @Deprecated
    default void beforeDeliver(MessageReference reference) {
 
    }
@@ -290,7 +315,10 @@ public interface ActiveMQServerPlugin {
     * After a message is delivered to a client consumer
     *
     * @param reference
+    *
+    * @deprecated use {@link #afterDeliver(ServerConsumer, MessageReference)}
     */
+   @Deprecated
    default void afterDeliver(MessageReference reference) {
 
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/plugin/MethodCalledVerifier.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/plugin/MethodCalledVerifier.java
@@ -239,13 +239,13 @@ public class MethodCalledVerifier implements ActiveMQServerPlugin {
    }
 
    @Override
-   public void beforeDeliver(MessageReference reference) {
+   public void beforeDeliver(ServerConsumer consumer, MessageReference reference) {
       Preconditions.checkNotNull(reference);
       methodCalled(BEFORE_DELIVER);
    }
 
    @Override
-   public void afterDeliver(MessageReference reference) {
+   public void afterDeliver(ServerConsumer consumer, MessageReference reference) {
       Preconditions.checkNotNull(reference);
       methodCalled(AFTER_DELIVER);
    }


### PR DESCRIPTION
Adding ServerConsumer as an argument to both the beforeDeliver and
afterDeliver methods inside ActiveMQServerPlugin and deprecated the old
methods