### PR TITLE
ARTEMIS-1800 - fix duplicate metrics update on scheduled message cancel

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ScheduledDeliveryHandler.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ScheduledDeliveryHandler.java
@@ -37,5 +37,7 @@ public interface ScheduledDeliveryHandler {
 
    List<MessageReference> cancel(Filter filter) throws ActiveMQException;
 
+   List<MessageReference> cancel(Filter filter, boolean updateMetrics) throws ActiveMQException;
+
    MessageReference removeReferenceWithID(long id) throws ActiveMQException;
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
@@ -1544,7 +1544,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
             txCount = 0;
          }
 
-         List<MessageReference> cancelled = scheduledDeliveryHandler.cancel(filter1);
+         List<MessageReference> cancelled = scheduledDeliveryHandler.cancel(filter1, false);
          for (MessageReference messageReference : cancelled) {
             messageAction.actMessage(tx, messageReference);
             count++;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ScheduledDeliveryHandlerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ScheduledDeliveryHandlerImpl.java
@@ -115,8 +115,9 @@ public class ScheduledDeliveryHandlerImpl implements ScheduledDeliveryHandler {
       return refs;
    }
 
+
    @Override
-   public List<MessageReference> cancel(final Filter filter) throws ActiveMQException {
+   public List<MessageReference> cancel(Filter filter, boolean updateMetrics) throws ActiveMQException {
       List<MessageReference> refs = new ArrayList<>();
 
       synchronized (scheduledReferences) {
@@ -127,11 +128,18 @@ public class ScheduledDeliveryHandlerImpl implements ScheduledDeliveryHandler {
             if (filter == null || filter.match(ref.getMessage())) {
                iter.remove();
                refs.add(ref);
-               metrics.decrementMetrics(ref);
+               if (updateMetrics) {
+                  metrics.decrementMetrics(ref);
+               }
             }
          }
       }
       return refs;
+   }
+
+   @Override
+   public List<MessageReference> cancel(final Filter filter) throws ActiveMQException {
+      return cancel(filter, true);
    }
 
    @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlTest.java
@@ -2510,6 +2510,29 @@ public class QueueControlTest extends ManagementTestBase {
       Assert.assertEquals(new String(body), "theBody");
    }
 
+   @Test
+   public void testGetScheduledCountOnRemove() throws Exception {
+      long delay = Integer.MAX_VALUE;
+      SimpleString address = RandomUtil.randomSimpleString();
+      SimpleString queue = RandomUtil.randomSimpleString();
+
+      session.createQueue(address, RoutingType.MULTICAST, queue, null, durable);
+
+      QueueControl queueControl = createManagementControl(address, queue);
+      Assert.assertEquals(0, queueControl.getScheduledCount());
+
+      ClientProducer producer = session.createProducer(address);
+      ClientMessage message = session.createMessage(durable);
+      message.putLongProperty(Message.HDR_SCHEDULED_DELIVERY_TIME, System.currentTimeMillis() + delay);
+      producer.send(message);
+
+      queueControl.removeAllMessages();
+
+      Assert.assertEquals(0, queueControl.getMessageCount());
+
+      session.deleteQueue(queue);
+   }
+
    // Package protected ---------------------------------------------
 
    // Protected -----------------------------------------------------


### PR DESCRIPTION
When removing scheduled messages from a queue the scheduled message
metrics were being decremented twice