### PR TITLE
ARTEMIS-1916 Remove Jmx ArtemisRMIServerSocketFactory

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/ConnectorServerFactory.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/ConnectorServerFactory.java
@@ -25,7 +25,6 @@ import javax.management.remote.JMXConnectorServer;
 import javax.management.remote.JMXConnectorServerFactory;
 import javax.management.remote.JMXServiceURL;
 import javax.management.remote.rmi.RMIConnectorServer;
-import javax.net.ServerSocketFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLServerSocketFactory;
@@ -184,7 +183,6 @@ public class ConnectorServerFactory {
          throw new IllegalArgumentException("server must be set");
       }
       JMXServiceURL url = new JMXServiceURL(this.serviceUrl);
-      setupArtemisRMIServerSocketFactory();
       if (isClientAuth()) {
          this.secured = true;
       }
@@ -240,11 +238,6 @@ public class ConnectorServerFactory {
       environment.put(RMIConnectorServer.RMI_CLIENT_SOCKET_FACTORY_ATTRIBUTE, rcsf);
    }
 
-   private void setupArtemisRMIServerSocketFactory() {
-      RMIServerSocketFactory rmiServerSocketFactory = new ArtemisRMIServerSocketFactory(getRmiServerHost());
-      environment.put(RMIConnectorServer.RMI_SERVER_SOCKET_FACTORY_ATTRIBUTE, rmiServerSocketFactory);
-   }
-
    private static class ArtemisSslRMIServerSocketFactory implements RMIServerSocketFactory {
       private SSLServerSocketFactory sssf;
       private boolean clientAuth;
@@ -263,20 +256,5 @@ public class ConnectorServerFactory {
          return ss;
       }
    }
-
-   private static class ArtemisRMIServerSocketFactory implements RMIServerSocketFactory {
-      private String rmiServerHost;
-
-      ArtemisRMIServerSocketFactory(String rmiServerHost) {
-         this.rmiServerHost = rmiServerHost;
-      }
-
-      @Override
-      public ServerSocket createServerSocket(int port) throws IOException {
-         ServerSocket serverSocket = (ServerSocket) ServerSocketFactory.getDefault().createServerSocket(port, 50, InetAddress.getByName(rmiServerHost));
-         return serverSocket;
-      }
-   }
-
 
 }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/jdbc/JdbcSharedStateManagerTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/jdbc/JdbcSharedStateManagerTest.java
@@ -57,7 +57,7 @@ public class JdbcSharedStateManagerTest extends ActiveMQTestBase {
          sqlProvider);
    }
 
-   @Test(timeout = 10000)
+   @Test(timeout = 30000)
    public void shouldStartIfTableNotExist() throws Exception {
       final JdbcSharedStateManager sharedStateManager = createSharedStateManager();
       try {
@@ -67,7 +67,7 @@ public class JdbcSharedStateManagerTest extends ActiveMQTestBase {
       }
    }
 
-   @Test(timeout = 10000)
+   @Test(timeout = 30000)
    public void shouldStartIfTableExistEmpty() throws Exception {
       final TestJDBCDriver fakeDriver = createFakeDriver(false);
       fakeDriver.start();
@@ -80,7 +80,7 @@ public class JdbcSharedStateManagerTest extends ActiveMQTestBase {
       }
    }
 
-   @Test(timeout = 10000)
+   @Test(timeout = 30000)
    public void shouldStartIfTableExistInitialized() throws Exception {
       final TestJDBCDriver fakeDriver = createFakeDriver(true);
       fakeDriver.start();
@@ -93,7 +93,7 @@ public class JdbcSharedStateManagerTest extends ActiveMQTestBase {
       }
    }
 
-   @Test(timeout = 10000)
+   @Test(timeout = 30000)
    public void shouldStartTwoIfTableNotExist() throws Exception {
       final JdbcSharedStateManager liveSharedStateManager = createSharedStateManager();
       final JdbcSharedStateManager backupSharedStateManager = createSharedStateManager();


### PR DESCRIPTION
The ArtemisRMIServerSocketFactory doesn't do anything special,
instead the existence of this impl class causes jmx client
failed to connect (for reason not known, probably not fully
implemented the functionality). It turns out just fine
to use JDK's impl. This class is not necessary.