### PR TITLE
ARTEMIS-1891 Sending synchronization finished packet starves when thread pool is full

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/replication/ReplicationManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/replication/ReplicationManager.java
@@ -120,7 +120,7 @@ public final class ReplicationManager implements ActiveMQComponent {
 
    private final Queue<OperationContext> pendingTokens = new ConcurrentLinkedQueue<>();
 
-   private final ExecutorFactory executorFactory;
+   private final ExecutorFactory ioExecutorFactory;
 
    private final Executor replicationStream;
 
@@ -142,12 +142,12 @@ public final class ReplicationManager implements ActiveMQComponent {
    public ReplicationManager(CoreRemotingConnection remotingConnection,
                              final long timeout,
                              final long initialReplicationSyncTimeout,
-                             final ExecutorFactory executorFactory) {
-      this.executorFactory = executorFactory;
+                             final ExecutorFactory ioExecutorFactory) {
+      this.ioExecutorFactory = ioExecutorFactory;
       this.initialReplicationSyncTimeout = initialReplicationSyncTimeout;
       this.replicatingChannel = remotingConnection.getChannel(CHANNEL_ID.REPLICATION.id, -1);
       this.remotingConnection = remotingConnection;
-      this.replicationStream = executorFactory.getExecutor();
+      this.replicationStream = ioExecutorFactory.getExecutor();
       this.timeout = timeout;
    }
 
@@ -355,7 +355,7 @@ public final class ReplicationManager implements ActiveMQComponent {
          return null;
       }
 
-      final OperationContext repliToken = OperationContextImpl.getContext(executorFactory);
+      final OperationContext repliToken = OperationContextImpl.getContext(ioExecutorFactory);
       if (lineUp) {
          repliToken.replicationLineUp();
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/SharedNothingLiveActivation.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/SharedNothingLiveActivation.java
@@ -169,7 +169,7 @@ public class SharedNothingLiveActivation extends LiveActivation {
          ReplicationFailureListener listener = new ReplicationFailureListener();
          rc.addCloseListener(listener);
          rc.addFailureListener(listener);
-         replicationManager = new ReplicationManager(rc, clusterConnection.getCallTimeout(), replicatedPolicy.getInitialReplicationSyncTimeout(), activeMQServer.getExecutorFactory());
+         replicationManager = new ReplicationManager(rc, clusterConnection.getCallTimeout(), replicatedPolicy.getInitialReplicationSyncTimeout(), activeMQServer.getIOExecutorFactory());
          replicationManager.start();
          Thread t = new Thread(new Runnable() {
             @Override


### PR DESCRIPTION
After sending pages, the thread will hold the storage manager write lock and send synchronization finished packet(use the parent thread pool) to the backup node. At the same time, thread pool is full bcs they are waiting for the storage manager read lock to write the page or journal, leading to replication starting failure. Here we use io executor to send replicate packet to fix thread pool starvation problem.