### PR TITLE
ARTEMIS-2065 Change routing-type isnt destructive.

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -44,7 +44,6 @@ import io.netty.channel.Channel;
 
 import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
 import org.apache.activemq.artemis.api.core.Pair;
-import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.client.impl.ServerLocatorInternal;
 import org.apache.activemq.artemis.core.config.Configuration;
@@ -1903,8 +1902,8 @@ public interface ActiveMQServerLogger extends BasicLogger {
    void undeployAddress(SimpleString addressName);
 
    @LogMessage(level = Logger.Level.INFO)
-   @Message(id = 224077, value = "Undeploying {0} queue {1}", format = Message.Format.MESSAGE_FORMAT)
-   void undeployQueue(RoutingType routingType, SimpleString queueName);
+   @Message(id = 224077, value = "Undeploying queue {0}", format = Message.Format.MESSAGE_FORMAT)
+   void undeployQueue(SimpleString queueName);
 
    @LogMessage(level = Logger.Level.WARN)
    @Message(id = 224078, value = "The size of duplicate cache detection (<id_cache-size/>) appears to be too large {0}. It should be no greater than the number of messages that can be squeezed into conformation buffer (<confirmation-window-size/>) {1}.", format = Message.Format.MESSAGE_FORMAT)

--- a/tests/integration-tests/src/test/resources/reload-queue-routingtype-updated.xml
+++ b/tests/integration-tests/src/test/resources/reload-queue-routingtype-updated.xml
@@ -23,17 +23,21 @@ under the License.
                xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
 
    <core xmlns="urn:activemq:core">
-      <address-settings>
-         <address-setting match="#">
-            <config-delete-queues>FORCE</config-delete-queues>
-         </address-setting>
-      </address-settings>
+      <security-enabled>false</security-enabled>
+
+      <acceptors>
+         <!-- Default ActiveMQ Artemis Acceptor.  Multi-protocol adapter.  Currently supports ActiveMQ Artemis Core, OpenWire, STOMP, AMQP, MQTT, and HornetQ Core. -->
+         <!-- performance tests have shown that openWire performs best with these buffer sizes -->
+         <acceptor name="artemis">tcp://0.0.0.0:61616?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576</acceptor>
+
+      </acceptors>
+
 
       <addresses>
          <address name="myAddress">
-            <anycast>
+            <multicast>
                <queue name="myQueue"/>
-            </anycast>
+            </multicast>
          </address>
       </addresses>
    </core>

--- a/tests/integration-tests/src/test/resources/reload-queue-routingtype.xml
+++ b/tests/integration-tests/src/test/resources/reload-queue-routingtype.xml
@@ -23,17 +23,20 @@ under the License.
                xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
 
    <core xmlns="urn:activemq:core">
-      <address-settings>
-         <address-setting match="#">
-            <config-delete-queues>FORCE</config-delete-queues>
-         </address-setting>
-      </address-settings>
+      <security-enabled>false</security-enabled>
+
+      <acceptors>
+         <!-- Default ActiveMQ Artemis Acceptor.  Multi-protocol adapter.  Currently supports ActiveMQ Artemis Core, OpenWire, STOMP, AMQP, MQTT, and HornetQ Core. -->
+         <!-- performance tests have shown that openWire performs best with these buffer sizes -->
+         <acceptor name="artemis">tcp://0.0.0.0:61616?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576</acceptor>
+
+      </acceptors>
 
       <addresses>
          <address name="myAddress">
-            <multicast>
+            <anycast>
                <queue name="myQueue"/>
-            </multicast>
+            </anycast>
          </address>
       </addresses>
    </core>


### PR DESCRIPTION
Revert previous fix
Keep original ConfigChangeTest
Apply new non-destructive fix.
Enhance tests to ensure messages in queues are not lost either on reload when running or when config changed on-restart (e.g. queue i not destroyed)