### PR TITLE
ARTEMIS-1997 - un-needed SimpleString creation on hotpath with Filters

### DIFF
--- a/artemis-selector/pom.xml
+++ b/artemis-selector/pom.xml
@@ -33,6 +33,11 @@
 
    <dependencies>
       <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-commons</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+      <dependency>
          <groupId>xml-apis</groupId>
          <artifactId>xml-apis</artifactId>
          <optional>true</optional>

--- a/artemis-selector/src/main/java/org/apache/activemq/artemis/selector/filter/Filterable.java
+++ b/artemis-selector/src/main/java/org/apache/activemq/artemis/selector/filter/Filterable.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.selector.filter;
 
+import org.apache.activemq.artemis.api.core.SimpleString;
+
 /**
  * A Filterable is the object being evaluated by the filters.  It provides
  * access to filtered properties.
@@ -41,7 +43,7 @@ public interface Filterable {
     * @param name
     * @return
     */
-   Object getProperty(String name);
+   Object getProperty(SimpleString name);
 
    /**
     * Used by the NoLocal filter.

--- a/artemis-selector/src/main/java/org/apache/activemq/artemis/selector/filter/PropertyExpression.java
+++ b/artemis-selector/src/main/java/org/apache/activemq/artemis/selector/filter/PropertyExpression.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.selector.filter;
 
+import org.apache.activemq.artemis.api.core.SimpleString;
+
 /**
  * Represents a property expression
  *
@@ -23,9 +25,13 @@ package org.apache.activemq.artemis.selector.filter;
  */
 public class PropertyExpression implements Expression {
 
-   private final String name;
+   private final SimpleString name;
 
    public PropertyExpression(String name) {
+      this(SimpleString.toSimpleString(name));
+   }
+
+   public PropertyExpression(SimpleString name) {
       this.name = name;
    }
 
@@ -35,7 +41,7 @@ public class PropertyExpression implements Expression {
    }
 
    public String getName() {
-      return name;
+      return name.toString();
    }
 
    /**
@@ -43,7 +49,7 @@ public class PropertyExpression implements Expression {
     */
    @Override
    public String toString() {
-      return name;
+      return name.toString();
    }
 
    /**

--- a/artemis-selector/src/test/java/org/apache/activemq/artemis/selector/SelectorTest.java
+++ b/artemis-selector/src/test/java/org/apache/activemq/artemis/selector/SelectorTest.java
@@ -18,6 +18,7 @@ package org.apache.activemq.artemis.selector;
 
 import java.util.HashMap;
 
+import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.selector.filter.BooleanExpression;
 import org.apache.activemq.artemis.selector.filter.FilterException;
 import org.apache.activemq.artemis.selector.filter.Filterable;
@@ -100,14 +101,15 @@ public class SelectorTest {
       }
 
       @Override
-      public Object getProperty(String name) {
-         if ("JMSType".equals(name)) {
+      public Object getProperty(SimpleString name) {
+         String stringName = name.toString();
+         if ("JMSType".equals(stringName)) {
             return type;
          }
-         if ("JMSMessageID".equals(name)) {
+         if ("JMSMessageID".equals(stringName)) {
             return messageId;
          }
-         return properties.get(name);
+         return properties.get(stringName);
       }
 
       public Object getDestination() {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/filter/impl/FilterImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/filter/impl/FilterImpl.java
@@ -154,7 +154,7 @@ public class FilterImpl implements Filter {
             // Proton stores JMSMessageID as NATIVE_MESSAGE_ID that is an arbitrary string
             String amqpNativeID = msg.getStringProperty(NATIVE_MESSAGE_ID);
             if (amqpNativeID != null) {
-               return new SimpleString(amqpNativeID);
+               return SimpleString.toSimpleString(amqpNativeID);
             }
          }
          // It's the stringified (hex) representation of a user id that can be used in a selector expression
@@ -162,7 +162,7 @@ public class FilterImpl implements Filter {
          if (userID.startsWith("ID:")) {
             return SimpleString.toSimpleString(userID);
          } else {
-            return new SimpleString("ID:" + msg.getUserID());
+            return SimpleString.toSimpleString("ID:" + msg.getUserID());
          }
       } else if (FilterConstants.ACTIVEMQ_PRIORITY.equals(fieldName)) {
          return Integer.valueOf(msg.getPriority());
@@ -190,10 +190,10 @@ public class FilterImpl implements Filter {
       }
 
       @Override
-      public Object getProperty(String id) {
+      public Object getProperty(SimpleString id) {
          Object result = null;
-         if (id.startsWith(FilterConstants.ACTIVEMQ_PREFIX.toString())) {
-            result = getHeaderFieldValue(message, new SimpleString(id));
+         if (id.startsWith(FilterConstants.ACTIVEMQ_PREFIX)) {
+            result = getHeaderFieldValue(message, id);
          }
          if (result == null) {
             result = message.getObjectProperty(id);


### PR DESCRIPTION
Create the SimpleString on construction of PropertyExpression so it can be re-used instead of creating it every time its filtered in the FilterImpl