### PR TITLE
ARTEMIS-1355 Default config for client reconnection attempts does not…

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/client/ActiveMQClient.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/client/ActiveMQClient.java
@@ -107,7 +107,7 @@ public final class ActiveMQClient {
 
    public static final long DEFAULT_MAX_RETRY_INTERVAL = ActiveMQDefaultConfiguration.getDefaultMaxRetryInterval();
 
-   public static final int DEFAULT_RECONNECT_ATTEMPTS = 0;
+   public static final int DEFAULT_RECONNECT_ATTEMPTS = -1;
 
    public static final int INITIAL_CONNECT_ATTEMPTS = 1;
 


### PR DESCRIPTION
… match documentation

As per docs DEFAULT_RECONNECT_ATTEMPTS should be -1 by default not 0
https://activemq.apache.org/artemis/docs/latest/client-reconnection.html