### PR TITLE
ARTEMIS-1353 ensure replication packet order

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationResponseMessageV2.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationResponseMessageV2.java
@@ -23,12 +23,7 @@ import org.apache.activemq.artemis.utils.DataConstants;
 public final class ReplicationResponseMessageV2 extends ReplicationResponseMessage {
 
    boolean synchronizationIsFinishedAcknowledgement = false;
-
-   public ReplicationResponseMessageV2(final boolean synchronizationIsFinishedAcknowledgement) {
-      super(REPLICATION_RESPONSE_V2);
-
-      this.synchronizationIsFinishedAcknowledgement = synchronizationIsFinishedAcknowledgement;
-   }
+   boolean synchronizationIsStartedAcknowledgement = false;
 
    public ReplicationResponseMessageV2() {
       super(PacketImpl.REPLICATION_RESPONSE_V2);
@@ -43,28 +38,41 @@ public final class ReplicationResponseMessageV2 extends ReplicationResponseMessa
       return this;
    }
 
+   public boolean isSynchronizationIsStartedAcknowledgement() {
+      return synchronizationIsStartedAcknowledgement;
+   }
+
+   public ReplicationResponseMessageV2 setSynchronizationIsStartedAcknowledgement(boolean synchronizationIsStartedAcknowledgement) {
+      this.synchronizationIsStartedAcknowledgement = synchronizationIsStartedAcknowledgement;
+      return this;
+   }
+
    @Override
    public int expectedEncodeSize() {
       return PACKET_HEADERS_SIZE +
-         DataConstants.SIZE_BOOLEAN; // buffer.writeBoolean(synchronizationIsFinishedAcknowledgement);
+         DataConstants.SIZE_BOOLEAN + // buffer.writeBoolean(synchronizationIsFinishedAcknowledgement);
+         DataConstants.SIZE_BOOLEAN;  // buffer.writeBoolean(synchronizationIsStartedAcknowledgement);
    }
 
    @Override
    public void encodeRest(final ActiveMQBuffer buffer) {
       super.encodeRest(buffer);
       buffer.writeBoolean(synchronizationIsFinishedAcknowledgement);
+      buffer.writeBoolean(synchronizationIsStartedAcknowledgement);
    }
 
    @Override
    public void decodeRest(final ActiveMQBuffer buffer) {
       super.decodeRest(buffer);
       synchronizationIsFinishedAcknowledgement = buffer.readBoolean();
+      synchronizationIsStartedAcknowledgement = buffer.readBoolean();
    }
 
    @Override
    public String toString() {
       StringBuffer buf = new StringBuffer(getParentString());
       buf.append(", synchronizationIsFinishedAcknowledgement=" + synchronizationIsFinishedAcknowledgement);
+      buf.append(", synchronizationIsStartedAcknowledgement=" + synchronizationIsStartedAcknowledgement);
       buf.append("]");
       return buf.toString();
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationStartSyncMessage.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationStartSyncMessage.java
@@ -18,10 +18,8 @@ package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
 import java.security.InvalidParameterException;
 import java.util.Arrays;
-import java.util.List;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
-import org.apache.activemq.artemis.core.journal.impl.JournalFile;
 import org.apache.activemq.artemis.core.persistence.impl.journal.AbstractJournalStorageManager;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
 import org.apache.activemq.artemis.utils.DataConstants;
@@ -70,44 +68,22 @@ public class ReplicationStartSyncMessage extends PacketImpl {
       super(REPLICATION_START_FINISH_SYNC);
    }
 
-   public ReplicationStartSyncMessage(List<Long> filenames) {
-      this();
-      ids = new long[filenames.size()];
-      for (int i = 0; i < filenames.size(); i++) {
-         ids[i] = filenames.get(i);
-      }
-      dataType = SyncDataType.LargeMessages;
-      nodeID = ""; // this value will be ignored
-   }
-
    public ReplicationStartSyncMessage(String nodeID) {
       this();
       synchronizationIsFinished = true;
       this.nodeID = nodeID;
    }
 
-   public ReplicationStartSyncMessage(JournalFile[] datafiles,
-                                      AbstractJournalStorageManager.JournalContent contentType,
+   public ReplicationStartSyncMessage(long[] ids,
+                                      SyncDataType dataType,
                                       String nodeID,
                                       boolean allowsAutoFailBack) {
       this();
       this.nodeID = nodeID;
       this.allowsAutoFailBack = allowsAutoFailBack;
-      synchronizationIsFinished = false;
-      ids = new long[datafiles.length];
-      for (int i = 0; i < datafiles.length; i++) {
-         ids[i] = datafiles[i].getFileID();
-      }
-      switch (contentType) {
-         case MESSAGES:
-            dataType = SyncDataType.JournalMessages;
-            break;
-         case BINDINGS:
-            dataType = SyncDataType.JournalBindings;
-            break;
-         default:
-            throw new IllegalArgumentException();
-      }
+      this.synchronizationIsFinished = false;
+      this.ids = ids;
+      this.dataType = dataType;
    }
 
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/replication/ReplicationEndpoint.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/replication/ReplicationEndpoint.java
@@ -475,8 +475,9 @@ public final class ReplicationEndpoint implements ChannelHandler, ActiveMQCompon
 
       if (packet.isSynchronizationFinished()) {
          finishSynchronization(packet.getNodeID());
-         replicationResponseMessage.setSynchronizationIsFinishedAcknowledgement(true);
-         return replicationResponseMessage;
+         return replicationResponseMessage.setSynchronizationIsFinishedAcknowledgement(true);
+      } else {
+         replicationResponseMessage.setSynchronizationIsStartedAcknowledgement(true);
       }
 
       switch (packet.getDataType()) {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/util/BackupSyncDelay.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/util/BackupSyncDelay.java
@@ -170,7 +170,7 @@ public class BackupSyncDelay implements Interceptor {
                   receivedUpToDate = true;
                   assert onHold == null;
                   onHold = packet;
-                  PacketImpl response = new ReplicationResponseMessageV2(true);
+                  PacketImpl response = new ReplicationResponseMessageV2().setSynchronizationIsFinishedAcknowledgement(true);
                   channel.send(response);
                   return;
                }


### PR DESCRIPTION
Incorrect ordering of replication packets may happen because of
useExecutor parameter in the sendReplicatePacket method.
ReplicationStartSyncMessage packets are sent as first, but they are sent
with useExecutor=true. Although ReplicationSyncFileMessage packets are
sent after ReplicationStartSyncMessage packets, they are sent with
useExecutor=false. So sending of ReplicationStartSyncMessage packets is
scheduled to executor and there is no guarantee when the task will be
executed, whereas ReplicationStartSyncMessage packets are sent
immediately.

The solution is to wait for an ack for ReplicationStartSyncMessages.