### PR TITLE
ARTEMIS-1477 Add classifiers to the native transports

### DIFF
--- a/artemis-core-client/pom.xml
+++ b/artemis-core-client/pom.xml
@@ -74,11 +74,13 @@
       </dependency>
       <dependency>
          <groupId>io.netty</groupId>
-         <artifactId>netty-transport-native-kqueue</artifactId>
+         <artifactId>netty-transport-native-epoll</artifactId>
+         <classifier>${netty-transport-native-epoll-classifier}</classifier>
       </dependency>
       <dependency>
          <groupId>io.netty</groupId>
-         <artifactId>netty-transport-native-epoll</artifactId>
+         <artifactId>netty-transport-native-kqueue</artifactId>
+         <classifier>${netty-transport-native-kqueue-classifier}</classifier>
       </dependency>
       <dependency>
          <groupId>io.netty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,9 @@
 
       <cdi-api.version>1.2</cdi-api.version>
       <geronimo-annotation_1.2_spec.version>1.0</geronimo-annotation_1.2_spec.version>
+
+      <netty-transport-native-epoll-classifier>linux-x86_64</netty-transport-native-epoll-classifier>
+      <netty-transport-native-kqueue-classifier>osx-x86_64</netty-transport-native-kqueue-classifier>
    </properties>
 
    <scm>
@@ -496,12 +499,14 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
             <version>${netty.version}</version>
+            <classifier>${netty-transport-native-epoll-classifier}</classifier>
             <!-- License: Apache 2.0 -->
          </dependency>
          <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-kqueue</artifactId>
             <version>${netty.version}</version>
+            <classifier>${netty-transport-native-kqueue-classifier}</classifier>
             <!-- License: Apache 2.0 -->
          </dependency>
          <dependency>


### PR DESCRIPTION
The changes to remove netty all removes the classifiers that add the
dependency to the netty transport that includes the compiled native
library wrapper.  Add those classifiers back in.