### PR TITLE
ARTEMIS-1810 JDBCSequentialFileFactoryDriver should check <=0 read length

### DIFF
--- a/artemis-jdbc-store/src/test/java/org/apache/activemq/artemis/jdbc/file/JDBCSequentialFileFactoryTest.java
+++ b/artemis-jdbc-store/src/test/java/org/apache/activemq/artemis/jdbc/file/JDBCSequentialFileFactoryTest.java
@@ -97,6 +97,66 @@ public class JDBCSequentialFileFactoryTest {
    }
 
    @Test
+   public void testReadZeroBytesOnEmptyFile() throws Exception {
+      JDBCSequentialFile file = (JDBCSequentialFile) factory.createSequentialFile("test.txt");
+      file.open();
+      try {
+         final ByteBuffer readBuffer = ByteBuffer.allocate(0);
+         final int bytes = file.read(readBuffer);
+         assertEquals(0, bytes);
+      } finally {
+         file.close();
+      }
+   }
+
+   @Test
+   public void testReadZeroBytesOnNotEmptyFile() throws Exception {
+      final int fileLength = 8;
+      JDBCSequentialFile file = (JDBCSequentialFile) factory.createSequentialFile("test.txt");
+      file.open();
+      try {
+         file.writeDirect(ByteBuffer.allocate(fileLength), true);
+         assertEquals(fileLength, file.size());
+         final ByteBuffer readBuffer = ByteBuffer.allocate(0);
+         final int bytes = file.read(readBuffer);
+         assertEquals(0, bytes);
+      } finally {
+         file.close();
+      }
+   }
+
+   @Test
+   public void testReadOutOfBoundsOnEmptyFile() throws Exception {
+      JDBCSequentialFile file = (JDBCSequentialFile) factory.createSequentialFile("test.txt");
+      file.open();
+      try {
+         final ByteBuffer readBuffer = ByteBuffer.allocate(1);
+         file.position(1);
+         final int bytes = file.read(readBuffer);
+         assertTrue("bytes read should be < 0", bytes < 0);
+      } finally {
+         file.close();
+      }
+   }
+
+   @Test
+   public void testReadOutOfBoundsOnNotEmptyFile() throws Exception {
+      final int fileLength = 8;
+      JDBCSequentialFile file = (JDBCSequentialFile) factory.createSequentialFile("test.txt");
+      file.open();
+      try {
+         file.writeDirect(ByteBuffer.allocate(fileLength), true);
+         assertEquals(fileLength, file.size());
+         file.position(fileLength + 1);
+         final ByteBuffer readBuffer = ByteBuffer.allocate(fileLength);
+         final int bytes = file.read(readBuffer);
+         assertTrue("bytes read should be < 0", bytes < 0);
+      } finally {
+         file.close();
+      }
+   }
+
+   @Test
    public void testCreateFiles() throws Exception {
       int noFiles = 100;
       List<SequentialFile> files = new LinkedList<>();


### PR DESCRIPTION
In order to avoid out of bounds reads to happen, the reading of the file
should avoid those readings to hit the DMBS and just return the expected
value.