### PR TITLE
Removed quotation marks from if statement in artemis.cmd

### DIFF
--- a/artemis-distribution/src/main/resources/bin/artemis.cmd
+++ b/artemis-distribution/src/main/resources/bin/artemis.cmd
@@ -18,7 +18,7 @@ rem under the License.
 
 setlocal
 
-if NOT "%ARTEMIS_HOME%"=="" goto CHECK_ARTEMIS_HOME
+if NOT %ARTEMIS_HOME%=="" goto CHECK_ARTEMIS_HOME
 PUSHD .
 CD %~dp0..
 set ARTEMIS_HOME="%CD%"


### PR DESCRIPTION
These were causing an error when %ARTEMIS_HOME% string contains quotes also, for example : "C:\Program Files\Apache\Artemis\apache-artemis-2.3.0"

Error produced :
C:\>artemis
Files\Apache\Artemis\apache-artemis-2.3.0""=="" was unexpected at this time.
