### PR TITLE
ARTEMIS-1193 upgrade byteman 2.2.0 -> 3.0.10

### DIFF
--- a/tests/extra-tests/pom.xml
+++ b/tests/extra-tests/pom.xml
@@ -34,7 +34,7 @@
 
    <properties>
       <tools.jar>${java.home}/../lib/tools.jar</tools.jar>
-      <byteman.version>2.2.0</byteman.version>
+      <byteman.version>3.0.10</byteman.version>
       <activemq.basedir>${project.basedir}/../..</activemq.basedir>
       <jboss-jts.version>4.17.13.Final</jboss-jts.version>
       <hornetq.version>2.4.7.Final</hornetq.version>


### PR DESCRIPTION
Version 3.x of Byteman adds ability to instrument classes with Java 8 features, notably lambdas. One of the previous commits added lambdas in class that is often instrumented by byteman extra-tests. This change fixes those tests.