### PR TITLE
ARTEMIS-1980 Warn on failed check of table existence should be info

### DIFF
--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/drivers/AbstractJDBCDriver.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/drivers/AbstractJDBCDriver.java
@@ -227,7 +227,12 @@ public abstract class AbstractJDBCDriver {
                   }
                }
             } catch (SQLException e) {
-               logger.warn(JDBCUtils.appendSQLExceptionDetails(new StringBuilder("Can't verify the initialization of table ").append(tableName).append(" due to:"), e, sqlProvider.getCountJournalRecordsSQL()));
+               //that's not a real issue and do not deserve any user-level log:
+               //some DBMS just return stale information about table existence
+               //and can fail on later attempts to access them
+               if (logger.isTraceEnabled()) {
+                  logger.trace(JDBCUtils.appendSQLExceptionDetails(new StringBuilder("Can't verify the initialization of table ").append(tableName).append(" due to:"), e, sqlProvider.getCountJournalRecordsSQL()));
+               }
                try {
                   connection.rollback();
                } catch (SQLException rollbackEx) {


### PR DESCRIPTION
DB2 metadata checks should erroneously report stale table existence on
not existing/just deleted table, making the subsequent warning logs
of failed SELECT COUNT useless and scaring: should be better to let
them lowered to INFO level