### PR TITLE
ARTEMIS-1181 Fix broken links in user-manual

### DIFF
--- a/docs/user-manual/en/address-model.md
+++ b/docs/user-manual/en/address-model.md
@@ -442,7 +442,7 @@ The special name allows the protocol manager to quickly identify the required cl
 
 When a client requests to subscribe to a point to point address.  The protocol manager will look up the queue associated with the point to point address.  This queue should have the same name as the addresss.
 
-**Note:** If the queue is auto created, it will be auto deleted once there are no consumers and no messages in it.  For more information on auto create see the next section [Configuring Addresses and Queues via Address Settings](#Configuring-Addresses-and-Queues-via-Address-Settings)
+**Note:** If the queue is auto created, it will be auto deleted once there are no consumers and no messages in it.  For more information on auto create see the next section [Configuring Addresses and Queues via Address Settings](#configuring-addresses-and-queues-via-address-settings)
 
 ## Configuring Addresses and Queues via Address Settings
 
@@ -483,13 +483,13 @@ appropriate chapter if available.
 
 `max-delivery-attempts` defines how many time a cancelled message can be
 redelivered before sending to the `dead-letter-address`. A full
-explanation can be found [here](undelivered-messages.md#Configuring-Dead-Letter-Addresses).
+explanation can be found [here](undelivered-messages.md#configuring-dead-letter-addresses).
 
 `redelivery-delay` defines how long to wait before attempting redelivery
-of a cancelled message. see [here](undelivered-messages.md#Configuring-Delayed-Redelivery).
+of a cancelled message. see [here](undelivered-messages.md#configuring-delayed-redelivery).
 
 `expiry-address` defines where to send a message that has expired. see
-[here](message-expiry.md#Configuring-Expiry-Addresses).
+[here](message-expiry.md#configuring-expiry-addresses).
 
 `expiry-delay` defines the expiration time that will be used for
 messages which are using the default expiration time (i.e. 0). For
@@ -504,11 +504,11 @@ default is "-1".
 see [here](last-value-queues.md).
 
 `max-size-bytes` and `page-size-bytes` are used to set paging on an
-address. This is explained [here](paging.md#Configuration).
+address. This is explained [here](paging.md#configuration).
 
 `redistribution-delay` defines how long to wait when the last consumer
 is closed on a queue before redistributing any messages. see
-[here](clusters.md#Message-Redistribution).
+[here](clusters.md#message-redistribution).
 
 `send-to-dla-on-no-route`. If a message is sent to an address, but the
 server does not route it to any queues, for example, there might be no

--- a/docs/user-manual/en/configuration-index.md
+++ b/docs/user-manual/en/configuration-index.md
@@ -63,7 +63,7 @@ Name | Description
 [diverts](diverts.md "Diverting and Splitting Message Flows")        |  [a list of diverts to use](#divert-type)
 [global-max-size](paging.md#global-max-size) | The amount in bytes before all addresses are considered full. Default is half of the memory used by the JVM (-Xmx argument).
 [graceful-shutdown-enabled](graceful-shutdown.md "Graceful Server Shutdown")      |  true means that graceful shutdown is enabled. Default=true
-[graceful-shutdown-timeout](graceful-shutdown.md "Graceful Server Shutdown")      |  Timeout on waitin for clients to disconnect before server shutdown. Default=-1
+[graceful-shutdown-timeout](graceful-shutdown.md "Graceful Server Shutdown")      |  Timeout on waiting for clients to disconnect before server shutdown. Default=-1
 [grouping-handler](message-grouping.md "Message Grouping")             |  Message Group configuration
 [id-cache-size](duplicate-detection.md "Configuring the Duplicate ID Cache")  |  The duplicate detection circular cache size. Default=20000
 [jmx-domain](management.md "Configuring JMX")                               |  the JMX domain used to registered MBeans in the MBeanServer. Default=org.apache.activemq
@@ -74,9 +74,9 @@ Name | Description
 [journal-compact-percentage](persistence.md)                                        |  The percentage of live data on which we consider compacting the journal. Default=30
 [journal-directory](persistence.md)                                                 |  the directory to store the journal files in. Default=data/journal
 [journal-file-size](persistence.md)                                                 |  the size (in bytes) of each journal file. Default=10485760 (10 MB)
-[journal-max-io](persistence.md#configuring.message.journal.journal-max-io)           |  the maximum number of write requests that can be in the AIO queue at any one time. Default is 4096 for AIO and 1 for NIO, ignored for MAPPED.
-[journal-min-files](persistence.md#configuring.message.journal.journal-min-files)     |  how many journal files to pre-create. Default=2
-[journal-pool-files](persistence.md#configuring.message.journal.journal-pool-files)     |  The upper theshold of the journal file pool,-1 (default) means no Limit. The system will create as many files as needed however when reclaiming files it will shrink back to the `journal-pool-files`
+[journal-max-io](persistence.md#configuring-the-message-journal)           |  the maximum number of write requests that can be in the AIO queue at any one time. Default is 4096 for AIO and 1 for NIO, ignored for MAPPED.
+[journal-min-files](persistence.md#configuring-the-message-journal)     |  how many journal files to pre-create. Default=2
+[journal-pool-files](persistence.md#configuring-the-message-journal)     |  The upper threshold of the journal file pool,-1 (default) means no Limit. The system will create as many files as needed however when reclaiming files it will shrink back to the `journal-pool-files`
 [journal-sync-non-transactional](persistence.md)                                      |  if true wait for non transaction data to be synced to the journal before returning response to client. Default=true
 [journal-sync-transactional](persistence.md)                                          |  if true wait for transaction data to be synchronized to the journal before returning response to client. Default=true
 [journal-type](persistence.md)                                                        |  the type of journal to use. Default=ASYNCIO
@@ -103,7 +103,7 @@ Name | Description
 [queues](address-model.md "Predefined Queues")       |  [a list of queue to be created](#queue-type)
 [remoting-incoming-interceptors](intercepting-operations.md "Intercepting Operations")                                                   |  A list of interceptor
 [resolveProtocols]()  |  Use [ServiceLoader](http://docs.oracle.com/javase/tutorial/ext/basics/spi.html) to load protocol modules. Default=true
-[scheduled-thread-pool-max-size](thread-pooling.md#server.scheduled.thread.pool "Server Scheduled Thread Pool")|  Maximum number of threads to use for the scheduled thread pool. Default=5
+[scheduled-thread-pool-max-size](thread-pooling.md#server-scheduled-thread-pool "Server Scheduled Thread Pool")|  Maximum number of threads to use for the scheduled thread pool. Default=5
 [security-enabled](security.md "Security")  |  true means that security is enabled. Default=true
 [security-invalidation-interval](security.md "Security")                                   |  how long (in ms) to wait before invalidating the security cache. Default=10000
 system-property-prefix | Prefix for replacing configuration settings using Bean Utils.
@@ -113,9 +113,9 @@ system-property-prefix | Prefix for replacing configuration settings using Bean 
 [transaction-timeout](transaction-config.md "Resource Manager Configuration")              |  how long (in ms) before a transaction can be removed from the resource manager after create time. Default=300000
 [transaction-timeout-scan-period](transaction-config.md "Resource Manager Configuration")  |  how often (in ms) to scan for timeout transactions. Default=1000
 [wild-card-routing-enabled](wildcard-routing.md "Routing Messages With Wild Cards")        |  true means that the server supports wild card routing. Default=true
-[network-check-NIC](network-isolation.md) | The NIC (Network Interface Controller) to be used on InetAddress.isReacheable
+[network-check-NIC](network-isolation.md) | The NIC (Network Interface Controller) to be used on InetAddress.isReachable
 [network-check-URL](network-isolation.md) | The list of http URIs to be used to validate the network
-[network-check-list](network-isolation.md) | The list of pings to be used on ping or InetAddress.isReacheable
+[network-check-list](network-isolation.md) | The list of pings to be used on ping or InetAddress.isReachable
 [network-check-ping-command](network-isolation.md) | The command used to oping IPV4 addresses
 [network-check-ping6-command](network-isolation.md) | The command used to oping IPV6 addresses
 [critical-analyzer](critical-analysis.md) | Enable or disable the critical analysis (default true)

--- a/docs/user-manual/en/flow-control.md
+++ b/docs/user-manual/en/flow-control.md
@@ -170,7 +170,7 @@ but instead pages messages to storage.
 
 To configure an address with a maximum size and tell the server that you
 want to block producers for this address if it becomes full, you need to
-define an AddressSettings ([Configuring Queues Via Address Settings](address-model.md#configuring-addresses-and-queues-via-address-setting)) block for the address and specify
+define an AddressSettings ([Configuring Queues Via Address Settings](address-model.md#configuring-addresses-and-queues-via-address-settings)) block for the address and specify
 `max-size-bytes` and `address-full-policy`
 
 The address block applies to all queues registered to that address. I.e.

--- a/docs/user-manual/en/message-grouping.md
+++ b/docs/user-manual/en/message-grouping.md
@@ -120,7 +120,7 @@ file.
     </grouping-handler>
 
 The *address* attribute refers to a [cluster connection and the address
-it uses](#clusters.address), refer to the clustering section on how to
+it uses](clusters.md#configuring-cluster-connections), refer to the clustering section on how to
 configure clusters. The *timeout* attribute referees to how long to wait
 for a decision to be made, an exception will be thrown during the send
 if this timeout is reached, this ensures that strict ordering is kept.

--- a/docs/user-manual/en/persistence.md
+++ b/docs/user-manual/en/persistence.md
@@ -85,10 +85,10 @@ implementations. Apache ActiveMQ Artemis ships with two implementations:
     on any platform where there's a Java 4+ runtime.
     
     Under power failure durability requirements it will perform at least on par with the NIO journal with the only 
-    exception of Linux OS with kernel less or equals 2.6, in which the [*msync*](https://docs.oracle.com/javase/6/docs/api/java/nio/MappedByteBuffer.html#force()) implementation necessary to ensure 
-    durable writes was different (and slower) from the [*fsync*](https://docs.oracle.com/javase/6/docs/api/java/nio/channels/FileChannel.html#force(boolean)) used is case of NIO journal.
+    exception of Linux OS with kernel less or equals 2.6, in which the [*msync*](https://docs.oracle.com/javase/6/docs/api/java/nio/MappedByteBuffer.html#force%28%29)) implementation necessary to ensure 
+    durable writes was different (and slower) from the [*fsync*](https://docs.oracle.com/javase/6/docs/api/java/nio/channels/FileChannel.html#force%28boolean%29) used is case of NIO journal.
     
-    It benefits by the configuration of OS [huge pages](https://en.wikipedia.org/wiki/Page_(computer_memory)#Huge_pages),
+    It benefits by the configuration of OS [huge pages](https://en.wikipedia.org/wiki/Page_%28computer_memory%29),
     in particular when is used a big number of journal files and sizing them as multiple of the OS page size in bytes.    
 
 The standard Apache ActiveMQ Artemis core server uses two instances of the journal:

--- a/docs/user-manual/en/protocols-interoperability.md
+++ b/docs/user-manual/en/protocols-interoperability.md
@@ -141,8 +141,7 @@ OpenWire support you must configure a Netty Acceptor, like so:
 The Apache ActiveMQ Artemis server will then listens on port 61616 for incoming
 openwire commands. Please note the "protocols" is not mandatory here.
 The openwire configuration conforms to Apache ActiveMQ Artemis's "Single Port" feature.
-Please refer to [Configuring Single
-Port](#configuring-transports.single-port) for details.
+Please refer to [Configuring Single Port](configuring-transports.md#single-port-support) for details.
 
 Please refer to the openwire example for more coding details.
 
@@ -566,7 +565,7 @@ message to a normal message, before sending it to the client.
 If a large message is compressed, the server will uncompressed it before
 sending it to stomp clients. The default value of
 `stompMinLargeMessageSize` is the same as the default value of
-[min-large-message-size](large-messages.md#Configuring-Parameters).
+[min-large-message-size](large-messages.md#configuring-parameters).
 
 ### Stomp Over Web Sockets
 

--- a/docs/user-manual/en/rest.md
+++ b/docs/user-manual/en/rest.md
@@ -43,7 +43,7 @@ of the REST interface?
     HTTP uniform interface provides all the interoperability you need to
     communicate between different languages, platforms, and even
     messaging implementations that choose to implement the same RESTful
-    interface as Apache ActiveMQ Artemis (i.e. the [REST-\*](http://rest-star.org)
+    interface as Apache ActiveMQ Artemis (i.e. the [REST-\*](http://www.jboss.org/reststar)
     effort.)
 
 -   No envelope (e.g. SOAP) or feed (e.g. Atom) format requirements. You
@@ -57,7 +57,7 @@ of the REST interface?
 
 ## Installation and Configuration
 
-Apache ActiveMQ Artemis's REST interface is installed as a Web archive (WAR). It depends on the [RESTEasy](http://jboss.org/resteasy) project and can currently only run within a servlet container. Installing the Apache ActiveMQ Artemis REST interface is a little bit different depending whether Apache ActiveMQ Artemis is already embedded (e.g. you're deploying within Wildfly) or configured on the network somewhere, or you want the ActiveMQ Artemis REST WAR itself to startup and manage the Apache ActiveMQ Artemis server.
+Apache ActiveMQ Artemis's REST interface is installed as a Web archive (WAR). It depends on the [RESTEasy](http://resteasy.jboss.org) project and can currently only run within a servlet container. Installing the Apache ActiveMQ Artemis REST interface is a little bit different depending whether Apache ActiveMQ Artemis is already embedded (e.g. you're deploying within Wildfly) or configured on the network somewhere, or you want the ActiveMQ Artemis REST WAR itself to startup and manage the Apache ActiveMQ Artemis server.
 
 ### Installing Within Pre-configured Environment
 
@@ -293,7 +293,7 @@ following relative URI pattern:
 
 The base of the URI is the base URL of the WAR you deployed the Apache ActiveMQ Artemis
 REST server within as defined in the [Installation and
-Configuration](#install) section of this document. Replace the `{name}`
+Configuration](#installation-and-configuration) section of this document. Replace the `{name}`
 string within the above URI pattern with the name of the queue or topic
 you are interested in interacting with. Next, perform your HEAD or GET
 request on this URI. Here's what a request/response would look like.
@@ -338,11 +338,11 @@ with a Queue resource.
 
 -   `msg-pull-consumers`. This is a URL for creating consumers that will
     pull from a queue. The semantics of this link are described in
-    [Consuming Messages via Pull](#message-pull).
+    [Consuming Messages via Pull](#consuming-messages-via-pull).
 
 -   `msg-push-consumers`. This is a URL for registering other URLs you
     want the Apache ActiveMQ Artemis REST server to push messages to. The semantics of
-    this link are described in [Pushing Messages](#message-push).
+    this link are described in [Pushing Messages](#pushing-messages).
 
 ### Topic Resource Response Headers
 
@@ -358,16 +358,16 @@ with a Topic resource.
 
 -   `msg-pull-subscriptions`. This is a URL for creating subscribers
     that will pull from a topic. The semantics of this link are
-    described in [Consuming Messages via Pull](#message-pull).
+    described in [Consuming Messages via Pull](#consuming-messages-via-pull).
 
 -   `msg-push-subscriptions`. This is a URL for registering other URLs
     you want the Apache ActiveMQ Artemis REST server to push messages to. The semantics
-    of this link are described in [Pushing Messages](#message-push).
+    of this link are described in [Pushing Messages](#pushing-messages).
 
 ## Posting Messages
 
 This chapter discusses the protocol for posting messages to a queue or a
-topic. In [Apache ActiveMQ Artemis REST Interface Basics](#basics), you saw that a
+topic. In [Apache ActiveMQ Artemis REST Interface Basics](#apache-activemq-artemis-rest-interface-basics), you saw that a
 queue or topic resource publishes variable custom headers that are links
 to other RESTful resources. The `msg-create` header is a URL you can
 post a message to. Messages are published to a queue or topic by sending


### PR DESCRIPTION
Either caused by improper escaping, or the #fragment is wrong