### PR TITLE
ARTEMIS-1690 remove not needed "mvn install"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: java
+install: true
 script: mvn -Pfast-tests -Pextra-tests -B install
 cache:
   directories:


### PR DESCRIPTION
"mvn install" is called by travis-ci itself, let's skip it in favour of our own "mvn install"