### PR TITLE
ARTEMIS-1545 Ensure JMS security exceptions occur if NON-PERSISTENT

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/client/ActiveMQClient.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/client/ActiveMQClient.java
@@ -83,7 +83,7 @@ public final class ActiveMQClient {
 
    public static final boolean DEFAULT_BLOCK_ON_DURABLE_SEND = true;
 
-   public static final boolean DEFAULT_BLOCK_ON_NON_DURABLE_SEND = false;
+   public static final boolean DEFAULT_BLOCK_ON_NON_DURABLE_SEND = true;
 
    public static final boolean DEFAULT_AUTO_GROUP = false;
 

--- a/tests/jms-tests/src/test/resources/broker.xml
+++ b/tests/jms-tests/src/test/resources/broker.xml
@@ -52,6 +52,16 @@
             <permission type="browse" roles="guest,def"/>
             <permission type="send" roles="guest,def"/>
          </security-setting>
-     </security-settings>
+     
+           <security-setting match="guest.cannot.send">
+               <permission type="createDurableQueue" roles="guest,def"/>
+               <permission type="deleteDurableQueue" roles="guest,def"/>
+               <permission type="createNonDurableQueue" roles="guest,def"/>
+               <permission type="deleteNonDurableQueue" roles="guest,def"/>
+               <permission type="consume" roles="guest,def"/>
+               <permission type="browse" roles="guest,def"/>
+               <permission type="send" roles="def"/>
+           </security-setting>
+       </security-settings>
    </core>
 </configuration>


### PR DESCRIPTION
Add test case to ensure exception behaviour on JMS MessageProducer send is the same, if message is sent persistently or non-persistently when using default settings.
Update default setting to ensure behaviour is the same, as per expectation when using JMS by default. (e.g. no setting overrides)