### PR TITLE
ARTEMIS-2055 Lock LM on PacketHandler on clear

### DIFF
--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/LargeMessageOnShutdownTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/LargeMessageOnShutdownTest.java
@@ -73,7 +73,7 @@ public class LargeMessageOnShutdownTest extends ActiveMQTestBase {
             condition = "!flagged(\"testLargeMessageOnShutdown\")",
             action =
                "org.apache.activemq.artemis.tests.extras.byteman.LargeMessageOnShutdownTest.stopServer();" +
-               "waitFor(\"testLargeMessageOnShutdown\");" +
+               "waitFor(\"testLargeMessageOnShutdown\", 5000);" +
                "flag(\"testLargeMessageOnShutdown\")"
          ),
          @BMRule(


### PR DESCRIPTION
@clebertsuconic The original fix can still result in the same issue it's just less frequent.  I've added a locking approach here.  The perf impact is minimal there's only contention during broker shutdown.  The original test I added uses ByteMan to inject a wait/signal on to get the threads in the correct position of the race. 