### PR TITLE
ARTEMIS-1314 Fixing issues with JMS selectors on AMQP

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
@@ -33,6 +33,7 @@ import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.persistence.Persister;
 import org.apache.activemq.artemis.protocol.amqp.converter.AMQPConverter;
+import org.apache.activemq.artemis.protocol.amqp.converter.AMQPMessageIdHelper;
 import org.apache.activemq.artemis.protocol.amqp.converter.AMQPMessageSupport;
 import org.apache.activemq.artemis.protocol.amqp.util.NettyWritable;
 import org.apache.activemq.artemis.protocol.amqp.util.TLSEncode;
@@ -557,7 +558,6 @@ public class AMQPMessage extends RefCountMessage {
       }
    }
 
-
    @Override
    public org.apache.activemq.artemis.api.core.Message setUserID(Object userID) {
       return null;
@@ -725,7 +725,6 @@ public class AMQPMessage extends RefCountMessage {
       return this;
    }
 
-
    @Override
    public byte[] getExtraBytesProperty(SimpleString key) throws ActiveMQPropertyConversionException {
       if (extraProperties == null) {
@@ -735,7 +734,6 @@ public class AMQPMessage extends RefCountMessage {
       }
    }
 
-
    @Override
    public byte[] removeExtraBytesProperty(SimpleString key) throws ActiveMQPropertyConversionException {
       if (extraProperties == null) {
@@ -744,8 +742,6 @@ public class AMQPMessage extends RefCountMessage {
          return (byte[])extraProperties.removeProperty(key);
       }
    }
-
-
 
    @Override
    public org.apache.activemq.artemis.api.core.Message putBooleanProperty(String key, boolean value) {
@@ -904,9 +900,19 @@ public class AMQPMessage extends RefCountMessage {
    @Override
    public Object getObjectProperty(String key) {
       if (key.equals(MessageUtil.TYPE_HEADER_NAME.toString())) {
-         return getProperties().getSubject();
+         if (getProperties() != null) {
+            return getProperties().getSubject();
+         }
       } else if (key.equals(MessageUtil.CONNECTION_ID_PROPERTY_NAME.toString())) {
          return getConnectionID();
+      } else if (key.equals(MessageUtil.JMSXGROUPID)) {
+         return getGroupID();
+      } else if (key.equals(MessageUtil.JMSXUSERID)) {
+         return getAMQPUserID();
+      } else if (key.equals(MessageUtil.CORRELATIONID_HEADER_NAME.toString())) {
+         if (getProperties() != null && getProperties().getCorrelationId() != null) {
+            return AMQPMessageIdHelper.INSTANCE.toCorrelationIdString(getProperties().getCorrelationId());
+         }
       } else {
          Object value = getApplicationPropertiesMap().get(key);
          if (value instanceof UnsignedInteger ||
@@ -918,6 +924,8 @@ public class AMQPMessage extends RefCountMessage {
             return value;
          }
       }
+
+      return null;
    }
 
    @Override

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/converter/AMQPMessageIdHelper.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/converter/AMQPMessageIdHelper.java
@@ -1,5 +1,4 @@
 /*
- *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -16,7 +15,6 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- *
  */
 package org.apache.activemq.artemis.protocol.amqp.converter;
 
@@ -28,26 +26,32 @@ import org.apache.qpid.proton.amqp.Binary;
 import org.apache.qpid.proton.amqp.UnsignedLong;
 
 /**
- * Helper class for identifying and converting message-id and correlation-id values between the
- * AMQP types and the Strings values used by JMS.
+ * Helper class for identifying and converting message-id and correlation-id
+ * values between the AMQP types and the Strings values used by JMS.
+ *
  * <p>
- * AMQP messages allow for 4 types of message-id/correlation-id: message-id-string,
- * message-id-binary, message-id-uuid, or message-id-ulong. In order to accept or return a
- * string representation of these for interoperability with other AMQP clients, the following
- * encoding can be used after removing or before adding the "ID:" prefix used for a JMSMessageID
+ * AMQP messages allow for 4 types of message-id/correlation-id:
+ * message-id-string, message-id-binary, message-id-uuid, or message-id-ulong.
+ * In order to accept or return a string representation of these for
+ * interoperability with other AMQP clients, the following encoding can be used
+ * after removing or before adding the "ID:" prefix used for a JMSMessageID
  * value:<br>
- * <p>
+ *
  * {@literal "AMQP_BINARY:<hex representation of binary content>"}<br>
  * {@literal "AMQP_UUID:<string representation of uuid>"}<br>
  * {@literal "AMQP_ULONG:<string representation of ulong>"}<br>
  * {@literal "AMQP_STRING:<string>"}<br>
+ *
  * <p>
- * The AMQP_STRING encoding exists only for escaping message-id-string values that happen to
- * begin with one of the encoding prefixes (including AMQP_STRING itself). It MUST NOT be used
- * otherwise.
+ * The AMQP_STRING encoding exists only for escaping message-id-string values
+ * that happen to begin with one of the encoding prefixes (including AMQP_STRING
+ * itself). It MUST NOT be used otherwise.
+ *
  * <p>
- * When provided a string for conversion which attempts to identify itself as an encoded binary,
- * uuid, or ulong but can't be converted into the indicated format, an exception will be thrown.
+ * When provided a string for conversion which attempts to identify itself as an
+ * encoded binary, uuid, or ulong but can't be converted into the indicated
+ * format, an exception will be thrown.
+ *
  */
 public class AMQPMessageIdHelper {
 
@@ -57,109 +61,213 @@ public class AMQPMessageIdHelper {
    public static final String AMQP_UUID_PREFIX = "AMQP_UUID:";
    public static final String AMQP_ULONG_PREFIX = "AMQP_ULONG:";
    public static final String AMQP_BINARY_PREFIX = "AMQP_BINARY:";
+   public static final String AMQP_NO_PREFIX = "AMQP_NO_PREFIX:";
+   public static final String JMS_ID_PREFIX = "ID:";
 
+   private static final String AMQP_PREFIX = "AMQP_";
+   private static final int JMS_ID_PREFIX_LENGTH = JMS_ID_PREFIX.length();
    private static final int AMQP_UUID_PREFIX_LENGTH = AMQP_UUID_PREFIX.length();
    private static final int AMQP_ULONG_PREFIX_LENGTH = AMQP_ULONG_PREFIX.length();
    private static final int AMQP_STRING_PREFIX_LENGTH = AMQP_STRING_PREFIX.length();
    private static final int AMQP_BINARY_PREFIX_LENGTH = AMQP_BINARY_PREFIX.length();
+   private static final int AMQP_NO_PREFIX_LENGTH = AMQP_NO_PREFIX.length();
    private static final char[] HEX_CHARS = "0123456789ABCDEF".toCharArray();
 
    /**
-    * Takes the provided AMQP messageId style object, and convert it to a base string. Encodes
-    * type information as a prefix where necessary to convey or escape the type of the provided
-    * object.
+    * Checks whether the given string begins with "ID:" prefix used to denote a
+    * JMSMessageID
     *
-    * @param messageId
-    *        the raw messageId object to process
-    * @return the base string to be used in creating the actual id.
+    * @param string
+    *        the string to check
+    * @return true if and only id the string begins with "ID:"
     */
-   public String toBaseMessageIdString(Object messageId) {
-      if (messageId == null) {
-         return null;
-      } else if (messageId instanceof String) {
-         String stringId = (String) messageId;
+   public boolean hasMessageIdPrefix(String string) {
+      if (string == null) {
+         return false;
+      }
 
-         // If the given string has a type encoding prefix,
-         // we need to escape it as an encoded string (even if
-         // the existing encoding prefix was also for string)
-         if (hasTypeEncodingPrefix(stringId)) {
-            return AMQP_STRING_PREFIX + stringId;
+      return string.startsWith(JMS_ID_PREFIX);
+   }
+
+   public String toMessageIdString(Object idObject) {
+      if (idObject instanceof String) {
+         final String stringId = (String) idObject;
+
+         boolean hasMessageIdPrefix = hasMessageIdPrefix(stringId);
+         if (!hasMessageIdPrefix) {
+            // For JMSMessageID, has no "ID:" prefix, we need to record
+            // that for later use as a JMSCorrelationID.
+            return JMS_ID_PREFIX + AMQP_NO_PREFIX + stringId;
+         } else if (hasTypeEncodingPrefix(stringId, JMS_ID_PREFIX_LENGTH)) {
+            // We are for a JMSMessageID value, but have 'ID:' followed by
+            // one of the encoding prefixes. Need to escape the entire string
+            // to preserve for later re-use as a JMSCorrelationID.
+            return JMS_ID_PREFIX + AMQP_STRING_PREFIX + stringId;
          } else {
+            // It has "ID:" prefix and doesn't have encoding prefix, use it as-is.
             return stringId;
          }
-      } else if (messageId instanceof UUID) {
-         return AMQP_UUID_PREFIX + messageId.toString();
-      } else if (messageId instanceof UnsignedLong) {
-         return AMQP_ULONG_PREFIX + messageId.toString();
-      } else if (messageId instanceof Binary) {
-         ByteBuffer dup = ((Binary) messageId).asByteBuffer();
+      } else {
+         // Not a string, convert it
+         return convertToIdString(idObject);
+      }
+   }
+
+   public String toCorrelationIdString(Object idObject) {
+      if (idObject instanceof String) {
+         final String stringId = (String) idObject;
+
+         boolean hasMessageIdPrefix = hasMessageIdPrefix(stringId);
+         if (!hasMessageIdPrefix) {
+            // For JMSCorrelationID, has no "ID:" prefix, use it as-is.
+            return stringId;
+         } else if (hasTypeEncodingPrefix(stringId, JMS_ID_PREFIX_LENGTH)) {
+            // We are for a JMSCorrelationID value, but have 'ID:' followed by
+            // one of the encoding prefixes. Need to escape the entire string
+            // to preserve for later re-use as a JMSCorrelationID.
+            return JMS_ID_PREFIX + AMQP_STRING_PREFIX + stringId;
+         } else {
+            // It has "ID:" prefix and doesn't have encoding prefix, use it as-is.
+            return stringId;
+         }
+      } else {
+         // Not a string, convert it
+         return convertToIdString(idObject);
+      }
+   }
+
+   /**
+    * Takes the provided non-String AMQP message-id/correlation-id object, and
+    * convert it it to a String usable as either a JMSMessageID or
+    * JMSCorrelationID value, encoding the type information as a prefix to
+    * convey for later use in reversing the process if used to set
+    * JMSCorrelationID on a message.
+    *
+    * @param idObject
+    *        the object to process
+    * @return string to be used for the actual JMS ID.
+    */
+   private String convertToIdString(Object idObject) {
+      if (idObject == null) {
+         return null;
+      }
+
+      if (idObject instanceof UUID) {
+         return JMS_ID_PREFIX + AMQP_UUID_PREFIX + idObject.toString();
+      } else if (idObject instanceof UnsignedLong) {
+         return JMS_ID_PREFIX + AMQP_ULONG_PREFIX + idObject.toString();
+      } else if (idObject instanceof Binary) {
+         ByteBuffer dup = ((Binary) idObject).asByteBuffer();
 
          byte[] bytes = new byte[dup.remaining()];
          dup.get(bytes);
 
          String hex = convertBinaryToHexString(bytes);
 
-         return AMQP_BINARY_PREFIX + hex;
+         return JMS_ID_PREFIX + AMQP_BINARY_PREFIX + hex;
       } else {
-         throw new IllegalArgumentException("Unsupported type provided: " + messageId.getClass());
+         throw new IllegalArgumentException("Unsupported type provided: " + idObject.getClass());
       }
    }
 
+   private boolean hasTypeEncodingPrefix(String stringId, int offset) {
+      if (!stringId.startsWith(AMQP_PREFIX, offset)) {
+         return false;
+      }
+
+      return hasAmqpBinaryPrefix(stringId, offset) || hasAmqpUuidPrefix(stringId, offset) || hasAmqpUlongPrefix(stringId, offset)
+         || hasAmqpStringPrefix(stringId, offset) || hasAmqpNoPrefix(stringId, offset);
+   }
+
+   private boolean hasAmqpStringPrefix(String stringId, int offset) {
+      return stringId.startsWith(AMQP_STRING_PREFIX, offset);
+   }
+
+   private boolean hasAmqpUlongPrefix(String stringId, int offset) {
+      return stringId.startsWith(AMQP_ULONG_PREFIX, offset);
+   }
+
+   private boolean hasAmqpUuidPrefix(String stringId, int offset) {
+      return stringId.startsWith(AMQP_UUID_PREFIX, offset);
+   }
+
+   private boolean hasAmqpBinaryPrefix(String stringId, int offset) {
+      return stringId.startsWith(AMQP_BINARY_PREFIX, offset);
+   }
+
+   private boolean hasAmqpNoPrefix(String stringId, int offset) {
+      return stringId.startsWith(AMQP_NO_PREFIX, offset);
+   }
+
    /**
-    * Takes the provided base id string and return the appropriate amqp messageId style object.
-    * Converts the type based on any relevant encoding information found as a prefix.
+    * Takes the provided id string and return the appropriate amqp messageId
+    * style object. Converts the type based on any relevant encoding information
+    * found as a prefix.
     *
-    * @param baseId
-    *        the object to be converted to an AMQP MessageId value.
+    * @param origId
+    *        the object to be converted
     * @return the AMQP messageId style object
-    * @throws ActiveMQAMQPIllegalStateException
-    *         if the provided baseId String indicates an encoded type but can't be converted to
-    *         that type.
+    *
+    * @throws IllegalArgument
+    *         if the provided baseId String indicates an encoded type but can't
+    *         be converted to that type.
     */
-   public Object toIdObject(String baseId) throws ActiveMQAMQPIllegalStateException {
-      if (baseId == null) {
+   public Object toIdObject(final String origId) throws ActiveMQAMQPIllegalStateException {
+      if (origId == null) {
          return null;
       }
 
+      if (!AMQPMessageIdHelper.INSTANCE.hasMessageIdPrefix(origId)) {
+         // We have a string without any "ID:" prefix, it is an
+         // application-specific String, use it as-is.
+         return origId;
+      }
+
       try {
-         if (hasAmqpUuidPrefix(baseId)) {
-            String uuidString = strip(baseId, AMQP_UUID_PREFIX_LENGTH);
+         if (hasAmqpNoPrefix(origId, JMS_ID_PREFIX_LENGTH)) {
+            // Prefix telling us there was originally no "ID:" prefix,
+            // strip it and return the remainder
+            return origId.substring(JMS_ID_PREFIX_LENGTH + AMQP_NO_PREFIX_LENGTH);
+         } else if (hasAmqpUuidPrefix(origId, JMS_ID_PREFIX_LENGTH)) {
+            String uuidString = origId.substring(JMS_ID_PREFIX_LENGTH + AMQP_UUID_PREFIX_LENGTH);
             return UUID.fromString(uuidString);
-         } else if (hasAmqpUlongPrefix(baseId)) {
-            String longString = strip(baseId, AMQP_ULONG_PREFIX_LENGTH);
-            return UnsignedLong.valueOf(longString);
-         } else if (hasAmqpStringPrefix(baseId)) {
-            return strip(baseId, AMQP_STRING_PREFIX_LENGTH);
-         } else if (hasAmqpBinaryPrefix(baseId)) {
-            String hexString = strip(baseId, AMQP_BINARY_PREFIX_LENGTH);
+         } else if (hasAmqpUlongPrefix(origId, JMS_ID_PREFIX_LENGTH)) {
+            String ulongString = origId.substring(JMS_ID_PREFIX_LENGTH + AMQP_ULONG_PREFIX_LENGTH);
+            return UnsignedLong.valueOf(ulongString);
+         } else if (hasAmqpStringPrefix(origId, JMS_ID_PREFIX_LENGTH)) {
+            return origId.substring(JMS_ID_PREFIX_LENGTH + AMQP_STRING_PREFIX_LENGTH);
+         } else if (hasAmqpBinaryPrefix(origId, JMS_ID_PREFIX_LENGTH)) {
+            String hexString = origId.substring(JMS_ID_PREFIX_LENGTH + AMQP_BINARY_PREFIX_LENGTH);
             byte[] bytes = convertHexStringToBinary(hexString);
             return new Binary(bytes);
          } else {
-            // We have a string without any type prefix, transmit it as-is.
-            return baseId;
+            // We have a string without any encoding prefix needing processed,
+            // so transmit it as-is, including the "ID:"
+            return origId;
          }
-      } catch (IllegalArgumentException e) {
-         throw new ActiveMQAMQPIllegalStateException("Unable to convert ID value");
+      } catch (IllegalArgumentException iae) {
+         throw new ActiveMQAMQPIllegalStateException(iae.getMessage());
       }
    }
 
    /**
-    * Convert the provided hex-string into a binary representation where each byte represents
-    * two characters of the hex string.
-    * <p>
+    * Convert the provided hex-string into a binary representation where each
+    * byte represents two characters of the hex string.
+    *
     * The hex characters may be upper or lower case.
     *
     * @param hexString
-    *        string to convert to a binary value.
+    *        string to convert
     * @return a byte array containing the binary representation
     * @throws IllegalArgumentException
-    *         if the provided String is a non-even length or contains non-hex characters
+    *         if the provided String is a non-even length or contains non-hex
+    *         characters
     */
    public byte[] convertHexStringToBinary(String hexString) throws IllegalArgumentException {
       int length = hexString.length();
 
-      // As each byte needs two characters in the hex encoding, the string must be an even
-      // length.
+      // As each byte needs two characters in the hex encoding, the string must
+      // be an even length.
       if (length % 2 != 0) {
          throw new IllegalArgumentException("The provided hex String must be an even length, but was of length " + length + ": " + hexString);
       }
@@ -179,14 +287,32 @@ public class AMQPMessageIdHelper {
       return binary;
    }
 
+   private int hexCharToInt(char ch, String orig) throws IllegalArgumentException {
+      if (ch >= '0' && ch <= '9') {
+         // subtract '0' to get difference in position as an int
+         return ch - '0';
+      } else if (ch >= 'A' && ch <= 'F') {
+         // subtract 'A' to get difference in position as an int
+         // and then add 10 for the offset of 'A'
+         return ch - 'A' + 10;
+      } else if (ch >= 'a' && ch <= 'f') {
+         // subtract 'a' to get difference in position as an int
+         // and then add 10 for the offset of 'a'
+         return ch - 'a' + 10;
+      }
+
+      throw new IllegalArgumentException("The provided hex string contains non-hex character '" + ch + "': " + orig);
+   }
+
    /**
-    * Convert the provided binary into a hex-string representation where each character
-    * represents 4 bits of the provided binary, i.e each byte requires two characters.
-    * <p>
+    * Convert the provided binary into a hex-string representation where each
+    * character represents 4 bits of the provided binary, i.e each byte requires
+    * two characters.
+    *
     * The returned hex characters are upper-case.
     *
     * @param bytes
-    *        the binary value to convert to a hex String instance.
+    *        binary to convert
     * @return a String containing a hex representation of the bytes
     */
    public String convertBinaryToHexString(byte[] bytes) {
@@ -205,48 +331,5 @@ public class AMQPMessageIdHelper {
       }
 
       return builder.toString();
-   }
-
-   // ----- Internal implementation ------------------------------------------//
-
-   private boolean hasTypeEncodingPrefix(String stringId) {
-      return hasAmqpBinaryPrefix(stringId) || hasAmqpUuidPrefix(stringId) || hasAmqpUlongPrefix(stringId) || hasAmqpStringPrefix(stringId);
-   }
-
-   private boolean hasAmqpStringPrefix(String stringId) {
-      return stringId.startsWith(AMQP_STRING_PREFIX);
-   }
-
-   private boolean hasAmqpUlongPrefix(String stringId) {
-      return stringId.startsWith(AMQP_ULONG_PREFIX);
-   }
-
-   private boolean hasAmqpUuidPrefix(String stringId) {
-      return stringId.startsWith(AMQP_UUID_PREFIX);
-   }
-
-   private boolean hasAmqpBinaryPrefix(String stringId) {
-      return stringId.startsWith(AMQP_BINARY_PREFIX);
-   }
-
-   private String strip(String id, int numChars) {
-      return id.substring(numChars);
-   }
-
-   private int hexCharToInt(char ch, String orig) throws IllegalArgumentException {
-      if (ch >= '0' && ch <= '9') {
-         // subtract '0' to get difference in position as an int
-         return ch - '0';
-      } else if (ch >= 'A' && ch <= 'F') {
-         // subtract 'A' to get difference in position as an int
-         // and then add 10 for the offset of 'A'
-         return ch - 'A' + 10;
-      } else if (ch >= 'a' && ch <= 'f') {
-         // subtract 'a' to get difference in position as an int
-         // and then add 10 for the offset of 'a'
-         return ch - 'a' + 10;
-      }
-
-      throw new IllegalArgumentException("The provided hex string contains non-hex character '" + ch + "': " + orig);
    }
 }

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/AmqpMessage.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/AmqpMessage.java
@@ -390,6 +390,31 @@ public class AmqpMessage {
    }
 
    /**
+    * Sets the Subject property on an outbound message using the provided String
+    *
+    * @param subject the String Subject value to set.
+    */
+   public void setSubject(String subject) {
+      checkReadOnly();
+      lazyCreateProperties();
+      getWrappedMessage().setSubject(subject);
+   }
+
+   /**
+    * Return the set Subject value in String form, if there are no properties
+    * in the given message return null.
+    *
+    * @return the set Subject in String form or null if not set.
+    */
+   public String getSubject() {
+      if (message.getProperties() == null) {
+         return null;
+      }
+
+      return message.getProperties().getSubject();
+   }
+
+   /**
     * Sets the durable header on the outgoing message.
     *
     * @param durable the boolean durable value to set.


### PR DESCRIPTION
Allows for JMS selectors on JMSCorrelationID as well as JMSXGroupID
and JMSXUserID along with some fixes to avoid an NPE case and fixes
to the conversion of AMQP MessageID and CorrelationID values when
doing cross protocol mappings.  Adds new tests to cover more cases
of using the JMS selector with Qpid JMS and the AMQP test client.