### PR TITLE
CLI Create command may cause un-replaced keys contained in broker.xml

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
@@ -30,6 +30,7 @@ import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -483,7 +484,7 @@ public class Create extends InputAbstract {
 
       context.out.println(String.format("Creating ActiveMQ Artemis instance at: %s", directory.getCanonicalPath()));
 
-      HashMap<String, String> filters = new HashMap<>();
+      HashMap<String, String> filters = new LinkedHashMap<>();
 
       filters.put("${master-slave}", isSlave() ? "slave" : "master");
 


### PR DESCRIPTION
As HashMap does not supply predictable iteration order,  the variable
"HashMap filters = new HashMap()" defined in 
org.apache.activemq.artemis.cli.commands.Create is dangerous, some keys
,let's say '${cluster-password},  may be put later than put '${cluster-security-settings}',
but its position in hasmap is ahead of '${cluster-security-settings}'.
as a result, '<cluster-password>${cluster-password}</cluster-password>' may
appear in broker.xml, without replacing the hash map key '${cluster-password}'
to user defined value.
I use LinkedHashMap to resolve this problem.
Please check it.
