### PR TITLE
ARTEMIS-1393 CriticalAnalyzer timeout uses System::currentTimeMillis

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/critical/CriticalAnalyzer.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/critical/CriticalAnalyzer.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.utils.critical;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.activemq.artemis.core.server.ActiveMQComponent;
 
 public interface CriticalAnalyzer extends ActiveMQComponent {
@@ -29,13 +31,13 @@ public interface CriticalAnalyzer extends ActiveMQComponent {
 
    void remove(CriticalComponent component);
 
-   CriticalAnalyzer setCheckTime(long timeout);
+   CriticalAnalyzer setCheckTime(long timeout, TimeUnit unit);
 
-   long getCheckTime();
+   long getCheckTimeNanoSeconds();
 
-   CriticalAnalyzer setTimeout(long timeout);
+   CriticalAnalyzer setTimeout(long timeout, TimeUnit unit);
 
-   long getTimeout();
+   long getTimeout(TimeUnit unit);
 
    CriticalAnalyzer addAction(CriticalAction action);
 

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/critical/CriticalComponent.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/critical/CriticalComponent.java
@@ -20,7 +20,7 @@ package org.apache.activemq.artemis.utils.critical;
 /**
  * A Critical component enters and leaves a critical state.
  * You update a long every time you enter a critical path
- * you update a different long with a System.currentMillis every time you leave that path.
+ * you update a different long with a System.nanoTime every time you leave that path.
  *
  * If the enterCritical > leaveCritical at any point, then you need to measure the timeout.
  * if the system stops responding, then you have something irresponsive at the system.

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/critical/EmptyCriticalAnalyzer.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/critical/EmptyCriticalAnalyzer.java
@@ -17,6 +17,8 @@
 
 package org.apache.activemq.artemis.utils.critical;
 
+import java.util.concurrent.TimeUnit;
+
 public class EmptyCriticalAnalyzer implements CriticalAnalyzer {
 
    private static final EmptyCriticalAnalyzer instance = new EmptyCriticalAnalyzer();
@@ -59,22 +61,22 @@ public class EmptyCriticalAnalyzer implements CriticalAnalyzer {
    }
 
    @Override
-   public CriticalAnalyzer setCheckTime(long timeout) {
-      return this;
+   public CriticalAnalyzer setCheckTime(long timeout, TimeUnit unit) {
+      return null;
    }
 
    @Override
-   public long getCheckTime() {
+   public long getCheckTimeNanoSeconds() {
       return 0;
    }
 
    @Override
-   public CriticalAnalyzer setTimeout(long timeout) {
-      return this;
+   public CriticalAnalyzer setTimeout(long timeout, TimeUnit unit) {
+      return null;
    }
 
    @Override
-   public long getTimeout() {
+   public long getTimeout(TimeUnit unit) {
       return 0;
    }
 

--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/critical/CriticalAnalyzerTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/critical/CriticalAnalyzerTest.java
@@ -42,7 +42,7 @@ public class CriticalAnalyzerTest {
 
    @Test
    public void testAction() throws Exception {
-      analyzer = new CriticalAnalyzerImpl().setTimeout(100).setCheckTime(50);
+      analyzer = new CriticalAnalyzerImpl().setTimeout(100, TimeUnit.MILLISECONDS).setCheckTime(50, TimeUnit.MILLISECONDS);
       analyzer.add(new CriticalComponent() {
          @Override
          public boolean isExpired(long timeout) {
@@ -66,7 +66,7 @@ public class CriticalAnalyzerTest {
 
    @Test
    public void testActionOnImpl() throws Exception {
-      analyzer = new CriticalAnalyzerImpl().setTimeout(10).setCheckTime(5);
+      analyzer = new CriticalAnalyzerImpl().setTimeout(10, TimeUnit.MILLISECONDS).setCheckTime(5, TimeUnit.MILLISECONDS);
       CriticalComponent component = new CriticalComponentImpl(analyzer, 2);
       analyzer.add(component);
 
@@ -89,8 +89,29 @@ public class CriticalAnalyzerTest {
    }
 
    @Test
+   public void testEnterNoLeaveNoExpire() throws Exception {
+      analyzer = new CriticalAnalyzerImpl().setTimeout(10, TimeUnit.MILLISECONDS).setCheckTime(5, TimeUnit.MILLISECONDS);
+      CriticalComponent component = new CriticalComponentImpl(analyzer, 2);
+      component.enterCritical(0);
+      Assert.assertFalse(component.isExpired(TimeUnit.MINUTES.toNanos(1)));
+      analyzer.stop();
+
+   }
+
+   @Test
+   public void testEnterNoLeaveExpire() throws Exception {
+      analyzer = new CriticalAnalyzerImpl().setTimeout(10, TimeUnit.MILLISECONDS).setCheckTime(5, TimeUnit.MILLISECONDS);
+      CriticalComponent component = new CriticalComponentImpl(analyzer, 2);
+      component.enterCritical(0);
+      Thread.sleep(50);
+      Assert.assertTrue(component.isExpired(0));
+      analyzer.stop();
+
+   }
+
+   @Test
    public void testNegative() throws Exception {
-      analyzer = new CriticalAnalyzerImpl().setTimeout(10).setCheckTime(5);
+      analyzer = new CriticalAnalyzerImpl().setTimeout(10, TimeUnit.MILLISECONDS).setCheckTime(5, TimeUnit.MILLISECONDS);
       CriticalComponent component = new CriticalComponentImpl(analyzer, 1);
       analyzer.add(component);
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -506,7 +506,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
       /** Calling this for cases where the server was stopped and now is being restarted... failback, etc...*/
       this.analyzer.clear();
 
-      this.getCriticalAnalyzer().setCheckTime(configuration.getCriticalAnalyzerCheckPeriod()).setTimeout(configuration.getCriticalAnalyzerTimeout());
+      this.getCriticalAnalyzer().setCheckTime(configuration.getCriticalAnalyzerCheckPeriod(), TimeUnit.MILLISECONDS).setTimeout(configuration.getCriticalAnalyzerTimeout(), TimeUnit.MILLISECONDS);
 
       if (configuration.isCriticalAnalyzer()) {
          this.getCriticalAnalyzer().start();
@@ -1437,7 +1437,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
       checkSessionLimit(validatedUser);
 
       callBrokerPlugins(hasBrokerPlugins() ? plugin -> plugin.beforeCreateSession(name, username, minLargeMessageSize, connection,
-            autoCommitSends, autoCommitAcks, preAcknowledge, xa, defaultAddress, callback, autoCreateQueues, context, prefixes) : null);
+                                                                                  autoCommitSends, autoCommitAcks, preAcknowledge, xa, defaultAddress, callback, autoCreateQueues, context, prefixes) : null);
 
       final ServerSessionImpl session = internalCreateSession(name, username, password, validatedUser, minLargeMessageSize, connection, autoCommitSends, autoCommitAcks, preAcknowledge, xa, defaultAddress, callback, context, autoCreateQueues, prefixes);
 
@@ -1838,7 +1838,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
       }
 
       callBrokerPlugins(hasBrokerPlugins() ? plugin -> plugin.beforeDestroyQueue(queueName, session, checkConsumerCount,
-            removeConsumers, autoDeleteAddress) : null);
+                                                                                 removeConsumers, autoDeleteAddress) : null);
 
       addressSettingsRepository.clearCache();
 
@@ -1882,7 +1882,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
       callPostQueueDeletionCallbacks(address, queueName);
 
       callBrokerPlugins(hasBrokerPlugins() ? plugin -> plugin.afterDestroyQueue(queue, address, session, checkConsumerCount,
-            removeConsumers, autoDeleteAddress) : null);
+                                                                                removeConsumers, autoDeleteAddress) : null);
    }
 
    @Override
@@ -2456,13 +2456,13 @@ public class ActiveMQServerImpl implements ActiveMQServer {
 
    private void undeployAddressesAndQueueNotInConfiguration(Configuration configuration) throws Exception {
       Set<String> addressesInConfig = configuration.getAddressConfigurations().stream()
-                                                   .map(CoreAddressConfiguration::getName)
-                                                   .collect(Collectors.toSet());
+         .map(CoreAddressConfiguration::getName)
+         .collect(Collectors.toSet());
 
       Set<String> queuesInConfig = configuration.getAddressConfigurations().stream()
-                                                .map(CoreAddressConfiguration::getQueueConfigurations)
-                                                .flatMap(List::stream).map(CoreQueueConfiguration::getName)
-                                                .collect(Collectors.toSet());
+         .map(CoreAddressConfiguration::getQueueConfigurations)
+         .flatMap(List::stream).map(CoreQueueConfiguration::getName)
+         .collect(Collectors.toSet());
 
       for (SimpleString addressName : listAddressNames()) {
          AddressSettings addressSettings = getAddressSettingsRepository().getMatch(addressName.toString());
@@ -2521,8 +2521,8 @@ public class ActiveMQServerImpl implements ActiveMQServer {
       Queue queue = updateQueue(config.getName(), config.getRoutingType(), config.getMaxConsumers(), config.getPurgeOnNoConsumers());
       if (queue == null) {
          queue = createQueue(SimpleString.toSimpleString(config.getAddress()), config.getRoutingType(),
-            queueName, SimpleString.toSimpleString(config.getFilterString()), null,
-            config.isDurable(), false, true, false, false, config.getMaxConsumers(), config.getPurgeOnNoConsumers(), true);
+                             queueName, SimpleString.toSimpleString(config.getFilterString()), null,
+                             config.isDurable(), false, true, false, false, config.getMaxConsumers(), config.getPurgeOnNoConsumers(), true);
       }
       return queue;
    }


### PR DESCRIPTION
The timeout logic is changed to use System::nanoTime, less sensible to OS clock changes.
The volatile set on CriticalMeasure are changed with cheaper lazySet.