### PR TITLE
[ARTEMIS-1209] JMS OpenWire client cannot read notifications from activemq.notifications topic

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireMessageConverter.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireMessageConverter.java
@@ -94,6 +94,8 @@ public class OpenWireMessageConverter implements MessageConverter<OpenwireMessag
    private static final String AMQ_MSG_DROPPABLE = AMQ_PREFIX + "DROPPABLE";
    private static final String AMQ_MSG_COMPRESSED = AMQ_PREFIX + "COMPRESSED";
 
+   private static final String AMQ_NOTIFICATIONS_DESTINATION = "activemq.notifications";
+
    private final WireFormat marshaller;
 
    public OpenWireMessageConverter(WireFormat marshaller) {
@@ -774,7 +776,8 @@ public class OpenWireMessageConverter implements MessageConverter<OpenwireMessag
       if (props != null) {
          for (SimpleString s : props) {
             String keyStr = s.toString();
-            if (keyStr.startsWith("_AMQ") || keyStr.startsWith("__HDR_")) {
+            if ((keyStr.startsWith("_AMQ") || keyStr.startsWith("__HDR_")) &&
+                    !(actualDestination.toString().contains(AMQ_NOTIFICATIONS_DESTINATION))) {
                continue;
             }
             Object prop = coreMessage.getObjectProperty(s);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/SimpleOpenWireTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/SimpleOpenWireTest.java
@@ -38,6 +38,7 @@ import javax.jms.TemporaryQueue;
 import javax.jms.TemporaryTopic;
 import javax.jms.TextMessage;
 import javax.jms.Topic;
+import javax.jms.TopicConnection;
 import javax.jms.TopicPublisher;
 import javax.jms.TopicSession;
 import javax.jms.TopicSubscriber;
@@ -1463,6 +1464,27 @@ public class SimpleOpenWireTest extends BasicOpenWireTest {
          }
          if (connection2 != null) {
             connection2.close();
+         }
+      }
+   }
+
+   @Test
+   public void testNotificationProperties() throws Exception {
+      try (TopicConnection topicConnection = factory.createTopicConnection()) {
+         TopicSession topicSession = topicConnection.createTopicSession(false, Session.AUTO_ACKNOWLEDGE);
+         Topic notificationsTopic = topicSession.createTopic("activemq.notifications");
+         TopicSubscriber subscriber = topicSession.createSubscriber(notificationsTopic);
+         List<Message> receivedMessages = new ArrayList<>();
+         subscriber.setMessageListener(receivedMessages::add);
+         topicConnection.start();
+
+         while (receivedMessages.size() == 0) {
+            Thread.sleep(1000);
+         }
+
+         for (Message message : receivedMessages) {
+            assertNotNull(message);
+            assertNotNull(message.getStringProperty("_AMQ_NotifType"));
          }
       }
    }


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/ARTEMIS-1209