### PR TITLE
ARTEMIS-1626 Disable thread leak check for failing tests

### DIFF
--- a/artemis-cli/src/test/java/org/apache/activemq/cli/test/ArtemisTest.java
+++ b/artemis-cli/src/test/java/org/apache/activemq/cli/test/ArtemisTest.java
@@ -129,7 +129,6 @@ public class ArtemisTest extends CliTestBase {
       long nanoTime = SyncCalculation.toNanos(totalAvg, writes, false);
       System.out.println("nanoTime avg = " + nanoTime);
       assertEquals(0, LibaioContext.getTotalMaxIO());
-
    }
 
    @Test

--- a/artemis-cli/src/test/java/org/apache/activemq/cli/test/CliTestBase.java
+++ b/artemis-cli/src/test/java/org/apache/activemq/cli/test/CliTestBase.java
@@ -21,9 +21,11 @@ import org.apache.activemq.artemis.cli.commands.Run;
 import org.apache.activemq.artemis.cli.commands.tools.LockAbstract;
 import org.apache.activemq.artemis.spi.core.security.jaas.PropertiesLoader;
 import org.apache.activemq.artemis.utils.ThreadLeakCheckRule;
+import org.apache.activemq.artemis.utils.UnitTestWatcher;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
@@ -34,7 +36,7 @@ public class CliTestBase {
    public TemporaryFolder temporaryFolder;
 
    @Rule
-   public ThreadLeakCheckRule leakCheckRule = new ThreadLeakCheckRule();
+   public RuleChain testCheckRule = ThreadLeakCheckRule.getRule().around(new UnitTestWatcher());
 
    private String original = System.getProperty("java.security.auth.login.config");
 

--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/ActiveMQScheduledComponentTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/ActiveMQScheduledComponentTest.java
@@ -31,11 +31,12 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 
 public class ActiveMQScheduledComponentTest {
 
    @Rule
-   public ThreadLeakCheckRule rule = new ThreadLeakCheckRule();
+   public RuleChain testCheckRule = ThreadLeakCheckRule.getRule().around(new UnitTestWatcher());
 
    ScheduledExecutorService scheduledExecutorService;
    ExecutorService executorService;

--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/SimpleFutureTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/SimpleFutureTest.java
@@ -20,11 +20,13 @@ package org.apache.activemq.artemis.utils;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 
 public class SimpleFutureTest {
 
    @Rule
-   public ThreadLeakCheckRule threadLeakCheckRule = new ThreadLeakCheckRule();
+   public RuleChain testCheckRule = ThreadLeakCheckRule.getRule().around(new UnitTestWatcher());
+
 
    @Test
    public void testFuture() throws Exception {

--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/TestObserver.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/TestObserver.java
@@ -1,0 +1,24 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.utils;
+
+import org.junit.runner.Description;
+
+public interface TestObserver {
+   void testSucceeded(Description description);
+   void testFailed(Throwable e, Description description);
+}

--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/UnitTestWatcher.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/UnitTestWatcher.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.utils;
+
+import org.apache.activemq.artemis.utils.collections.ConcurrentHashSet;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+import java.util.Set;
+
+public class UnitTestWatcher extends TestWatcher {
+
+   //make it static to allow other rules in a chain
+   //to register themselves without having a reference to this rule.
+   public static Set<TestObserver> observers = new ConcurrentHashSet();
+
+   @Override
+   protected void succeeded(Description description) {
+      try {
+         for (TestObserver observer : observers) {
+            observer.testSucceeded(description);
+         }
+      } finally {
+         observers.clear();
+      }
+   }
+
+   @Override
+   protected void failed(Throwable e, Description description) {
+      try {
+         for (TestObserver observer : observers) {
+            observer.testFailed(e, description);
+         }
+      } finally {
+         observers.clear();
+      }
+   }
+
+   public static void addObserver(TestObserver observer) {
+      observers.add(observer);
+   }
+
+   public static void disableCheck() {
+      observers.clear();
+   }
+}

--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/critical/CriticalAnalyzerTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/critical/CriticalAnalyzerTest.java
@@ -25,11 +25,12 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 
 public class CriticalAnalyzerTest {
 
    @Rule
-   public ThreadLeakCheckRule rule = new ThreadLeakCheckRule();
+   public RuleChain testCheckRule = ThreadLeakCheckRule.getRule();
 
    private CriticalAnalyzer analyzer;
 

--- a/artemis-jdbc-store/src/test/java/org/apache/activemq/artemis/jdbc/file/JDBCSequentialFileFactoryTest.java
+++ b/artemis-jdbc-store/src/test/java/org/apache/activemq/artemis/jdbc/file/JDBCSequentialFileFactoryTest.java
@@ -46,6 +46,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -55,7 +56,8 @@ import static org.junit.Assert.fail;
 public class JDBCSequentialFileFactoryTest {
 
    @Rule
-   public ThreadLeakCheckRule leakCheckRule = new ThreadLeakCheckRule();
+   public RuleChain testCheckRule = ThreadLeakCheckRule.getRule();
+
 
    private static String className = EmbeddedDriver.class.getCanonicalName();
 

--- a/artemis-jdbc-store/src/test/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalLoaderCallbackTest.java
+++ b/artemis-jdbc-store/src/test/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalLoaderCallbackTest.java
@@ -26,6 +26,7 @@ import org.apache.activemq.artemis.utils.ThreadLeakCheckRule;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -33,7 +34,7 @@ import static org.junit.Assert.assertTrue;
 public class JDBCJournalLoaderCallbackTest {
 
    @Rule
-   public ThreadLeakCheckRule threadLeakCheckRule = new ThreadLeakCheckRule();
+   public RuleChain testCheckRule = ThreadLeakCheckRule.getRule();
 
    @Test
    public void testAddDeleteRecord() throws Exception {

--- a/artemis-junit/pom.xml
+++ b/artemis-junit/pom.xml
@@ -69,6 +69,12 @@
          <artifactId>artemis-commons</artifactId>
          <version>${project.version}</version>
       </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-commons</artifactId>
+         <type>test-jar</type>
+         <version>${project.version}</version>
+      </dependency>
 
       <dependency>
          <groupId>org.apache.geronimo.specs</groupId>

--- a/artemis-junit/src/main/java/org/apache/activemq/artemis/junit/ThreadLeakCheckRule.java
+++ b/artemis-junit/src/main/java/org/apache/activemq/artemis/junit/ThreadLeakCheckRule.java
@@ -17,49 +17,23 @@
 
 package org.apache.activemq.artemis.junit;
 
-import java.lang.ref.WeakReference;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnector;
+import org.apache.activemq.artemis.utils.UnitTestWatcher;
 import org.jboss.logging.Logger;
 import org.junit.Assert;
-import org.junit.rules.ExternalResource;
+import org.junit.rules.RuleChain;
 
 /**
  * Messaging tests are usually Thread intensive and a thread leak or a server leakage may affect future tests.
  * This Rule will prevent Threads leaking from one test into another by checking left over threads.
  * This will also clear Client Thread Pools from ActiveMQClient.
  */
-public class ThreadLeakCheckRule extends ExternalResource {
+public class ThreadLeakCheckRule extends org.apache.activemq.artemis.utils.ThreadLeakCheckRule {
 
    private static Logger log = Logger.getLogger(ThreadLeakCheckRule.class);
 
-   private static Set<String> knownThreads = new HashSet<>();
-
-   boolean enabled = true;
-
-   private Map<Thread, StackTraceElement[]> previousThreads;
-
-   public void disable() {
-      enabled = false;
-   }
-
-   /**
-    * Override to set up your specific external resource.
-    *
-    * @throws Throwable if setup fails (which will disable {@code after})
-    */
-   @Override
-   protected void before() throws Throwable {
-      // do nothing
-
-      previousThreads = Thread.getAllStackTraces();
-
+   private ThreadLeakCheckRule() {
    }
 
    /**
@@ -104,112 +78,9 @@ public class ThreadLeakCheckRule extends ExternalResource {
          // clearing just to help GC
          previousThreads = null;
       }
-
    }
 
-   private static int failedGCCalls = 0;
-
-   public static void forceGC() {
-
-      if (failedGCCalls >= 10) {
-         log.info("ignoring forceGC call since it seems System.gc is not working anyways");
-         return;
-      }
-      log.info("#test forceGC");
-      CountDownLatch finalized = new CountDownLatch(1);
-      WeakReference<DumbReference> dumbReference = new WeakReference<>(new DumbReference(finalized));
-
-      long timeout = System.currentTimeMillis() + 1000;
-
-      // A loop that will wait GC, using the minimal time as possible
-      while (!(dumbReference.get() == null && finalized.getCount() == 0) && System.currentTimeMillis() < timeout) {
-         System.gc();
-         System.runFinalization();
-         try {
-            finalized.await(100, TimeUnit.MILLISECONDS);
-         } catch (InterruptedException e) {
-         }
-      }
-
-      if (dumbReference.get() != null) {
-         failedGCCalls++;
-         log.info("It seems that GC is disabled at your VM");
-      } else {
-         // a success would reset the count
-         failedGCCalls = 0;
-      }
-      log.info("#test forceGC Done ");
+   public static RuleChain getRule() {
+      return RuleChain.outerRule(new ThreadLeakCheckRule()).around(new UnitTestWatcher());
    }
-
-   public static void removeKownThread(String name) {
-      knownThreads.remove(name);
-   }
-
-   public static void addKownThread(String name) {
-      knownThreads.add(name);
-   }
-
-   private boolean checkThread() {
-      boolean failedThread = false;
-
-      Map<Thread, StackTraceElement[]> postThreads = Thread.getAllStackTraces();
-
-      if (postThreads != null && previousThreads != null && postThreads.size() > previousThreads.size()) {
-
-         for (Thread aliveThread : postThreads.keySet()) {
-            if (aliveThread.isAlive() && !isExpectedThread(aliveThread) && !previousThreads.containsKey(aliveThread)) {
-               if (!failedThread) {
-                  System.out.println("*********************************************************************************");
-                  System.out.println("LEAKING THREADS");
-               }
-               failedThread = true;
-               System.out.println("=============================================================================");
-               System.out.println("Thread " + aliveThread + " is still alive with the following stackTrace:");
-               StackTraceElement[] elements = postThreads.get(aliveThread);
-               for (StackTraceElement el : elements) {
-                  System.out.println(el);
-               }
-            }
-
-         }
-         if (failedThread) {
-            System.out.println("*********************************************************************************");
-         }
-      }
-
-      return failedThread;
-   }
-
-   /**
-    * if it's an expected thread... we will just move along ignoring it
-    *
-    * @param thread
-    * @return
-    */
-   private boolean isExpectedThread(Thread thread) {
-
-      for (String known : knownThreads) {
-         if (thread.getName().contains(known)) {
-            return true;
-         }
-      }
-
-      return false;
-   }
-
-   protected static class DumbReference {
-
-      private CountDownLatch finalized;
-
-      public DumbReference(CountDownLatch finalized) {
-         this.finalized = finalized;
-      }
-
-      @Override
-      public void finalize() throws Throwable {
-         finalized.countDown();
-         super.finalize();
-      }
-   }
-
 }

--- a/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/ActiveMQConsumerResourceTest.java
+++ b/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/ActiveMQConsumerResourceTest.java
@@ -51,7 +51,7 @@ public class ActiveMQConsumerResourceTest {
    ActiveMQConsumerResource consumer = new ActiveMQConsumerResource(server.getVmURL(), TEST_QUEUE);
 
    @Rule
-   public RuleChain ruleChain = RuleChain.outerRule(new ThreadLeakCheckRule()).outerRule(server).around(consumer);
+   public RuleChain ruleChain = ThreadLeakCheckRule.getRule().around(server).around(consumer);
 
    ClientMessage sent = null;
 

--- a/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/ActiveMQDynamicProducerResourceTest.java
+++ b/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/ActiveMQDynamicProducerResourceTest.java
@@ -54,7 +54,7 @@ public class ActiveMQDynamicProducerResourceTest {
    ActiveMQDynamicProducerResource producer = new ActiveMQDynamicProducerResource(server.getVmURL(), TEST_QUEUE_ONE);
 
    @Rule
-   public RuleChain ruleChain = RuleChain.outerRule(new ThreadLeakCheckRule()).around(server).around(producer);
+   public RuleChain ruleChain = ThreadLeakCheckRule.getRule().around(server).around(producer);
 
    ClientMessage sentOne = null;
    ClientMessage sentTwo = null;

--- a/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/ActiveMQDynamicProducerResourceWithoutAddressExceptionTest.java
+++ b/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/ActiveMQDynamicProducerResourceWithoutAddressExceptionTest.java
@@ -52,7 +52,7 @@ public class ActiveMQDynamicProducerResourceWithoutAddressExceptionTest {
    }
 
    @Rule
-   public RuleChain ruleChain = RuleChain.outerRule(new ThreadLeakCheckRule()).around(server).around(producer);
+   public RuleChain ruleChain = ThreadLeakCheckRule.getRule().around(server).around(producer);
 
    ClientMessage sentOne = null;
 

--- a/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/ActiveMQDynamicProducerResourceWithoutAddressTest.java
+++ b/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/ActiveMQDynamicProducerResourceWithoutAddressTest.java
@@ -55,7 +55,7 @@ public class ActiveMQDynamicProducerResourceWithoutAddressTest {
    ActiveMQDynamicProducerResource producer = new ActiveMQDynamicProducerResource(server.getVmURL());
 
    @Rule
-   public RuleChain ruleChain = RuleChain.outerRule(new ThreadLeakCheckRule()).around(server).around(producer);
+   public RuleChain ruleChain = ThreadLeakCheckRule.getRule().around(server).around(producer);
 
    ClientMessage sentOne = null;
    ClientMessage sentTwo = null;

--- a/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/ActiveMQProducerResourceTest.java
+++ b/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/ActiveMQProducerResourceTest.java
@@ -53,8 +53,7 @@ public class ActiveMQProducerResourceTest {
    ActiveMQProducerResource producer = new ActiveMQProducerResource(server.getVmURL(), TEST_ADDRESS);
 
    @Rule
-   public RuleChain ruleChain = RuleChain.outerRule(new ThreadLeakCheckRule()).around(server).around(producer);
-
+   public RuleChain ruleChain = ThreadLeakCheckRule.getRule().around(server).around(producer);
 
    ClientMessage sent = null;
 

--- a/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/EmbeddedActiveMQResourceCustomConfigurationTest.java
+++ b/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/EmbeddedActiveMQResourceCustomConfigurationTest.java
@@ -49,7 +49,7 @@ public class EmbeddedActiveMQResourceCustomConfigurationTest {
    private EmbeddedActiveMQResource server = new EmbeddedActiveMQResource(customConfiguration);
 
    @Rule
-   public RuleChain rulechain = RuleChain.outerRule(new ThreadLeakCheckRule()).around(server);
+   public RuleChain rulechain = ThreadLeakCheckRule.getRule().around(server);
 
    @After
    public void tear() {

--- a/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/EmbeddedActiveMQResourceFileConfigurationTest.java
+++ b/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/EmbeddedActiveMQResourceFileConfigurationTest.java
@@ -42,7 +42,7 @@ public class EmbeddedActiveMQResourceFileConfigurationTest {
    private EmbeddedActiveMQResource server = new EmbeddedActiveMQResource("embedded-artemis-server.xml");
 
    @Rule
-   public RuleChain rulechain = RuleChain.outerRule(new ThreadLeakCheckRule()).around(server);
+   public RuleChain rulechain = ThreadLeakCheckRule.getRule().around(server);
 
    @After
    public void tear() {

--- a/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/EmbeddedActiveMQResourceTest.java
+++ b/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/EmbeddedActiveMQResourceTest.java
@@ -53,7 +53,7 @@ public class EmbeddedActiveMQResourceTest {
    public EmbeddedActiveMQResource server = new EmbeddedActiveMQResource();
 
    @Rule
-   public RuleChain rulechain = RuleChain.outerRule(new ThreadLeakCheckRule()).around(server);
+   public RuleChain rulechain = ThreadLeakCheckRule.getRule().around(server);
 
    ClientMessage sent = null;
 

--- a/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/EmbeddedJMSResourceMultipleFileConfigurationTest.java
+++ b/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/EmbeddedJMSResourceMultipleFileConfigurationTest.java
@@ -52,7 +52,7 @@ public class EmbeddedJMSResourceMultipleFileConfigurationTest {
    public EmbeddedJMSResource jmsServer = new EmbeddedJMSResource("embedded-artemis-minimal-server.xml", "embedded-artemis-jms-only.xml");
 
    @Rule
-   public RuleChain rulechain = RuleChain.outerRule(new ThreadLeakCheckRule()).around(jmsServer);
+   public RuleChain rulechain = ThreadLeakCheckRule.getRule().around(jmsServer);
 
    ConnectionFactory connectionFactory;
    Connection connection;

--- a/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/EmbeddedJMSResourceQueueTest.java
+++ b/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/EmbeddedJMSResourceQueueTest.java
@@ -56,7 +56,7 @@ public class EmbeddedJMSResourceQueueTest {
    public EmbeddedJMSResource jmsServer = new EmbeddedJMSResource();
 
    @Rule
-   public RuleChain rulechain = RuleChain.outerRule(new ThreadLeakCheckRule()).around(jmsServer);
+   public RuleChain rulechain = ThreadLeakCheckRule.getRule().around(jmsServer);
 
    Message pushed = null;
 

--- a/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/EmbeddedJMSResourceSingleFileConfigurationTest.java
+++ b/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/EmbeddedJMSResourceSingleFileConfigurationTest.java
@@ -52,7 +52,7 @@ public class EmbeddedJMSResourceSingleFileConfigurationTest {
    public EmbeddedJMSResource jmsServer = new EmbeddedJMSResource("embedded-artemis-jms-server.xml");
 
    @Rule
-   public RuleChain rulechain = RuleChain.outerRule(new ThreadLeakCheckRule()).around(jmsServer);
+   public RuleChain rulechain = ThreadLeakCheckRule.getRule().around(jmsServer);
 
    ConnectionFactory connectionFactory;
    Connection connection;

--- a/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/EmbeddedJMSResourceTopicTest.java
+++ b/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/EmbeddedJMSResourceTopicTest.java
@@ -63,7 +63,7 @@ public class EmbeddedJMSResourceTopicTest {
    public EmbeddedJMSResource jmsServer = new EmbeddedJMSResource();
 
    @Rule
-   public RuleChain rulechain = RuleChain.outerRule(new ThreadLeakCheckRule()).around(jmsServer);
+   public RuleChain rulechain = ThreadLeakCheckRule.getRule().around(jmsServer);
 
    Message pushed = null;
 

--- a/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/MultipleEmbeddedActiveMQResourcesTest.java
+++ b/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/MultipleEmbeddedActiveMQResourcesTest.java
@@ -49,7 +49,7 @@ public class MultipleEmbeddedActiveMQResourcesTest {
    public EmbeddedActiveMQResource serverTwo = new EmbeddedActiveMQResource(1);
 
    @Rule
-   public RuleChain rulechain = RuleChain.outerRule(new ThreadLeakCheckRule()).around(serverOne).around(serverTwo);
+   public RuleChain rulechain = ThreadLeakCheckRule.getRule().around(serverOne).around(serverTwo);
 
    @Before
    public void setUp() throws Exception {

--- a/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/MultipleEmbeddedJMSResourcesTest.java
+++ b/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/MultipleEmbeddedJMSResourcesTest.java
@@ -44,7 +44,7 @@ public class MultipleEmbeddedJMSResourcesTest {
    public EmbeddedJMSResource jmsServerTwo = new EmbeddedJMSResource(1);
 
    @Rule
-   public RuleChain rulechain = RuleChain.outerRule(new ThreadLeakCheckRule()).around(jmsServerOne).around(jmsServerTwo);
+   public RuleChain rulechain = ThreadLeakCheckRule.getRule().around(jmsServerOne).around(jmsServerTwo);
 
    @Test
    public void testMultipleServers() throws Exception {

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/files/FileMoveManagerTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/files/FileMoveManagerTest.java
@@ -45,6 +45,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
 
 public class FileMoveManagerTest {
@@ -53,7 +54,7 @@ public class FileMoveManagerTest {
    public TemporaryFolder temporaryFolder;
 
    @Rule
-   public ThreadLeakCheckRule leakCheckRule = new ThreadLeakCheckRule();
+   public RuleChain testCheckRule = ThreadLeakCheckRule.getRule();
 
    private File dataLocation;
    private FileMoveManager manager;

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
@@ -138,6 +138,7 @@ import org.apache.activemq.artemis.utils.CleanupSystemPropertiesRule;
 import org.apache.activemq.artemis.utils.Env;
 import org.apache.activemq.artemis.utils.FileUtil;
 import org.apache.activemq.artemis.utils.ThreadDumpUtil;
+import org.apache.activemq.artemis.utils.UnitTestWatcher;
 import org.apache.activemq.artemis.utils.actors.OrderedExecutorFactory;
 import org.apache.activemq.artemis.utils.RandomUtil;
 import org.apache.activemq.artemis.utils.ThreadLeakCheckRule;
@@ -147,6 +148,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
 import org.junit.rules.TestRule;
@@ -166,7 +168,7 @@ public abstract class ActiveMQTestBase extends Assert {
 
    /** This will make sure threads are not leaking between tests */
    @Rule
-   public ThreadLeakCheckRule leakCheckRule = new ThreadLeakCheckRule();
+   public RuleChain testCheckRule = ThreadLeakCheckRule.getRule();
 
    /** This will cleanup any system property changed inside tests */
    @Rule
@@ -394,7 +396,7 @@ public abstract class ActiveMQTestBase extends Assert {
    }
 
    protected void disableCheckThread() {
-      leakCheckRule.disable();
+      UnitTestWatcher.disableCheck();
    }
 
    protected String getName() {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/broadcast/JGroupsBroadcastTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/broadcast/JGroupsBroadcastTest.java
@@ -21,6 +21,7 @@ import org.apache.activemq.artemis.api.core.BroadcastEndpointFactory;
 import org.apache.activemq.artemis.api.core.ChannelBroadcastEndpointFactory;
 import org.apache.activemq.artemis.api.core.jgroups.JChannelManager;
 import org.apache.activemq.artemis.utils.ThreadLeakCheckRule;
+import org.apache.activemq.artemis.utils.UnitTestWatcher;
 import org.jgroups.JChannel;
 import org.jgroups.conf.PlainConfigurator;
 import org.junit.After;
@@ -28,6 +29,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 
 public class JGroupsBroadcastTest {
 
@@ -42,7 +44,7 @@ public class JGroupsBroadcastTest {
    }
 
    @Rule
-   public ThreadLeakCheckRule threadLeakCheckRule = new ThreadLeakCheckRule();
+   public RuleChain testCheckRule = ThreadLeakCheckRule.getRule().around(new UnitTestWatcher());
 
    private final String jgroupsConfigString = "UDP(oob_thread_pool.max_threads=300;" + "bind_addr=127.0.0.1;oob_thread_pool.keep_alive_time=1000;" + "max_bundle_size=31k;mcast_send_buf_size=640000;" + "internal_thread_pool.keep_alive_time=60000;" + "internal_thread_pool.rejection_policy=discard;" + "mcast_recv_buf_size=25000000;bind_port=55200;" + "internal_thread_pool.queue_max_size=100;" + "mcast_port=45688;thread_pool.min_threads=20;" + "oob_thread_pool.rejection_policy=discard;" + "thread_pool.max_threads=300;enable_diagnostics=false;" + "thread_pool.enabled=true;internal_thread_pool.queue_enabled=true;" + "ucast_recv_buf_size=20000000;ucast_send_buf_size=640000;" + "internal_thread_pool.enabled=true;oob_thread_pool.enabled=true;" + "ip_ttl=2;thread_pool.rejection_policy=discard;thread_pool.keep_alive_time=5000;" + "internal_thread_pool.max_threads=10;thread_pool.queue_enabled=true;" + "mcast_addr=230.0.0.4;singleton_name=udp;max_bundle_timeout=30;" + "oob_thread_pool.queue_enabled=false;internal_thread_pool.min_threads=1;" + "bundler_type=old;oob_thread_pool.min_threads=20;" + "thread_pool.queue_max_size=1000):PING(num_initial_members=3;" + "timeout=2000):MERGE3(min_interval=20000;max_interval=100000)" + ":FD_SOCK(bind_addr=127.0.0.1;start_port=54200):FD_ALL(interval=3000;" + "timeout=15000):VERIFY_SUSPECT(bind_addr=127.0.0.1;" + "timeout=1500):pbcast.NAKACK2(max_msg_batch_size=100;" + "xmit_table_msgs_per_row=10000;xmit_table_max_compaction_time=10000;" + "xmit_table_num_rows=100;xmit_interval=1000):UNICAST3(xmit_table_msgs_per_row=10000;" + "xmit_table_max_compaction_time=10000;xmit_table_num_rows=20)" + ":pbcast.STABLE(desired_avg_gossip=50000;max_bytes=400000;" + "stability_delay=1000):pbcast.GMS(print_local_addr=true;" + "view_bundling=true;join_timeout=3000;view_ack_collection_timeout=5000;" + "resume_task_timeout=7500):UFC(max_credits=1m;min_threshold=0.40)" + ":MFC(max_credits=1m;min_threshold=0.40):FRAG2(frag_size=30k)" + ":RSVP(resend_interval=500;ack_on_delivery=false;timeout=60000)";
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jdbc/store/journal/JDBCJournalTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jdbc/store/journal/JDBCJournalTest.java
@@ -36,17 +36,19 @@ import org.apache.activemq.artemis.jdbc.store.sql.PropertySQLProvider;
 import org.apache.activemq.artemis.jdbc.store.sql.SQLProvider;
 import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.ThreadLeakCheckRule;
+import org.apache.activemq.artemis.utils.UnitTestWatcher;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 
 import static org.apache.activemq.artemis.jdbc.store.sql.PropertySQLProvider.Factory.SQLDialect.DERBY;
 
 public class JDBCJournalTest extends ActiveMQTestBase {
 
    @Rule
-   public ThreadLeakCheckRule threadLeakCheckRule = new ThreadLeakCheckRule();
+   public RuleChain testCheckRule = ThreadLeakCheckRule.getRule().around(new UnitTestWatcher());
 
    private static final String JOURNAL_TABLE_NAME = "MESSAGE_JOURNAL";
 


### PR DESCRIPTION
The ThreadLeakCheckRule is used to check thread leaks
after each test is finished. However when a test fails, it is
not necessary to check leaking threads because the test
failure should be fixed anyway. And leaking threads in a
failed test may well be a result of the failure (once the test
is fixed the thread leak may be gone).

If a failed test also leaks threads, it takes a long time before
the thread leak check finishes (60 seconds checking time),
thus it takes a long time to finish, especially when tests are
run in batches with failures.

So to improve this, it should be reasonable to just enable
the thread leaking check for each test passes, and disable
the check when a test fails.