### PR TITLE
ARTEMIS-1951 Fix NPE on updateQueue with NULL user

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -512,6 +512,11 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
             changed = true;
             queue.setExclusive(exclusive);
          }
+         if (logger.isDebugEnabled()) {
+            if (user == null && queue.getUser() != null) {
+               logger.debug("Ignoring updating Queue to a NULL user");
+            }
+         }
          if (user != null && !user.equals(queue.getUser())) {
             changed = true;
             queue.setUser(user);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -2970,7 +2970,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
                             Boolean purgeOnNoConsumers,
                             Boolean exclusive,
                             String user) throws Exception {
-      final QueueBinding queueBinding = this.postOffice.updateQueue(new SimpleString(name), routingType, maxConsumers, purgeOnNoConsumers, exclusive, new SimpleString(user));
+      final QueueBinding queueBinding = this.postOffice.updateQueue(new SimpleString(name), routingType, maxConsumers, purgeOnNoConsumers, exclusive, SimpleString.toSimpleString(user));
       if (queueBinding != null) {
          final Queue queue = queueBinding.getQueue();
          return queue;


### PR DESCRIPTION
The previous commits of ARTEMIS-1951 were using SimpleString::new that were
throwing NPE when the String parameter is null.
This fix is just using SimpleString::toSimpleString that won't throw NPE.