### PR TITLE
ARTEMIS-1342: Support Netty Native KQueue on macOS

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/Env.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/Env.java
@@ -61,6 +61,7 @@ public final class Env {
 
    private static final String OS = System.getProperty("os.name").toLowerCase();
    private static final boolean IS_LINUX = OS.startsWith("linux");
+   private static final boolean IS_MAC = OS.startsWith("mac");
    private static final boolean IS_64BIT = checkIs64bit();
 
    private Env() {
@@ -85,6 +86,10 @@ public final class Env {
 
    public static boolean isLinuxOs() {
       return IS_LINUX == true;
+   }
+
+   public static boolean isMacOs() {
+      return IS_MAC == true;
    }
 
    public static boolean is64BitJvm() {

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/ActiveMQClientLogger.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/ActiveMQClientLogger.java
@@ -536,4 +536,9 @@ public interface ActiveMQClientLogger extends BasicLogger {
    @Message(id = 214033, value = "Cannot resolve host ",
            format = Message.Format.MESSAGE_FORMAT)
    void unableToResolveHost(@Cause UnknownHostException e);
+
+   @LogMessage(level = Logger.Level.WARN)
+   @Message(id = 214034, value = "Unable to check KQueue availability ",
+       format = Message.Format.MESSAGE_FORMAT)
+   void unableToCheckKQueueAvailability(@Cause Throwable e);
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/KQueue.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/KQueue.java
@@ -21,31 +21,31 @@ import org.apache.activemq.artemis.core.client.ActiveMQClientLogger;
 import org.apache.activemq.artemis.utils.Env;
 
 /**
- * Tells if <a href="http://netty.io/wiki/native-transports.html">{@code netty-transport-native-epoll}</a> is supported.
+ * Tells if <a href="http://netty.io/wiki/native-transports.html">{@code netty-transport-native-kqueue}</a> is supported.
  */
-public final class Epoll {
+public final class KQueue {
 
-   private static final boolean IS_EPOLL_AVAILABLE = isEpollAvailable();
+   private static final boolean IS_KQUEUE_AVAILABLE = isKQueueAvailable();
 
-   private static boolean isEpollAvailable() {
+   private static boolean isKQueueAvailable() {
       try {
-         if (Env.is64BitJvm() && Env.isLinuxOs()) {
-            return io.netty.channel.epoll.Epoll.isAvailable();
+         if (Env.is64BitJvm() && Env.isMacOs()) {
+            return io.netty.channel.kqueue.KQueue.isAvailable();
          } else {
             return false;
          }
       } catch (Throwable e) {
-         ActiveMQClientLogger.LOGGER.unableToCheckEpollAvailability(e);
+         ActiveMQClientLogger.LOGGER.unableToCheckKQueueAvailability(e);
          return false;
       }
 
    }
 
-   private Epoll() {
+   private KQueue() {
 
    }
 
    public static boolean isAvailable() {
-      return IS_EPOLL_AVAILABLE;
+      return IS_KQUEUE_AVAILABLE;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/TransportConstants.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/TransportConstants.java
@@ -53,6 +53,8 @@ public class TransportConstants {
 
    public static final String USE_EPOLL_PROP_NAME = "useEpoll";
 
+   public static final String USE_KQUEUE_PROP_NAME = "useKQueue";
+
    @Deprecated
    /**
     * @deprecated Use USE_GLOBAL_WORKER_POOL_PROP_NAME
@@ -157,6 +159,8 @@ public class TransportConstants {
 
    public static final boolean DEFAULT_USE_EPOLL = true;
 
+   public static final boolean DEFAULT_USE_KQUEUE = true;
+
    public static final boolean DEFAULT_USE_INVM = false;
 
    public static final boolean DEFAULT_USE_SERVLET = false;
@@ -255,6 +259,7 @@ public class TransportConstants {
       allowableAcceptorKeys.add(TransportConstants.HTTP_UPGRADE_ENABLED_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.USE_NIO_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.USE_EPOLL_PROP_NAME);
+      allowableAcceptorKeys.add(TransportConstants.USE_KQUEUE_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.USE_INVM_PROP_NAME);
       //noinspection deprecation
       allowableAcceptorKeys.add(TransportConstants.PROTOCOL_PROP_NAME);
@@ -309,6 +314,7 @@ public class TransportConstants {
       allowableConnectorKeys.add(TransportConstants.USE_NIO_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.USE_NIO_GLOBAL_WORKER_POOL_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.USE_EPOLL_PROP_NAME);
+      allowableConnectorKeys.add(TransportConstants.USE_KQUEUE_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.USE_GLOBAL_WORKER_POOL_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.HOST_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.PORT_PROP_NAME);

--- a/artemis-features/src/main/resources/features.xml
+++ b/artemis-features/src/main/resources/features.xml
@@ -36,6 +36,7 @@
 		<bundle>mvn:io.netty/netty-codec/${netty.version}</bundle>
 		<bundle>mvn:io.netty/netty-handler/${netty.version}</bundle>
 		<bundle>mvn:io.netty/netty-transport-native-epoll/${netty.version}</bundle>
+		<bundle>mvn:io.netty/netty-transport-native-kqueue/${netty.version}</bundle>
 		<bundle>mvn:io.netty/netty-transport-native-unix-common/${netty.version}</bundle>
 	</feature>
 

--- a/artemis-features/src/main/resources/features.xml
+++ b/artemis-features/src/main/resources/features.xml
@@ -36,6 +36,7 @@
 		<bundle>mvn:io.netty/netty-codec/${netty.version}</bundle>
 		<bundle>mvn:io.netty/netty-handler/${netty.version}</bundle>
 		<bundle>mvn:io.netty/netty-transport-native-epoll/${netty.version}</bundle>
+		<bundle>mvn:io.netty/netty-transport-native-unix-common/${netty.version}</bundle>
 	</feature>
 
 	<feature name="artemis-core" version="${pom.version}" description="ActiveMQ Artemis broker libraries">

--- a/artemis-journal/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBufWrapper.java
+++ b/artemis-journal/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBufWrapper.java
@@ -36,6 +36,7 @@ import io.netty.util.internal.PlatformDependent;
  */
 public final class UnpooledUnsafeDirectByteBufWrapper extends AbstractReferenceCountedByteBuf {
 
+   private static final byte ZERO = 0;
    private ByteBuffer buffer;
    private int arrayOffset;
    private byte[] array;
@@ -563,7 +564,11 @@ public final class UnpooledUnsafeDirectByteBufWrapper extends AbstractReferenceC
    @Override
    public ByteBuf setZero(int index, int length) {
       if (hasMemoryAddress()) {
-         UnsafeByteBufUtil.setZero(this, addr(index), index, length);
+         if (length == 0) {
+            return this;
+         }
+         this.checkIndex(index, length);
+         PlatformDependent.setMemory(addr(index), length, ZERO);
       } else {
          //prefer Arrays::fill here?
          UnsafeByteBufUtil.setZero(array, idx(index), length);

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
       <jgroups.version>3.6.13.Final</jgroups.version>
       <maven.assembly.plugin.version>2.4</maven.assembly.plugin.version>
       <mockito.version>2.8.47</mockito.version>
-      <netty.version>4.1.9.Final</netty.version>
+      <netty.version>4.1.14.Final</netty.version>
       <proton.version>0.20.0</proton.version>
       <resteasy.version>3.0.19.Final</resteasy.version>
       <slf4j.version>1.7.21</slf4j.version>

--- a/tests/smoke-tests/src/main/resources/servers/expire/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/expire/broker.xml
@@ -98,23 +98,24 @@ under the License.
       <acceptors>
 
          <!-- useEpoll means: it will use Netty epoll if you are on a system (Linux) that supports it -->
+         <!-- useKQueue means: it will use Netty kqueue if you are on a system (MacOS) that supports it -->
          <!-- amqpCredits: The number of credits sent to AMQP producers -->
          <!-- amqpLowCredits: The server will send the # credits specified at amqpCredits at this low mark -->
 
          <!-- Acceptor for every supported protocol -->
-         <acceptor name="artemis">tcp://0.0.0.0:61616?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=CORE,AMQP,STOMP,HORNETQ,MQTT,OPENWIRE;useEpoll=true;amqpCredits=1000;amqpLowCredits=300</acceptor>
+         <acceptor name="artemis">tcp://0.0.0.0:61616?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=CORE,AMQP,STOMP,HORNETQ,MQTT,OPENWIRE;useEpoll=true;useKQueue;amqpCredits=1000;amqpLowCredits=300</acceptor>
 
          <!-- AMQP Acceptor.  Listens on default AMQP port for AMQP traffic.-->
-         <acceptor name="amqp">tcp://0.0.0.0:5672?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=AMQP;useEpoll=true;amqpCredits=1000;amqpMinCredits=300</acceptor>
+         <acceptor name="amqp">tcp://0.0.0.0:5672?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=AMQP;useEpoll=true;useKQueue=true;amqpCredits=1000;amqpMinCredits=300</acceptor>
 
          <!-- STOMP Acceptor. -->
-         <acceptor name="stomp">tcp://0.0.0.0:61613?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=STOMP;useEpoll=true</acceptor>
+         <acceptor name="stomp">tcp://0.0.0.0:61613?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=STOMP;useEpoll=true;useKQueue=true</acceptor>
 
          <!-- HornetQ Compatibility Acceptor.  Enables HornetQ Core and STOMP for legacy HornetQ clients. -->
-         <acceptor name="hornetq">tcp://0.0.0.0:5445?protocols=HORNETQ,STOMP;useEpoll=true</acceptor>
+         <acceptor name="hornetq">tcp://0.0.0.0:5445?protocols=HORNETQ,STOMP;useEpoll=true;useKQueue=true</acceptor>
 
          <!-- MQTT Acceptor -->
-         <acceptor name="mqtt">tcp://0.0.0.0:1883?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=MQTT;useEpoll=true</acceptor>
+         <acceptor name="mqtt">tcp://0.0.0.0:1883?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=MQTT;useEpoll=true;useKQueue=true</acceptor>
 
       </acceptors>
 


### PR DESCRIPTION
Add support for KQueue for when server or client runs on macOS. This is inline with the epoll support for linux

This currently is branched off https://github.com/apache/activemq-artemis/pull/1452, as such that PR needs to go first, then i will rebase.

As such don't merge this until that.