### PR TITLE
Revert "[ARTEMIS-1819] Missing fields on listAllConsumersAsJSON, list…

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -53,7 +53,6 @@ import org.apache.activemq.artemis.api.core.JsonUtil;
 import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
-import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl;
 import org.apache.activemq.artemis.api.core.management.AddressControl;
 import org.apache.activemq.artemis.api.core.management.BridgeControl;
@@ -1832,19 +1831,6 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
          for (RemotingConnection connection : connections) {
             JsonObjectBuilder obj = JsonLoader.createObjectBuilder().add("connectionID", connection.getID().toString()).add("clientAddress", connection.getRemoteAddress()).add("creationTime", connection.getCreationTime()).add("implementation", connection.getClass().getSimpleName()).add("sessionCount", server.getSessions(connection.getID().toString()).size());
-
-            List<ServerSession> sessions = server.getSessions(connection.getID().toString());
-
-            if (sessions.size() > 0) {
-               if (sessions.get(0).getMetaData(ClientSession.JMS_SESSION_CLIENT_ID_PROPERTY) != null) {
-                  obj.add("clientID", sessions.get(0).getMetaData(ClientSession.JMS_SESSION_CLIENT_ID_PROPERTY));
-               } else {
-                  obj.add("clientID", "");
-               }
-            } else {
-               obj.add("clientID", "");
-            }
-
             array.add(obj);
          }
          return array.build().toString();
@@ -1961,18 +1947,6 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
       if (consumer.getFilter() != null) {
          obj.add("filter", consumer.getFilter().getFilterString().toString());
       }
-
-      obj.add("destinationName", consumer.getQueue().getAddress().toString());
-
-      if (consumer.getQueueType().getType() == 0) {
-         obj.add("destinationType", "topic");
-      } else if (consumer.getQueueType().getType() == 1) {
-         obj.add("destinationType", "queue");
-      } else {
-         obj.add("destinationType", "");
-      }
-
-      obj.add("durable", consumer.getQueue().isDurable());
 
       return obj.build();
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
@@ -1317,13 +1317,11 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       Assert.assertTrue(first.getString("clientAddress").length() > 0);
       Assert.assertTrue(first.getJsonNumber("creationTime").longValue() > 0);
       Assert.assertEquals(0, first.getJsonNumber("sessionCount").longValue());
-      Assert.assertEquals("", first.getString("clientID"));
 
       Assert.assertTrue(second.getString("connectionID").length() > 0);
       Assert.assertTrue(second.getString("clientAddress").length() > 0);
       Assert.assertTrue(second.getJsonNumber("creationTime").longValue() > 0);
       Assert.assertEquals(1, second.getJsonNumber("sessionCount").longValue());
-      Assert.assertEquals("", second.getString("clientID"));
    }
 
    @Test
@@ -1366,9 +1364,6 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       Assert.assertEquals(false, first.getBoolean("browseOnly"));
       Assert.assertTrue(first.getJsonNumber("creationTime").longValue() > 0);
       Assert.assertEquals(0, first.getJsonNumber("deliveringCount").longValue());
-      Assert.assertEquals(queueName.toString(), first.getString("destinationName"));
-      Assert.assertEquals("queue", first.getString("destinationType"));
-      Assert.assertFalse(first.getBoolean("durable"));
 
       Assert.assertNotNull(second.getJsonNumber("consumerID").longValue());
       Assert.assertTrue(second.getString("connectionID").length() > 0);
@@ -1382,9 +1377,6 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       Assert.assertEquals(0, second.getJsonNumber("deliveringCount").longValue());
       Assert.assertTrue(second.getString("filter").length() > 0);
       Assert.assertEquals(filter, second.getString("filter"));
-      Assert.assertEquals(queueName.toString(), second.getString("destinationName"));
-      Assert.assertEquals("queue", second.getString("destinationType"));
-      Assert.assertFalse(second.getBoolean("durable"));
    }
 
    @Test
@@ -1449,9 +1441,6 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       Assert.assertEquals(queueName.toString(), first.getString("queueName"));
       Assert.assertEquals(false, first.getBoolean("browseOnly"));
       Assert.assertEquals(0, first.getJsonNumber("deliveringCount").longValue());
-      Assert.assertEquals(queueName.toString(), first.getString("destinationName"));
-      Assert.assertEquals("queue", first.getString("destinationType"));
-      Assert.assertFalse(first.getBoolean("durable"));
 
       Assert.assertTrue(second.getJsonNumber("creationTime").longValue() > 0);
       Assert.assertNotNull(second.getJsonNumber("consumerID").longValue());
@@ -1463,9 +1452,6 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       Assert.assertEquals(queueName.toString(), second.getString("queueName"));
       Assert.assertEquals(false, second.getBoolean("browseOnly"));
       Assert.assertEquals(0, second.getJsonNumber("deliveringCount").longValue());
-      Assert.assertEquals(queueName.toString(), second.getString("destinationName"));
-      Assert.assertEquals("queue", second.getString("destinationType"));
-      Assert.assertFalse(second.getBoolean("durable"));
    }
 
    @Test


### PR DESCRIPTION
…ConsumersAsJSON and listConnectionsAsJSON"

This reverts commit c3fbd1b9e479f87898e0acd53f386d588c997632.

Based on the discussion on the PR
https://github.com/apache/activemq-artemis/pull/2035 this shouldn't have
been merged. It's importing JMS-specific code into the core broker which
is something we've worked hard to eliminate in recent releases.