### PR TITLE
NO-JIRA Updates to management.md doc [WIP]

### DIFF
--- a/docs/user-manual/en/intercepting-operations.md
+++ b/docs/user-manual/en/intercepting-operations.md
@@ -14,7 +14,7 @@ All interceptors are protocol specific.
 An interceptor for the core protocol must implement the interface `Interceptor`:
 
 ``` java
-package org.apache.artemis.activemq.api.core.interceptor;
+package org.apache.activemq.artemis.api.core.interceptor;
 
 public interface Interceptor
 {

--- a/examples/features/standard/message-group/readme.html
+++ b/examples/features/standard/message-group/readme.html
@@ -36,7 +36,7 @@ under the License.
      <li>Messages in a message group will be all delivered to no more than one of the queue's consumers. The consumer that receives the
      first message of a group will receive all the messages that belong to the group.</li>
 
-     <p>You can make any message belong to a message group by setting its 'JMXGroupID' string property to the group id.
+     <p>You can make any message belong to a message group by setting its 'JMSXGroupID' string property to the group id.
      In this example we create a message group 'Group-0'. And make such a message group of 10 messages. It also create two consumers on the queue
      where the 10 'Group-0' group messages are to be sent. You can see that with message grouping enabled, all the 10 messages will be received by
      the first consumer. The second consumer will receive none. </p>


### PR DESCRIPTION
(I am marking this as WIP because I would like to hear first if these are changes in right direction, and also would want to link (create) doc page for the web console at the same time.)

* add Jolokia to the initial list of ways to access management API
* remove mentions of core queues, etc. (pre-addressing change)
* activemq.notifications can be consumed with any client
* activemq.management can be accessed only with Core or Core JMS clients
* *.management.*Control are interfaces, not classes
* remove ObjectNames from the summary of management methods.
    IMO that made the short paragraphs hard to read.
    And one can intuitively find them in jconsole,
    or use the Builder class to construct them in code.
* move the note about empty filter to the queue management section
* add code snippet for creating ObjectName with ObjectNameBuilder
* mention web console and bin/artemis for interactive management
* fix few typos