### PR TITLE
ARTEMIS-2059 NettyWritable should use UTF-8 exact length to encode strings

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/util/NettyWritable.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/util/NettyWritable.java
@@ -17,12 +17,11 @@
 package org.apache.activemq.artemis.protocol.amqp.util;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-
-import org.apache.qpid.proton.codec.ReadableBuffer;
-import org.apache.qpid.proton.codec.WritableBuffer;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.WritableBuffer;
 
 /**
  * {@link WritableBuffer} implementation that wraps a Netty {@link ByteBuf} to
@@ -106,7 +105,8 @@ public class NettyWritable implements WritableBuffer {
 
    @Override
    public void put(String value) {
-      nettyBuffer.writeCharSequence(value, StandardCharsets.UTF_8);
+      final int utf8Bytes = ByteBufUtil.utf8Bytes(value);
+      ByteBufUtil.reserveAndWriteUtf8(nettyBuffer, value, utf8Bytes);
    }
 
    @Override

--- a/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/util/NettyWritableTest.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/util/NettyWritableTest.java
@@ -16,18 +16,18 @@
  */
 package org.apache.activemq.artemis.protocol.amqp.util;
 
+import java.nio.ByteBuffer;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.junit.Test;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
-
-import java.nio.ByteBuffer;
-
-import org.apache.qpid.proton.codec.ReadableBuffer;
-import org.junit.Test;
-
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 
 /**
  * Tests for behavior of NettyWritable
@@ -117,6 +117,16 @@ public class NettyWritableTest {
       assertEquals(0, writable.position());
       writable.put(input);
       assertEquals(1, writable.position());
+   }
+
+   @Test
+   public void testPutStringWithNonAsciiCharsUseExactLength() {
+      final String string = Character.toString((char) 129);
+      final int utf8Bytes = ByteBufUtil.utf8Bytes(string);
+      assert string.length() < utf8Bytes;
+      final ByteBuf buffer = Unpooled.buffer(utf8Bytes, utf8Bytes);
+      final NettyWritable nettyWritable = new NettyWritable(buffer);
+      nettyWritable.put(string);
    }
 
    @Test


### PR DESCRIPTION
NettyWritable.put(String) tries to enlarge the buffer used to write a UTF-8 string until ByteBufUtil.utf8MaxBytes.
That means that it will fail or will enlarge any ByteBuf that is perfectly sized to contain the encoded string.