### PR TITLE
ARTEMIS-856 Fixing ScaleDownTest

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
@@ -2516,7 +2516,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
 
             // Only move onto the next position if the consumer on the current position was used.
             // When using group we don't need to load balance to the next position
-            if (!exclusive && groupConsumer == null) {
+            if (redistributor == null && !exclusive && groupConsumer == null) {
                pos++;
             }
 
@@ -3029,7 +3029,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
             }
 
             // Only move onto the next position if the consumer on the current position was used.
-            if (!exclusive && groupConsumer == null) {
+            if (redistributor == null && !exclusive && groupConsumer == null) {
                pos++;
             }
 


### PR DESCRIPTION
Don't increment the pos if redistributor. causes pos to be > size thus index out of bounds when getting the consumer on next loop.