### PR TITLE
ARTEMIS-2015 PriorityLinkedListImpl::isEmpty is not thread-safe

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/collections/PriorityLinkedList.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/collections/PriorityLinkedList.java
@@ -18,7 +18,8 @@ package org.apache.activemq.artemis.utils.collections;
 
 /**
  * A type of linked list which maintains items according to a priority
- * and allows adding and removing of elements at both ends, and peeking
+ * and allows adding and removing of elements at both ends, and peeking.<br>
+ * Only {@link #size()} and {@link #isEmpty()} are safe to be called concurrently.
  */
 public interface PriorityLinkedList<T> {
 
@@ -30,9 +31,17 @@ public interface PriorityLinkedList<T> {
 
    void clear();
 
+   /**
+    * Returns the size of this list.<br>
+    * It is safe to be called concurrently.
+    */
    int size();
 
    LinkedListIterator<T> iterator();
 
+   /**
+    * Returns {@code true} if empty, {@code false} otherwise.<br>
+    * It is safe to be called concurrently.
+    */
    boolean isEmpty();
 }


### PR DESCRIPTION
PriorityLinkedListImpl::size access is changed to be safely
observable by a thread different from the one allowed to write
the list.