### PR TITLE
ARTEMIS-1318 Uses unbuffered MAPPED Journal if no data-sync is required

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalStorageManager.java
@@ -137,7 +137,11 @@ public class JournalStorageManager extends AbstractJournalStorageManager {
             break;
          case MAPPED:
             ActiveMQServerLogger.LOGGER.journalUseMAPPED();
-            journalFF = MappedSequentialFileFactory.buffered(config.getJournalLocation(), config.getJournalFileSize(), config.getJournalBufferSize_NIO(), config.getJournalBufferTimeout_NIO(), criticalErrorListener);
+            if (config.isJournalDatasync()) {
+               journalFF = MappedSequentialFileFactory.buffered(config.getJournalLocation(), config.getJournalFileSize(), config.getJournalBufferSize_NIO(), config.getJournalBufferTimeout_NIO(), criticalErrorListener);
+            } else {
+               journalFF = MappedSequentialFileFactory.unbuffered(config.getJournalLocation(), config.getJournalFileSize(), criticalErrorListener);
+            }
             break;
          default:
             throw ActiveMQMessageBundle.BUNDLE.invalidJournalType2(config.getJournalType());


### PR DESCRIPTION
In order to reduce memory footprint, CPU usage and reduce latencies it avoid to use the TimedBuffer on the MAPPED journal if no datasync is required.