### PR TITLE
ARTEMIS-1679 Stopping consumer no need to wait until all queued tasks…

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientConsumerImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientConsumerImpl.java
@@ -482,8 +482,6 @@ public final class ClientConsumerImpl implements ClientConsumerInternal {
 
    @Override
    public void stop(final boolean waitForOnMessage) throws ActiveMQException {
-      waitForOnMessageToComplete(waitForOnMessage);
-
       if (browseOnly) {
          // stop shouldn't affect browser delivery
          return;
@@ -496,6 +494,7 @@ public final class ClientConsumerImpl implements ClientConsumerInternal {
 
          stopped = true;
       }
+      waitForOnMessageToComplete(waitForOnMessage);
    }
 
    @Override


### PR DESCRIPTION
Sping's SimpleMessageListenerContainer shutdown will stop consumers and then close them. It will take lots of time(each consumer costs 10s at most) if there are lots of consumers bcs stop process will wait until all queued tasks done. We assume that waiting for the current task is enough and this will accelerate spring shutting down process.