### PR TITLE
ARTEMIS-1836 Bug with broker when running on Windows,

### DIFF
--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile
@@ -18,6 +18,7 @@
 ARTEMIS_HOME='${artemis.home}'
 ARTEMIS_INSTANCE='${artemis.instance}'
 ARTEMIS_DATA_DIR='${artemis.instance.data}'
+ARTEMIS_ETC_DIR='${artemis.instance.etc}'
 
 # The logging config will need an URI
 # this will be encoded in case you use spaces or special characters

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile.cmd
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile.cmd
@@ -18,8 +18,8 @@ rem under the License.
 
 set ARTEMIS_HOME="${artemis.home}"
 set ARTEMIS_INSTANCE="${artemis.instance}"
-set ARTEMIS_ETC_INSTANCE='${artemis.instance.etc}'
-set ARTEMIS_DATA_DIR='${artemis.instance.data}'
+set ARTEMIS_DATA_DIR="${artemis.instance.data}"
+set ARTEMIS_ETC_DIR="${artemis.instance.etc}"
 
 
 rem The logging config will need an URI
@@ -32,7 +32,7 @@ rem Cluster Properties: Used to pass arguments to ActiveMQ Artemis which can be 
 rem set ARTEMIS_CLUSTER_PROPS=-Dactivemq.remoting.default.port=61617 -Dactivemq.remoting.amqp.port=5673 -Dactivemq.remoting.stomp.port=61614 -Dactivemq.remoting.hornetq.port=5446
 
 rem Java Opts
-set JAVA_ARGS=${java-opts} -XX:+PrintClassHistogram -XX:+UseG1GC -XX:+AggressiveOpts -Xms512M -Xmx1024M -Xbootclasspath/a:%ARTEMIS_HOME%\lib\${logmanager} -Djava.security.auth.login.config=%ARTEMIS_INSTANCE_ETC%\login.config -Dhawtio.offline="true" -Dhawtio.realm=activemq -Dhawtio.role=${role} -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal -Djolokia.policyLocation=%ARTEMIS_INSTANCE_ETC_URI%\jolokia-access.xml -Dartemis.instance=%ARTEMIS_INSTANCE%
+set JAVA_ARGS=${java-opts} -XX:+PrintClassHistogram -XX:+UseG1GC -XX:+AggressiveOpts -Xms512M -Xmx1024M -Xbootclasspath/a:%ARTEMIS_HOME%\lib\${logmanager} -Djava.security.auth.login.config=%ARTEMIS_ETC_DIR%\login.config -Dhawtio.offline="true" -Dhawtio.realm=activemq -Dhawtio.role=${role} -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal -Djolokia.policyLocation=%ARTEMIS_INSTANCE_ETC_URI%\jolokia-access.xml -Dartemis.instance=%ARTEMIS_INSTANCE%
 
 rem There might be options that you only want to enable on specifc commands, like setting a JMX port
 rem See https://issues.apache.org/jira/browse/ARTEMIS-318


### PR DESCRIPTION
Bug with broker when running on Windows cannot find login.config

The Windows variable ARTEMIS_ETC_INSTANCE was not set correctly,
as it was used as ARTEMIS_INSTANCE_ETC. So the fix is to make sure
that the two match, and additionally they it was renamed to more
closely match the other variables naming convention. This was done
in two files; so when 'artemis create mybroker' is run on a Windows
machine, the broker is correctly configured with login.config.

Minor fix of changing use of single quotes to correct usage of
double quotes when declaring variable.

Issue: https://issues.apache.org/jira/browse/ARTEMIS-1836