### PR TITLE
[ARTEMIS-2050] It is possible to get AMQ224000: Failure in initialisa…

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/SharedStoreBackupActivation.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/SharedStoreBackupActivation.java
@@ -114,7 +114,7 @@ public final class SharedStoreBackupActivation extends Activation {
 
             activeMQServer.getNodeManager().releaseBackup();
          }
-         if (sharedStoreSlavePolicy.isAllowAutoFailBack()) {
+         if (sharedStoreSlavePolicy.isAllowAutoFailBack() && ActiveMQServerImpl.SERVER_STATE.STOPPING != activeMQServer.getState() && ActiveMQServerImpl.SERVER_STATE.STOPPED != activeMQServer.getState()) {
             startFailbackChecker();
          }
       } catch (ClosedChannelException | InterruptedException e) {


### PR DESCRIPTION
…tion: java.lang.NullPointerException during shutdown of backup server with shared store

Issue: https://issues.apache.org/jira/browse/ARTEMIS-2050

PR(2.6.x): https://github.com/apache/activemq-artemis/pull/2265
PR(master): https://github.com/apache/activemq-artemis/pull/2264

Cherry-picked from f45a0c472833cddcbfa5725f299bb3a21956e53f