### PR TITLE
ARTEMIS-1945 InVMNodeManager shared state should be volatile

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/InVMNodeManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/InVMNodeManager.java
@@ -49,7 +49,7 @@ public final class InVMNodeManager extends NodeManager {
       LIVE, PAUSED, FAILING_BACK, NOT_STARTED
    }
 
-   public State state = NOT_STARTED;
+   public volatile State state = NOT_STARTED;
 
    public long failoverPause = 0L;
 
@@ -147,9 +147,7 @@ public final class InVMNodeManager extends NodeManager {
 
    @Override
    public void releaseBackup() {
-      if (backupLock != null) {
-         backupLock.release();
-      }
+      backupLock.release();
    }
 
    @Override


### PR DESCRIPTION
State access should be atomic to be visibile between
different threads.