### PR TITLE
ARTEMIS-1240 Disconnect at client side on decoding error

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/ActiveMQClientLogger.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/ActiveMQClientLogger.java
@@ -451,4 +451,7 @@ public interface ActiveMQClientLogger extends BasicLogger {
    @Message(id = 214030, value = "Failed to bind {0}={1}", format = Message.Format.MESSAGE_FORMAT)
    void failedToBind(String p1, String p2, @Cause Throwable cause);
 
+   @LogMessage(level = Logger.Level.ERROR)
+   @Message(id = 214031, value = "Failed to decode buffer, disconnect immediately.", format = Message.Format.MESSAGE_FORMAT)
+   void disconnectOnErrorDecoding(@Cause Throwable cause);
 }


### PR DESCRIPTION
When a broken packet arrives at client side it causes decoding error.
Currently artemis doesn't handle it properly. It should catch such
errors and disconnect the underlying connection, logging a proper
warning message