### PR TITLE
ARTEMIS-1712 Add additional null check in TX rollback handler

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
@@ -1156,7 +1156,13 @@ public class OpenWireConnection extends AbstractRemotingConnection implements Se
       @Override
       public Response processRollbackTransaction(TransactionInfo info) throws Exception {
          Transaction tx = lookupTX(info.getTransactionId(), null, true);
-         AMQSession amqSession = (AMQSession) tx.getProtocolData();
+
+         final AMQSession amqSession;
+         if (tx != null) {
+            amqSession = (AMQSession) tx.getProtocolData();
+         } else {
+            amqSession = null;
+         }
 
          if (info.getTransactionId().isXATransaction() && tx == null) {
             throw newXAException("Transaction '" + info.getTransactionId() + "' has not been started.", XAException.XAER_NOTA);


### PR DESCRIPTION
Check for AMQSession being null before handling various TX state checks
in order to ensure the correct errors are thrown and TX rollback is
handled properly.