### PR TITLE
ARTEMIS-1312 TimedBuffer doubled timeout with blocking flush

### DIFF
--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/buffer/TimedBuffer.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/buffer/TimedBuffer.java
@@ -395,7 +395,7 @@ public final class TimedBuffer {
             }
             //it could wait until the timeout is expired
             final long timeFromTheLastFlush = System.nanoTime() - lastFlushTime;
-            final long timeToSleep = timeFromTheLastFlush - timeout;
+            final long timeToSleep = timeout - timeFromTheLastFlush;
             if (timeToSleep > 0) {
                sleepIfPossible(timeToSleep);
             }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/TimedBufferTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/TimedBufferTest.java
@@ -385,7 +385,7 @@ public class TimedBufferTest extends ActiveMQTestBase {
    @Test
    public void timeoutShouldMatchFlushIOPSWithNotBlockingFlush() {
       //use a large timeout in order to be reactive
-      final long timeout = TimeUnit.SECONDS.toNanos(2);
+      final long timeout = TimeUnit.MILLISECONDS.toNanos(100);
       assert ((int) timeout) > 0;
       //it is optimistic: the timeout and the blockingDeviceFlushTime are a perfect match
       final long deviceTime = timeout;
@@ -426,7 +426,7 @@ public class TimedBufferTest extends ActiveMQTestBase {
    @Test
    public void timeoutShouldMatchFlushIOPSWithBlockingFlush() {
       //use a large timeout in order to be reactive
-      final long timeout = TimeUnit.SECONDS.toNanos(2);
+      final long timeout = TimeUnit.MILLISECONDS.toNanos(100);
       assert ((int) timeout) > 0;
       //it is optimistic: the timeout and the blockingDeviceFlushTime are a perfect match
       final long deviceTime = timeout;


### PR DESCRIPTION
It fixes one of the TimedBuffer timing test using the correct math to perform the sleep on TimedBuffer