### PR TITLE
NO-JIRA make MessageConsumerTest deterministic

### DIFF
--- a/tests/jms-tests/pom.xml
+++ b/tests/jms-tests/pom.xml
@@ -65,6 +65,11 @@
          <version>${project.version}</version>
       </dependency>
       <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-junit</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+      <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
       </dependency>


### PR DESCRIPTION
The method testStopConnectionDuringOnMessage in this class was relying
on sleep() calls for critical timing. This test fails sometimes on
fast-tests so I modified it to use a latch and a few waitFor calls to be
more deterministic. It also runs in a third of the time now.