### PR TITLE
ARTEMIS-2068 save reading any file to get AMQP large msg size

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/ICoreMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/ICoreMessage.java
@@ -42,6 +42,11 @@ public interface ICoreMessage extends Message {
    ActiveMQBuffer getReadOnlyBodyBuffer();
 
    /**
+    * Returns the length in bytes of the body buffer.
+    */
+   int getBodyBufferSize();
+
+   /**
     * Returns a readOnlyBodyBuffer or a decompressed one if the message is compressed.
     * or the large message buffer.
     * @return

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessage.java
@@ -217,6 +217,13 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
       return new ChannelBufferWrapper(buffer.slice(BODY_OFFSET, endOfBodyPosition - BUFFER_HEADER_SPACE).setIndex(0, endOfBodyPosition - BUFFER_HEADER_SPACE).asReadOnly());
    }
 
+   @Override
+   public int getBodyBufferSize() {
+      checkEncode();
+      internalWritableBuffer();
+      return endOfBodyPosition - BUFFER_HEADER_SPACE;
+   }
+
    /**
     * This will return the proper buffer to represent the data of the Message. If compressed it will decompress.
     * If large, it will read from the file or streaming.

--- a/artemis-core-client/src/test/java/org/apache/activemq/artemis/message/CoreMessageTest.java
+++ b/artemis-core-client/src/test/java/org/apache/activemq/artemis/message/CoreMessageTest.java
@@ -82,6 +82,14 @@ public class CoreMessageTest {
       Assert.assertEquals(TEXT, TextMessageUtil.readBodyText(decodedMessage.getReadOnlyBodyBuffer()).toString());
    }
 
+   @Test
+   public void testBodyBufferSize() {
+      final CoreMessage decodedMessage = decodeMessage();
+      final int bodyBufferSize = decodedMessage.getBodyBufferSize();
+      final int readonlyBodyBufferReadableBytes = decodedMessage.getReadOnlyBodyBuffer().readableBytes();
+      Assert.assertEquals(bodyBufferSize, readonlyBodyBufferReadableBytes);
+   }
+
    /** The message is received, then sent to the other side untouched */
    @Test
    public void sendThroughPackets() {

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/converter/jms/ServerJMSBytesMessage.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/converter/jms/ServerJMSBytesMessage.java
@@ -54,7 +54,7 @@ public class ServerJMSBytesMessage extends ServerJMSMessage implements BytesMess
 
    @Override
    public long getBodyLength() throws JMSException {
-      return message.getReadOnlyBodyBuffer().readableBytes();
+      return message.getBodyBufferSize();
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/LargeServerMessageImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/LargeServerMessageImpl.java
@@ -224,6 +224,31 @@ public final class LargeServerMessageImpl extends CoreMessage implements LargeSe
    }
 
    @Override
+   public int getBodyBufferSize() {
+      final boolean closeFile = file == null || !file.isOpen();
+      try {
+         openFile();
+         final long fileSize = file.size();
+         int fileSizeAsInt = (int) fileSize;
+         if (fileSizeAsInt < 0) {
+            logger.warnf("suspicious large message file size of %d bytes for %s, will use %d instead.",
+                         fileSize, file.getFileName(), Integer.MAX_VALUE);
+            fileSizeAsInt = Integer.MAX_VALUE;
+         }
+         return fileSizeAsInt;
+      } catch (Exception e) {
+         throw new RuntimeException(e);
+      } finally {
+         if (closeFile) {
+            try {
+               file.close();
+            } catch (Exception ignored) {
+            }
+         }
+      }
+   }
+
+   @Override
    public boolean isLargeMessage() {
       return true;
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/LargeMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/LargeMessageTest.java
@@ -2289,6 +2289,32 @@ public class LargeMessageTest extends LargeMessageTestBase {
       log.debug("Thread done");
    }
 
+   @Test
+   public void testLargeMessageBodySize() throws Exception {
+      ActiveMQServer server = createServer(true, isNetty(), storeType);
+
+      server.start();
+
+      LargeServerMessageImpl fileMessage = new LargeServerMessageImpl((JournalStorageManager) server.getStorageManager());
+
+      fileMessage.setMessageID(1005);
+
+      Assert.assertEquals(0, fileMessage.getBodyBufferSize());
+
+      for (int i = 0; i < largeMessageSize; i++) {
+         fileMessage.addBytes(new byte[]{ActiveMQTestBase.getSamplebyte(i)});
+      }
+
+      Assert.assertEquals(largeMessageSize, fileMessage.getBodyBufferSize());
+
+      // The server would be doing this
+      fileMessage.putLongProperty(Message.HDR_LARGE_BODY_SIZE, largeMessageSize);
+
+      fileMessage.releaseResources();
+
+      Assert.assertEquals(largeMessageSize, fileMessage.getBodyBufferSize());
+   }
+
    // The ClientConsumer should be able to also send ServerLargeMessages as that's done by the CoreBridge
    @Test
    public void testSendServerMessage() throws Exception {


### PR DESCRIPTION
ServerJMSBytesMessage::getBodyLength can save reading
the whole large message file by reading just its
file size