### PR TITLE
ARTEMIS-1423 numeric filtering for ActiveMQServerControl.listQueues()

### DIFF
--- a/artemis-cli/src/test/java/org/apache/activemq/cli/test/ArtemisTest.java
+++ b/artemis-cli/src/test/java/org/apache/activemq/cli/test/ArtemisTest.java
@@ -745,10 +745,8 @@ public class ArtemisTest extends CliTestBase {
          statQueue.execute(context);
          lines = getOutputLines(context, false);
 
-         // Header line + 1 queues
-         Assert.assertEquals("rows returned filtering by MESSAGE_COUNT", 2, lines.size());
-         String[] columns = lines.get(1).split("\\|");
-         Assert.assertEquals("queue name filtering by MESSAGE_COUNT ", "Test1", columns[2].trim());
+         // Header line + 0 queues
+         Assert.assertEquals("rows returned filtering by MESSAGE_COUNT", 1, lines.size());
 
          //check all queues containing address "Test1" are displayed using Filter field MESSAGE_ADDED
          context = new TestActionContext();
@@ -760,10 +758,8 @@ public class ArtemisTest extends CliTestBase {
          statQueue.setValue("20");
          statQueue.execute(context);
          lines = getOutputLines(context, false);
-         // Header line + 1 queues
-         Assert.assertEquals("rows returned filtering by MESSAGES_ADDED", 2, lines.size());
-         columns = lines.get(1).split("\\|");
-         Assert.assertEquals("queue name filtered by MESSAGE_ADDED", "Test20", columns[2].trim());
+         // Header line + 0 queues
+         Assert.assertEquals("rows returned filtering by MESSAGES_ADDED", 1, lines.size());
 
          //check all queues containing address "Test1" are displayed using Filter field DELIVERING_COUNT
          context = new TestActionContext();
@@ -775,7 +771,7 @@ public class ArtemisTest extends CliTestBase {
          statQueue.setValue("10");
          statQueue.execute(context);
          lines = getOutputLines(context, false);
-         columns = lines.get(1).split("\\|");
+         String[] columns = lines.get(1).split("\\|");
          // Header line + 1 queues
          Assert.assertEquals("rows returned filtering by DELIVERING_COUNT", 2, lines.size());
          Assert.assertEquals("queue name filtered by DELIVERING_COUNT ", "Test1", columns[2].trim());
@@ -880,7 +876,6 @@ public class ArtemisTest extends CliTestBase {
          lines = getOutputLines(context, false);
          // Header line + 0 queue
          Assert.assertEquals("No stdout for wrong OPERATION", 0, lines.size());
-
          lines = getOutputLines(context, true);
          // 1 error line
          Assert.assertEquals("stderr for wrong OPERATION", 1, lines.size());

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/predicate/ActiveMQFilterPredicate.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/predicate/ActiveMQFilterPredicate.java
@@ -23,7 +23,7 @@ import com.google.common.base.Predicate;
 public class ActiveMQFilterPredicate<T> implements Predicate<T> {
 
    enum Operation {
-      CONTAINS, EQUALS;
+      CONTAINS, EQUALS, GREATER_THAN, LESS_THAN;
    }
 
    protected String field;
@@ -77,6 +77,10 @@ public class ActiveMQFilterPredicate<T> implements Predicate<T> {
                return equals(field, value);
             case CONTAINS:
                return contains(field, value);
+            case GREATER_THAN:
+               return false;
+            case LESS_THAN:
+               return false;
          }
       }
       return true;
@@ -88,6 +92,81 @@ public class ActiveMQFilterPredicate<T> implements Predicate<T> {
             return true;
       }
       return false;
+   }
+
+   public boolean matches(long field) {
+      long longValue;
+      if (operation != null) {
+
+         try {
+            longValue = Long.parseLong(value);
+         } catch (NumberFormatException ex) {
+            //cannot compare
+            return false;
+         }
+
+         switch (operation) {
+            case EQUALS:
+               return field == longValue;
+            case CONTAINS:
+               return false;
+            case LESS_THAN:
+               return field < longValue;
+            case GREATER_THAN:
+               return field > longValue;
+         }
+      }
+      return true;
+   }
+
+   public boolean matches(int field) {
+      int intValue;
+      if (operation != null) {
+
+         try {
+            intValue = Integer.parseInt(value);
+         } catch (NumberFormatException ex) {
+            //cannot compare
+            return false;
+         }
+
+         switch (operation) {
+            case EQUALS:
+               return field == intValue;
+            case CONTAINS:
+               return false;
+            case LESS_THAN:
+               return field < intValue;
+            case GREATER_THAN:
+               return field > intValue;
+         }
+      }
+      return true;
+   }
+
+   public boolean matches(float field) {
+      float floatValue;
+      if (operation != null) {
+
+         try {
+            floatValue = Float.parseFloat(value);
+         } catch (NumberFormatException ex) {
+            //cannot compare
+            return false;
+         }
+
+         switch (operation) {
+            case EQUALS:
+               return field == floatValue;
+            case CONTAINS:
+               return false;
+            case LESS_THAN:
+               return field < floatValue;
+            case GREATER_THAN:
+               return field > floatValue;
+         }
+      }
+      return true;
    }
 
    private boolean equals(Object field, Object value) {


### PR DESCRIPTION
This also applies to listAddresses()/listSessions()

Also added GREATER_THAN and LESS_THAN operations, this  allows the listQueues() to support queries such as "Message_Count GREATER_THAN 1000" or "Consumer_Count LESS_THAN 2"

- When LESS_THAN or GREATER_THAN is used with a String column, nothing is matched. 
- When CONTAINS is applied to a numeric column nothing is matched.
