### PR TITLE
ARTEMIS-1829 Remove deprecated plugin's messageExpired implementations

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/plugin/ActiveMQServerPlugin.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/plugin/ActiveMQServerPlugin.java
@@ -566,7 +566,7 @@ public interface ActiveMQServerPlugin {
     * @throws ActiveMQException
     */
    default void messageExpired(MessageReference message, SimpleString messageExpiryAddress, ServerConsumer consumer) throws ActiveMQException {
-
+      messageExpired(message, messageExpiryAddress);
    }
 
    /**

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/plugin/impl/LoggingActiveMQServerPlugin.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/plugin/impl/LoggingActiveMQServerPlugin.java
@@ -595,15 +595,10 @@ public class LoggingActiveMQServerPlugin implements ActiveMQServerPlugin, Serial
       }
    }
 
-   /**
-    * A message has been expired
-    *
-    * @param message              The expired message
-    * @param messageExpiryAddress The message expiry address if exists
-    * @throws ActiveMQException
-    */
    @Override
-   public void messageExpired(MessageReference message, SimpleString messageExpiryAddress) throws ActiveMQException {
+   public void messageExpired(MessageReference message,
+                              SimpleString messageExpiryAddress,
+                              ServerConsumer consumer) {
       if (logAll || logInternalEvents) {
          LoggingActiveMQServerPluginLogger.LOGGER.messageExpired(message, messageExpiryAddress);
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/plugin/impl/NotificationActiveMQServerPlugin.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/plugin/impl/NotificationActiveMQServerPlugin.java
@@ -139,7 +139,9 @@ public class NotificationActiveMQServerPlugin implements ActiveMQServerPlugin {
    }
 
    @Override
-   public void messageExpired(MessageReference message, SimpleString messageExpiryAddress) throws ActiveMQException {
+   public void messageExpired(MessageReference message,
+                              SimpleString messageExpiryAddress,
+                              ServerConsumer consumer) {
       final ManagementService managementService = getManagementService();
 
       if (managementService != null && sendExpiredNotifications) {


### PR DESCRIPTION
NotificationActiveMQServerPlugin and LoggingActiveMQServerPlugin are
implementing the deprecated version of
ActiveMQServerPlugin::messageExpired that is not called by the
new version of the method or any other part of the code