### PR TITLE
ARTEMIS-1482 Enhance test to ensure len check is done before byte[] init

### DIFF
--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/SimpleStringTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/SimpleStringTest.java
@@ -28,7 +28,7 @@ public class SimpleStringTest {
    @Test
    public void testOutOfBoundsThrownOnMalformedString() {
       ByteBuf byteBuffer = ByteBufAllocator.DEFAULT.buffer(5);
-      byteBuffer.writeInt(100);
+      byteBuffer.writeInt(Integer.MAX_VALUE);
 
       Exception e = null;
       try {


### PR DESCRIPTION
Set the int to Integer.MAX_VALUE thus if the len check is not done before byte[] initialization the test would blow with an OOM.