### PR TITLE
ARTEMIS-1256 PagingOMETest.testPageCleanup fails

### DIFF
--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/PagingOMETest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/PagingOMETest.java
@@ -145,6 +145,9 @@ public class PagingOMETest extends ActiveMQTestBase {
 
       session.start();
 
+      queue.forceDelivery();
+      Assert.assertTrue("Queue could not flush executor.", queue.flushExecutor());
+
       assertEquals(numberOfMessages, queue.getMessageCount());
 
       // The consumer has to be created after the queue.getMessageCount assertion


### PR DESCRIPTION
Queue.getMessageCount does not guarantee you get accurate number
of messages on the queue. To get precise number, the test must
wait until all asynchronous tasks on the queue are finished.