### PR TITLE
ARTEMIS-1403 - Fix wildcard matching to always respect delimiters

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/Match.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/Match.java
@@ -35,6 +35,8 @@ public class Match<T> {
 
    private static final String WILDCARD_REPLACEMENT = ".*";
 
+   private static final String WILDCARD_CHILD_REPLACEMENT = "(\\..+)*";
+
    private static final String DOT = ".";
 
    private static final String DOT_REPLACEMENT = "\\.";
@@ -59,7 +61,7 @@ public class Match<T> {
          actMatch = actMatch.replace(Match.WORD_WILDCARD, Match.WORD_WILDCARD_REPLACEMENT);
 
          // this one has to be done by last as we are using .* and it could be replaced wrongly
-         actMatch = actMatch.replace(Match.WILDCARD, Match.WILDCARD_REPLACEMENT);
+         actMatch = actMatch.replace(Match.WILDCARD, Match.WILDCARD_CHILD_REPLACEMENT);
       }
       pattern = Pattern.compile(actMatch);
 

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/settings/RepositoryTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/settings/RepositoryTest.java
@@ -59,6 +59,9 @@ public class RepositoryTest extends ActiveMQTestBase {
       Assert.assertEquals("ab#", repo.getMatch("a.b.c"));
       Assert.assertEquals("abd#", repo.getMatch("a.b.d.lll"));
       Assert.assertEquals("root", repo.getMatch("z.z.z.z.z"));
+      Assert.assertEquals("root", repo.getMatch("a.babc"));
+      Assert.assertEquals("ab#", repo.getMatch("a.b.dabc"));
+      Assert.assertEquals("abd#", repo.getMatch("a.b.d"));
    }
 
    @Test


### PR DESCRIPTION
The regular expressions for wildcard matching now properly respects the last
delimiter in a pattern and will not match a pattern missing the
delimiter by mistake