### PR TITLE
ARTEMIS-1772 Reduce memory footprint and allocations of QueueImpl

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/collections/LinkedListImpl.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/collections/LinkedListImpl.java
@@ -30,7 +30,7 @@ public class LinkedListImpl<E> implements LinkedList<E> {
 
    private static final int INITIAL_ITERATOR_ARRAY_SIZE = 10;
 
-   private final Node<E> head = new Node<>(null);
+   private final Node<E> head = new NodeHolder<>(null);
 
    private Node<E> tail = null;
 
@@ -91,7 +91,7 @@ public class LinkedListImpl<E> implements LinkedList<E> {
       if (ret != null) {
          removeAfter(head);
 
-         return ret.val;
+         return ret.val();
       } else {
          return null;
       }
@@ -218,29 +218,37 @@ public class LinkedListImpl<E> implements LinkedList<E> {
       throw new IllegalStateException("Cannot find iter to remove");
    }
 
+   private static final class NodeHolder<T> extends Node<T> {
+
+      private final T val;
+
+      //only the head is allowed to hold a null
+      private NodeHolder(T e) {
+         val = e;
+      }
+
+      @Override
+      protected T val() {
+         return val;
+      }
+   }
+
    public static class Node<T> {
 
       private Node<T> next;
 
       private Node<T> prev;
 
-      private final T val;
-
       private int iterCount;
 
       @SuppressWarnings("unchecked")
-      protected Node() {
-         val = (T)this;
-      }
-
-      //only the head is allowed to hold a null
-      private Node(T e) {
-         val = e;
+      protected T val() {
+         return (T) this;
       }
 
       @Override
       public String toString() {
-         return val == this ? "Intrusive Node" : "Node, value = " + val;
+         return val() == this ? "Intrusive Node" : "Node, value = " + val();
       }
 
       private static <T> Node<T> with(final T o) {
@@ -254,7 +262,7 @@ public class LinkedListImpl<E> implements LinkedList<E> {
                return node;
             }
          }
-         return new Node(o);
+         return new NodeHolder<>(o);
       }
    }
 
@@ -298,14 +306,14 @@ public class LinkedListImpl<E> implements LinkedList<E> {
             repeat = false;
 
             if (e != null) {
-               return e.val;
+               return e.val();
             } else {
                if (canAdvance()) {
                   advance();
 
                   e = getNode();
 
-                  return e.val;
+                  return e.val();
                } else {
                   throw new NoSuchElementException();
                }
@@ -326,7 +334,7 @@ public class LinkedListImpl<E> implements LinkedList<E> {
 
          repeat = false;
 
-         return e.val;
+         return e.val();
       }
 
       @Override

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
@@ -1269,11 +1269,9 @@ public class OpenWireConnection extends AbstractRemotingConnection implements Se
             for (ListIterator<MessageReference> referenceIterator = ackRefs.listIterator(ackRefs.size()); referenceIterator.hasPrevious(); ) {
                MessageReference ref = referenceIterator.previous();
 
-               Long consumerID = ref.getConsumerId();
-
                ServerConsumer consumer = null;
-               if (consumerID != null) {
-                  consumer = session.getCoreSession().locateConsumer(consumerID);
+               if (ref.hasConsumerId()) {
+                  consumer = session.getCoreSession().locateConsumer(ref.getConsumerId());
                }
 
                if (consumer != null) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/MessageReference.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/MessageReference.java
@@ -91,9 +91,13 @@ public interface MessageReference {
 
    void acknowledge(Transaction tx, AckReason reason) throws Exception;
 
-   void setConsumerId(Long consumerID);
+   void emptyConsumerID();
 
-   Long getConsumerId();
+   void setConsumerId(long consumerID);
+
+   boolean hasConsumerId();
+
+   long getConsumerId();
 
    void handled();
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/LastValueQueue.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/LastValueQueue.java
@@ -175,7 +175,9 @@ public class LastValueQueue extends QueueImpl {
 
       private volatile MessageReference ref;
 
-      private Long consumerId;
+      private long consumerID;
+
+      private boolean hasConsumerID = false;
 
       HolderReference(final SimpleString prop, final MessageReference ref) {
          this.prop = prop;
@@ -309,20 +311,28 @@ public class LastValueQueue extends QueueImpl {
          return ref.getMessage().getMemoryEstimate();
       }
 
-      /* (non-Javadoc)
-       * @see org.apache.activemq.artemis.core.server.MessageReference#setConsumerId(java.lang.Long)
-       */
       @Override
-      public void setConsumerId(Long consumerID) {
-         this.consumerId = consumerID;
+      public void emptyConsumerID() {
+         this.hasConsumerID = false;
       }
 
-      /* (non-Javadoc)
-       * @see org.apache.activemq.artemis.core.server.MessageReference#getConsumerId()
-       */
       @Override
-      public Long getConsumerId() {
-         return this.consumerId;
+      public void setConsumerId(long consumerID) {
+         this.hasConsumerID = true;
+         this.consumerID = consumerID;
+      }
+
+      @Override
+      public boolean hasConsumerId() {
+         return hasConsumerID;
+      }
+
+      @Override
+      public long getConsumerId() {
+         if (!this.hasConsumerID) {
+            throw new IllegalStateException("consumerID isn't specified: please check hasConsumerId first");
+         }
+         return this.consumerID;
       }
 
       @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/RefsOperation.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/RefsOperation.java
@@ -81,7 +81,7 @@ public class RefsOperation extends TransactionOperationAbstract {
       List<MessageReference> ackedRefs = new ArrayList<>();
 
       for (MessageReference ref : refsToAck) {
-         ref.setConsumerId(null);
+         ref.emptyConsumerID();
 
          if (logger.isTraceEnabled()) {
             logger.trace("rolling back " + ref);
@@ -189,7 +189,7 @@ public class RefsOperation extends TransactionOperationAbstract {
    public synchronized List<MessageReference> getListOnConsumer(long consumerID) {
       List<MessageReference> list = new LinkedList<>();
       for (MessageReference ref : refsToAck) {
-         if (ref.getConsumerId() != null && ref.getConsumerId().equals(consumerID)) {
+         if (ref.hasConsumerId() && ref.getConsumerId() == consumerID) {
             list.add(ref);
          }
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/plugin/impl/LoggingActiveMQServerPlugin.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/plugin/impl/LoggingActiveMQServerPlugin.java
@@ -629,7 +629,7 @@ public class LoggingActiveMQServerPlugin implements ActiveMQServerPlugin, Serial
 
             // info level logging
             LoggingActiveMQServerPluginLogger.LOGGER.messageAcknowledged((message == null ? UNAVAILABLE : Long.toString(message.getMessageID())),
-                                                                         (ref == null ? UNAVAILABLE : Long.toString(ref.getConsumerId())),
+                                                                         (ref == null ? UNAVAILABLE : ref.hasConsumerId() ? Long.toString(ref.getConsumerId()) : null),
                                                                          (queue == null ? UNAVAILABLE : queue.getName().toString()),
                                                                          reason);
          }


### PR DESCRIPTION
It includes:
- Message References: no longer uses boxed primitives and AtomicInteger
- Node: intrusive nodes no longer need a reference field holding itself
- RefCountMessage: no longer uses AtomicInteger, but AtomicIntegerFieldUpdater