### PR TITLE
ARTEMIS-2102 delete paging directory or table if address is removed

### DIFF
--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/file/JDBCSequentialFileFactoryDriver.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/file/JDBCSequentialFileFactoryDriver.java
@@ -246,6 +246,10 @@ public class JDBCSequentialFileFactoryDriver extends AbstractJDBCDriver {
       }
    }
 
+   public int writeToFile(JDBCSequentialFile file, byte[] data) throws SQLException {
+      return writeToFile(file, data, true);
+   }
+
    /**
     * Persists data to this files associated database mapping.
     *
@@ -254,7 +258,7 @@ public class JDBCSequentialFileFactoryDriver extends AbstractJDBCDriver {
     * @return
     * @throws SQLException
     */
-   public int writeToFile(JDBCSequentialFile file, byte[] data) throws SQLException {
+   public int writeToFile(JDBCSequentialFile file, byte[] data, boolean append) throws SQLException {
       synchronized (connection) {
          connection.setAutoCommit(false);
          appendToLargeObject.setLong(1, file.getId());
@@ -266,7 +270,12 @@ public class JDBCSequentialFileFactoryDriver extends AbstractJDBCDriver {
                if (blob == null) {
                   blob = connection.createBlob();
                }
-               bytesWritten = blob.setBytes(blob.length() + 1, data);
+               if (append) {
+                  bytesWritten = blob.setBytes(blob.length() + 1, data);
+               } else {
+                  blob.truncate(0);
+                  bytesWritten = blob.setBytes(1, data);
+               }
                rs.updateBlob(1, blob);
                rs.updateRow();
             }

--- a/artemis-jdbc-store/src/test/java/org/apache/activemq/artemis/jdbc/file/JDBCSequentialFileFactoryTest.java
+++ b/artemis-jdbc-store/src/test/java/org/apache/activemq/artemis/jdbc/file/JDBCSequentialFileFactoryTest.java
@@ -202,6 +202,32 @@ public class JDBCSequentialFileFactoryTest {
    }
 
    @Test
+   public void testWriteToFile() throws Exception {
+      JDBCSequentialFile file = (JDBCSequentialFile) factory.createSequentialFile("test.txt");
+      file.open();
+
+      ActiveMQBuffer src = ActiveMQBuffers.fixedBuffer(1);
+      src.writeByte((byte)7);
+
+      file.internalWrite(src, null);
+      checkData(file, src);
+      assertEquals(1, file.size());
+      file.close();
+
+      file = (JDBCSequentialFile) factory.createSequentialFile("test.txt");
+      file.open();
+
+      int bufferSize = 1024;
+      src = ActiveMQBuffers.fixedBuffer(bufferSize);
+      for (int i = 0; i < bufferSize; i++) {
+         src.writeByte((byte)i);
+      }
+      file.internalWrite(src, null, false);
+      checkData(file, src);
+      assertEquals(bufferSize, file.size());
+   }
+
+   @Test
    public void testCopyFile() throws Exception {
       JDBCSequentialFile file = (JDBCSequentialFile) factory.createSequentialFile("test.txt");
       file.open();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/PagingStore.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/PagingStore.java
@@ -184,4 +184,6 @@ public interface PagingStore extends ActiveMQComponent, RefCountMessageListener 
     * This method will re-enable cleanup of pages. Notice that it will also start cleanup threads.
     */
    void enableCleanup();
+
+   void destroy() throws Exception;
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/PagingStoreFactory.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/PagingStoreFactory.java
@@ -49,6 +49,8 @@ public interface PagingStoreFactory {
 
    SequentialFileFactory newFileFactory(SimpleString address) throws Exception;
 
+   void removeFileFactory(SequentialFileFactory fileFactory) throws Exception;
+
    void injectMonitor(FileStoreMonitor monitor) throws Exception;
 
    default ScheduledExecutorService getScheduledExecutor() {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingManagerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingManagerImpl.java
@@ -317,6 +317,7 @@ public final class PagingManagerImpl implements PagingManager {
          PagingStore store = stores.remove(storeName);
          if (store != null) {
             store.stop();
+            store.destroy();
          }
       } finally {
          syncLock.readLock().unlock();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingStoreFactoryDatabase.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingStoreFactoryDatabase.java
@@ -18,7 +18,9 @@ package org.apache.activemq.artemis.core.paging.impl;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -94,6 +96,8 @@ public class PagingStoreFactoryDatabase implements PagingStoreFactory {
 
    private final IOCriticalErrorListener criticalErrorListener;
 
+   private final Map<SequentialFileFactory, String> factoryToTableName;
+
    public PagingStoreFactoryDatabase(final DatabaseStorageConfiguration dbConf,
                                      final StorageManager storageManager,
                                      final long syncTimeout,
@@ -108,6 +112,7 @@ public class PagingStoreFactoryDatabase implements PagingStoreFactory {
       this.syncTimeout = syncTimeout;
       this.dbConf = dbConf;
       this.criticalErrorListener = critialErrorListener;
+      this.factoryToTableName = new HashMap<>();
       start();
    }
 
@@ -181,6 +186,32 @@ public class PagingStoreFactoryDatabase implements PagingStoreFactory {
    }
 
    @Override
+   public synchronized void removeFileFactory(SequentialFileFactory fileFactory) throws Exception {
+      ((JDBCSequentialFileFactory)fileFactory).destroy();
+      String tableName = factoryToTableName.remove(fileFactory);
+      if (tableName != null) {
+         SimpleString removeTableName = SimpleString.toSimpleString(tableName);
+         JDBCSequentialFile directoryList = (JDBCSequentialFile) pagingFactoryFileFactory.createSequentialFile(DIRECTORY_NAME);
+         directoryList.open();
+
+         int size = ((Long) directoryList.size()).intValue();
+         ActiveMQBuffer buffer = readActiveMQBuffer(directoryList, size);
+
+         ActiveMQBuffer writeBuffer = ActiveMQBuffers.fixedBuffer(size);
+
+         while (buffer.readableBytes() > 0) {
+            SimpleString table = buffer.readSimpleString();
+            if (!removeTableName.equals(table)) {
+               writeBuffer.writeSimpleString(table);
+            }
+         }
+
+         directoryList.write(writeBuffer, true, null, false);
+         directoryList.close();
+      }
+   }
+
+   @Override
    public void setPagingManager(final PagingManager pagingManager) {
       this.pagingManager = pagingManager;
    }
@@ -249,6 +280,7 @@ public class PagingStoreFactoryDatabase implements PagingStoreFactory {
       if (jdbcNetworkTimeout >= 0) {
          fileFactory.setNetworkTimeout(this.executorFactory.getExecutor(), jdbcNetworkTimeout);
       }
+      factoryToTableName.put(fileFactory, directoryName);
       return fileFactory;
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingStoreFactoryNIO.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingStoreFactoryNIO.java
@@ -45,6 +45,7 @@ import org.apache.activemq.artemis.core.server.files.FileStoreMonitor;
 import org.apache.activemq.artemis.core.settings.HierarchicalRepository;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.utils.ExecutorFactory;
+import org.apache.activemq.artemis.utils.FileUtil;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
 import org.apache.activemq.artemis.utils.actors.ArtemisExecutor;
 
@@ -171,6 +172,14 @@ public class PagingStoreFactoryNIO implements PagingStoreFactory {
       }
 
       return factory;
+   }
+
+   @Override
+   public synchronized void removeFileFactory(SequentialFileFactory fileFactory) throws Exception {
+      File directory = fileFactory.getDirectory();
+      if (directory.exists()) {
+         FileUtil.deleteDirectory(directory);
+      }
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingStoreImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingStoreImpl.java
@@ -967,6 +967,13 @@ public class PagingStoreImpl implements PagingStore {
       return;
    }
 
+   @Override
+   public void destroy() throws Exception {
+      if (fileFactory != null) {
+         storeFactory.removeFileFactory(fileFactory);
+      }
+   }
+
    private static class FinishPageMessageOperation implements TransactionOperation {
 
       private final PageTransactionInfo pageTransaction;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -2588,6 +2588,8 @@ public class ActiveMQServerImpl implements ActiveMQServer {
 
       JournalLoadInformation[] journalInfo = loadJournals();
 
+      removeExtraAddressStores();
+
       final ServerInfo dumper = new ServerInfo(this, pagingManager);
 
       long dumpInfoInterval = configuration.getServerDumpInterval();
@@ -3446,6 +3448,17 @@ public class ActiveMQServerImpl implements ActiveMQServer {
       AtomicInteger i = connectedClientIds.get(clientId);
       if (i != null && i.decrementAndGet() == 0) {
          connectedClientIds.remove(clientId);
+      }
+   }
+
+   private void removeExtraAddressStores() throws Exception {
+      SimpleString[] storeNames = pagingManager.getStoreNames();
+      if (storeNames != null && storeNames.length > 0) {
+         for (SimpleString storeName : storeNames) {
+            if (getAddressInfo(storeName) == null) {
+               pagingManager.deletePageStore(storeName);
+            }
+         }
       }
    }
 

--- a/tests/performance-tests/src/test/java/org/apache/activemq/artemis/tests/performance/storage/PersistMultiThreadTest.java
+++ b/tests/performance-tests/src/test/java/org/apache/activemq/artemis/tests/performance/storage/PersistMultiThreadTest.java
@@ -469,5 +469,9 @@ public class PersistMultiThreadTest extends ActiveMQTestBase {
       public boolean checkReleasedMemory() {
          return true;
       }
+
+      @Override
+      public void destroy() throws Exception {
+      }
    }
 }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/paging/impl/PagingStoreImplTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/paging/impl/PagingStoreImplTest.java
@@ -803,6 +803,10 @@ public class PagingStoreImplTest extends ActiveMQTestBase {
       }
 
       @Override
+      public void removeFileFactory(SequentialFileFactory fileFactory) throws Exception {
+      }
+
+      @Override
       public PagingStore newStore(final SimpleString destinationName, final AddressSettings addressSettings) {
          return null;
       }


### PR DESCRIPTION
Our app uses clientRequestor to get message count or other metrics.

When the broker is globally full(all addresses enters into paging mode), each request by clientRequestor will create a temporary reply queue causing a new paging directory is created. After each request clientRequestor is closed and the temporary queue is deleted, the broker only purges the queue data.

This will leave hundreds of thousands directories soon and if we restart broker the bootstrap process would be very slow(cost about 30 minutes to reloadPageStores and reapplySettings).

We should delete paging directory to fix the problem.