### PR TITLE
ARTEMIS-1250 ClusteredMessageCounterTest.testNonDurableMessageAddedWithPaging fails

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/ClusteredMessageCounterTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/ClusteredMessageCounterTest.java
@@ -127,10 +127,12 @@ public class ClusteredMessageCounterTest extends ClusterTestBase {
 
          addConsumer(1, 1, "queue0", null);
 
+         waitForBindings(0, "queues", 1, 1, false);
+
          System.out.println("sending.....");
          send(0, "queues", numMsg, durable, null);
 
-         verifyReceiveAllOnSingleConsumer(true, numMsg, 1);
+         verifyReceiveAllOnSingleConsumer(true, 0, numMsg, 1);
 
          QueueControl control = (QueueControl) servers[1].getManagementService().getResource(ResourceNames.CORE_QUEUE + "queue0");
 


### PR DESCRIPTION
Before sending of messages to server 0 begins, the test
should wait until consumer is registered at RemoteQueueBindingImpl
on server 0. Otherwise some messages may not be rebalanced
to server 1.

(cherry picked from commit c5a25d33226aa261204e0a2779b0e87bfdcf1395)