### PR TITLE
ARTEMIS-1940: premature release of pooled buffers during send can cause AMQP connection failures

### DIFF
--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/AmqpConnection.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/AmqpConnection.java
@@ -49,6 +49,7 @@ import org.apache.qpid.proton.engine.EndpointState;
 import org.apache.qpid.proton.engine.Event;
 import org.apache.qpid.proton.engine.Event.Type;
 import org.apache.qpid.proton.engine.Sasl;
+import org.apache.qpid.proton.engine.Session;
 import org.apache.qpid.proton.engine.Transport;
 import org.apache.qpid.proton.engine.impl.CollectorImpl;
 import org.apache.qpid.proton.engine.impl.TransportImpl;
@@ -105,6 +106,7 @@ public class AmqpConnection extends AmqpAbstractResource<Connection> implements 
    private boolean authenticated;
    private int maxFrameSize = DEFAULT_MAX_FRAME_SIZE;
    private int channelMax = DEFAULT_CHANNEL_MAX;
+   private int sessionIncomingCapacity = 0;
    private long connectTimeout = DEFAULT_CONNECT_TIMEOUT;
    private long closeTimeout = DEFAULT_CLOSE_TIMEOUT;
    private long drainTimeout = DEFAULT_DRAIN_TIMEOUT;
@@ -279,7 +281,9 @@ public class AmqpConnection extends AmqpAbstractResource<Connection> implements 
          @Override
          public void run() {
             checkClosed();
-            session.setEndpoint(getEndpoint().session());
+            Session protonSession = getEndpoint().session();
+            protonSession.setIncomingCapacity(sessionIncomingCapacity);
+            session.setEndpoint(protonSession);
             session.setStateInspector(getStateInspector());
             session.open(request);
             pumpToProtonTransport(request);
@@ -381,6 +385,14 @@ public class AmqpConnection extends AmqpAbstractResource<Connection> implements 
 
    public void setChannelMax(int channelMax) {
       this.channelMax = channelMax;
+   }
+
+   public int getSessionIncomingCapacity() {
+      return sessionIncomingCapacity;
+   }
+
+   public void setSessionIncomingCapacity(int capacity) {
+      this.sessionIncomingCapacity = capacity;
    }
 
    public long getConnectTimeout() {


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/ARTEMIS-1940 for details.