### PR TITLE
ARTEMIS-2052 - Fix defaultConsumerWindowSize negotiation

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionImpl.java
@@ -1887,8 +1887,8 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
       // consumer
 
       // TODO: this could semantically change on other servers. I know for instance on stomp this is just an ignore
-      if (windowSize != 0) {
-         sessionContext.sendConsumerCredits(consumer, windowSize);
+      if (consumer.getClientWindowSize() != 0) {
+         sessionContext.sendConsumerCredits(consumer, consumer.getClientWindowSize());
       }
 
       return consumer;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -876,7 +876,14 @@ public class ActiveMQServerImpl implements ActiveMQServer {
          throw ActiveMQMessageBundle.BUNDLE.queueNameIsNull();
       }
 
-      final AddressSettings addressSettings = getAddressSettingsRepository().getMatch(name.toString());
+      QueueQueryResult response;
+
+      Binding binding = getPostOffice().getBinding(name);
+
+      final SimpleString addressName = binding != null && binding.getType() == BindingType.LOCAL_QUEUE
+            ? binding.getAddress() : name;
+
+      final AddressSettings addressSettings = getAddressSettingsRepository().getMatch(addressName.toString());
 
       boolean autoCreateQueues = addressSettings.isAutoCreateQueues();
       boolean defaultPurgeOnNoConsumers = addressSettings.isDefaultPurgeOnNoConsumers();
@@ -884,10 +891,6 @@ public class ActiveMQServerImpl implements ActiveMQServer {
       boolean defaultExclusiveQueue = addressSettings.isDefaultExclusiveQueue();
       boolean defaultLastValueQueue = addressSettings.isDefaultLastValueQueue();
       int defaultConsumerWindowSize = addressSettings.getDefaultConsumerWindowSize();
-
-      QueueQueryResult response;
-
-      Binding binding = getPostOffice().getBinding(name);
 
       SimpleString managementAddress = getManagementService() != null ? getManagementService().getManagementAddress() : null;
 


### PR DESCRIPTION
The name used for looking up address settings for a queue now uses the
address name if there is a local queue binding