### PR TITLE
ARTEMIS-1633 - fire message routing callbacks for all results

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/plugin/ConfigurationVerifier.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/plugin/ConfigurationVerifier.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.core.postoffice.RoutingStatus;
+import org.apache.activemq.artemis.core.server.RoutingContext;
 import org.apache.activemq.artemis.core.server.ServerSession;
 import org.apache.activemq.artemis.core.server.plugin.ActiveMQServerPlugin;
 import org.apache.activemq.artemis.core.transaction.Transaction;
@@ -40,6 +41,7 @@ public class ConfigurationVerifier implements ActiveMQServerPlugin, Serializable
    public String value2;
    public String value3;
    public AtomicInteger afterSendCounter = new AtomicInteger();
+   public AtomicInteger successRoutedCounter = new AtomicInteger();
 
    @Override
    public void init(Map<String, String> properties) {
@@ -59,6 +61,14 @@ public class ConfigurationVerifier implements ActiveMQServerPlugin, Serializable
                          boolean noAutoCreateQueue,
                          RoutingStatus result) throws ActiveMQException {
       afterSendCounter.incrementAndGet();
+   }
+
+   @Override
+   public void afterMessageRoute(Message message, RoutingContext context, boolean direct, boolean rejectDuplicates,
+         RoutingStatus result) throws ActiveMQException {
+      if (result == RoutingStatus.OK) {
+         successRoutedCounter.incrementAndGet();
+      }
    }
 
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/plugin/CorePluginTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/plugin/CorePluginTest.java
@@ -129,12 +129,14 @@ public class CorePluginTest extends JMSTestBase {
             BEFORE_REMOVE_ADDRESS, AFTER_REMOVE_ADDRESS);
       verifier.validatePluginMethodsEquals(1, AFTER_CREATE_CONNECTION, AFTER_DESTROY_CONNECTION,
             BEFORE_CREATE_CONSUMER, AFTER_CREATE_CONSUMER, BEFORE_CLOSE_CONSUMER, AFTER_CLOSE_CONSUMER,
-            BEFORE_CREATE_QUEUE, AFTER_CREATE_QUEUE, MESSAGE_ACKED, BEFORE_SEND, AFTER_SEND, BEFORE_MESSAGE_ROUTE,
-            AFTER_MESSAGE_ROUTE, BEFORE_ADD_ADDRESS, AFTER_ADD_ADDRESS);
+            BEFORE_CREATE_QUEUE, AFTER_CREATE_QUEUE, MESSAGE_ACKED, BEFORE_SEND, AFTER_SEND, BEFORE_ADD_ADDRESS, AFTER_ADD_ADDRESS);
       verifier.validatePluginMethodsEquals(2, BEFORE_CREATE_SESSION, AFTER_CREATE_SESSION, BEFORE_CLOSE_SESSION,
             AFTER_CLOSE_SESSION);
+      verifier.validatePluginMethodsAtLeast(1, BEFORE_MESSAGE_ROUTE,
+            AFTER_MESSAGE_ROUTE);
 
       assertEquals("configurationVerifier is invoked", 1, configurationVerifier.afterSendCounter.get());
+      assertEquals("configurationVerifier is invoked", 1, configurationVerifier.successRoutedCounter.get());
       assertEquals("configurationVerifier config set", "val_1", configurationVerifier.value1);
    }
 


### PR DESCRIPTION
Make sure ActiveMQServer plugin implementations are always notified of
message route events