### PR TITLE
ARTEMIS-1788 JDBC HA should use JDBC Network Timeout

### DIFF
--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/drivers/AbstractJDBCDriver.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/drivers/AbstractJDBCDriver.java
@@ -141,6 +141,9 @@ public abstract class AbstractJDBCDriver {
                throw e;
             }
          }
+         if (this.networkTimeoutMillis >= 0 && this.networkTimeoutExecutor == null) {
+            logger.warn("Unable to set a network timeout on the JDBC connection: networkTimeoutExecutor is null");
+         }
          if (this.networkTimeoutMillis >= 0 && this.networkTimeoutExecutor != null) {
             try {
                connection.setNetworkTimeout(this.networkTimeoutExecutor, this.networkTimeoutMillis);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/jdbc/JdbcSharedStateManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/jdbc/JdbcSharedStateManager.java
@@ -24,6 +24,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
+import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 
 import org.apache.activemq.artemis.jdbc.store.drivers.AbstractJDBCDriver;
@@ -52,11 +53,14 @@ final class JdbcSharedStateManager extends AbstractJDBCDriver implements SharedS
    private long timeDifferenceMillisFromDb = 0;
 
    public static JdbcSharedStateManager usingDataSource(String holderId,
+                                                        int networkTimeout,
+                                                        Executor networkTimeoutExecutor,
                                                         long locksExpirationMillis,
                                                         long maxAllowedMillisFromDbTime,
                                                         DataSource dataSource,
                                                         SQLProvider provider) {
       final JdbcSharedStateManager sharedStateManager = new JdbcSharedStateManager(holderId, locksExpirationMillis, maxAllowedMillisFromDbTime);
+      sharedStateManager.setNetworkTimeout(networkTimeoutExecutor, networkTimeout);
       sharedStateManager.setDataSource(dataSource);
       sharedStateManager.setSqlProvider(provider);
       try {
@@ -73,7 +77,26 @@ final class JdbcSharedStateManager extends AbstractJDBCDriver implements SharedS
                                                            String jdbcConnectionUrl,
                                                            String jdbcDriverClass,
                                                            SQLProvider provider) {
+      return JdbcSharedStateManager.usingConnectionUrl(holderId,
+                                                       -1,
+                                                       null,
+                                                       locksExpirationMillis,
+                                                       maxAllowedMillisFromDbTime,
+                                                       jdbcConnectionUrl,
+                                                       jdbcDriverClass,
+                                                       provider);
+   }
+
+   public static JdbcSharedStateManager usingConnectionUrl(String holderId,
+                                                           int networkTimeout,
+                                                           Executor networkTimeoutExecutor,
+                                                           long locksExpirationMillis,
+                                                           long maxAllowedMillisFromDbTime,
+                                                           String jdbcConnectionUrl,
+                                                           String jdbcDriverClass,
+                                                           SQLProvider provider) {
       final JdbcSharedStateManager sharedStateManager = new JdbcSharedStateManager(holderId, locksExpirationMillis, maxAllowedMillisFromDbTime);
+      sharedStateManager.setNetworkTimeout(networkTimeoutExecutor, networkTimeout);
       sharedStateManager.setJdbcConnectionUrl(jdbcConnectionUrl);
       sharedStateManager.setJdbcDriverClass(jdbcDriverClass);
       sharedStateManager.setSqlProvider(provider);

--- a/docs/user-manual/en/persistence.md
+++ b/docs/user-manual/en/persistence.md
@@ -456,6 +456,7 @@ To configure Apache ActiveMQ Artemis to use a database for persisting messages a
 
     The JDBC network connection timeout in milliseconds. The default value
     is 20000 milliseconds (ie 20 seconds).
+    When using a shared store it is recommended to set it less then or equal to `jdbc-lock-expiration`.
     
 -   `jdbc-lock-renew-period`
 


### PR DESCRIPTION
JdbcNodeManager is configured to use the same network timeout
value of the journal and to validate all the timeout values
related to a correct HA behaviour.