### PR TITLE
ARTEMIS-1843 Update Qpid JMS 0.32.0 and Proton-j 0.27.1

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPSessionCallback.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPSessionCallback.java
@@ -71,6 +71,7 @@ import org.apache.qpid.proton.amqp.messaging.Rejected;
 import org.apache.qpid.proton.amqp.transaction.TransactionalState;
 import org.apache.qpid.proton.amqp.transport.AmqpError;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
+import org.apache.qpid.proton.codec.ReadableBuffer;
 import org.apache.qpid.proton.engine.Delivery;
 import org.apache.qpid.proton.engine.EndpointState;
 import org.apache.qpid.proton.engine.Receiver;
@@ -441,7 +442,7 @@ public class AMQPSessionCallback implements SessionCallback {
                           final Delivery delivery,
                           SimpleString address,
                           int messageFormat,
-                          byte[] data) throws Exception {
+                          ReadableBuffer data) throws Exception {
       AMQPMessage message = new AMQPMessage(messageFormat, data, coreMessageObjectPools);
       if (address != null) {
          message.setAddress(address);

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPConnectionContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPConnectionContext.java
@@ -16,6 +16,12 @@
  */
 package org.apache.activemq.artemis.protocol.amqp.proton;
 
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.FAILOVER_SERVER_LIST;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.HOSTNAME;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.NETWORK_HOST;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.PORT;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.SCHEME;
+
 import java.net.URI;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -25,7 +31,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import io.netty.buffer.ByteBuf;
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.protocol.amqp.broker.AMQPConnectionCallback;
 import org.apache.activemq.artemis.protocol.amqp.broker.AMQPSessionCallback;
@@ -52,11 +57,7 @@ import org.apache.qpid.proton.engine.Session;
 import org.apache.qpid.proton.engine.Transport;
 import org.jboss.logging.Logger;
 
-import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.FAILOVER_SERVER_LIST;
-import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.HOSTNAME;
-import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.NETWORK_HOST;
-import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.PORT;
-import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.SCHEME;
+import io.netty.buffer.ByteBuf;
 
 public class AMQPConnectionContext extends ProtonInitializable implements EventHandler {
 
@@ -118,11 +119,11 @@ public class AMQPConnectionContext extends ProtonInitializable implements EventH
       transport.setChannelMax(channelMax);
       transport.setInitialRemoteMaxFrameSize(protocolManager.getInitialRemoteMaxFrameSize());
       transport.setMaxFrameSize(maxFrameSize);
+      transport.setOutboundFrameSizeLimit(maxFrameSize);
       if (!isIncomingConnection && saslClientFactory != null) {
          handler.createClientSASL();
       }
    }
-
 
    public void scheduledFlush() {
       handler.scheduledFlush();

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerReceiverContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerReceiverContext.java
@@ -40,6 +40,7 @@ import org.apache.qpid.proton.amqp.transaction.TransactionalState;
 import org.apache.qpid.proton.amqp.transport.AmqpError;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.apache.qpid.proton.amqp.transport.ReceiverSettleMode;
+import org.apache.qpid.proton.codec.ReadableBuffer;
 import org.apache.qpid.proton.engine.Delivery;
 import org.apache.qpid.proton.engine.Receiver;
 import org.jboss.logging.Logger;
@@ -221,10 +222,8 @@ public class ProtonServerReceiverContext extends ProtonInitializable implements 
          receiver = ((Receiver) delivery.getLink());
 
          Transaction tx = null;
-         byte[] data;
 
-         data = new byte[delivery.available()];
-         receiver.recv(data, 0, data.length);
+         ReadableBuffer data = receiver.recv();
          receiver.advance();
 
          if (delivery.getRemoteState() instanceof TransactionalState) {

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/util/NettyWritable.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/util/NettyWritable.java
@@ -18,19 +18,25 @@ package org.apache.activemq.artemis.protocol.amqp.util;
 
 import java.nio.ByteBuffer;
 
-import io.netty.buffer.ByteBuf;
+import org.apache.qpid.proton.codec.ReadableBuffer;
 import org.apache.qpid.proton.codec.WritableBuffer;
 
-/**
- * This is to use NettyBuffer within Proton
- */
+import io.netty.buffer.ByteBuf;
 
+/**
+ * {@link WritableBuffer} implementation that wraps a Netty {@link ByteBuf} to
+ * allow use of Netty buffers to be used when encoding AMQP messages.
+ */
 public class NettyWritable implements WritableBuffer {
 
    final ByteBuf nettyBuffer;
 
    public NettyWritable(ByteBuf nettyBuffer) {
       this.nettyBuffer = nettyBuffer;
+   }
+
+   public ByteBuf getByteBuf() {
+      return nettyBuffer;
    }
 
    @Override
@@ -75,7 +81,7 @@ public class NettyWritable implements WritableBuffer {
 
    @Override
    public int remaining() {
-      return nettyBuffer.capacity() - nettyBuffer.writerIndex();
+      return nettyBuffer.maxCapacity() - nettyBuffer.writerIndex();
    }
 
    @Override
@@ -93,8 +99,23 @@ public class NettyWritable implements WritableBuffer {
       nettyBuffer.writeBytes(payload);
    }
 
+   public void put(ByteBuf payload) {
+      nettyBuffer.writeBytes(payload);
+   }
+
    @Override
    public int limit() {
       return nettyBuffer.capacity();
+   }
+
+   @Override
+   public void put(ReadableBuffer buffer) {
+      if (buffer.hasArray()) {
+         nettyBuffer.writeBytes(buffer.array(), buffer.arrayOffset(), buffer.remaining());
+      } else {
+         while (buffer.hasRemaining()) {
+            nettyBuffer.writeByte(buffer.get());
+         }
+      }
    }
 }

--- a/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/util/NettyReadableTest.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/util/NettyReadableTest.java
@@ -1,0 +1,454 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.util;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.junit.Test;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+/**
+ * Tests for the ReadableBuffer wrapper that uses Netty ByteBuf underneath
+ */
+public class NettyReadableTest {
+
+   @Test
+   public void testWrapBuffer() {
+      ByteBuf byteBuffer = Unpooled.buffer(100, 100);
+
+      NettyReadable buffer = new NettyReadable(byteBuffer);
+
+      assertEquals(100, buffer.capacity());
+      assertSame(byteBuffer, buffer.getByteBuf());
+      assertSame(buffer, buffer.reclaimRead());
+   }
+
+   @Test
+   public void testArrayAccess() {
+      ByteBuf byteBuffer = Unpooled.buffer(100, 100);
+      NettyReadable buffer = new NettyReadable(byteBuffer);
+
+      assertTrue(buffer.hasArray());
+      assertSame(buffer.array(), byteBuffer.array());
+      assertEquals(buffer.arrayOffset(), byteBuffer.arrayOffset());
+   }
+
+   @Test
+   public void testArrayAccessWhenNoArray() {
+      ByteBuf byteBuffer = Unpooled.directBuffer();
+      NettyReadable buffer = new NettyReadable(byteBuffer);
+
+      assertFalse(buffer.hasArray());
+   }
+
+   @Test
+   public void testByteBuffer() {
+      byte[] data = new byte[] {0, 1, 2, 3, 4};
+      ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+      NettyReadable buffer = new NettyReadable(byteBuffer);
+
+      ByteBuffer nioBuffer = buffer.byteBuffer();
+      assertEquals(data.length, nioBuffer.remaining());
+
+      for (int i = 0; i < data.length; i++) {
+         assertEquals(data[i], nioBuffer.get());
+      }
+   }
+
+   @Test
+   public void testGet() {
+      byte[] data = new byte[] {0, 1, 2, 3, 4};
+      ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+      NettyReadable buffer = new NettyReadable(byteBuffer);
+
+      for (int i = 0; i < data.length; i++) {
+         assertEquals(data[i], buffer.get());
+      }
+
+      assertFalse(buffer.hasRemaining());
+
+      try {
+         buffer.get();
+         fail("Should throw an IndexOutOfBoundsException");
+      } catch (IndexOutOfBoundsException ioe) {
+      }
+   }
+
+   @Test
+   public void testGetIndex() {
+      byte[] data = new byte[] {0, 1, 2, 3, 4};
+      ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+      NettyReadable buffer = new NettyReadable(byteBuffer);
+
+      for (int i = 0; i < data.length; i++) {
+         assertEquals(data[i], buffer.get(i));
+      }
+
+      assertTrue(buffer.hasRemaining());
+   }
+
+   @Test
+   public void testGetShort() {
+      byte[] data = new byte[] {0, 1};
+      ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+      NettyReadable buffer = new NettyReadable(byteBuffer);
+
+      assertEquals(1, buffer.getShort());
+      assertFalse(buffer.hasRemaining());
+
+      try {
+         buffer.getShort();
+         fail("Should throw an IndexOutOfBoundsException");
+      } catch (IndexOutOfBoundsException ioe) {
+      }
+   }
+
+   @Test
+   public void testGetInt() {
+      byte[] data = new byte[] {0, 0, 0, 1};
+      ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+      NettyReadable buffer = new NettyReadable(byteBuffer);
+
+      assertEquals(1, buffer.getInt());
+      assertFalse(buffer.hasRemaining());
+
+      try {
+         buffer.getInt();
+         fail("Should throw an IndexOutOfBoundsException");
+      } catch (IndexOutOfBoundsException ioe) {
+      }
+   }
+
+   @Test
+   public void testGetLong() {
+      byte[] data = new byte[] {0, 0, 0, 0, 0, 0, 0, 1};
+      ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+      NettyReadable buffer = new NettyReadable(byteBuffer);
+
+      assertEquals(1, buffer.getLong());
+      assertFalse(buffer.hasRemaining());
+
+      try {
+         buffer.getLong();
+         fail("Should throw an IndexOutOfBoundsException");
+      } catch (IndexOutOfBoundsException ioe) {
+      }
+   }
+
+   @Test
+   public void testGetFloat() {
+      byte[] data = new byte[] {0, 0, 0, 0};
+      ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+      NettyReadable buffer = new NettyReadable(byteBuffer);
+
+      assertEquals(0, buffer.getFloat(), 0.0);
+      assertFalse(buffer.hasRemaining());
+
+      try {
+         buffer.getFloat();
+         fail("Should throw an IndexOutOfBoundsException");
+      } catch (IndexOutOfBoundsException ioe) {
+      }
+   }
+
+   @Test
+   public void testGetDouble() {
+      byte[] data = new byte[] {0, 0, 0, 0, 0, 0, 0, 0};
+      ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+      NettyReadable buffer = new NettyReadable(byteBuffer);
+
+      assertEquals(0, buffer.getDouble(), 0.0);
+      assertFalse(buffer.hasRemaining());
+
+      try {
+         buffer.getDouble();
+         fail("Should throw an IndexOutOfBoundsException");
+      } catch (IndexOutOfBoundsException ioe) {
+      }
+   }
+
+   @Test
+   public void testGetBytes() {
+      byte[] data = new byte[] {0, 1, 2, 3, 4};
+      ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+      NettyReadable buffer = new NettyReadable(byteBuffer);
+
+      byte[] target = new byte[data.length];
+
+      buffer.get(target);
+      assertFalse(buffer.hasRemaining());
+      assertArrayEquals(data, target);
+
+      try {
+         buffer.get(target);
+         fail("Should throw an IndexOutOfBoundsException");
+      } catch (IndexOutOfBoundsException ioe) {
+      }
+   }
+
+   @Test
+   public void testGetBytesIntInt() {
+      byte[] data = new byte[] {0, 1, 2, 3, 4};
+      ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+      NettyReadable buffer = new NettyReadable(byteBuffer);
+
+      byte[] target = new byte[data.length];
+
+      buffer.get(target, 0, target.length);
+      assertFalse(buffer.hasRemaining());
+      assertArrayEquals(data, target);
+
+      try {
+         buffer.get(target, 0, target.length);
+         fail("Should throw an IndexOutOfBoundsException");
+      } catch (IndexOutOfBoundsException ioe) {
+      }
+   }
+
+   @Test
+   public void testGetBytesToWritableBuffer() {
+      byte[] data = new byte[] {0, 1, 2, 3, 4};
+      ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+      NettyReadable buffer = new NettyReadable(byteBuffer);
+      ByteBuf targetBuffer = Unpooled.buffer(data.length, data.length);
+      NettyWritable target = new NettyWritable(targetBuffer);
+
+      buffer.get(target);
+      assertFalse(buffer.hasRemaining());
+      assertArrayEquals(targetBuffer.array(), data);
+   }
+
+   @Test
+   public void testGetBytesToWritableBufferThatIsDirect() {
+      byte[] data = new byte[] {0, 1, 2, 3, 4};
+      ByteBuf byteBuffer = Unpooled.directBuffer(data.length, data.length);
+      byteBuffer.writeBytes(data);
+      NettyReadable buffer = new NettyReadable(byteBuffer);
+      ByteBuf targetBuffer = Unpooled.buffer(data.length, data.length);
+      NettyWritable target = new NettyWritable(targetBuffer);
+
+      buffer.get(target);
+      assertFalse(buffer.hasRemaining());
+
+      for (int i = 0; i < data.length; i++) {
+         assertEquals(data[i], target.getByteBuf().readByte());
+      }
+   }
+
+   @Test
+   public void testDuplicate() {
+      byte[] data = new byte[] {0, 1, 2, 3, 4};
+      ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+      NettyReadable buffer = new NettyReadable(byteBuffer);
+
+      ReadableBuffer duplicate = buffer.duplicate();
+
+      for (int i = 0; i < data.length; i++) {
+         assertEquals(data[i], duplicate.get());
+      }
+
+      assertFalse(duplicate.hasRemaining());
+   }
+
+   @Test
+   public void testSlice() {
+      byte[] data = new byte[] {0, 1, 2, 3, 4};
+      ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+      NettyReadable buffer = new NettyReadable(byteBuffer);
+
+      ReadableBuffer slice = buffer.slice();
+
+      for (int i = 0; i < data.length; i++) {
+         assertEquals(data[i], slice.get());
+      }
+
+      assertFalse(slice.hasRemaining());
+   }
+
+   @Test
+   public void testLimit() {
+      byte[] data = new byte[] {1, 2};
+      ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+      NettyReadable buffer = new NettyReadable(byteBuffer);
+
+      assertEquals(data.length, buffer.limit());
+      buffer.limit(1);
+      assertEquals(1, buffer.limit());
+      assertEquals(1, buffer.get());
+      assertFalse(buffer.hasRemaining());
+
+      try {
+         buffer.get();
+         fail("Should throw an IndexOutOfBoundsException");
+      } catch (IndexOutOfBoundsException ioe) {
+      }
+   }
+
+   @Test
+   public void testClear() {
+      byte[] data = new byte[] {0, 1, 2, 3, 4};
+      ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+      NettyReadable buffer = new NettyReadable(byteBuffer);
+
+      byte[] target = new byte[data.length];
+
+      buffer.get(target);
+      assertFalse(buffer.hasRemaining());
+      assertArrayEquals(data, target);
+
+      try {
+         buffer.get(target);
+         fail("Should throw an IndexOutOfBoundsException");
+      } catch (IndexOutOfBoundsException ioe) {
+      }
+
+      buffer.clear();
+      assertTrue(buffer.hasRemaining());
+      assertEquals(data.length, buffer.remaining());
+      buffer.get(target);
+      assertFalse(buffer.hasRemaining());
+      assertArrayEquals(data, target);
+   }
+
+   @Test
+   public void testRewind() {
+      byte[] data = new byte[] {0, 1, 2, 3, 4};
+      ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+      NettyReadable buffer = new NettyReadable(byteBuffer);
+
+      for (int i = 0; i < data.length; i++) {
+         assertEquals(data[i], buffer.get());
+      }
+
+      assertFalse(buffer.hasRemaining());
+      buffer.rewind();
+      assertTrue(buffer.hasRemaining());
+
+      for (int i = 0; i < data.length; i++) {
+         assertEquals(data[i], buffer.get());
+      }
+   }
+
+   @Test
+   public void testReset() {
+      byte[] data = new byte[] {0, 1, 2, 3, 4};
+      ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+      NettyReadable buffer = new NettyReadable(byteBuffer);
+
+      buffer.mark();
+
+      for (int i = 0; i < data.length; i++) {
+         assertEquals(data[i], buffer.get());
+      }
+
+      assertFalse(buffer.hasRemaining());
+      buffer.reset();
+      assertTrue(buffer.hasRemaining());
+
+      for (int i = 0; i < data.length; i++) {
+         assertEquals(data[i], buffer.get());
+      }
+   }
+
+   @Test
+   public void testGetPosition() {
+      byte[] data = new byte[] {0, 1, 2, 3, 4};
+      ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+      NettyReadable buffer = new NettyReadable(byteBuffer);
+
+      assertEquals(buffer.position(), 0);
+      for (int i = 0; i < data.length; i++) {
+         assertEquals(buffer.position(), i);
+         assertEquals(data[i], buffer.get());
+         assertEquals(buffer.position(), i + 1);
+      }
+   }
+
+   @Test
+   public void testSetPosition() {
+      byte[] data = new byte[] {0, 1, 2, 3, 4};
+      ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+      NettyReadable buffer = new NettyReadable(byteBuffer);
+
+      for (int i = 0; i < data.length; i++) {
+         assertEquals(data[i], buffer.get());
+      }
+
+      assertFalse(buffer.hasRemaining());
+      buffer.position(0);
+      assertTrue(buffer.hasRemaining());
+
+      for (int i = 0; i < data.length; i++) {
+         assertEquals(data[i], buffer.get());
+      }
+   }
+
+   @Test
+   public void testFlip() {
+      byte[] data = new byte[] {0, 1, 2, 3, 4};
+      ByteBuf byteBuffer = Unpooled.wrappedBuffer(data);
+      NettyReadable buffer = new NettyReadable(byteBuffer);
+
+      buffer.mark();
+
+      for (int i = 0; i < data.length; i++) {
+         assertEquals(data[i], buffer.get());
+      }
+
+      assertFalse(buffer.hasRemaining());
+      buffer.flip();
+      assertTrue(buffer.hasRemaining());
+
+      for (int i = 0; i < data.length; i++) {
+         assertEquals(data[i], buffer.get());
+      }
+   }
+
+   @Test
+   public void testReadUTF8() throws CharacterCodingException {
+      String testString = "test-string-1";
+      byte[] asUtf8bytes = testString.getBytes(StandardCharsets.UTF_8);
+      ByteBuf byteBuffer = Unpooled.wrappedBuffer(asUtf8bytes);
+
+      NettyReadable buffer = new NettyReadable(byteBuffer);
+
+      assertEquals(testString, buffer.readUTF8());
+   }
+
+   @Test
+   public void testReadString() throws CharacterCodingException {
+      String testString = "test-string-1";
+      byte[] asUtf8bytes = testString.getBytes(StandardCharsets.UTF_8);
+      ByteBuf byteBuffer = Unpooled.wrappedBuffer(asUtf8bytes);
+
+      NettyReadable buffer = new NettyReadable(byteBuffer);
+
+      assertEquals(testString, buffer.readString(StandardCharsets.UTF_8.newDecoder()));
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/util/NettyWritableTest.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/util/NettyWritableTest.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.ByteBuffer;
+
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.junit.Test;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+/**
+ * Tests for behavior of NettyWritable
+ */
+public class NettyWritableTest {
+
+   @Test
+   public void testGetBuffer() {
+      ByteBuf buffer = Unpooled.buffer(1024);
+      NettyWritable writable = new NettyWritable(buffer);
+
+      assertSame(buffer, writable.getByteBuf());
+   }
+
+   @Test
+   public void testLimit() {
+      ByteBuf buffer = Unpooled.buffer(1024);
+      NettyWritable writable = new NettyWritable(buffer);
+
+      assertEquals(buffer.capacity(), writable.limit());
+   }
+
+   @Test
+   public void testRemaining() {
+      ByteBuf buffer = Unpooled.buffer(1024);
+      NettyWritable writable = new NettyWritable(buffer);
+
+      assertEquals(buffer.maxCapacity(), writable.remaining());
+      writable.put((byte) 0);
+      assertEquals(buffer.maxCapacity() - 1, writable.remaining());
+   }
+
+   @Test
+   public void testHasRemaining() {
+      ByteBuf buffer = Unpooled.buffer(100, 100);
+      NettyWritable writable = new NettyWritable(buffer);
+
+      assertTrue(writable.hasRemaining());
+      writable.put((byte) 0);
+      assertTrue(writable.hasRemaining());
+      buffer.writerIndex(buffer.maxCapacity());
+      assertFalse(writable.hasRemaining());
+   }
+
+   @Test
+   public void testGetPosition() {
+      ByteBuf buffer = Unpooled.buffer(1024);
+      NettyWritable writable = new NettyWritable(buffer);
+
+      assertEquals(0, writable.position());
+      writable.put((byte) 0);
+      assertEquals(1, writable.position());
+   }
+
+   @Test
+   public void testSetPosition() {
+      ByteBuf buffer = Unpooled.buffer(1024);
+      NettyWritable writable = new NettyWritable(buffer);
+
+      assertEquals(0, writable.position());
+      writable.position(1);
+      assertEquals(1, writable.position());
+   }
+
+   @Test
+   public void testPutByteBuffer() {
+      ByteBuffer input = ByteBuffer.allocate(1024);
+      input.put((byte) 1);
+      input.flip();
+
+      ByteBuf buffer = Unpooled.buffer(1024);
+      NettyWritable writable = new NettyWritable(buffer);
+
+      assertEquals(0, writable.position());
+      writable.put(input);
+      assertEquals(1, writable.position());
+   }
+
+   @Test
+   public void testPutByteBuf() {
+      ByteBuf input = Unpooled.buffer();
+      input.writeByte((byte) 1);
+
+      ByteBuf buffer = Unpooled.buffer(1024);
+      NettyWritable writable = new NettyWritable(buffer);
+
+      assertEquals(0, writable.position());
+      writable.put(input);
+      assertEquals(1, writable.position());
+   }
+
+   @Test
+   public void testPutReadableBuffer() {
+      doPutReadableBufferTestImpl(true);
+      doPutReadableBufferTestImpl(false);
+   }
+
+   private void doPutReadableBufferTestImpl(boolean readOnly) {
+      ByteBuffer buf = ByteBuffer.allocate(1024);
+      buf.put((byte) 1);
+      buf.flip();
+      if (readOnly) {
+         buf = buf.asReadOnlyBuffer();
+      }
+
+      ReadableBuffer input = new ReadableBuffer.ByteBufferReader(buf);
+
+      if (readOnly) {
+         assertFalse("Expected buffer not to hasArray()", input.hasArray());
+      } else {
+         assertTrue("Expected buffer to hasArray()", input.hasArray());
+      }
+
+      ByteBuf buffer = Unpooled.buffer(1024);
+      NettyWritable writable = new NettyWritable(buffer);
+
+      assertEquals(0, writable.position());
+      writable.put(input);
+      assertEquals(1, writable.position());
+   }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -92,10 +92,10 @@
       <maven.assembly.plugin.version>2.4</maven.assembly.plugin.version>
       <mockito.version>2.8.47</mockito.version>
       <netty.version>4.1.22.Final</netty.version>
-      <proton.version>0.26.0</proton.version>
+      <proton.version>0.27.1</proton.version>
       <resteasy.version>3.0.19.Final</resteasy.version>
       <slf4j.version>1.7.21</slf4j.version>
-      <qpid.jms.version>0.30.0</qpid.jms.version>
+      <qpid.jms.version>0.32.0</qpid.jms.version>
       <johnzon.version>0.9.5</johnzon.version>
       <json-p.spec.version>1.0-alpha-1</json-p.spec.version>
       <javax.inject.version>1</javax.inject.version>


### PR DESCRIPTION
Use new no copy variants for the delivery send and receive and make
use of the ReadableBuffer type that is now used to convery tranfer
payloads without a copy.  Also set max outgoing frame size to match
the configured maxFrameSize for the AMQP protocol head to avoid the
case where an overly large frame can be written instead of chunking
a large message.