### PR TITLE
ARTEMIS-1313 getAddresses in PostOfficeImpl does not correctly return…

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/SimpleAddressManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/SimpleAddressManager.java
@@ -169,7 +169,7 @@ public class SimpleAddressManager implements AddressManager {
    @Override
    public Set<SimpleString> getAddresses() {
       Set<SimpleString> addresses = new HashSet<>();
-      addresses.addAll(mappings.keySet());
+      addresses.addAll(addressInfoMap.keySet());
       return addresses;
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/RedeployTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/RedeployTest.java
@@ -136,6 +136,7 @@ public class RedeployTest extends ActiveMQTestBase {
 
       try {
          latch.await(10, TimeUnit.SECONDS);
+         Assert.assertNotNull(getAddressInfo(embeddedJMS, "config_test_address_removal_no_queue"));
          Assert.assertNotNull(getAddressInfo(embeddedJMS, "config_test_address_removal"));
          Assert.assertNotNull(getAddressInfo(embeddedJMS, "config_test_queue_removal"));
          Assert.assertTrue(listQueuesNamesForAddress(embeddedJMS, "config_test_queue_removal").contains("config_test_queue_removal_queue_1"));
@@ -153,6 +154,7 @@ public class RedeployTest extends ActiveMQTestBase {
          embeddedJMS.getActiveMQServer().getReloadManager().setTick(tick);
          latch.await(10, TimeUnit.SECONDS);
 
+         Assert.assertNull(getAddressInfo(embeddedJMS, "config_test_address_removal_no_queue"));
          Assert.assertNull(getAddressInfo(embeddedJMS, "config_test_address_removal"));
          Assert.assertNotNull(getAddressInfo(embeddedJMS, "config_test_queue_removal"));
          Assert.assertTrue(listQueuesNamesForAddress(embeddedJMS, "config_test_queue_removal").contains("config_test_queue_removal_queue_1"));

--- a/tests/integration-tests/src/test/resources/reload-address-queues.xml
+++ b/tests/integration-tests/src/test/resources/reload-address-queues.xml
@@ -127,6 +127,10 @@ under the License.
                <queue name="config_test_address_removal_queue"/>
             </multicast>
          </address>
+         <address name="config_test_address_removal_no_queue">
+            <multicast>
+            </multicast>
+         </address>
          <address name="permanent_test_queue_removal">
             <multicast>
                <queue name="permanent_test_queue_removal_queue_1"/>


### PR DESCRIPTION
… all addresses

Fix so that getAddresses uses addressInfoMap instead of the mappings so that addresses without queues also are returned