### PR TITLE
ARTEMIS-1366 Hide Advisory Address from Management Console

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -442,7 +442,9 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
          // only register address if it is new
          if (result) {
             try {
-               managementService.registerAddress(addressInfo);
+               if (!addressInfo.isInternal()) {
+                  managementService.registerAddress(addressInfo);
+               }
             } catch (Exception e) {
                e.printStackTrace();
             }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/AddressInfo.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/AddressInfo.java
@@ -24,6 +24,9 @@ import org.apache.activemq.artemis.api.core.RoutingType;
 
 public class AddressInfo {
 
+   //from openwire
+   public static final SimpleString ADVISORY_TOPIC = new SimpleString("ActiveMQ.Advisory.");
+
    private long id;
 
    private final SimpleString name;
@@ -33,8 +36,7 @@ public class AddressInfo {
    private Set<RoutingType> routingTypes;
 
    public AddressInfo(SimpleString name) {
-      this.name = name;
-      routingTypes = new HashSet<>();
+      this(name, new HashSet<>());
    }
 
    /**
@@ -127,4 +129,7 @@ public class AddressInfo {
       return buff.toString();
    }
 
+   public boolean isInternal() {
+      return this.name.startsWith(ADVISORY_TOPIC);
+   }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ManagementControlHelper.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ManagementControlHelper.java
@@ -96,7 +96,7 @@ public class ManagementControlHelper {
 
    // Private -------------------------------------------------------
 
-   private static Object createProxy(final ObjectName objectName,
+   public static Object createProxy(final ObjectName objectName,
                                      final Class mbeanInterface,
                                      final MBeanServer mbeanServer) {
       return MBeanServerInvocationHandler.newProxyInstance(mbeanServer, objectName, mbeanInterface, false);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/OpenWireTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/OpenWireTestBase.java
@@ -104,6 +104,9 @@ public class OpenWireTestBase extends ActiveMQTestBase {
 
          server.getConfiguration().putSecurityRoles("#", roles);
       }
+
+      mbeanServer = MBeanServerFactory.createMBeanServer();
+      server.setMBeanServer(mbeanServer);
       addServer(server);
       jmsServer = new JMSServerManagerImpl(server);
       namingContext = new InVMNamingContext();
@@ -111,8 +114,6 @@ public class OpenWireTestBase extends ActiveMQTestBase {
       jmsServer.start();
 
       registerConnectionFactory();
-
-      mbeanServer = MBeanServerFactory.createMBeanServer();
       System.out.println("debug: server started");
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/management/OpenWireManagementTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/management/OpenWireManagementTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.openwire.management;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.advisory.ConsumerEventSource;
+import org.apache.activemq.advisory.ProducerEventSource;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl;
+import org.apache.activemq.artemis.api.core.management.ObjectNameBuilder;
+import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.server.impl.AddressInfo;
+import org.apache.activemq.artemis.tests.integration.management.ManagementControlHelper;
+import org.apache.activemq.artemis.tests.integration.openwire.OpenWireTestBase;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.Session;
+
+public class OpenWireManagementTest extends OpenWireTestBase {
+
+   private ActiveMQServerControl serverControl;
+   private SimpleString queueName1 = new SimpleString("queue1");
+   private SimpleString queueName2 = new SimpleString("queue2");;
+   private SimpleString queueName3 = new SimpleString("queue3");;
+
+   private ConnectionFactory factory;
+
+   @Before
+   @Override
+   public void setUp() throws Exception {
+      super.setUp();
+      serverControl = (ActiveMQServerControl) ManagementControlHelper.createProxy(ObjectNameBuilder.DEFAULT.getActiveMQServerObjectName(), ActiveMQServerControl.class, mbeanServer);
+      factory = new ActiveMQConnectionFactory(urlString);
+   }
+
+   @Override
+   protected void extraServerConfig(Configuration serverConfig) {
+      serverConfig.setJMXManagementEnabled(true);
+   }
+
+   @Test
+   public void testHiddenInternalAddress() throws Exception {
+      server.createQueue(queueName1, RoutingType.ANYCAST, queueName1, null, true, false, -1, false, true);
+      server.createQueue(queueName2, RoutingType.ANYCAST, queueName2, null, true, false, -1, false, true);
+      server.createQueue(queueName3, RoutingType.ANYCAST, queueName3, null, true, false, -1, false, true);
+
+
+      String[] addresses = serverControl.getAddressNames();
+      assertEquals(3, addresses.length);
+      for (String addr : addresses) {
+         assertFalse(addr.startsWith(AddressInfo.ADVISORY_TOPIC.toString()));
+      }
+
+      try (Connection connection = factory.createConnection()) {
+         connection.start();
+         Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+         Destination destination = session.createQueue(queueName1.toString());
+
+         ConsumerEventSource consumerEventSource = new ConsumerEventSource(connection, destination);
+         consumerEventSource.setConsumerListener(consumerEvent -> {
+         });
+         consumerEventSource.start();
+
+         ProducerEventSource producerEventSource = new ProducerEventSource(connection, destination);
+         producerEventSource.setProducerListener(producerEvent -> {
+         });
+         producerEventSource.start();
+
+         //after that point several advisory addresses are created.
+         //make sure they are not accessible via management api.
+         addresses = serverControl.getAddressNames();
+         for (String addr : addresses) {
+            assertFalse(addr.startsWith(AddressInfo.ADVISORY_TOPIC.toString()));
+         }
+         consumerEventSource.stop();
+         producerEventSource.stop();
+      }
+   }
+}


### PR DESCRIPTION
Openwire consumer is listed twice below "consumers" tab.
First it shows correctly the requested queue consume.
Second it shows consumer from multicast queue ActiveMQ.Advisory.
The second one is internal and should be hidden.