### PR TITLE
NO-JIRA use random available port in WebServerComponentTest

### DIFF
--- a/artemis-web/src/main/java/org/apache/activemq/artemis/component/WebServerComponent.java
+++ b/artemis-web/src/main/java/org/apache/activemq/artemis/component/WebServerComponent.java
@@ -56,6 +56,7 @@ public class WebServerComponent implements ExternalComponent {
    private URI uri;
    private String jolokiaUrl;
    private List<WebAppContext> webContexts;
+   private ServerConnector connector;
 
    @Override
    public void configure(ComponentDTO config, String artemisInstance, String artemisHome) throws Exception {
@@ -63,7 +64,6 @@ public class WebServerComponent implements ExternalComponent {
       uri = new URI(webServerConfig.bind);
       server = new Server();
       String scheme = uri.getScheme();
-      ServerConnector connector = null;
 
       if ("https".equals(scheme)) {
          SslContextFactory sslFactory = new SslContextFactory();
@@ -170,6 +170,13 @@ public class WebServerComponent implements ExternalComponent {
    @Override
    public boolean isStarted() {
       return server != null && server.isStarted();
+   }
+
+   /**
+    * @return started server's port number; useful if it was specified as 0 (to use a random port)
+    */
+   public int getPort() {
+      return (connector != null) ? connector.getLocalPort() : -1;
    }
 
    private WebAppContext deployWar(String url, String warFile, Path warDirectory) throws IOException {

--- a/artemis-web/src/test/java/org/apache/activemq/cli/test/WebServerComponentTest.java
+++ b/artemis-web/src/test/java/org/apache/activemq/cli/test/WebServerComponentTest.java
@@ -78,13 +78,14 @@ public class WebServerComponentTest extends Assert {
    @Test
    public void simpleServer() throws Exception {
       WebServerDTO webServerDTO = new WebServerDTO();
-      webServerDTO.bind = "http://localhost:8161";
+      webServerDTO.bind = "http://localhost:0";
       webServerDTO.path = "webapps";
       WebServerComponent webServerComponent = new WebServerComponent();
       Assert.assertFalse(webServerComponent.isStarted());
       webServerComponent.configure(webServerDTO, "./src/test/resources/", "./src/test/resources/");
       testedComponents.add(webServerComponent);
       webServerComponent.start();
+      final int port = webServerComponent.getPort();
       // Make the connection attempt.
       CountDownLatch latch = new CountDownLatch(1);
       final ClientHandler clientHandler = new ClientHandler(latch);
@@ -95,7 +96,7 @@ public class WebServerComponentTest extends Assert {
             ch.pipeline().addLast(clientHandler);
          }
       });
-      Channel ch = bootstrap.connect("localhost", 8161).sync().channel();
+      Channel ch = bootstrap.connect("localhost", port).sync().channel();
 
       URI uri = new URI(URL);
       // Prepare the HTTP request.
@@ -116,12 +117,13 @@ public class WebServerComponentTest extends Assert {
    @Test
    public void testComponentStopBehavior() throws Exception {
       WebServerDTO webServerDTO = new WebServerDTO();
-      webServerDTO.bind = "http://localhost:8161";
+      webServerDTO.bind = "http://localhost:0";
       webServerDTO.path = "webapps";
       WebServerComponent webServerComponent = new WebServerComponent();
       Assert.assertFalse(webServerComponent.isStarted());
       webServerComponent.configure(webServerDTO, "./src/test/resources/", "./src/test/resources/");
       webServerComponent.start();
+      final int port = webServerComponent.getPort();
       // Make the connection attempt.
       CountDownLatch latch = new CountDownLatch(1);
       final ClientHandler clientHandler = new ClientHandler(latch);
@@ -132,7 +134,7 @@ public class WebServerComponentTest extends Assert {
             ch.pipeline().addLast(clientHandler);
          }
       });
-      Channel ch = bootstrap.connect("localhost", 8161).sync().channel();
+      Channel ch = bootstrap.connect("localhost", port).sync().channel();
 
       URI uri = new URI(URL);
       // Prepare the HTTP request.
@@ -158,7 +160,7 @@ public class WebServerComponentTest extends Assert {
    @Test
    public void simpleSecureServer() throws Exception {
       WebServerDTO webServerDTO = new WebServerDTO();
-      webServerDTO.bind = "https://localhost:8448";
+      webServerDTO.bind = "https://localhost:0";
       webServerDTO.path = "webapps";
       webServerDTO.keyStorePath = "./src/test/resources/server.keystore";
       webServerDTO.keyStorePassword = "password";
@@ -168,6 +170,7 @@ public class WebServerComponentTest extends Assert {
       webServerComponent.configure(webServerDTO, "./src/test/resources/", "./src/test/resources/");
       testedComponents.add(webServerComponent);
       webServerComponent.start();
+      final int port = webServerComponent.getPort();
       // Make the connection attempt.
       String keyStoreProvider = "JKS";
 
@@ -188,7 +191,7 @@ public class WebServerComponentTest extends Assert {
             ch.pipeline().addLast(clientHandler);
          }
       });
-      Channel ch = bootstrap.connect("localhost", 8448).sync().channel();
+      Channel ch = bootstrap.connect("localhost", port).sync().channel();
 
       URI uri = new URI(SECURE_URL);
       // Prepare the HTTP request.
@@ -209,7 +212,7 @@ public class WebServerComponentTest extends Assert {
    @Test
    public void simpleSecureServerWithClientAuth() throws Exception {
       WebServerDTO webServerDTO = new WebServerDTO();
-      webServerDTO.bind = "https://localhost:8448";
+      webServerDTO.bind = "https://localhost:0";
       webServerDTO.path = "webapps";
       webServerDTO.keyStorePath = "./src/test/resources/server.keystore";
       webServerDTO.keyStorePassword = "password";
@@ -222,6 +225,7 @@ public class WebServerComponentTest extends Assert {
       webServerComponent.configure(webServerDTO, "./src/test/resources/", "./src/test/resources/");
       testedComponents.add(webServerComponent);
       webServerComponent.start();
+      final int port = webServerComponent.getPort();
       // Make the connection attempt.
       String keyStoreProvider = "JKS";
 
@@ -242,7 +246,7 @@ public class WebServerComponentTest extends Assert {
             ch.pipeline().addLast(clientHandler);
          }
       });
-      Channel ch = bootstrap.connect("localhost", 8448).sync().channel();
+      Channel ch = bootstrap.connect("localhost", port).sync().channel();
 
       URI uri = new URI(SECURE_URL);
       // Prepare the HTTP request.


### PR DESCRIPTION
This should put a stop to the Apache Jenkins failing with

> Test Result (2 failures / + 2)
>     org.apache.activemq.cli.test.WebServerComponentTest.testComponentStopBehavior
>     org.apache.activemq.cli.test.WebServerComponentTest.simpleServer


 