### PR TITLE
ARTEMIS-1728 Reclaim memory when page cursor complete

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageSubscriptionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageSubscriptionImpl.java
@@ -334,7 +334,9 @@ final class PageSubscriptionImpl implements PageSubscription {
          }
 
          infoPG.acks.clear();
+         infoPG.acks = Collections.synchronizedSet(new LinkedHashSet<PagePosition>());
          infoPG.removedReferences.clear();
+         infoPG.removedReferences = new ConcurrentHashSet<>();
       }
 
       tx.addOperation(new TransactionOperationAbstract() {
@@ -901,11 +903,11 @@ final class PageSubscriptionImpl implements PageSubscription {
       private final long pageId;
 
       // Confirmed ACKs on this page
-      private final Set<PagePosition> acks = Collections.synchronizedSet(new LinkedHashSet<PagePosition>());
+      private Set<PagePosition> acks = Collections.synchronizedSet(new LinkedHashSet<PagePosition>());
 
       private WeakReference<PageCache> cache;
 
-      private final Set<PagePosition> removedReferences = new ConcurrentHashSet<>();
+      private Set<PagePosition> removedReferences = new ConcurrentHashSet<>();
 
       // The page was live at the time of the creation
       private final boolean wasLive;


### PR DESCRIPTION
Free hash set used to hold page position for acks and removed refs.
The two set is cleared, but they still hold a big array.

It is safe to replace the old one with empty set.