### PR TITLE
ARTEMIS-1642 Add log info to FileStoreMonitor

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/files/FileStoreMonitor.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/files/FileStoreMonitor.java
@@ -70,7 +70,12 @@ public class FileStoreMonitor extends ActiveMQScheduledComponent {
       synchronized (monitorLock) {
          // JDBC storage may return this as null, and we may need to ignore it
          if (file != null && file.exists()) {
-            addStore(Files.getFileStore(file.toPath()));
+            try {
+               addStore(Files.getFileStore(file.toPath()));
+            } catch (IOException e) {
+               logger.error("Error getting file store for " + file.getAbsolutePath(), e);
+               throw e;
+            }
          }
          return this;
       }


### PR DESCRIPTION
Adding log info in case that an IOException is thrown from
the underlying file system to provide information for debugging.