### PR TITLE
ARTEMIS-1422 fix RedeployTest after match change

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/RedeployTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/RedeployTest.java
@@ -137,21 +137,21 @@ public class RedeployTest extends ActiveMQTestBase {
 
       try {
          latch.await(10, TimeUnit.SECONDS);
-         Assert.assertNotNull(getAddressInfo(embeddedJMS, "config_test_address_removal_no_queue"));
-         Assert.assertNotNull(getAddressInfo(embeddedJMS, "config_test_address_removal"));
-         Assert.assertNotNull(getAddressInfo(embeddedJMS, "config_test_queue_removal"));
-         Assert.assertTrue(listQueuesNamesForAddress(embeddedJMS, "config_test_queue_removal").contains("config_test_queue_removal_queue_1"));
-         Assert.assertTrue(listQueuesNamesForAddress(embeddedJMS, "config_test_queue_removal").contains("config_test_queue_removal_queue_2"));
+         Assert.assertNotNull(getAddressInfo(embeddedJMS, "config.test.address.removal.no.queue"));
+         Assert.assertNotNull(getAddressInfo(embeddedJMS, "config.test.address.removal"));
+         Assert.assertNotNull(getAddressInfo(embeddedJMS, "config.test.queue.removal"));
+         Assert.assertTrue(listQueuesNamesForAddress(embeddedJMS, "config.test.queue.removal").contains("config.test.queue.removal.queue.1"));
+         Assert.assertTrue(listQueuesNamesForAddress(embeddedJMS, "config.test.queue.removal").contains("config.test.queue.removal.queue.2"));
 
-         Assert.assertNotNull(getAddressInfo(embeddedJMS, "permanent_test_address_removal"));
-         Assert.assertNotNull(getAddressInfo(embeddedJMS, "permanent_test_queue_removal"));
-         Assert.assertTrue(listQueuesNamesForAddress(embeddedJMS, "permanent_test_queue_removal").contains("permanent_test_queue_removal_queue_1"));
-         Assert.assertTrue(listQueuesNamesForAddress(embeddedJMS, "permanent_test_queue_removal").contains("permanent_test_queue_removal_queue_2"));
+         Assert.assertNotNull(getAddressInfo(embeddedJMS, "permanent.test.address.removal"));
+         Assert.assertNotNull(getAddressInfo(embeddedJMS, "permanent.test.queue.removal"));
+         Assert.assertTrue(listQueuesNamesForAddress(embeddedJMS, "permanent.test.queue.removal").contains("permanent.test.queue.removal.queue.1"));
+         Assert.assertTrue(listQueuesNamesForAddress(embeddedJMS, "permanent.test.queue.removal").contains("permanent.test.queue.removal.queue.2"));
 
-         Assert.assertNotNull(getAddressInfo(embeddedJMS, "config_test_queue_change"));
-         Assert.assertTrue(listQueuesNamesForAddress(embeddedJMS, "config_test_queue_change").contains("config_test_queue_change_queue"));
-         Assert.assertEquals(10, getQueue(embeddedJMS, "config_test_queue_change_queue").getMaxConsumers());
-         Assert.assertEquals(false, getQueue(embeddedJMS, "config_test_queue_change_queue").isPurgeOnNoConsumers());
+         Assert.assertNotNull(getAddressInfo(embeddedJMS, "config.test.queue.change"));
+         Assert.assertTrue(listQueuesNamesForAddress(embeddedJMS, "config.test.queue.change").contains("config.test.queue.change.queue"));
+         Assert.assertEquals(10, getQueue(embeddedJMS, "config.test.queue.change.queue").getMaxConsumers());
+         Assert.assertEquals(false, getQueue(embeddedJMS, "config.test.queue.change.queue").isPurgeOnNoConsumers());
 
          Files.copy(url2.openStream(), brokerXML, StandardCopyOption.REPLACE_EXISTING);
          brokerXML.toFile().setLastModified(System.currentTimeMillis() + 1000);
@@ -159,21 +159,21 @@ public class RedeployTest extends ActiveMQTestBase {
          embeddedJMS.getActiveMQServer().getReloadManager().setTick(tick);
          latch.await(10, TimeUnit.SECONDS);
 
-         Assert.assertNull(getAddressInfo(embeddedJMS, "config_test_address_removal_no_queue"));
-         Assert.assertNull(getAddressInfo(embeddedJMS, "config_test_address_removal"));
-         Assert.assertNotNull(getAddressInfo(embeddedJMS, "config_test_queue_removal"));
-         Assert.assertTrue(listQueuesNamesForAddress(embeddedJMS, "config_test_queue_removal").contains("config_test_queue_removal_queue_1"));
-         Assert.assertFalse(listQueuesNamesForAddress(embeddedJMS, "config_test_queue_removal").contains("config_test_queue_removal_queue_2"));
+         Assert.assertNull(getAddressInfo(embeddedJMS, "config.test.address.removal.no.queue"));
+         Assert.assertNull(getAddressInfo(embeddedJMS, "config.test.address.removal"));
+         Assert.assertNotNull(getAddressInfo(embeddedJMS, "config.test.queue.removal"));
+         Assert.assertTrue(listQueuesNamesForAddress(embeddedJMS, "config.test.queue.removal").contains("config.test.queue.removal.queue.1"));
+         Assert.assertFalse(listQueuesNamesForAddress(embeddedJMS, "config.test.queue.removal").contains("config.test.queue.removal.queue.2"));
 
-         Assert.assertNotNull(getAddressInfo(embeddedJMS, "permanent_test_address_removal"));
-         Assert.assertNotNull(getAddressInfo(embeddedJMS, "permanent_test_queue_removal"));
-         Assert.assertTrue(listQueuesNamesForAddress(embeddedJMS, "permanent_test_queue_removal").contains("permanent_test_queue_removal_queue_1"));
-         Assert.assertTrue(listQueuesNamesForAddress(embeddedJMS, "permanent_test_queue_removal").contains("permanent_test_queue_removal_queue_2"));
+         Assert.assertNotNull(getAddressInfo(embeddedJMS, "permanent.test.address.removal"));
+         Assert.assertNotNull(getAddressInfo(embeddedJMS, "permanent.test.queue.removal"));
+         Assert.assertTrue(listQueuesNamesForAddress(embeddedJMS, "permanent.test.queue.removal").contains("permanent.test.queue.removal.queue.1"));
+         Assert.assertTrue(listQueuesNamesForAddress(embeddedJMS, "permanent.test.queue.removal").contains("permanent.test.queue.removal.queue.2"));
 
-         Assert.assertNotNull(getAddressInfo(embeddedJMS, "config_test_queue_change"));
-         Assert.assertTrue(listQueuesNamesForAddress(embeddedJMS, "config_test_queue_change").contains("config_test_queue_change_queue"));
-         Assert.assertEquals(1, getQueue(embeddedJMS, "config_test_queue_change_queue").getMaxConsumers());
-         Assert.assertEquals(true, getQueue(embeddedJMS, "config_test_queue_change_queue").isPurgeOnNoConsumers());
+         Assert.assertNotNull(getAddressInfo(embeddedJMS, "config.test.queue.change"));
+         Assert.assertTrue(listQueuesNamesForAddress(embeddedJMS, "config.test.queue.change").contains("config.test.queue.change.queue"));
+         Assert.assertEquals(1, getQueue(embeddedJMS, "config.test.queue.change.queue").getMaxConsumers());
+         Assert.assertEquals(true, getQueue(embeddedJMS, "config.test.queue.change.queue").isPurgeOnNoConsumers());
       } finally {
          embeddedJMS.stop();
       }

--- a/tests/integration-tests/src/test/resources/reload-address-queues-updated.xml
+++ b/tests/integration-tests/src/test/resources/reload-address-queues-updated.xml
@@ -99,7 +99,7 @@ under the License.
             <address-full-policy>BLOCK</address-full-policy>
          </address-setting>
          
-         <address-setting match="config_#">
+         <address-setting match="config.#">
             <auto-create-queues>false</auto-create-queues>
             <dead-letter-address>DLQ</dead-letter-address>
             <expiry-address>ExpiryQueue</expiry-address>
@@ -113,19 +113,19 @@ under the License.
       </address-settings>
       
       <addresses>
-         <address name="config_test_queue_removal">
+         <address name="config.test.queue.removal">
             <multicast>
-               <queue name="config_test_queue_removal_queue_1"/>
+               <queue name="config.test.queue.removal.queue.1"/>
             </multicast>
          </address>
-         <address name="permanent_test_queue_removal">
+         <address name="permanent.test.queue.removal">
             <multicast>
-               <queue name="permanent_test_queue_removal_queue_1"/>
+               <queue name="permanent.test.queue.removal.queue.1"/>
             </multicast>
          </address>
-         <address name="config_test_queue_change">
+         <address name="config.test.queue.change">
             <multicast>
-               <queue name="config_test_queue_change_queue" max-consumers="1" purge-on-no-consumers="true" />
+               <queue name="config.test.queue.change.queue" max-consumers="1" purge-on-no-consumers="true" />
             </multicast>
          </address>
       </addresses>

--- a/tests/integration-tests/src/test/resources/reload-address-queues.xml
+++ b/tests/integration-tests/src/test/resources/reload-address-queues.xml
@@ -102,7 +102,7 @@ under the License.
             <address-full-policy>BLOCK</address-full-policy>
          </address-setting>
          
-         <address-setting match="config_#">
+         <address-setting match="config.#">
             <auto-create-queues>false</auto-create-queues>
             <dead-letter-address>DLQ</dead-letter-address>
             <expiry-address>ExpiryQueue</expiry-address>
@@ -116,35 +116,35 @@ under the License.
       </address-settings>
 
       <addresses>
-         <address name="config_test_queue_removal">
+         <address name="config.test.queue.removal">
             <multicast>
-               <queue name="config_test_queue_removal_queue_1"/>
-               <queue name="config_test_queue_removal_queue_2"/>
+               <queue name="config.test.queue.removal.queue.1"/>
+               <queue name="config.test.queue.removal.queue.2"/>
             </multicast>
          </address>
-         <address name="config_test_address_removal">
+         <address name="config.test.address.removal">
             <multicast>
-               <queue name="config_test_address_removal_queue"/>
+               <queue name="config.test.address.removal.queue"/>
             </multicast>
          </address>
-         <address name="config_test_address_removal_no_queue">
+         <address name="config.test.address.removal.no.queue">
             <multicast>
             </multicast>
          </address>
-         <address name="permanent_test_queue_removal">
+         <address name="permanent.test.queue.removal">
             <multicast>
-               <queue name="permanent_test_queue_removal_queue_1"/>
-               <queue name="permanent_test_queue_removal_queue_2"/>
+               <queue name="permanent.test.queue.removal.queue.1"/>
+               <queue name="permanent.test.queue.removal.queue.2"/>
             </multicast>
          </address>
-         <address name="permanent_test_address_removal">
+         <address name="permanent.test.address.removal">
             <multicast>
-               <queue name="permanent_test_address_removal_queue"/>
+               <queue name="permanent.test.address.removal.queue"/>
             </multicast>
          </address>
-         <address name="config_test_queue_change">
+         <address name="config.test.queue.change">
             <multicast>
-               <queue name="config_test_queue_change_queue" max-consumers="10" purge-on-no-consumers="false" />
+               <queue name="config.test.queue.change.queue" max-consumers="10" purge-on-no-consumers="false" />
             </multicast>
          </address>
       </addresses>


### PR DESCRIPTION
Commit 8bd8e2bd5d4fc2fc3e69bcfbb20799bc55bc1e9e for ARTEMIS-1403
broke RedeployTest because it wasn't using the proper delimiter
in the address/queue names and matches.