### PR TITLE
ARTEMIS-1610 - Properly remove an address from the WildcardAddressManager

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/AddressManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/AddressManager.java
@@ -70,7 +70,7 @@ public interface AddressManager {
     *  it will throw an exception if the address doesn't exist */
    AddressInfo updateAddressInfo(SimpleString addressName, Collection<RoutingType> routingTypes) throws Exception;
 
-   AddressInfo removeAddressInfo(SimpleString address);
+   AddressInfo removeAddressInfo(SimpleString address) throws Exception;
 
    AddressInfo getAddressInfo(SimpleString address);
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/SimpleAddressManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/SimpleAddressManager.java
@@ -325,7 +325,7 @@ public class SimpleAddressManager implements AddressManager {
    }
 
    @Override
-   public AddressInfo removeAddressInfo(SimpleString address) {
+   public AddressInfo removeAddressInfo(SimpleString address) throws Exception {
       return addressInfoMap.remove(address);
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/WildcardAddressManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/WildcardAddressManager.java
@@ -23,6 +23,7 @@ import org.apache.activemq.artemis.core.postoffice.Address;
 import org.apache.activemq.artemis.core.postoffice.Binding;
 import org.apache.activemq.artemis.core.postoffice.Bindings;
 import org.apache.activemq.artemis.core.postoffice.BindingsFactory;
+import org.apache.activemq.artemis.core.server.impl.AddressInfo;
 import org.apache.activemq.artemis.core.transaction.Transaction;
 
 import java.util.Collection;
@@ -95,8 +96,10 @@ public class WildcardAddressManager extends SimpleAddressManager {
          } else {
             for (Address destAdd : add.getLinkedAddresses()) {
                Bindings bindings = super.getBindingsForRoutingAddress(destAdd.getAddress());
-               for (Binding b : bindings.getBindings()) {
-                  super.addMappingInternal(binding.getAddress(), b);
+               if (bindings != null) {
+                  for (Binding b : bindings.getBindings()) {
+                     super.addMappingInternal(binding.getAddress(), b);
+                  }
                }
             }
          }
@@ -124,6 +127,15 @@ public class WildcardAddressManager extends SimpleAddressManager {
          removeAndUpdateAddressMap(add);
       }
       return binding;
+   }
+
+   @Override
+   public AddressInfo removeAddressInfo(SimpleString address) throws Exception {
+      final AddressInfo removed = super.removeAddressInfo(address);
+      if (removed != null) {
+         removeAndUpdateAddressMap(new AddressImpl(removed.getName(), wildcardConfiguration));
+      }
+      return removed;
    }
 
    @Override


### PR DESCRIPTION
When an address is removed from the address manager its linked addresses
also need to be removed if there are no more bindings for the address