### PR TITLE
ARTEMIS-1335 Update Netty to 4.1.14 - MQTT fix

### DIFF
--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTProtocolHandler.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTProtocolHandler.java
@@ -171,7 +171,7 @@ public class MQTTProtocolHandler extends ChannelInboundHandlerAdapter {
       connectionEntry.ttl = connect.variableHeader().keepAliveTimeSeconds() * 1500L;
 
       String clientId = connect.payload().clientIdentifier();
-      session.getConnectionManager().connect(clientId, connect.payload().userName(), connect.payload().password(), connect.variableHeader().isWillFlag(), connect.payload().willMessage(), connect.payload().willTopic(), connect.variableHeader().isWillRetain(), connect.variableHeader().willQos(), connect.variableHeader().isCleanSession());
+      session.getConnectionManager().connect(clientId, connect.payload().userName(), connect.payload().passwordInBytes(), connect.variableHeader().isWillFlag(), connect.payload().willMessageInBytes(), connect.payload().willTopic(), connect.variableHeader().isWillRetain(), connect.variableHeader().willQos(), connect.variableHeader().isCleanSession());
    }
 
    void disconnect(boolean error) {


### PR DESCRIPTION
Fix for MQTT in connect due to deprecated methods bug causing NPE, call new methods and null check ourselves.

Also raised https://github.com/netty/netty/issues/7076 upstream but i guess we will keep this, as the old methods are deprecated anyhow.