### PR TITLE
ARTEMIS-1205: AMQP Shared Durable Subscriber incorrect behaviour

### DIFF
--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
@@ -128,6 +128,8 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
 
    private final boolean cacheDestinations;
 
+   private final boolean amqpCompatibleQueues;
+
    private ClientSession initialSession;
 
    private final Exception creationStack;
@@ -146,6 +148,7 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
                              final int dupsOKBatchSize,
                              final int transactionBatchSize,
                              final boolean cacheDestinations,
+                             final boolean amqpCompatibleQueues,
                              final ClientSessionFactory sessionFactory) {
       this.options = options;
 
@@ -168,6 +171,8 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
       this.transactionBatchSize = transactionBatchSize;
 
       this.cacheDestinations = cacheDestinations;
+
+      this.amqpCompatibleQueues = amqpCompatibleQueues;
 
       creationStack = new Exception();
    }
@@ -657,9 +662,9 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
                                               ClientSession session,
                                               int type) {
       if (isXA) {
-         return new ActiveMQXASession(options, this, transacted, true, acknowledgeMode, cacheDestinations, session, type);
+         return new ActiveMQXASession(options, this, transacted, true, acknowledgeMode, cacheDestinations, amqpCompatibleQueues, session, type);
       } else {
-         return new ActiveMQSession(options, this, transacted, false, acknowledgeMode, cacheDestinations, session, type);
+         return new ActiveMQSession(options, this, transacted, false, acknowledgeMode, cacheDestinations, amqpCompatibleQueues, session, type);
       }
    }
 

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnectionFactory.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnectionFactory.java
@@ -88,6 +88,8 @@ public class ActiveMQConnectionFactory implements ConnectionFactoryOptions, Exte
 
    private boolean finalizeChecks;
 
+   private boolean amqpCompatibleQueues;
+
    @Override
    public void writeExternal(ObjectOutput out) throws IOException {
       URI uri = toURI();
@@ -439,6 +441,15 @@ public class ActiveMQConnectionFactory implements ConnectionFactoryOptions, Exte
       this.cacheDestinations = cacheDestinations;
    }
 
+   public synchronized boolean isAmqpCompatibleQueues() {
+      return this.amqpCompatibleQueues;
+   }
+
+   public synchronized void setAmqpCompatibleQueues(final boolean amqpCompatibleQueues) {
+      checkWrite();
+      this.amqpCompatibleQueues = amqpCompatibleQueues;
+   }
+
    public synchronized long getClientFailureCheckPeriod() {
       return serverLocator.getClientFailureCheckPeriod();
    }
@@ -777,19 +788,19 @@ public class ActiveMQConnectionFactory implements ConnectionFactoryOptions, Exte
 
       if (isXA) {
          if (type == ActiveMQConnection.TYPE_GENERIC_CONNECTION) {
-            connection = new ActiveMQXAConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, cacheDestinations, factory);
+            connection = new ActiveMQXAConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, cacheDestinations, amqpCompatibleQueues, factory);
          } else if (type == ActiveMQConnection.TYPE_QUEUE_CONNECTION) {
-            connection = new ActiveMQXAConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, cacheDestinations, factory);
+            connection = new ActiveMQXAConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, cacheDestinations, amqpCompatibleQueues,factory);
          } else if (type == ActiveMQConnection.TYPE_TOPIC_CONNECTION) {
-            connection = new ActiveMQXAConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, cacheDestinations, factory);
+            connection = new ActiveMQXAConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, cacheDestinations, amqpCompatibleQueues, factory);
          }
       } else {
          if (type == ActiveMQConnection.TYPE_GENERIC_CONNECTION) {
-            connection = new ActiveMQConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, cacheDestinations, factory);
+            connection = new ActiveMQConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, cacheDestinations, amqpCompatibleQueues, factory);
          } else if (type == ActiveMQConnection.TYPE_QUEUE_CONNECTION) {
-            connection = new ActiveMQConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, cacheDestinations, factory);
+            connection = new ActiveMQConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, cacheDestinations, amqpCompatibleQueues, factory);
          } else if (type == ActiveMQConnection.TYPE_TOPIC_CONNECTION) {
-            connection = new ActiveMQConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, cacheDestinations, factory);
+            connection = new ActiveMQConnection(this, username, password, type, clientID, dupsOKBatchSize, transactionBatchSize, cacheDestinations, amqpCompatibleQueues, factory);
          }
       }
 

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQDestination.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQDestination.java
@@ -102,24 +102,30 @@ public class ActiveMQDestination implements Destination, Serializable, Reference
       }
    }
 
-   public static String createQueueNameForDurableSubscription(final boolean isDurable,
-                                                              final String clientID,
-                                                              final String subscriptionName) {
-      if (clientID != null) {
+   public static String createQueueNameForSubscription(final boolean amqpCompatibleQueues,
+                                                       final boolean isDurable,
+                                                       final String clientID,
+                                                       final String subscriptionName) {
+      final String clientId;
+      final String subscription;
+      if (amqpCompatibleQueues) {
+         clientId = clientID;
+         subscription = subscriptionName;
+      } else {
+         clientId = clientID == null ? null : ActiveMQDestination.escape(clientID);
+         subscription = ActiveMQDestination.escape(subscriptionName);
+      }
+      if (clientId != null) {
          if (isDurable) {
-            return ActiveMQDestination.escape(clientID) + SEPARATOR +
-               ActiveMQDestination.escape(subscriptionName);
+            return clientId + SEPARATOR + subscription;
          } else {
-            return "nonDurable" + SEPARATOR +
-               ActiveMQDestination.escape(clientID) + SEPARATOR +
-               ActiveMQDestination.escape(subscriptionName);
+            return "nonDurable" + SEPARATOR + clientId + SEPARATOR + subscription;
          }
       } else {
          if (isDurable) {
-            return ActiveMQDestination.escape(subscriptionName);
+            return subscription;
          } else {
-            return "nonDurable" + SEPARATOR +
-               ActiveMQDestination.escape(subscriptionName);
+            return "nonDurable" + SEPARATOR + subscription;
          }
       }
    }

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
@@ -99,6 +99,8 @@ public class ActiveMQSession implements QueueSession, TopicSession {
 
    private final boolean cacheDestination;
 
+   private final boolean amqpCompatibleQueues;
+
    private final Map<String, Topic> topicCache = new ConcurrentHashMap<>();
 
    private final Map<String, Queue> queueCache = new ConcurrentHashMap<>();
@@ -111,6 +113,7 @@ public class ActiveMQSession implements QueueSession, TopicSession {
                              final boolean xa,
                              final int ackMode,
                              final boolean cacheDestination,
+                             final boolean amqpCompatibleQueues,
                              final ClientSession session,
                              final int sessionType) {
       this.options = options;
@@ -128,6 +131,8 @@ public class ActiveMQSession implements QueueSession, TopicSession {
       this.xa = xa;
 
       this.cacheDestination = cacheDestination;
+
+      this.amqpCompatibleQueues = amqpCompatibleQueues;
    }
 
    // Session implementation ----------------------------------------
@@ -627,7 +632,7 @@ public class ActiveMQSession implements QueueSession, TopicSession {
             throw new InvalidDestinationException("Cannot create a durable subscription on a temporary topic");
          }
 
-         queueName = new SimpleString(ActiveMQDestination.createQueueNameForDurableSubscription(durability == ConsumerDurability.DURABLE, connection.getClientID(), subscriptionName));
+         queueName = new SimpleString(ActiveMQDestination.createQueueNameForSubscription(amqpCompatibleQueues,durability == ConsumerDurability.DURABLE, connection.getClientID(), subscriptionName));
 
          if (durability == ConsumerDurability.DURABLE) {
             try {
@@ -750,7 +755,7 @@ public class ActiveMQSession implements QueueSession, TopicSession {
                   throw new InvalidDestinationException("Cannot create a durable subscription on a temporary topic");
                }
 
-               queueName = new SimpleString(ActiveMQDestination.createQueueNameForDurableSubscription(true, connection.getClientID(), subscriptionName));
+               queueName = new SimpleString(ActiveMQDestination.createQueueNameForSubscription(amqpCompatibleQueues,true, connection.getClientID(), subscriptionName));
 
                QueueQuery subResponse = session.queueQuery(queueName);
 
@@ -918,7 +923,7 @@ public class ActiveMQSession implements QueueSession, TopicSession {
          throw new IllegalStateException("Cannot unsubscribe using a QueueSession");
       }
 
-      SimpleString queueName = new SimpleString(ActiveMQDestination.createQueueNameForDurableSubscription(true, connection.getClientID(), name));
+      SimpleString queueName = new SimpleString(ActiveMQDestination.createQueueNameForSubscription(amqpCompatibleQueues,true, connection.getClientID(), name));
 
       try {
          QueueQuery response = session.queueQuery(queueName);

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQXAConnection.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQXAConnection.java
@@ -42,8 +42,9 @@ public final class ActiveMQXAConnection extends ActiveMQConnection implements XA
                                final int dupsOKBatchSize,
                                final int transactionBatchSize,
                                final boolean cacheDestinations,
+                               final boolean amqpCompatibleQueues,
                                final ClientSessionFactory sessionFactory) {
-      super(options, username, password, connectionType, clientID, dupsOKBatchSize, transactionBatchSize, cacheDestinations, sessionFactory);
+      super(options, username, password, connectionType, clientID, dupsOKBatchSize, transactionBatchSize, cacheDestinations, amqpCompatibleQueues, sessionFactory);
    }
 
    @Override

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQXASession.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQXASession.java
@@ -37,8 +37,9 @@ public class ActiveMQXASession extends ActiveMQSession implements XAQueueSession
                                boolean xa,
                                int ackMode,
                                boolean cacheDestinations,
+                               boolean amqpCompatibleQueues,
                                ClientSession session,
                                int sessionType) {
-      super(options, connection, transacted, xa, ackMode, cacheDestinations, session, sessionType);
+      super(options, connection, transacted, xa, ackMode, cacheDestinations, amqpCompatibleQueues, session, sessionType);
    }
 }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java
@@ -738,6 +738,9 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
                                          boolean shared,
                                          boolean global,
                                          boolean isVolatile) {
+      if (pubId.endsWith("|global")) {
+         global = true;
+      }
       String queue = clientId == null || clientId.isEmpty() || global ? pubId : clientId + "." + pubId;
       if (shared) {
          if (queue.contains("|")) {

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
@@ -1093,7 +1093,7 @@ public class OpenWireConnection extends AbstractRemotingConnection implements Se
 
       @Override
       public Response processRemoveSubscription(RemoveSubscriptionInfo subInfo) throws Exception {
-         SimpleString subQueueName = new SimpleString(org.apache.activemq.artemis.jms.client.ActiveMQDestination.createQueueNameForDurableSubscription(true, subInfo.getClientId(), subInfo.getSubscriptionName()));
+         SimpleString subQueueName = new SimpleString(org.apache.activemq.artemis.jms.client.ActiveMQDestination.createQueueNameForSubscription(false,true, subInfo.getClientId(), subInfo.getSubscriptionName()));
          server.destroyQueue(subQueueName);
 
          return null;

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQConsumer.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQConsumer.java
@@ -150,7 +150,7 @@ public class AMQConsumer {
          addressInfo.addRoutingType(RoutingType.MULTICAST);
       }
       if (isDurable) {
-         queueName = new SimpleString(org.apache.activemq.artemis.jms.client.ActiveMQDestination.createQueueNameForDurableSubscription(true, clientID, subscriptionName));
+         queueName = new SimpleString(org.apache.activemq.artemis.jms.client.ActiveMQDestination.createQueueNameForSubscription(false,true, clientID, subscriptionName));
          QueueQueryResult result = session.getCoreSession().executeQueueQuery(queueName);
          if (result.isExists()) {
             // Already exists

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRAManagedConnectionFactory.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRAManagedConnectionFactory.java
@@ -588,6 +588,14 @@ public final class ActiveMQRAManagedConnectionFactory implements ManagedConnecti
       mcfProperties.setCacheDestinations(cacheDestinations);
    }
 
+   public Boolean isAmqpCompatibleQueues() {
+      return mcfProperties.isAmqpCompatibleQueues();
+   }
+
+   public void setAmqpCompatibleQueues(final Boolean amqpCompatibleQueues) {
+      mcfProperties.setAmqpCompatibleQueues(amqpCompatibleQueues);
+   }
+
    public Integer getScheduledThreadPoolMaxSize() {
       return mcfProperties.getScheduledThreadPoolMaxSize();
    }

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
@@ -661,6 +661,32 @@ public class ActiveMQResourceAdapter implements ResourceAdapter, Serializable {
    }
 
    /**
+    * Set amqpCompatibleQueues
+    *
+    * @param amqpCompatibleQueues The value
+    */
+   public void setAmqpCompatibleQueues(final Boolean amqpCompatibleQueues) {
+      if (ActiveMQResourceAdapter.trace) {
+         ActiveMQRALogger.LOGGER.trace("setAmqpCompatibleQueues(" + amqpCompatibleQueues + ")");
+      }
+
+      raProperties.setAmqpCompatibleQueues(amqpCompatibleQueues);
+   }
+
+   /**
+    * Get isAmqpCompatibleQueues
+    *
+    * @return The value
+    */
+   public Boolean isAmqpCompatibleQueues() {
+      if (ActiveMQResourceAdapter.trace) {
+         ActiveMQRALogger.LOGGER.trace("isAmqpCompatibleQueues()");
+      }
+
+      return raProperties.isAmqpCompatibleQueues();
+   }
+
+   /**
     * Set compressLargeMessage
     *
     * @param compressLargeMessage The value

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ConnectionFactoryProperties.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ConnectionFactoryProperties.java
@@ -114,6 +114,8 @@ public class ConnectionFactoryProperties implements ConnectionFactoryOptions {
 
    private Boolean cacheDestinations;
 
+   private Boolean amqpCompatibleQueues;
+
    private Integer initialMessagePacketSize;
 
    private Integer scheduledThreadPoolMaxSize;
@@ -627,6 +629,21 @@ public class ConnectionFactoryProperties implements ConnectionFactoryOptions {
       }
       hasBeenUpdated = true;
       this.cacheDestinations = cacheDestinations;
+   }
+
+   public Boolean isAmqpCompatibleQueues() {
+      if (ConnectionFactoryProperties.trace) {
+         ActiveMQRALogger.LOGGER.trace("isAmqpCompatibleQueues()");
+      }
+      return amqpCompatibleQueues;
+   }
+
+   public void setAmqpCompatibleQueues(final Boolean amqpCompatibleQueues) {
+      if (ConnectionFactoryProperties.trace) {
+         ActiveMQRALogger.LOGGER.trace("setAmqpCompatibleQueues(" + amqpCompatibleQueues + ")");
+      }
+      hasBeenUpdated = true;
+      this.amqpCompatibleQueues = amqpCompatibleQueues;
    }
 
    public Integer getScheduledThreadPoolMaxSize() {

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQMessageHandler.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQMessageHandler.java
@@ -112,7 +112,7 @@ public class ActiveMQMessageHandler implements MessageHandler, FailoverEventList
       // Create the message consumer
       SimpleString selectorString = selector == null || selector.trim().equals("") ? null : new SimpleString(selector);
       if (activation.isTopic() && spec.isSubscriptionDurable()) {
-         SimpleString queueName = new SimpleString(ActiveMQDestination.createQueueNameForDurableSubscription(true, spec.getClientID(), spec.getSubscriptionName()));
+         SimpleString queueName = new SimpleString(ActiveMQDestination.createQueueNameForSubscription(spec.isAmqpCompatibleQueues(),true, spec.getClientID(), spec.getSubscriptionName()));
 
          QueueQuery subResponse = session.queueQuery(queueName);
 

--- a/examples/features/sub-modules/artemis-ra-rar/src/main/resources/ra.xml
+++ b/examples/features/sub-modules/artemis-ra-rar/src/main/resources/ra.xml
@@ -264,6 +264,12 @@
         <config-property-name>CacheDestinations</config-property-name>
         <config-property-type>java.lang.Boolean</config-property-type>
         <config-property-value>false</config-property-value>
+      </config-property
+      <config-property>
+        <description>Set if to use AMQP compatible queue naming or legacy naming</description>
+        <config-property-name>AmqpCompatibleQueues</config-property-name>
+        <config-property-type>java.lang.Boolean</config-property-type>
+        <config-property-value>true</config-property-value>
       </config-property>-->
 
       <outbound-resourceadapter>

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSClientTestSupport.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSClientTestSupport.java
@@ -23,6 +23,7 @@ import javax.jms.Connection;
 import javax.jms.ExceptionListener;
 import javax.jms.JMSException;
 
+import org.apache.activemq.artemis.jms.client.ActiveMQJMSConnectionFactory;
 import org.apache.qpid.jms.JmsConnectionFactory;
 import org.jboss.logging.Logger;
 import org.junit.After;
@@ -135,6 +136,61 @@ public abstract class JMSClientTestSupport extends AmqpClientTestSupport {
    private Connection createConnection(URI remoteURI, String username, String password, String clientId, boolean start) throws JMSException {
       JmsConnectionFactory factory = new JmsConnectionFactory(remoteURI);
 
+      Connection connection = trackJMSConnection(factory.createConnection(username, password));
+
+      connection.setExceptionListener(new ExceptionListener() {
+         @Override
+         public void onException(JMSException exception) {
+            exception.printStackTrace();
+         }
+      });
+
+      if (clientId != null && !clientId.isEmpty()) {
+         connection.setClientID(clientId);
+      }
+
+      if (start) {
+         connection.start();
+      }
+
+      return connection;
+   }
+
+
+   protected String getBrokerCoreJMSConnectionString() {
+
+      try {
+         int port = AMQP_PORT;
+
+         String uri = null;
+
+         if (isUseSSL()) {
+            uri = "tcp://127.0.0.1:" + port;
+         } else {
+            uri = "tcp://127.0.0.1:" + port;
+         }
+
+         if (!getJmsConnectionURIOptions().isEmpty()) {
+            uri = uri + "?" + getJmsConnectionURIOptions();
+         }
+
+         return uri;
+      } catch (Exception e) {
+         throw new RuntimeException();
+      }
+   }
+
+   protected Connection createCoreConnection() throws JMSException {
+      return createCoreConnection(getBrokerCoreJMSConnectionString(), null, null, null, true);
+   }
+
+   protected Connection createCoreConnection(String clientId) throws JMSException {
+      return createCoreConnection(getBrokerCoreJMSConnectionString(), null, null, clientId, true);
+   }
+
+   private Connection createCoreConnection(String connectionString, String username, String password, String clientId, boolean start) throws JMSException {
+      ActiveMQJMSConnectionFactory factory = new ActiveMQJMSConnectionFactory(connectionString);
+      factory.setAmqpCompatibleQueues(true);
       Connection connection = trackJMSConnection(factory.createConnection(username, password));
 
       connection.setExceptionListener(new ExceptionListener() {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSSharedConsumerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSSharedConsumerTest.java
@@ -18,7 +18,6 @@ package org.apache.activemq.artemis.tests.integration.amqp;
 
 import javax.jms.Connection;
 import javax.jms.DeliveryMode;
-import javax.jms.ExceptionListener;
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.MessageConsumer;
@@ -27,7 +26,6 @@ import javax.jms.Session;
 import javax.jms.TextMessage;
 import javax.jms.Topic;
 
-import org.apache.activemq.artemis.jms.client.ActiveMQJMSConnectionFactory;
 import org.junit.Test;
 
 public class JMSSharedConsumerTest extends JMSClientTestSupport {
@@ -111,56 +109,4 @@ public class JMSSharedConsumerTest extends JMSClientTestSupport {
       testSharedConsumer(connection, connection2);
 
    }
-
-
-   protected String getBrokerCoreJMSConnectionString() {
-
-      try {
-         int port = AMQP_PORT;
-
-         String uri = null;
-
-         if (isUseSSL()) {
-            uri = "tcp://127.0.0.1:" + port;
-         } else {
-            uri = "tcp://127.0.0.1:" + port;
-         }
-
-         if (!getJmsConnectionURIOptions().isEmpty()) {
-            uri = uri + "?" + getJmsConnectionURIOptions();
-         }
-
-         return uri;
-      } catch (Exception e) {
-         throw new RuntimeException();
-      }
-   }
-
-   protected Connection createCoreConnection() throws JMSException {
-      return createCoreConnection(getBrokerCoreJMSConnectionString(), null, null, null, true);
-   }
-
-   private Connection createCoreConnection(String connectionString, String username, String password, String clientId, boolean start) throws JMSException {
-      ActiveMQJMSConnectionFactory factory = new ActiveMQJMSConnectionFactory(connectionString);
-
-      Connection connection = trackJMSConnection(factory.createConnection(username, password));
-
-      connection.setExceptionListener(new ExceptionListener() {
-         @Override
-         public void onException(JMSException exception) {
-            exception.printStackTrace();
-         }
-      });
-
-      if (clientId != null && !clientId.isEmpty()) {
-         connection.setClientID(clientId);
-      }
-
-      if (start) {
-         connection.start();
-      }
-
-      return connection;
-   }
-
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSSharedDurableConsumerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSSharedDurableConsumerTest.java
@@ -18,7 +18,6 @@ package org.apache.activemq.artemis.tests.integration.amqp;
 
 import javax.jms.Connection;
 import javax.jms.DeliveryMode;
-import javax.jms.ExceptionListener;
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.MessageConsumer;
@@ -27,7 +26,6 @@ import javax.jms.Session;
 import javax.jms.TextMessage;
 import javax.jms.Topic;
 
-import org.apache.activemq.artemis.jms.client.ActiveMQJMSConnectionFactory;
 import org.junit.Test;
 
 public class JMSSharedDurableConsumerTest extends JMSClientTestSupport {
@@ -68,6 +66,11 @@ public class JMSSharedDurableConsumerTest extends JMSClientTestSupport {
          }
          assertNotNull("Should have received a message by now.", received);
          assertTrue("Should be an instance of TextMessage", received instanceof TextMessage);
+
+         consumer2.close();
+         consumer1.close();
+         //Ensure unsubscribe works!
+         session1.unsubscribe("SharedConsumer");
       } finally {
          connection1.close();
          connection2.close();
@@ -111,56 +114,4 @@ public class JMSSharedDurableConsumerTest extends JMSClientTestSupport {
       testSharedDurableConsumer(connection, connection2);
 
    }
-
-
-   protected String getBrokerCoreJMSConnectionString() {
-
-      try {
-         int port = AMQP_PORT;
-
-         String uri = null;
-
-         if (isUseSSL()) {
-            uri = "tcp://127.0.0.1:" + port;
-         } else {
-            uri = "tcp://127.0.0.1:" + port;
-         }
-
-         if (!getJmsConnectionURIOptions().isEmpty()) {
-            uri = uri + "?" + getJmsConnectionURIOptions();
-         }
-
-         return uri;
-      } catch (Exception e) {
-         throw new RuntimeException();
-      }
-   }
-
-   protected Connection createCoreConnection() throws JMSException {
-      return createCoreConnection(getBrokerCoreJMSConnectionString(), null, null, null, true);
-   }
-
-   private Connection createCoreConnection(String connectionString, String username, String password, String clientId, boolean start) throws JMSException {
-      ActiveMQJMSConnectionFactory factory = new ActiveMQJMSConnectionFactory(connectionString);
-
-      Connection connection = trackJMSConnection(factory.createConnection(username, password));
-
-      connection.setExceptionListener(new ExceptionListener() {
-         @Override
-         public void onException(JMSException exception) {
-            exception.printStackTrace();
-         }
-      });
-
-      if (clientId != null && !clientId.isEmpty()) {
-         connection.setClientID(clientId);
-      }
-
-      if (start) {
-         connection.start();
-      }
-
-      return connection;
-   }
-
 }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/ra/ActiveMQResourceAdapterConfigTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/ra/ActiveMQResourceAdapterConfigTest.java
@@ -259,6 +259,12 @@ public class ActiveMQResourceAdapterConfigTest extends ActiveMQTestBase {
       "         <config-property-type>boolean</config-property-type>" +
       "         <config-property-value></config-property-value>" +
       "      </config-property>" +
+      "      <config-property>" +
+      "         <description>Set if to use AMQP compatible queue naming or legacy naming</description>" +
+      "         <config-property-name>AmqpCompatibleQueues</config-property-name>" +
+      "         <config-property-type>boolean</config-property-type>" +
+      "         <config-property-value></config-property-value>" +
+      "      </config-property>" +
       "      <config-property>\n" +
       "         <description>max number of threads for scheduled thread pool</description>\n" +
       "         <config-property-name>ScheduledThreadPoolMaxSize</config-property-name>\n" +


### PR DESCRIPTION
adding support into Artemis Client to support AMQP compatibility with escape behaviour, in essence AMQP does not escape, as such make it configurable for the core client to also not escape default behaviour it continues to escape, meaning previous PR with adding this into the AMQP protocol handler does not need to be done, to avoid breaking changes.

adding test, and ensuring unsubscirbe works as per JMS spec for AMQP also noted as broken