### PR TITLE
ARTEMIS-1534 added openwire logging (trace level) to log openwire commands

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
@@ -261,6 +261,11 @@ public class OpenWireConnection extends AbstractRemotingConnection implements Se
 
          Command command = (Command) wireFormat.unmarshal(buffer);
 
+         // log the openwire command
+         if (logger.isTraceEnabled()) {
+            logger.trace("connectionID: " + connectionID + " RECEIVED: " + (command == null ? "NULL" : command));
+         }
+
          boolean responseRequired = command.isResponseRequired();
          int commandId = command.getCommandId();
 
@@ -434,6 +439,12 @@ public class OpenWireConnection extends AbstractRemotingConnection implements Se
    }
 
    public void physicalSend(Command command) throws IOException {
+
+      if (logger.isTraceEnabled()) {
+         logger.trace("connectionID: " + (getTransportConnection() == null ? "" : getTransportConnection().getID())
+                         + " SENDING: " + (command == null ? "NULL" : command));
+      }
+
       try {
          ByteSequence bytes = wireFormat.marshal(command);
          ActiveMQBuffer buffer = OpenWireUtil.toActiveMQBuffer(bytes);


### PR DESCRIPTION
 that are received/sent by the broker. This is similar to the CORE protocol packet level logging in org/apache/activemq/artemis/core/protocol/core/impl/ChannelImpl.java and org/apache/activemq/artemis/core/protocol/core/impl/RemotingConnectionImpl.java

an example of some of the log output below:

``
2017-12-05 08:12:30,021 TRACE [org.apache.activemq.artemis.core.protocol.openwire.OpenWireConnection] connectionID: 286f9ade SENDING: BrokerInfo {commandId = 0, responseRequired = false, brokerId = 94d4b9e5-d98b-11e7-9855-a860b60c8b30, brokerURL = tcp:///127.0.0.1:61616, slaveBroker = false, masterBroker = false, faultTolerantConfiguration = false, networkConnection = false, duplexConnection = false, peerBrokerInfos = null, brokerName = macbook-pro.home, connectionId = 0, brokerUploadUrl = null, networkProperties = null}
....
2017-12-05 08:12:30,070 TRACE [org.apache.activemq.artemis.core.protocol.openwire.OpenWireConnection] connectionID: 286f9ade RECEIVED: ConnectionInfo {commandId = 1, responseRequired = true, connectionId = ID:macbook-pro.home-61087-1512457949732-1:1, clientId = ID:macbook-pro.home-61087-1512457949732-0:1, clientIp = null, userName = admin, password = *****, brokerPath = null, brokerMasterConnector = false, manageable = true, clientMaster = true, faultTolerant = false, failoverReconnect = false}

...
2017-12-05 08:12:30,555 TRACE [org.apache.activemq.artemis.core.protocol.openwire.OpenWireConnection] connectionID: 286f9ade RECEIVED: ActiveMQTextMessage {commandId = 5, responseRequired = true, messageId = ID:macbook-pro.home-61087-1512457949732-1:1:1:1:1, originalDestination = null, originalTransactionId = null, producerId = ID:macbook-pro.home-61087-1512457949732-1:1:1:1, destination = queue://mytest.q1, transactionId = null, expiration = 0, timestamp = 1512457950535, arrival = 0, brokerInTime = 0, brokerOutTime = 0, correlationId = null, replyTo = null, persistent = true, type = null, priority = 4, groupID = null, groupSequence = 0, targetConsumerId = null, compressed = false, userID = null, content = org.apache.activemq.util.ByteSequence@725ae02e, marshalledProperties = null, dataStructure = null, redeliveryCounter = 0, size = 0, properties = null, readOnlyProperties = false, readOnlyBody = false, droppable = false, jmsXGroupFirstForConsumer = false, text = 012345678901234567890123456789012345678901234...890123456789}
``
  