### PR TITLE
[ARTEMIS-1670] NPE was found in when dropping durable subscriptions from a topic

### DIFF
--- a/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/impl/JMSServerManagerImpl.java
+++ b/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/impl/JMSServerManagerImpl.java
@@ -1666,6 +1666,9 @@ public class JMSServerManagerImpl implements JMSServerManager, ActivateCallback 
       @Override
       public boolean delete(SimpleString queueName) throws Exception {
          Queue queue = server.locateQueue(queueName);
+         if (queue == null) {
+            return false;
+         }
          SimpleString address = queue.getAddress();
          AddressSettings settings = server.getAddressSettingsRepository().getMatch(address.toString());
          long consumerCount = queue.getConsumerCount();


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/ARTEMIS-1670

The proposed fix will check whether the Queue is null or not when trying to delete it from it's Thread.