### PR TITLE
ARTEMIS-1806 JDBC Connection leaks

### DIFF
--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/file/JDBCFileUtils.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/file/JDBCFileUtils.java
@@ -44,8 +44,12 @@ class JDBCFileUtils {
    }
 
    static JDBCSequentialFileFactoryDriver getDBFileDriver(DataSource dataSource, SQLProvider provider) throws SQLException {
-      JDBCSequentialFileFactoryDriver dbDriver;
-      if (POSTGRESQL.equals(PropertySQLProvider.Factory.investigateDialect(dataSource.getConnection()))) {
+      final JDBCSequentialFileFactoryDriver dbDriver;
+      final PropertySQLProvider.Factory.SQLDialect sqlDialect;
+      try (Connection connection = dataSource.getConnection()) {
+         sqlDialect = PropertySQLProvider.Factory.investigateDialect(connection);
+      }
+      if (POSTGRESQL.equals(sqlDialect)) {
          dbDriver = new PostgresSequentialSequentialFileDriver(dataSource, provider);
       } else {
          dbDriver = new JDBCSequentialFileFactoryDriver(dataSource, provider);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/SharedStoreBackupActivation.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/SharedStoreBackupActivation.java
@@ -215,8 +215,11 @@ public final class SharedStoreBackupActivation extends Activation {
 
                            // ensure that the server to which we are failing back actually starts fully before we restart
                            nodeManager.start();
-                           nodeManager.awaitLiveStatus();
-                           nodeManager.stop();
+                           try {
+                              nodeManager.awaitLiveStatus();
+                           } finally {
+                              nodeManager.stop();
+                           }
 
                            synchronized (failbackCheckerGuard) {
                               if (cancelFailBackChecker || !sharedStoreSlavePolicy.isRestartBackup())


### PR DESCRIPTION
The JDBC Connection leaks on:
- JDBCFileUtils::getDBFileDriver(DataSource, SQLProvider)
- SharedStoreBackupActivation.FailbackChecker::run on a failed awaitLiveStatus