### PR TITLE
ARTEMIS-1247 - Allow to enable replicated journal (not only at compilation time)

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/replication/ReplicatedJournal.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/replication/ReplicatedJournal.java
@@ -44,7 +44,12 @@ import org.apache.activemq.artemis.core.replication.ReplicationManager.ADD_OPERA
  */
 public class ReplicatedJournal implements Journal {
 
-   private static final boolean trace = false;
+   private static final boolean trace = isTraceEnabled(false);
+
+   private static boolean isTraceEnabled(boolean defaultValue) {
+	   String traceEnabled = System.getProperty("artemis.trace.enabled");
+	   return (! "".equals(traceEnabled)) ? Boolean.valueOf(traceEnabled) : defaultValue;
+   }
 
    private static void trace(final String message) {
       System.out.println("ReplicatedJournal::" + message);


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/ARTEMIS-1247
Upstream Issue (Widfly): https://issues.jboss.org/browse/WFLY-8983
Upstream Issue (EAP): https://issues.jboss.org/browse/JBEAP-11622

I've added a system property 'artemis.trace.enabled' that can be pass to 'turn on' the replicated journal. It seems to me the easiest and simple way of implement this, however feel free to disagree :) and point me to a better approach !