### PR TITLE
ARTEMIS-1895 - Add duplicate metadata failure callback to ActiveMQServerPlugin

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -1523,6 +1523,9 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
       ServerSession sessionWithMetaData = server.lookupSession(key, data);
       if (sessionWithMetaData != null && sessionWithMetaData != this) {
          // There is a duplication of this property
+         if (server.hasBrokerPlugins()) {
+            server.callBrokerPlugins(plugin -> plugin.duplicateSessionMetadataFailure(this, key, data));
+         }
          return false;
       } else {
          addMetaData(key, data);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/plugin/ActiveMQServerPlugin.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/plugin/ActiveMQServerPlugin.java
@@ -158,6 +158,18 @@ public interface ActiveMQServerPlugin {
    }
 
    /**
+    * Called when adding session metadata fails because the metadata is a duplicate
+    *
+    * @param session
+    * @param key
+    * @param data
+    * @throws ActiveMQException
+    */
+   default void duplicateSessionMetadataFailure(ServerSession session, String key, String data) throws ActiveMQException {
+
+   }
+
+   /**
     * After session metadata is added to the session
     *
     * @param session


### PR DESCRIPTION
Add a callback on duplicate metadata which will allow extra functionality to be added.