### PR TITLE
ARTEMIS-1208 Do not use reconnect-atempts=-1 in tests

### DIFF
--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/BMFailoverTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/BMFailoverTest.java
@@ -350,7 +350,7 @@ public class BMFailoverTest extends FailoverTestBase {
    }
 
    private void createSessionFactory() throws Exception {
-      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setReconnectAttempts(15);
 
       sf = createSessionFactoryAndWaitForTopology(locator, 2);
    }

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/jms/bridge/ClusteredBridgeTestBase.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/jms/bridge/ClusteredBridgeTestBase.java
@@ -171,7 +171,7 @@ public abstract class ClusteredBridgeTestBase extends ActiveMQTestBase {
          backupNode.start();
          waitForRemoteBackupSynchronization(backupNode.getActiveMQServer());
 
-         locator = ActiveMQClient.createServerLocatorWithHA(liveConnector).setReconnectAttempts(-1);
+         locator = ActiveMQClient.createServerLocatorWithHA(liveConnector).setReconnectAttempts(15);
          sessionFactory = locator.createSessionFactory();
       }
 
@@ -191,7 +191,7 @@ public abstract class ClusteredBridgeTestBase extends ActiveMQTestBase {
             @Override
             public ConnectionFactory createConnectionFactory() throws Exception {
                ActiveMQConnectionFactory cf = ActiveMQJMSClient.createConnectionFactoryWithHA(JMSFactoryType.XA_CF, liveConnector);
-               cf.getServerLocator().setReconnectAttempts(-1);
+               cf.getServerLocator().setReconnectAttempts(15);
                return cf;
             }
          };

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/jms/ra/MDBMultipleHandlersServerDisconnectTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/jms/ra/MDBMultipleHandlersServerDisconnectTest.java
@@ -82,8 +82,8 @@ public class MDBMultipleHandlersServerDisconnectTest extends ActiveMQRATestBase 
    @Before
    public void setUp() throws Exception {
       nettyLocator = createNettyNonHALocator();
-      nettyLocator.setRetryInterval(10);
-      nettyLocator.setReconnectAttempts(-1);
+      nettyLocator.setRetryInterval(100);
+      nettyLocator.setReconnectAttempts(300);
       mapCounter.clear();
       resourceAdapter = null;
       super.setUp();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ConsumerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ConsumerTest.java
@@ -128,7 +128,7 @@ public class ConsumerTest extends ActiveMQTestBase {
    public void testStressConnection() throws Exception {
 
       for (int i = 0; i < 10; i++) {
-         ServerLocator locatorSendx = createFactory(isNetty()).setReconnectAttempts(-1);
+         ServerLocator locatorSendx = createFactory(isNetty()).setReconnectAttempts(15);
          ClientSessionFactory factoryx = locatorSendx.createSessionFactory();
          factoryx.close();
          locatorSendx.close();
@@ -770,7 +770,7 @@ public class ConsumerTest extends ActiveMQTestBase {
                @Override
                public void onMessage(final ClientMessage msg) {
                   try {
-                     ServerLocator locatorSendx = createFactory(isNetty()).setReconnectAttempts(-1);
+                     ServerLocator locatorSendx = createFactory(isNetty()).setReconnectAttempts(15);
                      ClientSessionFactory factoryx = locatorSendx.createSessionFactory();
                      ClientSession sessionSend = factoryx.createSession(true, true);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ServerLocatorConnectTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ServerLocatorConnectTest.java
@@ -105,7 +105,7 @@ public class ServerLocatorConnectTest extends ActiveMQTestBase {
    @Test
    public void testMultipleConnectorSingleServerConnectReconnect() throws Exception {
       ServerLocatorInternal locator = (ServerLocatorInternal) ActiveMQClient.createServerLocatorWithoutHA(createTransportConfiguration(isNetty(), false, generateParams(0, isNetty())), createTransportConfiguration(isNetty(), false, generateParams(1, isNetty())), createTransportConfiguration(isNetty(), false, generateParams(2, isNetty())), createTransportConfiguration(isNetty(), false, generateParams(3, isNetty())), createTransportConfiguration(isNetty(), false, generateParams(4, isNetty())));
-      locator.setReconnectAttempts(-1);
+      locator.setReconnectAttempts(15);
       ClientSessionFactoryInternal csf = locator.connect();
       assertNotNull(csf);
       assertEquals(csf.numConnections(), 1);
@@ -131,7 +131,7 @@ public class ServerLocatorConnectTest extends ActiveMQTestBase {
    @Test
    public void testMultipleConnectorSingleServerNoConnectAttemptReconnect() throws Exception {
       ServerLocatorInternal locator = (ServerLocatorInternal) ActiveMQClient.createServerLocatorWithoutHA(createTransportConfiguration(isNetty(), false, generateParams(1, isNetty())), createTransportConfiguration(isNetty(), false, generateParams(2, isNetty())), createTransportConfiguration(isNetty(), false, generateParams(3, isNetty())), createTransportConfiguration(isNetty(), false, generateParams(4, isNetty())), createTransportConfiguration(isNetty(), false, generateParams(5, isNetty())));
-      locator.setReconnectAttempts(-1);
+      locator.setReconnectAttempts(15);
       CountDownLatch countDownLatch = new CountDownLatch(1);
       Connector target = new Connector(locator, countDownLatch);
       Thread t = new Thread(target);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/TemporaryQueueTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/TemporaryQueueTest.java
@@ -314,7 +314,7 @@ public class TemporaryQueueTest extends SingleServerTestBase {
 
    @Test
    public void testRecreateConsumerOverServerFailure() throws Exception {
-      ServerLocator serverWithReattach = createInVMNonHALocator().setReconnectAttempts(-1).setRetryInterval(1000).setConfirmationWindowSize(-1).setConnectionTTL(TemporaryQueueTest.CONNECTION_TTL).setClientFailureCheckPeriod(TemporaryQueueTest.CONNECTION_TTL / 3);
+      ServerLocator serverWithReattach = createInVMNonHALocator().setReconnectAttempts(30).setRetryInterval(1000).setConfirmationWindowSize(-1).setConnectionTTL(TemporaryQueueTest.CONNECTION_TTL).setClientFailureCheckPeriod(TemporaryQueueTest.CONNECTION_TTL / 3);
       ClientSessionFactory reattachSF = createSessionFactory(serverWithReattach);
 
       ClientSession session = reattachSF.createSession(false, false);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/ClusterTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/ClusterTestBase.java
@@ -1427,7 +1427,7 @@ public abstract class ClusterTestBase extends ActiveMQTestBase {
 
       TransportConfiguration serverToTC = createTransportConfiguration(netty, false, params);
 
-      locators[node] = addServerLocator(ActiveMQClient.createServerLocatorWithHA(serverToTC)).setRetryInterval(100).setRetryIntervalMultiplier(1d).setReconnectAttempts(-1).setBlockOnNonDurableSend(blocking).setBlockOnDurableSend(blocking);
+      locators[node] = addServerLocator(ActiveMQClient.createServerLocatorWithHA(serverToTC)).setRetryInterval(100).setRetryIntervalMultiplier(1d).setReconnectAttempts(300).setBlockOnNonDurableSend(blocking).setBlockOnDurableSend(blocking);
 
       final String identity = "TestClientConnector,live=" + node + ",backup=" + backupNode;
       ((ServerLocatorInternal) locators[node]).setIdentity(identity);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/AsynchronousFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/AsynchronousFailoverTest.java
@@ -137,7 +137,7 @@ public class AsynchronousFailoverTest extends FailoverTestBase {
       try {
          for (int i = 0; i < numIts; i++) {
             AsynchronousFailoverTest.log.info("Iteration " + i);
-            ServerLocator locator = getServerLocator().setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setReconnectAttempts(-1).setConfirmationWindowSize(10 * 1024 * 1024);
+            ServerLocator locator = getServerLocator().setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setReconnectAttempts(15).setConfirmationWindowSize(10 * 1024 * 1024);
             sf = createSessionFactoryAndWaitForTopology(locator, 2);
             try {
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/BackupSyncJournalTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/BackupSyncJournalTest.java
@@ -79,7 +79,7 @@ public class BackupSyncJournalTest extends FailoverTestBase {
       startBackupServer = false;
       super.setUp();
       setNumberOfMessages(defaultNMsgs);
-      locator = (ServerLocatorInternal) getServerLocator().setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setReconnectAttempts(-1);
+      locator = (ServerLocatorInternal) getServerLocator().setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setReconnectAttempts(15);
       sessionFactory = createSessionFactoryAndWaitForTopology(locator, 1);
       syncDelay = new BackupSyncDelay(backupServer, liveServer);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailBackAutoTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailBackAutoTest.java
@@ -232,7 +232,7 @@ public class FailBackAutoTest extends FailoverTestBase {
 
    private void createSessionFactory() throws Exception {
       locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setFailoverOnInitialConnection(true) // unnecessary?
-         .setReconnectAttempts(-1);
+         .setReconnectAttempts(15);
       sf = createSessionFactoryAndWaitForTopology(locator, 2);
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailBackManualTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailBackManualTest.java
@@ -50,7 +50,7 @@ public class FailBackManualTest extends FailoverTestBase {
 
    @Test
    public void testNoAutoFailback() throws Exception {
-      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setFailoverOnInitialConnection(true).setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setFailoverOnInitialConnection(true).setReconnectAttempts(15);
 
       ClientSessionFactoryInternal sf = createSessionFactoryAndWaitForTopology(locator, 2);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailoverListenerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailoverListenerTest.java
@@ -171,7 +171,7 @@ public class FailoverListenerTest extends FailoverTestBase {
 
    private void createSessionFactory(int members) throws Exception {
       locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setFailoverOnInitialConnection(true) // unnecessary?
-         .setReconnectAttempts(-1);
+         .setReconnectAttempts(15);
       sf = createSessionFactoryAndWaitForTopology(locator, members);
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailoverOnFlowControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailoverOnFlowControlTest.java
@@ -42,7 +42,7 @@ public class FailoverOnFlowControlTest extends FailoverTestBase {
 
    @Test
    public void testOverflowSend() throws Exception {
-      ServerLocator locator = getServerLocator().setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setReconnectAttempts(-1).setProducerWindowSize(1000).setRetryInterval(123);
+      ServerLocator locator = getServerLocator().setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setReconnectAttempts(300).setProducerWindowSize(1000).setRetryInterval(100);
       final ArrayList<ClientSession> sessionList = new ArrayList<>();
       Interceptor interceptorClient = new Interceptor() {
          AtomicInteger count = new AtomicInteger(0);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailoverTest.java
@@ -109,7 +109,7 @@ public class FailoverTest extends FailoverTestBase {
    // https://issues.jboss.org/browse/HORNETQ-685
    @Test(timeout = 120000)
    public void testTimeoutOnFailover() throws Exception {
-      locator.setCallTimeout(1000).setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setAckBatchSize(0).setReconnectAttempts(-1);
+      locator.setCallTimeout(1000).setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setAckBatchSize(0).setReconnectAttempts(300).setRetryInterval(100);
 
       ((InVMNodeManager) nodeManager).failoverPause = 500;
 
@@ -174,7 +174,7 @@ public class FailoverTest extends FailoverTestBase {
    // https://issues.jboss.org/browse/HORNETQ-685
    @Test(timeout = 120000)
    public void testTimeoutOnFailoverConsume() throws Exception {
-      locator.setCallTimeout(5000).setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setAckBatchSize(0).setBlockOnAcknowledge(true).setReconnectAttempts(-1).setAckBatchSize(0);
+      locator.setCallTimeout(5000).setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setAckBatchSize(0).setBlockOnAcknowledge(true).setReconnectAttempts(300).setRetryInterval(100).setAckBatchSize(0);
 
       ((InVMNodeManager) nodeManager).failoverPause = 5000L;
 
@@ -328,7 +328,7 @@ public class FailoverTest extends FailoverTestBase {
    // https://issues.jboss.org/browse/HORNETQ-685
    @Test(timeout = 120000)
    public void testTimeoutOnFailoverTransactionCommit() throws Exception {
-      locator.setCallTimeout(5000).setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setAckBatchSize(0).setReconnectAttempts(-1);
+      locator.setCallTimeout(5000).setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setAckBatchSize(0).setReconnectAttempts(300).setRetryInterval(100);
 
       ((InVMNodeManager) nodeManager).failoverPause = 5000L;
 
@@ -392,7 +392,7 @@ public class FailoverTest extends FailoverTestBase {
    // https://issues.jboss.org/browse/HORNETQ-685
    @Test(timeout = 120000)
    public void testTimeoutOnFailoverTransactionRollback() throws Exception {
-      locator.setCallTimeout(2000).setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setAckBatchSize(0).setReconnectAttempts(-1);
+      locator.setCallTimeout(2000).setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setAckBatchSize(0).setReconnectAttempts(300).setRetryInterval(100);
 
       ((InVMNodeManager) nodeManager).failoverPause = 5000L;
 
@@ -445,7 +445,7 @@ public class FailoverTest extends FailoverTestBase {
     */
    @Test(timeout = 120000)
    public void testNonTransactedWithZeroConsumerWindowSize() throws Exception {
-      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setAckBatchSize(0).setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setAckBatchSize(0).setReconnectAttempts(300).setRetryInterval(100);
 
       createClientSessionFactory();
 
@@ -709,7 +709,7 @@ public class FailoverTest extends FailoverTestBase {
    }
 
    protected void createSessionFactory() throws Exception {
-      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setReconnectAttempts(300).setRetryInterval(100);
 
       sf = createSessionFactoryAndWaitForTopology(locator, 2);
    }
@@ -788,7 +788,7 @@ public class FailoverTest extends FailoverTestBase {
    // https://jira.jboss.org/jira/browse/HORNETQ-285
    @Test(timeout = 120000)
    public void testFailoverOnInitialConnection() throws Exception {
-      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setFailoverOnInitialConnection(true).setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setFailoverOnInitialConnection(true).setReconnectAttempts(300).setRetryInterval(100);
 
       sf = createSessionFactoryAndWaitForTopology(locator, 2);
 
@@ -1597,7 +1597,7 @@ public class FailoverTest extends FailoverTestBase {
 
    @Test(timeout = 120000)
    public void testFailThenReceiveMoreMessagesAfterFailover2() throws Exception {
-      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setBlockOnAcknowledge(true).setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setBlockOnAcknowledge(true).setReconnectAttempts(300).setRetryInterval(100);
 
       sf = createSessionFactoryAndWaitForTopology(locator, 2);
 
@@ -1649,7 +1649,7 @@ public class FailoverTest extends FailoverTestBase {
    }
 
    private void doSimpleSendAfterFailover(final boolean durable, final boolean temporary) throws Exception {
-      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setBlockOnAcknowledge(true).setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setBlockOnAcknowledge(true).setReconnectAttempts(300).setRetryInterval(100);
 
       sf = createSessionFactoryAndWaitForTopology(locator, 2);
 
@@ -1676,7 +1676,7 @@ public class FailoverTest extends FailoverTestBase {
 
    @Test(timeout = 120000)
    public void testForceBlockingReturn() throws Exception {
-      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setBlockOnAcknowledge(true).setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setBlockOnAcknowledge(true).setReconnectAttempts(300).setRetryInterval(100);
 
       createClientSessionFactory();
 
@@ -1728,7 +1728,7 @@ public class FailoverTest extends FailoverTestBase {
 
    @Test(timeout = 120000)
    public void testCommitOccurredUnblockedAndResendNoDuplicates() throws Exception {
-      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setReconnectAttempts(-1).setBlockOnAcknowledge(true);
+      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setReconnectAttempts(300).setRetryInterval(100).setBlockOnAcknowledge(true);
 
       sf = createSessionFactoryAndWaitForTopology(locator, 2);
 
@@ -1859,7 +1859,7 @@ public class FailoverTest extends FailoverTestBase {
 
    @Test(timeout = 120000)
    public void testCommitDidNotOccurUnblockedAndResend() throws Exception {
-      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setBlockOnAcknowledge(true).setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setBlockOnAcknowledge(true).setReconnectAttempts(300).setRetryInterval(100);
 
       sf = createSessionFactoryAndWaitForTopology(locator, 2);
 
@@ -2059,7 +2059,7 @@ public class FailoverTest extends FailoverTestBase {
 
    @Test(timeout = 120000)
    public void testLiveAndBackupBackupComesBackNewFactory() throws Exception {
-      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setFailoverOnInitialConnection(true).setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setFailoverOnInitialConnection(true).setReconnectAttempts(300).setRetryInterval(100);
 
       sf = createSessionFactoryAndWaitForTopology(locator, 2);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/LiveToLiveFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/LiveToLiveFailoverTest.java
@@ -163,7 +163,7 @@ public class LiveToLiveFailoverTest extends FailoverTest {
 
    @Override
    protected void createSessionFactory() throws Exception {
-      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setReconnectAttempts(300).setRetryInterval(100);
 
       sf = createSessionFactoryAndWaitForTopology(locator, getConnectorTransportConfiguration(true, 0), 2);
 
@@ -217,7 +217,7 @@ public class LiveToLiveFailoverTest extends FailoverTest {
    @Override
    @Test
    public void testFailoverOnInitialConnection() throws Exception {
-      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setFailoverOnInitialConnection(true).setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setFailoverOnInitialConnection(true).setReconnectAttempts(300).setRetryInterval(100);
 
       sf = createSessionFactoryAndWaitForTopology(locator, 2);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/MultipleLivesMultipleBackupsFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/MultipleLivesMultipleBackupsFailoverTest.java
@@ -73,7 +73,7 @@ public class MultipleLivesMultipleBackupsFailoverTest extends MultipleBackupsFai
 
       waitForServerToStart(servers.get(4).getServer());
 
-      locator = getServerLocator(0).setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setBlockOnAcknowledge(true).setReconnectAttempts(-1);
+      locator = getServerLocator(0).setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setBlockOnAcknowledge(true).setReconnectAttempts(15);
 
       ClientSessionFactoryInternal sf = createSessionFactoryAndWaitForTopology(locator, 4, servers.get(0).getServer());
       ClientSession session = sendAndConsume(sf, true);
@@ -84,7 +84,7 @@ public class MultipleLivesMultipleBackupsFailoverTest extends MultipleBackupsFai
 
       int liveAfter0 = waitForNewLive(10000, true, servers, 1, 2);
 
-      locator2 = getServerLocator(3).setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setBlockOnAcknowledge(true).setReconnectAttempts(-1);
+      locator2 = getServerLocator(3).setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setBlockOnAcknowledge(true).setReconnectAttempts(15);
 
       ClientSessionFactoryInternal sf2 = createSessionFactoryAndWaitForTopology(locator2, 4);
       ClientSession session2 = sendAndConsume(sf2, true);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/MultipleServerFailoverTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/MultipleServerFailoverTestBase.java
@@ -192,11 +192,11 @@ public abstract class MultipleServerFailoverTestBase extends ActiveMQTestBase {
    }
 
    protected ServerLocatorInternal getServerLocator(int node) throws Exception {
-      return (ServerLocatorInternal) addServerLocator(ActiveMQClient.createServerLocatorWithHA(getConnectorTransportConfiguration(true, node))).setRetryInterval(50).setReconnectAttempts(-1).setInitialConnectAttempts(-1);
+      return (ServerLocatorInternal) addServerLocator(ActiveMQClient.createServerLocatorWithHA(getConnectorTransportConfiguration(true, node))).setRetryInterval(100).setReconnectAttempts(300).setInitialConnectAttempts(300);
    }
 
    protected ServerLocatorInternal getBackupServerLocator(int node) throws Exception {
-      return (ServerLocatorInternal) addServerLocator(ActiveMQClient.createServerLocatorWithHA(getConnectorTransportConfiguration(false, node))).setRetryInterval(50).setReconnectAttempts(-1).setInitialConnectAttempts(-1);
+      return (ServerLocatorInternal) addServerLocator(ActiveMQClient.createServerLocatorWithHA(getConnectorTransportConfiguration(false, node))).setRetryInterval(100).setReconnectAttempts(300).setInitialConnectAttempts(300);
    }
 
    protected ClientSession createSession(ClientSessionFactory sf,

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/NettyFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/NettyFailoverTest.java
@@ -48,7 +48,7 @@ public class NettyFailoverTest extends FailoverTest {
       params.put(TransportConstants.HOST_PROP_NAME, "127.0.0.1");
       TransportConfiguration tc = createTransportConfiguration(true, false, params);
 
-      ServerLocator locator = addServerLocator(ActiveMQClient.createServerLocatorWithHA(tc)).setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setBlockOnAcknowledge(true).setReconnectAttempts(-1);
+      ServerLocator locator = addServerLocator(ActiveMQClient.createServerLocatorWithHA(tc)).setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setBlockOnAcknowledge(true).setReconnectAttempts(15);
 
       ClientSessionFactoryInternal sf = createSessionFactoryAndWaitForTopology(locator, 2);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/PagingFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/PagingFailoverTest.java
@@ -87,7 +87,7 @@ public class PagingFailoverTest extends FailoverTestBase {
    }
 
    public void internalTestPage(final boolean transacted, final boolean failBeforeConsume) throws Exception {
-      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setReconnectAttempts(15);
 
       sf = createSessionFactoryAndWaitForTopology(locator, 2);
       session = addClientSession(sf.createSession(!transacted, !transacted, 0));
@@ -165,7 +165,7 @@ public class PagingFailoverTest extends FailoverTestBase {
 
    @Test
    public void testExpireMessage() throws Exception {
-      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setReconnectAttempts(15);
 
       ClientSessionFactoryInternal sf = createSessionFactoryAndWaitForTopology(locator, 2);
       session = sf.createSession(true, true, 0);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/SingleLiveMultipleBackupsFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/SingleLiveMultipleBackupsFailoverTest.java
@@ -80,7 +80,7 @@ public class SingleLiveMultipleBackupsFailoverTest extends MultipleBackupsFailov
       // for logging and debugging
       topology.setOwner("testMultipleFailovers");
 
-      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setBlockOnAcknowledge(true).setReconnectAttempts(-1);
+      locator.setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setBlockOnAcknowledge(true).setReconnectAttempts(15);
 
       ClientSessionFactoryInternal sf = createSessionFactoryAndWaitForTopology(locator, 2);
       int backupNode;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/MultiThreadRandomReattachTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/MultiThreadRandomReattachTestBase.java
@@ -1129,7 +1129,7 @@ public abstract class MultiThreadRandomReattachTestBase extends MultiThreadReatt
     */
    @Override
    protected ServerLocator createLocator() throws Exception {
-      ServerLocator locator = createInVMNonHALocator().setReconnectAttempts(-1).setConfirmationWindowSize(1024 * 1024);
+      ServerLocator locator = createInVMNonHALocator().setReconnectAttempts(15).setConfirmationWindowSize(1024 * 1024);
       return locator;
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/NettyMultiThreadRandomReattachTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/NettyMultiThreadRandomReattachTest.java
@@ -31,7 +31,7 @@ public class NettyMultiThreadRandomReattachTest extends MultiThreadRandomReattac
 
    @Override
    protected ServerLocator createLocator() throws Exception {
-      return createNettyNonHALocator().setReconnectAttempts(-1).setConfirmationWindowSize(1024 * 1024).setAckBatchSize(0);
+      return createNettyNonHALocator().setReconnectAttempts(15).setConfirmationWindowSize(1024 * 1024).setAckBatchSize(0);
    }
 
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/OrderReattachTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/OrderReattachTest.java
@@ -66,7 +66,7 @@ public class OrderReattachTest extends ActiveMQTestBase {
       server = createServer(false, isNetty);
 
       server.start();
-      ServerLocator locator = createFactory(isNetty).setReconnectAttempts(-1).setConfirmationWindowSize(1024 * 1024).setBlockOnNonDurableSend(false).setBlockOnAcknowledge(false);
+      ServerLocator locator = createFactory(isNetty).setReconnectAttempts(15).setConfirmationWindowSize(1024 * 1024).setBlockOnNonDurableSend(false).setBlockOnAcknowledge(false);
 
       ClientSessionFactory sf = createSessionFactory(locator);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/RandomReattachTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/RandomReattachTest.java
@@ -205,7 +205,7 @@ public class RandomReattachTest extends ActiveMQTestBase {
       for (int its = 0; its < numIts; its++) {
          RandomReattachTest.log.info("####" + getName() + " iteration #" + its);
          start();
-         ServerLocator locator = createInVMNonHALocator().setReconnectAttempts(-1).setConfirmationWindowSize(1024 * 1024);
+         ServerLocator locator = createInVMNonHALocator().setReconnectAttempts(15).setConfirmationWindowSize(1024 * 1024);
 
          ClientSessionFactory sf = createSessionFactory(locator);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/ReattachTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/ReattachTest.java
@@ -193,7 +193,7 @@ public class ReattachTest extends ActiveMQTestBase {
 
       final double retryMultiplier = 1d;
 
-      final int reconnectAttempts = -1;
+      final int reconnectAttempts = 60;
 
       locator.setRetryInterval(retryInterval).setRetryIntervalMultiplier(retryMultiplier).setReconnectAttempts(reconnectAttempts).setConfirmationWindowSize(1024 * 1024);
 
@@ -268,7 +268,7 @@ public class ReattachTest extends ActiveMQTestBase {
 
       final double retryMultiplier = 1d;
 
-      final int reconnectAttempts = -1;
+      final int reconnectAttempts = 60;
 
       final long asyncFailDelay = 2000;
 
@@ -448,11 +448,11 @@ public class ReattachTest extends ActiveMQTestBase {
 
       try {
 
-         final long retryInterval = 50;
+         final long retryInterval = 100;
 
          final double retryMultiplier = 1d;
 
-         final int reconnectAttempts = -1;
+         final int reconnectAttempts = 300;
 
          locator.setRetryInterval(retryInterval).setRetryIntervalMultiplier(retryMultiplier).setReconnectAttempts(reconnectAttempts).setConfirmationWindowSize(1024 * 1024);
 
@@ -543,7 +543,7 @@ public class ReattachTest extends ActiveMQTestBase {
 
       final double retryMultiplier = 1d;
 
-      final int reconnectAttempts = -1;
+      final int reconnectAttempts = 60;
 
       locator.setRetryInterval(retryInterval).setRetryIntervalMultiplier(retryMultiplier).setReconnectAttempts(reconnectAttempts).setConfirmationWindowSize(1024 * 1024);
 
@@ -622,11 +622,11 @@ public class ReattachTest extends ActiveMQTestBase {
 
    @Test
    public void testCreateQueue() throws Exception {
-      final long retryInterval = 50;
+      final long retryInterval = 100;
 
       final double retryMultiplier = 1d;
 
-      final int reconnectAttempts = -1;
+      final int reconnectAttempts = 300;
 
       locator.setRetryInterval(retryInterval).setRetryIntervalMultiplier(retryMultiplier).setReconnectAttempts(reconnectAttempts).setConfirmationWindowSize(1024 * 1024);
 
@@ -749,7 +749,7 @@ public class ReattachTest extends ActiveMQTestBase {
 
       final double retryMultiplier = 1d;
 
-      final int reconnectAttempts = -1;
+      final int reconnectAttempts = 60;
 
       locator.setRetryInterval(retryInterval).setRetryIntervalMultiplier(retryMultiplier).setReconnectAttempts(reconnectAttempts).setConfirmationWindowSize(1024 * 1024);
 
@@ -828,7 +828,7 @@ public class ReattachTest extends ActiveMQTestBase {
 
       final double retryMultiplier = 2d;
 
-      final int reconnectAttempts = -1;
+      final int reconnectAttempts = 60;
 
       locator.setRetryInterval(retryInterval).setRetryIntervalMultiplier(retryMultiplier).setReconnectAttempts(reconnectAttempts).setConfirmationWindowSize(1024 * 1024);
 
@@ -895,7 +895,7 @@ public class ReattachTest extends ActiveMQTestBase {
 
       final double retryMultiplier = 2d;
 
-      final int reconnectAttempts = -1;
+      final int reconnectAttempts = 60;
 
       final long maxRetryInterval = 1000;
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/restart/ClusterRestartTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/restart/ClusterRestartTest.java
@@ -43,7 +43,7 @@ public class ClusterRestartTest extends ClusterTestBase {
       System.out.println("server 0 = " + getServer(0).getNodeID());
       System.out.println("server 1 = " + getServer(1).getNodeID());
 
-      setupSessionFactory(0, isNetty(), -1);
+      setupSessionFactory(0, isNetty(), 15);
       setupSessionFactory(1, isNetty());
 
       // create some dummy queues to ensure that the test queue has a high numbered binding
@@ -106,7 +106,7 @@ public class ClusterRestartTest extends ClusterTestBase {
 
       System.out.println("server 0 = " + getServer(0).getNodeID());
       System.out.println("server 1 = " + getServer(1).getNodeID());
-      setupSessionFactory(0, isNetty(), -1);
+      setupSessionFactory(0, isNetty(), 15);
       setupSessionFactory(1, isNetty());
 
       // create some dummy queues to ensure that the test queue has a high numbered binding

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingWithFailoverAndCountersTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingWithFailoverAndCountersTest.java
@@ -280,7 +280,7 @@ public class PagingWithFailoverAndCountersTest extends ActiveMQTestBase {
    public void testValidateDeliveryAndCounters() throws Exception {
       startLive();
 
-      ServerLocator locator = SpawnedServerSupport.createLocator(PORT1).setInitialConnectAttempts(-1).setReconnectAttempts(-1).setRetryInterval(100);
+      ServerLocator locator = SpawnedServerSupport.createLocator(PORT1).setInitialConnectAttempts(300).setReconnectAttempts(300).setRetryInterval(100);
 
       ClientSessionFactory factory = locator.createSessionFactory();
 
@@ -349,7 +349,7 @@ public class PagingWithFailoverAndCountersTest extends ActiveMQTestBase {
 
       assertTrue(messageCount >= 0);
 
-      locator = SpawnedServerSupport.createLocator(PORT1).setInitialConnectAttempts(100).setReconnectAttempts(-1).setRetryInterval(100);
+      locator = SpawnedServerSupport.createLocator(PORT1).setInitialConnectAttempts(100).setReconnectAttempts(300).setRetryInterval(100);
 
       factory = locator.createSessionFactory();
 


### PR DESCRIPTION
If a connection to a broker is configured with parameter reconnect-atempts=-1 and something goes wrong with the broker, the test may hang indefinitely. It happens in cases where the session is created in main test thread.