### PR TITLE
ARTEMIS-1507 ActiveMQConnectionTimedOutException is thrown even though no timeout expired

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ChannelImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ChannelImpl.java
@@ -397,6 +397,11 @@ public final class ChannelImpl implements Channel {
                start = now;
             }
 
+            if (closed && toWait > 0 && response == null) {
+               Throwable cause = ActiveMQClientMessageBundle.BUNDLE.connectionDestroyed();
+               throw ActiveMQClientMessageBundle.BUNDLE.unblockingACall(cause);
+            }
+
             if (response == null) {
                throw ActiveMQClientMessageBundle.BUNDLE.timedOutSendingPacket(connection.getBlockingCallTimeout(), packet.getType());
             }


### PR DESCRIPTION
When the execution of code jumps out of the while cycle,
it should check whether the blocking-call-timeout expired or not.
If no, ActiveMQUnBlockedException should be thrown
instead of ActiveMQConnectionTimedOutException.