### PR TITLE
ARTEMIS-1179: Add Optional Client JMS Destination Cache

### DIFF
--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
@@ -125,6 +125,8 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
    private final int dupsOKBatchSize;
 
    private final int transactionBatchSize;
+   
+   private final boolean cacheDestinations;
 
    private ClientSession initialSession;
 
@@ -143,6 +145,7 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
                              final String clientID,
                              final int dupsOKBatchSize,
                              final int transactionBatchSize,
+                             final boolean cacheDestinations,
                              final ClientSessionFactory sessionFactory) {
       this.options = options;
 
@@ -163,6 +166,8 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
       this.dupsOKBatchSize = dupsOKBatchSize;
 
       this.transactionBatchSize = transactionBatchSize;
+      
+      this.cacheDestinations = cacheDestinations;
 
       creationStack = new Exception();
    }
@@ -654,9 +659,9 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
                                               ClientSession session,
                                               int type) {
       if (isXA) {
-         return new ActiveMQXASession(options, this, transacted, true, acknowledgeMode, session, type);
+         return new ActiveMQXASession(options, this, transacted, true, acknowledgeMode, cacheDestinations, session, type);
       } else {
-         return new ActiveMQSession(options, this, transacted, false, acknowledgeMode, session, type);
+         return new ActiveMQSession(options, this, transacted, false, acknowledgeMode, cacheDestinations, session, type);
       }
    }
 

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnectionFactory.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnectionFactory.java
@@ -84,6 +84,8 @@ public class ActiveMQConnectionFactory implements ConnectionFactoryOptions, Exte
 
    private String deserializationWhiteList;
 
+   private boolean cacheDestinations;
+
    private boolean finalizeChecks;
 
    @Override
@@ -428,6 +430,15 @@ public class ActiveMQConnectionFactory implements ConnectionFactoryOptions, Exte
       this.transactionBatchSize = transactionBatchSize;
    }
 
+   public synchronized boolean isCacheDestinations() {
+      return this.cacheDestinations;
+   }
+
+   public synchronized void setCacheDestinations(final boolean cacheDestinations) {
+      checkWrite();
+      this.cacheDestinations = cacheDestinations;
+   }
+
    public synchronized long getClientFailureCheckPeriod() {
       return serverLocator.getClientFailureCheckPeriod();
    }
@@ -766,19 +777,19 @@ public class ActiveMQConnectionFactory implements ConnectionFactoryOptions, Exte
 
       if (isXA) {
          if (type == ActiveMQConnection.TYPE_GENERIC_CONNECTION) {
-            connection = new ActiveMQXAConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, factory);
+            connection = new ActiveMQXAConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, cacheDestinations, factory);
          } else if (type == ActiveMQConnection.TYPE_QUEUE_CONNECTION) {
-            connection = new ActiveMQXAConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, factory);
+            connection = new ActiveMQXAConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, cacheDestinations, factory);
          } else if (type == ActiveMQConnection.TYPE_TOPIC_CONNECTION) {
-            connection = new ActiveMQXAConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, factory);
+            connection = new ActiveMQXAConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, cacheDestinations, factory);
          }
       } else {
          if (type == ActiveMQConnection.TYPE_GENERIC_CONNECTION) {
-            connection = new ActiveMQConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, factory);
+            connection = new ActiveMQConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, cacheDestinations, factory);
          } else if (type == ActiveMQConnection.TYPE_QUEUE_CONNECTION) {
-            connection = new ActiveMQConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, factory);
+            connection = new ActiveMQConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, cacheDestinations, factory);
          } else if (type == ActiveMQConnection.TYPE_TOPIC_CONNECTION) {
-            connection = new ActiveMQConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, factory);
+            connection = new ActiveMQConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, cacheDestinations, factory);
          }
       }
 

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
@@ -45,8 +45,10 @@ import javax.jms.TransactionInProgressException;
 import javax.transaction.xa.XAResource;
 import java.io.Serializable;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.ActiveMQQueueExistsException;
@@ -94,6 +96,12 @@ public class ActiveMQSession implements QueueSession, TopicSession {
    private boolean recoverCalled;
 
    private final Set<ActiveMQMessageConsumer> consumers = new HashSet<>();
+   
+   private final boolean cacheDestination;
+   
+   private final Map<String, Topic> topicCache = new ConcurrentHashMap<>();
+
+   private final Map<String, Queue> queueCache = new ConcurrentHashMap<>();
 
    // Constructors --------------------------------------------------
 
@@ -102,6 +110,7 @@ public class ActiveMQSession implements QueueSession, TopicSession {
                              final boolean transacted,
                              final boolean xa,
                              final int ackMode,
+                             final boolean cacheDestination,
                              final ClientSession session,
                              final int sessionType) {
       this.options = options;
@@ -117,6 +126,8 @@ public class ActiveMQSession implements QueueSession, TopicSession {
       this.transacted = transacted;
 
       this.xa = xa;
+
+      this.cacheDestination = cacheDestination;
    }
 
    // Session implementation ----------------------------------------
@@ -367,7 +378,17 @@ public class ActiveMQSession implements QueueSession, TopicSession {
       }
 
       try {
-         return internalCreateQueue(queueName, false);
+         Queue queue = null;
+         if (cacheDestination) {
+            queue = queueCache.get(queueName);
+         }
+         if (queue == null) {
+            queue = internalCreateQueue(queueName, false);
+         }
+         if (cacheDestination) {
+            queueCache.put(queueName, queue);
+         }
+         return queue;
       } catch (ActiveMQException e) {
          throw JMSExceptionHelper.convertFromActiveMQException(e);
       }
@@ -396,9 +417,18 @@ public class ActiveMQSession implements QueueSession, TopicSession {
       if (sessionType == ActiveMQSession.TYPE_QUEUE_SESSION) {
          throw new IllegalStateException("Cannot create a topic on a QueueSession");
       }
-
       try {
-         return internalCreateTopic(topicName, false);
+         Topic topic = null;
+         if (cacheDestination) {
+            topic = topicCache.get(topicName);
+         }
+         if (topic == null) {
+            topic = internalCreateTopic(topicName, false);
+         }
+         if (cacheDestination) {
+            topicCache.put(topicName, topic);
+         }
+         return topic;
       } catch (ActiveMQException e) {
          throw JMSExceptionHelper.convertFromActiveMQException(e);
       }

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQXAConnection.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQXAConnection.java
@@ -41,8 +41,9 @@ public final class ActiveMQXAConnection extends ActiveMQConnection implements XA
                                final String clientID,
                                final int dupsOKBatchSize,
                                final int transactionBatchSize,
+                               final boolean cacheDestinations,
                                final ClientSessionFactory sessionFactory) {
-      super(options, username, password, connectionType, clientID, dupsOKBatchSize, transactionBatchSize, sessionFactory);
+      super(options, username, password, connectionType, clientID, dupsOKBatchSize, transactionBatchSize, cacheDestinations, sessionFactory);
    }
 
    @Override

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQXASession.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQXASession.java
@@ -36,8 +36,9 @@ public class ActiveMQXASession extends ActiveMQSession implements XAQueueSession
                                boolean transacted,
                                boolean xa,
                                int ackMode,
+                               boolean cacheDestinations,
                                ClientSession session,
                                int sessionType) {
-      super(options, connection, transacted, xa, ackMode, session, sessionType);
+      super(options, connection, transacted, xa, ackMode, cacheDestinations, session, sessionType);
    }
 }

--- a/artemis-jms-client/src/test/java/org/apache/activemq/artemis/uri/ConnectionFactoryURITest.java
+++ b/artemis-jms-client/src/test/java/org/apache/activemq/artemis/uri/ConnectionFactoryURITest.java
@@ -400,6 +400,18 @@ public class ConnectionFactoryURITest {
       checkEquals(bean, connectionFactoryWithHA, factory);
    }
 
+   @Test
+   public void testCacheDestinations() throws Exception {
+      ActiveMQConnectionFactory factory = parser.newObject(new URI("tcp://localhost:3030"), null);
+
+      Assert.assertFalse(factory.isCacheDestinations());
+
+      factory = parser.newObject(new URI("tcp://localhost:3030?cacheDestinations=true"), null);
+
+      Assert.assertTrue(factory.isCacheDestinations());
+
+   }
+
    private void populate(StringBuilder sb,
                          BeanUtilsBean bean,
                          ActiveMQConnectionFactory factory) throws IllegalAccessException, InvocationTargetException {

--- a/docs/user-manual/en/perf-tuning.md
+++ b/docs/user-manual/en/perf-tuning.md
@@ -150,6 +150,11 @@ tuning:
     java.lang.String does not require copying before it is written to
     the wire, so if you re-use `SimpleString` instances between calls
     then you can avoid some unnecessary copying.
+    
+-   If using frameworks like Spring, configure destinations permanently broker side
+    and enable `destinationCache` on the client side. 
+    See the [Setting The Destination Cache](using-jms.md)
+                                                          for more information on this.
 
 ## Tuning Transport Settings
 

--- a/docs/user-manual/en/using-jms.md
+++ b/docs/user-manual/en/using-jms.md
@@ -377,3 +377,15 @@ consumer to send acknowledgements in batches rather than individually
 saving valuable bandwidth. This can be configured on the connection
 factory via the `transactionBatchSize` element and is set in bytes.
 The default is 1024 \* 1024.
+
+### Setting The Destination Cache
+
+Many frameworks such as Spring resolve the destination by name on every operation,
+this can cause a performance issue and extra calls to the broker, 
+in a scenario where destinations (addresses) are permanent broker side, 
+such as they are managed by a platform or operations team.
+using `destinationCache` element, you can toggle on the destination cache 
+to improve the performance and reduce the calls to the broker.
+This should not be used if destinations (addresses) are not permanent broker side, 
+as in dynamic creation/deletion.
+


### PR DESCRIPTION
Add topic and queue cache maps in Session.
Add configuration to use cache or not with defaulting to false, which keeps existing behaviour as the default.
Add documentation.