### PR TITLE
fix some eclipse raw types warnings

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/ConnectorServerFactory.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/ConnectorServerFactory.java
@@ -16,7 +16,12 @@
  */
 package org.apache.activemq.artemis.core.server.management;
 
-import org.apache.activemq.artemis.core.remoting.impl.ssl.SSLSupport;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.rmi.server.RMIClientSocketFactory;
+import java.rmi.server.RMIServerSocketFactory;
+import java.util.Map;
 
 import javax.management.JMException;
 import javax.management.MBeanServer;
@@ -30,12 +35,8 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLServerSocketFactory;
 import javax.rmi.ssl.SslRMIClientSocketFactory;
-import java.io.IOException;
-import java.net.InetAddress;
-import java.net.ServerSocket;
-import java.rmi.server.RMIClientSocketFactory;
-import java.rmi.server.RMIServerSocketFactory;
-import java.util.Map;
+
+import org.apache.activemq.artemis.core.remoting.impl.ssl.SSLSupport;
 
 public class ConnectorServerFactory {
 
@@ -64,7 +65,7 @@ public class ConnectorServerFactory {
    private MBeanServer server;
    private String serviceUrl;
    private String rmiServerHost;
-   private Map environment;
+   private Map<String,Object> environment;
    private ObjectName objectName;
    private JMXConnectorServer connectorServer;
 
@@ -137,11 +138,11 @@ public class ConnectorServerFactory {
       this.rmiServerHost = rmiServerHost;
    }
 
-   public Map getEnvironment() {
+   public Map<String,Object> getEnvironment() {
       return environment;
    }
 
-   public void setEnvironment(Map environment) {
+   public void setEnvironment(Map<String,Object> environment) {
       this.environment = environment;
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/MBeanServerFactory.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/MBeanServerFactory.java
@@ -16,9 +16,10 @@
  */
 package org.apache.activemq.artemis.core.server.management;
 
-import javax.management.MBeanServer;
 import java.lang.management.ManagementFactory;
 import java.util.List;
+
+import javax.management.MBeanServer;
 
 public class MBeanServerFactory {
 
@@ -69,9 +70,9 @@ public class MBeanServerFactory {
 
    public void init() throws Exception {
       if (this.locateExistingServerIfPossible) {
-         List servers = javax.management.MBeanServerFactory.findMBeanServer(null);
+         List<MBeanServer> servers = javax.management.MBeanServerFactory.findMBeanServer(null);
          if (servers != null && servers.size() > 0) {
-            this.server = (MBeanServer) servers.get(0);
+            this.server = servers.get(0);
          }
          if (this.server == null) {
             this.server = ManagementFactory.getPlatformMBeanServer();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/jaas/PropertiesLoader.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/jaas/PropertiesLoader.java
@@ -29,14 +29,14 @@ public class PropertiesLoader {
    static Map<FileNameKey, ReloadableProperties> staticCache = new HashMap<>();
    protected boolean debug;
 
-   public void init(Map options) {
+   public void init(Map<String,?> options) {
       debug = booleanOption("debug", options);
       if (debug) {
          logger.debug("Initialized debug");
       }
    }
 
-   public ReloadableProperties load(String nameProperty, String fallbackName, Map options) {
+   public ReloadableProperties load(String nameProperty, String fallbackName, Map<String,?> options) {
       ReloadableProperties result;
       FileNameKey key = new FileNameKey(nameProperty, fallbackName, options);
       key.setDebug(debug);
@@ -52,7 +52,7 @@ public class PropertiesLoader {
       return result.obtained();
    }
 
-   private static boolean booleanOption(String name, Map options) {
+   private static boolean booleanOption(String name, Map<String,?> options) {
       return Boolean.parseBoolean((String) options.get(name));
    }
 
@@ -64,7 +64,7 @@ public class PropertiesLoader {
       private boolean decrypt;
       private boolean debug;
 
-      public FileNameKey(String nameProperty, String fallbackName, Map options) {
+      public FileNameKey(String nameProperty, String fallbackName, Map<String,?> options) {
          this.file = new File(baseDir(options), stringOption(nameProperty, fallbackName, options));
          absPath = file.getAbsolutePath();
          reload = booleanOption("reload", options);
@@ -97,12 +97,12 @@ public class PropertiesLoader {
          this.decrypt = decrypt;
       }
 
-      private String stringOption(String key, String nameDefault, Map options) {
+      private String stringOption(String key, String nameDefault, Map<String,?> options) {
          Object result = options.get(key);
          return result != null ? result.toString() : nameDefault;
       }
 
-      private File baseDir(Map options) {
+      private File baseDir(Map<String,?> options) {
          File baseDir = null;
          if (options.get("baseDir") != null) {
             baseDir = new File((String) options.get("baseDir"));

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/security/jaas/StubCertificateLoginModule.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/security/jaas/StubCertificateLoginModule.java
@@ -16,21 +16,22 @@
  */
 package org.apache.activemq.artemis.core.security.jaas;
 
+import java.util.Set;
+
 import javax.security.auth.login.LoginException;
 import javax.security.cert.X509Certificate;
-import java.util.Set;
 
 import org.apache.activemq.artemis.spi.core.security.jaas.CertificateLoginModule;
 
 public class StubCertificateLoginModule extends CertificateLoginModule {
 
    final String userName;
-   final Set groupNames;
+   final Set<String> groupNames;
 
    String lastUserName;
    X509Certificate[] lastCertChain;
 
-   public StubCertificateLoginModule(String userName, Set groupNames) {
+   public StubCertificateLoginModule(String userName, Set<String> groupNames) {
       this.userName = userName;
       this.groupNames = groupNames;
    }
@@ -42,7 +43,7 @@ public class StubCertificateLoginModule extends CertificateLoginModule {
    }
 
    @Override
-   protected Set getUserRoles(String username) throws LoginException {
+   protected Set<String> getUserRoles(String username) throws LoginException {
       lastUserName = username;
       return this.groupNames;
    }


### PR DESCRIPTION
in the process improving the type signature of getPrincipalsInRole, which was returning a Set<RolePrincipal>, but was adding things from createGroupPrincipal to the set, and createGroupPrincipal can return an object that only implements Principal, not RolePrincipal.