### PR TITLE
NO-JIRA Fix documentation for <broadcast-group> <connection-ref> ...

### DIFF
--- a/docs/user-manual/en/clusters.md
+++ b/docs/user-manual/en/clusters.md
@@ -148,7 +148,7 @@ group:
           <jgroups-file>test-jgroups-file_ping.xml</jgroups-file>
           <jgroups-channel>activemq_broadcast_channel</jgroups-channel>
           <broadcast-period>2000</broadcast-period>
-        <connector-ref connector-name="netty-connector"/>
+          <connector-ref>netty-connector</connector-ref>
        </broadcast-group>
     </broadcast-groups>
 

--- a/examples/features/standard/no-consumer-buffering/readme.html
+++ b/examples/features/standard/no-consumer-buffering/readme.html
@@ -53,7 +53,7 @@ under the License.
      <pre class="prettyprint">
      <code>
    &lt;connection-factory name="ConnectionFactory"&gt;
-      &lt;connector-ref connector-name="netty-connector"/&gt;
+      &lt;connector-ref&gt;netty-connector&lt;/connector-ref&gt;
       &lt;entries&gt;
          &lt;entry name="ConnectionFactory"/&gt;
       &lt;/entries&gt;

--- a/examples/features/standard/producer-rate-limit/readme.html
+++ b/examples/features/standard/producer-rate-limit/readme.html
@@ -40,7 +40,7 @@ under the License.
      <pre class="prettyprint">
      <code>
    &lt;connection-factory name="ConnectionFactory"&gt;
-      &lt;connector-ref connector-name="netty-connector"/&gt;
+      &lt;connector-ref&gt;netty-connector&lt;/connector-ref&gt;
       &lt;entries&gt;
          &lt;entry name="ConnectionFactory"/&gt;
       &lt;/entries&gt;


### PR DESCRIPTION
Followup to #553, eliminate all occurrences of the old connector-ref
 config (that used to use connector-name attribute) in broker.xml.

~~CC @zhabba Can you have a look please? I hope I eliminated it all... at least grep -R says so.~~ edit: I guess that won't be necessary, lets trust grep.