### PR TITLE
[ARTEMIS-2061] reorder of recovery manager to start after broker is readt

### DIFF
--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
@@ -240,8 +240,6 @@ public class ActiveMQResourceAdapter implements ResourceAdapter, Serializable {
 
       tm = ServiceUtils.getTransactionManager();
 
-      recoveryManager.start(useAutoRecovery);
-
       this.ctx = ctx;
 
       if (!configured.getAndSet(true)) {
@@ -251,6 +249,8 @@ public class ActiveMQResourceAdapter implements ResourceAdapter, Serializable {
             throw new ResourceAdapterInternalException("Unable to create activation", e);
          }
       }
+
+      recoveryManager.start(useAutoRecovery);
 
       ActiveMQRALogger.LOGGER.resourceAdaptorStarted();
    }
@@ -272,6 +272,8 @@ public class ActiveMQResourceAdapter implements ResourceAdapter, Serializable {
          }
       }
 
+      recoveryManager.stop();
+
       activations.clear();
 
       for (ActiveMQRAManagedConnectionFactory managedConnectionFactory : managedConnectionFactories) {
@@ -292,8 +294,6 @@ public class ActiveMQResourceAdapter implements ResourceAdapter, Serializable {
       if (recoveryActiveMQConnectionFactory != null) {
          recoveryActiveMQConnectionFactory.close();
       }
-
-      recoveryManager.stop();
 
       ActiveMQRALogger.LOGGER.raStopped();
    }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARTEMIS-2061

The RA starts recovery manager before the broker is set up. It can happens the recovery manager tries to reach un-prepared broker which leads to errors on the side of the recovery manager.