### PR TITLE
ARTEMIS-1586 Reduce GC pressure due to string allocations on Core messages

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/SimpleString.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/SimpleString.java
@@ -21,6 +21,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.netty.buffer.ByteBuf;
+import org.apache.activemq.artemis.utils.AbstractByteBufPool;
+import org.apache.activemq.artemis.utils.AbstractPool;
+import org.apache.activemq.artemis.utils.ByteUtil;
 import org.apache.activemq.artemis.utils.DataConstants;
 
 /**
@@ -58,6 +61,13 @@ public final class SimpleString implements CharSequence, Serializable, Comparabl
          return null;
       }
       return new SimpleString(string);
+   }
+
+   public static SimpleString toSimpleString(final String string, StringSimpleStringPool pool) {
+      if (pool == null) {
+         return toSimpleString(string);
+      }
+      return pool.getOrCreate(string);
    }
 
    // Constructors
@@ -134,7 +144,6 @@ public final class SimpleString implements CharSequence, Serializable, Comparabl
       return subSeq(start, end);
    }
 
-
    public static SimpleString readNullableSimpleString(ByteBuf buffer) {
       int b = buffer.readByte();
       if (b == DataConstants.NULL) {
@@ -143,13 +152,20 @@ public final class SimpleString implements CharSequence, Serializable, Comparabl
       return readSimpleString(buffer);
    }
 
-
    public static SimpleString readSimpleString(ByteBuf buffer) {
       int len = buffer.readInt();
-      if (len > buffer.readableBytes()) {
-         throw new IndexOutOfBoundsException();
+      return readSimpleString(buffer, len);
+   }
+
+   public static SimpleString readSimpleString(ByteBuf buffer, ByteBufSimpleStringPool pool) {
+      if (pool == null) {
+         return readSimpleString(buffer);
       }
-      byte[] data = new byte[len];
+      return pool.getOrCreate(buffer);
+   }
+
+   public static SimpleString readSimpleString(final ByteBuf buffer, final int length) {
+      byte[] data = new byte[length];
       buffer.readBytes(data);
       return new SimpleString(data);
    }
@@ -168,8 +184,6 @@ public final class SimpleString implements CharSequence, Serializable, Comparabl
       buffer.writeInt(data.length);
       buffer.writeBytes(data);
    }
-
-
 
    public SimpleString subSeq(final int start, final int end) {
       int len = data.length >> 1;
@@ -258,21 +272,29 @@ public final class SimpleString implements CharSequence, Serializable, Comparabl
 
       if (other instanceof SimpleString) {
          SimpleString s = (SimpleString) other;
-
-         if (data.length != s.data.length) {
-            return false;
-         }
-
-         for (int i = 0; i < data.length; i++) {
-            if (data[i] != s.data[i]) {
+         if (s.hash != 0 && this.hash != 0) {
+            if (s.hash != this.hash)
                return false;
-            }
          }
-
-         return true;
+         if (s.str != null && this.str != null) {
+            return this.str.equals(s.str);
+         } else {
+            return ByteUtil.equals(this.data, s.data);
+         }
       } else {
          return false;
       }
+   }
+
+   /**
+    * Returns {@code true} if  the {@link SimpleString} encoded content into {@code bytes} is equals to {@code s},
+    * {@code false} otherwise.
+    * <p>
+    * It assumes that the {@code bytes} content is read using {@link SimpleString#readSimpleString(ByteBuf, int)} ie starting right after the
+    * length field.
+    */
+   public boolean equals(final ByteBuf byteBuf, final int offset, final int length) {
+      return ByteUtil.equals(data, byteBuf, offset, length);
    }
 
    @Override
@@ -451,6 +473,67 @@ public final class SimpleString implements CharSequence, Serializable, Comparabl
          int high = data[j++] << 8 & 0xFF00;
 
          dst[d++] = (char) (low | high);
+      }
+   }
+
+   public static final class ByteBufSimpleStringPool extends AbstractByteBufPool<SimpleString> {
+
+      private static final int UUID_LENGTH = 36;
+
+      private final int maxLength;
+
+      public ByteBufSimpleStringPool() {
+         this.maxLength = UUID_LENGTH;
+      }
+
+      public ByteBufSimpleStringPool(final int capacity, final int maxCharsLength) {
+         super(capacity);
+         this.maxLength = maxCharsLength;
+      }
+
+      @Override
+      protected boolean isEqual(final SimpleString entry, final ByteBuf byteBuf, final int offset, final int length) {
+         if (entry == null) {
+            return false;
+         }
+         return entry.equals(byteBuf, offset, length);
+      }
+
+      @Override
+      protected boolean canPool(final ByteBuf byteBuf, final int length) {
+         assert length % 2 == 0 : "length must be a multiple of 2";
+         final int expectedStringLength = length >> 1;
+         return expectedStringLength <= maxLength;
+      }
+
+      @Override
+      protected SimpleString create(final ByteBuf byteBuf, final int length) {
+         return readSimpleString(byteBuf, length);
+      }
+   }
+
+   public static final class StringSimpleStringPool extends AbstractPool<String, SimpleString> {
+
+      public StringSimpleStringPool() {
+         super();
+      }
+
+      public StringSimpleStringPool(final int capacity) {
+         super(capacity);
+      }
+
+      @Override
+      protected SimpleString create(String value) {
+         return toSimpleString(value);
+      }
+
+      @Override
+      protected boolean isEqual(SimpleString entry, String value) {
+         if (entry == null) {
+            return false;
+         }
+         assert entry.str != null : "the entry must be created with a String embedded";
+         return entry.toString().equals(value);
       }
    }
 }

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/AbstractByteBufPool.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/AbstractByteBufPool.java
@@ -1,0 +1,164 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.utils;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.internal.MathUtil;
+import io.netty.util.internal.PlatformDependent;
+
+/**
+ * Thread-safe {@code <T>} interner.
+ * <p>
+ * Differently from {@link String#intern()} it contains a fixed amount of entries and
+ * when used by concurrent threads it doesn't ensure the uniqueness of the entries ie
+ * the same entry could be allocated multiple times by concurrent calls.
+ */
+public abstract class AbstractByteBufPool<T> {
+
+   public static final int DEFAULT_POOL_CAPACITY = 32;
+
+   private final T[] entries;
+   private final int mask;
+   private final int shift;
+
+   public AbstractByteBufPool() {
+      this(DEFAULT_POOL_CAPACITY);
+   }
+
+   public AbstractByteBufPool(final int capacity) {
+      entries = (T[]) new Object[MathUtil.findNextPositivePowerOfTwo(capacity)];
+      mask = entries.length - 1;
+      //log2 of entries.length
+      shift = 31 - Integer.numberOfLeadingZeros(entries.length);
+   }
+
+   /**
+    * Batch hash code implementation that works at its best if {@code bytes}
+    * contains a {@link org.apache.activemq.artemis.api.core.SimpleString} encoded.
+    */
+   private static int hashCode(final ByteBuf bytes, final int offset, final int length) {
+      if (PlatformDependent.isUnaligned() && PlatformDependent.hasUnsafe()) {
+         //if the platform allows it, the hash code could be computed without bounds checking
+         if (bytes.hasArray()) {
+            return onHeapHashCode(bytes.array(), bytes.arrayOffset() + offset, length);
+         } else if (bytes.hasMemoryAddress()) {
+            return offHeapHashCode(bytes.memoryAddress(), offset, length);
+         }
+      }
+      return byteBufHashCode(bytes, offset, length);
+   }
+
+   private static int onHeapHashCode(final byte[] bytes, final int offset, final int length) {
+      final int intCount = length >>> 1;
+      final int byteCount = length & 1;
+      int hashCode = 1;
+      int arrayIndex = offset;
+      for (int i = 0; i < intCount; i++) {
+         hashCode = 31 * hashCode + PlatformDependent.getShort(bytes, arrayIndex);
+         arrayIndex += 2;
+      }
+      for (int i = 0; i < byteCount; i++) {
+         hashCode = 31 * hashCode + PlatformDependent.getByte(bytes, arrayIndex++);
+      }
+      return hashCode;
+   }
+
+   private static int offHeapHashCode(final long address, final int offset, final int length) {
+      final int intCount = length >>> 1;
+      final int byteCount = length & 1;
+      int hashCode = 1;
+      int arrayIndex = offset;
+      for (int i = 0; i < intCount; i++) {
+         hashCode = 31 * hashCode + PlatformDependent.getShort(address + arrayIndex);
+         arrayIndex += 2;
+      }
+      for (int i = 0; i < byteCount; i++) {
+         hashCode = 31 * hashCode + PlatformDependent.getByte(address + arrayIndex++);
+      }
+      return hashCode;
+   }
+
+   private static int byteBufHashCode(final ByteBuf byteBuf, final int offset, final int length) {
+      final int intCount = length >>> 1;
+      final int byteCount = length & 1;
+      int hashCode = 1;
+      int arrayIndex = offset;
+      for (int i = 0; i < intCount; i++) {
+         final short shortLE = byteBuf.getShortLE(arrayIndex);
+         final short nativeShort = PlatformDependent.BIG_ENDIAN_NATIVE_ORDER ? Short.reverseBytes(shortLE) : shortLE;
+         hashCode = 31 * hashCode + nativeShort;
+         arrayIndex += 2;
+      }
+      for (int i = 0; i < byteCount; i++) {
+         hashCode = 31 * hashCode + byteBuf.getByte(arrayIndex++);
+      }
+      return hashCode;
+   }
+
+   /**
+    * Returns {@code true} if {@code length}'s {@code byteBuf} content from {@link ByteBuf#readerIndex()} can be pooled,
+    * {@code false} otherwise.
+    */
+   protected abstract boolean canPool(ByteBuf byteBuf, int length);
+
+   /**
+    * Create a new entry.
+    */
+   protected abstract T create(ByteBuf byteBuf, int length);
+
+   /**
+    * Returns {@code true} if the {@code entry} content is the same of {@code byteBuf} at the specified {@code offset}
+    * and {@code length} {@code false} otherwise.
+    */
+   protected abstract boolean isEqual(T entry, ByteBuf byteBuf, int offset, int length);
+
+   /**
+    * Returns a pooled entry if possible, a new one otherwise.
+    * <p>
+    * The {@code byteBuf}'s {@link ByteBuf#readerIndex()} is incremented by {@code length} after it.
+    */
+   public final T getOrCreate(final ByteBuf byteBuf) {
+      final int length = byteBuf.readInt();
+      if (!canPool(byteBuf, length)) {
+         return create(byteBuf, length);
+      } else {
+         if (!byteBuf.isReadable(length)) {
+            throw new IndexOutOfBoundsException();
+         }
+         final int bytesOffset = byteBuf.readerIndex();
+         final int hashCode = hashCode(byteBuf, bytesOffset, length);
+         //fast % operation with power of 2 entries.length
+         final int firstIndex = hashCode & mask;
+         final T firstEntry = entries[firstIndex];
+         if (isEqual(firstEntry, byteBuf, bytesOffset, length)) {
+            byteBuf.skipBytes(length);
+            return firstEntry;
+         }
+         final int secondIndex = (hashCode >> shift) & mask;
+         final T secondEntry = entries[secondIndex];
+         if (isEqual(secondEntry, byteBuf, bytesOffset, length)) {
+            byteBuf.skipBytes(length);
+            return secondEntry;
+         }
+         final T internedEntry = create(byteBuf, length);
+         final int entryIndex = firstEntry == null ? firstIndex : secondIndex;
+         entries[entryIndex] = internedEntry;
+         return internedEntry;
+      }
+   }
+}

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/AbstractPool.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/AbstractPool.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.utils;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.internal.MathUtil;
+
+/**
+ * Thread-safe {@code <T>} interner.
+ * <p>
+ * Differently from {@link String#intern()} it contains a fixed amount of entries and
+ * when used by concurrent threads it doesn't ensure the uniqueness of the entries ie
+ * the same entry could be allocated multiple times by concurrent calls.
+ */
+public abstract class AbstractPool<I, O> {
+
+   public static final int DEFAULT_POOL_CAPACITY = 32;
+
+   private final O[] entries;
+   private final int mask;
+   private final int shift;
+
+   public AbstractPool() {
+      this(DEFAULT_POOL_CAPACITY);
+   }
+
+   public AbstractPool(final int capacity) {
+      entries = (O[]) new Object[MathUtil.findNextPositivePowerOfTwo(capacity)];
+      mask = entries.length - 1;
+      //log2 of entries.length
+      shift = 31 - Integer.numberOfLeadingZeros(entries.length);
+   }
+
+   /**
+    * Create a new entry.
+    */
+   protected abstract O create(I value);
+
+   /**
+    * Returns {@code true} if the {@code entry} content is equal to {@code value};
+    */
+   protected abstract boolean isEqual(O entry, I value);
+
+   protected int hashCode(I value) {
+      return value.hashCode();
+   }
+
+   /**
+    * Returns and interned entry if possible, a new one otherwise.
+    * <p>
+    * The {@code byteBuf}'s {@link ByteBuf#readerIndex()} is incremented by {@code length} after it.
+    */
+   public final O getOrCreate(final I value) {
+      if (value == null) {
+         return null;
+      }
+      final int hashCode = hashCode(value);
+      //fast % operation with power of 2 entries.length
+      final int firstIndex = hashCode & mask;
+      final O firstEntry = entries[firstIndex];
+      if (isEqual(firstEntry, value)) {
+         return firstEntry;
+      }
+      final int secondIndex = (hashCode >> shift) & mask;
+      final O secondEntry = entries[secondIndex];
+      if (isEqual(secondEntry, value)) {
+         return secondEntry;
+      }
+      final O internedEntry = create(value);
+      final int entryIndex = firstEntry == null ? firstIndex : secondIndex;
+      entries[entryIndex] = internedEntry;
+      return internedEntry;
+   }
+}

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/collections/TypedProperties.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/collections/TypedProperties.java
@@ -28,6 +28,7 @@ import io.netty.buffer.ByteBuf;
 import org.apache.activemq.artemis.api.core.ActiveMQPropertyConversionException;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.logs.ActiveMQUtilBundle;
+import org.apache.activemq.artemis.utils.AbstractByteBufPool;
 import org.apache.activemq.artemis.utils.ByteUtil;
 import org.apache.activemq.artemis.utils.DataConstants;
 
@@ -329,7 +330,8 @@ public class TypedProperties {
       }
    }
 
-   public synchronized void decode(final ByteBuf buffer) {
+   public synchronized void decode(final ByteBuf buffer,
+                                   final TypedPropertiesDecoderPools keyValuePools) {
       byte b = buffer.readByte();
 
       if (b == DataConstants.NULL) {
@@ -342,10 +344,7 @@ public class TypedProperties {
          size = 0;
 
          for (int i = 0; i < numHeaders; i++) {
-            int len = buffer.readInt();
-            byte[] data = new byte[len];
-            buffer.readBytes(data);
-            SimpleString key = new SimpleString(data);
+            final SimpleString key = SimpleString.readSimpleString(buffer, keyValuePools == null ? null : keyValuePools.getPropertyKeysPool());
 
             byte type = buffer.readByte();
 
@@ -403,7 +402,7 @@ public class TypedProperties {
                   break;
                }
                case STRING: {
-                  val = new StringValue(buffer);
+                  val = StringValue.readStringValue(buffer, keyValuePools == null ? null : keyValuePools.getPropertyValuesPool());
                   doPutValue(key, val);
                   break;
                }
@@ -413,6 +412,10 @@ public class TypedProperties {
             }
          }
       }
+   }
+
+   public synchronized void decode(final ByteBuf buffer) {
+      decode(buffer, null);
    }
 
    public synchronized void encode(final ByteBuf buffer) {
@@ -881,7 +884,7 @@ public class TypedProperties {
       }
    }
 
-   private static final class StringValue extends PropertyValue {
+   public static final class StringValue extends PropertyValue {
 
       final SimpleString val;
 
@@ -889,8 +892,12 @@ public class TypedProperties {
          this.val = val;
       }
 
-      private StringValue(final ByteBuf buffer) {
-         val = SimpleString.readSimpleString(buffer);
+      static StringValue readStringValue(final ByteBuf byteBuf, ByteBufStringValuePool pool) {
+         if (pool == null) {
+            return new StringValue(SimpleString.readSimpleString(byteBuf));
+         } else {
+            return pool.getOrCreate(byteBuf);
+         }
       }
 
       @Override
@@ -907,6 +914,90 @@ public class TypedProperties {
       @Override
       public int encodeSize() {
          return DataConstants.SIZE_BYTE + SimpleString.sizeofString(val);
+      }
+
+      public static final class ByteBufStringValuePool extends AbstractByteBufPool<StringValue> {
+
+         private static final int UUID_LENGTH = 36;
+
+         private final int maxLength;
+
+         public ByteBufStringValuePool() {
+            this.maxLength = UUID_LENGTH;
+         }
+
+         public ByteBufStringValuePool(final int capacity, final int maxCharsLength) {
+            super(capacity);
+            this.maxLength = maxCharsLength;
+         }
+
+         @Override
+         protected boolean isEqual(final StringValue entry, final ByteBuf byteBuf, final int offset, final int length) {
+            if (entry == null || entry.val == null) {
+               return false;
+            }
+            return entry.val.equals(byteBuf, offset, length);
+         }
+
+         @Override
+         protected boolean canPool(final ByteBuf byteBuf, final int length) {
+            assert length % 2 == 0 : "length must be a multiple of 2";
+            final int expectedStringLength = length >> 1;
+            return expectedStringLength <= maxLength;
+         }
+
+         @Override
+         protected StringValue create(final ByteBuf byteBuf, final int length) {
+            return new StringValue(SimpleString.readSimpleString(byteBuf, length));
+         }
+      }
+   }
+
+   public static class TypedPropertiesDecoderPools {
+
+      private SimpleString.ByteBufSimpleStringPool propertyKeysPool;
+      private TypedProperties.StringValue.ByteBufStringValuePool propertyValuesPool;
+
+      public TypedPropertiesDecoderPools() {
+         this.propertyKeysPool = new SimpleString.ByteBufSimpleStringPool();
+         this.propertyValuesPool = new TypedProperties.StringValue.ByteBufStringValuePool();
+      }
+
+      public TypedPropertiesDecoderPools(int keyPoolCapacity, int valuePoolCapacity, int maxCharsLength) {
+         this.propertyKeysPool = new SimpleString.ByteBufSimpleStringPool(keyPoolCapacity, maxCharsLength);
+         this.propertyValuesPool = new TypedProperties.StringValue.ByteBufStringValuePool(valuePoolCapacity, maxCharsLength);
+      }
+
+      public SimpleString.ByteBufSimpleStringPool getPropertyKeysPool() {
+         return propertyKeysPool;
+      }
+
+      public TypedProperties.StringValue.ByteBufStringValuePool getPropertyValuesPool() {
+         return propertyValuesPool;
+      }
+   }
+
+   public static class TypedPropertiesStringSimpleStringPools {
+
+      private SimpleString.StringSimpleStringPool propertyKeysPool;
+      private SimpleString.StringSimpleStringPool propertyValuesPool;
+
+      public TypedPropertiesStringSimpleStringPools() {
+         this.propertyKeysPool = new SimpleString.StringSimpleStringPool();
+         this.propertyValuesPool = new SimpleString.StringSimpleStringPool();
+      }
+
+      public TypedPropertiesStringSimpleStringPools(int keyPoolCapacity, int valuePoolCapacity) {
+         this.propertyKeysPool = new SimpleString.StringSimpleStringPool(keyPoolCapacity);
+         this.propertyValuesPool = new SimpleString.StringSimpleStringPool(valuePoolCapacity);
+      }
+
+      public SimpleString.StringSimpleStringPool getPropertyKeysPool() {
+         return propertyKeysPool;
+      }
+
+      public SimpleString.StringSimpleStringPool getPropertyValuesPool() {
+         return propertyValuesPool;
       }
    }
 

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientMessageImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientMessageImpl.java
@@ -30,6 +30,7 @@ import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.client.ActiveMQClientMessageBundle;
 import org.apache.activemq.artemis.core.message.LargeBodyEncoder;
 import org.apache.activemq.artemis.core.message.impl.CoreMessage;
+import org.apache.activemq.artemis.core.message.impl.CoreMessageObjectPools;
 import org.apache.activemq.artemis.reader.MessageUtil;
 import org.apache.activemq.artemis.utils.UUID;
 import org.apache.activemq.artemis.utils.collections.TypedProperties;
@@ -57,6 +58,10 @@ public class ClientMessageImpl extends CoreMessage implements ClientMessageInter
     * Constructor for when reading from remoting
     */
    public ClientMessageImpl() {
+   }
+
+   public ClientMessageImpl(CoreMessageObjectPools coreMessageObjectPools) {
+      super(coreMessageObjectPools);
    }
 
    protected ClientMessageImpl(ClientMessageImpl other) {
@@ -96,9 +101,20 @@ public class ClientMessageImpl extends CoreMessage implements ClientMessageInter
                             final long expiration,
                             final long timestamp,
                             final byte priority,
-                            final int initialMessageBufferSize) {
+                            final int initialMessageBufferSize,
+                            final CoreMessageObjectPools coreMessageObjectPools) {
+      super(coreMessageObjectPools);
       this.setType(type).setExpiration(expiration).setTimestamp(timestamp).setDurable(durable).
            setPriority(priority).initBuffer(initialMessageBufferSize);
+   }
+
+   public ClientMessageImpl(final byte type,
+                            final boolean durable,
+                            final long expiration,
+                            final long timestamp,
+                            final byte priority,
+                            final int initialMessageBufferSize) {
+      this(type, durable, expiration, timestamp, priority, initialMessageBufferSize, null);
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionImpl.java
@@ -43,6 +43,7 @@ import org.apache.activemq.artemis.api.core.client.SendAcknowledgementHandler;
 import org.apache.activemq.artemis.api.core.client.SessionFailureListener;
 import org.apache.activemq.artemis.core.client.ActiveMQClientLogger;
 import org.apache.activemq.artemis.core.client.ActiveMQClientMessageBundle;
+import org.apache.activemq.artemis.core.message.impl.CoreMessageObjectPools;
 import org.apache.activemq.artemis.core.remoting.FailureListener;
 import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
@@ -147,6 +148,8 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
    private final ConfirmationWindowWarning confirmationWindowWarning;
 
    private final Executor closeExecutor;
+
+   private final CoreMessageObjectPools coreMessageObjectPools = new CoreMessageObjectPools();
 
    ClientSessionImpl(final ClientSessionFactoryInternal sessionFactory,
                      final String name,
@@ -869,7 +872,7 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
                                       final long expiration,
                                       final long timestamp,
                                       final byte priority) {
-      return new ClientMessageImpl(type, durable, expiration, timestamp, priority, initialMessagePacketSize);
+      return new ClientMessageImpl(type, durable, expiration, timestamp, priority, initialMessagePacketSize, coreMessageObjectPools);
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessageObjectPools.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessageObjectPools.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.message.impl;
+
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.utils.collections.TypedProperties;
+
+public class CoreMessageObjectPools {
+
+   private Supplier<SimpleString.ByteBufSimpleStringPool> addressDecoderPool = Suppliers.memoize(SimpleString.ByteBufSimpleStringPool::new);
+   private Supplier<TypedProperties.TypedPropertiesDecoderPools> propertiesDecoderPools = Suppliers.memoize(TypedProperties.TypedPropertiesDecoderPools::new);
+
+   private Supplier<SimpleString.StringSimpleStringPool> addressStringSimpleStringPool = Suppliers.memoize(SimpleString.StringSimpleStringPool::new);
+   private Supplier<TypedProperties.TypedPropertiesStringSimpleStringPools> propertiesStringSimpleStringPools = Suppliers.memoize(TypedProperties.TypedPropertiesStringSimpleStringPools::new);
+
+   public CoreMessageObjectPools() {
+   }
+
+   public SimpleString.ByteBufSimpleStringPool getAddressDecoderPool() {
+      return addressDecoderPool.get();
+   }
+
+   public SimpleString.StringSimpleStringPool getAddressStringSimpleStringPool() {
+      return addressStringSimpleStringPool.get();
+   }
+
+
+   public TypedProperties.TypedPropertiesDecoderPools getPropertiesDecoderPools() {
+      return propertiesDecoderPools.get();
+   }
+
+   public TypedProperties.TypedPropertiesStringSimpleStringPools getPropertiesStringSimpleStringPools() {
+      return propertiesStringSimpleStringPools.get();
+   }
+}

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/ClientPacketDecoder.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/ClientPacketDecoder.java
@@ -19,6 +19,7 @@ package org.apache.activemq.artemis.core.protocol;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.core.client.impl.ClientLargeMessageImpl;
 import org.apache.activemq.artemis.core.client.impl.ClientMessageImpl;
+import org.apache.activemq.artemis.core.message.impl.CoreMessageObjectPools;
 import org.apache.activemq.artemis.core.protocol.core.CoreRemotingConnection;
 import org.apache.activemq.artemis.core.protocol.core.Packet;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketDecoder;
@@ -32,7 +33,7 @@ import static org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl.SES
 public class ClientPacketDecoder extends PacketDecoder {
 
    private static final long serialVersionUID = 6952614096979334582L;
-   public static final ClientPacketDecoder INSTANCE = new ClientPacketDecoder();
+   protected final CoreMessageObjectPools coreMessageObjectPools = new CoreMessageObjectPools();
 
    @Override
    public Packet decode(final ActiveMQBuffer in, CoreRemotingConnection connection) {
@@ -52,9 +53,9 @@ public class ClientPacketDecoder extends PacketDecoder {
       switch (packetType) {
          case SESS_RECEIVE_MSG: {
             if (connection.isVersionBeforeAddressChange()) {
-               packet = new SessionReceiveMessage_1X(new ClientMessageImpl());
+               packet = new SessionReceiveMessage_1X(new ClientMessageImpl(coreMessageObjectPools));
             } else {
-               packet = new SessionReceiveMessage(new ClientMessageImpl());
+               packet = new SessionReceiveMessage(new ClientMessageImpl(coreMessageObjectPools));
             }
             break;
          }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ActiveMQClientProtocolManager.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ActiveMQClientProtocolManager.java
@@ -409,7 +409,7 @@ public class ActiveMQClientProtocolManager implements ClientProtocolManager {
                                      List<Interceptor> incomingInterceptors,
                                      List<Interceptor> outgoingInterceptors,
                                      TopologyResponseHandler topologyResponseHandler) {
-      this.connection = new RemotingConnectionImpl(getPacketDecoder(), transportConnection, callTimeout, callFailoverTimeout, incomingInterceptors, outgoingInterceptors);
+      this.connection = new RemotingConnectionImpl(createPacketDecoder(), transportConnection, callTimeout, callFailoverTimeout, incomingInterceptors, outgoingInterceptors);
 
       this.topologyResponseHandler = topologyResponseHandler;
 
@@ -510,8 +510,8 @@ public class ActiveMQClientProtocolManager implements ClientProtocolManager {
       }
    }
 
-   protected PacketDecoder getPacketDecoder() {
-      return ClientPacketDecoder.INSTANCE;
+   protected PacketDecoder createPacketDecoder() {
+      return new ClientPacketDecoder();
    }
 
    private void forceReturnChannel1(ActiveMQException cause) {

--- a/artemis-core-client/src/test/java/org/apache/activemq/artemis/message/CoreMessageTest.java
+++ b/artemis-core-client/src/test/java/org/apache/activemq/artemis/message/CoreMessageTest.java
@@ -337,7 +337,7 @@ public class CoreMessageTest {
 
    public String generate(String body) throws Exception {
 
-      ClientMessageImpl message = new ClientMessageImpl(MESSAGE_TYPE, DURABLE, EXPIRATION, TIMESTAMP, PRIORITY, 10 * 1024);
+      ClientMessageImpl message = new ClientMessageImpl(MESSAGE_TYPE, DURABLE, EXPIRATION, TIMESTAMP, PRIORITY, 10 * 1024, null);
       TextMessageUtil.writeBodyText(message.getBodyBuffer(), SimpleString.toSimpleString(body));
 
       message.setAddress(ADDRESS);

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQStreamMessage.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQStreamMessage.java
@@ -73,7 +73,7 @@ public final class ActiveMQStreamMessage extends ActiveMQMessage implements Stre
 
    // For testing only
    public ActiveMQStreamMessage() {
-      message = new ClientMessageImpl((byte) 0, false, 0, 0, (byte) 4, 1500);
+      message = new ClientMessageImpl((byte) 0, false, 0, 0, (byte) 4, 1500, null);
    }
 
    // Public --------------------------------------------------------

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/ServerPacketDecoder.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/ServerPacketDecoder.java
@@ -84,15 +84,14 @@ import static org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl.SES
 public class ServerPacketDecoder extends ClientPacketDecoder {
 
    private static final long serialVersionUID = 3348673114388400766L;
-   public static final ServerPacketDecoder INSTANCE = new ServerPacketDecoder();
 
-   private static SessionSendMessage decodeSessionSendMessage(final ActiveMQBuffer in, CoreRemotingConnection connection) {
+   private SessionSendMessage decodeSessionSendMessage(final ActiveMQBuffer in, CoreRemotingConnection connection) {
       final SessionSendMessage sendMessage;
 
       if (connection.isVersionBeforeAddressChange()) {
-         sendMessage = new SessionSendMessage_1X(new CoreMessage());
+         sendMessage = new SessionSendMessage_1X(new CoreMessage(this.coreMessageObjectPools));
       } else {
-         sendMessage = new SessionSendMessage(new CoreMessage());
+         sendMessage = new SessionSendMessage(new CoreMessage(this.coreMessageObjectPools));
       }
 
       sendMessage.decode(in);
@@ -259,5 +258,4 @@ public class ServerPacketDecoder extends ClientPacketDecoder {
 
       return packet;
    }
-
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/CoreProtocolManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/CoreProtocolManager.java
@@ -116,7 +116,7 @@ public class CoreProtocolManager implements ProtocolManager<Interceptor> {
 
       Executor connectionExecutor = server.getExecutorFactory().getExecutor();
 
-      final CoreRemotingConnection rc = new RemotingConnectionImpl(ServerPacketDecoder.INSTANCE, connection, incomingInterceptors, outgoingInterceptors, config.isAsyncConnectionExecutionEnabled() ? connectionExecutor : null, server.getNodeID());
+      final CoreRemotingConnection rc = new RemotingConnectionImpl(new ServerPacketDecoder(), connection, incomingInterceptors, outgoingInterceptors, config.isAsyncConnectionExecutionEnabled() ? connectionExecutor : null, server.getNodeID());
 
       Channel channel1 = rc.getChannel(CHANNEL_ID.SESSION.id, -1);
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ActiveMQServerSideProtocolManagerFactory.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ActiveMQServerSideProtocolManagerFactory.java
@@ -65,8 +65,8 @@ public class ActiveMQServerSideProtocolManagerFactory implements ClientProtocolM
    class ActiveMQReplicationProtocolManager extends ActiveMQClientProtocolManager {
 
       @Override
-      protected PacketDecoder getPacketDecoder() {
-         return ServerPacketDecoder.INSTANCE;
+      protected PacketDecoder createPacketDecoder() {
+         return new ServerPacketDecoder();
       }
    }
 }


### PR DESCRIPTION
The commit contains: 
- 2 string pools implementation (ByteBuf and generic ones) 
- TypedProperties keys/values string pooling 
- Core/Client Message string pooling - optimized (no bound checks/batch) string/ByteBuf hashCodes and equals implementation