### PR TITLE
ARTEMIS-1447 JDBC NodeManager to support JDBC HA Shared Store

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/jdbc/ActiveMQScheduledLeaseLock.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/jdbc/ActiveMQScheduledLeaseLock.java
@@ -92,7 +92,7 @@ final class ActiveMQScheduledLeaseLock extends ActiveMQScheduledComponent implem
       }
       //logic to detect slowness of DB and/or the scheduled executor service
       detectAndReportRenewSlowness(lockName, lastRenewStart, renewStart, renewPeriodMillis, lock.expirationMillis());
-      this.lastLockRenewStart = lastRenewStart;
+      this.lastLockRenewStart = renewStart;
    }
 
    private static void detectAndReportRenewSlowness(String lockName,


### PR DESCRIPTION
It fixes the NPE on server start due to:
 - missing SqlProviderFactory
 - missing executor factory/scheduled pool (ie using exclusive scheduled pools)

It fixes the WARNINGS due to wrong slowness detection while renewing JdbcLeaseLock.