### PR TITLE
ARTEMIS-1750 Improve Scalability of AMQP Protocol

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/ActiveMQChannelHandler.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/ActiveMQChannelHandler.java
@@ -65,7 +65,7 @@ public class ActiveMQChannelHandler extends ChannelDuplexHandler {
       ByteBuf buffer = (ByteBuf) msg;
 
       try {
-         handler.bufferReceived(channelId(ctx.channel()), new ChannelBufferWrapper(buffer));
+         handler.bufferReceived(channelId(ctx.channel()), new ChannelBufferWrapper(buffer, true));
       } finally {
          buffer.release();
       }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/client/ProtonClientProtocolManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/client/ProtonClientProtocolManager.java
@@ -45,11 +45,6 @@ public class ProtonClientProtocolManager extends ProtonProtocolManager implement
    }
 
    @Override
-   public void stop() {
-      throw new UnsupportedOperationException();
-   }
-
-   @Override
    public RemotingConnection connect(Connection transportConnection, long callTimeout, long callFailoverTimeout, List<Interceptor> incomingInterceptors, List<Interceptor> outgoingInterceptors, TopologyResponseHandler topologyResponseHandler) {
       throw new UnsupportedOperationException();
    }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPConnectionContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPConnectionContext.java
@@ -123,6 +123,13 @@ public class AMQPConnectionContext extends ProtonInitializable implements EventH
       }
    }
 
+   /** Execute using the same ProtonHandler executor.
+    *  This is for situations where you would rather wait on an executor
+    *  instead of blocking a thread */
+   public void executeInHandler(Runnable run) {
+      handler.execute(run);
+   }
+
    public boolean isIncomingConnection() {
       return isIncomingConnection;
    }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPConnectionContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPConnectionContext.java
@@ -108,7 +108,7 @@ public class AMQPConnectionContext extends ProtonInitializable implements EventH
 
       this.scheduledPool = scheduledPool;
       connectionCallback.setConnection(this);
-      this.handler = new ProtonHandler(protocolManager.getServer().getExecutorFactory().getExecutor(), isIncomingConnection);
+      this.handler = new ProtonHandler(protocolManager, protocolManager.getServer().getExecutorFactory().getExecutor(), isIncomingConnection);
       handler.addEventHandler(this);
       Transport transport = handler.getTransport();
       transport.setEmitFlowEventOnSend(false);

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/handler/ProtonHandler.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/handler/ProtonHandler.java
@@ -141,6 +141,10 @@ public class ProtonHandler extends ProtonInitializable {
       }
    }
 
+   public void execute(Runnable runnable) {
+      flushExecutor.execute(runnable);
+   }
+
    public int capacity() {
       lock.lock();
       try {

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireProtocolManager.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireProtocolManager.java
@@ -132,6 +132,8 @@ public class OpenWireProtocolManager implements ProtocolManager<Interceptor>, Cl
 
    private final OpenWireFormat wireFormat;
 
+   private boolean active = false;
+
    private final Map<SimpleString, RoutingType> prefixes = new HashMap<>();
 
    private final Map<DestinationFilter, Integer> vtConsumerDestinationMatchers = new HashMap<>();
@@ -154,6 +156,21 @@ public class OpenWireProtocolManager implements ProtocolManager<Interceptor>, Cl
       if (cc != null) {
          cc.addClusterTopologyListener(this);
       }
+   }
+
+   @Override
+   public void start() {
+      active = true;
+   }
+
+   @Override
+   public void stop() {
+      active = false;
+   }
+
+   @Override
+   public boolean isActive() {
+      return active;
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/CoreProtocolManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/CoreProtocolManager.java
@@ -78,6 +78,8 @@ public class CoreProtocolManager implements ProtocolManager<Interceptor> {
 
    private final Map<SimpleString, RoutingType> prefixes = new HashMap<>();
 
+   boolean started;
+
    public CoreProtocolManager(final CoreProtocolManagerFactory factory,
                               final ActiveMQServer server,
                               final List<Interceptor> incomingInterceptors,
@@ -89,6 +91,21 @@ public class CoreProtocolManager implements ProtocolManager<Interceptor> {
       this.incomingInterceptors = incomingInterceptors;
 
       this.outgoingInterceptors = outgoingInterceptors;
+   }
+
+   @Override
+   public void start() {
+      started = true;
+   }
+
+   @Override
+   public void stop() {
+      started = false;
+   }
+
+   @Override
+   public boolean isActive() {
+      return started;
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/AbstractAcceptor.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/AbstractAcceptor.java
@@ -43,4 +43,27 @@ public abstract class AbstractAcceptor implements Acceptor {
       }
    }
 
+   /**
+    * To be called by acceptors implementation, so we can call protocolManager.start
+    * @throws Exception
+    */
+   @Override
+   public void start() throws Exception {
+      for (ProtocolManager protocol : protocolMap.values()) {
+         protocol.start();
+      }
+   }
+
+   /**
+    * To be called by acceptors implementation, so we can call protocolManager.stop
+    * @throws Exception
+    */
+   @Override
+   public void stop() throws Exception {
+      for (ProtocolManager protocol : protocolMap.values()) {
+         protocol.stop();
+      }
+   }
+
+
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMAcceptor.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMAcceptor.java
@@ -132,6 +132,8 @@ public final class InVMAcceptor extends AbstractAcceptor {
          return;
       }
 
+      super.start();
+
       InVMRegistry.instance.registerAcceptor(id, this);
 
       if (notificationService != null) {
@@ -148,7 +150,7 @@ public final class InVMAcceptor extends AbstractAcceptor {
    }
 
    @Override
-   public synchronized void stop() {
+   public synchronized void stop() throws Exception {
       if (!started) {
          return;
       }
@@ -178,6 +180,8 @@ public final class InVMAcceptor extends AbstractAcceptor {
       started = false;
 
       paused = false;
+
+      super.stop();
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptor.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptor.java
@@ -319,6 +319,8 @@ public class NettyAcceptor extends AbstractAcceptor {
          return;
       }
 
+      super.start();
+
       String acceptorType;
 
       if (useInvm) {
@@ -613,7 +615,7 @@ public class NettyAcceptor extends AbstractAcceptor {
    }
 
    @Override
-   public synchronized void stop() {
+   public synchronized void stop() throws Exception {
       if (channelClazz == null) {
          return;
       }
@@ -676,6 +678,7 @@ public class NettyAcceptor extends AbstractAcceptor {
          }
       }
 
+      super.stop();
       paused = false;
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/protocol/AbstractProtocolManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/protocol/AbstractProtocolManager.java
@@ -46,6 +46,23 @@ public abstract class AbstractProtocolManager<P, I extends BaseInterceptor<P>, C
       }
    }
 
+   volatile boolean started;
+
+   @Override
+   public void start() {
+      started = true;
+   }
+
+   @Override
+   public void stop() {
+      started = false;
+   }
+
+   @Override
+   public boolean isActive() {
+      return started;
+   }
+
    @Override
    public void setAnycastPrefix(String anycastPrefix) {
       for (String prefix : anycastPrefix.split(",")) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/protocol/ProtocolManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/protocol/ProtocolManager.java
@@ -74,4 +74,11 @@ public interface ProtocolManager<P extends BaseInterceptor> {
    void setMulticastPrefix(String multicastPrefix);
 
    Map<SimpleString, RoutingType> getPrefixes();
+
+
+   void start();
+
+   void stop();
+
+   boolean isActive();
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpSendReceiveTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpSendReceiveTest.java
@@ -89,7 +89,7 @@ public class AmqpSendReceiveTest extends AmqpClientTestSupport {
 
       Queue queue = getProxyToQueue(getQueueName());
       assertNotNull(queue);
-      assertEquals(0, queue.getMessageCount());
+      Wait.assertEquals(0, queue::getMessageCount);
    }
 
    @Test(timeout = 60000)
@@ -341,7 +341,7 @@ public class AmqpSendReceiveTest extends AmqpClientTestSupport {
 
       receiver2.close();
 
-      assertEquals(MSG_COUNT - 2, queueView.getMessageCount());
+      Wait.assertEquals(MSG_COUNT - 2, queueView::getMessageCount);
 
       connection.close();
    }


### PR DESCRIPTION
AMQP Processing happens at the Netty thread right now.
This is limiting processing of anything other than the current connection
as this requires locking of the queue.

This required us to add a semaphore to avoid extreme pressure from incoming netty into the server.