### PR TITLE
ARTEMIS-2101 Do not cluster OpenWire advisory topics

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireProtocolManager.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireProtocolManager.java
@@ -154,6 +154,9 @@ public class OpenWireProtocolManager implements ProtocolManager<Interceptor>, Cl
       if (cc != null) {
          cc.addClusterTopologyListener(this);
       }
+      if (supportAdvisory) {
+         clusterManager.addToIgnoredAddressPrefixes(AdvisorySupport.ADVISORY_TOPIC_PREFIX);
+      }
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/impl/ClusterConnectionBridge.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/impl/ClusterConnectionBridge.java
@@ -350,6 +350,16 @@ public class ClusterConnectionBridge extends BridgeImpl {
       filterString += "!" + storeAndForwardPrefix;
       filterString += ",!" + managementAddress;
       filterString += ",!" + managementNotificationAddress;
+      final String originalFilterString = filterString;
+      for (String ignoredPrefix : clusterManager.getIgnoredAddressPrefixes()) {
+         final String ignoredPrefixPredicate = "!" + ignoredPrefix;
+         if (!originalFilterString.contains(ignoredPrefixPredicate)) {
+            if (originalFilterString.contains(ignoredPrefix)) {
+               logger.warnf("%s will be ignored even if configured differently: please consider removing it from cluster configuration", ignoredPrefix);
+            }
+            filterString += "," + ignoredPrefixPredicate;
+         }
+      }
       return filterString;
    }
 


### PR DESCRIPTION
ClusterConnectionBridge needs to ignore any advisory topic
address in the filter used by the notification consumer on
bridge activation