### PR TITLE
ARTEMIS-1804 don't call deprecated SslHandler#close() to avoid NPE in Netty

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnection.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnection.java
@@ -238,12 +238,10 @@ public class NettyConnection implements Connection {
       boolean inEventLoop = eventLoop.inEventLoop();
       //if we are in an event loop we need to close the channel after the writes have finished
       if (!inEventLoop) {
-         final SslHandler sslHandler = (SslHandler) channel.pipeline().get("ssl");
-         closeSSLAndChannel(sslHandler, channel, false);
+         closeSSLAndChannel(channel, false);
       } else {
          eventLoop.execute(() -> {
-            final SslHandler sslHandler = (SslHandler) channel.pipeline().get("ssl");
-            closeSSLAndChannel(sslHandler, channel, true);
+            closeSSLAndChannel(channel, true);
          });
       }
 
@@ -555,26 +553,12 @@ public class NettyConnection implements Connection {
       return super.toString() + "[ID=" + getID() + ", local= " + channel.localAddress() + ", remote=" + channel.remoteAddress() + "]";
    }
 
-   private void closeSSLAndChannel(SslHandler sslHandler, final Channel channel, boolean inEventLoop) {
+   private void closeSSLAndChannel(final Channel channel, boolean inEventLoop) {
       checkFlushBatchBuffer();
-      if (sslHandler != null) {
-         try {
-            ChannelFuture sslCloseFuture = sslHandler.close();
-            sslCloseFuture.addListener(future -> channel.close());
-            if (!inEventLoop && !sslCloseFuture.awaitUninterruptibly(DEFAULT_WAIT_MILLIS)) {
-               ActiveMQClientLogger.LOGGER.timeoutClosingSSL();
-            }
-         } catch (Throwable t) {
-            // ignore
-            if (ActiveMQClientLogger.LOGGER.isTraceEnabled()) {
-               ActiveMQClientLogger.LOGGER.trace(t.getMessage(), t);
-            }
-         }
-      } else {
-         ChannelFuture closeFuture = channel.close();
-         if (!inEventLoop && !closeFuture.awaitUninterruptibly(DEFAULT_WAIT_MILLIS)) {
-            ActiveMQClientLogger.LOGGER.timeoutClosingNettyChannel();
-         }
+      // closing the channel results in closing any sslHandler first; SslHandler#close() was deprecated by netty
+      ChannelFuture closeFuture = channel.close();
+      if (!inEventLoop && !closeFuture.awaitUninterruptibly(DEFAULT_WAIT_MILLIS)) {
+         ActiveMQClientLogger.LOGGER.timeoutClosingNettyChannel();
       }
    }
 


### PR DESCRIPTION
The stacktrace of the exception involves a deprecated method. For some reason, using the recommended alternative does not produce the exception... Could this PR be step in the right direction?

The Netty exception appears when OpenWire client which is using SSL disconnects:

2018-05-04 09:56:44,424 WARN  [io.netty.handler.ssl.SslHandler] [id: 0x1dcd30fa, L:/127.0.0.1:61617 ! R:/127.0.0.1:33006] flush() raised a masked exception.: java.lang.NullPointerException
        at io.netty.handler.ssl.SslHandler.wrapAndFlush(SslHandler.java:760) [netty-all-4.1.24.Final.jar:4.1.24.Final]
        at io.netty.handler.ssl.SslHandler.flush(SslHandler.java:752) [netty-all-4.1.24.Final.jar:4.1.24.Final]
        at io.netty.handler.ssl.SslHandler.flush(SslHandler.java:1625) [netty-all-4.1.24.Final.jar:4.1.24.Final]
        at io.netty.handler.ssl.SslHandler.access$600(SslHandler.java:165) [netty-all-4.1.24.Final.jar:4.1.24.Final]
        at io.netty.handler.ssl.SslHandler$1.run(SslHandler.java:649) [netty-all-4.1.24.Final.jar:4.1.24.Final]
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163) [netty-all-4.1.24.Final.jar:4.1.24.Final]
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:404) [netty-all-4.1.24.Final.jar:4.1.24.Final]
        at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:309) [netty-all-4.1.24.Final.jar:4.1.24.Final]
        at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:884) [netty-all-4.1.24.Final.jar:4.1.24.Final]
        at org.apache.activemq.artemis.utils.ActiveMQThreadFactory$1.run(ActiveMQThreadFactory.java:118) [artemis-commons-2.6.0-SNAPSHOT.jar:2.6.0-SNAPSHOT]