### PR TITLE
ARTEMIS-1502 added addressMemorySize and paging info to addresslist 

### DIFF
--- a/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/addresses.js
+++ b/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/addresses.js
@@ -55,6 +55,26 @@ var ARTEMIS = (function(ARTEMIS) {
                 field: 'queueCount',
                 displayName: 'Queue Count',
                 width: '*'
+            },
+            {
+                field: 'addressMemorySize',
+                displayName: 'Memory Size',
+                width: '*'
+            },
+            {
+                field: 'paging',
+                displayName: 'Paging',
+                width: '*'
+            },
+            {
+                field: 'numberOfPages',
+                displayName: 'Number Of Pages',
+                width: '*'
+            },
+            {
+                field: 'numberOfBytesPerPage',
+                displayName: 'Bytes Per Page',
+                width: '*'
             }
         ];
         $scope.filter = {
@@ -63,6 +83,10 @@ var ARTEMIS = (function(ARTEMIS) {
                 {id: 'NAME', name: 'Name'},
                 {id: 'ROUTING_TYPES', name: 'Routing Types'},
                 {id: 'QUEUE_COUNT', name: 'Queue Count'},
+                {id: 'ADDRESS_MEMORY_SIZE', name: 'Memory Size'},
+                {id: 'PAGING', name: 'Paging'},
+                {id: 'NUMBER_OF_PAGES', name: 'Number Of Pages'},
+                {id: 'NUMBER_OF_BYTES_PER_PAGE', name: 'Bytes Per Page'}
             ],
             operationOptions: [
                 {id: 'EQUALS', name: 'Equals'},

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -1736,7 +1736,11 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
       clearIO();
       try {
-         final Set<SimpleString> addresses = server.getPostOffice().getAddresses();
+         List<AddressControl> addresses = new ArrayList<>();
+         Object[] addressControls = server.getManagementService().getResources(AddressControl.class);
+         for (int i = 0; i < addressControls.length; i++) {
+            addresses.add((AddressControl) addressControls[i]);
+         }
          AddressView view = new AddressView(server);
          view.setCollection(addresses);
          view.setOptions(options);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/AddressView.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/AddressView.java
@@ -19,12 +19,16 @@ package org.apache.activemq.artemis.core.management.impl.view;
 import javax.json.JsonObjectBuilder;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.api.core.management.AddressControl;
 import org.apache.activemq.artemis.core.management.impl.view.predicate.AddressFilterPredicate;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.impl.AddressInfo;
 import org.apache.activemq.artemis.utils.JsonLoader;
+import org.jboss.logging.Logger;
 
-public class AddressView extends ActiveMQAbstractView<SimpleString> {
+public class AddressView extends ActiveMQAbstractView<AddressControl> {
+
+   private static final Logger logger = Logger.getLogger(AddressView.class);
 
    private static final String defaultSortColumn = "creationTime";
 
@@ -42,17 +46,56 @@ public class AddressView extends ActiveMQAbstractView<SimpleString> {
    }
 
    @Override
-   public JsonObjectBuilder toJson(SimpleString addressName) {
+   public JsonObjectBuilder toJson(AddressControl addressControl) {
 
-      AddressInfo address = server.getAddressInfo(addressName);
-      JsonObjectBuilder obj = JsonLoader.createObjectBuilder().add("id", toString(address.getId())).add("name", toString(address.getName())).add("routingTypes", toString(address.getRoutingTypes()));
+      AddressInfo address = server.getAddressInfo(new SimpleString(addressControl.getAddress()));
+      JsonObjectBuilder obj = JsonLoader.createObjectBuilder().add("id", toString(address.getId())).add("name", addressControl.getAddress()).add("routingTypes", toString(address.getRoutingTypes()));
 
       try {
-         obj.add("queueCount", toString(server.bindingQuery(address.getName()).getQueueNames().size()));
-         return obj;
+         obj.add("queueCount", toString(addressControl.getQueueNames().length));
       } catch (Exception e) {
-         obj.add("queueCount", 0);
+         if (logger.isDebugEnabled()) {
+            logger.debug("setting queueCount", e);
+         }
+         obj.add("queueCount", "0");
       }
+
+      try {
+         obj.add("addressMemorySize", toString(addressControl.getAddressSize()));
+      } catch (Exception e) {
+         if (logger.isDebugEnabled()) {
+            logger.debug("setting addressMemorySize", e);
+         }
+         obj.add("addressMemorySize", "0");
+      }
+
+      try {
+         obj.add("paging", toString(addressControl.isPaging()));
+      } catch (Exception e) {
+         if (logger.isDebugEnabled()) {
+            logger.debug("setting paging", e);
+         }
+         obj.add("paging", "false");
+      }
+
+      try {
+         obj.add("numberOfPages", toString(addressControl.getNumberOfPages()));
+      } catch (Exception e) {
+         if (logger.isDebugEnabled()) {
+            logger.debug("setting numberOfPages", e);
+         }
+         obj.add("numberOfPages", "0");
+      }
+
+      try {
+         obj.add("numberOfBytesPerPage", toString(addressControl.getNumberOfBytesPerPage()));
+      } catch (Exception e) {
+         if (logger.isDebugEnabled()) {
+            logger.debug("setting numberOfBytesPerPage", e);
+         }
+         obj.add("numberOfBytesPerPage", "0");
+      }
+
       return obj;
    }
 


### PR DESCRIPTION
Added addressMemorySize, isPaging, numberOfPages, BytesPerPage to the address summary in the addresses panel in the web console. This allows addresses to be filtered by those attributes in the web console