### PR TITLE
ARTEMIS-1321 Remove final to allow this class to be proxied

### DIFF
--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRASession.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRASession.java
@@ -59,7 +59,7 @@ import org.apache.activemq.artemis.jms.client.ActiveMQSession;
 /**
  * A joint interface for JMS sessions
  */
-public final class ActiveMQRASession implements QueueSession, TopicSession, XAQueueSession, XATopicSession {
+public class ActiveMQRASession implements QueueSession, TopicSession, XAQueueSession, XATopicSession {
 
    /**
     * Trace enabled


### PR DESCRIPTION
I'm proposing this small change in order to allow Apache TomEE to proxy this class using its DynamicSubclass mechanism, thus allowing Apache TomEE to use Artemis as a JMS provider.