### PR TITLE
ARTEMIS-1516 - Ensure JNDI via Tomcat Resource works

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/uri/BeanSupport.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/uri/BeanSupport.java
@@ -19,12 +19,14 @@ package org.apache.activemq.artemis.utils.uri;
 
 import java.beans.PropertyDescriptor;
 import java.io.UnsupportedEncodingException;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 
 import org.apache.commons.beanutils.BeanUtilsBean;
@@ -67,6 +69,38 @@ public class BeanSupport {
          beanUtils.populate(obj, data);
       }
       return obj;
+   }
+
+   public static <P> P setProperties(P bean, Properties properties)
+      throws IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+      synchronized (beanUtils) {
+         PropertyDescriptor[] descriptors = beanUtils.getPropertyUtils().getPropertyDescriptors(bean);
+         for (PropertyDescriptor descriptor : descriptors) {
+            if (descriptor.getReadMethod() != null && isWriteable(descriptor, null)) {
+               String value = properties.getProperty(descriptor.getName());
+               if (value != null) {
+                  beanUtils.setProperty(bean, descriptor.getName(), value);
+               }
+            }
+         }
+      }
+      return bean;
+   }
+
+   public static <P> Properties getProperties(P bean, Properties properties)
+      throws IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+      synchronized (beanUtils) {
+         PropertyDescriptor[] descriptors = beanUtils.getPropertyUtils().getPropertyDescriptors(bean);
+         for (PropertyDescriptor descriptor : descriptors) {
+            if (descriptor.getReadMethod() != null && isWriteable(descriptor, null)) {
+               String value = beanUtils.getProperty(bean, descriptor.getName());
+               if (value != null) {
+                  properties.put(descriptor.getName(), value);
+               }
+            }
+         }
+      }
+      return properties;
    }
 
    public static void setData(URI uri,

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQQueue.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQQueue.java
@@ -18,8 +18,6 @@ package org.apache.activemq.artemis.jms.client;
 
 import javax.jms.Queue;
 
-import org.apache.activemq.artemis.api.core.SimpleString;
-
 /**
  * ActiveMQ Artemis implementation of a JMS Queue.
  * <br>
@@ -32,35 +30,30 @@ public class ActiveMQQueue extends ActiveMQDestination implements Queue {
 
    // Static --------------------------------------------------------
 
-   public static SimpleString createAddressFromName(final String name) {
-      return new SimpleString(name);
-   }
-
    // Attributes ----------------------------------------------------
 
    // Constructors --------------------------------------------------
-
-   public ActiveMQQueue(final String name) {
-      super(name, name, TYPE.QUEUE, null);
+   public ActiveMQQueue() {
+      this(null);
    }
 
-   public ActiveMQQueue(final String name, boolean temporary) {
-      super(name, name, temporary ? TYPE.TEMP_QUEUE : TYPE.QUEUE, null);
+   public ActiveMQQueue(final String address) {
+      super(address, TYPE.QUEUE, null);
+   }
+
+   public ActiveMQQueue(final String address, boolean temporary) {
+      super(address, temporary ? TYPE.TEMP_QUEUE : TYPE.QUEUE, null);
    }
 
    /**
     * @param address
-    * @param name
     * @param temporary
     * @param session
     */
-   public ActiveMQQueue(String address, String name, boolean temporary, ActiveMQSession session) {
-      super(address, name, temporary ? TYPE.TEMP_QUEUE : TYPE.QUEUE, session);
+   public ActiveMQQueue(String address, boolean temporary, ActiveMQSession session) {
+      super(address, temporary ? TYPE.TEMP_QUEUE : TYPE.QUEUE, session);
    }
 
-   public ActiveMQQueue(final String address, final String name) {
-      super(address, name, TYPE.QUEUE, null);
-   }
 
    // Queue implementation ------------------------------------------
 
@@ -68,12 +61,12 @@ public class ActiveMQQueue extends ActiveMQDestination implements Queue {
 
    @Override
    public String getQueueName() {
-      return name;
+      return getAddress();
    }
 
    @Override
    public String toString() {
-      return "ActiveMQQueue[" + name + "]";
+      return "ActiveMQQueue[" + getAddress() + "]";
    }
 
    @Override

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQTemporaryQueue.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQTemporaryQueue.java
@@ -37,19 +37,21 @@ public class ActiveMQTemporaryQueue extends ActiveMQQueue implements TemporaryQu
    // TemporaryQueue implementation ------------------------------------------
 
    // Public --------------------------------------------------------
+   public ActiveMQTemporaryQueue() {
+      this(null, null);
+   }
 
    /**
     * @param address
-    * @param name
     * @param session
     */
-   public ActiveMQTemporaryQueue(String address, String name, ActiveMQSession session) {
-      super(address, name, true, session);
+   public ActiveMQTemporaryQueue(String address, ActiveMQSession session) {
+      super(address, true, session);
    }
 
    @Override
    public String toString() {
-      return "ActiveMQTemporaryQueue[" + name + "]";
+      return "ActiveMQTemporaryQueue[" + getAddress() + "]";
    }
 
    @Override

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQTemporaryTopic.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQTemporaryTopic.java
@@ -29,9 +29,12 @@ public class ActiveMQTemporaryTopic extends ActiveMQTopic implements TemporaryTo
    // Static --------------------------------------------------------
 
    // Constructors --------------------------------------------------
+   public ActiveMQTemporaryTopic() {
+      this(null, null);
+   }
 
-   protected ActiveMQTemporaryTopic(final String address, final String name, final ActiveMQSession session) {
-      super(address, name, true, session);
+   public ActiveMQTemporaryTopic(final String address, final ActiveMQSession session) {
+      super(address, true, session);
    }
 
    // Public --------------------------------------------------------

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQTopic.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQTopic.java
@@ -18,8 +18,6 @@ package org.apache.activemq.artemis.jms.client;
 
 import javax.jms.Topic;
 
-import org.apache.activemq.artemis.api.core.SimpleString;
-
 /**
  * ActiveMQ Artemis implementation of a JMS Topic.
  * <br>
@@ -31,44 +29,42 @@ public class ActiveMQTopic extends ActiveMQDestination implements Topic {
    private static final long serialVersionUID = 7873614001276404156L;
    // Static --------------------------------------------------------
 
-   public static SimpleString createAddressFromName(final String name) {
-      return new SimpleString(name);
-   }
-
    // Attributes ----------------------------------------------------
 
    // Constructors --------------------------------------------------
-
-   public ActiveMQTopic(final String name) {
-      this(name, false);
+   public ActiveMQTopic() {
+      this(null);
    }
 
-   public ActiveMQTopic(final String name, boolean temporary) {
-      super(name, name, TYPE.TOPIC, null);
+   public ActiveMQTopic(final String address) {
+      this(address, false);
+   }
+
+   public ActiveMQTopic(final String address, boolean temporary) {
+      super(address, TYPE.TOPIC, null);
    }
 
    /**
     * @param address
-    * @param name
     * @param temporary
     * @param session
     */
-   protected ActiveMQTopic(String address, String name, boolean temporary, ActiveMQSession session) {
-      super(address, name, temporary ? TYPE.TEMP_TOPIC : TYPE.TOPIC, session);
+   protected ActiveMQTopic(String address, boolean temporary, ActiveMQSession session) {
+      super(address, temporary ? TYPE.TEMP_TOPIC : TYPE.TOPIC, session);
    }
 
    // Topic implementation ------------------------------------------
 
    @Override
    public String getTopicName() {
-      return name;
+      return getName();
    }
 
    // Public --------------------------------------------------------
 
    @Override
    public String toString() {
-      return "ActiveMQTopic[" + name + "]";
+      return "ActiveMQTopic[" + getName() + "]";
    }
 
    @Override

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jndi/JNDIStorable.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jndi/JNDIStorable.java
@@ -16,32 +16,27 @@
  */
 package org.apache.activemq.artemis.jndi;
 
-import javax.naming.NamingException;
-import javax.naming.Reference;
-import javax.naming.Referenceable;
-import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.Properties;
+
+import javax.naming.NamingException;
+import javax.naming.Reference;
+import javax.naming.Referenceable;
 
 /**
  * Facilitates objects to be stored in JNDI as properties
- *
- * @since 1.0
  */
-public abstract class JNDIStorable implements Referenceable, Externalizable {
+public abstract class JNDIStorable implements Referenceable {
 
    /**
     * Set the properties that will represent the instance in JNDI
     *
     * @param props
     *     The properties to use when building the new isntance.
-    *
-    * @return a new, unmodifiable, map containing any unused properties, or empty if none were.
     */
-   protected abstract Map<String, String> buildFromProperties(Map<String, String> props);
+   protected abstract void buildFromProperties(Properties props);
 
    /**
     * Initialize the instance from properties stored in JNDI
@@ -49,7 +44,7 @@ public abstract class JNDIStorable implements Referenceable, Externalizable {
     * @param props
     *     The properties to use when initializing the new instance.
     */
-   protected abstract void populateProperties(Map<String, String> props);
+   protected abstract void populateProperties(Properties props);
 
    /**
     * set the properties for this instance as retrieved from JNDI
@@ -59,8 +54,8 @@ public abstract class JNDIStorable implements Referenceable, Externalizable {
     *
     * @return a new, unmodifiable, map containing any unused properties, or empty if none were.
     */
-   public synchronized Map<String, String> setProperties(Map<String, String> props) {
-      return buildFromProperties(props);
+   synchronized void setProperties(Properties props) {
+      buildFromProperties(props);
    }
 
    /**
@@ -68,8 +63,8 @@ public abstract class JNDIStorable implements Referenceable, Externalizable {
     *
     * @return the properties
     */
-   public synchronized Map<String, String> getProperties() {
-      Map<String, String> properties = new LinkedHashMap<>();
+   synchronized Properties getProperties() {
+      Properties properties = new Properties();
       populateProperties(properties);
       return properties;
    }
@@ -87,30 +82,29 @@ public abstract class JNDIStorable implements Referenceable, Externalizable {
    }
 
    /**
-    * @see Externalizable#readExternal(ObjectInput)
+    * Method for class's implementing externalizable to delegate to if not custom implementing.
+    *
+    * @param in
+    * @throws IOException
+    * @throws ClassNotFoundException
+    * @see java.io.Externalizable#readExternal(java.io.ObjectInput)
     */
-   @SuppressWarnings("unchecked")
-   @Override
-   public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
-      Map<String, String> props = (Map<String, String>) in.readObject();
+   public void readObject(ObjectInput in) throws IOException, ClassNotFoundException {
+      Properties props = (Properties)in.readObject();
       if (props != null) {
          setProperties(props);
       }
    }
 
    /**
-    * @see Externalizable#writeExternal(ObjectOutput)
+    * Method for class's implementing externalizable to delegate to if not custom implementing.
+    *
+    * @param out
+    * @throws IOException
+    * @see java.io.Externalizable#writeExternal(java.io.ObjectOutput)
     */
-   @Override
-   public void writeExternal(ObjectOutput out) throws IOException {
+   public void writeObject(ObjectOutput out) throws IOException {
       out.writeObject(getProperties());
    }
 
-   protected String getProperty(Map<String, String> map, String key, String defaultValue) {
-      String value = map.get(key);
-      if (value != null) {
-         return value;
-      }
-      return defaultValue;
-   }
 }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/converter/jms/ServerJMSMessage.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/converter/jms/ServerJMSMessage.java
@@ -139,7 +139,7 @@ public class ServerJMSMessage implements Message {
    public final Destination getJMSReplyTo() throws JMSException {
       SimpleString reply = MessageUtil.getJMSReplyTo(message);
       if (reply != null) {
-         return new ServerDestination(reply.toString());
+         return new ServerDestination(reply);
       } else {
          return null;
       }
@@ -148,7 +148,6 @@ public class ServerJMSMessage implements Message {
    @Override
    public final void setJMSReplyTo(Destination replyTo) throws JMSException {
       MessageUtil.setJMSReplyTo(message, replyTo == null ? null : ((ActiveMQDestination) replyTo).getSimpleAddress());
-
    }
 
    @Override
@@ -158,7 +157,7 @@ public class ServerJMSMessage implements Message {
       if (sdest == null) {
          return null;
       } else {
-         return new ServerDestination(sdest.toString());
+         return new ServerDestination(sdest);
       }
    }
 

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/jms/referenceable/ConnectionFactoryObjectFactory.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/jms/referenceable/ConnectionFactoryObjectFactory.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,29 +16,10 @@
  */
 package org.apache.activemq.artemis.jms.referenceable;
 
-import javax.naming.Context;
-import javax.naming.Name;
-import javax.naming.Reference;
-import javax.naming.spi.ObjectFactory;
-import java.util.Hashtable;
-
 /**
- * A DestinationObjectFactory.
+ * Done for back compatibility with the package/class move.
  *
- * Given a Reference - reconstructs an ActiveMQDestination
+ * Should be removed on next major version change.
  */
-public class DestinationObjectFactory implements ObjectFactory {
-
-   @Override
-   public Object getObjectInstance(final Object ref,
-                                   final Name name,
-                                   final Context ctx,
-                                   final Hashtable<?, ?> props) throws Exception {
-      Reference r = (Reference) ref;
-
-      byte[] bytes = (byte[]) r.get("ActiveMQ-DEST").getContent();
-
-      // Deserialize
-      return SerializableObjectRefAddr.deserialize(bytes);
-   }
+public class ConnectionFactoryObjectFactory extends org.apache.activemq.artemis.ra.referenceable.ActiveMQRAConnectionFactoryObjectFactory {
 }

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/jms/referenceable/SerializableObjectRefAddr.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/jms/referenceable/SerializableObjectRefAddr.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,29 +16,16 @@
  */
 package org.apache.activemq.artemis.jms.referenceable;
 
-import javax.naming.Context;
-import javax.naming.Name;
-import javax.naming.Reference;
-import javax.naming.spi.ObjectFactory;
-import java.util.Hashtable;
+import javax.naming.NamingException;
 
 /**
- * A ConnectionFactoryObjectFactory.
+ * Done for back compatibility with the package/class move.
  *
- * Given a reference - reconstructs an ActiveMQRAConnectionFactory
+ * Should be removed on next major version change.
  */
-public class ConnectionFactoryObjectFactory implements ObjectFactory {
+public class SerializableObjectRefAddr extends org.apache.activemq.artemis.ra.referenceable.SerializableObjectRefAddr {
 
-   @Override
-   public Object getObjectInstance(final Object ref,
-                                   final Name name,
-                                   final Context ctx,
-                                   final Hashtable<?, ?> props) throws Exception {
-      Reference r = (Reference) ref;
-
-      byte[] bytes = (byte[]) r.get("ActiveMQ-CF").getContent();
-
-      // Deserialize
-      return SerializableObjectRefAddr.deserialize(bytes);
+   public SerializableObjectRefAddr(final String type, final Object content) throws NamingException {
+      super(type, content);
    }
 }

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRAConnectionFactoryImpl.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRAConnectionFactoryImpl.java
@@ -35,8 +35,8 @@ import javax.resource.ResourceException;
 import javax.resource.spi.ConnectionManager;
 
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
-import org.apache.activemq.artemis.jms.referenceable.ConnectionFactoryObjectFactory;
-import org.apache.activemq.artemis.jms.referenceable.SerializableObjectRefAddr;
+import org.apache.activemq.artemis.ra.referenceable.ActiveMQRAConnectionFactoryObjectFactory;
+import org.apache.activemq.artemis.ra.referenceable.SerializableObjectRefAddr;
 
 /**
  * The connection factory
@@ -118,7 +118,7 @@ public class ActiveMQRAConnectionFactoryImpl implements ActiveMQRAConnectionFact
       }
       if (reference == null) {
          try {
-            reference = new Reference(this.getClass().getCanonicalName(), new SerializableObjectRefAddr("ActiveMQ-CF", this), ConnectionFactoryObjectFactory.class.getCanonicalName(), null);
+            reference = new Reference(this.getClass().getCanonicalName(), new SerializableObjectRefAddr("ActiveMQ-CF", this), ActiveMQRAConnectionFactoryObjectFactory.class.getCanonicalName(), null);
          } catch (NamingException e) {
             ActiveMQRALogger.LOGGER.errorCreatingReference(e);
          }

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/referenceable/ActiveMQRAConnectionFactoryObjectFactory.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/referenceable/ActiveMQRAConnectionFactoryObjectFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.ra.referenceable;
+
+import javax.naming.Context;
+import javax.naming.Name;
+import javax.naming.Reference;
+import javax.naming.spi.ObjectFactory;
+import java.util.Hashtable;
+
+/**
+ * A ConnectionFactoryObjectFactory.
+ *
+ * Given a reference - reconstructs an ActiveMQRAConnectionFactory
+ */
+public class ActiveMQRAConnectionFactoryObjectFactory implements ObjectFactory {
+
+   @Override
+   public Object getObjectInstance(final Object ref,
+                                   final Name name,
+                                   final Context ctx,
+                                   final Hashtable<?, ?> props) throws Exception {
+      Reference r = (Reference) ref;
+
+      byte[] bytes = (byte[]) r.get("ActiveMQ-CF").getContent();
+
+      // Deserialize
+      return SerializableObjectRefAddr.deserialize(bytes);
+   }
+}

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/referenceable/SerializableObjectRefAddr.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/referenceable/SerializableObjectRefAddr.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.jms.referenceable;
+package org.apache.activemq.artemis.ra.referenceable;
 
 import javax.naming.NamingException;
 import javax.naming.RefAddr;

--- a/docs/user-manual/en/SUMMARY.md
+++ b/docs/user-manual/en/SUMMARY.md
@@ -56,6 +56,7 @@
 * [REST Interface](rest.md)
 * [Embedding Apache ActiveMQ Artemis](embedding-activemq.md)
 * [Apache Karaf](karaf.md)
+* [Apache Tomcat](tomcat.md)
 * [Spring Integration](spring-integration.md)
 * [CDI Integration](cdi-integration.md)
 * [Intercepting Operations](intercepting-operations.md)

--- a/docs/user-manual/en/tomcat.md
+++ b/docs/user-manual/en/tomcat.md
@@ -1,0 +1,39 @@
+# Apache ActiveMQ Artemis - Apache Tomcat Support
+
+
+##Apache Tomcat resource context client configuration
+
+Apache ActiveMQ Artemis provides support for configuring the client, in the tomcat resource context.xml of Tomcat container.
+
+This is very similar to the way this is done in ActiveMQ 5.x so anyone migrating should find this familiar.
+Please note though the connection url and properties that can be set for ActiveMQ Artemis are different please see [Migration Documentation](https://activemq.apache.org/artemis/migration/)
+
+#### Example of Connection Factory
+````
+<Context>
+    ...
+  <Resource name="jms/ConnectionFactory" auth="Container" type="org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory" description="JMS Connection Factory"
+        factory="org.apache.activemq.artemis.jndi.JNDIReferenceFactory" brokerURL="tcp://localhost:61616" />
+    ...
+</Context>
+````
+
+#### Example of Destination (Queue and Topic)
+
+````
+<Context>
+  ...
+  <Resource name="jms/ExampleQueue" auth="Container" type="org.apache.activemq.artemis.jms.client.ActiveMQQueue" description="JMS Queue"
+        factory="org.apache.activemq.artemis.jndi.JNDIReferenceFactory" address="ExampleQueue" />
+  ...
+  <Resource name="jms/ExampleTopic" auth="Container" type="org.apache.activemq.artemis.jms.client.ActiveMQTopic" description="JMS Topic"
+         factory="org.apache.activemq.artemis.jndi.JNDIReferenceFactory" address="ExampleTopic" />
+  ...
+</Context>
+````
+
+#### Example Tomcat App
+
+A sample tomcat app with the container context configured as an example can be seen here: 
+
+/examples/features/sub-modules/tomcat

--- a/examples/features/sub-modules/pom.xml
+++ b/examples/features/sub-modules/pom.xml
@@ -50,7 +50,8 @@ under the License.
          <id>release</id>
          <modules>
             <module>artemis-ra-rar</module>
-	         <module>inter-broker-bridge</module>
+            <module>inter-broker-bridge</module>
+            <module>tomcat</module>
          </modules>
       </profile>
    </profiles>

--- a/examples/features/sub-modules/tomcat/README
+++ b/examples/features/sub-modules/tomcat/README
@@ -1,0 +1,21 @@
+# Apache ActiveMQ Artemis Tomcat Integration JNDI Resources Sample
+
+This is a Sample Tomcat application showing JNDI resource in tomcat context.xml for ConnectionFactory 
+and Destination for Apache ActiveMQ Artemis.
+
+The sample context.xml used by the tomcat in this example can be found under:
+/src/tomcat7-maven-plugin/resources/context.xml
+
+To run 
+
+start Apache ActiveMQ Artemis on port 61616
+ 
+then
+
+mvn clean install tomcat7:exec-war
+
+then to send message 
+
+http://localhost:8080/tomcat-sample/send
+
+this will cause a "hello world" message to send, and the consumer should consume and output it to sysout.

--- a/examples/features/sub-modules/tomcat/pom.xml
+++ b/examples/features/sub-modules/tomcat/pom.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.activemq.examples.modules</groupId>
+        <artifactId>broker-modules</artifactId>
+        <version>2.5.0-SNAPSHOT</version>
+    </parent>
+
+
+    <artifactId>artemis-tomcat-jndi-resources-sample</artifactId>
+    <packaging>war</packaging>
+    <name>Artemis Tomcat JNDI Resources Example</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <projectBaseUri>${project.baseUri}</projectBaseUri>
+        <java.version>1.6</java.version>
+
+        <servlet-api.version>3.0-alpha-1</servlet-api.version>
+    </properties>
+
+    <dependencies>
+
+        <!-- Spring Dependencies -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-jms</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        
+        
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-jms-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <version>${servlet-api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.tomcat.maven</groupId>
+                <artifactId>tomcat7-maven-plugin</artifactId>
+                <version>2.1</version>
+
+                <configuration>
+                    <contextFile>${project.basedir}\src\tomcat7-maven-plugin\resources\context.xml</contextFile>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>tomcat-war-exec</id>
+                        <goals>
+                            <goal>exec-war</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <warRunDependencies>
+                                <warRunDependency>
+                                    <dependency>
+                                        <groupId>org.apache.activemq.examples.modules</groupId>
+                                        <artifactId>artemis-tomcat-jndi-resources-sample</artifactId>
+                                        <version>${project.version}</version>
+                                        <type>war</type>
+                                    </dependency>
+                                </warRunDependency>
+                            </warRunDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+
+                <!--<configuration>-->
+                <!--<port>9090</port>-->
+                <!--<path>/</path>-->
+                <!--</configuration>-->
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/features/sub-modules/tomcat/src/main/java/org/apache/activemq/artemis/example/tomcat/sample/SendMessageController.java
+++ b/examples/features/sub-modules/tomcat/src/main/java/org/apache/activemq/artemis/example/tomcat/sample/SendMessageController.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.example.tomcat.sample;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.Session;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.core.MessageCreator;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class SendMessageController {
+    
+    @Autowired
+    private JmsTemplate jmsTemplate;
+    
+    
+    @RequestMapping("/send")
+    public @ResponseBody String send(@RequestParam(value="text", defaultValue="hello world") final String text) {
+        jmsTemplate.send(new MessageCreator() {
+            @Override
+            public Message createMessage(Session session) throws JMSException {
+                return session.createTextMessage(text);
+            }
+        });
+        return "sent: " + text;
+    }
+}

--- a/examples/features/sub-modules/tomcat/src/main/java/org/apache/activemq/artemis/example/tomcat/sample/SystemOutPrintLnMessageListener.java
+++ b/examples/features/sub-modules/tomcat/src/main/java/org/apache/activemq/artemis/example/tomcat/sample/SystemOutPrintLnMessageListener.java
@@ -14,30 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.protocol.amqp.converter.jms;
+package org.apache.activemq.artemis.example.tomcat.sample;
 
-import javax.jms.JMSException;
-import javax.jms.Queue;
+import javax.jms.Message;
+import javax.jms.MessageListener;
 
-import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.jms.client.ActiveMQDestination;
 
-/**
- * This is just here to avoid all the client checks we need with valid JMS destinations, protocol convertors don't need to
- * adhere to the jms. semantics.
- */
-public class ServerDestination extends ActiveMQDestination implements Queue {
-
-   public ServerDestination(String address) {
-      super(address, TYPE.DESTINATION, null);
-   }
-
-   public ServerDestination(SimpleString address) {
-      super(address, TYPE.DESTINATION, null);
-   }
-
+public class SystemOutPrintLnMessageListener implements MessageListener {
    @Override
-   public String getQueueName() throws JMSException {
-      return getName();
+   public void onMessage(Message message) {
+      System.out.println(message);
    }
 }

--- a/examples/features/sub-modules/tomcat/src/main/webapp/WEB-INF/application-context.xml
+++ b/examples/features/sub-modules/tomcat/src/main/webapp/WEB-INF/application-context.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:jee="http://www.springframework.org/schema/jee"
+       xmlns:mvc="http://www.springframework.org/schema/mvc"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/mvc
+        http://www.springframework.org/schema/mvc/spring-mvc.xsd
+        http://www.springframework.org/schema/jee
+        http://www.springframework.org/schema/jee/spring-jee.xsd">
+
+
+    <jee:jndi-lookup id="connectionFactory" jndi-name="java:comp/env/jms/connectionFactory" />
+    <jee:jndi-lookup id="InputQueue" jndi-name="java:comp/env/jms/InputQueue" />
+
+    <bean id="InputListener" class="org.apache.activemq.artemis.example.tomcat.sample.SystemOutPrintLnMessageListener" />
+    
+    <bean id="jmsTemplate" class="org.springframework.jms.core.JmsTemplate" >
+        <property name="connectionFactory">
+            <bean class="org.springframework.jms.connection.CachingConnectionFactory" >
+                <property name="targetConnectionFactory" ref="connectionFactory" />
+            </bean>
+        </property>
+        <property name="defaultDestination" ref="InputQueue" />
+    </bean>
+    
+    <bean id="messageListenerContainer"
+          class="org.springframework.jms.listener.DefaultMessageListenerContainer">
+        <property name="connectionFactory" ref="connectionFactory" />
+        <property name="destination" ref="InputQueue" />
+        <property name="messageListener" ref="InputListener" />
+    </bean>
+</beans>

--- a/examples/features/sub-modules/tomcat/src/main/webapp/WEB-INF/dispatcher-servlet.xml
+++ b/examples/features/sub-modules/tomcat/src/main/webapp/WEB-INF/dispatcher-servlet.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:mvc="http://www.springframework.org/schema/mvc"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/mvc
+    	http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+    
+    <context:component-scan base-package="org.apache.activemq.artemis.example.tomcat.sample" />
+    <mvc:annotation-driven />
+</beans>

--- a/examples/features/sub-modules/tomcat/src/main/webapp/WEB-INF/web.xml
+++ b/examples/features/sub-modules/tomcat/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
+
+
+    <listener>
+        <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
+    </listener>
+
+
+    <context-param>
+        <param-name>contextConfigLocation</param-name>
+        <param-value>WEB-INF/application-context.xml</param-value>
+    </context-param>
+
+    <servlet>
+        <servlet-name>dispatcher</servlet-name>
+        <servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>dispatcher</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+    
+    
+</web-app>

--- a/examples/features/sub-modules/tomcat/src/tomcat7-maven-plugin/resources/context.xml
+++ b/examples/features/sub-modules/tomcat/src/tomcat7-maven-plugin/resources/context.xml
@@ -1,0 +1,28 @@
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Context>
+    <Resource name="jms/connectionFactory"
+              auth="Container"
+              type="org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"
+              description="JMS Connection Factory"
+              factory="org.apache.activemq.artemis.jndi.JNDIReferenceFactory"
+              brokerURL="(tcp://localhost:61616)?ha=true&amp;useKQueue=false&amp;useEpoll=false"/>
+    
+    <Resource name="jms/InputQueue"
+              auth="Container"
+              type="org.apache.activemq.artemis.jms.client.ActiveMQQueue"
+              factory="org.apache.activemq.artemis.jndi.JNDIReferenceFactory"
+              address="InputQueue"/>
+
+</Context>

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/ReferenceableTest.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/ReferenceableTest.java
@@ -25,6 +25,7 @@ import javax.jms.Session;
 import javax.jms.TextMessage;
 import javax.naming.Reference;
 import javax.naming.Referenceable;
+import javax.naming.spi.ObjectFactory;
 import java.io.Serializable;
 
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
@@ -32,8 +33,6 @@ import org.apache.activemq.artemis.jms.client.ActiveMQDestination;
 import org.apache.activemq.artemis.jms.client.ActiveMQJMSConnectionFactory;
 import org.apache.activemq.artemis.jms.client.ActiveMQQueue;
 import org.apache.activemq.artemis.jms.client.ActiveMQTopic;
-import org.apache.activemq.artemis.jms.referenceable.ConnectionFactoryObjectFactory;
-import org.apache.activemq.artemis.jms.referenceable.DestinationObjectFactory;
 import org.apache.activemq.artemis.jms.tests.util.ProxyAssertSupport;
 import org.junit.Test;
 
@@ -81,7 +80,7 @@ public class ReferenceableTest extends JMSTestCase {
 
       Class<?> factoryClass = Class.forName(factoryName);
 
-      ConnectionFactoryObjectFactory factory = (ConnectionFactoryObjectFactory) factoryClass.newInstance();
+      ObjectFactory factory = (ObjectFactory) factoryClass.newInstance();
 
       Object instance = factory.getObjectInstance(cfRef, null, null, null);
 
@@ -100,7 +99,7 @@ public class ReferenceableTest extends JMSTestCase {
 
       Class<?> factoryClass = Class.forName(factoryName);
 
-      DestinationObjectFactory factory = (DestinationObjectFactory) factoryClass.newInstance();
+      ObjectFactory factory = (ObjectFactory) factoryClass.newInstance();
 
       Object instance = factory.getObjectInstance(queueRef, null, null, null);
 
@@ -121,7 +120,7 @@ public class ReferenceableTest extends JMSTestCase {
 
       Class factoryClass = Class.forName(factoryName);
 
-      DestinationObjectFactory factory = (DestinationObjectFactory) factoryClass.newInstance();
+      ObjectFactory factory = (ObjectFactory) factoryClass.newInstance();
 
       Object instance = factory.getObjectInstance(topicRef, null, null, null);
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/jms/jndi/ObjectFactoryTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/jms/jndi/ObjectFactoryTest.java
@@ -1,0 +1,138 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.unit.jms.jndi;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.naming.Reference;
+
+import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.apache.activemq.artemis.jms.client.ActiveMQDestination;
+import org.apache.activemq.artemis.jndi.JNDIReferenceFactory;
+import org.apache.activemq.artemis.utils.RandomUtil;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ObjectFactoryTest {
+
+   @Test(timeout = 1000)
+   public void testConnectionFactory() throws Exception {
+      // Create sample connection factory
+      ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory("vm://0");
+
+      String clientID = RandomUtil.randomString();
+      String user = RandomUtil.randomString();
+      String password = RandomUtil.randomString();
+      long clientFailureCheckPeriod = RandomUtil.randomPositiveLong();
+      long connectionTTL = RandomUtil.randomPositiveLong();
+      long callTimeout = RandomUtil.randomPositiveLong();
+      int minLargeMessageSize = RandomUtil.randomPositiveInt();
+      int consumerWindowSize = RandomUtil.randomPositiveInt();
+      int consumerMaxRate = RandomUtil.randomPositiveInt();
+      int confirmationWindowSize = RandomUtil.randomPositiveInt();
+      int producerMaxRate = RandomUtil.randomPositiveInt();
+      boolean blockOnAcknowledge = RandomUtil.randomBoolean();
+      boolean blockOnDurableSend = RandomUtil.randomBoolean();
+      boolean blockOnNonDurableSend = RandomUtil.randomBoolean();
+      boolean autoGroup = RandomUtil.randomBoolean();
+      boolean preAcknowledge = RandomUtil.randomBoolean();
+      String loadBalancingPolicyClassName = RandomUtil.randomString();
+      boolean useGlobalPools = RandomUtil.randomBoolean();
+      int scheduledThreadPoolMaxSize = RandomUtil.randomPositiveInt();
+      int threadPoolMaxSize = RandomUtil.randomPositiveInt();
+      long retryInterval = RandomUtil.randomPositiveLong();
+      double retryIntervalMultiplier = RandomUtil.randomDouble();
+      int reconnectAttempts = RandomUtil.randomPositiveInt();
+      factory.setClientID(clientID);
+      factory.setUser(user);
+      factory.setPassword(password);
+      factory.setClientFailureCheckPeriod(clientFailureCheckPeriod);
+      factory.setConnectionTTL(connectionTTL);
+      factory.setCallTimeout(callTimeout);
+      factory.setMinLargeMessageSize(minLargeMessageSize);
+      factory.setConsumerWindowSize(consumerWindowSize);
+      factory.setConsumerMaxRate(consumerMaxRate);
+      factory.setConfirmationWindowSize(confirmationWindowSize);
+      factory.setProducerMaxRate(producerMaxRate);
+      factory.setBlockOnAcknowledge(blockOnAcknowledge);
+      factory.setBlockOnDurableSend(blockOnDurableSend);
+      factory.setBlockOnNonDurableSend(blockOnNonDurableSend);
+      factory.setAutoGroup(autoGroup);
+      factory.setPreAcknowledge(preAcknowledge);
+      factory.setConnectionLoadBalancingPolicyClassName(loadBalancingPolicyClassName);
+      factory.setUseGlobalPools(useGlobalPools);
+      factory.setScheduledThreadPoolMaxSize(scheduledThreadPoolMaxSize);
+      factory.setThreadPoolMaxSize(threadPoolMaxSize);
+      factory.setRetryInterval(retryInterval);
+      factory.setRetryIntervalMultiplier(retryIntervalMultiplier);
+      factory.setReconnectAttempts(reconnectAttempts);
+
+
+      // Create reference
+      Reference ref = JNDIReferenceFactory.createReference(factory.getClass().getName(), factory);
+
+      // Get object created based on reference
+      ActiveMQConnectionFactory temp;
+      JNDIReferenceFactory refFactory = new JNDIReferenceFactory();
+      temp = (ActiveMQConnectionFactory)refFactory.getObjectInstance(ref, null, null, null);
+
+      // Check settings
+      Assert.assertEquals(clientID, temp.getClientID());
+      Assert.assertEquals(user, temp.getUser());
+      Assert.assertEquals(password, temp.getPassword());
+      Assert.assertEquals(clientFailureCheckPeriod, temp.getClientFailureCheckPeriod());
+      Assert.assertEquals(connectionTTL, temp.getConnectionTTL());
+      Assert.assertEquals(callTimeout, temp.getCallTimeout());
+      Assert.assertEquals(minLargeMessageSize, temp.getMinLargeMessageSize());
+      Assert.assertEquals(consumerWindowSize, temp.getConsumerWindowSize());
+      Assert.assertEquals(consumerMaxRate, temp.getConsumerMaxRate());
+      Assert.assertEquals(confirmationWindowSize, temp.getConfirmationWindowSize());
+      Assert.assertEquals(producerMaxRate, temp.getProducerMaxRate());
+      Assert.assertEquals(blockOnAcknowledge, temp.isBlockOnAcknowledge());
+      Assert.assertEquals(blockOnDurableSend, temp.isBlockOnDurableSend());
+      Assert.assertEquals(blockOnNonDurableSend, temp.isBlockOnNonDurableSend());
+      Assert.assertEquals(autoGroup, temp.isAutoGroup());
+      Assert.assertEquals(preAcknowledge, temp.isPreAcknowledge());
+      Assert.assertEquals(loadBalancingPolicyClassName, temp.getConnectionLoadBalancingPolicyClassName());
+      Assert.assertEquals(useGlobalPools, temp.isUseGlobalPools());
+      Assert.assertEquals(scheduledThreadPoolMaxSize, temp.getScheduledThreadPoolMaxSize());
+      Assert.assertEquals(threadPoolMaxSize, temp.getThreadPoolMaxSize());
+      Assert.assertEquals(retryInterval, temp.getRetryInterval());
+      Assert.assertEquals(retryIntervalMultiplier, temp.getRetryIntervalMultiplier(), 0.0001);
+      Assert.assertEquals(reconnectAttempts, temp.getReconnectAttempts());
+
+   }
+
+   @Test(timeout = 1000)
+   public void testDestination() throws Exception {
+      // Create sample destination
+      ActiveMQDestination dest = (ActiveMQDestination) ActiveMQJMSClient.createQueue(RandomUtil.randomString());
+
+      // Create reference
+      Reference ref = JNDIReferenceFactory.createReference(dest.getClass().getName(), dest);
+
+      // Get object created based on reference
+      ActiveMQDestination temp;
+      JNDIReferenceFactory refFactory = new JNDIReferenceFactory();
+      temp = (ActiveMQDestination)refFactory.getObjectInstance(ref, null, null, null);
+
+      // Check settings
+      assertEquals(dest.getAddress(), temp.getAddress());
+   }
+}

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/jms/jndi/StringRefAddrReferenceTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/jms/jndi/StringRefAddrReferenceTest.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.unit.jms.jndi;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.naming.Reference;
+import javax.naming.StringRefAddr;
+import javax.naming.spi.ObjectFactory;
+import java.util.Enumeration;
+import java.util.Properties;
+
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.apache.activemq.artemis.jms.client.ActiveMQQueue;
+import org.apache.activemq.artemis.jms.client.ActiveMQTopic;
+import org.apache.activemq.artemis.jndi.JNDIReferenceFactory;
+import org.junit.Test;
+
+/**
+ * Test to simulate JNDI references created using String properties in containers such as Apache Tomcat.
+ */
+public class StringRefAddrReferenceTest {
+
+   private static final String FACTORY = "factory";
+   private static final String TYPE = "type";
+
+   @Test(timeout = 10000)
+   public void testActiveMQQueueFromPropertiesJNDI() throws Exception {
+      Properties properties = new Properties();
+      properties.setProperty(TYPE, ActiveMQQueue.class.getName());
+      properties.setProperty(FACTORY, JNDIReferenceFactory.class.getName());
+
+      String address = "foo.bar.queue";
+
+      properties.setProperty("address", address);
+
+      Reference reference = from(properties);
+      ActiveMQQueue object = getObject(reference, ActiveMQQueue.class);
+
+      assertEquals(address, object.getAddress());
+
+   }
+
+   @Test(timeout = 10000)
+   public void testActiveMQTopicFromPropertiesJNDI() throws Exception {
+      Properties properties = new Properties();
+      properties.setProperty(TYPE, ActiveMQTopic.class.getName());
+      properties.setProperty(FACTORY, JNDIReferenceFactory.class.getName());
+
+      String address = "foo.bar.topic";
+
+      properties.setProperty("address", address);
+
+      Reference reference = from(properties);
+      ActiveMQTopic object = getObject(reference, ActiveMQTopic.class);
+
+      assertEquals(address, object.getAddress());
+
+   }
+
+   @Test(timeout = 10000)
+   public void testActiveMQConnectionFactoryFromPropertiesJNDI() throws Exception {
+      Properties properties = new Properties();
+      properties.setProperty(TYPE, ActiveMQConnectionFactory.class.getName());
+      properties.setProperty(FACTORY, JNDIReferenceFactory.class.getName());
+
+      String brokerURL = "vm://0";
+      String connectionTTL = "1000";
+      String preAcknowledge = "true";
+
+      properties.setProperty("brokerURL", brokerURL);
+      properties.setProperty("connectionTTL", connectionTTL);
+      properties.setProperty("preAcknowledge", preAcknowledge);
+
+      Reference reference = from(properties);
+      ActiveMQConnectionFactory object = getObject(reference, ActiveMQConnectionFactory.class);
+
+      assertEquals(Long.parseLong(connectionTTL), object.getConnectionTTL());
+      assertEquals(Boolean.parseBoolean(preAcknowledge), object.isPreAcknowledge());
+
+   }
+
+   private <T> T getObject(Reference reference, Class<T> tClass) throws Exception {
+      String factoryName = reference.getFactoryClassName();
+      Class<?> factoryClass = Class.forName(factoryName);
+      ObjectFactory factory = (ObjectFactory) factoryClass.newInstance();
+      Object o = factory.getObjectInstance(reference, null, null, null);
+      if (tClass.isAssignableFrom(tClass)) {
+         return tClass.cast(o);
+      } else {
+         throw new IllegalStateException("Expected class, " + tClass.getName());
+      }
+   }
+
+   public Reference from(Properties properties) {
+      String type = (String) properties.remove("type");
+      String factory = (String) properties.remove("factory");
+      Reference result = new Reference(type, factory, null);
+      for (Enumeration iter = properties.propertyNames(); iter.hasMoreElements();) {
+         String key = (String)iter.nextElement();
+         result.add(new StringRefAddr(key, properties.getProperty(key)));
+      }
+      return result;
+   }
+}

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/ra/ConnectionFactoryPropertiesTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/ra/ConnectionFactoryPropertiesTest.java
@@ -43,6 +43,9 @@ public class ConnectionFactoryPropertiesTest extends ActiveMQTestBase {
       UNSUPPORTED_CF_PROPERTIES.add("discoveryGroupName");
       UNSUPPORTED_CF_PROPERTIES.add("incomingInterceptorList");
       UNSUPPORTED_CF_PROPERTIES.add("outgoingInterceptorList");
+      UNSUPPORTED_CF_PROPERTIES.add("user");
+      UNSUPPORTED_CF_PROPERTIES.add("userName");
+      UNSUPPORTED_CF_PROPERTIES.add("password");
 
       UNSUPPORTED_RA_PROPERTIES = new TreeSet<>();
       UNSUPPORTED_RA_PROPERTIES.add("HA");
@@ -62,6 +65,7 @@ public class ConnectionFactoryPropertiesTest extends ActiveMQTestBase {
       UNSUPPORTED_RA_PROPERTIES.add("useMaskedPassword");
       UNSUPPORTED_RA_PROPERTIES.add("useAutoRecovery");
       UNSUPPORTED_RA_PROPERTIES.add("useLocalTx");
+      UNSUPPORTED_RA_PROPERTIES.add("user");
       UNSUPPORTED_RA_PROPERTIES.add("userName");
       UNSUPPORTED_RA_PROPERTIES.add("jgroupsChannelLocatorClass");
       UNSUPPORTED_RA_PROPERTIES.add("jgroupsChannelRefName");

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/ra/referenceable/DestinationObjectFactoryTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/ra/referenceable/DestinationObjectFactoryTest.java
@@ -14,13 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.tests.unit.jms.referenceable;
+package org.apache.activemq.artemis.tests.unit.ra.referenceable;
 
 import javax.naming.Reference;
+import javax.naming.spi.ObjectFactory;
 
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
 import org.apache.activemq.artemis.jms.client.ActiveMQDestination;
-import org.apache.activemq.artemis.jms.referenceable.DestinationObjectFactory;
 import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.RandomUtil;
 import org.junit.Assert;
@@ -41,8 +41,9 @@ public class DestinationObjectFactoryTest extends ActiveMQTestBase {
    public void testReference() throws Exception {
       ActiveMQDestination queue = (ActiveMQDestination) ActiveMQJMSClient.createQueue(RandomUtil.randomString());
       Reference reference = queue.getReference();
-
-      DestinationObjectFactory factory = new DestinationObjectFactory();
+      String factoryName = reference.getFactoryClassName();
+      Class<?> factoryClass = Class.forName(factoryName);
+      ObjectFactory factory = (ObjectFactory) factoryClass.newInstance();
       Object object = factory.getObjectInstance(reference, null, null, null);
       Assert.assertNotNull(object);
       Assert.assertTrue(object instanceof ActiveMQDestination);


### PR DESCRIPTION
Apply fix so that when using JNDI via tomcat resource it works. 
Replace original extract of JNDIStorable taken from Qpid, and use ActiveMQ5's as fits better to address this issue. (which primary use case is users migrating from 5.x)
Refactored ActiveMQConnectionFactory to externalise and turn into reference by StringRefAddr's instead of custom RefAddr which isnt standard.
Refactored ActiveMQDestinations similar
Refactored ActiveMQDestination to remove redundent and duplicated name field and ensured getters still behave the same