### PR TITLE
ARTEMIS-1329 fix openwire noLocal flag

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQConsumer.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQConsumer.java
@@ -95,7 +95,8 @@ public class AMQConsumer {
          } else {
             preAck = true;
          }
-         String noLocalSelector = MessageUtil.CONNECTION_ID_PROPERTY_NAME.toString() + "<>'" + info.getClientId() + "'";
+         String id = info.getClientId() != null ? info.getClientId() : this.getId().getConnectionId();
+         String noLocalSelector = MessageUtil.CONNECTION_ID_PROPERTY_NAME.toString() + "<>'" + id + "'";
          if (selector == null) {
             selector = new SimpleString(noLocalSelector);
          } else {

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQSession.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQSession.java
@@ -317,11 +317,7 @@ public class AMQSession implements SessionCallback {
 
       org.apache.activemq.artemis.api.core.Message originalCoreMsg = getConverter().inbound(messageSend);
 
-      if (connection.isNoLocal()) {
-         //Note: advisory messages are dealt with in
-         //OpenWireProtocolManager#fireAdvisory
-         originalCoreMsg.putStringProperty(MessageUtil.CONNECTION_ID_PROPERTY_NAME.toString(), this.connection.getState().getInfo().getConnectionId().getValue());
-      }
+      originalCoreMsg.putStringProperty(MessageUtil.CONNECTION_ID_PROPERTY_NAME.toString(), this.connection.getState().getInfo().getClientId());
 
       /* ActiveMQ failover transport will attempt to reconnect after connection failure.  Any sent messages that did
       * not receive acks will be resent.  (ActiveMQ broker handles this by returning a last sequence id received to

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/NoLocalSubscriberTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/NoLocalSubscriberTest.java
@@ -26,7 +26,6 @@ import javax.jms.TextMessage;
 import javax.jms.Topic;
 import javax.jms.TopicSubscriber;
 
-import org.apache.activemq.artemis.reader.MessageUtil;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
 import org.apache.activemq.artemis.tests.util.JMSTestBase;
 import org.apache.activemq.artemis.utils.RandomUtil;
@@ -147,7 +146,6 @@ public class NoLocalSubscriberTest extends JMSTestBase {
          Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
          MessageProducer messageProducer = session.createProducer(topic);
          TextMessage textMessage = session.createTextMessage("M3");
-         textMessage.setStringProperty(MessageUtil.CONNECTION_ID_PROPERTY_NAME.toString(), clientID);
          messageProducer.send(textMessage);
          connection.close();
       }
@@ -161,7 +159,6 @@ public class NoLocalSubscriberTest extends JMSTestBase {
          Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
          MessageProducer messageProducer = session.createProducer(topic);
          TextMessage textMessage = session.createTextMessage("M4");
-         textMessage.setStringProperty(MessageUtil.CONNECTION_ID_PROPERTY_NAME.toString(), clientID + "_different");
          messageProducer.send(textMessage);
          connection.close();
       }


### PR DESCRIPTION
Previous [PR](https://github.com/apache/activemq-artemis/pull/1725/files) was invalid, because some other test was broken. I hope this fix is ok. Can @gaohoward confirm, please?