### PR TITLE
remove extra quotes in Windows script

### DIFF
--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis.cmd
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis.cmd
@@ -59,7 +59,7 @@ set JVM_ARGS=%JVM_ARGS% -classpath %ARTEMIS_HOME%\lib\artemis-boot.jar
 set JVM_ARGS=%JVM_ARGS% -Dartemis.home=%ARTEMIS_HOME%
 set JVM_ARGS=%JVM_ARGS% -Dartemis.instance=%ARTEMIS_INSTANCE%
 set JVM_ARGS=%JVM_ARGS% -Ddata.dir=%ARTEMIS_DATA_DIR%
-set JVM_ARGS=%JVM_ARGS% -Dartemis.instance.etc="%ARTEMIS_INSTANCE_ETC%"
+set JVM_ARGS=%JVM_ARGS% -Dartemis.instance.etc=%ARTEMIS_INSTANCE_ETC%
 set JVM_ARGS=%JVM_ARGS% -Djava.util.logging.manager=%ARTEMIS_LOG_MANAGER%
 set JVM_ARGS=%JVM_ARGS% -Dlogging.configuration=%ARTEMIS_LOGGING_CONF%
 if not "%DEBUG_ARGS%"=="" set JVM_ARGS=%JVM_ARGS% %DEBUG_ARGS%


### PR DESCRIPTION
A double set of quotation marks were preventing successful Windows
implementation.

Lines 48 and 62 of artemis.cmd both have quotation marks, resulting 
in an empty string being read before the file path: 
https://github.com/apache/activemq-artemis/blob/32296cac7e654df95e827e43dc68b7ee336ece6e/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis.cmd#L48-L62