### PR TITLE
[ARTEMIS-1475] Fix NPE in ActiveMQMessageHandler#setup

### DIFF
--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRALogger.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRALogger.java
@@ -24,6 +24,8 @@ import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 
+import javax.jms.IllegalStateException;
+
 /**
  * Logger Code 15
  * <br>
@@ -144,4 +146,7 @@ public interface ActiveMQRALogger extends BasicLogger {
    @LogMessage(level = Logger.Level.DEBUG)
    @Message(id = 153001, value = "using different ActiveMQRAConnectionFactory", format = Message.Format.MESSAGE_FORMAT)
    void warnDifferentConnectionfactory();
+
+   @Message(id = 153002, value = "Cannot create a subscriber on the durable subscription since it already has subscriber(s)")
+   IllegalStateException canNotCreatedNonSharedSubscriber();
 }

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQActivationSpec.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQActivationSpec.java
@@ -96,7 +96,7 @@ public class ActiveMQActivationSpec extends ConnectionFactoryProperties implemen
    /**
     * If this is true, a durable subscription could be shared by multiple MDB instances
     */
-   private Boolean shareSubscriptions;
+   private Boolean shareSubscriptions = false;
 
    /**
     * The user

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQMessageHandler.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQMessageHandler.java
@@ -122,7 +122,7 @@ public class ActiveMQMessageHandler implements MessageHandler, FailoverEventList
             // As a deployed MDB could set up multiple instances in order to process messages in parallel.
             if (sessionNr == 0 && subResponse.getConsumerCount() > 0) {
                if (!spec.isShareSubscriptions()) {
-                  throw new javax.jms.IllegalStateException("Cannot create a subscriber on the durable subscription since it already has subscriber(s)");
+                  throw ActiveMQRALogger.LOGGER.canNotCreatedNonSharedSubscriber();
                } else if (ActiveMQRALogger.LOGGER.isDebugEnabled()) {
                   logger.debug("the mdb on destination " + queueName + " already had " +
                                                    subResponse.getConsumerCount() +


### PR DESCRIPTION
* initialize ActiveMQActivationSpec#shareSubscriptions to false
* i18n of the exception thrown by ActiveMQMessageHandler if it is not
  possible to create a non-shared subscriber

JIRA: https://issues.apache.org/jira/browse/ARTEMIS-1475