### PR TITLE
ARTEMIS-821 Add support for scheduled message for STOMP

### DIFF
--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/Stomp.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/Stomp.java
@@ -98,6 +98,14 @@ public interface Stomp {
          String TYPE = "type";
 
          String PERSISTENT = "persistent";
+
+         // Extensions
+
+         // ActiveMQ 5.x Scheduled Message Compatibility.
+         String AMQ_SCHEDULED_DELAY = "AMQ_SCHEDULED_DELAY";
+
+         // Provides a hard time of delivery option (Epoch based)
+         String AMQ_SCHEDULED_TIME = "AMQ_SCHEDULED_TIME";
       }
 
       interface Message {

--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompUtils.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompUtils.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.stomp;
 
+import static org.apache.activemq.artemis.api.core.Message.HDR_SCHEDULED_DELIVERY_TIME;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -67,6 +69,23 @@ public class StompUtils {
       String expiration = headers.remove(Stomp.Headers.Send.EXPIRATION_TIME);
       if (expiration != null) {
          msg.setExpiration(Long.parseLong(expiration));
+      }
+
+      // Extension headers
+      String scheduledDelay = headers.remove(Stomp.Headers.Send.AMQ_SCHEDULED_DELAY);
+      if (scheduledDelay != null) {
+         long delay = Long.parseLong(scheduledDelay);
+         if (delay > 0) {
+            msg.putLongProperty(HDR_SCHEDULED_DELIVERY_TIME, System.currentTimeMillis() + delay);
+         }
+      }
+
+      String scheduledTime = headers.remove(Stomp.Headers.Send.AMQ_SCHEDULED_TIME);
+      if (scheduledTime != null) {
+         long deliveryTime = Long.parseLong(scheduledTime);
+         if (deliveryTime > 0) {
+            msg.putLongProperty(HDR_SCHEDULED_DELIVERY_TIME, deliveryTime);
+         }
       }
 
       // now the general headers


### PR DESCRIPTION
Adds headers AMQ_SCHEDULED_DELAY and AMQ_SCHEDULED_TIME to STOMP
protocol handling to allow for delayed and scheduled time of a
message.  The AMQ_SCHEDULED_DELAY brings forward the same option
from the 5.x broker and the AMQ_SCHEDULED_TIME option adds a fixed
time of delivery alternative to match that of AMQP and others.