### PR TITLE
ARTEMIS-1522 add date to timestamp in logs

### DIFF
--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/logging.properties
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/logging.properties
@@ -51,4 +51,4 @@ handler.FILE.formatter=PATTERN
 # Formatter pattern configuration
 formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.PATTERN.properties=pattern
-formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] %s%E%n
+formatter.PATTERN.pattern=%d %-5p [%c] %s%E%n


### PR DESCRIPTION
Currently the date can derived from the log file postfix but in scenarios where you are only seeing snippets of log files or these log files are being manipulated later; it makes it much easier if the date is printed with the log entry.

I understand people want to reduce log space but adding the date would avoid any potential ambiguity.

current format
``
11:56:49,051 INFO  [org.apache.activemq.artemis.core.server] AMQ221007: Server is now live
``
Suggested new format
``
2017-11-24 15:24:11,803 INFO  [org.apache.activemq.artemis.core.server] AMQ221007: Server is now live
``