### PR TITLE
ARTEMIS-2001 - JMSXGroupID and JMSXUserID in getPropertyNames

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/reader/MessageUtil.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/reader/MessageUtil.java
@@ -152,9 +152,11 @@ public class MessageUtil {
       HashSet<String> set = new HashSet<>();
 
       for (SimpleString propName : message.getPropertyNames()) {
-         if ((!propName.startsWith(JMS) || propName.startsWith(JMSX) ||
-            propName.startsWith(JMS_)) && !propName.startsWith(CONNECTION_ID_PROPERTY_NAME) && !propName.equals(Message.HDR_ROUTING_TYPE) &&
-            !propName.startsWith(Message.HDR_ROUTE_TO_IDS)) {
+         if (propName.equals(Message.HDR_GROUP_ID)) {
+            set.add(MessageUtil.JMSXGROUPID);
+         } else if (propName.equals(Message.HDR_VALIDATED_USER)) {
+            set.add(MessageUtil.JMSXUSERID);
+         } else if ((!propName.startsWith(JMS) || propName.startsWith(JMSX) || propName.startsWith(JMS_)) && !propName.startsWith(CONNECTION_ID_PROPERTY_NAME) && !propName.equals(Message.HDR_ROUTING_TYPE) && !propName.startsWith(Message.HDR_ROUTE_TO_IDS)) {
             set.add(propName.toString());
          }
       }

--- a/artemis-jms-client/src/test/java/org/apache/activemq/artemis/jms/client/ActiveMQMessagePropertiesTest.java
+++ b/artemis-jms-client/src/test/java/org/apache/activemq/artemis/jms/client/ActiveMQMessagePropertiesTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.jms.client;
+
+import java.util.Enumeration;
+import javax.jms.JMSException;
+import org.apache.activemq.artemis.core.client.impl.ClientMessageImpl;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+public class ActiveMQMessagePropertiesTest {
+
+   @Test
+   public void testJMSXGroupID() throws JMSException {
+      ActiveMQMessage activeMQMessage = newBlankActiveMQMessage();
+
+      assertFalse(contains(activeMQMessage.getPropertyNames(), "JMSXGroupID"));
+
+      activeMQMessage.setStringProperty("JMSXGroupID", "Bob");
+      assertEquals("Bob", activeMQMessage.getStringProperty("JMSXGroupID"));
+
+      assertTrue(contains(activeMQMessage.getPropertyNames(), "JMSXGroupID"));
+   }
+
+   @Test
+   public void testJMSXUserID() throws JMSException {
+      ActiveMQMessage activeMQMessage = newBlankActiveMQMessage();
+
+      assertFalse(contains(activeMQMessage.getPropertyNames(), "JMSXUserID"));
+
+      activeMQMessage.setStringProperty("JMSXUserID", "Bob");
+      assertEquals("Bob", activeMQMessage.getStringProperty("JMSXUserID"));
+
+      assertTrue(contains(activeMQMessage.getPropertyNames(), "JMSXUserID"));
+   }
+
+   private boolean contains(Enumeration<String> enumeration, String key) {
+      while (enumeration.hasMoreElements()) {
+         if (enumeration.nextElement().equals(key)) {
+            return true;
+         }
+      }
+      return false;
+   }
+
+   private ActiveMQMessage newBlankActiveMQMessage() throws JMSException {
+      ActiveMQMessage activeMQMessage = new ActiveMQMessage(new ClientMessageImpl(), null);
+      activeMQMessage.clearBody();
+      activeMQMessage.clearProperties();
+      return activeMQMessage;
+   }
+}


### PR DESCRIPTION
Ensure JMSXGroupID and JMSXUserID is correctly returned by JMS getPropertyNames when set.