### PR TITLE
ARTEMIS-1687 reduce logging for fast-tests

### DIFF
--- a/artemis-cli/src/test/java/org/apache/activemq/cli/test/ArtemisTest.java
+++ b/artemis-cli/src/test/java/org/apache/activemq/cli/test/ArtemisTest.java
@@ -538,7 +538,7 @@ public class ArtemisTest extends CliTestBase {
       Artemis.main("create", instanceFolder.getAbsolutePath(), "--force", "--silent", "--no-web", "--no-autotune", "--require-login");
       System.setProperty("artemis.instance", instanceFolder.getAbsolutePath());
 
-      Artemis.main("perf-journal", "--journal-type", "NIO", "--writes", "5", "--tries", "1", "--verbose");
+      Artemis.main("perf-journal", "--journal-type", "NIO", "--writes", "5", "--tries", "1");
 
    }
 
@@ -581,8 +581,8 @@ public class ArtemisTest extends CliTestBase {
          }
          Artemis.internalExecute("data", "print", "--f");
 
-         assertEquals(Integer.valueOf(100), Artemis.internalExecute("producer", "--message-count", "100", "--verbose", "--user", "admin", "--password", "admin"));
-         assertEquals(Integer.valueOf(100), Artemis.internalExecute("consumer", "--verbose", "--break-on-null", "--receive-timeout", "100", "--user", "admin", "--password", "admin"));
+         assertEquals(Integer.valueOf(100), Artemis.internalExecute("producer", "--message-count", "100", "--user", "admin", "--password", "admin"));
+         assertEquals(Integer.valueOf(100), Artemis.internalExecute("consumer", "--break-on-null", "--receive-timeout", "100", "--user", "admin", "--password", "admin"));
 
          ActiveMQConnectionFactory cf = new ActiveMQConnectionFactory("tcp://localhost:61616");
          Connection connection = cf.createConnection("admin", "admin");
@@ -603,20 +603,20 @@ public class ArtemisTest extends CliTestBase {
          connection.close();
          cf.close();
 
-         assertEquals(Integer.valueOf(1), Artemis.internalExecute("browser", "--txt-size", "50", "--verbose", "--filter", "fruit='banana'", "--user", "admin", "--password", "admin"));
+         assertEquals(Integer.valueOf(1), Artemis.internalExecute("browser", "--txt-size", "50", "--filter", "fruit='banana'", "--user", "admin", "--password", "admin"));
 
-         assertEquals(Integer.valueOf(100), Artemis.internalExecute("browser", "--txt-size", "50", "--verbose", "--filter", "fruit='orange'", "--user", "admin", "--password", "admin"));
+         assertEquals(Integer.valueOf(100), Artemis.internalExecute("browser", "--txt-size", "50", "--filter", "fruit='orange'", "--user", "admin", "--password", "admin"));
 
-         assertEquals(Integer.valueOf(101), Artemis.internalExecute("browser", "--txt-size", "50", "--verbose", "--user", "admin", "--password", "admin"));
+         assertEquals(Integer.valueOf(101), Artemis.internalExecute("browser", "--txt-size", "50", "--user", "admin", "--password", "admin"));
 
          // should only receive 10 messages on browse as I'm setting messageCount=10
-         assertEquals(Integer.valueOf(10), Artemis.internalExecute("browser", "--txt-size", "50", "--verbose", "--message-count", "10", "--user", "admin", "--password", "admin"));
+         assertEquals(Integer.valueOf(10), Artemis.internalExecute("browser", "--txt-size", "50", "--message-count", "10", "--user", "admin", "--password", "admin"));
 
          // Nothing was consumed until here as it was only browsing, check it's receiving again
-         assertEquals(Integer.valueOf(1), Artemis.internalExecute("consumer", "--txt-size", "50", "--verbose", "--break-on-null", "--receive-timeout", "100", "--filter", "fruit='banana'", "--user", "admin", "--password", "admin"));
+         assertEquals(Integer.valueOf(1), Artemis.internalExecute("consumer", "--txt-size", "50", "--break-on-null", "--receive-timeout", "100", "--filter", "fruit='banana'", "--user", "admin", "--password", "admin"));
 
          // Checking it was acked before
-         assertEquals(Integer.valueOf(100), Artemis.internalExecute("consumer", "--txt-size", "50", "--verbose", "--break-on-null", "--receive-timeout", "100", "--user", "admin", "--password", "admin"));
+         assertEquals(Integer.valueOf(100), Artemis.internalExecute("consumer", "--txt-size", "50", "--break-on-null", "--receive-timeout", "100", "--user", "admin", "--password", "admin"));
       } finally {
          stopServer();
       }

--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/ThreadLeakCheckRule.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/ThreadLeakCheckRule.java
@@ -78,7 +78,7 @@ public class ThreadLeakCheckRule extends TestWatcher {
     */
    @Override
    protected void finished(Description description) {
-      log.info("checking thread enabled? " + enabled + " testFailed? " + testFailed);
+      log.debug("checking thread enabled? " + enabled + " testFailed? " + testFailed);
       try {
          if (enabled) {
             boolean failed = true;

--- a/artemis-junit/pom.xml
+++ b/artemis-junit/pom.xml
@@ -45,6 +45,11 @@
          <artifactId>jboss-logging</artifactId>
       </dependency>
       <dependency>
+         <groupId>org.jboss.logmanager</groupId>
+         <artifactId>jboss-logmanager</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-jms-server</artifactId>
          <version>${project.version}</version>

--- a/artemis-junit/src/main/java/org/apache/activemq/artemis/junit/EmbeddedActiveMQResource.java
+++ b/artemis-junit/src/main/java/org/apache/activemq/artemis/junit/EmbeddedActiveMQResource.java
@@ -41,6 +41,7 @@ import org.apache.activemq.artemis.core.server.BindingQueryResult;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ;
+import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.junit.rules.ExternalResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,7 +84,7 @@ public class EmbeddedActiveMQResource extends ExternalResource {
     * Create a default EmbeddedActiveMQResource
     */
    public EmbeddedActiveMQResource() {
-      configuration = new ConfigurationImpl().setName(SERVER_NAME).setPersistenceEnabled(false).setSecurityEnabled(false).addAcceptorConfiguration(new TransportConfiguration(InVMAcceptorFactory.class.getName()));
+      configuration = new ConfigurationImpl().setName(SERVER_NAME).setPersistenceEnabled(false).setSecurityEnabled(false).addAcceptorConfiguration(new TransportConfiguration(InVMAcceptorFactory.class.getName())).addAddressesSetting("#", new AddressSettings().setDeadLetterAddress(SimpleString.toSimpleString("dla")).setExpiryAddress(SimpleString.toSimpleString("expiry")));
       init();
    }
 

--- a/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/MultipleEmbeddedActiveMQResourcesTest.java
+++ b/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/MultipleEmbeddedActiveMQResourcesTest.java
@@ -18,7 +18,7 @@ package org.apache.activemq.artemis.junit;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
-import org.junit.After;
+import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -53,14 +53,11 @@ public class MultipleEmbeddedActiveMQResourcesTest {
 
    @Before
    public void setUp() throws Exception {
+      serverOne.getServer().getActiveMQServer().getAddressSettingsRepository().addMatch("#", new AddressSettings().setDeadLetterAddress(SimpleString.toSimpleString("DLA")).setExpiryAddress(SimpleString.toSimpleString("Expiry")));
+      serverTwo.getServer().getActiveMQServer().getAddressSettingsRepository().addMatch("#", new AddressSettings().setDeadLetterAddress(SimpleString.toSimpleString("DLA")).setExpiryAddress(SimpleString.toSimpleString("Expiry")));
+
       serverOne.createQueue(TEST_ADDRESS_ONE, TEST_QUEUE_ONE);
       serverTwo.createQueue(TEST_ADDRESS_TWO, TEST_QUEUE_TWO);
-   }
-
-   @After
-   public void tearDown() {
-      serverOne.stop();
-      serverTwo.stop();
    }
 
    @Test

--- a/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/MultipleEmbeddedJMSResourcesTest.java
+++ b/artemis-junit/src/test/java/org/apache/activemq/artemis/junit/MultipleEmbeddedJMSResourcesTest.java
@@ -18,6 +18,8 @@ package org.apache.activemq.artemis.junit;
 
 import javax.jms.Message;
 
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -48,6 +50,9 @@ public class MultipleEmbeddedJMSResourcesTest {
 
    @Test
    public void testMultipleServers() throws Exception {
+      jmsServerOne.getJmsServer().getActiveMQServer().getAddressSettingsRepository().addMatch("#", new AddressSettings().setDeadLetterAddress(SimpleString.toSimpleString("DLA")).setExpiryAddress(SimpleString.toSimpleString("Expiry")));
+      jmsServerTwo.getJmsServer().getActiveMQServer().getAddressSettingsRepository().addMatch("#", new AddressSettings().setDeadLetterAddress(SimpleString.toSimpleString("DLA")).setExpiryAddress(SimpleString.toSimpleString("Expiry")));
+
       Message pushedOne = jmsServerOne.pushMessage(TEST_QUEUE_ONE, TEST_BODY);
       assertNotNull(String.format(ASSERT_PUSHED_FORMAT, TEST_QUEUE_ONE), pushedOne);
 

--- a/artemis-rest/src/test/java/org/apache/activemq/artemis/rest/test/EmbeddedTestServer.java
+++ b/artemis-rest/src/test/java/org/apache/activemq/artemis/rest/test/EmbeddedTestServer.java
@@ -16,12 +16,14 @@
  */
 package org.apache.activemq.artemis.rest.test;
 
+import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
 import org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
+import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.rest.MessageServiceConfiguration;
 import org.apache.activemq.artemis.rest.MessageServiceManager;
 import org.jboss.resteasy.plugins.server.tjws.TJWSEmbeddedJaxrsServer;
@@ -68,6 +70,9 @@ class EmbeddedTestServer {
          Configuration configuration = new ConfigurationImpl().setPersistenceEnabled(false).setSecurityEnabled(false).addAcceptorConfiguration(new TransportConfiguration(InVMAcceptorFactory.class.getName()));
 
          activeMQServer = ActiveMQServers.newActiveMQServer(configuration);
+         // set DLA and expiry to avoid spamming the log with warnings
+         activeMQServer.getAddressSettingsRepository().addMatch("#", new AddressSettings().setDeadLetterAddress(SimpleString.toSimpleString("DLA")).setExpiryAddress(SimpleString.toSimpleString("Expiry")));
+
          activeMQServer.start();
       }
       tjws.start();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/filter/impl/FilterImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/filter/impl/FilterImpl.java
@@ -79,7 +79,10 @@ public class FilterImpl implements Filter {
       try {
          booleanExpression = SelectorParser.parse(filterStr.toString());
       } catch (Throwable e) {
-         ActiveMQServerLogger.LOGGER.invalidFilter(filterStr, e);
+         ActiveMQServerLogger.LOGGER.invalidFilter(filterStr);
+         if (ActiveMQServerLogger.LOGGER.isDebugEnabled()) {
+            ActiveMQServerLogger.LOGGER.debug("Invalid filter", e);
+         }
          throw ActiveMQMessageBundle.BUNDLE.invalidFilter(e, filterStr);
       }
       return new FilterImpl(filterStr, booleanExpression);
@@ -105,7 +108,7 @@ public class FilterImpl implements Filter {
          boolean result = booleanExpression.matches(new FilterableServerMessage(message));
          return result;
       } catch (Exception e) {
-         ActiveMQServerLogger.LOGGER.invalidFilter(sfilterString, e);
+         ActiveMQServerLogger.LOGGER.invalidFilter(sfilterString);
          if (ActiveMQServerLogger.LOGGER.isDebugEnabled()) {
             ActiveMQServerLogger.LOGGER.debug("Invalid filter", e);
          }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1600,7 +1600,7 @@ public interface ActiveMQServerLogger extends BasicLogger {
 
    @LogMessage(level = Logger.Level.ERROR)
    @Message(id = 224006, value = "Invalid filter: {0}", format = Message.Format.MESSAGE_FORMAT)
-   void invalidFilter(SimpleString filter, @Cause Throwable cause);
+   void invalidFilter(SimpleString filter);
 
    @LogMessage(level = Logger.Level.ERROR)
    @Message(id = 224007, value = "page subscription = {0} error={1}", format = Message.Format.MESSAGE_FORMAT)

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
@@ -365,8 +365,6 @@ public abstract class ActiveMQTestBase extends Assert {
       InVMRegistry.instance.clear();
 
       // checkFreePort(TransportConstants.DEFAULT_PORT);
-
-      logAndSystemOut("#test " + getName());
    }
 
    public static void assertEqualsByteArrays(final byte[] expected, final byte[] actual) {

--- a/pom.xml
+++ b/pom.xml
@@ -1001,11 +1001,10 @@
       </profile>
       <profile>
          <!-- This will represent a subset of the tests
-              This is used on PR checks on the Jenkins instance at build.apache.org -->
+              This is used on PR checks -->
          <id>fast-tests</id>
          <modules>
             <module>artemis-dto</module>
-            <module>artemis-web</module>
             <module>artemis-cli</module>
             <module>artemis-commons</module>
             <module>artemis-selector</module>
@@ -1017,7 +1016,6 @@
             <module>artemis-journal</module>
             <module>artemis-jdbc-store</module>
             <module>artemis-ra</module>
-            <module>artemis-rest</module>
             <module>artemis-service-extensions</module>
             <module>artemis-maven-plugin</module>
             <module>integration/activemq-spring-integration</module>

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/ActiveMQServerTestCase.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/ActiveMQServerTestCase.java
@@ -42,6 +42,7 @@ import org.apache.activemq.artemis.core.postoffice.Binding;
 import org.apache.activemq.artemis.core.postoffice.impl.LocalQueueBinding;
 import org.apache.activemq.artemis.core.security.Role;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.jms.server.JMSServerManager;
 import org.apache.activemq.artemis.jms.tests.tools.ServerManagement;
 import org.apache.activemq.artemis.jms.tests.tools.container.Server;
@@ -205,6 +206,8 @@ public abstract class ActiveMQServerTestCase {
    }
 
    protected void deployAdministeredObjects() throws Exception {
+      // set DLA and expiry to avoid spamming the log with warnings
+      getJmsServer().getAddressSettingsRepository().addMatch("#", new AddressSettings().setDeadLetterAddress(SimpleString.toSimpleString("DLA")).setExpiryAddress(SimpleString.toSimpleString("Expiry")));
       createTopic("Topic1");
       createTopic("Topic2");
       createTopic("Topic3");

--- a/tests/joram-tests/src/test/java/org/apache/activemq/artemis/common/SpawnedJMSServer.java
+++ b/tests/joram-tests/src/test/java/org/apache/activemq/artemis/common/SpawnedJMSServer.java
@@ -20,10 +20,12 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
 
+import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
+import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.jms.server.JMSServerManager;
 import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
 import org.apache.activemq.artemis.utils.FileUtil;
@@ -87,6 +89,8 @@ public class SpawnedJMSServer {
 
          // disable server persistence since JORAM tests do not restart server
          server = ActiveMQServers.newActiveMQServer(config, useFiles);
+         // set DLA and expiry to avoid spamming the log with warnings
+         server.getAddressSettingsRepository().addMatch("#", new AddressSettings().setDeadLetterAddress(SimpleString.toSimpleString("DLA")).setExpiryAddress(SimpleString.toSimpleString("Expiry")));
 
          serverManager = new JMSServerManagerImpl(server);
          serverManager.start();

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/JournalImplTestUnit.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/JournalImplTestUnit.java
@@ -2891,18 +2891,22 @@ public abstract class JournalImplTestUnit extends JournalImplTestBase {
          update(i);
       }
 
-      System.out.println("Before stop ****************************");
-      System.out.println(journal.debug());
-      System.out.println("*****************************************");
+      /**
+       * Enable System.outs again if test fails and needs to be debugged
+       */
+
+      //      System.out.println("Before stop ****************************");
+      //      System.out.println(journal.debug());
+      //      System.out.println("*****************************************");
 
       stopJournal();
       createJournal();
       startJournal();
       loadAndCheck();
 
-      System.out.println("After start ****************************");
-      System.out.println(journal.debug());
-      System.out.println("*****************************************");
+      //      System.out.println("After start ****************************");
+      //      System.out.println(journal.debug());
+      //      System.out.println("*****************************************");
 
       journal.forceMoveNextFile();
 
@@ -2910,49 +2914,49 @@ public abstract class JournalImplTestUnit extends JournalImplTestBase {
          delete(i);
       }
 
-      System.out.println("After delete ****************************");
-      System.out.println(journal.debug());
-      System.out.println("*****************************************");
+      //      System.out.println("After delete ****************************");
+      //      System.out.println(journal.debug());
+      //      System.out.println("*****************************************");
 
       for (int i = 100; i < 200; i++) {
          updateTx(transactionID, i);
       }
 
-      System.out.println("After updatetx ****************************");
-      System.out.println(journal.debug());
-      System.out.println("*****************************************");
+      //      System.out.println("After updatetx ****************************");
+      //      System.out.println(journal.debug());
+      //      System.out.println("*****************************************");
 
       journal.forceMoveNextFile();
 
       commit(transactionID++);
 
-      System.out.println("After commit ****************************");
-      System.out.println(journal.debug());
-      System.out.println("*****************************************");
+      //      System.out.println("After commit ****************************");
+      //      System.out.println(journal.debug());
+      //      System.out.println("*****************************************");
 
       for (int i = 100; i < 200; i++) {
          updateTx(transactionID, i);
          deleteTx(transactionID, i);
       }
 
-      System.out.println("After delete ****************************");
-      System.out.println(journal.debug());
-      System.out.println("*****************************************");
+      //      System.out.println("After delete ****************************");
+      //      System.out.println(journal.debug());
+      //      System.out.println("*****************************************");
 
       commit(transactionID++);
 
-      System.out.println("Before reclaim/after commit ****************************");
-      System.out.println(journal.debug());
-      System.out.println("*****************************************");
+      //      System.out.println("Before reclaim/after commit ****************************");
+      //      System.out.println(journal.debug());
+      //      System.out.println("*****************************************");
 
       stopJournal();
       createJournal();
       startJournal();
       loadAndCheck();
 
-      System.out.println("After reclaim ****************************");
-      System.out.println(journal.debug());
-      System.out.println("*****************************************");
+      //      System.out.println("After reclaim ****************************");
+      //      System.out.println(journal.debug());
+      //      System.out.println("*****************************************");
 
       journal.forceMoveNextFile();
       checkAndReclaimFiles();

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/ra/ActiveMQResourceAdapterConfigTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/ra/ActiveMQResourceAdapterConfigTest.java
@@ -436,7 +436,6 @@ public class ActiveMQResourceAdapterConfigTest extends ActiveMQTestBase {
          assertEquals(el.toString(), elementsByTagName.getLength(), 1);
          Node configPropertyNameNode = elementsByTagName.item(0);
          String configPropertyName = configPropertyNameNode.getTextContent();
-         System.out.println("configPropertyName = " + configPropertyName);
          Method setter = methodList.remove("set" + configPropertyName);
          assertNotNull("setter " + configPropertyName + " does not exist", setter);
          Class c = lookupType(setter);
@@ -459,8 +458,6 @@ public class ActiveMQResourceAdapterConfigTest extends ActiveMQTestBase {
          }
          System.out.println(newConfig);
          fail("methods not shown please see previous and add");
-      } else {
-         System.out.println(commentedOutConfigs);
       }
    }
 


### PR DESCRIPTION
Logging for the "fast-tests" profile used for PR builds could be reduced
significantly. This would save time as well as prevent log truncation
(Travis CI only supports logs up to 4MB).