### PR TITLE
ARTEMIS-1291 - fix incorrect links in the documentation

### DIFF
--- a/docs/hacking-guide/en/tests.md
+++ b/docs/hacking-guide/en/tests.md
@@ -22,20 +22,20 @@ The broker is comprised of POJOs so it's simple to configure and run a broker in
 Even complex test-cases involving multiple clustered brokers are relatively easy to write. Almost every test in the 
 test-suite follows this pattern - configure broker, start broker, test functionality, stop broker.
 
-The test-suite uses JUnit to manage test execution and life-cycle.  Most tests extend [`org.apache.activemq.artemis.tests.util.ActiveMQTestBase`](../../../artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java)
+The test-suite uses JUnit to manage test execution and life-cycle.  Most tests extend [`org.apache.activemq.artemis.tests.util.ActiveMQTestBase`](https://github.com/apache/activemq-artemis/blob/master/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java)
 which contains JUnit setup and tear-down methods as well as a wealth of utility functions to configure, start, manage,
 and stop brokers as well as perform other common tasks.
 
-Check out [`org.apache.activemq.artemis.tests.integration.SimpleTest`](../../../tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/SimpleTest.java).
+Check out [`org.apache.activemq.artemis.tests.integration.SimpleTest`](https://github.com/apache/activemq-artemis/blob/master/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/SimpleTest.java).
 It's a very simple test-case that extends `org.apache.activemq.artemis.tests.util.ActiveMQTestBase` and uses its methods
 to configure a server, run a test, and then `super.tearDown()` cleans it up once the test completes. The test-case 
 includes comments to explain everything. As the name implies, this is a simple test-case that demonstrates the most basic
 functionality of the test-suite. A simple test like this takes less than a second to run on modern hardware.
 
 Although `org.apache.activemq.artemis.tests.integration.SimpleTest` is simple it could be simpler still by extending
-[`org.apache.activemq.artemis.tests.util.SingleServerTestBase`](../../../artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/SingleServerTestBase.java).
+[`org.apache.activemq.artemis.tests.util.SingleServerTestBase`](https://github.com/apache/activemq-artemis/blob/master/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/SingleServerTestBase.java).
 This class does all the setup of a simple server automatically and provides the test-case with a `ServerLocator`, 
-`ClientSessionFactory`, and `ClientSession` instance. [`org.apache.activemq.artemis.tests.integration.SingleServerSimpleTest`](../../../tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/SingleServerSimpleTest.java)
+`ClientSessionFactory`, and `ClientSession` instance. [`org.apache.activemq.artemis.tests.integration.SingleServerSimpleTest`](https://github.com/apache/activemq-artemis/blob/master//tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/SingleServerSimpleTest.java)
 is an example based on `org.apache.activemq.artemis.tests.integration.SimpleTest` but extends `org.apache.activemq.artemis.tests.util.SingleServerTestBase`
 which eliminates all the setup and class variables which are provided by `SingleServerTestBase` itself.
 
@@ -46,7 +46,7 @@ which eliminates all the setup and class variables which are provided by `Single
 An important task for any test-case is to clean up all the resources it creates when it runs. This includes the server
 instance itself and any resources created to connect to it (e.g. instances of `ServerLocator`, `ClientSessionFactory`,
 `ClientSession`, etc.). This task is typically completed in the test's `tearDown()` method.  However, `ActiveMQTestBase` 
-(and other classes which extend it) simplifies this process. As [`org.apache.activemq.artemis.tests.integration.SimpleTest`](../../../tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/SimpleTest.java)
+(and other classes which extend it) simplifies this process. As [`org.apache.activemq.artemis.tests.integration.SimpleTest`](https://github.com/apache/activemq-artemis/blob/master/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/SimpleTest.java)
 demonstrates, there are several methods you can use when creating your test which will ensure proper clean up _automatically_
 when the test is torn down. These include:
 

--- a/docs/user-manual/en/broker-plugins.md
+++ b/docs/user-manual/en/broker-plugins.md
@@ -5,7 +5,7 @@ creating a plugin. Multiple plugins can be registered at the same time and they 
 together and executed in the order they are registered.  (i.e. the first plugin registered 
 is always executed first).
 
-Creating a plugin is very simple. It requires implementing the [`ActiveMQServerPlugin`](../../../artemis-server/src/main/java/org/apache/activemq/artemis/core/server/plugin/ActiveMQServerPlugin.java)
+Creating a plugin is very simple. It requires implementing the [`ActiveMQServerPlugin`](https://github.com/apache/activemq-artemis/blob/master/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/plugin/ActiveMQServerPlugin.java)
 interface, making sure the plugin is on the classpath, and registering it with the broker.  Only the methods that you want to add behavior for need to be implemented as all of the interface methods are default methods.
 
 ## Adding the plugin to the classpath


### PR DESCRIPTION
Some links in the documentation point to non-existent pages within the Apache website. The links make reference to classes and code in the documentation. This patch updates them to point to the source code in Github.