### PR TITLE
Log STOMP transaction starts with debug level instead of error

### DIFF
--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompProtocolManager.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompProtocolManager.java
@@ -365,7 +365,7 @@ public class StompProtocolManager extends AbstractProtocolManager<StompFrame, St
    }
 
    public void beginTransaction(StompConnection connection, String txID) throws Exception {
-      ActiveMQServerLogger.LOGGER.stompBeginTX(txID);
+      ActiveMQServerLogger.LOGGER.debugf("-------------------------------Stomp begin tx: %s", txID);
       if (transactedSessions.containsKey(txID)) {
          ActiveMQServerLogger.LOGGER.stompErrorTXExists(txID);
          throw new ActiveMQStompException(connection, "Transaction already started: " + txID);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1711,10 +1711,6 @@ public interface ActiveMQServerLogger extends BasicLogger {
    @Message(id = 224030, value = "Could not cancel reference {0}", format = Message.Format.MESSAGE_FORMAT)
    void errorCancellingRefOnBridge(@Cause Exception e, MessageReference ref2);
 
-   @LogMessage(level = Logger.Level.DEBUG)
-   @Message(id = 224031, value = "-------------------------------Stomp begin tx: {0}", format = Message.Format.MESSAGE_FORMAT)
-   void stompBeginTX(String txID);
-
    @LogMessage(level = Logger.Level.ERROR)
    @Message(id = 224032, value = "Failed to pause bridge", format = Message.Format.MESSAGE_FORMAT)
    void errorPausingBridge(@Cause Exception e);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1711,7 +1711,7 @@ public interface ActiveMQServerLogger extends BasicLogger {
    @Message(id = 224030, value = "Could not cancel reference {0}", format = Message.Format.MESSAGE_FORMAT)
    void errorCancellingRefOnBridge(@Cause Exception e, MessageReference ref2);
 
-   @LogMessage(level = Logger.Level.ERROR)
+   @LogMessage(level = Logger.Level.DEBUG)
    @Message(id = 224031, value = "-------------------------------Stomp begin tx: {0}", format = Message.Format.MESSAGE_FORMAT)
    void stompBeginTX(String txID);
 


### PR DESCRIPTION
I don't think error is appropriate here. Perhaps info, but went for debug.