### PR TITLE
ARTEMIS-2095 - Typed Properties ThreadSafety

### DIFF
--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/TypedPropertiesConcurrencyTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/TypedPropertiesConcurrencyTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.utils;
+
+
+import java.util.ConcurrentModificationException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.utils.collections.TypedProperties;
+import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class TypedPropertiesConcurrencyTest {
+
+   // Constructors --------------------------------------------------
+
+   // Public --------------------------------------------------------
+
+
+   private SimpleString key = SimpleString.toSimpleString("key");
+
+   @Test
+   public void testClearAndToString() throws Exception {
+      TypedProperties props = new TypedProperties();
+
+      ExecutorService executorService = Executors.newFixedThreadPool(1000);
+
+      AtomicBoolean hasError = new AtomicBoolean();
+      CountDownLatch countDownLatch = new CountDownLatch(1);
+      for (int i = 0; i < 10000; i++) {
+         int g = i;
+         executorService.submit(() -> {
+            try {
+               countDownLatch.await();
+               for (int h = 0; h < 100; h++) {
+                  props.putSimpleStringProperty(SimpleString.toSimpleString("S" + h), SimpleString.toSimpleString("hello"));
+               }
+               props.clear();
+            } catch (ConcurrentModificationException t) {
+               hasError.set(true);
+               t.printStackTrace();
+            } catch (InterruptedException e) {
+            }
+         });
+      }
+      for (int i = 0; i < 10; i++) {
+         executorService.submit( () -> {
+            try {
+               countDownLatch.await();
+               for (int k = 0; k < 1000; k++) {
+                  props.toString();
+               }
+            } catch (ConcurrentModificationException t) {
+               hasError.set(true);
+               t.printStackTrace();
+            } catch (InterruptedException e) {
+            }
+
+         });
+      }
+
+      countDownLatch.countDown();
+      Thread.sleep(1000);
+      executorService.shutdown();
+      executorService.awaitTermination(10, TimeUnit.SECONDS);
+      executorService.shutdown();
+      Assert.assertFalse(hasError.get());
+   }
+
+
+   @Test
+   public void testGetPropertyNamesClearAndToString() throws Exception {
+      TypedProperties props = new TypedProperties();
+
+      ExecutorService executorService = Executors.newFixedThreadPool(1000);
+
+      AtomicBoolean hasError = new AtomicBoolean();
+      CountDownLatch countDownLatch = new CountDownLatch(1);
+      for (int i = 0; i < 10000; i++) {
+         int g = i;
+         executorService.submit(() -> {
+            try {
+               countDownLatch.await();
+               for (int h = 0; h < 100; h++) {
+                  props.putSimpleStringProperty(SimpleString.toSimpleString("S" + h), SimpleString.toSimpleString("hello"));
+               }
+               props.getPropertyNames().clear();
+            } catch (UnsupportedOperationException uoe) {
+               //Catch this as this would be acceptable, as the set is meant to be like an enumeration so a user should not modify and should expect an implementation to protect itself..
+            } catch (ConcurrentModificationException t) {
+               hasError.set(true);
+               t.printStackTrace();
+            } catch (InterruptedException e) {
+            }
+         });
+      }
+      for (int i = 0; i < 10; i++) {
+         executorService.submit( () -> {
+            try {
+               countDownLatch.await();
+               for (int k = 0; k < 1000; k++) {
+                  props.toString();
+               }
+            } catch (ConcurrentModificationException t) {
+               hasError.set(true);
+               t.printStackTrace();
+            } catch (InterruptedException e) {
+            }
+
+         });
+      }
+
+      countDownLatch.countDown();
+      Thread.sleep(1000);
+      executorService.shutdown();
+      executorService.awaitTermination(10, TimeUnit.SECONDS);
+      executorService.shutdown();
+      Assert.assertFalse(hasError.get());
+   }
+
+
+   @Test
+   public void testEncodedSizeAfterClearIsSameAsNewTypedProperties() throws Exception {
+      TypedProperties props = new TypedProperties();
+      props.putSimpleStringProperty(SimpleString.toSimpleString("helllllloooooo"), SimpleString.toSimpleString("raaaaaaaaaaaaaaaaaaaaaaaa"));
+
+      props.clear();
+
+      assertEquals(new TypedProperties().getEncodeSize(), props.getEncodeSize());
+
+   }
+
+   @Test
+   public void testMemoryOffsetAfterClearIsSameAsNewTypedProperties() throws Exception {
+      TypedProperties props = new TypedProperties();
+      props.putSimpleStringProperty(SimpleString.toSimpleString("helllllloooooo"), SimpleString.toSimpleString("raaaaaaaaaaaaaaaaaaaaaaaa"));
+
+      props.clear();
+
+      assertEquals(new TypedProperties().getMemoryOffset(), props.getMemoryOffset());
+
+   }
+}

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQMapMessage.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQMapMessage.java
@@ -21,8 +21,6 @@ import javax.jms.MapMessage;
 import javax.jms.MessageFormatException;
 import java.util.Collections;
 import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.Set;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.ActiveMQPropertyConversionException;
@@ -301,14 +299,7 @@ public class ActiveMQMapMessage extends ActiveMQMessage implements MapMessage {
 
    @Override
    public Enumeration getMapNames() throws JMSException {
-      Set<SimpleString> simplePropNames = map.getPropertyNames();
-      Set<String> propNames = new HashSet<>(simplePropNames.size());
-
-      for (SimpleString str : simplePropNames) {
-         propNames.add(str.toString());
-      }
-
-      return Collections.enumeration(propNames);
+      return Collections.enumeration(map.getMapNames());
    }
 
    @Override

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/converter/AmqpCoreConverter.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/converter/AmqpCoreConverter.java
@@ -60,7 +60,6 @@ import javax.jms.DeliveryMode;
 import javax.jms.JMSException;
 
 import org.apache.activemq.artemis.api.core.ICoreMessage;
-import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.message.impl.CoreMessageObjectPools;
 import org.apache.activemq.artemis.protocol.amqp.broker.AMQPMessage;
 import org.apache.activemq.artemis.protocol.amqp.converter.jms.ServerDestination;
@@ -298,12 +297,11 @@ public class AmqpCoreConverter {
 
    private static ServerJMSMessage processExtraProperties(ServerJMSMessage jms, TypedProperties properties) {
       if (properties != null) {
-         for (SimpleString str : properties.getPropertyNames()) {
-            if (str.equals(AMQPMessage.ADDRESS_PROPERTY)) {
-               continue;
+         properties.forEach((k, v) -> {
+            if (!k.equals(AMQPMessage.ADDRESS_PROPERTY)) {
+               jms.getInnerMessage().putObjectProperty(k, v);
             }
-            jms.getInnerMessage().putObjectProperty(str, properties.getProperty(str));
-         }
+         });
       }
 
       return jms;

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/converter/jms/ServerJMSMapMessage.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/converter/jms/ServerJMSMapMessage.java
@@ -21,8 +21,6 @@ import javax.jms.MapMessage;
 import javax.jms.MessageFormatException;
 import java.util.Collections;
 import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.Set;
 
 import org.apache.activemq.artemis.api.core.ActiveMQPropertyConversionException;
 import org.apache.activemq.artemis.api.core.ICoreMessage;
@@ -251,14 +249,7 @@ public final class ServerJMSMapMessage extends ServerJMSMessage implements MapMe
 
    @Override
    public Enumeration getMapNames() throws JMSException {
-      Set<SimpleString> simplePropNames = map.getPropertyNames();
-      Set<String> propNames = new HashSet<>(simplePropNames.size());
-
-      for (SimpleString str : simplePropNames) {
-         propNames.add(str.toString());
-      }
-
-      return Collections.enumeration(propNames);
+      return Collections.enumeration(map.getMapNames());
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/impl/ManagementServiceImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/impl/ManagementServiceImpl.java
@@ -679,9 +679,7 @@ public class ManagementServiceImpl implements ManagementService {
 
                if (notification.getProperties() != null) {
                   TypedProperties props = notification.getProperties();
-                  for (SimpleString name : notification.getProperties().getPropertyNames()) {
-                     notificationMessage.putObjectProperty(name, props.getProperty(name));
-                  }
+                  props.forEach(notificationMessage::putObjectProperty);
                }
 
                notificationMessage.putStringProperty(ManagementHelper.HDR_NOTIFICATION_TYPE, new SimpleString(notification.getType().toString()));


### PR DESCRIPTION
Add Concurrency Test to expose concurrency errors seen in logs.
Add Fix to ensure TypedProperties to ensure threadsafety
Add forEach and forEachKey to allow for provide a thread safe way of iterating through keys and values, without needing to duplicate the collection.
Add getMapNames method to remove code duplication and to ensure thread safe