### PR TITLE
ARTEMIS-2112 Remove JMX props from start scripts

### DIFF
--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis-service.xml
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis-service.xml
@@ -46,13 +46,6 @@
    <argument>-Dartemis.remoting.hornetq.port=5446</argument>
    -->
 
-   <!-- uncomment this if you want to connect jconsole to connect
-    <argument>-Dcom.sun.management.jmxremote</argument>
-    <argument>-Dcom.sun.management.jmxremote.port=8086</argument>
-    <argument>-Dcom.sun.management.jmxremote.ssl=false</argument>
-    <argument>-Dcom.sun.management.jmxremote.authenticate=false</argument>
-   -->
-
    <argument>-classpath</argument>
    <argument>%ARTEMIS_HOME%\lib\artemis-boot.jar</argument>
    <argument>-Dartemis.home=%ARTEMIS_HOME%</argument>

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile
@@ -34,13 +34,6 @@ ARTEMIS_INSTANCE_ETC_URI='${artemis.instance.etc.uri}'
 JAVA_ARGS="${java-opts} -XX:+PrintClassHistogram -XX:+UseG1GC -XX:+AggressiveOpts -Xms512M -Xmx2G -Dhawtio.realm=activemq  -Dhawtio.offline="true" -Dhawtio.role=${role} -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal -Djolokia.policyLocation=${ARTEMIS_INSTANCE_ETC_URI}jolokia-access.xml"
 
 #
-# There might be options that you only want to enable on specifc commands, like setting a JMX port
-# See https://issues.apache.org/jira/browse/ARTEMIS-318
-#if [ "$1" = "run" ]; then
-#  JAVA_ARGS="$JAVA_ARGS -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=1099 -Dcom.sun.management.jmxremote.rmi.port=1098 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
-#fi
-
-#
 # Logs Safepoints JVM pauses: Uncomment to enable them
 # In addition to the traditional GC logs you could enable some JVM flags to know any meaningful and "hidden" pause that could
 # affect the latencies of the services delivered by the broker, including those that are not reported by the classic GC logs

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile.cmd
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile.cmd
@@ -34,10 +34,6 @@ rem set ARTEMIS_CLUSTER_PROPS=-Dactivemq.remoting.default.port=61617 -Dactivemq.
 rem Java Opts
 set JAVA_ARGS=${java-opts} -XX:+PrintClassHistogram -XX:+UseG1GC -XX:+AggressiveOpts -Xms512M -Xmx1024M -Xbootclasspath/a:%ARTEMIS_HOME%\lib\${logmanager} -Djava.security.auth.login.config=%ARTEMIS_ETC_DIR%\login.config -Dhawtio.offline="true" -Dhawtio.realm=activemq -Dhawtio.role=${role} -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal -Djolokia.policyLocation=%ARTEMIS_INSTANCE_ETC_URI%\jolokia-access.xml -Dartemis.instance=%ARTEMIS_INSTANCE%
 
-rem There might be options that you only want to enable on specifc commands, like setting a JMX port
-rem See https://issues.apache.org/jira/browse/ARTEMIS-318
-rem if "%1"=="run" set JAVA_ARGS=%JAVA_ARGS% -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=1099 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false
-
 rem Logs Safepoints JVM pauses: Uncomment to enable them
 rem In addition to the traditional GC logs you could enable some JVM flags to know any meaningful and "hidden" pause that could
 rem affect the latencies of the services delivered by the broker, including those that are not reported by the classic GC logs


### PR DESCRIPTION
JMX configuration is now done via management.xml. Configuring JMX via
the start scripts could result in unexpected behavior since the
authorisation configuration from management.xml would be ignored.