### PR TITLE
 ARTEMIS-1809 adding example of mapping ActiveMQ 5.x Virtual Topic consumers

### DIFF
--- a/docs/user-manual/en/examples.md
+++ b/docs/user-manual/en/examples.md
@@ -641,7 +641,8 @@ OpenWire
 The `Openwire` example shows how to configure an Apache ActiveMQ Artemis server to
 communicate with an Apache ActiveMQ Artemis JMS client that uses open-wire protocol.
 
-You will find the queue example for open wire, and the chat example.
+You will find the queue example for open wire, and the chat example. The virtual-topic-mapping examples shows how to
+map the ActiveMQ 5.x Virtual Topic naming convention to work with the Artemis Address model.
 
 Paging
 ------

--- a/docs/user-manual/en/protocols-interoperability.md
+++ b/docs/user-manual/en/protocols-interoperability.md
@@ -230,7 +230,9 @@ In an acceptor url it would be:
 
 This will translate ```Consumer.A.VirtualTopic.Orders``` into a FQQN of ```VirtualTopic.Orders::Consumer.A``` using the
 int component ```2``` of the configuration to identify the consumer queue as the first two paths of the destination.
-```virtualTopicConsumerWildcards``` is multi valued using a ```,``` separator. 
+```virtualTopicConsumerWildcards``` is multi valued using a ```,``` separator.
+
+Please see Virtual Topic Mapping example contained in the OpenWire [examples](examples.md).
   
 ## MQTT
 

--- a/examples/protocols/openwire/pom.xml
+++ b/examples/protocols/openwire/pom.xml
@@ -44,6 +44,7 @@ under the License.
             <module>queue</module>
             <module>message-listener</module>
             <module>message-recovery</module>
+            <module>virtual-topic-mapping</module>
          </modules>
       </profile>
       <profile>
@@ -55,6 +56,7 @@ under the License.
             <module>queue</module>
             <module>message-listener</module>
             <module>message-recovery</module>
+            <module>virtual-topic-mapping</module>
          </modules>
       </profile>
    </profiles>

--- a/examples/protocols/openwire/virtual-topic-mapping/pom.xml
+++ b/examples/protocols/openwire/virtual-topic-mapping/pom.xml
@@ -1,0 +1,133 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+
+   <parent>
+      <groupId>org.apache.activemq.examples.openwire</groupId>
+      <artifactId>openwire-examples</artifactId>
+      <version>2.6.0-SNAPSHOT</version>
+   </parent>
+
+   <artifactId>virtual-topic-mapping</artifactId>
+   <packaging>jar</packaging>
+   <name>ActiveMQ Artemis OpenWire Virtual Topic Mapping Example</name>
+
+   <properties>
+      <activemq.basedir>${project.basedir}/../../../..</activemq.basedir>
+   </properties>
+
+   <dependencies>
+      <dependency>
+         <groupId>org.apache.geronimo.specs</groupId>
+         <artifactId>geronimo-jms_1.1_spec</artifactId>
+         <version>1.1</version>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>activemq-client</artifactId>
+         <version>${activemq5-version}</version>
+      </dependency>
+      <dependency>
+         <groupId>org.slf4j</groupId>
+         <artifactId>slf4j-nop</artifactId>
+      </dependency>
+   </dependencies>
+
+   <build>
+      <plugins>
+         <plugin>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-maven-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>create</id>
+                  <goals>
+                     <goal>create</goal>
+                  </goals>
+                  <configuration>
+                     <ignore>${noServer}</ignore>
+                  </configuration>
+               </execution>
+               <execution>
+                  <id>start</id>
+                  <goals>
+                     <goal>cli</goal>
+                  </goals>
+                  <configuration>
+                     <spawn>true</spawn>
+                     <ignore>${noServer}</ignore>
+                     <testURI>tcp://localhost:61616</testURI>
+                     <args>
+                        <param>run</param>
+                     </args>
+                  </configuration>
+               </execution>
+               <execution>
+                  <id>runClient</id>
+                  <goals>
+                     <goal>runClient</goal>
+                  </goals>
+                  <configuration>
+                     <clientClass>org.apache.activemq.artemis.jms.example.VirtualTopicMappingExample</clientClass>
+                  </configuration>
+               </execution>
+               <execution>
+                  <id>stop</id>
+                  <goals>
+                     <goal>cli</goal>
+                  </goals>
+                  <configuration>
+                     <ignore>${noServer}</ignore>
+                     <args>
+                        <param>stop</param>
+                     </args>
+                  </configuration>
+               </execution>
+            </executions>
+            <dependencies>
+               <dependency>
+                  <groupId>org.apache.activemq.examples.openwire</groupId>
+                  <artifactId>virtual-topic-mapping</artifactId>
+                  <version>${project.version}</version>
+               </dependency>
+            </dependencies>
+         </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-clean-plugin</artifactId>
+         </plugin>
+      </plugins>
+   </build>
+   <profiles>
+      <profile>
+         <id>release</id>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>com.vladsch.flexmark</groupId>
+                  <artifactId>markdown-page-generator-plugin</artifactId>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+   </profiles>
+</project>

--- a/examples/protocols/openwire/virtual-topic-mapping/readme.md
+++ b/examples/protocols/openwire/virtual-topic-mapping/readme.md
@@ -1,0 +1,27 @@
+# OpenWire Virtual Topic Mapping Example
+
+To run the example, simply type **mvn verify** from this directory, or **mvn -PnoServer verify** if you want to start
+and create the broker manually.
+
+Using ActiveMQ 5.x virtual topics, messages that are sent to a virtual topic can be consumed from a set of backing queues.
+This is similar to using an Artemis Address with a multicast binding and consuming from directly from the underlying
+queue using a FQQN (Fully Qualified Queue Name).
+
+In ActiveMQ 5.x the relation between the virtual topic and its backing queues is established by following a naming convention.
+For more details on Virtual Topics please see http://activemq.apache.org/virtual-destinations.html
+
+This example shows you how to map a virtual topic naming convention (from ActiveMQ 5.x) to use the Artemis Address model .
+The Artemis broker is configured to recognise the Virtual Topic Naming convention, using `virtualTopicConsumerWildcards`
+acceptor parameter and the consumer will be mapped internally to consume from the appropriate FQQN rather than the specified
+Address.
+
+The example sends a message to a topic (using openwire protocol) and an openwire consumer listens on the backing queue
+using the ActiveMQ 5.x virtual topic naming convention. Due to the acceptor url parameter `virtualTopicConsumerWildcards`,
+(see below), Artemis maps the consumer consuming from `Consumer.A.VirtualTopic.Orders` to actually consume from
+FQQN of `VirtualTopic.Orders::Consumer.A`
+
+
+```xml
+<acceptor name="artemis">tcp://0.0.0.0:61616?virtualTopicConsumerWildcards=Consumer.*.%3E%3B2</acceptor>
+```
+

--- a/examples/protocols/openwire/virtual-topic-mapping/src/main/java/org/apache/activemq/artemis/jms/example/VirtualTopicMappingExample.java
+++ b/examples/protocols/openwire/virtual-topic-mapping/src/main/java/org/apache/activemq/artemis/jms/example/VirtualTopicMappingExample.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.jms.example;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import javax.jms.Topic;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+
+/**
+ * The example sends a message to a topic (using openwire protocol) and an openwire consumer listens on the backing queue
+ * using the ActiveMQ 5.x virtual topic naming convention. Due to the acceptor parameter virtualTopicConsumerWildcards
+ * Artemis maps the consumer consuming from "Consumer.A.VirtualTopic.Orders" to actually consume from
+ * FQQN  "VirtualTopic.Orders::Consumer.A"
+ */
+public class VirtualTopicMappingExample {
+
+    public static void main(final String[] args) throws Exception {
+        Connection connection = null;
+        try {
+
+            ConnectionFactory cf = new ActiveMQConnectionFactory();
+
+            connection = cf.createConnection();
+            Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+            //create consumer on queue that is used by the Virtual Topic
+            Queue queue = session.createQueue("Consumer.A.VirtualTopic.Orders");
+            MessageConsumer messageConsumer = session.createConsumer(queue);
+            connection.start();
+
+
+            //send message to virtual topic
+            Topic topic = session.createTopic("VirtualTopic.Orders");
+            MessageProducer producer = session.createProducer(topic);
+            TextMessage message = session.createTextMessage("This is a text message");
+            producer.send(message);
+
+            System.out.println("Sent message with ID: " + message.getJMSMessageID() + " to Topic: " + topic.getTopicName());
+
+            //consume the message from the backing queue
+            TextMessage messageReceived = (TextMessage) messageConsumer.receive(5000);
+
+            if (messageReceived != null) {
+                System.out.println("Received message with ID: " + messageReceived.getJMSMessageID() + " from Queue: " + queue.getQueueName());
+            } else {
+                //unexpected outcome
+                throw new RuntimeException("EXAMPLE FAILED - No message received from Queue: " + queue.getQueueName());
+            }
+        } finally {
+            if (connection != null) {
+                connection.close();
+            }
+        }
+    }
+}

--- a/examples/protocols/openwire/virtual-topic-mapping/src/main/resources/activemq/server0/broker.xml
+++ b/examples/protocols/openwire/virtual-topic-mapping/src/main/resources/activemq/server0/broker.xml
@@ -1,0 +1,70 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration xmlns="urn:activemq"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:xi="http://www.w3.org/2001/XInclude"
+               xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+
+   <core xmlns="urn:activemq:core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="urn:activemq:core ">
+
+      <name>VirtualTopicMappingExample</name>
+      
+      <paging-directory>./data/paging</paging-directory>
+
+      <bindings-directory>./data/bindings</bindings-directory>
+
+      <journal-directory>./data/journal</journal-directory>
+
+      <large-messages-directory>./data/large-messages</large-messages-directory>
+
+
+      <acceptors>
+         <acceptor name="artemis">tcp://0.0.0.0:61616?virtualTopicConsumerWildcards=Consumer.*.%3E%3B2</acceptor>
+      </acceptors>
+
+
+      <security-settings>
+         <security-setting match="#">
+            <permission type="createNonDurableQueue" roles="guest"/>
+            <permission type="deleteNonDurableQueue" roles="guest"/>
+            <permission type="createDurableQueue" roles="guest"/>
+            <permission type="deleteDurableQueue" roles="guest"/>
+            <permission type="createAddress" roles="guest"/>
+            <permission type="deleteAddress" roles="guest"/>
+            <permission type="consume" roles="guest"/>
+            <permission type="browse" roles="guest"/>
+            <permission type="send" roles="guest"/>
+         </security-setting>
+      </security-settings>
+
+
+      <addresses>
+         <address name="VirtualTopic.Orders">
+            <multicast/>
+         </address>
+      </addresses>
+
+
+
+
+   </core>
+</configuration>


### PR DESCRIPTION
see contained examples/protocols/openwire/virtual-topic-mapping/readme.md for details.