### PR TITLE
ARTEMIS-1542 - AMQP message cluster-bridging fixi

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/impl/ClusterConnectionBridge.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/impl/ClusterConnectionBridge.java
@@ -182,7 +182,7 @@ public class ClusterConnectionBridge extends BridgeImpl {
 
       messageCopy.putExtraBytesProperty(Message.HDR_ROUTE_TO_IDS, queueIds);
 
-      messageCopy = super.beforeForward(messageCopy, null);
+      messageCopy = super.beforeForward(messageCopy, forwardingAddress);
 
       return messageCopy;
    }


### PR DESCRIPTION
Fixing and issue where AMQP messages would lose their address when being sent accross a cluster-bridge.