### PR TITLE
NO-JIRA: Fix test regression

### DIFF
--- a/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
@@ -1314,7 +1314,7 @@ public abstract class ActiveMQTestBase extends Assert {
     * @param backup
     */
    public static final void waitForRemoteBackupSynchronization(final ActiveMQServer backup) {
-      waitForRemoteBackup(null, 10, true, backup);
+      waitForRemoteBackup(null, 20, true, backup);
    }
 
    /**
@@ -1332,6 +1332,10 @@ public abstract class ActiveMQTestBase extends Assert {
       final long toWait = seconds * 1000;
       final long time = System.currentTimeMillis();
       int loop = 0;
+      //Note: if maxLoop is too small there won't be
+      //enough time for quorum vote to complete and
+      //will cause test to fail.
+      final int maxLoop = 40;
       while (true) {
          Activation activation = actualServer.getActivation();
          boolean isReplicated = !backup.getHAPolicy().isSharedStore();
@@ -1343,7 +1347,7 @@ public abstract class ActiveMQTestBase extends Assert {
                //we may have already failed over and changed the Activation
                if (actualServer.isStarted()) {
                   //let it fail a few time to have time to start stopping in the case of waiting to failback
-                  isRemoteUpToDate = loop++ > 10;
+                  isRemoteUpToDate = loop++ > maxLoop;
                } else {
                   //we could be waiting to failback or restart if the server is stopping
                   isRemoteUpToDate = false;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/QuorumFailOverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/QuorumFailOverTest.java
@@ -43,6 +43,11 @@ public class QuorumFailOverTest extends StaticClusterWithBackupFailoverTest {
       ((ReplicaPolicyConfiguration) servers[3].getConfiguration().getHAPolicyConfiguration()).setGroupName("group0");
       ((ReplicaPolicyConfiguration) servers[4].getConfiguration().getHAPolicyConfiguration()).setGroupName("group1");
       ((ReplicaPolicyConfiguration) servers[5].getConfiguration().getHAPolicyConfiguration()).setGroupName("group2");
+
+      //reduce the numbers so that the vote finishes faster
+      ((ReplicaPolicyConfiguration) servers[3].getConfiguration().getHAPolicyConfiguration()).setVoteRetries(5);
+      ((ReplicaPolicyConfiguration) servers[3].getConfiguration().getHAPolicyConfiguration()).setVoteRetryWait(500);
+
    }
 
    @Test


### PR DESCRIPTION
QuorumFailOverTest.testQuorumVotingLiveNotDead fails
because the quorum vote takes longer time to finish than
the test expects to.
(The test used to pass until commit ARTEMIS-1763)