### PR TITLE
ARTEMIS-1822: Change the method name 'lookupRecord' to 'containsRecord'.

### DIFF
--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/AbstractJournalUpdateTask.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/AbstractJournalUpdateTask.java
@@ -222,7 +222,7 @@ public abstract class AbstractJournalUpdateTask implements JournalReaderCallback
       writingChannel = null;
    }
 
-   public boolean lookupRecord(final long id) {
+   public boolean containsRecord(final long id) {
       return recordsSnapshot.contains(id);
    }
 

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalCompactor.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalCompactor.java
@@ -221,7 +221,7 @@ public class JournalCompactor extends AbstractJournalUpdateTask implements Journ
       if (logger.isTraceEnabled()) {
          logger.trace("Read Record " + info);
       }
-      if (lookupRecord(info.id)) {
+      if (containsRecord(info.id)) {
          JournalInternalRecord addRecord = new JournalAddRecord(true, info.id, info.getUserRecordType(), EncoderPersister.getInstance(), new ByteArrayEncoding(info.data));
          addRecord.setCompactCount((short) (info.compactCount + 1));
 
@@ -238,7 +238,7 @@ public class JournalCompactor extends AbstractJournalUpdateTask implements Journ
       if (logger.isTraceEnabled()) {
          logger.trace("Read Add Recprd TX " + transactionID + " info " + info);
       }
-      if (pendingTransactions.get(transactionID) != null || lookupRecord(info.id)) {
+      if (pendingTransactions.get(transactionID) != null || containsRecord(info.id)) {
          JournalTransaction newTransaction = getNewJournalTransaction(transactionID);
 
          JournalInternalRecord record = new JournalAddRecordTX(true, transactionID, info.id, info.getUserRecordType(), EncoderPersister.getInstance(),new ByteArrayEncoding(info.data));
@@ -370,7 +370,7 @@ public class JournalCompactor extends AbstractJournalUpdateTask implements Journ
          logger.trace("onReadUpdateRecord " + info);
       }
 
-      if (lookupRecord(info.id)) {
+      if (containsRecord(info.id)) {
          JournalInternalRecord updateRecord = new JournalAddRecord(false, info.id, info.userRecordType, EncoderPersister.getInstance(), new ByteArrayEncoding(info.data));
 
          updateRecord.setCompactCount((short) (info.compactCount + 1));
@@ -395,7 +395,7 @@ public class JournalCompactor extends AbstractJournalUpdateTask implements Journ
          logger.trace("onReadUpdateRecordTX " + info);
       }
 
-      if (pendingTransactions.get(transactionID) != null || lookupRecord(info.id)) {
+      if (pendingTransactions.get(transactionID) != null || containsRecord(info.id)) {
          JournalTransaction newTransaction = getNewJournalTransaction(transactionID);
 
          JournalInternalRecord updateRecordTX = new JournalAddRecordTX(false, transactionID, info.id, info.userRecordType, EncoderPersister.getInstance(), new ByteArrayEncoding(info.data));

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalImpl.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalImpl.java
@@ -993,7 +993,7 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
    }
 
    private void checkKnownRecordID(final long id) throws Exception {
-      if (records.containsKey(id) || pendingRecords.contains(id) || (compactor != null && compactor.lookupRecord(id))) {
+      if (records.containsKey(id) || pendingRecords.contains(id) || (compactor != null && compactor.containsRecord(id))) {
          return;
       }
 
@@ -1008,7 +1008,7 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
 
                known.set(records.containsKey(id)
                   || pendingRecords.contains(id)
-                  || (compactor != null && compactor.lookupRecord(id)));
+                  || (compactor != null && compactor.containsRecord(id)));
             } finally {
                journalLock.readLock().unlock();
             }

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalTransaction.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalTransaction.java
@@ -250,7 +250,7 @@ public class JournalTransaction {
             for (JournalUpdate trUpdate : pos) {
                JournalRecord posFiles = journal.getRecords().get(trUpdate.id);
 
-               if (compactor != null && compactor.lookupRecord(trUpdate.id)) {
+               if (compactor != null && compactor.containsRecord(trUpdate.id)) {
                   // This is a case where the transaction was opened after compacting was started,
                   // but the commit arrived while compacting was working
                   // We need to cache the counter update, so compacting will take the correct files when it is done


### PR DESCRIPTION
The method is named "lookupRecord".
"lookupRecord" seems to find a related record.
But the method is checking whether recordsSnapshot contains the id or not.
Thus, the method name "containsRecord" is more intuitive than "lookupRecord".