### PR TITLE
ARTEMIS-1606 - Change AddressInfo RoutingType Set to use EnumSet

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/CreateQueueTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/CreateQueueTest.java
@@ -74,7 +74,7 @@ public class CreateQueueTest extends ActiveMQTestBase {
          assertEquals(ActiveMQExceptionType.INTERNAL_ERROR, ae.getType());
       }
 
-      routingTypes = EnumSet.of(RoutingType.ANYCAST, RoutingType.MULTICAST);
+      routingTypes = EnumSet.of(RoutingType.MULTICAST);
       sendSession.createAddress(addressB, routingTypes, false);
       try {
          sendSession.createQueue(addressB, RoutingType.ANYCAST, queueB);


### PR DESCRIPTION
This is fixing the broken testUnsupportedRoutingType test