### PR TITLE
ARTEMIS-2064 make address & queue deployment more robust

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/CoreAddressConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/CoreAddressConfiguration.java
@@ -65,4 +65,14 @@ public class CoreAddressConfiguration implements Serializable {
    public List<CoreQueueConfiguration> getQueueConfigurations() {
       return queueConfigurations;
    }
+
+   @Override
+   public String toString() {
+      return "CoreAddressConfiguration[" +
+         "name=" + name +
+         ", routingTypes=" + routingTypes +
+         ", queueConfigurations=" + queueConfigurations +
+         "]";
+   }
+
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/CoreQueueConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/CoreQueueConfiguration.java
@@ -201,6 +201,7 @@ public class CoreQueueConfiguration implements Serializable {
       result = prime * result + ((lastValue == null) ? 0 : lastValue.hashCode());
       result = prime * result + ((consumersBeforeDispatch == null) ? 0 : consumersBeforeDispatch.hashCode());
       result = prime * result + ((delayBeforeDispatch == null) ? 0 : delayBeforeDispatch.hashCode());
+      result = prime * result + ((routingType == null) ? 0 : routingType.hashCode());
       return result;
    }
 
@@ -265,6 +266,29 @@ public class CoreQueueConfiguration implements Serializable {
       } else if (!delayBeforeDispatch.equals(other.delayBeforeDispatch)) {
          return false;
       }
+      if (routingType == null) {
+         if (other.routingType != null)
+            return false;
+      } else if (!routingType.equals(other.routingType)) {
+         return false;
+      }
       return true;
+   }
+
+   @Override
+   public String toString() {
+      return "CoreQueueConfiguration[" +
+         "name=" + name +
+         ", address=" + address +
+         ", routingType=" + routingType +
+         ", durable=" + durable +
+         ", filterString=" + filterString +
+         ", maxConsumers=" + maxConsumers +
+         ", purgeOnNoConsumers=" + purgeOnNoConsumers +
+         ", exclusive=" + exclusive +
+         ", lastValue=" + lastValue +
+         ", consumersBeforeDispatch=" + consumersBeforeDispatch +
+         ", delayBeforeDispatch=" + delayBeforeDispatch +
+         "]";
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/LegacyJMSConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/LegacyJMSConfiguration.java
@@ -24,7 +24,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URL;
-import java.util.List;
 import java.util.Map;
 
 import org.apache.activemq.artemis.api.core.RoutingType;
@@ -151,10 +150,9 @@ public class LegacyJMSConfiguration implements Deployable {
     */
    public void parseTopicConfiguration(final Node node) throws Exception {
       String topicName = node.getAttributes().getNamedItem(NAME_ATTR).getNodeValue();
-      List<CoreAddressConfiguration> coreAddressConfigurations = configuration.getAddressConfigurations();
-      coreAddressConfigurations.add(new CoreAddressConfiguration()
-                                       .setName(topicName)
-                                       .addRoutingType(RoutingType.MULTICAST));
+      configuration.addAddressConfiguration(new CoreAddressConfiguration()
+                                               .setName(topicName)
+                                               .addRoutingType(RoutingType.MULTICAST));
    }
 
    /**
@@ -174,22 +172,22 @@ public class LegacyJMSConfiguration implements Deployable {
       for (int i = 0; i < children.getLength(); i++) {
          Node child = children.item(i);
 
-         if (QUEUE_SELECTOR_NODE_NAME.equals(children.item(i).getNodeName())) {
-            Node selectorNode = children.item(i);
+         if (QUEUE_SELECTOR_NODE_NAME.equals(child.getNodeName())) {
+            Node selectorNode = child;
             Node attNode = selectorNode.getAttributes().getNamedItem("string");
             selectorString = attNode.getNodeValue();
          }
       }
 
-      List<CoreAddressConfiguration> coreAddressConfigurations = configuration.getAddressConfigurations();
-      coreAddressConfigurations.add(new CoreAddressConfiguration()
-                                       .setName(queueName)
-                                       .addRoutingType(RoutingType.ANYCAST)
-                                       .addQueueConfiguration(new CoreQueueConfiguration()
-                                                                 .setAddress(queueName)
-                                                                 .setName(queueName)
-                                                                 .setFilterString(selectorString)
-                                                                 .setRoutingType(RoutingType.ANYCAST)));
+      configuration.addAddressConfiguration(new CoreAddressConfiguration()
+                                               .setName(queueName)
+                                               .addRoutingType(RoutingType.ANYCAST)
+                                               .addQueueConfiguration(new CoreQueueConfiguration()
+                                                                         .setAddress(queueName)
+                                                                         .setName(queueName)
+                                                                         .setFilterString(selectorString)
+                                                                         .setDurable(durable)
+                                                                         .setRoutingType(RoutingType.ANYCAST)));
    }
 
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -770,8 +770,7 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
          Element node = (Element) elements.item(0);
          NodeList list = node.getElementsByTagName("address");
          for (int i = 0; i < list.getLength(); i++) {
-            CoreAddressConfiguration addrConfig = parseAddressConfiguration(list.item(i));
-            config.getAddressConfigurations().add(addrConfig);
+            config.addAddressConfiguration(parseAddressConfiguration(list.item(i)));
          }
       }
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1593,6 +1593,16 @@ public interface ActiveMQServerLogger extends BasicLogger {
    @Message(id = 22273,  value = "Address \"{0}\" is full. Bridge {1} will disconnect", format = Message.Format.MESSAGE_FORMAT)
    void bridgeAddressFull(String addressName, String bridgeName);
 
+   @LogMessage(level = Logger.Level.WARN)
+   @Message(id = 222274, value = "Failed to deploy address {0}: {1}",
+      format = Message.Format.MESSAGE_FORMAT)
+   void problemDeployingAddress(String addressName, String message);
+
+   @LogMessage(level = Logger.Level.WARN)
+   @Message(id = 222275, value = "Failed to deploy queue {0}: {1}",
+      format = Message.Format.MESSAGE_FORMAT)
+   void problemDeployingQueue(String queueName, String message);
+
    @LogMessage(level = Logger.Level.ERROR)
    @Message(id = 224000, value = "Failure in initialisation", format = Message.Format.MESSAGE_FORMAT)
    void initializationError(@Cause Throwable e);

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/AddressDeploymentFailedTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/AddressDeploymentFailedTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.extras.byteman;
+
+import java.util.UUID;
+
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.core.config.CoreAddressConfiguration;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(BMUnitRunner.class)
+public class AddressDeploymentFailedTest extends ActiveMQTestBase {
+
+   @Test
+   @BMRule(name = "blow up address deployment",
+      targetClass = "org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl",
+      targetMethod = "addOrUpdateAddressInfo(AddressInfo)",
+      targetLocation = "EXIT",
+      action = "throw new IllegalStateException(\"test exception\")")
+   public void testAddressDeploymentFailure() throws Exception {
+      ActiveMQServer server = createServer(false, createDefaultNettyConfig());
+      server.getConfiguration().addAddressConfiguration(new CoreAddressConfiguration().setName(UUID.randomUUID().toString()).addRoutingType(RoutingType.ANYCAST));
+      server.start();
+      assertTrue(server.getRemotingService().isStarted());
+   }
+}

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/QueueDeploymentFailedTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/QueueDeploymentFailedTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.extras.byteman;
+
+import java.util.UUID;
+
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.core.config.CoreAddressConfiguration;
+import org.apache.activemq.artemis.core.config.CoreQueueConfiguration;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(BMUnitRunner.class)
+public class QueueDeploymentFailedTest extends ActiveMQTestBase {
+
+   @Test
+   @BMRule(name = "blow up queue deployment",
+      targetClass = "org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl",
+      targetMethod = "createQueue(SimpleString,RoutingType,SimpleString,SimpleString,SimpleString,boolean,boolean,boolean,boolean,boolean,int,boolean,boolean,boolean,int,long,boolean",
+      targetLocation = "EXIT",
+      action = "throw new IllegalStateException(\"test exception\")")
+   public void testQueueDeploymentFailure() throws Exception {
+      ActiveMQServer server = createServer(false, createDefaultNettyConfig());
+      String address = UUID.randomUUID().toString();
+      server.getConfiguration().addAddressConfiguration(new CoreAddressConfiguration().setName(address).addRoutingType(RoutingType.ANYCAST).addQueueConfiguration(new CoreQueueConfiguration().setName(UUID.randomUUID().toString()).setRoutingType(RoutingType.ANYCAST).setAddress(address)));
+      server.start();
+      assertTrue(server.getRemotingService().isStarted());
+   }
+}


### PR DESCRIPTION
Any failure to deploy an address or queue will short-circuit the broker
initialization process preventing any other addresses or queues from
being deployed as well as other critical resources like acceptors, etc.