### PR TITLE
ARTEMIS-1504 Update Qpid JMS to 0.30.0 and proton-j to 0.26.0

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/handler/ProtonHandler.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/handler/ProtonHandler.java
@@ -16,7 +16,6 @@
  */
 package org.apache.activemq.artemis.protocol.amqp.proton.handler;
 
-import javax.security.auth.Subject;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -25,6 +24,8 @@ import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
+
+import javax.security.auth.Subject;
 
 import org.apache.activemq.artemis.protocol.amqp.proton.ProtonInitializable;
 import org.apache.activemq.artemis.protocol.amqp.sasl.ClientSASL;
@@ -42,6 +43,7 @@ import org.apache.qpid.proton.engine.EndpointState;
 import org.apache.qpid.proton.engine.Event;
 import org.apache.qpid.proton.engine.Sasl;
 import org.apache.qpid.proton.engine.Transport;
+import org.apache.qpid.proton.engine.impl.TransportInternal;
 import org.jboss.logging.Logger;
 
 import io.netty.buffer.ByteBuf;
@@ -93,6 +95,14 @@ public class ProtonHandler extends ProtonInitializable {
       });
       this.creationTime = System.currentTimeMillis();
       this.isServer = isServer;
+
+      try {
+         ((TransportInternal) transport).setUseReadOnlyOutputBuffer(false);
+      } catch (NoSuchMethodError nsme) {
+         // using a version at runtime where the optimization isn't available, ignore
+         log.trace("Proton output buffer optimisation unavailable");
+      }
+
       transport.bind(connection);
       connection.collect(collector);
    }

--- a/pom.xml
+++ b/pom.xml
@@ -92,10 +92,10 @@
       <maven.assembly.plugin.version>2.4</maven.assembly.plugin.version>
       <mockito.version>2.8.47</mockito.version>
       <netty.version>4.1.19.Final</netty.version>
-      <proton.version>0.25.0</proton.version>
+      <proton.version>0.26.0</proton.version>
       <resteasy.version>3.0.19.Final</resteasy.version>
       <slf4j.version>1.7.21</slf4j.version>
-      <qpid.jms.version>0.29.0</qpid.jms.version>
+      <qpid.jms.version>0.30.0</qpid.jms.version>
       <johnzon.version>0.9.5</johnzon.version>
       <json-p.spec.version>1.0-alpha-1</json-p.spec.version>
       <javax.inject.version>1</javax.inject.version>


### PR DESCRIPTION
Updates to latest Qpid JMS and the latest Proton-J release, use new proton-j setting to disable read-only buffers use to avoid netty issue with unnecessary extra copy and pool creation when use that types of buffers