### PR TITLE
ARTEMIS-1762 JdbcNodeManager shouldn't be used if no HA is configured

### DIFF
--- a/artemis-server/src/test/resources/database-store-no-hapolicy-config.xml
+++ b/artemis-server/src/test/resources/database-store-no-hapolicy-config.xml
@@ -1,0 +1,33 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<configuration
+        xmlns="urn:activemq"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="urn:activemq ../../main/resources/schema/artemis-server.xsd">
+   <core xmlns="urn:activemq:core">
+      <store>
+         <database-store>
+            <jdbc-connection-url>jdbc:derby:target/derby/database-store;create=true</jdbc-connection-url>
+            <bindings-table-name>BINDINGS</bindings-table-name>
+            <message-table-name>MESSAGE</message-table-name>
+            <large-message-table-name>LARGE_MESSAGE</large-message-table-name>
+            <page-store-table-name>PAGE_STORE</page-store-table-name>
+            <jdbc-driver-class-name>org.apache.derby.jdbc.EmbeddedDriver</jdbc-driver-class-name>
+         </database-store>
+      </store>
+   </core>
+</configuration>


### PR DESCRIPTION
It forces to use InVMNodeManager when no HA option is selected with JDBC persistence and includes the checks that the only valid JDBC HA options are SHARED_STORE_MASTER and SHARED_STORE_SLAVE.