### PR TITLE
ARTEMIS-1812 fix for missing (core) messages after master kill (HA)

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/ServerSessionPacketHandler.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/ServerSessionPacketHandler.java
@@ -658,6 +658,9 @@ public class ServerSessionPacketHandler implements ChannelHandler {
          try {
             final SessionSendMessage message = (SessionSendMessage) packet;
             requiresResponse = message.isRequiresResponse();
+            if (this.session.getMatchingQueue(message.getMessage().getAddressSimpleString(), RoutingType.ANYCAST) == null || this.session.getMatchingQueue(message.getMessage().getAddressSimpleString(), RoutingType.MULTICAST) == null) {
+               this.session.createQueue(message.getMessage().getAddressSimpleString(), message.getMessage().getAddressSimpleString(), RoutingType.ANYCAST, new SimpleString(""), false, true);
+            }
             this.session.send(EmbedMessageUtil.extractEmbedded(message.getMessage()), this.direct);
             if (requiresResponse) {
                response = new NullResponseMessage();


### PR DESCRIPTION
When I try to send some core messages to slave broker (master is dead), messages are lost. Debug console says "Couldn't find any bindings for address=TEST.foo". By digging into code, I think this is the spot, which is responsible for this bug: https://github.com/apache/activemq-artemis/blob/master/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java#L832 

I have tried to create queue with default values here. It fixes the bug, but it creates queue in each case queue was not found. Git blame says @clebertsuconic and @jbertram could know more about this. Do you guys have any idea, how to solve this (better)?