### PR TITLE
ARTEMIS-1544 Use the proper types when accessing ApplicationProperties

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/converter/AmqpCoreConverter.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/converter/AmqpCoreConverter.java
@@ -247,8 +247,8 @@ public class AmqpCoreConverter {
 
       final ApplicationProperties ap = amqp.getApplicationProperties();
       if (ap != null) {
-         for (Map.Entry<Object, Object> entry : (Set<Map.Entry<Object, Object>>) ap.getValue().entrySet()) {
-            setProperty(jms, entry.getKey().toString(), entry.getValue());
+         for (Map.Entry<String, Object> entry : (Set<Map.Entry<String, Object>>) ap.getValue().entrySet()) {
+            setProperty(jms, entry.getKey(), entry.getValue());
          }
       }
 


### PR DESCRIPTION
Use Map<String, Object> to access the ApplicationProperties section
which is the spec defined type for that section.  This will prevent
breakage should proton-j be updated to reflect that in the definition of
that class.