### PR TITLE
ARTEMIS-1444 Support Messages > JournalBufferSize in all Protocols

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/ICoreMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/ICoreMessage.java
@@ -82,7 +82,7 @@ public interface ICoreMessage extends Message {
       map.put("durable", isDurable());
       map.put("expiration", getExpiration());
       map.put("timestamp", getTimestamp());
-      map.put("priority", (int)getPriority());
+      map.put("priority", getPriority());
 
       return map;
    }

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/file/JDBCSequentialFileFactory.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/file/JDBCSequentialFileFactory.java
@@ -121,6 +121,11 @@ public class JDBCSequentialFileFactory implements SequentialFileFactory, ActiveM
    }
 
    @Override
+   public long getBufferSize() {
+      return dbDriver.getMaxSize();
+   }
+
+   @Override
    public synchronized void start() {
       try {
          if (!started) {

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalImpl.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalImpl.java
@@ -127,6 +127,16 @@ public class JDBCJournalImpl extends AbstractJDBCDriver implements Journal {
    public void flush() throws Exception {
    }
 
+   /**
+    * The max size record that can be stored in the journal
+    *
+    * @return
+    */
+   @Override
+   public long getMaxRecordSize() {
+      return sqlProvider.getMaxBlobSize();
+   }
+
    @Override
    protected void createSchema() throws SQLException {
       createTable(sqlProvider.getCreateJournalTableSQL());

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQMessage.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQMessage.java
@@ -69,7 +69,7 @@ public class ActiveMQMessage implements javax.jms.Message {
       Map<String, Object> jmsMessage = new HashMap<>();
 
       String deliveryMode = (Boolean) coreMessage.get("durable") ? "PERSISTENT" : "NON_PERSISTENT";
-      byte priority = (Byte) coreMessage.get("priority");
+      int priority = (Byte) coreMessage.get("priority");
       long timestamp = (Long) coreMessage.get("timestamp");
       long expiration = (Long) coreMessage.get("expiration");
 

--- a/artemis-jms-client/src/test/java/org/apache/activemq/artemis/jms/client/ConversionTest.java
+++ b/artemis-jms-client/src/test/java/org/apache/activemq/artemis/jms/client/ConversionTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.jms.client;
+
+import org.apache.activemq.artemis.api.core.ICoreMessage;
+import org.apache.activemq.artemis.core.client.impl.ClientMessageImpl;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test conversion from Core message to JMS message.
+ */
+public class ConversionTest {
+
+   @Test
+   public void testCoreToJMSConversion() {
+      ICoreMessage clientMessage = new ClientMessageImpl();
+      clientMessage.setDurable(true)
+              .setPriority((byte) 9)
+              .setExpiration(123456);
+      Map<String, Object> messageMap = clientMessage.toMap();
+      Map<String, Object> jmsMap = ActiveMQMessage.coreMaptoJMSMap(messageMap);
+
+      Object priority = jmsMap.get("JMSPriority");
+      assertTrue(priority instanceof Integer);
+      assertEquals(9, priority);
+   }
+}

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/SequentialFileFactory.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/SequentialFileFactory.java
@@ -101,4 +101,6 @@ public interface SequentialFileFactory {
    SequentialFileFactory setDatasync(boolean enabled);
 
    boolean isDatasync();
+
+   long getBufferSize();
 }

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/aio/AIOSequentialFileFactory.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/aio/AIOSequentialFileFactory.java
@@ -269,6 +269,11 @@ public final class AIOSequentialFileFactory extends AbstractSequentialFileFactor
       }
    }
 
+   @Override
+   public long getBufferSize() {
+      return bufferSize;
+   }
+
    /**
     * The same callback is used for Runnable executor.
     * This way we can save some memory over the pool.

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/mapped/MappedSequentialFileFactory.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/mapped/MappedSequentialFileFactory.java
@@ -41,6 +41,7 @@ public final class MappedSequentialFileFactory implements SequentialFileFactory 
    private boolean bufferPooling;
    //pools only the biggest one -> optimized for the common case
    private final ThreadLocal<ByteBuffer> bytesPool;
+   private final int bufferSize;
 
    private MappedSequentialFileFactory(File directory,
                                        int capacity,
@@ -57,6 +58,7 @@ public final class MappedSequentialFileFactory implements SequentialFileFactory 
       } else {
          timedBuffer = null;
       }
+      this.bufferSize = bufferSize;
       this.bufferPooling = true;
       this.bytesPool = new ThreadLocal<>();
    }
@@ -103,6 +105,11 @@ public final class MappedSequentialFileFactory implements SequentialFileFactory 
    @Override
    public boolean isDatasync() {
       return useDataSync;
+   }
+
+   @Override
+   public long getBufferSize() {
+      return bufferSize;
    }
 
    @Override

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/nio/NIOSequentialFileFactory.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/nio/NIOSequentialFileFactory.java
@@ -203,4 +203,9 @@ public final class NIOSequentialFileFactory extends AbstractSequentialFileFactor
       return bytes;
    }
 
+   @Override
+   public long getBufferSize() {
+      return bufferSize;
+   }
+
 }

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/Journal.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/Journal.java
@@ -279,4 +279,10 @@ public interface Journal extends ActiveMQComponent {
     * It will make sure there are no more pending operations on the Executors.
     * */
    void flush() throws Exception;
+
+   /**
+    * The max size record that can be stored in the journal
+    * @return
+    */
+   long getMaxRecordSize();
 }

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/FileWrapperJournal.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/FileWrapperJournal.java
@@ -104,6 +104,16 @@ public final class FileWrapperJournal extends JournalBase {
    }
 
    /**
+    * The max size record that can be stored in the journal
+    *
+    * @return
+    */
+   @Override
+   public long getMaxRecordSize() {
+      return journal.getMaxRecordSize();
+   }
+
+   /**
     * Write the record to the current file.
     */
    private void writeRecord(JournalInternalRecord encoder,

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalImpl.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalImpl.java
@@ -2200,6 +2200,16 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
       flushExecutor(compactorExecutor);
    }
 
+   /**
+    * The max size record that can be stored in the journal
+    *
+    * @return
+    */
+   @Override
+   public long getMaxRecordSize() {
+      return Math.min(getFileSize(), fileFactory.getBufferSize());
+   }
+
    private void flushExecutor(Executor executor) throws InterruptedException {
 
       if (executor != null) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/replication/ReplicatedJournal.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/replication/ReplicatedJournal.java
@@ -548,4 +548,9 @@ public class ReplicatedJournal implements Journal {
    public void replicationSyncFinished() {
       throw new UnsupportedOperationException("should never get called");
    }
+
+   @Override
+   public long getMaxRecordSize() {
+      return localJournal.getMaxRecordSize();
+   }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ServerSession.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ServerSession.java
@@ -16,12 +16,11 @@
  */
 package org.apache.activemq.artemis.core.server;
 
+import javax.json.JsonArrayBuilder;
+import javax.transaction.xa.Xid;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import javax.json.JsonArrayBuilder;
-import javax.transaction.xa.Xid;
 
 import org.apache.activemq.artemis.Closeable;
 import org.apache.activemq.artemis.api.core.Message;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/OpenWireLargeMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/OpenWireLargeMessageTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.openwire;
+
+import javax.jms.BytesMessage;
+import javax.jms.Connection;
+import javax.jms.DeliveryMode;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.junit.Before;
+import org.junit.Test;
+
+public class OpenWireLargeMessageTest extends BasicOpenWireTest {
+
+   public OpenWireLargeMessageTest() {
+      super();
+   }
+
+   public SimpleString lmAddress = new SimpleString("LargeMessageAddress");
+
+   @Override
+   @Before
+   public void setUp() throws Exception {
+      this.realStore = true;
+      super.setUp();
+      server.createQueue(lmAddress, RoutingType.ANYCAST, lmAddress, null, true, false);
+   }
+
+   @Test
+   public void testSendLargeMessage() throws Exception {
+      try (Connection connection = factory.createConnection()) {
+         Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+         Queue queue = session.createQueue(lmAddress.toString());
+         MessageProducer producer = session.createProducer(queue);
+         producer.setDeliveryMode(DeliveryMode.PERSISTENT);
+
+         // Create 100Mb Message
+         int size = 1024 * 1024 * 10;
+         byte[] bytes = new byte[size];
+         BytesMessage message = session.createBytesMessage();
+         message.writeBytes(bytes);
+         producer.send(message);
+      }
+   }
+}

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/replication/ReplicationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/replication/ReplicationTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
@@ -710,6 +711,11 @@ public final class ReplicationTest extends ActiveMQTestBase {
       @Override
       public void flush() throws Exception {
 
+      }
+
+      @Override
+      public long getMaxRecordSize() {
+         return ActiveMQDefaultConfiguration.getDefaultJournalBufferSizeAio();
       }
 
       @Override

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/fakes/FakeSequentialFileFactory.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/fakes/FakeSequentialFileFactory.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.activemq.artemis.ArtemisConstants;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
 import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
@@ -67,6 +68,11 @@ public class FakeSequentialFileFactory implements SequentialFileFactory {
    @Override
    public boolean isDatasync() {
       return false;
+   }
+
+   @Override
+   public long getBufferSize() {
+      return ArtemisConstants.DEFAULT_JOURNAL_BUFFER_SIZE_AIO;
    }
 
    @Override


### PR DESCRIPTION
Notice the use of a deprecated method message.getBodyBuffer() in ServerSessionImpl.  It's valid usage in this case.  

@clebertsuconic perhaps this should not be deprecated.  The alternative (to use ICoreMessage interface) would require significant refactor.