### PR TITLE
ARTEMIS-1996 MappedSequentialFileFactory may cause DirectByteBuffer off-heap memory leaks

### DIFF
--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/file/JDBCSequentialFile.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/file/JDBCSequentialFile.java
@@ -251,6 +251,11 @@ public class JDBCSequentialFile implements SequentialFile {
    }
 
    @Override
+   public void blockingWriteDirect(ByteBuffer bytes, boolean sync, boolean releaseBuffer) {
+      writeDirect(bytes, sync, null);
+   }
+
+   @Override
    public void writeDirect(ByteBuffer bytes, boolean sync) throws Exception {
       writeDirect(bytes, sync, null);
       // Are we meant to block here?

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/SequentialFile.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/SequentialFile.java
@@ -78,6 +78,20 @@ public interface SequentialFile {
    void writeDirect(ByteBuffer bytes, boolean sync) throws Exception;
 
    /**
+    * Write directly to the file without using any intermediate buffer and wait completion.<br>
+    * If {@code releaseBuffer} is {@code true} the provided {@code bytes} should be released
+    * through {@link SequentialFileFactory#releaseBuffer(ByteBuffer)}, if supported.
+    *
+    * @param bytes         the ByteBuffer must be compatible with the SequentialFile implementation (AIO or
+    *                      NIO). If {@code releaseBuffer} is {@code true} use a buffer from
+    *                      {@link SequentialFileFactory#newBuffer(int)}, {@link SequentialFileFactory#allocateDirectBuffer(int)}
+    *                      otherwise.
+    * @param sync          if {@code true} will durable flush the written data on the file, {@code false} otherwise
+    * @param releaseBuffer if {@code true} will release the buffer, {@code false} otherwise
+    */
+   void blockingWriteDirect(ByteBuffer bytes, boolean sync, boolean releaseBuffer) throws Exception;
+
+   /**
     * @param bytes the ByteBuffer must be compatible with the SequentialFile implementation (AIO or
     *              NIO). To be safe, use a buffer from the corresponding
     *              {@link SequentialFileFactory#newBuffer(int)}.

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/aio/AIOSequentialFileFactory.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/aio/AIOSequentialFileFactory.java
@@ -286,7 +286,7 @@ public final class AIOSequentialFileFactory extends AbstractSequentialFileFactor
       String errorMessage;
       int errorCode = -1;
       long writeSequence;
-
+      boolean releaseBuffer;
       long position;
       int bytes;
 
@@ -297,6 +297,7 @@ public final class AIOSequentialFileFactory extends AbstractSequentialFileFactor
             ", errorMessage='" + errorMessage + '\'' +
             ", errorCode=" + errorCode +
             ", writeSequence=" + writeSequence +
+            ", releaseBuffer=" + releaseBuffer +
             ", position=" + position +
             '}';
       }
@@ -332,7 +333,8 @@ public final class AIOSequentialFileFactory extends AbstractSequentialFileFactor
                                         IOCallback IOCallback,
                                         LibaioFile libaioFile,
                                         AIOSequentialFile sequentialFile,
-                                        ByteBuffer usedBuffer) {
+                                        ByteBuffer usedBuffer,
+                                        boolean releaseBuffer) {
          this.callback = IOCallback;
          this.sequentialFile = sequentialFile;
          this.error = false;
@@ -340,6 +342,7 @@ public final class AIOSequentialFileFactory extends AbstractSequentialFileFactor
          this.libaioFile = libaioFile;
          this.writeSequence = writeSequence;
          this.errorMessage = null;
+         this.releaseBuffer = releaseBuffer;
          return this;
       }
 
@@ -375,7 +378,7 @@ public final class AIOSequentialFileFactory extends AbstractSequentialFileFactor
                callback.done();
             }
 
-            if (buffer != null && reuseBuffers) {
+            if (buffer != null && reuseBuffers && releaseBuffer) {
                buffersControl.bufferDone(buffer);
             }
 

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/mapped/TimedSequentialFile.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/mapped/TimedSequentialFile.java
@@ -97,6 +97,11 @@ final class TimedSequentialFile implements SequentialFile {
    }
 
    @Override
+   public void blockingWriteDirect(ByteBuffer bytes,boolean sync, boolean releaseBuffer) throws Exception {
+      this.sequentialFile.blockingWriteDirect(bytes, sync, releaseBuffer);
+   }
+
+   @Override
    public void write(ActiveMQBuffer bytes, boolean sync, IOCallback callback) throws Exception {
       if (this.timedBuffer != null) {
          this.timedBuffer.addBytes(bytes, sync, callback);

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/fakes/FakeSequentialFileFactory.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/fakes/FakeSequentialFileFactory.java
@@ -33,6 +33,7 @@ import org.apache.activemq.artemis.core.io.SequentialFile;
 import org.apache.activemq.artemis.core.io.SequentialFileFactory;
 import org.apache.activemq.artemis.core.io.buffer.TimedBuffer;
 import org.apache.activemq.artemis.core.journal.EncodingSupport;
+import org.apache.activemq.artemis.core.journal.impl.SimpleWaitIOCallback;
 
 public class FakeSequentialFileFactory implements SequentialFileFactory {
 
@@ -415,6 +416,18 @@ public class FakeSequentialFileFactory implements SequentialFileFactory {
             action.run();
          }
 
+      }
+
+      @Override
+      public synchronized void blockingWriteDirect(ByteBuffer bytes,
+                                                   boolean sync,
+                                                   boolean releaseBuffer) throws Exception {
+         SimpleWaitIOCallback callback = new SimpleWaitIOCallback();
+         try {
+            writeDirect(bytes, sync, callback);
+         } finally {
+            callback.waitCompletion();
+         }
       }
 
       @Override


### PR DESCRIPTION
Compaction is now reusing direct ByteBuffers on both
reading and writing with explicit and deterministic
release to avoid high peak of native memory utilisation
after compaction.