### PR TITLE
NO-JIRA Tweak RedeployTest

### DIFF
--- a/tests/integration-tests/src/test/resources/reload-backup-changed.xml
+++ b/tests/integration-tests/src/test/resources/reload-backup-changed.xml
@@ -39,11 +39,12 @@ under the License.
       <large-messages-directory>${backup-data-dir}/large-messages</large-messages-directory>
 
       <acceptors>
-         <acceptor name="artemis">tcp://0.0.0.0:61617</acceptor>
+         <acceptor name="artemis">tcp://127.0.0.1:61617</acceptor>
       </acceptors>
 
       <connectors>
          <connector name="artemis">tcp://127.0.0.1:61617</connector>
+         <connector name="other">tcp://127.0.0.1:61616</connector>
       </connectors>
 
       <ha-policy>
@@ -54,29 +55,14 @@ under the License.
          </replication>
       </ha-policy>
 
-      <broadcast-groups>
-         <broadcast-group name="bg-group1">
-            <group-address>231.7.7.7</group-address>
-            <group-port>9876</group-port>
-            <broadcast-period>5000</broadcast-period>
-            <connector-ref>artemis</connector-ref>
-         </broadcast-group>
-      </broadcast-groups>
-
-      <discovery-groups>
-         <discovery-group name="dg-group1">
-            <group-address>231.7.7.7</group-address>
-            <group-port>9876</group-port>
-            <refresh-timeout>10000</refresh-timeout>
-         </discovery-group>
-      </discovery-groups>
-
       <cluster-connections>
          <cluster-connection name="my-cluster">
             <connector-ref>artemis</connector-ref>
             <message-load-balancing>STRICT</message-load-balancing>
             <max-hops>1</max-hops>
-            <discovery-group-ref discovery-group-name="dg-group1"/>
+            <static-connectors>
+               <connector-ref>other</connector-ref>
+            </static-connectors>
          </cluster-connection>
       </cluster-connections>
 

--- a/tests/integration-tests/src/test/resources/reload-backup-original.xml
+++ b/tests/integration-tests/src/test/resources/reload-backup-original.xml
@@ -39,11 +39,12 @@ under the License.
       <large-messages-directory>${backup-data-dir}/large-messages</large-messages-directory>
 
       <acceptors>
-         <acceptor name="artemis">tcp://0.0.0.0:61617</acceptor>
+         <acceptor name="artemis">tcp://127.0.0.1:61617</acceptor>
       </acceptors>
 
       <connectors>
          <connector name="artemis">tcp://127.0.0.1:61617</connector>
+         <connector name="other">tcp://127.0.0.1:61616</connector>
       </connectors>
 
       <ha-policy>
@@ -54,29 +55,14 @@ under the License.
          </replication>
       </ha-policy>
 
-      <broadcast-groups>
-         <broadcast-group name="bg-group1">
-            <group-address>231.7.7.7</group-address>
-            <group-port>9876</group-port>
-            <broadcast-period>5000</broadcast-period>
-            <connector-ref>artemis</connector-ref>
-         </broadcast-group>
-      </broadcast-groups>
-
-      <discovery-groups>
-         <discovery-group name="dg-group1">
-            <group-address>231.7.7.7</group-address>
-            <group-port>9876</group-port>
-            <refresh-timeout>10000</refresh-timeout>
-         </discovery-group>
-      </discovery-groups>
-
       <cluster-connections>
          <cluster-connection name="my-cluster">
             <connector-ref>artemis</connector-ref>
             <message-load-balancing>STRICT</message-load-balancing>
             <max-hops>1</max-hops>
-            <discovery-group-ref discovery-group-name="dg-group1"/>
+            <static-connectors>
+               <connector-ref>other</connector-ref>
+            </static-connectors>
          </cluster-connection>
       </cluster-connections>
 

--- a/tests/integration-tests/src/test/resources/reload-live-changed.xml
+++ b/tests/integration-tests/src/test/resources/reload-live-changed.xml
@@ -39,11 +39,12 @@ under the License.
       <large-messages-directory>${live-data-dir}/large-messages</large-messages-directory>
 
       <acceptors>
-         <acceptor name="artemis">tcp://0.0.0.0:61616</acceptor>
+         <acceptor name="artemis">tcp://127.0.0.1:61616</acceptor>
       </acceptors>
 
       <connectors>
          <connector name="artemis">tcp://127.0.0.1:61616</connector>
+         <connector name="other">tcp://127.0.0.1:61617</connector>
       </connectors>
 
       <ha-policy>
@@ -54,29 +55,14 @@ under the License.
          </replication>
       </ha-policy>
 
-      <broadcast-groups>
-         <broadcast-group name="bg-group1">
-            <group-address>231.7.7.7</group-address>
-            <group-port>9876</group-port>
-            <broadcast-period>5000</broadcast-period>
-            <connector-ref>artemis</connector-ref>
-         </broadcast-group>
-      </broadcast-groups>
-
-      <discovery-groups>
-         <discovery-group name="dg-group1">
-            <group-address>231.7.7.7</group-address>
-            <group-port>9876</group-port>
-            <refresh-timeout>10000</refresh-timeout>
-         </discovery-group>
-      </discovery-groups>
-
       <cluster-connections>
          <cluster-connection name="my-cluster">
             <connector-ref>artemis</connector-ref>
             <message-load-balancing>STRICT</message-load-balancing>
             <max-hops>1</max-hops>
-            <discovery-group-ref discovery-group-name="dg-group1"/>
+            <static-connectors>
+               <connector-ref>other</connector-ref>
+            </static-connectors>
          </cluster-connection>
       </cluster-connections>
 

--- a/tests/integration-tests/src/test/resources/reload-live-original.xml
+++ b/tests/integration-tests/src/test/resources/reload-live-original.xml
@@ -39,11 +39,12 @@ under the License.
       <large-messages-directory>${live-data-dir}/large-messages</large-messages-directory>
 
       <acceptors>
-         <acceptor name="artemis">tcp://0.0.0.0:61616</acceptor>
+         <acceptor name="artemis">tcp://127.0.0.1:61616</acceptor>
       </acceptors>
 
       <connectors>
          <connector name="artemis">tcp://127.0.0.1:61616</connector>
+         <connector name="other">tcp://127.0.0.1:61617</connector>
       </connectors>
 
       <ha-policy>
@@ -54,29 +55,14 @@ under the License.
          </replication>
       </ha-policy>
 
-      <broadcast-groups>
-         <broadcast-group name="bg-group1">
-            <group-address>231.7.7.7</group-address>
-            <group-port>9876</group-port>
-            <broadcast-period>5000</broadcast-period>
-            <connector-ref>artemis</connector-ref>
-         </broadcast-group>
-      </broadcast-groups>
-
-      <discovery-groups>
-         <discovery-group name="dg-group1">
-            <group-address>231.7.7.7</group-address>
-            <group-port>9876</group-port>
-            <refresh-timeout>10000</refresh-timeout>
-         </discovery-group>
-      </discovery-groups>
-
       <cluster-connections>
          <cluster-connection name="my-cluster">
             <connector-ref>artemis</connector-ref>
             <message-load-balancing>STRICT</message-load-balancing>
             <max-hops>1</max-hops>
-            <discovery-group-ref discovery-group-name="dg-group1"/>
+            <static-connectors>
+               <connector-ref>other</connector-ref>
+            </static-connectors>
          </cluster-connection>
       </cluster-connections>
 


### PR DESCRIPTION
1) Remove use of deprecated EmbeddedJMS.
2) Change test config to use static clustering as discovery may not work
in some CI environments.