### PR TITLE
ARTEMIS-1329 testNoLocalReconnect was failing with OpenWire protocol

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQConsumer.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQConsumer.java
@@ -95,7 +95,7 @@ public class AMQConsumer {
          } else {
             preAck = true;
          }
-         String noLocalSelector = MessageUtil.CONNECTION_ID_PROPERTY_NAME.toString() + "<>'" + this.getId().getConnectionId() + "'";
+         String noLocalSelector = MessageUtil.CONNECTION_ID_PROPERTY_NAME.toString() + "<>'" + info.getClientId() + "'";
          if (selector == null) {
             selector = new SimpleString(noLocalSelector);
          } else {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/NoLocalSubscriberTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/NoLocalSubscriberTest.java
@@ -26,6 +26,7 @@ import javax.jms.TextMessage;
 import javax.jms.Topic;
 import javax.jms.TopicSubscriber;
 
+import org.apache.activemq.artemis.reader.MessageUtil;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
 import org.apache.activemq.artemis.tests.util.JMSTestBase;
 import org.apache.activemq.artemis.utils.RandomUtil;
@@ -145,7 +146,9 @@ public class NoLocalSubscriberTest extends JMSTestBase {
          connection.setClientID(clientID);
          Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
          MessageProducer messageProducer = session.createProducer(topic);
-         messageProducer.send(session.createTextMessage("M3"));
+         TextMessage textMessage = session.createTextMessage("M3");
+         textMessage.setStringProperty(MessageUtil.CONNECTION_ID_PROPERTY_NAME.toString(), clientID);
+         messageProducer.send(textMessage);
          connection.close();
       }
 
@@ -157,7 +160,9 @@ public class NoLocalSubscriberTest extends JMSTestBase {
          connection.setClientID(clientID + "_different");
          Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
          MessageProducer messageProducer = session.createProducer(topic);
-         messageProducer.send(session.createTextMessage("M4"));
+         TextMessage textMessage = session.createTextMessage("M4");
+         textMessage.setStringProperty(MessageUtil.CONNECTION_ID_PROPERTY_NAME.toString(), clientID + "_different");
+         messageProducer.send(textMessage);
          connection.close();
       }
 


### PR DESCRIPTION
Can anybody review this? This fixes the issue, but I find it weird to assign client ID to CID (connection ID) property. Although the same thing is done [here](https://github.com/apache/activemq-artemis/blob/master/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQMessageProducer.java#L83)