### PR TITLE
ARTEMIS-1424 Openwire not work with different tightEncoding options

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireMessageConverter.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireMessageConverter.java
@@ -423,10 +423,10 @@ public class OpenWireMessageConverter implements MessageConverter<OpenwireMessag
       }
    }
 
-   public static MessageDispatch createMessageDispatch(MessageReference reference,
+   public MessageDispatch createMessageDispatch(MessageReference reference,
                                                        ICoreMessage message,
                                                        AMQConsumer consumer) throws IOException, JMSException {
-      ActiveMQMessage amqMessage = toAMQMessage(reference, message, consumer.getMarshaller(), consumer.getOpenwireDestination());
+      ActiveMQMessage amqMessage = toAMQMessage(reference, message, consumer.getOpenwireDestination());
 
       //we can use core message id for sequenceId
       amqMessage.getMessageId().setBrokerSequenceId(message.getMessageID());
@@ -441,9 +441,8 @@ public class OpenWireMessageConverter implements MessageConverter<OpenwireMessag
       return md;
    }
 
-   private static ActiveMQMessage toAMQMessage(MessageReference reference,
+   private ActiveMQMessage toAMQMessage(MessageReference reference,
                                                ICoreMessage coreMessage,
-                                               WireFormat marshaller,
                                                ActiveMQDestination actualDestination) throws IOException {
       ActiveMQMessage amqMsg = null;
       byte coreType = coreMessage.getType();

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireProtocolManager.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireProtocolManager.java
@@ -119,7 +119,7 @@ public class OpenWireProtocolManager implements ProtocolManager<Interceptor>, Cl
    private long maxInactivityDurationInitalDelay = 10 * 1000L;
    private boolean useKeepAlive = true;
 
-   private final OpenWireMessageConverter messageConverter;
+   private final OpenWireMessageConverter internalConverter;
 
    private final Map<SimpleString, RoutingType> prefixes = new HashMap<>();
 
@@ -131,7 +131,7 @@ public class OpenWireProtocolManager implements ProtocolManager<Interceptor>, Cl
       wireFactory.setCacheEnabled(false);
       advisoryProducerId.setConnectionId(ID_GENERATOR.generateId());
       scheduledPool = server.getScheduledPool();
-      this.messageConverter = new OpenWireMessageConverter(wireFactory.createWireFormat());
+      this.internalConverter = new OpenWireMessageConverter(wireFactory.createWireFormat());
 
       final ClusterManager clusterManager = this.server.getClusterManager();
 
@@ -140,10 +140,6 @@ public class OpenWireProtocolManager implements ProtocolManager<Interceptor>, Cl
       if (cc != null) {
          cc.addClusterTopologyListener(this);
       }
-   }
-
-   public OpenWireFormat getNewWireFormat() {
-      return (OpenWireFormat) wireFactory.createWireFormat();
    }
 
    @Override
@@ -582,5 +578,9 @@ public class OpenWireProtocolManager implements ProtocolManager<Interceptor>, Cl
          total.addAll(connection.getTemporaryDestinations());
       }
       return total;
+   }
+
+   public OpenWireMessageConverter getInternalConverter() {
+      return internalConverter;
    }
 }

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQConsumer.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQConsumer.java
@@ -51,7 +51,6 @@ import org.apache.activemq.command.MessageDispatch;
 import org.apache.activemq.command.MessageId;
 import org.apache.activemq.command.MessagePull;
 import org.apache.activemq.command.RemoveInfo;
-import org.apache.activemq.wireformat.WireFormat;
 
 public class AMQConsumer {
    private AMQSession session;
@@ -186,10 +185,6 @@ public class AMQConsumer {
       return info.getConsumerId();
    }
 
-   public WireFormat getMarshaller() {
-      return this.session.getMarshaller();
-   }
-
    public void acquireCredit(int n) throws Exception {
       if (messagePullHandler != null) {
          //don't acquire any credits when the pull handler controls it!!
@@ -217,7 +212,7 @@ public class AMQConsumer {
             //so we need to remove this property too.
             message.removeProperty(MessageUtil.CONNECTION_ID_PROPERTY_NAME);
          }
-         dispatch = OpenWireMessageConverter.createMessageDispatch(reference, message, this);
+         dispatch = session.getConverter().createMessageDispatch(reference, message, this);
          int size = dispatch.getMessage().getSize();
          reference.setProtocolData(dispatch.getMessage().getMessageId());
          session.deliverMessage(dispatch);

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQSession.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQSession.java
@@ -54,7 +54,6 @@ import org.apache.activemq.command.ProducerInfo;
 import org.apache.activemq.command.Response;
 import org.apache.activemq.command.SessionInfo;
 import org.apache.activemq.openwire.OpenWireFormat;
-import org.apache.activemq.wireformat.WireFormat;
 import org.jboss.logging.Logger;
 
 import static org.apache.activemq.artemis.core.protocol.openwire.util.OpenWireUtil.OPENWIRE_WILDCARD;
@@ -104,7 +103,7 @@ public class AMQSession implements SessionCallback {
    }
 
    public OpenWireMessageConverter getConverter() {
-      return converter;
+      return protocolManager.getInternalConverter();
    }
 
    public void initialize() {
@@ -435,10 +434,6 @@ public class AMQSession implements SessionCallback {
 
    public ActiveMQServer getCoreServer() {
       return this.server;
-   }
-
-   public WireFormat getMarshaller() {
-      return this.connection.getMarshaller();
    }
 
    public ConnectionInfo getConnectionInfo() {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/BasicOpenWireTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/BasicOpenWireTest.java
@@ -45,7 +45,9 @@ public class BasicOpenWireTest extends OpenWireTestBase {
    public TestName name = new TestName();
 
    protected static final String urlString = "tcp://" + OWHOST + ":" + OWPORT + "?wireFormat.cacheEnabled=true";
+   protected static final String urlStringLoose = "tcp://" + OWHOST + ":" + OWPORT + "?wireFormat.tightEncodingEnabled=false";
    protected ActiveMQConnectionFactory factory;
+   protected ActiveMQConnectionFactory looseFactory;
    protected ActiveMQXAConnectionFactory xaFactory;
 
    protected ActiveMQConnection connection;
@@ -85,6 +87,7 @@ public class BasicOpenWireTest extends OpenWireTestBase {
 
    protected void createFactories() {
       factory = new ActiveMQConnectionFactory(getConnectionUrl());
+      looseFactory = new ActiveMQConnectionFactory(urlStringLoose);
       xaFactory = new ActiveMQXAConnectionFactory(getConnectionUrl());
    }
 


### PR DESCRIPTION
If message senders and receivers uses different
wireformat.tightEncodingEnabled options, broker will get marshalling
problem. This is because when openwire messages are converted to
core messages, and later these core messages converted to openwire
messages, the broker uses a mashaller that comes with the connection
used to carry the messages.

For example, if a producer sents a message using option "wireformat
.tightEncodingEnabled=false" and a receiver tries to receive it
using 'true' for the same option, it'll never get it because the
broker will fail to use a "tight encoding" marshaller to
decode a 'loose encoded' message.

To fix the problem, we always use 'tight encoding' for internal
message converters.