### PR TITLE
ARTEMIS-1569 - Queue - User Enhancement

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/QueueControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/QueueControl.java
@@ -57,6 +57,12 @@ public interface QueueControl {
    boolean isDurable();
 
    /**
+    * Returns the user that is associated with creating the queue.
+    */
+   @Attribute(desc = "the user that created the queue")
+   String getUser();
+
+   /**
     * The routing type of this queue.
     */
    @Attribute(desc = "routing type of this queue")

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/CoreQueueConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/CoreQueueConfiguration.java
@@ -33,6 +33,8 @@ public class CoreQueueConfiguration implements Serializable {
 
    private boolean durable = true;
 
+   private String user = null;
+
    private Integer maxConsumers = ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers();
 
    private Boolean purgeOnNoConsumers = ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers();
@@ -56,6 +58,10 @@ public class CoreQueueConfiguration implements Serializable {
 
    public boolean isDurable() {
       return durable;
+   }
+
+   public String getUser() {
+      return user;
    }
 
    /**
@@ -103,6 +109,14 @@ public class CoreQueueConfiguration implements Serializable {
     */
    public CoreQueueConfiguration setPurgeOnNoConsumers(Boolean purgeOnNoConsumers) {
       this.purgeOnNoConsumers = purgeOnNoConsumers;
+      return this;
+   }
+
+   /**
+    * @param user the use you want to associate with creating the queue
+    */
+   public CoreQueueConfiguration setUser(String user) {
+      this.user = user;
       return this;
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -1076,6 +1076,7 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       boolean durable = true;
       int maxConsumers = ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers();
       boolean purgeOnNoConsumers = ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers();
+      String user = null;
 
       NamedNodeMap attributes = node.getAttributes();
       for (int i = 0; i < attributes.getLength(); i++) {
@@ -1098,10 +1099,12 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
             filterString = getAttributeValue(child, "string");
          } else if (child.getNodeName().equals("durable")) {
             durable = XMLUtil.parseBoolean(child);
+         } else if (child.getNodeName().equals("user")) {
+            user = getTrimmedTextContent(child);
          }
       }
 
-      return new CoreQueueConfiguration().setAddress(address).setName(name).setFilterString(filterString).setDurable(durable).setMaxConsumers(maxConsumers).setPurgeOnNoConsumers(purgeOnNoConsumers);
+      return new CoreQueueConfiguration().setAddress(address).setName(name).setFilterString(filterString).setDurable(durable).setMaxConsumers(maxConsumers).setPurgeOnNoConsumers(purgeOnNoConsumers).setUser(user);
    }
 
    protected CoreAddressConfiguration parseAddressConfiguration(final Node node) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/QueueControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/QueueControlImpl.java
@@ -176,6 +176,20 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
    }
 
    @Override
+   public String getUser() {
+      checkStarted();
+
+      clearIO();
+      try {
+         SimpleString user = queue.getUser();
+         return user == null ? null : user.toString();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+
+   @Override
    public String getRoutingType() {
       checkStarted();
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -2508,7 +2508,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
             // if the address::queue doesn't exist then create it
             try {
                createQueue(SimpleString.toSimpleString(config.getAddress()), config.getRoutingType(),
-                           queueName, SimpleString.toSimpleString(config.getFilterString()),null,
+                           queueName, SimpleString.toSimpleString(config.getFilterString()), SimpleString.toSimpleString(config.getUser()),
                            config.isDurable(),false,false,false,false,config.getMaxConsumers(),config.getPurgeOnNoConsumers(),true);
             } catch (ActiveMQQueueExistsException e) {
                // the queue may exist on a *different* address

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -477,6 +477,13 @@
                                  </xsd:documentation>
                               </xsd:annotation>
                            </xsd:element>
+                           <xsd:element name="user" type="xsd:string" maxOccurs="1" minOccurs="0">
+                              <xsd:annotation>
+                                 <xsd:documentation>
+                                    user to associate for creating the queue
+                                 </xsd:documentation>
+                              </xsd:annotation>
+                           </xsd:element>
                            <xsd:element ref="filter" maxOccurs="1" minOccurs="0"/>
                            <xsd:element name="durable" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
                               <xsd:annotation>
@@ -2987,6 +2994,7 @@
       <xsd:all>
          <xsd:element ref="filter" maxOccurs="1" minOccurs="0"/>
          <xsd:element name="durable" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0" />
+         <xsd:element name="user" type="xsd:string" maxOccurs="1" minOccurs="0" />
       </xsd:all>
       <xsd:attribute name="name" type="xsd:string" use="required"/>
       <xsd:attribute name="max-consumers" type="xsd:integer" use="optional"/>

--- a/artemis-tools/src/test/resources/artemis-configuration.xsd
+++ b/artemis-tools/src/test/resources/artemis-configuration.xsd
@@ -459,6 +459,13 @@
                                  </xsd:documentation>
                               </xsd:annotation>
                            </xsd:element>
+                           <xsd:element name="user" type="xsd:string" maxOccurs="1" minOccurs="0">
+                              <xsd:annotation>
+                                 <xsd:documentation>
+                                    user to associate for creating the queue
+                                 </xsd:documentation>
+                              </xsd:annotation>
+                           </xsd:element>
                            <xsd:element ref="filter" maxOccurs="1" minOccurs="0"/>
                            <xsd:element name="durable" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
                               <xsd:annotation>
@@ -2678,6 +2685,7 @@
       <xsd:all>
          <xsd:element ref="filter" maxOccurs="1" minOccurs="0"/>
          <xsd:element name="durable" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0" />
+         <xsd:element name="user" type="xsd:string" maxOccurs="1" minOccurs="0" />
       </xsd:all>
       <xsd:attribute name="name" type="xsd:string" use="required"/>
       <xsd:attribute name="max-consumers" type="xsd:integer" use="optional"/>

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlUsingCoreTest.java
@@ -72,6 +72,11 @@ public class QueueControlUsingCoreTest extends QueueControlTest {
          }
 
          @Override
+         public String getUser() {
+            return (String) proxy.retrieveAttributeValue("user");
+         }
+
+         @Override
          public int getConsumerCount() {
             return (Integer) proxy.retrieveAttributeValue("consumerCount", Integer.class);
          }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/QueueConfigRestartTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/QueueConfigRestartTest.java
@@ -60,6 +60,28 @@ public class QueueConfigRestartTest extends ActiveMQTestBase {
       QueueBinding queueBinding2 = (QueueBinding)server.getPostOffice().getBinding(queue);
       Assert.assertTrue(queueBinding2.getQueue().isPurgeOnNoConsumers());
    }
+
+   @Test
+   public void testQueueConfigUserAndRestart() throws Exception {
+      ActiveMQServer server = createServer(true);
+
+      server.start();
+
+      SimpleString address = new SimpleString("test.address");
+      SimpleString queue = new SimpleString("test.queue");
+
+      server.createQueue(address, RoutingType.MULTICAST, queue, null, SimpleString.toSimpleString("bob"), true, false, false, 10, true, true);
+
+      QueueBinding queueBinding1 = (QueueBinding)server.getPostOffice().getBinding(queue);
+      Assert.assertEquals(SimpleString.toSimpleString("bob"), queueBinding1.getQueue().getUser());
+
+      server.stop();
+
+      server.start();
+
+      QueueBinding queueBinding2 = (QueueBinding)server.getPostOffice().getBinding(queue);
+      Assert.assertTrue(queueBinding2.getQueue().isPurgeOnNoConsumers());
+   }
    // Package protected ---------------------------------------------
 
    // Protected -----------------------------------------------------


### PR DESCRIPTION
Expose User associated with creating Queue on JMX QueueControl (as attribute) 
Allow setting of the user to associate with creating the queue when configured in broker.xml (before only if created over wire is it possible to set the user)