### PR TITLE
ARTEMIS-1649 - enable openssl provider for Netty

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/TransportConstants.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/TransportConstants.java
@@ -113,6 +113,8 @@ public class TransportConstants {
 
    public static final String USE_DEFAULT_SSL_CONTEXT_PROP_NAME = "useDefaultSslContext";
 
+   public static final String SSL_PROVIDER = "sslProvider";
+
    public static final String NETTY_VERSION;
 
    /**
@@ -200,6 +202,10 @@ public class TransportConstants {
    public static final boolean DEFAULT_NEED_CLIENT_AUTH = false;
 
    public static final boolean DEFAULT_VERIFY_HOST = false;
+
+   public static final String DEFAULT_SSL_PROVIDER = "JDK";
+
+   public static final String OPENSSL_PROVIDER = "OPENSSL";
 
    public static final boolean DEFAULT_TRUST_ALL = false;
 
@@ -316,6 +322,7 @@ public class TransportConstants {
       allowableAcceptorKeys.add(TransportConstants.BACKLOG_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.CRL_PATH_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.HANDSHAKE_TIMEOUT);
+      allowableAcceptorKeys.add(TransportConstants.SSL_PROVIDER);
 
       ALLOWABLE_ACCEPTOR_KEYS = Collections.unmodifiableSet(allowableAcceptorKeys);
 
@@ -361,6 +368,7 @@ public class TransportConstants {
       allowableConnectorKeys.add(ActiveMQDefaultConfiguration.getPropPasswordCodec());
       allowableConnectorKeys.add(TransportConstants.NETTY_CONNECT_TIMEOUT);
       allowableConnectorKeys.add(TransportConstants.USE_DEFAULT_SSL_CONTEXT_PROP_NAME);
+      allowableConnectorKeys.add(TransportConstants.SSL_PROVIDER);
       allowableConnectorKeys.add(TransportConstants.HANDSHAKE_TIMEOUT);
       allowableConnectorKeys.add(TransportConstants.CRL_PATH_PROP_NAME);
 

--- a/docs/user-manual/en/configuring-transports.md
+++ b/docs/user-manual/en/configuring-transports.md
@@ -433,6 +433,16 @@ following additional properties:
 
     Valid values are `true` or `false`. Default is `false`.
 
+-   `sslProvider`
+    
+    Used to change the SSL Provider between `JDK` and `OPENSSL`. The default is `JDK`. 
+    If used with `OPENSSL` you can add `netty-tcnative` to your classpath to use the native 
+    installed openssl. This can be useful if you want to use special ciphersuite - elliptic curve combinations
+    which are support through openssl but not through the JDK provider. See https://en.wikipedia.org/wiki/Comparison_of_TLS_implementations
+    for more information's.
+    
+    
+    
 ## Configuring Netty HTTP
 
 Netty HTTP tunnels packets over the HTTP protocol. It can be useful in


### PR DESCRIPTION
We want to use the native Openssl Provider for netty to use the native openssl.
Added the supprt to switch between JDK and OpenSSL Provider.

see #1833