### PR TITLE
ARTEMIS-1401 Numerical overflow fix when using System::nanoTime

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnection.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnection.java
@@ -330,7 +330,7 @@ public class NettyConnection implements Connection {
             parkNanos = 1000L;
          }
          boolean canWrite;
-         while (!(canWrite = canWrite(requiredCapacity)) && System.nanoTime() < deadline) {
+         while (!(canWrite = canWrite(requiredCapacity)) && (System.nanoTime() - deadline) < 0) {
             //periodically check the connection state
             checkConnectionState();
             LockSupport.parkNanos(parkNanos);

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/buffer/TimedBuffer.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/buffer/TimedBuffer.java
@@ -386,7 +386,7 @@ public final class TimedBuffer {
                   lastFlushTime = System.nanoTime();
                   flush();
 
-               } else if (bufferObserver != null && System.nanoTime() > lastFlushTime + timeout) {
+               } else if (bufferObserver != null && System.nanoTime() - lastFlushTime > timeout) {
                   lastFlushTime = System.nanoTime();
                   // if not using flush we will spin and do the time checks manually
                   flush();

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/TimedBufferTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/TimedBufferTest.java
@@ -227,7 +227,7 @@ public class TimedBufferTest extends ActiveMQTestBase {
    private static void spinSleep(long timeout) {
       if (timeout > 0) {
          final long deadline = System.nanoTime() + timeout;
-         while (System.nanoTime() < deadline) {
+         while (System.nanoTime() - deadline < 0) {
             //spin wait
          }
       }


### PR DESCRIPTION
Quoting the [javadoc](https://docs.oracle.com/javase/8/docs/api/java/lang/System.html#nanoTime--):

> To compare two nanoTime values
> 
> long t0 = System.nanoTime();
> ...
> long t1 = System.nanoTime();
> one should use t1 - t0 < 0, not t1 < t0, because of the possibility of numerical overflow.