### PR TITLE
ARTEMIS-1593 RemotingConnectionImpl leaks

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/jaas/PropertiesLoader.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/jaas/PropertiesLoader.java
@@ -56,7 +56,7 @@ public class PropertiesLoader {
       return Boolean.parseBoolean((String) options.get(name));
    }
 
-   public class FileNameKey {
+   public static final class FileNameKey {
 
       final File file;
       final String absPath;


### PR DESCRIPTION
FileNameKey was holding a reference to PropertiesLoader.this due to its inner class definition, causing RemotingConnectionImpl to leak through a long chain of dependencies rooted in a PropertiesLoader's subclass property ie PropertiesLoaderModule::callbackHandler.
FileNameKey is turned into a inner static class to break this hidden dependency.