### PR TITLE
NO-JIRA - Page.write() should throw exception if file is closed

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/Page.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/Page.java
@@ -223,7 +223,7 @@ public final class Page implements Comparable<Page> {
 
    public synchronized void write(final PagedMessage message) throws Exception {
       if (!file.isOpen()) {
-         return;
+         throw ActiveMQMessageBundle.BUNDLE.cannotWriteToClosedFile(file);
       }
       final int messageEncodedSize = message.getEncodeSize();
       final int bufferSize = messageEncodedSize + Page.SIZE_RECORD;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQMessageBundle.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQMessageBundle.java
@@ -44,6 +44,7 @@ import org.apache.activemq.artemis.api.core.ActiveMQUnexpectedRoutingTypeForAddr
 import org.apache.activemq.artemis.api.core.DiscoveryGroupConfiguration;
 import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.io.SequentialFile;
 import org.apache.activemq.artemis.core.postoffice.Binding;
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.ReplicationSyncFileMessage;
 import org.apache.activemq.artemis.core.security.CheckType;
@@ -441,4 +442,7 @@ public interface ActiveMQMessageBundle {
 
    @Message(id = 229215, value = "Cannot delete queue {0} on binding {1} - it has {2} messages", format = Message.Format.MESSAGE_FORMAT)
    ActiveMQIllegalStateException cannotDeleteQueueWithMessages(SimpleString name, SimpleString queueName, long messageCount);
+
+   @Message(id = 119215, value = "Can't write to closed file: {0}", format = Message.Format.MESSAGE_FORMAT)
+   ActiveMQIOErrorException cannotWriteToClosedFile(SequentialFile file);
 }


### PR DESCRIPTION
In Page.write(final PagedMessage message) if the page file is closed
it returns silently. The caller has no way to know that if the message
is paged to file or not. It should throw an exception so that the
caller can handle it correctly.