### PR TITLE
ARTEMIS-1658 Add prefix option to ActivationSpec

### DIFF
--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQActivation.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQActivation.java
@@ -541,7 +541,14 @@ public class ActiveMQActivation {
                   throw ActiveMQRABundle.BUNDLE.noDestinationName();
                }
 
-               String calculatedDestinationName = destinationName.substring(destinationName.lastIndexOf('/') + 1);
+               String calculatedDestinationName;
+               if (isTopic && spec.getTopicPrefix() != null) {
+                  calculatedDestinationName = spec.getTopicPrefix() + destinationName.substring(destinationName.lastIndexOf('/') + 1);
+               } else if (!isTopic && spec.getQueuePrefix() != null) {
+                  calculatedDestinationName = spec.getQueuePrefix() + destinationName.substring(destinationName.lastIndexOf('/') + 1);
+               } else {
+                  calculatedDestinationName = destinationName.substring(destinationName.lastIndexOf('/') + 1);
+               }
 
                logger.debug("Unable to retrieve " + destinationName +
                                                 " from JNDI. Creating a new " + destinationType.getName() +

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQActivationSpec.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQActivationSpec.java
@@ -53,6 +53,7 @@ public class ActiveMQActivationSpec extends ConnectionFactoryProperties implemen
    public String strConnectionParameters;
    protected Boolean allowLocalTransactions;
 
+
    /**
     * The resource adapter
     */
@@ -134,6 +135,11 @@ public class ActiveMQActivationSpec extends ConnectionFactoryProperties implemen
    private Long setupInterval;
 
    private Boolean rebalanceConnections = false;
+
+   // Enables backwards compatibility of the pre 2.x addressing model
+   private String topicPrefix;
+
+   private String queuePrefix;
 
    /**
     * Constructor
@@ -366,6 +372,23 @@ public class ActiveMQActivationSpec extends ConnectionFactoryProperties implemen
       } else {
          return "Auto-acknowledge";
       }
+   }
+
+
+   public void setQueuePrefix(String prefix) {
+      this.queuePrefix = prefix;
+   }
+
+   public String getQueuePrefix() {
+      return queuePrefix;
+   }
+
+   public void setTopicPrefix(String prefix) {
+      this.topicPrefix = prefix;
+   }
+
+   public String getTopicPrefix() {
+      return topicPrefix;
    }
 
    /**
@@ -878,6 +901,10 @@ public class ActiveMQActivationSpec extends ConnectionFactoryProperties implemen
          return false;
       if (setupAttempts != null ? !setupAttempts.equals(that.setupAttempts) : that.setupAttempts != null)
          return false;
+      if (queuePrefix != null ? !queuePrefix.equals(that.queuePrefix) : that.queuePrefix != null)
+         return false;
+      if (topicPrefix != null ? !topicPrefix.equals(that.topicPrefix) : that.topicPrefix != null)
+         return false;
       return !(setupInterval != null ? !setupInterval.equals(that.setupInterval) : that.setupInterval != null);
 
    }
@@ -907,6 +934,8 @@ public class ActiveMQActivationSpec extends ConnectionFactoryProperties implemen
       result = 31 * result + (rebalanceConnections != null ? rebalanceConnections.hashCode() : 0);
       result = 31 * result + (setupAttempts != null ? setupAttempts.hashCode() : 0);
       result = 31 * result + (setupInterval != null ? setupInterval.hashCode() : 0);
+      result = 31 * result + (queuePrefix != null ? queuePrefix.hashCode() : 0);
+      result = 31 * result + (topicPrefix != null ? queuePrefix.hashCode() :0);
       return result;
    }
 }


### PR DESCRIPTION
Artemis 1.x RA would do a core queue lookup if it could not find the
Destination in JNDI.  We need to ensure that we can support the old
address model for backwards compatability.