### PR TITLE
ARTEMIS-1361 - Support Updating queue config from broker.xml at runtime

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -2473,10 +2473,20 @@ public class ActiveMQServerImpl implements ActiveMQServer {
 
    private void deployQueuesFromListCoreQueueConfiguration(List<CoreQueueConfiguration> queues) throws Exception {
       for (CoreQueueConfiguration config : queues) {
-         ActiveMQServerLogger.LOGGER.deployQueue(SimpleString.toSimpleString(config.getName()));
-
-         createQueue(SimpleString.toSimpleString(config.getAddress()), config.getRoutingType(), SimpleString.toSimpleString(config.getName()), SimpleString.toSimpleString(config.getFilterString()), null, config.isDurable(), false, true, false, false, config.getMaxConsumers(), config.getPurgeOnNoConsumers(), true);
+         addOrUpdateQueue(config);
       }
+   }
+
+   private Queue addOrUpdateQueue(CoreQueueConfiguration config) throws Exception {
+      SimpleString queueName = SimpleString.toSimpleString(config.getName());
+      ActiveMQServerLogger.LOGGER.deployQueue(queueName);
+      Queue queue = updateQueue(config.getName(), config.getRoutingType(), config.getMaxConsumers(), config.getPurgeOnNoConsumers());
+      if (queue == null) {
+         queue = createQueue(SimpleString.toSimpleString(config.getAddress()), config.getRoutingType(),
+            queueName, SimpleString.toSimpleString(config.getFilterString()), null,
+            config.isDurable(), false, true, false, false, config.getMaxConsumers(), config.getPurgeOnNoConsumers(), true);
+      }
+      return queue;
    }
 
    private void deployQueuesFromConfiguration() throws Exception {

--- a/tests/integration-tests/src/test/resources/reload-address-queues-updated.xml
+++ b/tests/integration-tests/src/test/resources/reload-address-queues-updated.xml
@@ -123,6 +123,11 @@ under the License.
                <queue name="permanent_test_queue_removal_queue_1"/>
             </multicast>
          </address>
+         <address name="config_test_queue_change">
+            <multicast>
+               <queue name="config_test_queue_change_queue" max-consumers="1" purge-on-no-consumers="true" />
+            </multicast>
+         </address>
       </addresses>
    </core>
 </configuration>

--- a/tests/integration-tests/src/test/resources/reload-address-queues.xml
+++ b/tests/integration-tests/src/test/resources/reload-address-queues.xml
@@ -142,6 +142,11 @@ under the License.
                <queue name="permanent_test_address_removal_queue"/>
             </multicast>
          </address>
+         <address name="config_test_queue_change">
+            <multicast>
+               <queue name="config_test_queue_change_queue" max-consumers="10" purge-on-no-consumers="false" />
+            </multicast>
+         </address>
       </addresses>
    </core>
 </configuration>


### PR DESCRIPTION
Add support to update Queue config via reload using existing updateQueue method at runtime.
Add/extend unit test cases to include testing reload of queue config.