### PR TITLE
Update SimpleString to give a more useful error message

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/SimpleString.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/SimpleString.java
@@ -180,7 +180,7 @@ public final class SimpleString implements CharSequence, Serializable, Comparabl
 
    public static SimpleString readSimpleString(final ByteBuf buffer, final int length) {
       if (length > buffer.readableBytes()) {
-         throw new IndexOutOfBoundsException();
+         throw new IndexOutOfBoundsException("Error reading simpleString length=" + length + " is greater than readableBytes=" + buffer.readableBytes());
       }
       byte[] data = new byte[length];
       buffer.readBytes(data);

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/SimpleString.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/SimpleString.java
@@ -180,7 +180,7 @@ public final class SimpleString implements CharSequence, Serializable, Comparabl
 
    public static SimpleString readSimpleString(final ByteBuf buffer, final int length) {
       if (length > buffer.readableBytes()) {
-         throw new IndexOutOfBoundsException("Error reading simpleString length=" + length + " is greater than readableBytes=" + buffer.readableBytes());
+         throw new IndexOutOfBoundsException("Error reading in simpleString, length=" + length + " is greater than readableBytes=" + buffer.readableBytes());
       }
       byte[] data = new byte[length];
       buffer.readBytes(data);


### PR DESCRIPTION
Currently we get.
java.lang.IndexOutOfBoundsException: **_null_**
	at org.apache.activemq.artemis.api.core.SimpleString.readSimpleString(SimpleString.java:183)
	at org.apache.activemq.artemis.api.core.SimpleString$ByteBufSimpleStringPool.create(SimpleString.java:584)
        ....

Should be 
java.lang.IndexOutOfBoundsException: **_Error reading in simpleString, length=YYY is greater than readableBytes=XXX_**
	at org.apache.activemq.artemis.api.core.SimpleString.readSimpleString(SimpleString.java:183)
	at org.apache.activemq.artemis.api.core.SimpleString$ByteBufSimpleStringPool.create(SimpleString.java:584)
        ...