### PR TITLE
ARTEMIS-1797 Auto-create-address flag shouldn't block temp destination creation

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -2745,7 +2745,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
 
       RoutingType routingType = addrInfo == null ? null : addrInfo.getRoutingType();
       RoutingType rt = (routingType == null ? ActiveMQDefaultConfiguration.getDefaultRoutingType() : routingType);
-      if (autoCreateAddress) {
+      if (autoCreateAddress || temporary) {
          if (info == null) {
             final AddressInfo addressInfo = new AddressInfo(addressToUse, rt);
             addressInfo.setAutoCreated(true);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpTempDestinationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpTempDestinationTest.java
@@ -17,10 +17,7 @@
 package org.apache.activemq.artemis.tests.integration.amqp;
 
 import static org.apache.activemq.transport.amqp.AmqpSupport.LIFETIME_POLICY;
-import static org.apache.activemq.transport.amqp.AmqpSupport.TEMP_QUEUE_CAPABILITY;
-import static org.apache.activemq.transport.amqp.AmqpSupport.TEMP_TOPIC_CAPABILITY;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -281,49 +278,5 @@ public class AmqpTempDestinationTest extends AmqpClientTestSupport {
       receiver.close();
 
       connection.close();
-   }
-
-   protected Source createDynamicSource(boolean topic) {
-
-      Source source = new Source();
-      source.setDynamic(true);
-      source.setDurable(TerminusDurability.NONE);
-      source.setExpiryPolicy(TerminusExpiryPolicy.LINK_DETACH);
-
-      // Set the dynamic node lifetime-policy
-      Map<Symbol, Object> dynamicNodeProperties = new HashMap<>();
-      dynamicNodeProperties.put(LIFETIME_POLICY, DeleteOnClose.getInstance());
-      source.setDynamicNodeProperties(dynamicNodeProperties);
-
-      // Set the capability to indicate the node type being created
-      if (!topic) {
-         source.setCapabilities(TEMP_QUEUE_CAPABILITY);
-      } else {
-         source.setCapabilities(TEMP_TOPIC_CAPABILITY);
-      }
-
-      return source;
-   }
-
-   protected Target createDynamicTarget(boolean topic) {
-
-      Target target = new Target();
-      target.setDynamic(true);
-      target.setDurable(TerminusDurability.NONE);
-      target.setExpiryPolicy(TerminusExpiryPolicy.LINK_DETACH);
-
-      // Set the dynamic node lifetime-policy
-      Map<Symbol, Object> dynamicNodeProperties = new HashMap<>();
-      dynamicNodeProperties.put(LIFETIME_POLICY, DeleteOnClose.getInstance());
-      target.setDynamicNodeProperties(dynamicNodeProperties);
-
-      // Set the capability to indicate the node type being created
-      if (!topic) {
-         target.setCapabilities(TEMP_QUEUE_CAPABILITY);
-      } else {
-         target.setCapabilities(TEMP_TOPIC_CAPABILITY);
-      }
-
-      return target;
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpTempDestinationTest2.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpTempDestinationTest2.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.amqp;
+
+public class AmqpTempDestinationTest2 extends AmqpTempDestinationTest {
+
+   @Override
+   protected boolean isAutoCreateAddresses() {
+      return false;
+   }
+}


### PR DESCRIPTION


When creating a temp destination and auto-create-address set to false, the
broker throws an error and refuse to create it. This doesn't conform to
normal use-case (like amqp dynamic flag) where the temp destination should
be allowed even if the auto-create-address is false.