### PR TITLE
ARTEMIS-1264 allow role mapping via chained login modules

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/CertificateUtil.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/CertificateUtil.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.core.remoting;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.handler.ssl.SslHandler;
+import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnection;
+import org.apache.activemq.artemis.spi.core.remoting.Connection;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.security.cert.X509Certificate;
+import java.security.Principal;
+
+public class CertificateUtil {
+
+   public static X509Certificate[] getCertsFromConnection(Connection connection) {
+      X509Certificate[] certificates = null;
+      if (connection instanceof NettyConnection) {
+         certificates = org.apache.activemq.artemis.utils.CertificateUtil.getCertsFromChannel(((NettyConnection) connection).getChannel());
+      }
+      return certificates;
+   }
+
+   public static Principal getPeerPrincipalFromConnection(Connection connection) {
+      Principal result = null;
+      if (connection instanceof NettyConnection) {
+         NettyConnection nettyConnection = (NettyConnection) connection;
+         ChannelHandler channelHandler = nettyConnection.getChannel().pipeline().get("ssl");
+         if (channelHandler != null && channelHandler instanceof SslHandler) {
+            SslHandler sslHandler = (SslHandler) channelHandler;
+            try {
+               result = sslHandler.engine().getSession().getPeerPrincipal();
+            } catch (SSLPeerUnverifiedException ignored) {
+            }
+         }
+      }
+
+      return result;
+   }
+}

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireProtocolManager.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireProtocolManager.java
@@ -17,7 +17,6 @@
 package org.apache.activemq.artemis.core.protocol.openwire;
 
 import javax.jms.InvalidClientIDException;
-import javax.security.cert.X509Certificate;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -44,7 +43,6 @@ import org.apache.activemq.artemis.api.core.client.TopologyMember;
 import org.apache.activemq.artemis.core.protocol.openwire.amq.AMQConnectionContext;
 import org.apache.activemq.artemis.core.protocol.openwire.amq.AMQProducerBrokerExchange;
 import org.apache.activemq.artemis.core.protocol.openwire.amq.AMQSession;
-import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnection;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyServerConnection;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
@@ -57,7 +55,6 @@ import org.apache.activemq.artemis.spi.core.protocol.ProtocolManagerFactory;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
 import org.apache.activemq.artemis.spi.core.remoting.Acceptor;
 import org.apache.activemq.artemis.spi.core.remoting.Connection;
-import org.apache.activemq.artemis.utils.CertificateUtil;
 import org.apache.activemq.artemis.utils.DataConstants;
 import org.apache.activemq.command.ActiveMQMessage;
 import org.apache.activemq.command.ActiveMQTopic;
@@ -462,12 +459,7 @@ public class OpenWireProtocolManager implements ProtocolManager<Interceptor>, Cl
    }
 
    public void validateUser(String login, String passcode, OpenWireConnection connection) throws Exception {
-      X509Certificate[] certificates = null;
-      if (connection.getTransportConnection() instanceof NettyConnection) {
-         certificates = CertificateUtil.getCertsFromChannel(((NettyConnection) connection.getTransportConnection()).getChannel());
-      }
-
-      server.getSecurityStore().authenticate(login, passcode, certificates);
+      server.getSecurityStore().authenticate(login, passcode, connection.getTransportConnection());
    }
 
    public void sendBrokerInfo(OpenWireConnection connection) throws Exception {

--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompConnection.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompConnection.java
@@ -16,7 +16,6 @@
  */
 package org.apache.activemq.artemis.core.protocol.stomp;
 
-import javax.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -561,8 +560,8 @@ public final class StompConnection implements RemotingConnection {
       manager.sendReply(this, frame);
    }
 
-   public boolean validateUser(final String login, final String pass, final X509Certificate[] certificates) {
-      this.valid = manager.validateUser(login, pass, certificates);
+   public boolean validateUser(final String login, final String pass, final Connection connection) {
+      this.valid = manager.validateUser(login, pass, connection);
       if (valid) {
          this.login = login;
          this.passcode = pass;

--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompProtocolManager.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompProtocolManager.java
@@ -16,7 +16,6 @@
  */
 package org.apache.activemq.artemis.core.protocol.stomp;
 
-import javax.security.cert.X509Certificate;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -36,6 +35,7 @@ import org.apache.activemq.artemis.core.io.IOCallback;
 import org.apache.activemq.artemis.core.message.impl.CoreMessage;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyServerConnection;
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
+import org.apache.activemq.artemis.core.remoting.CertificateUtil;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
 import org.apache.activemq.artemis.core.server.ServerSession;
@@ -320,16 +320,16 @@ public class StompProtocolManager extends AbstractProtocolManager<StompFrame, St
       return "activemq";
    }
 
-   public boolean validateUser(String login, String passcode, X509Certificate[] certificates) {
+   public boolean validateUser(String login, String passcode, Connection connection) {
       boolean validated = true;
 
       ActiveMQSecurityManager sm = server.getSecurityManager();
 
       if (sm != null && server.getConfiguration().isSecurityEnabled()) {
          if (sm instanceof ActiveMQSecurityManager3) {
-            validated = ((ActiveMQSecurityManager3) sm).validateUser(login, passcode, certificates) != null;
+            validated = ((ActiveMQSecurityManager3) sm).validateUser(login, passcode, connection) != null;
          } else if (sm instanceof ActiveMQSecurityManager2) {
-            validated = ((ActiveMQSecurityManager2) sm).validateUser(login, passcode, certificates);
+            validated = ((ActiveMQSecurityManager2) sm).validateUser(login, passcode, CertificateUtil.getCertsFromConnection(connection));
          } else {
             validated = sm.validateUser(login, passcode);
          }

--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/v10/StompFrameHandlerV10.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/v10/StompFrameHandlerV10.java
@@ -16,7 +16,6 @@
  */
 package org.apache.activemq.artemis.core.protocol.stomp.v10;
 
-import javax.security.cert.X509Certificate;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -28,9 +27,7 @@ import org.apache.activemq.artemis.core.protocol.stomp.StompDecoder;
 import org.apache.activemq.artemis.core.protocol.stomp.StompFrame;
 import org.apache.activemq.artemis.core.protocol.stomp.StompVersions;
 import org.apache.activemq.artemis.core.protocol.stomp.VersionedStompFrameHandler;
-import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnection;
 import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
-import org.apache.activemq.artemis.utils.CertificateUtil;
 import org.apache.activemq.artemis.utils.ExecutorFactory;
 
 import static org.apache.activemq.artemis.core.protocol.stomp.ActiveMQStompProtocolMessageBundle.BUNDLE;
@@ -55,12 +52,7 @@ public class StompFrameHandlerV10 extends VersionedStompFrameHandler implements 
       String clientID = headers.get(Stomp.Headers.Connect.CLIENT_ID);
       String requestID = headers.get(Stomp.Headers.Connect.REQUEST_ID);
 
-      X509Certificate[] certificates = null;
-      if (connection.getTransportConnection() instanceof NettyConnection) {
-         certificates = CertificateUtil.getCertsFromChannel(((NettyConnection) connection.getTransportConnection()).getChannel());
-      }
-
-      if (connection.validateUser(login, passcode, certificates)) {
+      if (connection.validateUser(login, passcode, connection.getTransportConnection())) {
          connection.setClientID(clientID);
          connection.setValid(true);
 

--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/v11/StompFrameHandlerV11.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/v11/StompFrameHandlerV11.java
@@ -16,7 +16,6 @@
  */
 package org.apache.activemq.artemis.core.protocol.stomp.v11;
 
-import javax.security.cert.X509Certificate;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
@@ -31,13 +30,11 @@ import org.apache.activemq.artemis.core.protocol.stomp.StompConnection;
 import org.apache.activemq.artemis.core.protocol.stomp.StompDecoder;
 import org.apache.activemq.artemis.core.protocol.stomp.StompFrame;
 import org.apache.activemq.artemis.core.protocol.stomp.VersionedStompFrameHandler;
-import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnection;
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.core.remoting.server.impl.RemotingServiceImpl;
 import org.apache.activemq.artemis.core.server.ActiveMQScheduledComponent;
 import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
 import org.apache.activemq.artemis.spi.core.protocol.ConnectionEntry;
-import org.apache.activemq.artemis.utils.CertificateUtil;
 import org.apache.activemq.artemis.utils.ExecutorFactory;
 
 import static org.apache.activemq.artemis.core.protocol.stomp.ActiveMQStompProtocolMessageBundle.BUNDLE;
@@ -70,13 +67,8 @@ public class StompFrameHandlerV11 extends VersionedStompFrameHandler implements 
       String clientID = headers.get(Stomp.Headers.Connect.CLIENT_ID);
       String requestID = headers.get(Stomp.Headers.Connect.REQUEST_ID);
 
-      X509Certificate[] certificates = null;
-      if (connection.getTransportConnection() instanceof NettyConnection) {
-         certificates = CertificateUtil.getCertsFromChannel(((NettyConnection) connection.getTransportConnection()).getChannel());
-      }
-
       try {
-         if (connection.validateUser(login, passcode, certificates)) {
+         if (connection.validateUser(login, passcode, connection.getTransportConnection())) {
             connection.setClientID(clientID);
             connection.setValid(true);
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -17,7 +17,6 @@
 package org.apache.activemq.artemis.core.server.impl;
 
 import javax.management.MBeanServer;
-import javax.security.cert.X509Certificate;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -98,7 +97,6 @@ import org.apache.activemq.artemis.core.postoffice.QueueBinding;
 import org.apache.activemq.artemis.core.postoffice.impl.DivertBinding;
 import org.apache.activemq.artemis.core.postoffice.impl.LocalQueueBinding;
 import org.apache.activemq.artemis.core.postoffice.impl.PostOfficeImpl;
-import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnection;
 import org.apache.activemq.artemis.core.remoting.server.RemotingService;
 import org.apache.activemq.artemis.core.remoting.server.impl.RemotingServiceImpl;
 import org.apache.activemq.artemis.core.replication.ReplicationEndpoint;
@@ -164,7 +162,6 @@ import org.apache.activemq.artemis.spi.core.protocol.SessionCallback;
 import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager;
 import org.apache.activemq.artemis.utils.ActiveMQThreadFactory;
 import org.apache.activemq.artemis.utils.ActiveMQThreadPoolExecutor;
-import org.apache.activemq.artemis.utils.CertificateUtil;
 import org.apache.activemq.artemis.utils.CompositeAddress;
 import org.apache.activemq.artemis.utils.ExecutorFactory;
 import org.apache.activemq.artemis.utils.OrderedExecutorFactory;
@@ -1308,11 +1305,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
       String validatedUser = "";
 
       if (securityStore != null) {
-         X509Certificate[] certificates = null;
-         if (connection.getTransportConnection() instanceof NettyConnection) {
-            certificates = CertificateUtil.getCertsFromChannel(((NettyConnection) connection.getTransportConnection()).getChannel());
-         }
-         validatedUser = securityStore.authenticate(username, password, certificates);
+         validatedUser = securityStore.authenticate(username, password, connection.getTransportConnection());
       }
 
       checkSessionLimit(validatedUser);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/ActiveMQSecurityManager3.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/ActiveMQSecurityManager3.java
@@ -16,12 +16,11 @@
  */
 package org.apache.activemq.artemis.spi.core.security;
 
-import javax.security.cert.X509Certificate;
 import java.util.Set;
 
 import org.apache.activemq.artemis.core.security.CheckType;
 import org.apache.activemq.artemis.core.security.Role;
-import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
+import org.apache.activemq.artemis.spi.core.remoting.Connection;
 
 /**
  * Used to validate whether a user is authorized to connect to the
@@ -43,7 +42,7 @@ public interface ActiveMQSecurityManager3 extends ActiveMQSecurityManager {
     * @param password the users password
     * @return the name of the validated user or null if the user isn't validated
     */
-   String validateUser(String user, String password, X509Certificate[] certificates);
+   String validateUser(String user, String password, Connection connection);
 
    /**
     * Determine whether the given user is valid and whether they have
@@ -65,5 +64,5 @@ public interface ActiveMQSecurityManager3 extends ActiveMQSecurityManager {
                               Set<Role> roles,
                               CheckType checkType,
                               String address,
-                              RemotingConnection connection);
+                              Connection connection);
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/jaas/Krb5SslCallback.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/jaas/Krb5SslCallback.java
@@ -14,18 +14,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.core.security;
+package org.apache.activemq.artemis.spi.core.security.jaas;
 
-import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.spi.core.remoting.Connection;
+import javax.security.auth.callback.Callback;
+import java.security.Principal;
 
-public interface SecurityStore {
+/**
+ * A Callback for SSL kerberos peer principal.
+ */
+public class Krb5SslCallback implements Callback {
 
-   String authenticate(String user, String password, Connection transportConnection) throws Exception;
+   Principal peerPrincipal;
 
-   void check(SimpleString address, CheckType checkType, SecurityAuth session) throws Exception;
+   /**
+    * Setter for peer Principal.
+    *
+    * @param principal The certificates to be returned.
+    */
+   public void setPeerPrincipal(Principal principal) {
+      peerPrincipal = principal;
+   }
 
-   boolean isSecurityEnabled();
-
-   void stop();
+   /**
+    * Getter for peer Principal.
+    *
+    * @return The principal being carried.
+    */
+   public Principal getPeerPrincipal() {
+      return peerPrincipal;
+   }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/jaas/Krb5SslLoginModule.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/jaas/Krb5SslLoginModule.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.spi.core.security.jaas;
+
+import org.jboss.logging.Logger;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.spi.LoginModule;
+import java.io.IOException;
+import java.security.Principal;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * populate a subject with kerberos and UserPrincipal from SSLContext peerPrincipal
+ */
+public class Krb5SslLoginModule implements LoginModule {
+
+   private static final Logger logger = Logger.getLogger(Krb5SslLoginModule.class);
+
+   private Subject subject;
+   private final List<Principal> principals = new LinkedList<>();
+   private CallbackHandler callbackHandler;
+   private boolean loginSucceeded;
+
+   @Override
+   public void initialize(Subject subject,
+                          CallbackHandler callbackHandler,
+                          Map<String, ?> sharedState,
+                          Map<String, ?> options) {
+      this.subject = subject;
+      this.callbackHandler = callbackHandler;
+   }
+
+   @Override
+   public boolean login() throws LoginException {
+      Callback[] callbacks = new Callback[1];
+
+      callbacks[0] = new Krb5SslCallback();
+      try {
+         callbackHandler.handle(callbacks);
+      } catch (IOException ioe) {
+         throw new LoginException(ioe.getMessage());
+      } catch (UnsupportedCallbackException uce) {
+         throw new LoginException(uce.getMessage() + " not available to obtain information from user");
+      }
+      principals.add(((Krb5SslCallback)callbacks[0]).getPeerPrincipal());
+      if (!principals.isEmpty()) {
+         loginSucceeded = true;
+      }
+      logger.debug("login " + principals);
+      return loginSucceeded;
+   }
+
+   @Override
+   public boolean commit() throws LoginException {
+      boolean result = loginSucceeded;
+      if (result) {
+         principals.add(new UserPrincipal(principals.get(0).getName()));
+         subject.getPrincipals().addAll(principals);
+      }
+
+      clear();
+
+      logger.debug("commit, result: " + result);
+
+      return result;
+   }
+
+   @Override
+   public boolean abort() throws LoginException {
+      clear();
+
+      logger.debug("abort");
+
+      return true;
+   }
+
+   private void clear() {
+      loginSucceeded = false;
+   }
+
+   @Override
+   public boolean logout() throws LoginException {
+      subject.getPrincipals().removeAll(principals);
+      principals.clear();
+      clear();
+
+      logger.debug("logout");
+
+      return true;
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/jaas/PropertiesLoginModule.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/jaas/PropertiesLoginModule.java
@@ -114,18 +114,24 @@ public class PropertiesLoginModule extends PropertiesLoader implements LoginModu
    @Override
    public boolean commit() throws LoginException {
       boolean result = loginSucceeded;
+      Set<UserPrincipal> authenticatedUsers = subject.getPrincipals(UserPrincipal.class);
       if (result) {
-         principals.add(new UserPrincipal(user));
+         UserPrincipal userPrincipal = new UserPrincipal(user);
+         principals.add(userPrincipal);
+         authenticatedUsers.add(userPrincipal);
+      }
 
-         Set<String> matchedRoles = roles.get(user);
+      // populate roles for UserPrincipal from other login modules too
+      for (UserPrincipal userPrincipal : authenticatedUsers) {
+         Set<String> matchedRoles = roles.get(userPrincipal.getName());
          if (matchedRoles != null) {
             for (String entry : matchedRoles) {
                principals.add(new RolePrincipal(entry));
             }
          }
-
-         subject.getPrincipals().addAll(principals);
       }
+
+      subject.getPrincipals().addAll(principals);
 
       // will whack loginSucceeded
       clear();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/security/SecurityTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/security/SecurityTest.java
@@ -54,6 +54,7 @@ import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl;
 import org.apache.activemq.artemis.core.server.impl.AddressInfo;
 import org.apache.activemq.artemis.core.settings.HierarchicalRepository;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
+import org.apache.activemq.artemis.spi.core.remoting.Connection;
 import org.apache.activemq.artemis.spi.core.security.ActiveMQJAASSecurityManager;
 import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager;
 import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager2;
@@ -1935,7 +1936,7 @@ public class SecurityTest extends ActiveMQTestBase {
          @Override
          public String validateUser(final String username,
                                     final String password,
-                                    final X509Certificate[] certificates) {
+                                    final Connection connection) {
             if ((username.equals("foo") || username.equals("bar") || username.equals("all")) && password.equals("frobnicate")) {
                return username;
             } else {
@@ -1959,9 +1960,9 @@ public class SecurityTest extends ActiveMQTestBase {
                                            final Set<Role> requiredRoles,
                                            final CheckType checkType,
                                            final String address,
-                                           final RemotingConnection connection) {
+                                           final Connection connection) {
 
-            if (!(connection.getTransportConnection() instanceof InVMConnection)) {
+            if (!(connection instanceof InVMConnection)) {
                return null;
             }
 

--- a/tests/integration-tests/src/test/resources/dual-authentication-roles.properties
+++ b/tests/integration-tests/src/test/resources/dual-authentication-roles.properties
@@ -16,3 +16,4 @@
 #
 
 consumers=consumer
+ALLOW_ALL=client@EXAMPLE.COM

--- a/tests/integration-tests/src/test/resources/login.config
+++ b/tests/integration-tests/src/test/resources/login.config
@@ -137,3 +137,14 @@ DualAuthenticationPropertiesLogin {
         org.apache.activemq.jaas.properties.user="dual-authentication-users.properties"
         org.apache.activemq.jaas.properties.role="dual-authentication-roles.properties";
 };
+
+Krb5SslPlus {
+
+    org.apache.activemq.artemis.spi.core.security.jaas.Krb5SslLoginModule optional
+        debug=true;
+
+    org.apache.activemq.artemis.spi.core.security.jaas.PropertiesLoginModule optional
+        debug=true
+        org.apache.activemq.jaas.properties.user="dual-authentication-users.properties"
+        org.apache.activemq.jaas.properties.role="dual-authentication-roles.properties";
+};


### PR DESCRIPTION
Add krb5sslloginmodule that will populate userPrincipal that can be mapped to roles independently
Generalised callback handlers to take a connection and pull certs or peerprincipal based on
callback. This bubbled up into api change in securitystore and security manager