### PR TITLE
ARTEMIS-1653 Allow database tables to be created externally

### DIFF
--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/drivers/AbstractJDBCDriver.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/drivers/AbstractJDBCDriver.java
@@ -109,7 +109,7 @@ public abstract class AbstractJDBCDriver {
    protected abstract void createSchema() throws SQLException;
 
    protected final void createTable(String... schemaSqls) throws SQLException {
-      createTableIfNotExists(connection, sqlProvider.getTableName(), schemaSqls);
+      createTableIfNotExists(sqlProvider.getTableName(), schemaSqls);
    }
 
    private void connect() throws SQLException {
@@ -174,9 +174,7 @@ public abstract class AbstractJDBCDriver {
       }
    }
 
-   private static void createTableIfNotExists(Connection connection,
-                                              String tableName,
-                                              String... sqls) throws SQLException {
+   private void createTableIfNotExists(String tableName, String... sqls) throws SQLException {
       logger.tracef("Validating if table %s didn't exist before creating", tableName);
       try {
          connection.setAutoCommit(false);
@@ -189,17 +187,27 @@ public abstract class AbstractJDBCDriver {
                if (sqlWarning != null) {
                   logger.warn(JDBCUtils.appendSQLExceptionDetails(new StringBuilder(), sqlWarning));
                }
-               try (Statement statement = connection.createStatement()) {
-                  for (String sql : sqls) {
-                     statement.executeUpdate(sql);
-                     final SQLWarning statementSqlWarning = statement.getWarnings();
-                     if (statementSqlWarning != null) {
-                        logger.warn(JDBCUtils.appendSQLExceptionDetails(new StringBuilder(), statementSqlWarning, sql));
-                     }
+            } else {
+               try (Statement statement = connection.createStatement();
+                     ResultSet cntRs = statement.executeQuery(sqlProvider.getCountJournalRecordsSQL())) {
+                  if (rs.next() && rs.getInt(1) > 0) {
+                     logger.tracef("Table %s did exist but is not empty. Skipping initialization.", tableName);
+                  } else {
+                     sqls = Arrays.copyOfRange(sqls, 1, sqls.length);
+                  }
+               }
+            }
+            try (Statement statement = connection.createStatement()) {
+               for (String sql : sqls) {
+                  statement.executeUpdate(sql);
+                  final SQLWarning statementSqlWarning = statement.getWarnings();
+                  if (statementSqlWarning != null) {
+                     logger.warn(JDBCUtils.appendSQLExceptionDetails(new StringBuilder(), statementSqlWarning, sql));
                   }
                }
             }
          }
+
          connection.commit();
       } catch (SQLException e) {
          final String sqlStatements = Stream.of(sqls).collect(Collectors.joining("\n"));

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/jdbc/TestJDBCDriver.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/jdbc/TestJDBCDriver.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.server.impl.jdbc;
+
+import java.sql.SQLException;
+
+import org.apache.activemq.artemis.jdbc.store.drivers.AbstractJDBCDriver;
+import org.apache.activemq.artemis.jdbc.store.sql.SQLProvider;
+
+public class TestJDBCDriver extends AbstractJDBCDriver {
+
+
+   public static TestJDBCDriver usingConnectionUrl(
+         String jdbcConnectionUrl,
+         String jdbcDriverClass,
+         SQLProvider provider) {
+      TestJDBCDriver driver = new TestJDBCDriver();
+      driver.setSqlProvider(provider);
+      driver.setJdbcConnectionUrl(jdbcConnectionUrl);
+      driver.setJdbcDriverClass(jdbcDriverClass);
+      return driver;
+   }
+
+   @Override
+   protected void prepareStatements() throws SQLException {
+   }
+
+   @Override
+   protected void createSchema() throws SQLException {
+      try {
+         connection.createStatement().execute(sqlProvider.createNodeManagerStoreTableSQL());
+      } catch (SQLException e) {
+      }
+   }
+
+}


### PR DESCRIPTION
In some environments it is not allowed to create a schema
by the application itself. With this change the AbstractJDBCDriver
now tests if an existing table is empty and executes further
statements in the same way it would if the table does not exist.

See [forum](http://activemq.2283324.n4.nabble.com/ARTEMIS-Server-doesn-t-start-if-JDBC-store-is-used-and-table-NODE-MANAGER-STORE-is-empty-td4735779.html) for details.