### PR TITLE
ARTEMIS-1315 Client disconnection may cause consumer to hang

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientConsumerInternal.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientConsumerInternal.java
@@ -68,4 +68,6 @@ public interface ClientConsumerInternal extends ClientConsumer {
    void start();
 
    ClientSession.QueueQuery getQueueInfo();
+
+   long getForceDeliveryCount();
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionImpl.java
@@ -1242,7 +1242,7 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
 
                      ClientConsumerInternal consumerInternal = entryx.getValue();
 
-                     sessionContext.recreateConsumerOnServer(consumerInternal);
+                     sessionContext.recreateConsumerOnServer(consumerInternal, entryx.getKey().getId(), started);
                   }
 
                   if ((!autoCommitAcks || !autoCommitSends) && workDone) {

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ActiveMQConsumerContext.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ActiveMQConsumerContext.java
@@ -26,6 +26,7 @@ public class ActiveMQConsumerContext extends ConsumerContext {
       this.id = id;
    }
 
+   @Override
    public long getId() {
       return id;
    }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/ConsumerContext.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/ConsumerContext.java
@@ -18,4 +18,5 @@ package org.apache.activemq.artemis.spi.core.remoting;
 
 public abstract class ConsumerContext {
 
+   public abstract long getId();
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/SessionContext.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/SessionContext.java
@@ -286,7 +286,7 @@ public abstract class SessionContext {
                                         boolean autoCommitAcks,
                                         boolean preAcknowledge) throws ActiveMQException;
 
-   public abstract void recreateConsumerOnServer(ClientConsumerInternal consumerInternal) throws ActiveMQException;
+   public abstract void recreateConsumerOnServer(ClientConsumerInternal consumerInternal, long consumerId, boolean isSessionStarted) throws ActiveMQException;
 
    public abstract void xaFailed(Xid xid) throws ActiveMQException;
 

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/DisconnectOnCriticalFailureTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/DisconnectOnCriticalFailureTest.java
@@ -18,7 +18,9 @@
 package org.apache.activemq.artemis.tests.extras.byteman;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.tests.util.JMSTestBase;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMRules;
@@ -30,6 +32,7 @@ import org.junit.runner.RunWith;
 import javax.jms.Connection;
 import javax.jms.ExceptionListener;
 import javax.jms.JMSException;
+import javax.jms.Message;
 import javax.jms.MessageConsumer;
 import javax.jms.MessageProducer;
 import javax.jms.Queue;
@@ -116,6 +119,64 @@ public class DisconnectOnCriticalFailureTest extends JMSTestBase {
          corruptPacket.set(true);
          MessageConsumer consumer = session.createConsumer(q1);
          consumer.receive(2000);
+
+         assertTrue(latch.await(5, TimeUnit.SECONDS));
+      } finally {
+         corruptPacket.set(false);
+
+         if (connection != null) {
+            connection.close();
+         }
+      }
+   }
+
+   @Test(timeout = 60000)
+   @BMRules(
+      rules = {@BMRule(
+         name = "Corrupt Decoding",
+         targetClass = "org.apache.activemq.artemis.core.protocol.ClientPacketDecoder",
+         targetMethod = "decode(org.apache.activemq.artemis.api.core.ActiveMQBuffer)",
+         targetLocation = "ENTRY",
+         action = "org.apache.activemq.artemis.tests.extras.byteman.DisconnectOnCriticalFailureTest.doThrow($1);")})
+   public void testClientDisconnectLarge() throws Exception {
+      Queue q1 = createQueue("queue1");
+      final Connection connection = nettyCf.createConnection();
+      final CountDownLatch latch = new CountDownLatch(1);
+      ServerLocator locator = ((ActiveMQConnectionFactory)nettyCf).getServerLocator();
+      int minSize = locator.getMinLargeMessageSize();
+      StringBuilder builder = new StringBuilder();
+      for (int i = 0; i < minSize; i++) {
+         builder.append("a");
+      }
+
+      try {
+         connection.setExceptionListener(new ExceptionListener() {
+            @Override
+            public void onException(JMSException e) {
+               latch.countDown();
+            }
+         });
+
+         Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+         MessageProducer producer = session.createProducer(q1);
+         TextMessage m = session.createTextMessage(builder.toString());
+         producer.send(m);
+         connection.start();
+
+         corruptPacket.set(true);
+         MessageConsumer consumer = session.createConsumer(q1);
+         Message lm = consumer.receive(2000);
+
+         //first receive won't crash because the packet
+         //is SESS_RECEIVE_LARGE_MSG
+         assertNotNull(lm);
+
+         //second receive will force server to send a
+         //"forced delivery" message, and will cause
+         //the exception to be thrown.
+         lm = consumer.receive(5000);
+         assertNull(lm);
 
          assertTrue(latch.await(5, TimeUnit.SECONDS));
       } finally {

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/client/impl/LargeMessageBufferTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/client/impl/LargeMessageBufferTest.java
@@ -786,6 +786,11 @@ public class LargeMessageBufferTest extends ActiveMQTestBase {
          return null;
       }
 
+      @Override
+      public long getForceDeliveryCount() {
+         return 0;
+      }
+
       /* (non-Javadoc)
        * @see org.apache.activemq.artemis.core.client.impl.ClientConsumerInternal#getNonXAsession()
        */


### PR DESCRIPTION
When calling a consumer to receive message with a timeout
(receive(long timeout), if the consumer's buffer is empty, it sends
a 'forced delivery' the waiting forever, expecting the server to
send back a 'forced delivery" message if the queue is empty.

If the connection is disconnected as the arrived 'forced
delivery' message is corrupted, this 'forced delivery' message
never gets to consumer. After the session is reconnected,
the consumer never knows that and stays waiting.

To fix that we can send a 'forced delivery' to server right
after the session is reconnected.