### PR TITLE
[ARTEMIS-1944] Typo mistake in broker.xml at journal-buffer-timeout explanation

### DIFF
--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/journal-buffer-settings.txt
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/journal-buffer-settings.txt
@@ -6,7 +6,7 @@
        That translates as a sync write every ${nanoseconds} nanoseconds.
 
        Note: If you specify 0 the system will perform writes directly to the disk.
-             We recommend this to be 0 if you are using journalType=MAPPED and ournal-datasync=false.
+             We recommend this to be 0 if you are using journalType=MAPPED and journal-datasync=false.
       -->
       <journal-buffer-timeout>${nanoseconds}</journal-buffer-timeout>
 


### PR DESCRIPTION
jira :- https://issues.apache.org/jira/browse/ARTEMIS-1944