### PR TITLE
ARTEMIS-2090 JDBC Journal is not deleting TX records

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jdbc/store/journal/JDBCJournalTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jdbc/store/journal/JDBCJournalTest.java
@@ -130,6 +130,13 @@ public class JDBCJournalTest extends ActiveMQTestBase {
    }
 
    @Test
+   public void testCleanupTxRecords() throws Exception {
+      journal.appendDeleteRecordTransactional(1, 1);
+      journal.appendCommitRecord(1, true);
+      assertEquals(0, journal.getNumberOfRecords());
+   }
+
+   @Test
    public void testCallbacks() throws Exception {
       final int noRecords = 10;
       final CountDownLatch done = new CountDownLatch(noRecords);


### PR DESCRIPTION
JDBCJournalImpl::cleanupTxRecords is not committing
the deleteJournalTxRecords statement leaving the
TX records into the journal