### PR TITLE
ARTEMIS-1655 Fix TransportConfiguration encode failing

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -1159,7 +1159,9 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
       Map<String, Object> params = configurations.get(0).getParams();
 
-      params.put(ActiveMQDefaultConfiguration.getPropMaskPassword(), mainConfig.isMaskPassword());
+      if (mainConfig.isMaskPassword() != null) {
+         params.put(ActiveMQDefaultConfiguration.getPropMaskPassword(), mainConfig.isMaskPassword());
+      }
 
       if (mainConfig.getPasswordCodec() != null) {
          params.put(ActiveMQDefaultConfiguration.getPropPasswordCodec(), mainConfig.getPasswordCodec());
@@ -1180,7 +1182,9 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
       Map<String, Object> params = configurations.get(0).getParams();
 
-      params.put(ActiveMQDefaultConfiguration.getPropMaskPassword(), mainConfig.isMaskPassword());
+      if (mainConfig.isMaskPassword() != null) {
+         params.put(ActiveMQDefaultConfiguration.getPropMaskPassword(), mainConfig.isMaskPassword());
+      }
 
       if (mainConfig.getPasswordCodec() != null) {
          params.put(ActiveMQDefaultConfiguration.getPropPasswordCodec(), mainConfig.getPasswordCodec());


### PR DESCRIPTION
Check for null on isMaskPassword, seems this regressed in bb84f679363f62e8b2663f63bf23f04133de481d change for ARTEMIS-1600