### PR TITLE
[ARTEMIS-2022] Create count messages 'group by' this property filter

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/QueueControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/QueueControl.java
@@ -297,6 +297,15 @@ public interface QueueControl {
    long countMessages() throws Exception;
 
    /**
+    * Counts the number of messages in this queue group by property received in the parameter using JSON serialization.
+    * In case no has property return amount of messages in the *_UNDEFINED_*
+    * <br>
+    * Using {@code null} or an empty filter will count <em>all</em> messages from this queue.
+    */
+   @Operation(desc = "Returns the number of the messages in the separate property value the queue", impact = MBeanOperationInfo.INFO)
+   String countMessagesProperty(@Parameter(name = "filter", desc = "This filter separate account messages") String filter) throws Exception;
+
+   /**
     * Removes the message corresponding to the specified message ID.
     *
     * @return {@code true} if the message was removed, {@code false} else

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/QueueControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/QueueControlImpl.java
@@ -64,6 +64,7 @@ import org.apache.activemq.artemis.utils.collections.LinkedListIterator;
 public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    public static final int FLUSH_LIMIT = 500;
+   public static final String UNDEFINED = "*_UNDEFINED_*";
    // Constants -----------------------------------------------------
 
    // Attributes ----------------------------------------------------
@@ -706,6 +707,32 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
                }
                return count;
             }
+         }
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public String countMessagesProperty(final String filter) throws Exception {
+      checkStarted();
+      clearIO();
+      try {
+         try (LinkedListIterator<MessageReference> iterator = queue.browserIterator()) {
+            Map<String, Integer> result = new HashMap<>();
+            String propertySearch = filter == null ? UNDEFINED : filter;
+            try {
+               while (iterator.hasNext()) {
+                  MessageReference ref = iterator.next();
+                  String messageProperty = ref.getMessage().getStringProperty(propertySearch);
+                  messageProperty = messageProperty == null ? UNDEFINED : messageProperty ;
+                  Integer value = result.getOrDefault(messageProperty, 0);
+                  result.put(messageProperty, ++value);
+               }
+            } catch (NoSuchElementException ignored) {
+               // this could happen through paging browsing
+            }
+            return JsonUtil.toJsonObject(result).toString();
          }
       } finally {
          blockOnIO();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlUsingCoreTest.java
@@ -102,6 +102,11 @@ public class QueueControlUsingCoreTest extends QueueControlTest {
          }
 
          @Override
+         public String countMessagesProperty(final String filter) throws Exception {
+            return (String) proxy.invokeOperation(String.class, "countMessagesProperty", filter);
+         }
+
+         @Override
          public boolean expireMessage(final long messageID) throws Exception {
             return (Boolean) proxy.invokeOperation("expireMessage", messageID);
          }


### PR DESCRIPTION
Create a new function this is responsibility count messages determined property filter, e return one object in json, where properties to object is value of property and this value is amount messages.
Actually in the project have only method count messages of determinate filter, but no has method group messages for respective property.