### PR TITLE
ARTEMIS-1643 Compaction must check against NULL records while replaying

### DIFF
--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalCompactor.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalCompactor.java
@@ -486,7 +486,11 @@ public class JournalCompactor extends AbstractJournalUpdateTask implements Journ
       @Override
       void execute() throws Exception {
          JournalRecord updateRecord = journal.getRecords().get(id);
-         updateRecord.addUpdateFile(usedFile, size);
+         if (updateRecord == null) {
+            ActiveMQJournalLogger.LOGGER.noRecordDuringCompactReplay(id);
+         } else {
+            updateRecord.addUpdateFile(usedFile, size);
+         }
       }
 
       @Override


### PR DESCRIPTION
JournalCompactor.UpdateCompactCommand::execute is checking if updateRecord is null to avoid on replay under huge load that will be thrown AMQ142028.