### PR TITLE
fix ARTEMIS_HOME check in Windows batch script

### DIFF
--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis.cmd
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis.cmd
@@ -19,10 +19,7 @@ rem under the License.
 setlocal
 
 if NOT "%ARTEMIS_INSTANCE%"=="" goto CHECK_ARTEMIS_INSTANCE
-PUSHD .
-CD %~dp0..
-set ARTEMIS_INSTANCE="%CD%"
-POPD
+set ARTEMIS_INSTANCE="%~dp0.."
 
 :CHECK_ARTEMIS_INSTANCE
 if exist %ARTEMIS_INSTANCE%\bin\artemis.cmd goto CHECK_JAVA

--- a/artemis-distribution/src/main/resources/bin/artemis.cmd
+++ b/artemis-distribution/src/main/resources/bin/artemis.cmd
@@ -19,10 +19,7 @@ rem under the License.
 setlocal
 
 if NOT "%ARTEMIS_HOME%"=="" goto CHECK_ARTEMIS_HOME
-PUSHD .
-CD %~dp0..
-set ARTEMIS_HOME="%CD%"
-POPD
+set ARTEMIS_HOME="%~dp0.."
 
 :CHECK_ARTEMIS_HOME
 if exist %ARTEMIS_HOME%\bin\artemis.cmd goto CHECK_JAVA


### PR DESCRIPTION
The batch script makes an attempt to detect `ARTEMIS_HOME`:
```bat
PUSHD .
CD %~dp0..
set ARTEMIS_HOME="%CD%"
POPD
```

This doesn't work because `%CD%` doesn't update when changing to a new directory. Here's the output from the above code with echo on:
```
C:\Users\dwickern>PUSHD .
C:\Users\dwickern>CD Z:\activemq\apache-artemis-2.4.0\bin\..
C:\Users\dwickern>set ARTEMIS_HOME="C:\Users\dwickern"
C:\Users\dwickern>POPD
```

I guess the original code tried to resolve the absolute path but it seems to work fine with relative paths.