### PR TITLE
ARTEMIS-1817 fix getting non-existent properties

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/collections/TypedProperties.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/collections/TypedProperties.java
@@ -176,7 +176,7 @@ public class TypedProperties {
    public Byte getByteProperty(final SimpleString key) throws ActiveMQPropertyConversionException {
       Object value = doGetProperty(key);
       if (value == null) {
-         return Byte.valueOf(null);
+         return null;
       } else if (value instanceof Byte) {
          return (Byte) value;
       } else if (value instanceof SimpleString) {
@@ -210,7 +210,7 @@ public class TypedProperties {
    public Double getDoubleProperty(final SimpleString key) throws ActiveMQPropertyConversionException {
       Object value = doGetProperty(key);
       if (value == null) {
-         return Double.valueOf(null);
+         return null;
       } else if (value instanceof Float) {
          return ((Float) value).doubleValue();
       } else if (value instanceof Double) {
@@ -224,7 +224,7 @@ public class TypedProperties {
    public Integer getIntProperty(final SimpleString key) throws ActiveMQPropertyConversionException {
       Object value = doGetProperty(key);
       if (value == null) {
-         return Integer.valueOf(null);
+         return null;
       } else if (value instanceof Integer) {
          return (Integer) value;
       } else if (value instanceof Byte) {
@@ -240,7 +240,7 @@ public class TypedProperties {
    public Long getLongProperty(final SimpleString key) throws ActiveMQPropertyConversionException {
       Object value = doGetProperty(key);
       if (value == null) {
-         return Long.valueOf(null);
+         return null;
       } else if (value instanceof Long) {
          return (Long) value;
       } else if (value instanceof Byte) {
@@ -258,7 +258,7 @@ public class TypedProperties {
    public Short getShortProperty(final SimpleString key) throws ActiveMQPropertyConversionException {
       Object value = doGetProperty(key);
       if (value == null) {
-         return Short.valueOf(null);
+         return null;
       } else if (value instanceof Byte) {
          return ((Byte) value).shortValue();
       } else if (value instanceof Short) {
@@ -272,7 +272,7 @@ public class TypedProperties {
    public Float getFloatProperty(final SimpleString key) throws ActiveMQPropertyConversionException {
       Object value = doGetProperty(key);
       if (value == null)
-         return Float.valueOf(null);
+         return null;
       if (value instanceof Float) {
          return ((Float) value);
       }

--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/TypedPropertiesTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/TypedPropertiesTest.java
@@ -117,6 +117,33 @@ public class TypedPropertiesTest {
    }
 
    @Test
+   public void testGetNonExistentProperties() {
+      // try getting properties that don't exist that should return null
+      SimpleString uuid = RandomUtil.randomSimpleString();
+      Assert.assertNull(props.getProperty(uuid));
+      Assert.assertNull(props.getByteProperty(uuid));
+      Assert.assertNull(props.getBytesProperty(uuid));
+      Assert.assertNull(props.getLongProperty(uuid));
+      Assert.assertNull(props.getFloatProperty(uuid));
+      Assert.assertNull(props.getDoubleProperty(uuid));
+      Assert.assertNull(props.getIntProperty(uuid));
+      Assert.assertNull(props.getShortProperty(uuid));
+      Assert.assertNull(props.getSimpleStringProperty(uuid));
+
+      // a boolean property which doesn't exist returns false instead of null
+      Assert.assertFalse(props.getBooleanProperty(uuid));
+
+      // a char property which doesn't exist return an NPE instead of null
+      try {
+         props.getCharProperty(uuid);
+      } catch (NullPointerException npe) {
+         // ignore
+      } catch (Exception e) {
+         Assert.fail("Should have received an NPE, but instead got: " + e.getMessage());
+      }
+   }
+
+   @Test
    public void testRemovePropertyOnEmptyProperties() throws Exception {
       Assert.assertFalse(props.containsProperty(key));
       Assert.assertNull(props.removeProperty(key));


### PR DESCRIPTION
Calling valueOf() on certain types with 'null' will actuall throw an
exception (e.g. NumberFormat exception for java.lang.Double) rather than
just returning null.