### PR TITLE
ARTEMIS-1205: AMQP Shared Durable Subscriber incorrect behaviour.

### DIFF
--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQDestination.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQDestination.java
@@ -124,18 +124,6 @@ public class ActiveMQDestination implements Destination, Serializable, Reference
       }
    }
 
-   public static String createQueueNameForSharedSubscription(final boolean isDurable,
-                                                             final String clientID,
-                                                             final String subscriptionName) {
-      if (clientID != null) {
-         return (isDurable ? "Durable" : "nonDurable") + SEPARATOR +
-            ActiveMQDestination.escape(clientID) + SEPARATOR +
-            ActiveMQDestination.escape(subscriptionName);
-      } else {
-         return (isDurable ? "Durable" : "nonDurable") + SEPARATOR +
-            ActiveMQDestination.escape(subscriptionName);
-      }
-   }
 
    public static Pair<String, String> decomposeQueueNameForDurableSubscription(final String queueName) {
       StringBuffer[] parts = new StringBuffer[2];

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java
@@ -738,7 +738,7 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
                                          boolean shared,
                                          boolean global,
                                          boolean isVolatile) {
-      String queue = clientId == null || clientId.isEmpty() || global ? pubId : clientId + "." + pubId;
+      String queue = clientId == null || clientId.isEmpty() || global ? escape(pubId) : escape(clientId) + "." + escape(pubId);
       if (shared) {
          if (queue.contains("|")) {
             queue = queue.split("\\|")[0];
@@ -748,5 +748,12 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
          }
       }
       return queue;
+   }
+
+   private static String escape(final String input) {
+      if (input == null) {
+         return "";
+      }
+      return input.replace("\\", "\\\\").replace(".", "\\.");
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSSharedDurableConsumerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSSharedDurableConsumerTest.java
@@ -32,6 +32,8 @@ import org.junit.Test;
 
 public class JMSSharedDurableConsumerTest extends JMSClientTestSupport {
 
+   public static final String SHARED_CONSUMER = "WithDot.SharedConsumer";
+
    @Override
    protected String getConfiguredProtocols() {
       return "AMQP,OPENWIRE,CORE";
@@ -45,8 +47,8 @@ public class JMSSharedDurableConsumerTest extends JMSClientTestSupport {
          Topic topic = session1.createTopic(getTopicName());
          Topic topic2 = session2.createTopic(getTopicName());
 
-         final MessageConsumer consumer1 = session1.createSharedDurableConsumer(topic, "SharedConsumer");
-         final MessageConsumer consumer2 = session2.createSharedDurableConsumer(topic2, "SharedConsumer");
+         final MessageConsumer consumer1 = session1.createSharedDurableConsumer(topic, SHARED_CONSUMER);
+         final MessageConsumer consumer2 = session2.createSharedDurableConsumer(topic2, SHARED_CONSUMER);
 
          MessageProducer producer = session1.createProducer(topic);
          producer.setDeliveryMode(DeliveryMode.PERSISTENT);


### PR DESCRIPTION
Fix that ActiveMQDestination escapes \\ and . with \\\\ and \\.
Update test case to test this and ensure regression doesn't occur.