### PR TITLE
ARTEMIS-1995 Client fail over fails when live shut down too soon

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/LiveToLiveFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/LiveToLiveFailoverTest.java
@@ -362,6 +362,11 @@ public class LiveToLiveFailoverTest extends FailoverTest {
    @Ignore
    public void testCommitOccurredUnblockedAndResendNoDuplicates() throws Exception {
    }
+
+   @Override
+   @Ignore
+   public void testFailLiveTooSoon() throws Exception {
+   }
 }
 
 


### PR DESCRIPTION
In a live-backup scenario, if the live is restarted and shutdown too soon,
the client have a chance to fail on failover because it's internal topology
is inconsistent with the final status. The client keeps connecting to live
already shut down, never trying to connect to the backup.

It's a porting from HORNETQ-1572.

(Cherry-picked from master)