### PR TITLE
ARTEMIS-1207: Align order of when setClientId can be called with AcitveMQ5 and QPID

### DIFF
--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
@@ -267,8 +267,6 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
    public ConnectionMetaData getMetaData() throws JMSException {
       checkClosed();
 
-      justCreated = false;
-
       if (metaData == null) {
          metaData = new ActiveMQConnectionMetaData(thisVersion);
       }
@@ -323,7 +321,6 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
          session.stop();
       }
 
-      justCreated = false;
       started = false;
    }
 

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/ConnectionTest.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/ConnectionTest.java
@@ -98,6 +98,15 @@ public class ConnectionTest extends JMSTestCase {
    }
 
    @Test
+   public void testSetClientIdAfterStop() throws Exception {
+      try (Connection connection = createConnection()) {
+         connection.stop();
+         connection.setClientID("clientId");
+      }
+   }
+
+
+   @Test
    public void testSetClientAfterStart() throws Exception {
       Connection connection = null;
       try {
@@ -172,6 +181,14 @@ public class ConnectionTest extends JMSTestCase {
       metaData.getProviderVersion();
 
       connection.close();
+   }
+
+   @Test
+   public void testSetClientIdAfterGetMetadata() throws Exception {
+      try (Connection connection = createConnection()) {
+         connection.getMetaData();
+         connection.setClientID("clientId");
+      }
    }
 
    /**


### PR DESCRIPTION
Update ActiveMQConnection to change/alighn behaviour for addtional methods/
getMetaData
stop

Add test to avoid regression.