### PR TITLE
ARTEMIS-1370 - consumer command, does not offer a ClientID arg

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/ConnectionAbstract.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/ConnectionAbstract.java
@@ -35,9 +35,17 @@ public class ConnectionAbstract extends InputAbstract {
    @Option(name = "--password", description = "Password used to connect")
    protected String password;
 
+   @Option(name = "--clientID", description = "ClientID to be associated with connection")
+   String clientID;
+
 
    protected ActiveMQConnectionFactory createConnectionFactory() throws Exception {
       ActiveMQConnectionFactory cf = new ActiveMQConnectionFactory(brokerURL, user, password);
+
+      if(clientID!=null){
+         System.out.println("Consumer:: clientID = " + clientID);
+         cf.setClientID(clientID);
+      }
       try {
          Connection connection = cf.createConnection();
          connection.close();


### PR DESCRIPTION

minor update to add a clientID option so be associated with a connection used by the cli commands.