### PR TITLE
ARTEMIS-1342: Support Netty Native KQueue on macOS - Logging fix

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/ActiveMQClientLogger.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/ActiveMQClientLogger.java
@@ -392,6 +392,11 @@ public interface ActiveMQClientLogger extends BasicLogger {
            format = Message.Format.MESSAGE_FORMAT)
    void failedToSetChannelReadyForWriting(@Cause Throwable e);
 
+   @LogMessage(level = Logger.Level.WARN)
+   @Message(id = 212073, value = "Unable to check KQueue availability ",
+           format = Message.Format.MESSAGE_FORMAT)
+   void unableToCheckKQueueAvailability(@Cause Throwable e);
+
    @LogMessage(level = Logger.Level.ERROR)
    @Message(id = 214000, value = "Failed to call onMessage", format = Message.Format.MESSAGE_FORMAT)
    void onMessageError(@Cause Throwable e);
@@ -536,9 +541,4 @@ public interface ActiveMQClientLogger extends BasicLogger {
    @Message(id = 214033, value = "Cannot resolve host ",
            format = Message.Format.MESSAGE_FORMAT)
    void unableToResolveHost(@Cause UnknownHostException e);
-
-   @LogMessage(level = Logger.Level.WARN)
-   @Message(id = 214034, value = "Unable to check KQueue availability ",
-       format = Message.Format.MESSAGE_FORMAT)
-   void unableToCheckKQueueAvailability(@Cause Throwable e);
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/TransportConstants.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/TransportConstants.java
@@ -137,7 +137,7 @@ public class TransportConstants {
 
    public static final String WRITE_BUFFER_HIGH_WATER_MARK_PROPNAME = "writeBufferHighWaterMark";
 
-   public static final String REMOTING_THREADS_PROPNAME = "RemotingThreads";
+   public static final String REMOTING_THREADS_PROPNAME = "remotingThreads";
 
    public static final String BATCH_DELAY = "batchDelay";
 


### PR DESCRIPTION
Correct the logging id to correct matching id for level