### PR TITLE
ARTEMIS-1381 add JMX operation removeAllMessages() to the queue

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/QueueControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/QueueControl.java
@@ -247,6 +247,14 @@ public interface QueueControl {
                       @Parameter(name = "filter", desc = "A message filter (can be empty)") String filter) throws Exception;
 
    /**
+    * Removes all the message from the queue.
+    *
+    * @return the number of removed messages
+    */
+   @Operation(desc = "Remove all the messages from the Queue (and returns the number of removed messages)", impact = MBeanOperationInfo.ACTION)
+   int removeAllMessages() throws Exception;
+
+   /**
     * Expires all the message corresponding to the specified filter.
     * <br>
     * Using {@code null} or an empty filter will expire <em>all</em> messages from this queue.

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/QueueControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/QueueControlImpl.java
@@ -595,6 +595,11 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
    }
 
    @Override
+   public int removeAllMessages() throws Exception {
+      return removeMessages(FLUSH_LIMIT, null);
+   }
+
+   @Override
    public boolean expireMessage(final long messageID) throws Exception {
       checkStarted();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlTest.java
@@ -1271,6 +1271,29 @@ public class QueueControlTest extends ManagementTestBase {
    }
 
    @Test
+   public void testRemoveAllMessages() throws Exception {
+      SimpleString address = RandomUtil.randomSimpleString();
+      SimpleString queue = RandomUtil.randomSimpleString();
+
+      session.createQueue(address, queue, null, false);
+      ClientProducer producer = session.createProducer(address);
+
+      // send on queue
+      producer.send(session.createMessage(false));
+      producer.send(session.createMessage(false));
+
+      QueueControl queueControl = createManagementControl(address, queue);
+      Assert.assertEquals(2, getMessageCount(queueControl));
+
+      // removed matching messages to otherQueue
+      int removedMatchedMessagesCount = queueControl.removeAllMessages();
+      Assert.assertEquals(2, removedMatchedMessagesCount);
+      Assert.assertEquals(0, getMessageCount(queueControl));
+
+      session.deleteQueue(queue);
+   }
+
+   @Test
    public void testRemoveMessagesWithEmptyFilter() throws Exception {
       SimpleString address = RandomUtil.randomSimpleString();
       SimpleString queue = RandomUtil.randomSimpleString();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlUsingCoreTest.java
@@ -308,6 +308,11 @@ public class QueueControlUsingCoreTest extends QueueControlTest {
          }
 
          @Override
+         public int removeAllMessages() throws Exception {
+            return (Integer) proxy.invokeOperation( "removeAllMessages");
+         }
+
+         @Override
          public boolean removeMessage(final long messageID) throws Exception {
             return (Boolean) proxy.invokeOperation("removeMessage", messageID);
          }


### PR DESCRIPTION
it would be good to add a removeAllMessages() JMX operation to clear all messages from the queue, to make it a little more intuitive in various JMX browsers (such as jconsole)

adding an new method to the external facing QueueControl interface, AFAIK that should not break anything.