### PR TITLE
try to release if message is ReferenceCounted

### DIFF
--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTProtocolHandler.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTProtocolHandler.java
@@ -39,6 +39,7 @@ import io.netty.handler.codec.mqtt.MqttSubAckPayload;
 import io.netty.handler.codec.mqtt.MqttSubscribeMessage;
 import io.netty.handler.codec.mqtt.MqttUnsubAckMessage;
 import io.netty.handler.codec.mqtt.MqttUnsubscribeMessage;
+import io.netty.util.ReferenceCountUtil;
 import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
@@ -155,6 +156,8 @@ public class MQTTProtocolHandler extends ChannelInboundHandlerAdapter {
       } catch (Exception e) {
          log.debug("Error processing Control Packet, Disconnecting Client", e);
          disconnect(true);
+      } finally {
+          ReferenceCountUtil.release(msg);
       }
    }
 


### PR DESCRIPTION
Fix memory leak in MQTTProtocolHandler
Based on Netty User guide for 4.x