### PR TITLE
Chagning the way to interact with JGroups in the ResourceAdapter

### DIFF
--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRaUtils.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRaUtils.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import org.jgroups.JChannel;
+import org.apache.activemq.artemis.api.core.BroadcastEndpointFactory;
 
 /**
  * Various utility functions
@@ -236,19 +236,19 @@ public final class ActiveMQRaUtils {
 
    /**
     * Within AS7 the RA is loaded by JCA. properties can only be passed in String form. However if
-    * RA is configured using jgroups stack, we need to pass a Channel object. As is impossible with
-    * JCA, we use this method to allow a JChannel object to be located.
+    * RA is configured using jgroups stack, we need to pass a BroadcastEndpointFactory object. As is impossible with
+    * JCA, we use this method to allow a BroadcastEndpointFactory object to be located.
     */
-   public static JChannel locateJGroupsChannel(final String locatorClass, final String name) {
-      return AccessController.doPrivileged(new PrivilegedAction<JChannel>() {
+   public static BroadcastEndpointFactory locateBroadcastEndpointFactory(final String locatorClass, final String name) {
+      return AccessController.doPrivileged(new PrivilegedAction<BroadcastEndpointFactory>() {
          @Override
-         public JChannel run() {
+         public BroadcastEndpointFactory run() {
             try {
                ClassLoader loader = Thread.currentThread().getContextClassLoader();
                Class<?> aClass = loader.loadClass(locatorClass);
                Object o = aClass.newInstance();
-               Method m = aClass.getMethod("locateChannel", new Class[]{String.class});
-               return (JChannel) m.invoke(o, name);
+               Method m = aClass.getMethod("locateBroadcastEndpointFactory", new Class[]{String.class});
+               return (BroadcastEndpointFactory) m.invoke(o, name);
             } catch (Throwable e) {
                ActiveMQRALogger.LOGGER.debug(e.getMessage(), e);
                return null;

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
@@ -42,7 +42,6 @@ import java.util.regex.Pattern;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.BroadcastEndpointFactory;
-import org.apache.activemq.artemis.api.core.ChannelBroadcastEndpointFactory;
 import org.apache.activemq.artemis.api.core.DiscoveryGroupConfiguration;
 import org.apache.activemq.artemis.api.core.JGroupsFileBroadcastEndpointFactory;
 import org.apache.activemq.artemis.api.core.Pair;
@@ -61,7 +60,6 @@ import org.apache.activemq.artemis.service.extensions.ServiceUtils;
 import org.apache.activemq.artemis.service.extensions.xa.recovery.XARecoveryConfig;
 import org.apache.activemq.artemis.utils.SensitiveDataCodec;
 import org.jboss.logging.Logger;
-import org.jgroups.JChannel;
 
 /**
  * The resource adapter for ActiveMQ
@@ -1716,8 +1714,7 @@ public class ActiveMQResourceAdapter implements ResourceAdapter, Serializable {
 
          if (jgroupsLocatorClassName != null) {
             String jchannelRefName = raProperties.getJgroupsChannelRefName();
-            JChannel jchannel = ActiveMQRaUtils.locateJGroupsChannel(jgroupsLocatorClassName, jchannelRefName);
-            endpointFactory = new ChannelBroadcastEndpointFactory(jchannel, jgroupsChannel);
+            endpointFactory = ActiveMQRaUtils.locateBroadcastEndpointFactory(jgroupsLocatorClassName, jchannelRefName);
          } else if (discoveryAddress != null) {
             Integer discoveryPort = overrideProperties.getDiscoveryPort() != null ? overrideProperties.getDiscoveryPort() : getDiscoveryPort();
             if (discoveryPort == null) {
@@ -1817,8 +1814,7 @@ public class ActiveMQResourceAdapter implements ResourceAdapter, Serializable {
             String jgroupsLocatorClass = raProperties.getJgroupsChannelLocatorClass();
             if (jgroupsLocatorClass != null) {
                String jgroupsChannelRefName = raProperties.getJgroupsChannelRefName();
-               JChannel jchannel = ActiveMQRaUtils.locateJGroupsChannel(jgroupsLocatorClass, jgroupsChannelRefName);
-               endpointFactory = new ChannelBroadcastEndpointFactory(jchannel, jgroupsChannel);
+               endpointFactory = ActiveMQRaUtils.locateBroadcastEndpointFactory(jgroupsLocatorClass, jgroupsChannelRefName);
             }
             if (endpointFactory == null) {
                throw new IllegalArgumentException("must provide either TransportType or DiscoveryGroupAddress and DiscoveryGroupPort for ResourceAdapter Connection Factory");


### PR DESCRIPTION
Obtaining a BroadCastEndpointFactory instead of a JChannel to connect to JGroups to avoid issue and leak with JChannel lifecyle.
