### PR TITLE
ARTEMIS-1816 OpenWire should avoid ByteArrayOutputStream lazy allocation

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireMessageConverter.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireMessageConverter.java
@@ -504,6 +504,15 @@ public final class OpenWireMessageConverter {
       return md;
    }
 
+   private static final class EagerActiveMQBytesMessage extends ActiveMQBytesMessage {
+
+      EagerActiveMQBytesMessage(int size) {
+         this.bytesOut = new org.apache.activemq.util.ByteArrayOutputStream(size);
+         OutputStream os = bytesOut;
+         this.dataOut = new DataOutputStream(os);
+      }
+   }
+
    private static ActiveMQMessage toAMQMessage(MessageReference reference,
                                                ICoreMessage coreMessage,
                                                WireFormat marshaller,
@@ -518,7 +527,7 @@ public final class OpenWireMessageConverter {
 
       switch (coreType) {
          case org.apache.activemq.artemis.api.core.Message.BYTES_TYPE:
-            amqMsg = new ActiveMQBytesMessage();
+            amqMsg = new EagerActiveMQBytesMessage(0);
             bytes = toAMQMessageBytesType(buffer, isCompressed);
             break;
          case org.apache.activemq.artemis.api.core.Message.MAP_TYPE:


### PR DESCRIPTION
OpenWireMessageConverter::toAMQMessage on bytes messages is lazy
allocating a write buffer with a default size of 1024 even when
it won't be used to write anything.
It avoid an useless allocation by reducing it to new byte[0].