### PR TITLE
ARTEMIS-1985: Switch from XA_RDONLY to XA_OK as return value for prepare transaction via OpenWire

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
@@ -1464,7 +1464,7 @@ public class OpenWireConnection extends AbstractRemotingConnection implements Se
             internalSession.resetTX(null);
          }
 
-         return new IntegerResponse(XAResource.XA_RDONLY);
+         return new IntegerResponse(XAResource.XA_OK);
       }
 
       @Override


### PR DESCRIPTION
@clebertsuconic : Feedback for possible test cases needed (https://issues.apache.org/jira/browse/ARTEMIS-1985)