### PR TITLE
NO JIRA: Doc correction

### DIFF
--- a/docs/user-manual/en/client-reconnection.md
+++ b/docs/user-manual/en/client-reconnection.md
@@ -108,7 +108,7 @@ Client reconnection is configured using the following parameters:
 -   `reconnectAttempts`. This optional parameter determines the total
     number of reconnect attempts to make before giving up and shutting
     down. A value of `-1` signifies an unlimited number of attempts. The
-    default value is `0`.
+    default value is `-1`.
 
 If you're using JMS and you're using JNDI on the client to look up your
 JMS connection factory instances then you can specify these parameters


### PR DESCRIPTION
From here, it seems the default is -1 not 0 as originally stated in doc.
line 337
https://github.com/apache/activemq-artemis/blob/master/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java