### PR TITLE
ARTEMIS-1317 Expire messages that got expiredAck() from OpenWire client

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQConsumer.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQConsumer.java
@@ -298,8 +298,9 @@ public class AMQConsumer {
          }
       }
       if (ack.isExpiredAck()) {
-         //adjust delivering count for expired messages
-         this.serverConsumer.getQueue().decDelivering(ackList.size());
+         for (MessageReference ref : ackList) {
+            ref.getQueue().expire(ref);
+         }
       }
    }
 


### PR DESCRIPTION
This fixes org.apache.activemq.JmsSendReceiveWithMessageExpirationTest