### PR TITLE
ARTEMIS-1433 adding AddressMemoryUsage()/AddressMemoryUsagePercentage() 

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
@@ -438,6 +438,19 @@ public interface ActiveMQServerControl {
    @Attribute(desc = "global maximum limit for in-memory messages, in bytes")
    long getGlobalMaxSize();
 
+
+   /**
+    * Returns the  memory used by all the addresses on broker for in-memory messages
+    */
+   @Attribute(desc = "memory used by all the addresses on broker for in-memory messages")
+   long getAddressMemoryUsage();
+
+   /**
+    * Returns the memory used by all the addresses on broker as a percentage of global maximum limit
+    */
+   @Attribute(desc = "memory used by all the addresses on broker as a percentage of global maximum limit")
+   int getAddressMemoryUsagePercentage();
+
    // Operations ----------------------------------------------------
    @Operation(desc = "Isolate the broker", impact = MBeanOperationInfo.ACTION)
    boolean freezeReplication();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -578,6 +578,38 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
    }
 
    @Override
+   public long getAddressMemoryUsage() {
+      checkStarted();
+      clearIO();
+      try {
+         //this should not happen but if it does, return -1 to highlight it is not working
+         if (server.getPagingManager() == null) {
+            return -1L;
+         }
+         return server.getPagingManager().getGlobalSize();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public int getAddressMemoryUsagePercentage() {
+      long globalMaxSize = getGlobalMaxSize();
+      // no max size set implies 0% used
+      if (globalMaxSize <= 0) {
+         return 0;
+      }
+
+      long memoryUsed = getAddressMemoryUsage();
+      if (memoryUsed <= 0) {
+         return 0;
+      }
+
+      double result = (100D * memoryUsed) / globalMaxSize;
+      return (int) result;
+   }
+
+   @Override
    public boolean freezeReplication() {
       Activation activation = server.getActivation();
       if (activation instanceof SharedNothingLiveActivation) {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
@@ -620,6 +620,26 @@ public class ActiveMQServerControlUsingCoreTest extends ActiveMQServerControlTes
          }
 
          @Override
+         public long getAddressMemoryUsage() {
+            try {
+               return (Long) proxy.invokeOperation("getAddressMemoryUsage");
+            } catch (Exception e) {
+               e.printStackTrace();
+            }
+            return 0;
+         }
+
+         @Override
+         public int getAddressMemoryUsagePercentage() {
+            try {
+               return (Integer) proxy.invokeOperation(Integer.TYPE, "getAddressMemoryUsagePercentage");
+            } catch (Exception e) {
+               e.printStackTrace();
+            }
+            return 0;
+         }
+
+         @Override
          public boolean freezeReplication() {
 
             return false;


### PR DESCRIPTION

expose the total amount of memory used by the Addresses on the broker and express it as a percentage of the global-max-size limit. 