### PR TITLE
ARTEMIS-1186 Consumer.receive hangs if http acceptor with non-zero ba…

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptor.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptor.java
@@ -340,13 +340,13 @@ public class NettyAcceptor extends AbstractAcceptor {
             notificationService.sendNotification(notification);
          }
 
-         if (batchDelay > 0) {
-            flusher = new BatchFlusher();
-
-            batchFlusherFuture = scheduledThreadPool.scheduleWithFixedDelay(flusher, batchDelay, batchDelay, TimeUnit.MILLISECONDS);
-         }
-
          ActiveMQServerLogger.LOGGER.startedAcceptor(host, port, protocolsString);
+      }
+
+      if (batchDelay > 0) {
+         flusher = new BatchFlusher();
+
+         batchFlusherFuture = scheduledThreadPool.scheduleWithFixedDelay(flusher, batchDelay, batchDelay, TimeUnit.MILLISECONDS);
       }
    }
 


### PR DESCRIPTION
…tch-delay is configured

https://issues.apache.org/jira/browse/ARTEMIS-1186
https://issues.jboss.org/browse/JBEAP-6570

Upstream PR: https://github.com/apache/activemq-artemis/pull/1297