### PR TITLE
ARTEMIS-1246 AMQ119019: Queue already exists

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/ServerSessionPacketHandler.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/ServerSessionPacketHandler.java
@@ -18,7 +18,6 @@ package org.apache.activemq.artemis.core.protocol.core;
 
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
-import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
@@ -325,18 +324,21 @@ public class ServerSessionPacketHandler implements ChannelHandler {
                case SESS_BINDINGQUERY: {
                   requiresResponse = true;
                   SessionBindingQueryMessage request = (SessionBindingQueryMessage) packet;
-                  BindingQueryResult result = session.executeBindingQuery(request.getAddress(remotingConnection.getClientVersion()));
+                  final int clientVersion = remotingConnection.getClientVersion();
+                  BindingQueryResult result = session.executeBindingQuery(request.getAddress(clientVersion));
 
                   /* if the session is JMS and it's from an older client then we need to add the old prefix to the queue
                    * names otherwise the older client won't realize the queue exists and will try to create it and receive
                    * an error
                    */
-                  if (session.getMetaData(ClientSession.JMS_SESSION_IDENTIFIER_PROPERTY) != null && remotingConnection.getClientVersion() < PacketImpl.ADDRESSING_CHANGE_VERSION) {
-                     List<SimpleString> queueNames = new ArrayList<>();
-                     for (SimpleString queueName : result.getQueueNames()) {
-                        queueNames.add(PacketImpl.OLD_QUEUE_PREFIX.concat(queueName));
+                  if (clientVersion < PacketImpl.ADDRESSING_CHANGE_VERSION && session.getMetaData(ClientSession.JMS_SESSION_IDENTIFIER_PROPERTY) != null) {
+                     final List<SimpleString> queueNames = result.getQueueNames();
+                     if (!queueNames.isEmpty()) {
+                        final List<SimpleString> convertedQueueNames = request.convertQueueNames(clientVersion, queueNames);
+                        if (convertedQueueNames != queueNames) {
+                           result = new BindingQueryResult(result.isExists(), convertedQueueNames, result.isAutoCreateQueues(), result.isAutoCreateAddresses(), result.isDefaultPurgeOnNoConsumers(), result.getDefaultMaxConsumers());
+                        }
                      }
-                     result = new BindingQueryResult(result.isExists(), queueNames, result.isAutoCreateQueues(), result.isAutoCreateAddresses(), result.isDefaultPurgeOnNoConsumers(), result.getDefaultMaxConsumers());
                   }
 
                   if (channel.supports(PacketImpl.SESS_BINDINGQUERY_RESP_V4)) {


### PR DESCRIPTION
It fixes compatibility issues with JMS Core clients using the old address model, allowing the client to query JMS temporary queues too.