### PR TITLE
[ARTEMIS-1716] QueueControlImpl#listMessagesAsJSON fails when message contains a byte[] header

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/JsonUtil.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/JsonUtil.java
@@ -208,6 +208,9 @@ public final class JsonUtil {
          jsonObjectBuilder.add(key, param.toString());
       } else if (param == null) {
          jsonObjectBuilder.addNull(key);
+      } else if (param instanceof byte[]) {
+         JsonArrayBuilder byteArrayObject = toJsonArrayBuilder((byte[]) param);
+         jsonObjectBuilder.add(key, byteArrayObject);
       } else {
          throw ActiveMQClientMessageBundle.BUNDLE.invalidManagementParam(param.getClass().getName());
       }
@@ -233,6 +236,9 @@ public final class JsonUtil {
          jsonArrayBuilder.add(((Byte) param).shortValue());
       } else if (param == null) {
          jsonArrayBuilder.addNull();
+      } else if (param instanceof byte[]) {
+         JsonArrayBuilder byteArrayObject = toJsonArrayBuilder((byte[]) param);
+         jsonArrayBuilder.add(byteArrayObject);
       } else {
          throw ActiveMQClientMessageBundle.BUNDLE.invalidManagementParam(param.getClass().getName());
       }
@@ -256,6 +262,16 @@ public final class JsonUtil {
          }
       }
       return jsonObjectBuilder.build();
+   }
+
+   public static JsonArrayBuilder toJsonArrayBuilder(byte[] byteArray) {
+      JsonArrayBuilder jsonArrayBuilder = JsonLoader.createArrayBuilder();
+      if (byteArray != null) {
+         for (int i = 0; i < byteArray.length; i++) {
+            jsonArrayBuilder.add(((Byte) byteArray[i]).shortValue());
+         }
+      }
+      return jsonArrayBuilder;
    }
 
    public static JsonArray readJsonArray(String jsonString) {

--- a/artemis-core-client/src/test/java/org/apache/activemq/artemis/api/core/JsonUtilTest.java
+++ b/artemis-core-client/src/test/java/org/apache/activemq/artemis/api/core/JsonUtilTest.java
@@ -53,4 +53,30 @@ public class JsonUtilTest {
 
       Assert.assertEquals(2, jsonArray.size());
    }
+
+   @Test
+   public void testAddByteArrayToJsonObject() {
+      JsonObjectBuilder jsonObjectBuilder = JsonLoader.createObjectBuilder();
+      byte[] bytes = {0x0a, 0x1b, 0x2c, 0x3d, 0x4e, 0x5f};
+
+      JsonUtil.addToObject("not-null", "not-null", jsonObjectBuilder);
+      JsonUtil.addToObject("byteArray", bytes, jsonObjectBuilder);
+      JsonUtil.addToObject("null", null, jsonObjectBuilder);
+
+      JsonObject jsonObject = jsonObjectBuilder.build();
+
+      Assert.assertTrue(jsonObject.containsKey("byteArray"));
+      Assert.assertEquals(6, jsonObject.getJsonArray("byteArray").size());
+   }
+
+   @Test public void testAddByteArrayToJsonArray() {
+      JsonArrayBuilder jsonArrayBuilder = JsonLoader.createArrayBuilder();
+      byte[] bytes = {0x0a, 0x1b, 0x2c, 0x3d, 0x4e, 0x5f};
+
+      JsonUtil.addToArray(bytes, jsonArrayBuilder);
+
+      JsonArray jsonArray = jsonArrayBuilder.build();
+
+      Assert.assertEquals(1, jsonArray.size());
+   }
 }


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/ARTEMIS-1716