### PR TITLE
Modified artemis.cmd to be able to handle an ARTEMIS_HOME containing spaces

### DIFF
--- a/artemis-distribution/src/main/resources/bin/artemis.cmd
+++ b/artemis-distribution/src/main/resources/bin/artemis.cmd
@@ -25,7 +25,7 @@ set ARTEMIS_HOME="%CD%"
 POPD
 
 :CHECK_ARTEMIS_HOME
-if exist %ARTEMIS_HOME%\bin\artemis.cmd goto CHECK_JAVA
+if exist "%ARTEMIS_HOME%\bin\artemis.cmd" goto CHECK_JAVA
 
 :NO_HOME
 echo ARTEMIS_HOME environment variable is set incorrectly. Please set ARTEMIS_HOME.
@@ -53,8 +53,8 @@ set JAVA_ARGS=-XX:+UseParallelGC -XX:+AggressiveOpts -XX:+UseFastAccessorMethods
 rem "Create full JVM Args"
 set JVM_ARGS=%JAVA_ARGS%
 if not "%ARTEMIS_CLUSTER_PROPS%"=="" set JVM_ARGS=%JVM_ARGS% %ARTEMIS_CLUSTER_PROPS%
-set JVM_ARGS=%JVM_ARGS% -classpath %ARTEMIS_HOME%\lib\artemis-boot.jar
-set JVM_ARGS=%JVM_ARGS% -Dartemis.home=%ARTEMIS_HOME%
+set JVM_ARGS=%JVM_ARGS% -classpath "%ARTEMIS_HOME%\lib\artemis-boot.jar"
+set JVM_ARGS=%JVM_ARGS% -Dartemis.home="%ARTEMIS_HOME%"
 if not "%DEBUG_ARGS%"=="" set JVM_ARGS=%JVM_ARGS% %DEBUG_ARGS%
 
 "%_JAVACMD%" %JVM_ARGS% org.apache.activemq.artemis.boot.Artemis %*


### PR DESCRIPTION
For example : 'C:\Program Files\Apache\Artemis\apache-artemis-2.3.0'.