### PR TITLE
ARTEMIS-1749 - missing avariable in Windows Profile

### DIFF
--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile.cmd
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile.cmd
@@ -18,6 +18,7 @@ rem under the License.
 
 set ARTEMIS_HOME="${artemis.home}"
 set ARTEMIS_INSTANCE="${artemis.instance}"
+set ARTEMIS_ETC_INSTANCE='${artemis.instance.etc}'
 set ARTEMIS_DATA_DIR='${artemis.instance.data}'
 
 


### PR DESCRIPTION
An obvious fix is the missing definition of ARTEMIS_ETC_INSTANCE, in the Windows "artemis.profile.cmd"