### PR TITLE
ARTEMIS-1589 ActiveMQProtonRemotingConnection#getClientID() now returns remote client Id...

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/ActiveMQProtonRemotingConnection.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/ActiveMQProtonRemotingConnection.java
@@ -173,7 +173,7 @@ public class ActiveMQProtonRemotingConnection extends AbstractRemotingConnection
 
    @Override
    public String getClientID() {
-      return amqpConnection.getContainer();
+      return amqpConnection.getRemoteContainer();
    }
 
    public void open() {


### PR DESCRIPTION
...instead of server client Id