### PR TITLE
[ARTEMIS-1947] Session metadata in session management operation

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -1923,10 +1923,12 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
          obj.add("principal", sess.getValidatedUser());
       }
 
-      String metadata = sess.getMetaData() == null ? null : sess.getMetaData().toString();
-      if (metadata != null) {
-         // remove leading and trailing curly brackets
-         obj.add("metadata", metadata.substring(1, metadata.length() - 1));
+      if (sess.getMetaData() != null) {
+         final JsonObjectBuilder metadata = JsonLoader.createObjectBuilder();
+         for (Entry<String, String> entry : sess.getMetaData().entrySet()) {
+            metadata.add(entry.getKey(), entry.getValue());
+         }
+         obj.add("metadata", metadata);
       }
 
       array.add(obj);


### PR DESCRIPTION
Fill the session's metadata in JSON properties instead of serializing it
as an opaque String.

JIRA: https://issues.apache.org/jira/browse/ARTEMIS-1947