### PR TITLE
ARTEMIS-1269 Fixing blocked replication

### DIFF
--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/FileWrapperJournal.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/FileWrapperJournal.java
@@ -96,7 +96,7 @@ public final class FileWrapperJournal extends JournalBase {
                                IOCompletion callback) throws Exception {
       JournalInternalRecord addRecord = new JournalAddRecord(true, id, recordType, persister, record);
 
-      writeRecord(addRecord, sync, callback);
+      writeRecord(addRecord, false, -1, false, callback);
    }
 
    @Override
@@ -107,7 +107,9 @@ public final class FileWrapperJournal extends JournalBase {
     * Write the record to the current file.
     */
    private void writeRecord(JournalInternalRecord encoder,
-                            final boolean sync,
+                            final boolean tx,
+                            final long txID,
+                            final boolean removeTX,
                             final IOCompletion callback) throws Exception {
 
       lockAppend.lock();
@@ -115,30 +117,54 @@ public final class FileWrapperJournal extends JournalBase {
          if (callback != null) {
             callback.storeLineUp();
          }
-         currentFile = journal.switchFileIfNecessary(encoder.getEncodeSize());
+         testSwitchFiles(encoder);
+         if (txID >= 0) {
+            if (tx) {
+               AtomicInteger value;
+               if (removeTX) {
+                  value = transactions.remove(txID);
+               } else {
+                  value = transactions.get(txID);
+               }
+               if (value != null) {
+                  encoder.setNumberOfRecords(value.get());
+               }
+            } else {
+               count(txID);
+            }
+         }
          encoder.setFileID(currentFile.getRecordID());
 
          if (callback != null) {
-            currentFile.getFile().write(encoder, sync, callback);
+            currentFile.getFile().write(encoder, false, callback);
          } else {
-            currentFile.getFile().write(encoder, sync);
+            currentFile.getFile().write(encoder, false);
          }
       } finally {
          lockAppend.unlock();
       }
    }
 
+   private void testSwitchFiles(JournalInternalRecord encoder) throws Exception {
+      JournalFile oldFile = currentFile;
+      currentFile = journal.switchFileIfNecessary(encoder.getEncodeSize());
+      if (oldFile != currentFile) {
+         for (AtomicInteger value : transactions.values()) {
+            value.set(0);
+         }
+      }
+   }
+
    @Override
    public void appendDeleteRecord(long id, boolean sync, IOCompletion callback) throws Exception {
       JournalInternalRecord deleteRecord = new JournalDeleteRecord(id);
-      writeRecord(deleteRecord, sync, callback);
+      writeRecord(deleteRecord, false, -1, false, callback);
    }
 
    @Override
    public void appendDeleteRecordTransactional(long txID, long id, EncodingSupport record) throws Exception {
-      count(txID);
       JournalInternalRecord deleteRecordTX = new JournalDeleteRecordTX(txID, id, record);
-      writeRecord(deleteRecordTX, false, null);
+      writeRecord(deleteRecordTX, false, txID, false, null);
    }
 
    @Override
@@ -147,9 +173,8 @@ public final class FileWrapperJournal extends JournalBase {
                                             byte recordType,
                                             Persister persister,
                                             Object record) throws Exception {
-      count(txID);
       JournalInternalRecord addRecord = new JournalAddRecordTX(true, txID, id, recordType, persister, record);
-      writeRecord(addRecord, false, null);
+      writeRecord(addRecord, false, txID, false, null);
    }
 
    @Override
@@ -160,7 +185,7 @@ public final class FileWrapperJournal extends JournalBase {
                                   boolean sync,
                                   IOCompletion callback) throws Exception {
       JournalInternalRecord updateRecord = new JournalAddRecord(false, id, recordType, persister, record);
-      writeRecord(updateRecord, sync, callback);
+      writeRecord(updateRecord, false, -1, false, callback);
    }
 
    @Override
@@ -169,9 +194,8 @@ public final class FileWrapperJournal extends JournalBase {
                                                byte recordType,
                                                Persister persister,
                                                Object record) throws Exception {
-      count(txID);
       JournalInternalRecord updateRecordTX = new JournalAddRecordTX(false, txID, id, recordType, persister, record);
-      writeRecord(updateRecordTX, false, null);
+      writeRecord(updateRecordTX, false, txID, false, null);
    }
 
    @Override
@@ -180,12 +204,8 @@ public final class FileWrapperJournal extends JournalBase {
                                   IOCompletion callback,
                                   boolean lineUpContext) throws Exception {
       JournalInternalRecord commitRecord = new JournalCompleteRecordTX(TX_RECORD_TYPE.COMMIT, txID, null);
-      AtomicInteger value = transactions.remove(txID);
-      if (value != null) {
-         commitRecord.setNumberOfRecords(value.get());
-      }
 
-      writeRecord(commitRecord, true, callback);
+      writeRecord(commitRecord, true, txID, true, callback);
    }
 
    @Override
@@ -194,20 +214,18 @@ public final class FileWrapperJournal extends JournalBase {
                                    boolean sync,
                                    IOCompletion callback) throws Exception {
       JournalInternalRecord prepareRecord = new JournalCompleteRecordTX(TX_RECORD_TYPE.PREPARE, txID, transactionData);
-      AtomicInteger value = transactions.get(txID);
-      if (value != null) {
-         prepareRecord.setNumberOfRecords(value.get());
-      }
-      writeRecord(prepareRecord, sync, callback);
+      writeRecord(prepareRecord, true, txID, false, callback);
    }
 
    private int count(long txID) throws ActiveMQException {
       AtomicInteger defaultValue = new AtomicInteger(1);
       AtomicInteger count = transactions.putIfAbsent(txID, defaultValue);
       if (count != null) {
-         return count.incrementAndGet();
+         count.incrementAndGet();
+      } else {
+         count = defaultValue;
       }
-      return defaultValue.get();
+      return count.intValue();
    }
 
    @Override
@@ -218,11 +236,7 @@ public final class FileWrapperJournal extends JournalBase {
    @Override
    public void appendRollbackRecord(long txID, boolean sync, IOCompletion callback) throws Exception {
       JournalInternalRecord rollbackRecord = new JournalRollbackRecordTX(txID);
-      AtomicInteger value = transactions.remove(txID);
-      if (value != null) {
-         rollbackRecord.setNumberOfRecords(value.get());
-      }
-      writeRecord(rollbackRecord, sync, callback);
+      writeRecord(rollbackRecord, true, txID, true, callback);
    }
 
    // UNSUPPORTED STUFF

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ActiveMQPacketHandler.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ActiveMQPacketHandler.java
@@ -169,7 +169,7 @@ public class ActiveMQPacketHandler implements ChannelHandler {
 
          ServerSession session = server.createSession(request.getName(), activeMQPrincipal == null ? request.getUsername() : activeMQPrincipal.getUserName(), activeMQPrincipal == null ? request.getPassword() : activeMQPrincipal.getPassword(), request.getMinLargeMessageSize(), connection, request.isAutoCommitSends(), request.isAutoCommitAcks(), request.isPreAcknowledge(), request.isXA(), request.getDefaultAddress(), new CoreSessionCallback(request.getName(), protocolManager, channel, connection), true, sessionOperationContext, routingTypeMap);
 
-         ServerSessionPacketHandler handler = new ServerSessionPacketHandler(protocolManager, session, server.getStorageManager(), channel);
+         ServerSessionPacketHandler handler = new ServerSessionPacketHandler(server.getExecutorFactory().getExecutor(), protocolManager, session, server.getStorageManager(), channel);
          channel.setHandler(handler);
 
          // TODO - where is this removed?

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ClusterController.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ClusterController.java
@@ -326,6 +326,9 @@ public class ClusterController implements ActiveMQComponent {
       @Override
       public void handlePacket(Packet packet) {
          if (!isStarted()) {
+            if (channelHandler != null) {
+               channelHandler.handlePacket(packet);
+            }
             return;
          }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -1750,7 +1750,9 @@ public class ActiveMQServerImpl implements ActiveMQServer {
 
       queue.deleteQueue(removeConsumers);
 
-      if (autoDeleteAddress && postOffice != null && getAddressInfo(address).isAutoCreated()) {
+      AddressInfo addressInfo = getAddressInfo(address);
+
+      if (autoDeleteAddress && postOffice != null && addressInfo != null && addressInfo.isAutoCreated()) {
          try {
             removeAddressInfo(address, session);
          } catch (ActiveMQDeleteAddressException e) {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/ExpireWhileLoadBalanceTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/ExpireWhileLoadBalanceTest.java
@@ -76,7 +76,7 @@ public class ExpireWhileLoadBalanceTest extends ClusterTestBase {
       for (int i = 0; i <= 2; i++) {
          createQueue(i, "queues.testaddress", "queue0", null, true);
          getServer(i).createQueue(expiryQueue, RoutingType.ANYCAST, expiryQueue, null, true, false);
-         getServer(i).getAddressSettingsRepository().addMatch("queues.*", as);
+         getServer(i).getAddressSettingsRepository().addMatch("#", as);
 
       }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailoverTest.java
@@ -370,7 +370,7 @@ public class FailoverTest extends FailoverTestBase {
       }
       session.end(xid, XAResource.TMSUCCESS);
       session.prepare(xid);
-      crash(false, session);
+      crash(true, session);
 
       try {
          session.commit(xid, false);
@@ -417,7 +417,7 @@ public class FailoverTest extends FailoverTestBase {
 
       session.end(xid, XAResource.TMSUCCESS);
       session.prepare(xid);
-      crash(false, session);
+      crash(true, session);
 
       try {
          session.rollback(xid);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/MultiThreadRandomReattachTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/MultiThreadRandomReattachTest.java
@@ -16,8 +16,10 @@
  */
 package org.apache.activemq.artemis.tests.integration.cluster.reattach;
 
+import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.config.CoreAddressConfiguration;
 
 /**
  * A MultiThreadRandomReattachTest
@@ -28,6 +30,7 @@ public class MultiThreadRandomReattachTest extends MultiThreadRandomReattachTest
    protected void start() throws Exception {
       Configuration liveConf = createDefaultInVMConfig();
       server = createServer(false, liveConf);
+      server.getConfiguration().getAddressConfigurations().add(new CoreAddressConfiguration().setName(ADDRESS.toString()).addRoutingType(RoutingType.MULTICAST));
       server.start();
       waitForServerToStart(server);
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/NettyMultiThreadRandomReattachTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/NettyMultiThreadRandomReattachTest.java
@@ -16,8 +16,10 @@
  */
 package org.apache.activemq.artemis.tests.integration.cluster.reattach;
 
+import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.config.CoreAddressConfiguration;
 
 public class NettyMultiThreadRandomReattachTest extends MultiThreadRandomReattachTest {
 
@@ -25,6 +27,7 @@ public class NettyMultiThreadRandomReattachTest extends MultiThreadRandomReattac
    protected void start() throws Exception {
       Configuration liveConf = createDefaultNettyConfig();
       server = createServer(false, liveConf);
+      server.getConfiguration().getAddressConfigurations().add(new CoreAddressConfiguration().setName(ADDRESS.toString()).addRoutingType(RoutingType.MULTICAST));
       server.start();
       waitForServerToStart(server);
    }

--- a/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/replicationflow/ReplicationFlowControlTest.java
+++ b/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/replicationflow/ReplicationFlowControlTest.java
@@ -49,9 +49,9 @@ public class ReplicationFlowControlTest extends SmokeTestBase {
 
    private static Process server1;
 
-   static final int NUM_MESSAGES = 300_000;
-   static final int START_CONSUMERS = 100_000;
-   static final int START_SERVER = 101_000;
+   static final int NUM_MESSAGES = 50_000;
+   static final int START_CONSUMERS = 10_000;
+   static final int START_SERVER = 15_000;
    static final int NUMBER_OF_CONSUMERS = 10;
    static final ReusableLatch latch = new ReusableLatch(NUM_MESSAGES);
 
@@ -88,7 +88,7 @@ public class ReplicationFlowControlTest extends SmokeTestBase {
 
    private void internalTest(boolean failover) throws Exception {
 
-      int KILL_SERVER = failover ? 150_000 : -1;
+      int KILL_SERVER = failover ? 50_000 : -1;
 
       Connection connection = null;
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/JournalImplTestUnit.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/JournalImplTestUnit.java
@@ -597,10 +597,6 @@ public abstract class JournalImplTestUnit extends JournalImplTestBase {
       files1 = fileFactory.listFiles(fileExtension);
       Assert.assertTrue(files1.size() > 200);
 
-      Assert.assertEquals(numberOfFiles, files1.size());
-
-      System.out.println("we have " + files1.size() + " files now");
-
       stopJournal();
    }
 


### PR DESCRIPTION
If replication blocked anything on the journal
the processing from clients would be blocked
and nothing would work.

As part of this fix I am using an executor on ServerSessionPacketHandler
which will also scale better as the reader from Netty would be feed immediately.