### PR TITLE
ARTEMIS-1205: AMQP Shared Durable Subscriber - Document Update

### DIFF
--- a/docs/user-manual/en/configuration-index.md
+++ b/docs/user-manual/en/configuration-index.md
@@ -44,6 +44,7 @@ Name | Description
 [acceptors.acceptor](configuring-transports.md "Understanding Acceptors") | Each acceptor is composed for just an URL
 [address-settings](address-model.md "Configuring Addresses and Queues Via Address Settings")                                                    |  [a list of address-setting](#address-setting-type)
 [allow-failback](ha.md "Failing Back to live Server")                                                                              |  Should stop backup on live restart. default true
+[amqp-use-core-subscription-naming](using-AMQP.md "Message Conversions")  | If true uses CORE queue naming convention for AMQP. default false
 [async-connection-execution-enabled](connection-ttl.md "Configuring Asynchronous Connection Execution")  | If False delivery would be always asynchronous. default true
 [bindings-directory](persistence.md "Configuring the bindings journal")  | The folder in use for the bindings folder
 [bridges](core-bridges.md "Core Bridges")  | [a list of bridge](#bridge-type)

--- a/docs/user-manual/en/using-AMQP.md
+++ b/docs/user-manual/en/using-AMQP.md
@@ -28,6 +28,13 @@ If you send a body type that is not recognized by this specification the convers
 
 So, make sure you follow these conventions if you intend to cross protocols or languages. Especially on the message body.
 
+A compatibility setting, allows aligning the naming convention of AMQP queues (JMS Durable and Shared Subscriptions) with CORE.
+For backwards compatibility reasons, you need to explicitly enable this via broker configuration:
+
+* amqp-use-core-subscription-naming
+   * true - use queue naming convention that is aligned with CORE.
+   * false (DEFAULT) - use older naming convention.
+
 
 # Example
 


### PR DESCRIPTION
Update documents for new configuration toggle for 'amqp-use-core-subscription-naming '