### PR TITLE
ARTEMIS-1663 fix disparity on messagecount

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
@@ -1247,9 +1247,9 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
       if (pageSubscription != null) {
          // messageReferences will have depaged messages which we need to discount from the counter as they are
          // counted on the pageSubscription as well
-         return pendingMetrics.getMessageCount() + getScheduledCount() + getDeliveringCount() + pageSubscription.getMessageCount();
+         return messageReferences.size() + getScheduledCount() + getDeliveringCount() + pageSubscription.getMessageCount();
       } else {
-         return pendingMetrics.getMessageCount() + getScheduledCount() + getDeliveringCount();
+         return messageReferences.size() + getScheduledCount() + getDeliveringCount();
       }
    }
 


### PR DESCRIPTION
Reverting a change done in ARTEMIS-1663. https://github.com/apache/activemq-artemis/pull/1853

It seems the new messagecount != the original messageReferences.size all the time, it is more reliable to use the original messageReferences size as this is the actual collection's size.