### PR TITLE
ARTEMIS-1486 Core client should be notified if consumer is closed on …

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -1621,6 +1621,7 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
                for (ServerConsumer serverConsumer : serverConsumers) {
                   if (serverConsumer.sequentialID() == Long.valueOf(ID)) {
                      serverConsumer.close(true);
+                     serverConsumer.disconnect();
                      return true;
                   }
                }


### PR DESCRIPTION
…broker side

If consumer is closed on broker using e.g. Hawtio console, client connected as that consumer (representation of broker resource) should be notified about that fact and react to that. It doesn't seem to react. If consumer is closed, as a result of not being notified, client hangs in the air and cannot receive messages.