### PR TITLE
ARTEMIS-1615 Duplicate TypedProperties::checkCreateProperties

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/collections/TypedProperties.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/collections/TypedProperties.java
@@ -95,7 +95,6 @@ public class TypedProperties {
 
    public void putByteProperty(final SimpleString key, final byte value) {
       checkCreateProperties();
-      checkCreateProperties();
       doPutValue(key, ByteValue.valueOf(value));
    }
 


### PR DESCRIPTION
TypedProperties::putByteProperty contains a duplicate TypedProperties::checkCreateProperties: it needs to be removed