### PR TITLE
ARTEMIS-1754 LargeServerMessageImpl.toString() may leak files

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/LargeServerMessageImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/LargeServerMessageImpl.java
@@ -355,7 +355,7 @@ public final class LargeServerMessageImpl extends CoreMessage implements LargeSe
    @Override
    public String toString() {
       try {
-         return "LargeServerMessage[messageID=" + messageID + ",durable=" + isDurable() + ",userID=" + getUserID() + ",priority=" + this.getPriority() + ", timestamp=" + toDate(getTimestamp()) + ",expiration=" + toDate(getExpiration()) + ", durable=" + durable + ", address=" + getAddress() + ",size=" + getPersistentSize() + ",properties=" + (properties != null ? properties.toString() : "") + "]@" + System.identityHashCode(this);
+         return "LargeServerMessage[messageID=" + messageID + ",durable=" + isDurable() + ",userID=" + getUserID() + ",priority=" + this.getPriority() + ", timestamp=" + toDate(getTimestamp()) + ",expiration=" + toDate(getExpiration()) + ", durable=" + durable + ", address=" + getAddress() + ", properties=" + (properties != null ? properties.toString() : "") + "]@" + System.identityHashCode(this);
       } catch (Exception e) {
          e.printStackTrace();
          return "LargeServerMessage[messageID=" + messageID + "]";


### PR DESCRIPTION
This overridden method calls getPersistentSize() which may lead
to open the large file to get the size. Calling it alone will
cause the file being opened without closing it.