### PR TITLE
ARTEMIS-2062 Only attempt to refill credit when needed

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerReceiverContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerReceiverContext.java
@@ -299,7 +299,9 @@ public class ProtonServerReceiverContext extends ProtonInitializable implements 
    public void flow(int credits, int threshold) {
       // Use the SessionSPI to allocate producer credits, or default, always allocate credit.
       if (sessionSPI != null) {
-         sessionSPI.offerProducerCredit(address, credits, threshold, receiver);
+         if (receiver.getCredit() <= threshold) {
+            sessionSPI.offerProducerCredit(address, credits, threshold, receiver);
+         }
       } else {
          connection.lock();
          try {


### PR DESCRIPTION
Avoid firing the offerProducerCredit code when we know that the credit
is low enough that a refill is needed which avoids lock contention and
garbage creation as each inbound message is processed.