### PR TITLE
ARTEMIS-1438 Upgrade hawtio to latest (1.5.4)

### DIFF
--- a/artemis-hawtio/activemq-branding/src/main/webapp/plugin/js/plugin.js
+++ b/artemis-hawtio/activemq-branding/src/main/webapp/plugin/js/plugin.js
@@ -65,6 +65,31 @@ var activemqBranding = (function (self) {
             localStorage['branding'] = 'activemq';
             location.reload();
         }
+
+        /**
+         * By default tabs are pulled from the "container" perspective, here
+         * we can define includes or excludes to customize the available tabs
+         * in hawtio.  Use "href" to match from the start of a URL and "rhref"
+         * to match a URL via regex string.
+         * 
+         * Currently we need to exclude provided diagnostics,
+         * as it exposes proprietary Oracle JVM feature, flight recorder.
+         *
+         */
+        window['Perspective']['metadata'] = {
+            container: {
+                label: "Container",
+                lastPage: "#/help",
+                topLevelTabs: {
+                    excludes: [
+                        {
+                            href: "#/diagnostics"
+                        }
+                    ]
+                }
+            }
+        };
+
     });
     return self;
 })(activemqBranding || {});

--- a/artemis-hawtio/pom.xml
+++ b/artemis-hawtio/pom.xml
@@ -38,9 +38,9 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         
-        <hawtio.version>1.5.0</hawtio.version>
+        <hawtio.version>1.5.4</hawtio.version>
         <jline.version>3.2.0</jline.version>
-        <jolokia-version>1.3.6</jolokia-version>
+        <jolokia-version>1.3.7</jolokia-version>
         <junit-version>4.11</junit-version>
         <log4j-version>1.2.17</log4j-version>
         <maven-version>3.0.4</maven-version>

--- a/artemis-website/src/main/resources/hacking-guide/index.html
+++ b/artemis-website/src/main/resources/hacking-guide/index.html
@@ -19,7 +19,7 @@ under the License.
 <html>
 <head>
     <meta http-equiv="refresh"
-          content="3;url=https://github.com/apache/activemq-artemis/blob/master/docs/hacking-guide/en/SUMMARY.md"/>
+          content="3;url=https://activemq.apache.org/artemis/docs/latest/hacking-guide/index.html"/>
 </head>
 <h1>User Manual</h1>
 
@@ -28,6 +28,6 @@ under the License.
     build Apache ActiveMQ Artemis with the Hacking Guide you must use the maven release profile:
     <code>mvn clean install -Prelease</code>.</p>
 <p>You can view the current documentation directly on <a
-        href="https://github.com/apache/activemq-artemis/blob/master/docs/hacking-guide/en/SUMMARY.md">github</a>.</p>
+        href="https://activemq.apache.org/artemis/docs/latest/hacking-guide/index.html">https://activemq.apache.org/artemis</a>.</p>
 
 </html>

--- a/artemis-website/src/main/resources/user-manual/index.html
+++ b/artemis-website/src/main/resources/user-manual/index.html
@@ -20,7 +20,7 @@ under the License.
 <html>
 <head>
     <meta http-equiv="refresh"
-          content="3;url=https://github.com/apache/activemq-artemis/blob/master/docs/user-manual/en/SUMMARY.md"/>
+          content="3;url=https://activemq.apache.org/artemis/docs/latest/index.html"/>
 </head>
 
 <h1>User Manual</h1>
@@ -30,6 +30,6 @@ under the License.
     build Apache ActiveMQ Artemis with the User Manual you must use the maven release profile:
     <code>mvn clean install -Prelease</code>.</p>
 <p>You can view the current documentation directly on <a
-        href="https://github.com/apache/activemq-artemis/blob/master/docs/user-manual/en/SUMMARY.md">github</a>.</p>
+        href="https://activemq.apache.org/artemis/docs/latest/index.html">https://activemq.apache.org/artemis</a>.</p>
 
 </html>

--- a/pom.xml
+++ b/pom.xml
@@ -604,7 +604,7 @@
            <groupId>org.jolokia</groupId>
            <artifactId>jolokia-war</artifactId>
            <type>war</type>
-           <version>1.3.5</version>
+           <version>1.3.7</version>
            <!-- License: Apache 2.0 -->
         </dependency>
          <!-- ## End Jetty Wed Dependencies ## -->


### PR DESCRIPTION
Set hawtio to 1.5.4
Exclude diagnostics tab to avoid Flight Recorder being exposed.
Update jolokia to latest to match hawtio
Update current documentation links to artemis site instead of github causing blank load if docs are not local built.