### PR TITLE
ARTEMIS-1627 - Support removing addresses that do not have direct bindings

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/AddressManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/AddressManager.java
@@ -46,6 +46,8 @@ public interface AddressManager {
 
    Bindings getMatchingBindings(SimpleString address) throws Exception;
 
+   Bindings getDirectBindings(SimpleString address) throws Exception;
+
    SimpleString getMatchingQueue(SimpleString address, RoutingType routingType) throws Exception;
 
    SimpleString getMatchingQueue(SimpleString address, SimpleString queueName, RoutingType routingType) throws Exception;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/PostOffice.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/PostOffice.java
@@ -94,6 +94,8 @@ public interface PostOffice extends ActiveMQComponent {
 
    Bindings getMatchingBindings(SimpleString address) throws Exception;
 
+   Bindings getDirectBindings(SimpleString address) throws Exception;
+
    Map<SimpleString, Binding> getAllBindings();
 
    SimpleString getMatchingQueue(SimpleString address, RoutingType routingType) throws Exception;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -532,7 +532,7 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
    public AddressInfo removeAddressInfo(SimpleString address) throws Exception {
       synchronized (addressLock) {
          server.callBrokerPlugins(server.hasBrokerPlugins() ? plugin -> plugin.beforeRemoveAddress(address) : null);
-         Bindings bindingsForAddress = getBindingsForAddress(address);
+         final Bindings bindingsForAddress = getDirectBindings(address);
          if (bindingsForAddress.getBindings().size() > 0) {
             throw ActiveMQMessageBundle.BUNDLE.addressHasBindings(address);
          }
@@ -699,6 +699,11 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
    @Override
    public Bindings getMatchingBindings(final SimpleString address) throws Exception {
       return addressManager.getMatchingBindings(address);
+   }
+
+   @Override
+   public Bindings getDirectBindings(final SimpleString address) throws Exception {
+      return addressManager.getDirectBindings(address);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/SimpleAddressManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/SimpleAddressManager.java
@@ -55,7 +55,7 @@ public class SimpleAddressManager implements AddressManager {
    /**
     * HashMap<Address, Binding>
     */
-   private final ConcurrentMap<SimpleString, Bindings> mappings = new ConcurrentHashMap<>();
+   protected final ConcurrentMap<SimpleString, Bindings> mappings = new ConcurrentHashMap<>();
 
    /**
     * HashMap<QueueName, Binding>
@@ -129,6 +129,19 @@ public class SimpleAddressManager implements AddressManager {
          Address addCheck = new AddressImpl(binding.getAddress(), wildcardConfiguration);
 
          if (addCheck.matches(add)) {
+            bindings.addBinding(binding);
+         }
+      }
+
+      return bindings;
+   }
+
+   @Override
+   public Bindings getDirectBindings(final SimpleString address) throws Exception {
+      Bindings bindings = bindingsFactory.createBindings(address);
+
+      for (Binding binding : nameMap.values()) {
+         if (binding.getAddress().equals(address)) {
             bindings.addBinding(binding);
          }
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/WildcardAddressManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/WildcardAddressManager.java
@@ -133,6 +133,8 @@ public class WildcardAddressManager extends SimpleAddressManager {
    public AddressInfo removeAddressInfo(SimpleString address) throws Exception {
       final AddressInfo removed = super.removeAddressInfo(address);
       if (removed != null) {
+         //Remove from mappings so removeAndUpdateAddressMap processes and cleanup
+         mappings.remove(address);
          removeAndUpdateAddressMap(new AddressImpl(removed.getName(), wildcardConfiguration));
       }
       return removed;

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/WildcardAddressManagerUnitTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/WildcardAddressManagerUnitTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.config.WildcardConfiguration;
 import org.apache.activemq.artemis.core.filter.Filter;
 import org.apache.activemq.artemis.core.postoffice.Address;
 import org.apache.activemq.artemis.core.postoffice.Binding;
@@ -133,6 +134,65 @@ public class WildcardAddressManagerUnitTest extends ActiveMQTestBase {
       assertEquals(1, wildcardAddresses.size());
       assertNull(ad.getAddressInfo(SimpleString.toSimpleString("Topic1.#")));
       assertNull(wildcardAddresses.get(SimpleString.toSimpleString("Topic1.#")));
+   }
+
+   @Test
+   public void testWildCardAddressRemovalDifferentWildcard() throws Exception {
+
+      final WildcardConfiguration configuration = new WildcardConfiguration();
+      configuration.setAnyWords('>');
+      WildcardAddressManager ad = new WildcardAddressManager(new BindingFactoryFake(), configuration, null);
+      ad.addAddressInfo(new AddressInfo(SimpleString.toSimpleString("Topic1.>"), RoutingType.MULTICAST));
+      ad.addAddressInfo(new AddressInfo(SimpleString.toSimpleString("Topic1.test"), RoutingType.MULTICAST));
+      ad.addBinding(new BindingFake("Topic1.>", "one"));
+
+      assertEquals(1, ad.getBindingsForRoutingAddress(SimpleString.toSimpleString("Topic1.>")).getBindings().size());
+      assertEquals(1, ad.getBindingsForRoutingAddress(SimpleString.toSimpleString("Topic1.test")).getBindings().size());
+      assertEquals(0, ad.getDirectBindings(SimpleString.toSimpleString("Topic1.test")).getBindings().size());
+      assertEquals(1, ad.getDirectBindings(SimpleString.toSimpleString("Topic1.>")).getBindings().size());
+
+      //Remove the address
+      ad.removeAddressInfo(SimpleString.toSimpleString("Topic1.test"));
+
+      //should still have 1 address and binding
+      assertEquals(1, ad.getAddresses().size());
+      assertEquals(1, ad.getBindings().size());
+
+      ad.removeBinding(SimpleString.toSimpleString("one"), null);
+      ad.removeAddressInfo(SimpleString.toSimpleString("Topic1.>"));
+
+      assertEquals(0, ad.getAddresses().size());
+      assertEquals(0, ad.getBindings().size());
+   }
+
+   @Test
+   public void testWildCardAddressDirectBindings() throws Exception {
+
+      final WildcardConfiguration configuration = new WildcardConfiguration();
+      configuration.setAnyWords('>');
+      WildcardAddressManager ad = new WildcardAddressManager(new BindingFactoryFake(), configuration, null);
+      ad.addAddressInfo(new AddressInfo(SimpleString.toSimpleString("Topic1.>"), RoutingType.MULTICAST));
+      ad.addAddressInfo(new AddressInfo(SimpleString.toSimpleString("Topic1.test"), RoutingType.MULTICAST));
+      ad.addAddressInfo(new AddressInfo(SimpleString.toSimpleString("Topic1.test.test1"), RoutingType.MULTICAST));
+      ad.addAddressInfo(new AddressInfo(SimpleString.toSimpleString("Topic1.test.test2"), RoutingType.MULTICAST));
+      ad.addAddressInfo(new AddressInfo(SimpleString.toSimpleString("Topic2.>"), RoutingType.MULTICAST));
+      ad.addAddressInfo(new AddressInfo(SimpleString.toSimpleString("Topic2.test"), RoutingType.MULTICAST));
+      ad.addBinding(new BindingFake("Topic1.>", "one"));
+      ad.addBinding(new BindingFake("Topic1.test", "two"));
+      ad.addBinding(new BindingFake("Topic2.test", "three"));
+
+      assertEquals(1, ad.getBindingsForRoutingAddress(SimpleString.toSimpleString("Topic1.>")).getBindings().size());
+      assertEquals(2, ad.getBindingsForRoutingAddress(SimpleString.toSimpleString("Topic1.test")).getBindings().size());
+      assertEquals(1, ad.getBindingsForRoutingAddress(SimpleString.toSimpleString("Topic1.test.test1")).getBindings().size());
+      assertEquals(1, ad.getBindingsForRoutingAddress(SimpleString.toSimpleString("Topic1.test.test2")).getBindings().size());
+
+      assertEquals(1, ad.getDirectBindings(SimpleString.toSimpleString("Topic1.>")).getBindings().size());
+      assertEquals(1, ad.getDirectBindings(SimpleString.toSimpleString("Topic1.test")).getBindings().size());
+      assertEquals(0, ad.getDirectBindings(SimpleString.toSimpleString("Topic1.test1")).getBindings().size());
+      assertEquals(0, ad.getDirectBindings(SimpleString.toSimpleString("Topic1.test2")).getBindings().size());
+      assertEquals(0, ad.getDirectBindings(SimpleString.toSimpleString("Topic2.>")).getBindings().size());
+      assertEquals(1, ad.getDirectBindings(SimpleString.toSimpleString("Topic2.test")).getBindings().size());
+
    }
 
    class BindingFactoryFake implements BindingsFactory {

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/impl/fakes/FakePostOffice.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/impl/fakes/FakePostOffice.java
@@ -148,6 +148,12 @@ public class FakePostOffice implements PostOffice {
    }
 
    @Override
+   public Bindings getDirectBindings(final SimpleString address) {
+
+      return null;
+   }
+
+   @Override
    public Object getNotificationLock() {
 
       return null;


### PR DESCRIPTION
If there are no direct bindings on an address and only linked bindings
then the address should be able to be removed from the broker