### PR TITLE
ARTEMIS-1252 Add service loading of password codec to obtain its implementation from the app's root context

### DIFF
--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/PasswordMaskingUtilTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/PasswordMaskingUtilTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class PasswordMaskingUtilTest {
+
+   @Test
+   public void testGetCodecUsingServiceLoader() throws Exception {
+      SensitiveDataCodec<String> codec = PasswordMaskingUtil.getCodec(PasswordMaskingUtil.getDefaultCodec().getClass().getCanonicalName());
+      assertTrue(codec instanceof DefaultSensitiveStringCodec);
+   }
+
+   @Test(expected = IllegalArgumentException.class)
+   public void testGetCodecUsingInvalidCodec() throws Exception {
+      PasswordMaskingUtil.getCodec("codec doesn't exist");
+   }
+}

--- a/artemis-commons/src/test/resources/META-INF/services/org.apache.activemq.artemis.utils.SensitiveDataCodec
+++ b/artemis-commons/src/test/resources/META-INF/services/org.apache.activemq.artemis.utils.SensitiveDataCodec
@@ -1,0 +1,1 @@
+org.apache.activemq.artemis.utils.DefaultSensitiveStringCodec

--- a/docs/user-manual/en/configuration-index.md
+++ b/docs/user-manual/en/configuration-index.md
@@ -464,11 +464,12 @@ If you don't want to use the jar-with-dependencies, make sure the classpath is c
 
 Just copy "80cf731af62c290" and replace your plaintext password with it.
 
-#### Using a different decoder
+#### Using a custom decoder
 
-It is possible to use a different decoder rather than the built-in one.
-Simply make sure the decoder is in Apache ActiveMQ Artemis's classpath and configure
-the server to use it as follows:
+It is possible to use a custom decoder rather than the built-in one.
+Simply make sure the decoder is in Apache ActiveMQ Artemis's classpath. The custom decoder
+can also be service loaded rather than class loaded, if the decoder's service provider is installed in the classpath.
+Then configure the server to use it as follows:
 
 ```xml
     <password-codec>com.foo.SomeDecoder;key1=value1;key2=value2</password-codec>


### PR DESCRIPTION
Adds service loading to obtain implementation of password codec. If no service is found, the fallback is to use a class loader like before.

Refer to here for more information: https://issues.apache.org/jira/browse/ARTEMIS-1252