### PR TITLE
ARTEMIS-2096 Fixing DivertTopicToQueueTest

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
@@ -497,7 +497,7 @@ public class AMQPMessage extends RefCountMessage {
 
       // Copy the full message contents with delivery annotations as they will
       // be trimmed on send and may become useful on the broker at a later time.
-      data.get(newData);
+      view.get(newData);
 
       AMQPMessage newEncode = new AMQPMessage(this.messageFormat, newData, extraProperties, coreMessageObjectPools);
       newEncode.setMessageID(this.getMessageID());


### PR DESCRIPTION
This is fixing the test org.apache.activemq.artemis.tests.integration.amqp.DivertTopicToQueueTest

This test was broken because the copy wouldn't use the Buffer view gotten by data.duplicate().