### PR TITLE
ARTEMIS-1839 NettyConnector was ignoring sniHost

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnector.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnector.java
@@ -625,7 +625,7 @@ public class NettyConnector extends AbstractConnector {
          @Override
          public SSLEngine run() {
             if (verifyHost) {
-               return context.createSSLEngine(host, port);
+               return context.createSSLEngine(sniHost != null ? sniHost : host, port);
             } else {
                return context.createSSLEngine();
             }


### PR DESCRIPTION
This is fixing org.apache.activemq.artemis.tests.integration.ssl.CoreClientOverOneWaySSLKerb5Test#testOneWaySSLWithGoodClientCipherSuite