### PR TITLE
ARTEMIS-1550 - Support LVQ for OpenWire

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/Message.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/Message.java
@@ -183,6 +183,10 @@ public interface Message {
       return null;
    }
 
+   default Message setLastValueProperty(SimpleString lastValueName) {
+      return this;
+   }
+
    /**
     * @deprecated do not use this, use through ICoreMessage or ClientMessage
     */

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessage.java
@@ -599,6 +599,11 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
    }
 
    @Override
+   public Message setLastValueProperty(SimpleString lastValueName) {
+      return putStringProperty(Message.HDR_LAST_VALUE_NAME, lastValueName);
+   }
+
+   @Override
    public int getEncodeSize() {
       checkEncode();
       return buffer == null ? -1 : buffer.writerIndex();

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
@@ -62,7 +62,6 @@ import org.apache.qpid.proton.message.impl.MessageImpl;
 // see https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#section-message-format
 public class AMQPMessage extends RefCountMessage {
 
-   public static final String HDR_LAST_VALUE_NAME = org.apache.activemq.artemis.api.core.Message.HDR_LAST_VALUE_NAME.toString();
    public static final int DEFAULT_MESSAGE_PRIORITY = 4;
    public static final int MAX_MESSAGE_PRIORITY = 9;
 
@@ -1091,7 +1090,12 @@ public class AMQPMessage extends RefCountMessage {
 
    @Override
    public SimpleString getLastValueProperty() {
-      return getSimpleStringProperty(HDR_LAST_VALUE_NAME);
+      return getSimpleStringProperty(HDR_LAST_VALUE_NAME.toString());
+   }
+
+   @Override
+   public org.apache.activemq.artemis.api.core.Message setLastValueProperty(SimpleString lastValueName) {
+      return putStringProperty(HDR_LAST_VALUE_NAME, lastValueName);
    }
 
    @Override

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireMessageConverter.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireMessageConverter.java
@@ -771,6 +771,15 @@ public class OpenWireMessageConverter implements MessageConverter<OpenwireMessag
          }
       }
 
+      SimpleString lastValueProperty = coreMessage.getLastValueProperty();
+      if (lastValueProperty != null) {
+         try {
+            amqMsg.setStringProperty(org.apache.activemq.artemis.api.core.Message.HDR_LAST_VALUE_NAME.toString(), lastValueProperty.toString());
+         } catch (JMSException e) {
+            throw new IOException("failure to set lvq property " + dlqCause, e);
+         }
+      }
+
       Set<SimpleString> props = coreMessage.getPropertyNames();
       if (props != null) {
          for (SimpleString s : props) {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSClientTestSupport.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSClientTestSupport.java
@@ -234,7 +234,7 @@ public abstract class JMSClientTestSupport extends AmqpClientTestSupport {
    }
 
    protected Connection createOpenWireConnection() throws JMSException {
-      return createCoreConnection(getBrokerOpenWireJMSConnectionString(), null, null, null, true);
+      return createOpenWireConnection(getBrokerOpenWireJMSConnectionString(), null, null, null, true);
    }
 
    private Connection createOpenWireConnection(String connectionString, String username, String password, String clientId, boolean start) throws JMSException {


### PR DESCRIPTION
Add support for LVQ, using the same property key as core "_AMQ_LVQ_NAME"
Update current LVQ test case to correctly test OpenWire LVQ.