### PR TITLE
ARTEMIS-1841 fixing bug introduced by ARTEMIS-1770

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionImpl.java
@@ -1545,6 +1545,7 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
                if (logger.isDebugEnabled()) {
                   logger.debug(ex.getMessage(), ex);
                }
+               throw ex;
             } finally {
                endCall();
             }
@@ -1754,6 +1755,7 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
             if (logger.isDebugEnabled()) {
                logger.debug(ex.getMessage(), ex);
             }
+            throw ex;
          } finally {
             if (wasStarted) {
                start();


### PR DESCRIPTION
The change from ARTEMIS-1770 was a semantic change that caused the method to start swallowing exceptions. This restores the original semantics.