### PR TITLE
ARTEMIS-1301 Network failures recognition on backpressure while streaming large messages

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/CoreRemotingConnection.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/CoreRemotingConnection.java
@@ -117,6 +117,7 @@ public interface CoreRemotingConnection extends RemotingConnection {
     * @param size size we are trying to write
     * @param timeout
     * @return
+    * @throws IllegalStateException if the connection is closed
     */
    boolean blockUntilWritable(int size, long timeout);
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/Connection.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/Connection.java
@@ -53,6 +53,7 @@ public interface Connection {
     * @param timeout          the maximum time to wait
     * @param timeUnit         the time unit of the timeout argument
     * @return {@code true} if the connection can enqueue {@code requiredCapacity} bytes, {@code false} otherwise
+    * @throws IllegalStateException if the connection is closed
     */
    default boolean blockUntilWritable(final int requiredCapacity, final long timeout, final TimeUnit timeUnit) {
       return true;

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/netty/NettyConnectionTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/netty/NettyConnectionTest.java
@@ -19,6 +19,7 @@ package org.apache.activemq.artemis.tests.unit.core.remoting.impl.netty;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -71,6 +72,16 @@ public class NettyConnectionTest extends ActiveMQTestBase {
       buff.writeByte((byte) 0x00); // Netty buffer does lazy initialization.
       Assert.assertEquals(size, buff.capacity());
 
+   }
+
+   @Test(expected = IllegalStateException.class)
+   public void throwsExceptionOnBlockUntilWritableIfClosed() {
+      EmbeddedChannel channel = createChannel();
+      NettyConnection conn = new NettyConnection(emptyMap, channel, new MyListener(), false, false);
+      conn.close();
+      //to make sure the channel is closed it needs to run the pending tasks
+      channel.runPendingTasks();
+      conn.blockUntilWritable(0, 0, TimeUnit.NANOSECONDS);
    }
 
    private static EmbeddedChannel createChannel() {


### PR DESCRIPTION
NettyConnection's flow control provides backpressure while streaming large messages without taking in account disconnection/network failures: it is needed to recognize connection failures and react to them.

The fix allows NettyConnection (and CoreRemotingConnection too) to recognize a network failure while being backpressured and to fail fast while streaming large messages.