### PR TITLE
ARTEMIS-1781 Connector parameters not backward compatible

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/TransportConstantsV2.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/TransportConstantsV2.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.remoting.impl.netty;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * String constants from V2 of the protocol.
+ */
+public class TransportConstantsV2 {
+
+   public static final String SSL_ENABLED_PROP_NAME = "ssl-enabled";
+
+   public static final String HTTP_ENABLED_PROP_NAME = "http-enabled";
+
+   public static final String HTTP_CLIENT_IDLE_PROP_NAME = "http-client-idle-time";
+
+   public static final String HTTP_CLIENT_IDLE_SCAN_PERIOD = "http-client-idle-scan-period";
+
+   public static final String HTTP_RESPONSE_TIME_PROP_NAME = "http-response-time";
+
+   public static final String HTTP_SERVER_SCAN_PERIOD_PROP_NAME = "http-server-scan-period";
+
+   public static final String HTTP_REQUIRES_SESSION_ID = "http-requires-session-id";
+
+   public static final String USE_SERVLET_PROP_NAME = "use-servlet";
+
+   public static final String SERVLET_PATH = "servlet-path";
+
+   public static final String USE_NIO_PROP_NAME = "use-nio";
+
+   public static final String USE_NIO_GLOBAL_WORKER_POOL_PROP_NAME = "use-nio-global-worker-pool";
+
+   public static final String USE_INVM_PROP_NAME = "use-invm";
+
+   public static final String PROTOCOL_PROP_NAME = "protocol";
+
+   public static final String HOST_PROP_NAME = "host";
+
+   public static final String PORT_PROP_NAME = "port";
+
+   public static final String LOCAL_ADDRESS_PROP_NAME = "local-address";
+
+   public static final String LOCAL_PORT_PROP_NAME = "local-port";
+
+   public static final String KEYSTORE_PROVIDER_PROP_NAME = "key-store-provider";
+
+   public static final String KEYSTORE_PATH_PROP_NAME = "key-store-path";
+
+   public static final String KEYSTORE_PASSWORD_PROP_NAME = "key-store-password";
+
+   public static final String TRUSTSTORE_PROVIDER_PROP_NAME = "trust-store-provider";
+
+   public static final String TRUSTSTORE_PATH_PROP_NAME = "trust-store-path";
+
+   public static final String TRUSTSTORE_PASSWORD_PROP_NAME = "trust-store-password";
+
+   public static final String NEED_CLIENT_AUTH_PROP_NAME = "need-client-auth";
+
+   public static final String BACKLOG_PROP_NAME = "backlog";
+
+   public static final String TCP_NODELAY_PROPNAME = "tcp-no-delay";
+
+   public static final String TCP_SENDBUFFER_SIZE_PROPNAME = "tcp-send-buffer-size";
+
+   public static final String TCP_RECEIVEBUFFER_SIZE_PROPNAME = "tcp-receive-buffer-size";
+
+   public static final String NIO_REMOTING_THREADS_PROPNAME = "nio-remoting-threads";
+
+   public static final String BATCH_DELAY = "batch-delay";
+
+   public static final String DIRECT_DELIVER = "direct-deliver";
+
+   public static final String CLUSTER_CONNECTION = "cluster-connection";
+
+   public static final String STOMP_CONSUMERS_CREDIT = "stomp-consumer-credits";
+
+   public static final Map<String, String> V3_TO_V2_MAP = new HashMap<>();
+
+   static {
+      V3_TO_V2_MAP.put(TransportConstants.SSL_ENABLED_PROP_NAME, SSL_ENABLED_PROP_NAME);
+      V3_TO_V2_MAP.put(TransportConstants.HTTP_ENABLED_PROP_NAME, HTTP_ENABLED_PROP_NAME);
+      V3_TO_V2_MAP.put(TransportConstants.HTTP_CLIENT_IDLE_PROP_NAME, HTTP_CLIENT_IDLE_PROP_NAME);
+      V3_TO_V2_MAP.put(TransportConstants.HTTP_CLIENT_IDLE_SCAN_PERIOD, HTTP_CLIENT_IDLE_SCAN_PERIOD);
+      V3_TO_V2_MAP.put(TransportConstants.HTTP_RESPONSE_TIME_PROP_NAME, HTTP_RESPONSE_TIME_PROP_NAME);
+      V3_TO_V2_MAP.put(TransportConstants.HTTP_SERVER_SCAN_PERIOD_PROP_NAME, HTTP_SERVER_SCAN_PERIOD_PROP_NAME);
+      V3_TO_V2_MAP.put(TransportConstants.HTTP_REQUIRES_SESSION_ID, HTTP_REQUIRES_SESSION_ID);
+      V3_TO_V2_MAP.put(TransportConstants.USE_SERVLET_PROP_NAME, USE_SERVLET_PROP_NAME);
+      V3_TO_V2_MAP.put(TransportConstants.SERVLET_PATH, SERVLET_PATH);
+      V3_TO_V2_MAP.put(TransportConstants.USE_NIO_PROP_NAME, USE_NIO_PROP_NAME);
+      V3_TO_V2_MAP.put(TransportConstants.USE_NIO_GLOBAL_WORKER_POOL_PROP_NAME, USE_NIO_GLOBAL_WORKER_POOL_PROP_NAME);
+      V3_TO_V2_MAP.put(TransportConstants.USE_INVM_PROP_NAME, USE_INVM_PROP_NAME);
+      V3_TO_V2_MAP.put(TransportConstants.PROTOCOL_PROP_NAME, PROTOCOL_PROP_NAME);
+      V3_TO_V2_MAP.put(TransportConstants.HOST_PROP_NAME, HOST_PROP_NAME);
+      V3_TO_V2_MAP.put(TransportConstants.PORT_PROP_NAME, PORT_PROP_NAME);
+      V3_TO_V2_MAP.put(TransportConstants.LOCAL_ADDRESS_PROP_NAME, LOCAL_ADDRESS_PROP_NAME);
+      V3_TO_V2_MAP.put(TransportConstants.LOCAL_PORT_PROP_NAME, LOCAL_PORT_PROP_NAME);
+      V3_TO_V2_MAP.put(TransportConstants.KEYSTORE_PROVIDER_PROP_NAME, KEYSTORE_PROVIDER_PROP_NAME);
+      V3_TO_V2_MAP.put(TransportConstants.KEYSTORE_PATH_PROP_NAME, KEYSTORE_PATH_PROP_NAME);
+      V3_TO_V2_MAP.put(TransportConstants.KEYSTORE_PASSWORD_PROP_NAME, KEYSTORE_PASSWORD_PROP_NAME);
+      V3_TO_V2_MAP.put(TransportConstants.TRUSTSTORE_PROVIDER_PROP_NAME, TRUSTSTORE_PROVIDER_PROP_NAME);
+      V3_TO_V2_MAP.put(TransportConstants.TRUSTSTORE_PATH_PROP_NAME, TRUSTSTORE_PATH_PROP_NAME);
+      V3_TO_V2_MAP.put(TransportConstants.TRUSTSTORE_PASSWORD_PROP_NAME, TRUSTSTORE_PASSWORD_PROP_NAME);
+      V3_TO_V2_MAP.put(TransportConstants.NEED_CLIENT_AUTH_PROP_NAME, NEED_CLIENT_AUTH_PROP_NAME);
+      V3_TO_V2_MAP.put(TransportConstants.BACKLOG_PROP_NAME, BACKLOG_PROP_NAME);
+      V3_TO_V2_MAP.put(TransportConstants.TCP_NODELAY_PROPNAME, TCP_NODELAY_PROPNAME);
+      V3_TO_V2_MAP.put(TransportConstants.TCP_SENDBUFFER_SIZE_PROPNAME, TCP_SENDBUFFER_SIZE_PROPNAME);
+      V3_TO_V2_MAP.put(TransportConstants.TCP_RECEIVEBUFFER_SIZE_PROPNAME, TCP_RECEIVEBUFFER_SIZE_PROPNAME);
+      V3_TO_V2_MAP.put(TransportConstants.NIO_REMOTING_THREADS_PROPNAME, NIO_REMOTING_THREADS_PROPNAME);
+      V3_TO_V2_MAP.put(TransportConstants.BATCH_DELAY, BATCH_DELAY);
+      V3_TO_V2_MAP.put(TransportConstants.DIRECT_DELIVER, DIRECT_DELIVER);
+      V3_TO_V2_MAP.put(TransportConstants.CLUSTER_CONNECTION, CLUSTER_CONNECTION);
+      V3_TO_V2_MAP.put(TransportConstants.STOMP_CONSUMERS_CREDIT, STOMP_CONSUMERS_CREDIT);
+   }
+
+   /**
+    * Translates V3 strings to V2 strings.
+    * <p>
+    * Returns the string as if it's not found in the conversion map.
+    */
+   public static String fromV3(String name) {
+      if (V3_TO_V2_MAP.containsKey(name)) {
+         return V3_TO_V2_MAP.get(name);
+      }
+      return name;
+   }
+
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -1174,10 +1174,10 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
       if (mainConfig.isMaskPassword() != null) {
          params.put(ActiveMQDefaultConfiguration.getPropMaskPassword(), mainConfig.isMaskPassword());
-      }
 
-      if (mainConfig.getPasswordCodec() != null) {
-         params.put(ActiveMQDefaultConfiguration.getPropPasswordCodec(), mainConfig.getPasswordCodec());
+         if (mainConfig.isMaskPassword() && mainConfig.getPasswordCodec() != null) {
+            params.put(ActiveMQDefaultConfiguration.getPropPasswordCodec(), mainConfig.getPasswordCodec());
+         }
       }
 
       return configurations.get(0);
@@ -1197,10 +1197,10 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
       if (mainConfig.isMaskPassword() != null) {
          params.put(ActiveMQDefaultConfiguration.getPropMaskPassword(), mainConfig.isMaskPassword());
-      }
 
-      if (mainConfig.getPasswordCodec() != null) {
-         params.put(ActiveMQDefaultConfiguration.getPropPasswordCodec(), mainConfig.getPasswordCodec());
+         if (mainConfig.isMaskPassword() && mainConfig.getPasswordCodec() != null) {
+            params.put(ActiveMQDefaultConfiguration.getPropPasswordCodec(), mainConfig.getPasswordCodec());
+         }
       }
 
       return configurations.get(0);

--- a/tests/compatibility-tests/src/main/resources/hqclienttopologytest/artemisClient.groovy
+++ b/tests/compatibility-tests/src/main/resources/hqclienttopologytest/artemisClient.groovy
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package hqclienttopologytest
+
+import org.apache.activemq.artemis.api.core.TransportConfiguration
+import org.apache.activemq.artemis.api.core.client.ClusterTopologyListener
+import org.apache.activemq.artemis.api.core.client.TopologyMember
+import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory
+import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory
+
+import java.util.concurrent.CountDownLatch
+
+/*
+ * Creates Artemis connection factory
+ */
+
+Map<String, Object> params = new HashMap<String, Object>();
+params.put(TransportConstants.HOST_PROP_NAME, "localhost");
+params.put(TransportConstants.PORT_PROP_NAME, 61616);
+TransportConfiguration tc = new TransportConfiguration(NettyConnectorFactory.class.getName(), params);
+
+cf = new ActiveMQConnectionFactory(true, tc);
+latch = new CountDownLatch(1);
+transportParams = new HashMap<String, Object>();
+
+cf.getServerLocator().addClusterTopologyListener(new ClusterTopologyListener() {
+    @Override
+    void nodeUP(TopologyMember topologyMember, boolean last) {
+        println("Node up: " + topologyMember.getNodeId() + " " + topologyMember.getLive().getParams().toString());
+        transportParams.putAll(topologyMember.getLive().getParams());
+        latch.countDown();
+    }
+
+    @Override
+    void nodeDown(long eventUID, String nodeID) {
+    }
+})

--- a/tests/compatibility-tests/src/main/resources/hqclienttopologytest/artemisServer.groovy
+++ b/tests/compatibility-tests/src/main/resources/hqclienttopologytest/artemisServer.groovy
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package hqclienttopologytest
+
+import org.apache.activemq.artemis.core.config.ClusterConnectionConfiguration
+import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl
+import org.apache.activemq.artemis.core.server.JournalType
+import org.apache.activemq.artemis.jms.server.config.impl.JMSConfigurationImpl
+import org.apache.activemq.artemis.jms.server.embedded.EmbeddedJMS
+
+String folder = arg[0];
+
+configuration = new ConfigurationImpl();
+configuration.setJournalType(JournalType.NIO);
+println("folder:: " + folder);
+configuration.setBrokerInstance(new File(folder));
+configuration.addAcceptorConfiguration("artemis", "tcp://0.0.0.0:61616?anycastPrefix=jms.queue.&multicastPrefix=jms.topic.");
+configuration.addConnectorConfiguration("live", "tcp://127.0.0.1:61616?useNio=true;sslEnabled=false")
+configuration.setSecurityEnabled(false);
+configuration.setPersistenceEnabled(false);
+
+
+def cluster = new ClusterConnectionConfiguration();
+cluster.setName("my-cluster");
+cluster.setConnectorName("live");
+configuration.addClusterConfiguration(cluster);
+
+jmsConfiguration = new JMSConfigurationImpl();
+
+server = new EmbeddedJMS();
+server.setConfiguration(configuration);
+server.setJmsConfiguration(jmsConfiguration);
+server.start();

--- a/tests/compatibility-tests/src/main/resources/hqclienttopologytest/hornetqClient.groovy
+++ b/tests/compatibility-tests/src/main/resources/hqclienttopologytest/hornetqClient.groovy
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package hqclienttopologytest
+
+import org.hornetq.api.core.TransportConfiguration;
+import org.hornetq.api.core.client.ClusterTopologyListener;
+import org.hornetq.api.core.client.HornetQClient;
+import org.hornetq.api.core.client.ServerLocator;
+import org.hornetq.api.core.client.TopologyMember;
+import org.hornetq.core.remoting.impl.netty.NettyConnectorFactory;
+import org.hornetq.core.remoting.impl.netty.TransportConstants;
+import org.hornetq.jms.client.HornetQJMSConnectionFactory;
+
+import java.util.concurrent.CountDownLatch
+
+/*
+ * Creates HornetQ connection factory
+ */
+
+
+Map<String, Object> params = new HashMap<String, Object>();
+params.put(TransportConstants.HOST_PROP_NAME, "localhost");
+params.put(TransportConstants.PORT_PROP_NAME, 61616);
+def tc = new TransportConfiguration(NettyConnectorFactory.class.getName(), params);
+
+latch = new CountDownLatch(1);
+transportParams = new HashMap<String, Object>();
+
+ServerLocator locator = HornetQClient.createServerLocatorWithHA(tc);
+locator.addClusterTopologyListener(new ClusterTopologyListener() {
+    public void nodeUP(TopologyMember topologyMember, boolean b) {
+        println("Node up: " + topologyMember.getNodeId() + " " + topologyMember.getLive().getParams().toString());
+        transportParams.putAll(topologyMember.getLive().getParams());
+        latch.countDown();
+    }
+
+    public void nodeDown(long l, String s) {
+    }
+});
+
+cf = new HornetQJMSConnectionFactory(locator);

--- a/tests/compatibility-tests/src/main/resources/hqclienttopologytest/verifyTopologyChangeMessage.groovy
+++ b/tests/compatibility-tests/src/main/resources/hqclienttopologytest/verifyTopologyChangeMessage.groovy
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package hqclienttopologytest
+
+import org.apache.activemq.artemis.tests.compatibility.GroovyRun
+
+import javax.jms.Connection;
+import javax.jms.Session;
+import java.util.concurrent.TimeUnit;
+
+/*
+ * Opens JMS connection and verifies that transport config with correct parameters is received from the server.
+ */
+
+
+// starts an artemis server
+String serverType = arg[0];
+String clientType = arg[1];
+
+if (clientType.startsWith("ARTEMIS")) {
+    // Can't depend directly on artemis, otherwise it wouldn't compile in hornetq
+    GroovyRun.evaluate("hqclienttopologytest/artemisClient.groovy", "serverArg", serverType);
+} else {
+    // Can't depend directly on hornetq, otherwise it wouldn't compile in artemis
+    GroovyRun.evaluate("hqclienttopologytest/hornetqClient.groovy");
+}
+
+
+Connection connection = cf.createConnection();
+Session session = connection.createSession(true, Session.SESSION_TRANSACTED);
+
+try {
+    latch.await(5, TimeUnit.SECONDS);
+    System.out.println("Count is " + latch.getCount());
+    System.out.println("Retrieved transport params: " + transportParams);
+
+    // cluster topology message should arrive immediately after connecting
+    GroovyRun.assertEquals(0, (int) latch.getCount());
+
+    if (clientType.startsWith("ARTEMIS")) {
+        // Artemis client - obtained params should be camelCase
+        GroovyRun.assertFalse(transportParams.containsKey("ssl-enabled"));
+        GroovyRun.assertTrue(transportParams.containsKey("sslEnabled"));
+    } else {
+        // HornetQ client - obtained params should be dash-delimited
+        GroovyRun.assertTrue(transportParams.containsKey("ssl-enabled"));
+        GroovyRun.assertFalse(transportParams.containsKey("sslEnabled"));
+    }
+
+    // parameter activemq.passwordcodec should not be present
+    GroovyRun.assertFalse(transportParams.containsKey("activemq.passwordcodec"));
+} finally {
+    session.close();
+    connection.close();
+}

--- a/tests/compatibility-tests/src/test/java/org/apache/activemq/artemis/tests/compatibility/HQClientTopologyTest.java
+++ b/tests/compatibility-tests/src/test/java/org/apache/activemq/artemis/tests/compatibility/HQClientTopologyTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.tests.compatibility;
+
+import org.apache.activemq.artemis.utils.FileUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.apache.activemq.artemis.tests.compatibility.GroovyRun.HORNETQ_235;
+import static org.apache.activemq.artemis.tests.compatibility.GroovyRun.ONE_FIVE;
+import static org.apache.activemq.artemis.tests.compatibility.GroovyRun.SNAPSHOT;
+
+/**
+ * Runs Artemis server with HornetQ client and verifies that the client receives
+ * correct connector parameters (keys must be dash-delimited instead of camelCase).
+ */
+@RunWith(Parameterized.class)
+public class HQClientTopologyTest extends VersionedBaseTest {
+
+   @Parameterized.Parameters(name = "server={0}, producer={1}, consumer={2}")
+   public static Collection getParameters() {
+      List<Object[]> combinations = new ArrayList<>();
+
+      combinations.add(new Object[]{SNAPSHOT, HORNETQ_235, HORNETQ_235});
+      combinations.add(new Object[]{SNAPSHOT, ONE_FIVE, ONE_FIVE});
+      return combinations;
+   }
+
+   public HQClientTopologyTest(String server, String sender, String receiver) throws Exception {
+      super(server, sender, receiver);
+   }
+
+   @Before
+   public void setUp() throws Throwable {
+      FileUtil.deleteDirectory(serverFolder.getRoot());
+      evaluate(serverClassloader, "hqclienttopologytest/artemisServer.groovy", serverFolder.getRoot().getAbsolutePath());
+   }
+
+   @After
+   public void tearDown() throws Throwable {
+      execute(serverClassloader, "server.stop();");
+   }
+
+   @Test
+   public void topologyChangeMessageTest() throws Throwable {
+      evaluate(senderClassloader, "hqclienttopologytest/verifyTopologyChangeMessage.groovy", server, sender);
+   }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARTEMIS-1781
https://issues.jboss.org/browse/ENTMQBR-1034

Fixing backward compatibility with HornetQ:
* Translate transport parameters to dash notation instead of camel-case when talking to legacy clients.
* Do not add passwordCodec parameter unless maskPassword is true.