### PR TITLE
ARTEMIS-1365 Advisory consumers listed in Console

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/utils/PrefixUtil.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/utils/PrefixUtil.java
@@ -26,17 +26,6 @@ import org.apache.activemq.artemis.api.core.RoutingType;
 
 public class PrefixUtil {
 
-   public static Pair<SimpleString, RoutingType> getAddressAndRoutingType(SimpleString address,
-                                                                   RoutingType defaultRoutingType,
-                                                                   Map<SimpleString, RoutingType> prefixes) {
-      for (Map.Entry<SimpleString, RoutingType> entry : prefixes.entrySet()) {
-         if (address.startsWith(entry.getKey())) {
-            return new Pair<>(removePrefix(address, entry.getKey()), entry.getValue());
-         }
-      }
-      return new Pair<>(address, defaultRoutingType);
-   }
-
    public static Pair<SimpleString, Set<RoutingType>> getAddressAndRoutingTypes(SimpleString address,
                                                                           Set<RoutingType> defaultRoutingTypes,
                                                                           Map<SimpleString, RoutingType> prefixes) {
@@ -59,7 +48,7 @@ public class PrefixUtil {
       return address;
    }
 
-   private static SimpleString removePrefix(SimpleString string, SimpleString prefix) {
+   public static SimpleString removePrefix(SimpleString string, SimpleString prefix) {
       return string.subSeq(prefix.length(), string.length());
    }
 }

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireProtocolManager.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireProtocolManager.java
@@ -119,6 +119,11 @@ public class OpenWireProtocolManager implements ProtocolManager<Interceptor>, Cl
    private long maxInactivityDurationInitalDelay = 10 * 1000L;
    private boolean useKeepAlive = true;
 
+   private boolean supportAdvisory = true;
+   //prevents advisory addresses/queues to be registered
+   //to management service
+   private boolean suppressInternalManagementObjects = true;
+
    private final OpenWireMessageConverter internalConverter;
 
    private final Map<SimpleString, RoutingType> prefixes = new HashMap<>();
@@ -348,6 +353,9 @@ public class OpenWireProtocolManager implements ProtocolManager<Interceptor>, Cl
                             Command command,
                             ConsumerId targetConsumerId,
                             String originalConnectionId) throws Exception {
+      if (!this.isSupportAdvisory()) {
+         return;
+      }
       ActiveMQMessage advisoryMessage = new ActiveMQMessage();
 
       if (originalConnectionId == null) {
@@ -582,5 +590,21 @@ public class OpenWireProtocolManager implements ProtocolManager<Interceptor>, Cl
 
    public OpenWireMessageConverter getInternalConverter() {
       return internalConverter;
+   }
+
+   public boolean isSupportAdvisory() {
+      return supportAdvisory;
+   }
+
+   public void setSupportAdvisory(boolean supportAdvisory) {
+      this.supportAdvisory = supportAdvisory;
+   }
+
+   public boolean isSuppressInternalManagementObjects() {
+      return suppressInternalManagementObjects;
+   }
+
+   public void setSuppressInternalManagementObjects(boolean suppressInternalManagementObjects) {
+      this.suppressInternalManagementObjects = suppressInternalManagementObjects;
    }
 }

--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/VersionedStompFrameHandler.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/VersionedStompFrameHandler.java
@@ -20,6 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.core.server.impl.AddressInfo;
 import org.apache.activemq.artemis.api.core.ICoreMessage;
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.RoutingType;
@@ -350,7 +351,7 @@ public abstract class VersionedStompFrameHandler {
       if (typeHeader != null) {
          routingType = RoutingType.valueOf(typeHeader);
       } else {
-         routingType = connection.getSession().getCoreSession().getAddressAndRoutingType(SimpleString.toSimpleString(destination), null).getB();
+         routingType = connection.getSession().getCoreSession().getAddressAndRoutingType(new AddressInfo(new SimpleString(destination))).getRoutingType();
       }
       return routingType;
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServer.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServer.java
@@ -318,6 +318,10 @@ public interface ActiveMQServer extends ServiceComponent {
                      SimpleString user, boolean durable, boolean temporary, boolean autoCreated, Integer maxConsumers,
                      Boolean purgeOnNoConsumers, boolean autoCreateAddress) throws Exception;
 
+   Queue createQueue(AddressInfo addressInfo, SimpleString queueName, SimpleString filter,
+                     SimpleString user, boolean durable, boolean temporary, boolean autoCreated, Integer maxConsumers,
+                     Boolean purgeOnNoConsumers, boolean autoCreateAddress) throws Exception;
+
    Queue createQueue(SimpleString address, RoutingType routingType, SimpleString queueName, SimpleString filter,
                      SimpleString user, boolean durable, boolean temporary, boolean ignoreIfExists, boolean transientQueue,
                      boolean autoCreated, int maxConsumers, boolean purgeOnNoConsumers, boolean autoCreateAddress) throws Exception;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ServerSession.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ServerSession.java
@@ -115,6 +115,12 @@ public interface ServerSession extends SecurityAuth {
                      boolean temporary,
                      boolean durable) throws Exception;
 
+   Queue createQueue(AddressInfo address,
+                     SimpleString name,
+                     SimpleString filterString,
+                     boolean temporary,
+                     boolean durable) throws Exception;
+
    /**
     * Create queue with default delivery mode
     *
@@ -150,12 +156,22 @@ public interface ServerSession extends SecurityAuth {
                      boolean durable,
                      boolean autoCreated) throws Exception;
 
+   Queue createQueue(AddressInfo addressInfo,
+                     SimpleString name,
+                     SimpleString filterString,
+                     boolean temporary,
+                     boolean durable,
+                     boolean autoCreated) throws Exception;
+
    AddressInfo createAddress(SimpleString address,
                              Set<RoutingType> routingTypes,
                              boolean autoCreated) throws Exception;
 
    AddressInfo createAddress(SimpleString address,
                              RoutingType routingType,
+                             boolean autoCreated) throws Exception;
+
+   AddressInfo createAddress(AddressInfo addressInfo,
                              boolean autoCreated) throws Exception;
 
    void deleteQueue(SimpleString name) throws Exception;
@@ -270,13 +286,11 @@ public interface ServerSession extends SecurityAuth {
    /**
     * Get the canonical (i.e. non-prefixed) address and the corresponding routing-type.
     *
-    * @param address the address to inspect
-    * @param defaultRoutingType the {@code org.apache.activemq.artemis.api.core.RoutingType} to return if no prefix
-    *                           match is found.
+    * @param addressInfo the address to inspect
     * @return a {@code org.apache.activemq.artemis.api.core.Pair} representing the canonical (i.e. non-prefixed) address
     *         name and the {@code org.apache.activemq.artemis.api.core.RoutingType} corresponding to the that prefix.
     */
-   Pair<SimpleString, RoutingType> getAddressAndRoutingType(SimpleString address, RoutingType defaultRoutingType);
+   AddressInfo getAddressAndRoutingType(AddressInfo addressInfo);
 
    /**
     * Get the canonical (i.e. non-prefixed) address and the corresponding routing-type.

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -1674,6 +1674,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
    }
 
    @Override
+   @Deprecated
    public Queue createQueue(SimpleString address,
                             RoutingType routingType,
                             SimpleString queueName,
@@ -1686,6 +1687,11 @@ public class ActiveMQServerImpl implements ActiveMQServer {
                             Boolean purgeOnNoConsumers,
                             boolean autoCreateAddress) throws Exception {
       return createQueue(address, routingType, queueName, filter, user, durable, temporary, false, false, autoCreated, maxConsumers, purgeOnNoConsumers, autoCreateAddress);
+   }
+
+   @Override
+   public Queue createQueue(AddressInfo addressInfo, SimpleString queueName, SimpleString filter, SimpleString user, boolean durable, boolean temporary, boolean autoCreated, Integer maxConsumers, Boolean purgeOnNoConsumers, boolean autoCreateAddress) throws Exception {
+      return createQueue(addressInfo, queueName, filter, user, durable, temporary, false, false, autoCreated, maxConsumers, purgeOnNoConsumers, autoCreateAddress);
    }
 
    @Deprecated
@@ -2664,6 +2670,113 @@ public class ActiveMQServerImpl implements ActiveMQServer {
    @Override
    public AddressInfo getAddressInfo(SimpleString address) {
       return postOffice.getAddressInfo(address);
+   }
+
+   public Queue createQueue(final AddressInfo addrInfo,
+                            final SimpleString queueName,
+                            final SimpleString filterString,
+                            final SimpleString user,
+                            final boolean durable,
+                            final boolean temporary,
+                            final boolean ignoreIfExists,
+                            final boolean transientQueue,
+                            final boolean autoCreated,
+                            final int maxConsumers,
+                            final boolean purgeOnNoConsumers,
+                            final boolean autoCreateAddress) throws Exception {
+      final QueueBinding binding = (QueueBinding) postOffice.getBinding(queueName);
+      if (binding != null) {
+         if (ignoreIfExists) {
+            return binding.getQueue();
+         } else {
+            throw ActiveMQMessageBundle.BUNDLE.queueAlreadyExists(queueName, binding.getAddress());
+         }
+      }
+
+      final Filter filter = FilterImpl.createFilter(filterString);
+
+      final long txID = storageManager.generateID();
+      final long queueID = storageManager.generateID();
+
+      final QueueConfig.Builder queueConfigBuilder;
+
+      final SimpleString addressToUse = addrInfo == null ? queueName : addrInfo.getName();
+
+      queueConfigBuilder = QueueConfig.builderWith(queueID, queueName, addressToUse);
+
+      AddressInfo info = postOffice.getAddressInfo(addressToUse);
+
+      RoutingType routingType = addrInfo == null ? null : addrInfo.getRoutingType();
+      RoutingType rt = (routingType == null ? ActiveMQDefaultConfiguration.getDefaultRoutingType() : routingType);
+      if (autoCreateAddress) {
+         if (info == null) {
+            final AddressInfo addressInfo = new AddressInfo(addressToUse, rt);
+            addressInfo.setAutoCreated(true);
+            addressInfo.setInternal(addrInfo == null ? false : addrInfo.isInternal());
+            addAddressInfo(addressInfo);
+         } else if (!info.getRoutingTypes().contains(rt)) {
+            Set<RoutingType> routingTypes = new HashSet<>();
+            routingTypes.addAll(info.getRoutingTypes());
+            routingTypes.add(rt);
+            updateAddressInfo(info.getName(), routingTypes);
+         }
+      } else if (info == null) {
+         throw ActiveMQMessageBundle.BUNDLE.addressDoesNotExist(addressToUse);
+      } else if (!info.getRoutingTypes().contains(rt)) {
+         throw ActiveMQMessageBundle.BUNDLE.invalidRoutingTypeForAddress(rt, info.getName().toString(), info.getRoutingTypes());
+      }
+
+      final QueueConfig queueConfig = queueConfigBuilder.filter(filter).pagingManager(pagingManager).user(user).durable(durable).temporary(temporary).autoCreated(autoCreated).routingType(addrInfo.getRoutingType()).maxConsumers(maxConsumers).purgeOnNoConsumers(purgeOnNoConsumers).build();
+
+      callBrokerPlugins(hasBrokerPlugins() ? plugin -> plugin.beforeCreateQueue(queueConfig) : null);
+
+      final Queue queue = queueFactory.createQueueWith(queueConfig);
+
+      if (transientQueue) {
+         queue.setConsumersRefCount(new TransientQueueManagerImpl(this, queue.getName()));
+      } else {
+         queue.setConsumersRefCount(new QueueManagerImpl(this, queue.getName()));
+      }
+
+      final QueueBinding localQueueBinding = new LocalQueueBinding(queue.getAddress(), queue, nodeManager.getNodeId());
+
+      if (queue.isDurable()) {
+         storageManager.addQueueBinding(txID, localQueueBinding);
+      }
+
+      try {
+         postOffice.addBinding(localQueueBinding);
+         if (queue.isDurable()) {
+            storageManager.commitBindings(txID);
+         }
+      } catch (Exception e) {
+         try {
+            if (durable) {
+               storageManager.rollbackBindings(txID);
+            }
+            final PageSubscription pageSubscription = queue.getPageSubscription();
+            try {
+               queue.close();
+            } finally {
+               if (pageSubscription != null) {
+                  pageSubscription.destroy();
+               }
+            }
+         } catch (Throwable ignored) {
+            logger.debug(ignored.getMessage(), ignored);
+         }
+         throw e;
+      }
+
+      if (addrInfo == null || !addrInfo.isInternal()) {
+         managementService.registerQueue(queue, queue.getAddress(), storageManager);
+      }
+
+      callPostQueueCreationCallbacks(queue.getName());
+
+      callBrokerPlugins(hasBrokerPlugins() ? plugin -> plugin.afterCreateQueue(queue) : null);
+
+      return queue;
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/AddressInfo.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/AddressInfo.java
@@ -16,16 +16,15 @@
  */
 package org.apache.activemq.artemis.core.server.impl;
 
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.utils.PrefixUtil;
+
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
-import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.api.core.RoutingType;
-
 public class AddressInfo {
-
-   //from openwire
-   public static final SimpleString ADVISORY_TOPIC = new SimpleString("ActiveMQ.Advisory.");
 
    private long id;
 
@@ -34,6 +33,8 @@ public class AddressInfo {
    private boolean autoCreated = false;
 
    private Set<RoutingType> routingTypes;
+
+   private boolean internal = false;
 
    public AddressInfo(SimpleString name) {
       this(name, new HashSet<>());
@@ -130,6 +131,27 @@ public class AddressInfo {
    }
 
    public boolean isInternal() {
-      return this.name.startsWith(ADVISORY_TOPIC);
+      return this.internal;
    }
+
+   public void setInternal(boolean internal) {
+      this.internal = internal;
+   }
+
+   public AddressInfo create(SimpleString name, RoutingType routingType) {
+      AddressInfo info = new AddressInfo(name, routingType);
+      info.setInternal(this.internal);
+      return info;
+   }
+
+   public AddressInfo getAddressAndRoutingType(Map<SimpleString, RoutingType> prefixes) {
+      for (Map.Entry<SimpleString, RoutingType> entry : prefixes.entrySet()) {
+         if (this.getName().startsWith(entry.getKey())) {
+            AddressInfo newAddressInfo = this.create(PrefixUtil.removePrefix(this.getName(), entry.getKey()), entry.getValue());
+            return newAddressInfo;
+         }
+      }
+      return this;
+   }
+
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/HierarchicalRepository.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/HierarchicalRepository.java
@@ -23,6 +23,7 @@ import java.util.Set;
 /**
  * allows objects to be mapped against a regex pattern and held in order in a list
  */
+//tmp comment: Can we use AddressInfo as the 'match' key?
 public interface HierarchicalRepository<T> {
 
    void disableListeners();

--- a/docs/user-manual/en/protocols-interoperability.md
+++ b/docs/user-manual/en/protocols-interoperability.md
@@ -178,6 +178,33 @@ maxInactivityDurationInitalDelay. The shortest duration is taken for the connect
 
 More details please see [ActiveMQ InactivityMonitor](http://activemq.apache.org/activemq-inactivitymonitor.html).
 
+### Disable/Enable Advisories
+
+By default, advisory topics ([ActiveMQ Advisory](http://activemq.apache.org/advisory-message.html))
+are created in order to send certain type of advisory messages to listening clients. As a result,
+advisory addresses and queues will be displayed on the management console, along with user deployed
+addresses and queues. This sometimes cause confusion because the advisory objects are internally
+managed without user being aware of them. In addition, users may not want the advisory topics at all
+(they cause extra resources and performance penalty) and it is convenient to disable them at all
+from the broker side.
+
+The protocol provides two parameters to control advisory behaviors on the broker side.
+
+* supportAdvisory
+Whether or not the broker supports advisory messages. If the value is true, advisory addresses/
+queues will be created. If the value is false, no advisory addresses/queues are created. Default
+value is true. 
+
+* suppressInternalManagementObjects
+Whether or not the advisory addresses/queues, if any, will be registered to management service
+(e.g. JMX registry). If set to true, no advisory addresses/queues will be registered. If set to
+false, those are registered and will be displayed on the management console. Default value is
+true.
+
+The two parameters are configured on openwire acceptors, via URLs or API. For example:
+
+    <acceptor name="artemis">tcp://127.0.0.1:61616?protocols=CORE,AMQP,OPENWIRE;supportAdvisory=true;suppressInternalManagementObjects=false</acceptor>
+
 ## MQTT
 
 MQTT is a light weight, client to server, publish / subscribe messaging protocol.  MQTT has been specifically

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/management/OpenWireManagementTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/management/OpenWireManagementTest.java
@@ -17,24 +17,35 @@
 package org.apache.activemq.artemis.tests.integration.openwire.management;
 
 import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.advisory.AdvisorySupport;
 import org.apache.activemq.advisory.ConsumerEventSource;
 import org.apache.activemq.advisory.ProducerEventSource;
+import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl;
 import org.apache.activemq.artemis.api.core.management.ObjectNameBuilder;
 import org.apache.activemq.artemis.core.config.Configuration;
-import org.apache.activemq.artemis.core.server.impl.AddressInfo;
+import org.apache.activemq.artemis.jms.client.ActiveMQSession;
 import org.apache.activemq.artemis.tests.integration.management.ManagementControlHelper;
 import org.apache.activemq.artemis.tests.integration.openwire.OpenWireTestBase;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
 import javax.jms.Destination;
+import javax.jms.JMSException;
 import javax.jms.Session;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
 
+@RunWith(Parameterized.class)
 public class OpenWireManagementTest extends OpenWireTestBase {
 
    private ActiveMQServerControl serverControl;
@@ -43,6 +54,27 @@ public class OpenWireManagementTest extends OpenWireTestBase {
    private SimpleString queueName3 = new SimpleString("queue3");;
 
    private ConnectionFactory factory;
+
+   @Parameterized.Parameters(name = "useDefault={0},supportAdvisory={1},suppressJmx={2}")
+   public static Iterable<Object[]> data() {
+      return Arrays.asList(new Object[][] {
+         {true, false, false},
+         {false, true, false},
+         {false, true, true},
+         {false, false, false},
+         {false, false, true}
+      });
+   }
+
+   private boolean useDefault;
+   private boolean supportAdvisory;
+   private boolean suppressJmx;
+
+   public OpenWireManagementTest(boolean useDefault, boolean supportAdvisory, boolean suppressJmx) {
+      this.useDefault = useDefault;
+      this.supportAdvisory = supportAdvisory;
+      this.suppressJmx = suppressJmx;
+   }
 
    @Before
    @Override
@@ -55,6 +87,19 @@ public class OpenWireManagementTest extends OpenWireTestBase {
    @Override
    protected void extraServerConfig(Configuration serverConfig) {
       serverConfig.setJMXManagementEnabled(true);
+      if (useDefault) {
+         //don't set parameters explicitly
+         return;
+      }
+      Set<TransportConfiguration> acceptorConfigs = serverConfig.getAcceptorConfigurations();
+      for (TransportConfiguration tconfig : acceptorConfigs) {
+         if ("netty".equals(tconfig.getName())) {
+            Map<String, Object> params = tconfig.getExtraParams();
+            params.put("supportAdvisory", supportAdvisory);
+            params.put("suppressInternalManagementObjects", suppressJmx);
+            System.out.println("Now use properties: " + params);
+         }
+      }
    }
 
    @Test
@@ -67,7 +112,7 @@ public class OpenWireManagementTest extends OpenWireTestBase {
       String[] addresses = serverControl.getAddressNames();
       assertEquals(3, addresses.length);
       for (String addr : addresses) {
-         assertFalse(addr.startsWith(AddressInfo.ADVISORY_TOPIC.toString()));
+         assertFalse(addr.startsWith(AdvisorySupport.ADVISORY_TOPIC_PREFIX));
       }
 
       try (Connection connection = factory.createConnection()) {
@@ -88,11 +133,61 @@ public class OpenWireManagementTest extends OpenWireTestBase {
          //after that point several advisory addresses are created.
          //make sure they are not accessible via management api.
          addresses = serverControl.getAddressNames();
+         boolean hasInternalAddress = false;
          for (String addr : addresses) {
-            assertFalse(addr.startsWith(AddressInfo.ADVISORY_TOPIC.toString()));
+            hasInternalAddress = addr.startsWith(AdvisorySupport.ADVISORY_TOPIC_PREFIX);
+            if (hasInternalAddress) {
+               break;
+            }
          }
+         assertEquals(!useDefault && supportAdvisory && !suppressJmx, hasInternalAddress);
+
          consumerEventSource.stop();
          producerEventSource.stop();
+      }
+   }
+
+   @Test
+   public void testHiddenInternalQueue() throws Exception {
+
+      server.createQueue(queueName1, RoutingType.ANYCAST, queueName1, null, true, false, -1, false, true);
+
+      String[] queues = serverControl.getQueueNames();
+      assertEquals(1, queues.length);
+      for (String queue : queues) {
+         assertFalse(checkQueueFromInternalAddress(queue));
+      }
+
+      try (Connection connection = factory.createConnection()) {
+         connection.start();
+         Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+         Destination destination = session.createQueue(queueName1.toString());
+
+         //this causes advisory queues to be created
+         session.createProducer(destination);
+
+         queues = serverControl.getQueueNames();
+         boolean hasInternal = false;
+         String targetQueue = null;
+         for (String queue : queues) {
+            hasInternal = checkQueueFromInternalAddress(queue);
+            if (hasInternal) {
+               targetQueue = queue;
+               break;
+            }
+         }
+         assertEquals("targetQueue: " + targetQueue, !useDefault && supportAdvisory && !suppressJmx, hasInternal);
+      }
+   }
+
+   private boolean checkQueueFromInternalAddress(String queue) throws JMSException, ActiveMQException {
+      try (Connection coreConn = coreCf.createConnection()) {
+         ActiveMQSession session = (ActiveMQSession) coreConn.createSession();
+         ClientSession coreSession = session.getCoreSession();
+         ClientSession.QueueQuery query = coreSession.queueQuery(new SimpleString(queue));
+         assertTrue("Queue doesn't exist: " + queue, query.isExists());
+         SimpleString qAddr = query.getAddress();
+         return qAddr.toString().startsWith(AdvisorySupport.ADVISORY_TOPIC_PREFIX);
       }
    }
 }


### PR DESCRIPTION
Openwire clients create consumers to advisory topics to receive
notifications. As a result there are internal queues created
on advisory topics. Those consumer shouldn't be exposed via
management APIs which are used by the Console

To fix that the broker doesn't register any queues from
advisory addresses.