### PR TITLE
ARTEMIS-1179: Add Optional Client JMS Destination Cache

### DIFF
--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
@@ -126,6 +126,8 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
 
    private final int transactionBatchSize;
 
+   private final boolean cacheDestinations;
+
    private ClientSession initialSession;
 
    private final Exception creationStack;
@@ -143,6 +145,7 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
                              final String clientID,
                              final int dupsOKBatchSize,
                              final int transactionBatchSize,
+                             final boolean cacheDestinations,
                              final ClientSessionFactory sessionFactory) {
       this.options = options;
 
@@ -163,6 +166,8 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
       this.dupsOKBatchSize = dupsOKBatchSize;
 
       this.transactionBatchSize = transactionBatchSize;
+
+      this.cacheDestinations = cacheDestinations;
 
       creationStack = new Exception();
    }
@@ -654,9 +659,9 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
                                               ClientSession session,
                                               int type) {
       if (isXA) {
-         return new ActiveMQXASession(options, this, transacted, true, acknowledgeMode, session, type);
+         return new ActiveMQXASession(options, this, transacted, true, acknowledgeMode, cacheDestinations, session, type);
       } else {
-         return new ActiveMQSession(options, this, transacted, false, acknowledgeMode, session, type);
+         return new ActiveMQSession(options, this, transacted, false, acknowledgeMode, cacheDestinations, session, type);
       }
    }
 

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnectionFactory.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnectionFactory.java
@@ -84,6 +84,8 @@ public class ActiveMQConnectionFactory implements ConnectionFactoryOptions, Exte
 
    private String deserializationWhiteList;
 
+   private boolean cacheDestinations;
+
    private boolean finalizeChecks;
 
    @Override
@@ -428,6 +430,15 @@ public class ActiveMQConnectionFactory implements ConnectionFactoryOptions, Exte
       this.transactionBatchSize = transactionBatchSize;
    }
 
+   public synchronized boolean isCacheDestinations() {
+      return this.cacheDestinations;
+   }
+
+   public synchronized void setCacheDestinations(final boolean cacheDestinations) {
+      checkWrite();
+      this.cacheDestinations = cacheDestinations;
+   }
+
    public synchronized long getClientFailureCheckPeriod() {
       return serverLocator.getClientFailureCheckPeriod();
    }
@@ -766,19 +777,19 @@ public class ActiveMQConnectionFactory implements ConnectionFactoryOptions, Exte
 
       if (isXA) {
          if (type == ActiveMQConnection.TYPE_GENERIC_CONNECTION) {
-            connection = new ActiveMQXAConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, factory);
+            connection = new ActiveMQXAConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, cacheDestinations, factory);
          } else if (type == ActiveMQConnection.TYPE_QUEUE_CONNECTION) {
-            connection = new ActiveMQXAConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, factory);
+            connection = new ActiveMQXAConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, cacheDestinations, factory);
          } else if (type == ActiveMQConnection.TYPE_TOPIC_CONNECTION) {
-            connection = new ActiveMQXAConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, factory);
+            connection = new ActiveMQXAConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, cacheDestinations, factory);
          }
       } else {
          if (type == ActiveMQConnection.TYPE_GENERIC_CONNECTION) {
-            connection = new ActiveMQConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, factory);
+            connection = new ActiveMQConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, cacheDestinations, factory);
          } else if (type == ActiveMQConnection.TYPE_QUEUE_CONNECTION) {
-            connection = new ActiveMQConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, factory);
+            connection = new ActiveMQConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, cacheDestinations, factory);
          } else if (type == ActiveMQConnection.TYPE_TOPIC_CONNECTION) {
-            connection = new ActiveMQConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, factory);
+            connection = new ActiveMQConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, cacheDestinations, factory);
          }
       }
 

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQXAConnection.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQXAConnection.java
@@ -41,8 +41,9 @@ public final class ActiveMQXAConnection extends ActiveMQConnection implements XA
                                final String clientID,
                                final int dupsOKBatchSize,
                                final int transactionBatchSize,
+                               final boolean cacheDestinations,
                                final ClientSessionFactory sessionFactory) {
-      super(options, username, password, connectionType, clientID, dupsOKBatchSize, transactionBatchSize, sessionFactory);
+      super(options, username, password, connectionType, clientID, dupsOKBatchSize, transactionBatchSize, cacheDestinations, sessionFactory);
    }
 
    @Override

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQXASession.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQXASession.java
@@ -36,8 +36,9 @@ public class ActiveMQXASession extends ActiveMQSession implements XAQueueSession
                                boolean transacted,
                                boolean xa,
                                int ackMode,
+                               boolean cacheDestinations,
                                ClientSession session,
                                int sessionType) {
-      super(options, connection, transacted, xa, ackMode, session, sessionType);
+      super(options, connection, transacted, xa, ackMode, cacheDestinations, session, sessionType);
    }
 }

--- a/artemis-jms-client/src/test/java/org/apache/activemq/artemis/uri/ConnectionFactoryURITest.java
+++ b/artemis-jms-client/src/test/java/org/apache/activemq/artemis/uri/ConnectionFactoryURITest.java
@@ -400,6 +400,18 @@ public class ConnectionFactoryURITest {
       checkEquals(bean, connectionFactoryWithHA, factory);
    }
 
+   @Test
+   public void testCacheDestinations() throws Exception {
+      ActiveMQConnectionFactory factory = parser.newObject(new URI("tcp://localhost:3030"), null);
+
+      Assert.assertFalse(factory.isCacheDestinations());
+
+      factory = parser.newObject(new URI("tcp://localhost:3030?cacheDestinations=true"), null);
+
+      Assert.assertTrue(factory.isCacheDestinations());
+
+   }
+
    private void populate(StringBuilder sb,
                          BeanUtilsBean bean,
                          ActiveMQConnectionFactory factory) throws IllegalAccessException, InvocationTargetException {

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRAManagedConnectionFactory.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRAManagedConnectionFactory.java
@@ -580,6 +580,14 @@ public final class ActiveMQRAManagedConnectionFactory implements ManagedConnecti
       mcfProperties.setUseGlobalPools(useGlobalPools);
    }
 
+   public Boolean isCacheDestinations() {
+      return mcfProperties.isCacheDestinations();
+   }
+
+   public void setCacheDestinations(final Boolean cacheDestinations) {
+      mcfProperties.setCacheDestinations(cacheDestinations);
+   }
+
    public Integer getScheduledThreadPoolMaxSize() {
       return mcfProperties.getScheduledThreadPoolMaxSize();
    }

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
@@ -635,6 +635,32 @@ public class ActiveMQResourceAdapter implements ResourceAdapter, Serializable {
    }
 
    /**
+    * Set cacheDestinations
+    *
+    * @param cacheDestinations The value
+    */
+   public void setCacheDestinations(final Boolean cacheDestinations) {
+      if (ActiveMQResourceAdapter.trace) {
+         ActiveMQRALogger.LOGGER.trace("setCacheDestinations(" + cacheDestinations + ")");
+      }
+
+      raProperties.setCacheDestinations(cacheDestinations);
+   }
+
+   /**
+    * Get isCacheDestinations
+    *
+    * @return The value
+    */
+   public Boolean isCacheDestinations() {
+      if (ActiveMQResourceAdapter.trace) {
+         ActiveMQRALogger.LOGGER.trace("isCacheDestinations()");
+      }
+
+      return raProperties.isCacheDestinations();
+   }
+
+   /**
     * Set compressLargeMessage
     *
     * @param compressLargeMessage The value
@@ -1909,6 +1935,11 @@ public class ActiveMQResourceAdapter implements ResourceAdapter, Serializable {
       val = overrideProperties.isFailoverOnInitialConnection() != null ? overrideProperties.isFailoverOnInitialConnection() : raProperties.isFailoverOnInitialConnection();
       if (val != null) {
          cf.setFailoverOnInitialConnection(val);
+      }
+
+      val = overrideProperties.isCacheDestinations() != null ? overrideProperties.isCacheDestinations() : raProperties.isCacheDestinations();
+      if (val != null) {
+         cf.setCacheDestinations(val);
       }
 
       Integer val2 = overrideProperties.getConsumerMaxRate() != null ? overrideProperties.getConsumerMaxRate() : raProperties.getConsumerMaxRate();

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ConnectionFactoryProperties.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ConnectionFactoryProperties.java
@@ -112,6 +112,8 @@ public class ConnectionFactoryProperties implements ConnectionFactoryOptions {
 
    private Boolean useGlobalPools;
 
+   private Boolean cacheDestinations;
+
    private Integer initialMessagePacketSize;
 
    private Integer scheduledThreadPoolMaxSize;
@@ -610,6 +612,21 @@ public class ConnectionFactoryProperties implements ConnectionFactoryOptions {
       }
       hasBeenUpdated = true;
       this.useGlobalPools = useGlobalPools;
+   }
+
+   public Boolean isCacheDestinations() {
+      if (ConnectionFactoryProperties.trace) {
+         ActiveMQRALogger.LOGGER.trace("isCacheDestinations()");
+      }
+      return cacheDestinations;
+   }
+
+   public void setCacheDestinations(final Boolean cacheDestinations) {
+      if (ConnectionFactoryProperties.trace) {
+         ActiveMQRALogger.LOGGER.trace("setCacheDestinations(" + cacheDestinations + ")");
+      }
+      hasBeenUpdated = true;
+      this.cacheDestinations = cacheDestinations;
    }
 
    public Integer getScheduledThreadPoolMaxSize() {

--- a/docs/user-manual/en/perf-tuning.md
+++ b/docs/user-manual/en/perf-tuning.md
@@ -150,6 +150,11 @@ tuning:
     java.lang.String does not require copying before it is written to
     the wire, so if you re-use `SimpleString` instances between calls
     then you can avoid some unnecessary copying.
+    
+-   If using frameworks like Spring, configure destinations permanently broker side
+    and enable `destinationCache` on the client side. 
+    See the [Setting The Destination Cache](using-jms.md)
+                                                          for more information on this.
 
 ## Tuning Transport Settings
 

--- a/docs/user-manual/en/using-jms.md
+++ b/docs/user-manual/en/using-jms.md
@@ -377,3 +377,14 @@ consumer to send acknowledgements in batches rather than individually
 saving valuable bandwidth. This can be configured on the connection
 factory via the `transactionBatchSize` element and is set in bytes.
 The default is 1024 \* 1024.
+
+### Setting The Destination Cache
+
+Many frameworks such as Spring resolve the destination by name on every operation,
+this can cause a performance issue and extra calls to the broker, 
+in a scenario where destinations (addresses) are permanent broker side, 
+such as they are managed by a platform or operations team.
+using `destinationCache` element, you can toggle on the destination cache 
+to improve the performance and reduce the calls to the broker.
+This should not be used if destinations (addresses) are not permanent broker side, 
+as in dynamic creation/deletion.

--- a/examples/features/sub-modules/artemis-ra-rar/src/main/resources/ra.xml
+++ b/examples/features/sub-modules/artemis-ra-rar/src/main/resources/ra.xml
@@ -258,6 +258,12 @@
         <config-property-name>PasswordCodec</config-property-name>
         <config-property-type>java.lang.String</config-property-type>
         <config-property-value>org.apache.activemq.artemis.utils.DefaultSensitiveStringCodec;key=clusterpassword;algorithm=something</config-property-value>
+      </config-property>
+      <config-property>
+        <description>Cache destinations per session</description>
+        <config-property-name>CacheDestinations</config-property-name>
+        <config-property-type>java.lang.Boolean</config-property-type>
+        <config-property-value>false</config-property-value>
       </config-property>-->
 
       <outbound-resourceadapter>

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/ra/ActiveMQResourceAdapterConfigTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/ra/ActiveMQResourceAdapterConfigTest.java
@@ -253,6 +253,12 @@ public class ActiveMQResourceAdapterConfigTest extends ActiveMQTestBase {
       "         <config-property-type>boolean</config-property-type>\n" +
       "         <config-property-value></config-property-value>\n" +
       "      </config-property>\n" +
+      "      <config-property>" +
+      "         <description>Cache destinations per session</description>" +
+      "         <config-property-name>CacheDestinations</config-property-name>" +
+      "         <config-property-type>boolean</config-property-type>" +
+      "         <config-property-value></config-property-value>" +
+      "      </config-property>" +
       "      <config-property>\n" +
       "         <description>max number of threads for scheduled thread pool</description>\n" +
       "         <config-property-name>ScheduledThreadPoolMaxSize</config-property-name>\n" +


### PR DESCRIPTION
Add topic and queue cache maps in Session.
Add configuration to use cache or not with defaulting to false, which keeps existing behaviour as the default.
Add documentation.