### PR TITLE
ARTEMIS-1951 allow queue's user to be updated

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -512,7 +512,7 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
             changed = true;
             queue.setExclusive(exclusive);
          }
-         if ((user != null && !user.equals(queue.getUser()) || (user == null && queue.getUser() != null))) {
+         if (user != null && !user.equals(queue.getUser())) {
             changed = true;
             queue.setUser(SimpleString.toSimpleString(user));
          }


### PR DESCRIPTION
Fix so that it only updates if not null, to avoid user being unset from existing api's, 
This is similar to other values, that only change the value when not null.