### PR TITLE
ARTEMIS-856 Test fixes - Alternative

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -807,7 +807,7 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
                              boolean purgeOnNoConsumers,
                              boolean autoCreateAddress) throws Exception {
       AddressSettings addressSettings = server.getAddressSettingsRepository().getMatch(address == null ? name : address);
-      return createQueue(address, routingType, name, filterStr, durable, addressSettings.getDefaultMaxConsumers(), addressSettings.isDefaultPurgeOnNoConsumers(), addressSettings.isDefaultExclusiveQueue(), addressSettings.isDefaultLastValueQueue(), addressSettings.getDefaultConsumersBeforeDispatch(), addressSettings.getDefaultDelayBeforeDispatch(), addressSettings.isAutoCreateAddresses());
+      return createQueue(address, routingType, name, filterStr, durable, maxConsumers, purgeOnNoConsumers, addressSettings.isDefaultExclusiveQueue(), addressSettings.isDefaultLastValueQueue(), addressSettings.getDefaultConsumersBeforeDispatch(), addressSettings.getDefaultDelayBeforeDispatch(), autoCreateAddress);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -1766,7 +1766,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
                                  boolean exclusive,
                                  boolean lastValue) throws Exception {
       AddressSettings as = getAddressSettingsRepository().getMatch(address == null ? name.toString() : address.toString());
-      createSharedQueue(address, routingType, name, filterString, user, durable, as.getDefaultMaxConsumers(), as.isDefaultPurgeOnNoConsumers(), as.isDefaultExclusiveQueue(), as.isDefaultLastValueQueue(), as.getDefaultConsumersBeforeDispatch(), as.getDefaultDelayBeforeDispatch());
+      createSharedQueue(address, routingType, name, filterString, user, durable, maxConsumers, purgeOnNoConsumers, exclusive, lastValue, as.getDefaultConsumersBeforeDispatch(), as.getDefaultDelayBeforeDispatch());
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
@@ -2375,7 +2375,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
          MessageReference ref;
 
          Consumer handledconsumer = null;
-         SimpleString groupID;
+
          synchronized (this) {
 
             // Need to do these checks inside the synchronized
@@ -2442,7 +2442,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
 
                // If a group id is set, then this overrides the consumer chosen round-robin
 
-               groupID = extractGroupID(ref);
+               SimpleString groupID = extractGroupID(ref);
 
                if (groupID != null) {
                   groupConsumer = groups.get(groupID);
@@ -2490,10 +2490,15 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
                }
             }
 
-            if (pos == endPos || (redistributor != null || groupConsumer != null || exclusive)) {
+            if (redistributor != null || groupConsumer != null || exclusive) {
+               if (noDelivery > 0) {
+                  break;
+               }
+               noDelivery = 0;
+            } else if (pos == endPos) {
                // Round robin'd all
 
-               if (noDelivery == size && redistributor == null || ((redistributor != null || groupConsumer != null || exclusive) && noDelivery > 0)) {
+               if (noDelivery == size) {
                   if (handledconsumer != null) {
                      // this shouldn't really happen,
                      // however I'm keeping this as an assertion case future developers ever change the logic here on this class


### PR DESCRIPTION
@clebertsuconic 

Here's a slight alternative option to your pr (https://github.com/apache/activemq-artemis/pull/2209) i took the fixes for the server and control, but in the queueimpl I wanted to keep away from having the redistributor in the list (reason being later where want to try make the dispatch policies more pluggable it makes it very hard)

Also interestingly applying the same change that Franz has done for CPU here, but for the redistributor fixes many of the redistributor issues, essentially it was failing because it ended up in a spin.
https://github.com/apache/activemq-artemis/pull/2203



One case in the messageredistributiontest though still fails (testRedistributionWithMessageGroups), im looking into why it might, but if you can spot please do tell.

If you need master fixed asap, maybe merge your PR, and i can pr this over the top once i figure it out.

