### PR TITLE
Adds the Travis CI build status label on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ This file describes some minimum 'stuff one needs to know' to get started coding
 For details about the modifying the code, building the project, running tests, IDE integration, etc. see
 our [Hacking Guide](./docs/hacking-guide/en/SUMMARY.md).
 
+## Build Status
+
+Build Status: [![Build Status](https://travis-ci.org/apache/activemq-artemis.svg?branch=master)](https://travis-ci.org/apache/activemq-artemis)
+
 ## Building the ASYNC IO library
 
 ActiveMQ Artemis provides two journal persistence types, NIO (which uses the Java NIO libraries), and ASYNCIO which interacts with the linux kernel libaio library.   The ASYNCIO journal type should be used where possible as it is far superior in terms of performance.


### PR DESCRIPTION
Some of my colleagues suggested it would be useful to have the Travis CI build label right when accessing the project page.