### PR TITLE
ARTEMIS-1842 make sure quorum vote loops exits

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/qourum/SharedNothingBackupQuorum.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/qourum/SharedNothingBackupQuorum.java
@@ -64,7 +64,7 @@ public class SharedNothingBackupQuorum implements Quorum, SessionFailureListener
 
    private final NetworkHealthCheck networkHealthCheck;
 
-   private boolean stopped = false;
+   private volatile boolean stopped = false;
 
    /**
     * This is a safety net in case the live sends the first {@link ReplicationLiveIsStoppingMessage}


### PR DESCRIPTION
The stopped flag used to stop the quorum vote loop needs to be volatile
in order to be safely published between threads.