### PR TITLE
Implement support for intercepting additional MQTT control packets

### DIFF
--- a/examples/features/standard/interceptor-client-mqtt/src/main/java/org/apache/activemq/artemis/mqtt/example/InterceptorExample.java
+++ b/examples/features/standard/interceptor-client-mqtt/src/main/java/org/apache/activemq/artemis/mqtt/example/InterceptorExample.java
@@ -41,20 +41,20 @@ public class InterceptorExample {
       System.out.println("Connected to Artemis");
 
       // Subscribe to a topic
-      Topic[] topics = {new Topic("mqtt/example/interceptor", QoS.AT_LEAST_ONCE)};
+      Topic[] topics = {new Topic("mqtt/example/interceptor", QoS.EXACTLY_ONCE)};
       connection.subscribe(topics);
       System.out.println("Subscribed to topics.");
 
       // Publish message
       String payload1 = "This is message 1";
 
-      connection.publish("mqtt/example/interceptor", payload1.getBytes(), QoS.AT_LEAST_ONCE, false);
+      connection.publish("mqtt/example/interceptor", payload1.getBytes(), QoS.EXACTLY_ONCE, false);
 
       System.out.println("Sent message");
 
       // Receive the sent message
       Message message1 = connection.receive(5, TimeUnit.SECONDS);
-
+      
       String messagePayload = new String(message1.getPayload(), StandardCharsets.UTF_8);
 
       System.out.println("Received message: " + messagePayload);

--- a/examples/features/standard/interceptor-client-mqtt/src/main/java/org/apache/activemq/artemis/mqtt/example/SimpleMQTTInterceptor.java
+++ b/examples/features/standard/interceptor-client-mqtt/src/main/java/org/apache/activemq/artemis/mqtt/example/SimpleMQTTInterceptor.java
@@ -19,6 +19,7 @@ package org.apache.activemq.artemis.mqtt.example;
 import java.nio.charset.Charset;
 
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
+import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import org.apache.activemq.artemis.core.protocol.mqtt.MQTTInterceptor;
 
 
@@ -36,7 +37,9 @@ public class SimpleMQTTInterceptor implements MQTTInterceptor {
    public boolean intercept(final MqttMessage mqttMessage, RemotingConnection connection) {
       System.out.println("MQTT Interceptor gets called ");
 
+      System.out.println("A MQTT control packet was intercepted " + mqttMessage.fixedHeader().messageType());
 
+      // If you need to handle an specific packet type:
       if (mqttMessage instanceof MqttPublishMessage) {
          MqttPublishMessage message = (MqttPublishMessage) mqttMessage;
 
@@ -48,6 +51,12 @@ public class SimpleMQTTInterceptor implements MQTTInterceptor {
          String modifiedMessage = "Modified message ";
 
          message.payload().setBytes(0, modifiedMessage.getBytes());
+      }
+      else {
+         if (mqttMessage instanceof MqttConnectMessage) {
+            MqttConnectMessage connectMessage = (MqttConnectMessage) mqttMessage;
+            System.out.println("A MQTT CONNECT control packet was intercepted " + connectMessage);
+         }
       }
 
 

--- a/examples/features/standard/interceptor-client-mqtt/src/main/resources/activemq/server0/broker.xml
+++ b/examples/features/standard/interceptor-client-mqtt/src/main/resources/activemq/server0/broker.xml
@@ -39,6 +39,10 @@ under the License.
          <class-name>org.apache.activemq.artemis.mqtt.example.SimpleMQTTInterceptor</class-name>
       </remoting-incoming-interceptors>
 
+      <remoting-outgoing-interceptors>
+         <class-name>org.apache.activemq.artemis.mqtt.example.SimpleMQTTInterceptor</class-name>
+      </remoting-outgoing-interceptors>
+
       <bindings-directory>./data/bindings</bindings-directory>
 
       <journal-directory>./data/journal</journal-directory>


### PR DESCRIPTION
Previously, only the PUBLISH packet was intercepted. This patch modifies the code to add support for the other incoming/outgoing MQTT control packets.