### PR TITLE
ARTEMIS-1887 Setting default-max-consumers in address-setting not working

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/CoreQueueConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/CoreQueueConfiguration.java
@@ -45,6 +45,8 @@ public class CoreQueueConfiguration implements Serializable {
 
    private RoutingType routingType = ActiveMQDefaultConfiguration.getDefaultRoutingType();
 
+   private boolean isMaxConsumerConfigured = false;
+
    public CoreQueueConfiguration() {
    }
 
@@ -74,6 +76,15 @@ public class CoreQueueConfiguration implements Serializable {
 
    public Boolean isLastValue() {
       return lastValue;
+   }
+
+   public boolean isMaxConsumerConfigured() {
+      return isMaxConsumerConfigured;
+   }
+
+   public CoreQueueConfiguration setMaxConsumerConfigured(boolean isMaxConsumerConfigured) {
+      this.isMaxConsumerConfigured = isMaxConsumerConfigured;
+      return this;
    }
 
    /**
@@ -171,6 +182,7 @@ public class CoreQueueConfiguration implements Serializable {
       result = prime * result + ((purgeOnNoConsumers == null) ? 0 : purgeOnNoConsumers.hashCode());
       result = prime * result + ((exclusive == null) ? 0 : exclusive.hashCode());
       result = prime * result + ((lastValue == null) ? 0 : lastValue.hashCode());
+      result = prime * result + (isMaxConsumerConfigured ? 1331 : 1337);
       return result;
    }
 
@@ -189,6 +201,8 @@ public class CoreQueueConfiguration implements Serializable {
       } else if (!address.equals(other.address))
          return false;
       if (durable != other.durable)
+         return false;
+      if (isMaxConsumerConfigured != other.isMaxConsumerConfigured)
          return false;
       if (filterString == null) {
          if (other.filterString != null)

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -1093,6 +1093,7 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       String address = null;
       String filterString = null;
       boolean durable = true;
+      boolean maxConumserConfigured = false;
       int maxConsumers = ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers();
       boolean purgeOnNoConsumers = ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers();
       String user = null;
@@ -1105,6 +1106,7 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
          if (item.getNodeName().equals("max-consumers")) {
             maxConsumers = Integer.parseInt(item.getNodeValue());
             Validators.MAX_QUEUE_CONSUMERS.validate(name, maxConsumers);
+            maxConumserConfigured = true;
          } else if (item.getNodeName().equals("purge-on-no-consumers")) {
             purgeOnNoConsumers = Boolean.parseBoolean(item.getNodeValue());
          } else if (item.getNodeName().equals("exclusive")) {
@@ -1130,7 +1132,7 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       }
 
       return new CoreQueueConfiguration().setAddress(address).setName(name).setFilterString(filterString).setDurable(durable).setMaxConsumers(maxConsumers).setPurgeOnNoConsumers(purgeOnNoConsumers).setUser(user)
-                                         .setExclusive(exclusive).setLastValue(lastValue);
+                                         .setExclusive(exclusive).setLastValue(lastValue).setMaxConsumerConfigured(maxConumserConfigured);
    }
 
    protected CoreAddressConfiguration parseAddressConfiguration(final Node node) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -2541,15 +2541,18 @@ public class ActiveMQServerImpl implements ActiveMQServer {
          ActiveMQServerLogger.LOGGER.deployQueue(config.getName(), config.getAddress());
          AddressSettings as = addressSettingsRepository.getMatch(config.getAddress());
          // determine if there is an address::queue match; update it if so
+         int maxConsumerAddressSetting = as.getDefaultMaxConsumers();
+         int maxConsumerQueueConfig = config.getMaxConsumers();
+         int maxConsumer = (config.isMaxConsumerConfigured()) ? maxConsumerQueueConfig : maxConsumerAddressSetting;
          if (locateQueue(queueName) != null && locateQueue(queueName).getAddress().toString().equals(config.getAddress())) {
-            updateQueue(config.getName(), config.getRoutingType(), config.getMaxConsumers(), config.getPurgeOnNoConsumers(),
+            updateQueue(config.getName(), config.getRoutingType(), maxConsumer, config.getPurgeOnNoConsumers(),
                         config.isExclusive() == null ? as.isDefaultExclusiveQueue() : config.isExclusive());
          } else {
             // if the address::queue doesn't exist then create it
             try {
                createQueue(SimpleString.toSimpleString(config.getAddress()), config.getRoutingType(),
                            queueName, SimpleString.toSimpleString(config.getFilterString()), SimpleString.toSimpleString(config.getUser()),
-                           config.isDurable(),false,false,false,false,config.getMaxConsumers(),config.getPurgeOnNoConsumers(),
+                           config.isDurable(),false,false,false,false,maxConsumer,config.getPurgeOnNoConsumers(),
                            config.isExclusive() == null ? as.isDefaultExclusiveQueue() : config.isExclusive(),
                            config.isLastValue() == null ? as.isDefaultLastValueQueue() : config.isLastValue(), true);
             } catch (ActiveMQQueueExistsException e) {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/SecureConfigurationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/SecureConfigurationTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.activemq.artemis.tests.integration.server;
 
-import java.lang.IllegalStateException;
 import java.util.Arrays;
 import java.util.Collection;
 import javax.jms.Connection;
@@ -45,7 +44,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -56,7 +54,7 @@ public class SecureConfigurationTest extends ActiveMQTestBase {
    @Parameterized.Parameters(name = "{index}: protocol={0}")
    public static Collection<Object[]> parameters() {
       return Arrays.asList(new Object[][] {
-              {"CORE"}, {"AMQP"}, {"OPENWIRE"}
+         {"CORE"}, {"AMQP"}, {"OPENWIRE"}
       });
    }
 


### PR DESCRIPTION
When setting "default-max-consumers" in addressing setting in broker.xml
It has no effect on the "max-consumers" property on matching address queues.