### PR TITLE
ARTEMIS-1571 - Upgrade to Netty 4.1.19.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
       <jgroups.version>3.6.13.Final</jgroups.version>
       <maven.assembly.plugin.version>2.4</maven.assembly.plugin.version>
       <mockito.version>2.8.47</mockito.version>
-      <netty.version>4.1.18.Final</netty.version>
+      <netty.version>4.1.19.Final</netty.version>
       <proton.version>0.24.0</proton.version>
       <resteasy.version>3.0.19.Final</resteasy.version>
       <slf4j.version>1.7.21</slf4j.version>


### PR DESCRIPTION
There is a critical bug/regression found and announced in netty 4.1.18 fixed in 4.1.19

http://netty.io/news/2017/12/18/4-1-19-Final.html