### PR TITLE
ARTEMIS-1979 Table names with DB2 should be upper-cases

### DIFF
--- a/artemis-jdbc-store/src/main/resources/journal-sql.properties
+++ b/artemis-jdbc-store/src/main/resources/journal-sql.properties
@@ -89,3 +89,4 @@ table-names-case.oracle=upper
 max-blob-size.db2=2147483647
 create-file-table.db2=CREATE TABLE %s (ID BIGINT GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1), FILENAME VARCHAR(255), EXTENSION VARCHAR(10), DATA BLOB(2G), PRIMARY KEY(ID))
 append-to-file.db2=UPDATE %s SET DATA = (DATA || ?) WHERE ID=?
+table-names-case.db2=upper


### PR DESCRIPTION
DB2 JDBC driver fail to retrieve metadata information
if table names are lower-cases: similarly to Oracle, better
force any table name to be upper-cases to avoid broker being
unable to restart when lower-cases table names are used