### PR TITLE
NO-JIRA - minor updates to sample, so it works as described in comments

### DIFF
--- a/examples/features/standard/large-message/src/main/java/org/apache/activemq/artemis/jms/example/LargeMessageExample.java
+++ b/examples/features/standard/large-message/src/main/java/org/apache/activemq/artemis/jms/example/LargeMessageExample.java
@@ -46,7 +46,7 @@ public class LargeMessageExample {
     * This may take some considerable time to create, send and consume - if it takes too long or you
     * don't have enough disk space just reduce the file size here
     */
-   private static final long FILE_SIZE = 2L;// * 1024 * 1024 * 1024; // 2 GiB message
+   private static final long FILE_SIZE = 2L * 1024 * 1024 * 1024; // 2 GiB message
 
    public static void main(final String[] args) throws Exception {
       Process server = null;

--- a/examples/features/standard/large-message/src/main/resources/jndi.properties
+++ b/examples/features/standard/large-message/src/main/resources/jndi.properties
@@ -16,5 +16,5 @@
 # under the License.
 
 java.naming.factory.initial=org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory
-connectionFactory.ConnectionFactory=tcp://localhost:61616
+connectionFactory.ConnectionFactory=tcp://localhost:61616?minLargeMessageSize=10240
 queue.queue/exampleQueue=exampleQueue


### PR DESCRIPTION
The LargeMessageExample was not working as described in docs: 

- FILESIZE was set to 1 MiB instead of 2 GiB
I had a look at the previous change to FILE_SIZE and my guess is the change was included in a commit as an oversight.  Please let me know if the file size was meant to be reduced and I will modify the PR to reflect that.

- ?minLargeMessageSize=10240 was omitted from URL.