### PR TITLE
ARTEMIS-1801 removing null-unchecked dereferences

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/ActiveMQExceptionType.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/ActiveMQExceptionType.java
@@ -243,6 +243,10 @@ public enum ActiveMQExceptionType {
       public ActiveMQException createException(String msg) {
          return new ActiveMQDeleteAddressException(msg);
       }
+   },
+   NULL_REF(218) {
+      @Override
+      public ActiveMQException createException(String msg) { return new ActiveMQNullRefException(msg); }
    };
 
    private static final Map<Integer, ActiveMQExceptionType> TYPE_MAP;

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/ActiveMQNullRefException.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/ActiveMQNullRefException.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.api.core;
+
+/**
+ * An operation failed because is dereferencing null pointer.
+ */
+public class ActiveMQNullRefException extends ActiveMQException {
+   public ActiveMQNullRefException() {
+      super(ActiveMQExceptionType.NULL_REF);
+   }
+
+   public ActiveMQNullRefException(String msg) {
+      super(ActiveMQExceptionType.NULL_REF, msg);
+   }
+}

--- a/artemis-junit/src/main/java/org/apache/activemq/artemis/junit/EmbeddedJMSResource.java
+++ b/artemis-junit/src/main/java/org/apache/activemq/artemis/junit/EmbeddedJMSResource.java
@@ -233,7 +233,11 @@ public class EmbeddedJMSResource extends ExternalResource {
     * be stopped manually to support advanced testing scenarios.
     */
    public void stop() {
-      log.info("Stopping {}: {}", this.getClass().getSimpleName(), this.getServerName());
+      String name = "null";
+      if (jmsServer != null) {
+         name = this.getServerName();
+      }
+      log.info("Stopping {}: {}", this.getClass().getSimpleName(), name);
       if (internalClient != null) {
          internalClient.stop();
          internalClient = null;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageSubscriptionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageSubscriptionImpl.java
@@ -209,7 +209,7 @@ final class PageSubscriptionImpl implements PageSubscription {
          return false;
       }
       // if the current page is complete, we must move it out of the way
-      if (pageStore != null && pageStore.getCurrentPage() != null &&
+      if (pageStore.getCurrentPage() != null &&
           pageStore.getCurrentPage().getPageId() == position.getPageNr()) {
          pageStore.forceAnotherPage();
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1938,4 +1938,8 @@ public interface ActiveMQServerLogger extends BasicLogger {
    @LogMessage(level = Logger.Level.INFO)
    @Message(id = 224092, value = "Despite disabled persistence, page files will be persisted.", format = Message.Format.MESSAGE_FORMAT)
    void pageWillBePersisted();
+
+   @LogMessage(level = Logger.Level.ERROR)
+   @Message(id = 224093, value = "Reference to message is null", format = Message.Format.MESSAGE_FORMAT)
+   void nullRefMessage();
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -2780,7 +2780,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
          throw ActiveMQMessageBundle.BUNDLE.invalidRoutingTypeForAddress(rt, info.getName().toString(), info.getRoutingTypes());
       }
 
-      final QueueConfig queueConfig = queueConfigBuilder.filter(filter).pagingManager(pagingManager).user(user).durable(durable).temporary(temporary).autoCreated(autoCreated).routingType(addrInfo.getRoutingType()).maxConsumers(maxConsumers).purgeOnNoConsumers(purgeOnNoConsumers).exclusive(exclusive).lastValue(lastValue).build();
+      final QueueConfig queueConfig = queueConfigBuilder.filter(filter).pagingManager(pagingManager).user(user).durable(durable).temporary(temporary).autoCreated(autoCreated).routingType(rt).maxConsumers(maxConsumers).purgeOnNoConsumers(purgeOnNoConsumers).exclusive(exclusive).lastValue(lastValue).build();
 
       callBrokerPlugins(hasBrokerPlugins() ? plugin -> plugin.beforeCreateQueue(queueConfig) : null);
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
@@ -41,6 +41,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.ActiveMQNullRefException;
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.Pair;
 import org.apache.activemq.artemis.api.core.RoutingType;
@@ -97,6 +98,8 @@ import org.apache.activemq.artemis.utils.collections.TypedProperties;
 import org.apache.activemq.artemis.utils.critical.CriticalComponentImpl;
 import org.apache.activemq.artemis.utils.critical.EmptyCriticalAnalyzer;
 import org.jboss.logging.Logger;
+
+import static org.apache.activemq.artemis.api.core.ActiveMQExceptionType.NULL_REF;
 
 /**
  * Implementation of a Queue
@@ -2743,6 +2746,11 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
    private Message makeCopy(final MessageReference ref,
                             final boolean expiry,
                             final boolean copyOriginalHeaders) throws Exception {
+      if (ref == null) {
+         ActiveMQServerLogger.LOGGER.nullRefMessage();
+         throw new ActiveMQNullRefException("Reference to message is null");
+      }
+
       Message message = ref.getMessage();
       /*
        We copy the message and send that to the dla/expiry queue - this is
@@ -2758,7 +2766,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
       Message copy = message.copy(newID);
 
       if (copyOriginalHeaders) {
-         copy.referenceOriginalMessage(message, ref != null ? ref.getQueue().getName().toString() : null);
+         copy.referenceOriginalMessage(message, ref.getQueue().getName().toString());
       }
 
       copy.setExpiration(0);


### PR DESCRIPTION
There were some cases where value was checked for null and later directly dereferenced without check. I added checks. I am not sure about "default behaviour" tho. Can anybody check?