### PR TITLE
ARTEMIS-2117 Add custom LVQ Key and Non Destructive Queue into Broker

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/QueueAttributes.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/QueueAttributes.java
@@ -21,59 +21,155 @@ import java.io.Serializable;
 
 public class QueueAttributes implements Serializable {
 
+   public static final String ROUTING_TYPE = "routing-type";
+   public static final String FILTER_STRING = "filter-string";
+   public static final String DURABLE = "durable";
    public static final String MAX_CONSUMERS = "max-consumers";
    public static final String EXCLUSIVE = "exclusive";
    public static final String LAST_VALUE = "last-value";
+   public static final String LAST_VALUE_KEY = "last-value-key";
+   public static final String NON_DESTRUCTIVE = "non-destructive";
    public static final String PURGE_ON_NO_CONSUMERS = "purge-on-no-consumers";
+   public static final String CONSUMERS_BEFORE_DISPATCH = "consumers-before-dispatch";
+   public static final String DELAY_BEFORE_DISPATCH = "delay-before-dispatch";
 
+   private RoutingType routingType;
+   private SimpleString filterString;
+   private Boolean durable;
    private Integer maxConsumers;
    private Boolean exclusive;
    private Boolean lastValue;
+   private SimpleString lastValueKey;
+   private Boolean nonDestructive;
    private Boolean purgeOnNoConsumers;
+   private Integer consumersBeforeDispatch;
+   private Long delayBeforeDispatch;
 
    public void set(String key, String value) {
       if (key != null && value != null) {
-         if (key.equals(MAX_CONSUMERS)) {
+         if (key.equals(ROUTING_TYPE)) {
+            setRoutingType(RoutingType.valueOf(value.toUpperCase()));
+         } else if (key.equals(FILTER_STRING)) {
+            setFilterString(SimpleString.toSimpleString(value));
+         } else if (key.equals(DURABLE)) {
+            setDurable(Boolean.valueOf(value));
+         } else if (key.equals(MAX_CONSUMERS)) {
             setMaxConsumers(Integer.valueOf(value));
          } else if (key.equals(EXCLUSIVE)) {
             setExclusive(Boolean.valueOf(value));
          } else if (key.equals(LAST_VALUE)) {
             setLastValue(Boolean.valueOf(value));
+         } else if (key.equals(LAST_VALUE_KEY)) {
+            setLastValueKey(SimpleString.toSimpleString(value));
+         } else if (key.equals(NON_DESTRUCTIVE)) {
+            setNonDestructive(Boolean.valueOf(value));
          } else if (key.equals(PURGE_ON_NO_CONSUMERS)) {
             setPurgeOnNoConsumers(Boolean.valueOf(value));
+         } else if (key.equals(CONSUMERS_BEFORE_DISPATCH)) {
+            setConsumersBeforeDispatch(Integer.valueOf(value));
+         } else if (key.equals(DELAY_BEFORE_DISPATCH)) {
+            setDelayBeforeDispatch(Long.valueOf(value));
          }
       }
+   }
+
+   public RoutingType getRoutingType() {
+      return routingType;
+   }
+
+   public QueueAttributes setRoutingType(RoutingType routingType) {
+      this.routingType = routingType;
+      return this;
+   }
+
+   public SimpleString getFilterString() {
+      return filterString;
+   }
+
+   public QueueAttributes setFilterString(SimpleString filterString) {
+      this.filterString = filterString;
+      return this;
+   }
+
+   public Boolean getDurable() {
+      return durable;
+   }
+
+   public QueueAttributes setDurable(Boolean durable) {
+      this.durable = durable;
+      return this;
    }
 
    public Integer getMaxConsumers() {
       return maxConsumers;
    }
 
-   public void setMaxConsumers(Integer maxConsumers) {
+   public QueueAttributes setMaxConsumers(Integer maxConsumers) {
       this.maxConsumers = maxConsumers;
+      return this;
    }
 
    public Boolean getExclusive() {
       return exclusive;
    }
 
-   public void setExclusive(Boolean exclusive) {
+   public QueueAttributes setExclusive(Boolean exclusive) {
       this.exclusive = exclusive;
+      return this;
    }
 
    public Boolean getLastValue() {
       return lastValue;
    }
 
-   public void setLastValue(Boolean lastValue) {
+   public QueueAttributes setLastValue(Boolean lastValue) {
       this.lastValue = lastValue;
+      return this;
+   }
+
+   public SimpleString getLastValueKey() {
+      return lastValueKey;
+   }
+
+   public QueueAttributes setLastValueKey(SimpleString lastValueKey) {
+      this.lastValueKey = lastValueKey;
+      return this;
+   }
+
+   public Boolean getNonDestructive() {
+      return nonDestructive;
+   }
+
+   public QueueAttributes setNonDestructive(Boolean nonDestructive) {
+      this.nonDestructive = nonDestructive;
+      return this;
    }
 
    public Boolean getPurgeOnNoConsumers() {
       return purgeOnNoConsumers;
    }
 
-   public void setPurgeOnNoConsumers(Boolean purgeOnNoConsumers) {
+   public QueueAttributes setPurgeOnNoConsumers(Boolean purgeOnNoConsumers) {
       this.purgeOnNoConsumers = purgeOnNoConsumers;
+      return this;
    }
+
+   public Integer getConsumersBeforeDispatch() {
+      return consumersBeforeDispatch;
+   }
+
+   public QueueAttributes setConsumersBeforeDispatch(Integer consumersBeforeDispatch) {
+      this.consumersBeforeDispatch = consumersBeforeDispatch;
+      return this;
+   }
+
+   public Long getDelayBeforeDispatch() {
+      return delayBeforeDispatch;
+   }
+
+   public QueueAttributes setDelayBeforeDispatch(Long delayBeforeDispatch) {
+      this.delayBeforeDispatch = delayBeforeDispatch;
+      return this;
+   }
+
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
@@ -471,6 +471,10 @@ public final class ActiveMQDefaultConfiguration {
 
    public static final boolean DEFAULT_LAST_VALUE = false;
 
+   public static final SimpleString DEFAULT_LAST_VALUE_KEY = null;
+
+   public static final boolean DEFAULT_NON_DESTRUCTIVE = false;
+
    public static final boolean DEFAULT_PURGE_ON_NO_CONSUMERS = false;
 
    public static final int DEFAULT_CONSUMERS_BEFORE_DISPATCH = 0;
@@ -1301,7 +1305,15 @@ public final class ActiveMQDefaultConfiguration {
    }
 
    public static boolean getDefaultLastValue() {
-      return DEFAULT_EXCLUSIVE;
+      return DEFAULT_LAST_VALUE;
+   }
+
+   public static SimpleString getDefaultLastValueKey() {
+      return DEFAULT_LAST_VALUE_KEY;
+   }
+
+   public static boolean getDefaultNonDestructive() {
+      return DEFAULT_NON_DESTRUCTIVE;
    }
 
    public static boolean getDefaultPurgeOnNoConsumers() {

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/client/ClientSession.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/client/ClientSession.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.QueueAttributes;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.RoutingType;
 
@@ -79,6 +80,14 @@ public interface ClientSession extends XAResource, AutoCloseable {
       Boolean isDefaultLastValueQueue();
 
       Boolean isDefaultExclusive();
+
+      SimpleString getDefaultLastValueKey();
+
+      Boolean isDefaultNonDestructive();
+
+      Integer getDefaultConsumersBeforeDispatch();
+
+      Long getDefaultDelayBeforeDispatch();
    }
 
    /**
@@ -147,6 +156,14 @@ public interface ClientSession extends XAResource, AutoCloseable {
       Boolean isExclusive();
 
       Boolean isLastValue();
+
+      SimpleString getLastValueKey();
+
+      Boolean isNonDestructive();
+
+      Integer getConsumersBeforeDispatch();
+
+      Long getDelayBeforeDispatch();
 
       Integer getDefaultConsumerWindowSize();
    }
@@ -482,6 +499,17 @@ public interface ClientSession extends XAResource, AutoCloseable {
                           boolean durable, Integer maxConsumers, Boolean purgeOnNoConsumers, Boolean exclusive, Boolean lastValue) throws ActiveMQException;
 
    /**
+    * Creates Shared queue. A queue that will exist as long as there are consumers or is durable.
+    *
+    * @param address   the queue will be bound to this address
+    * @param queueName the name of the queue
+    * @param queueAttributes attributes for the queue
+    * @throws ActiveMQException in an exception occurs while creating the queue
+    */
+   void createSharedQueue(SimpleString address, SimpleString queueName, QueueAttributes queueAttributes) throws ActiveMQException;
+
+
+   /**
     * Creates a <em>non-temporary</em> queue.
     *
     * @param address   the queue will be bound to this address
@@ -586,6 +614,17 @@ public interface ClientSession extends XAResource, AutoCloseable {
                     boolean durable, boolean autoCreated, int maxConsumers, boolean purgeOnNoConsumers, Boolean exclusive, Boolean lastValue) throws ActiveMQException;
 
    /**
+    * Creates a <em>non-temporary</em> queue.
+    *
+    * @param address      the queue will be bound to this address
+    * @param queueName    the name of the queue
+    * @param autoCreated  whether to mark this queue as autoCreated or not
+    * @param queueAttributes attributes for the queue
+    * @throws ActiveMQException
+    */
+   void createQueue(SimpleString address, SimpleString queueName, boolean autoCreated, QueueAttributes queueAttributes) throws ActiveMQException;
+
+   /**
     * Creates a <em>non-temporary</em>queue.
     *
     * @param address     the queue will be bound to this address
@@ -667,6 +706,16 @@ public interface ClientSession extends XAResource, AutoCloseable {
     */
    void createTemporaryQueue(SimpleString address, RoutingType routingType, SimpleString queueName, SimpleString filter, int maxConsumers,
                              boolean purgeOnNoConsumers, Boolean exclusive, Boolean lastValue) throws ActiveMQException;
+
+   /**
+    * Creates a <em>temporary</em> queue with a filter.
+    *
+    * @param address   the queue will be bound to this address
+    * @param queueName the name of the queue
+    * @param queueAttributes attributes for the queue
+    * @throws ActiveMQException in an exception occurs while creating the queue
+    */
+   void createTemporaryQueue(SimpleString address, SimpleString queueName, QueueAttributes queueAttributes) throws ActiveMQException;
 
    /**
     * Creates a <em>temporary</em> queue with a filter.

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
@@ -599,6 +599,8 @@ public interface ActiveMQServerControl {
                       @Parameter(name = "purgeOnNoConsumers", desc = "Delete this queue when the last consumer disconnects") boolean purgeOnNoConsumers,
                       @Parameter(name = "exclusive", desc = "If the queue should route exclusively to one consumer") boolean exclusive,
                       @Parameter(name = "lastValue", desc = "Use last-value semantics") boolean lastValue,
+                      @Parameter(name = "lastValueKey", desc = "Use the specified property key for the last value") String lastValueKey,
+                      @Parameter(name = "nonDestructive", desc = "If the queue is non-destructive") boolean nonDestructive,
                       @Parameter(name = "consumersBeforeDispatch", desc = "Number of consumers needed before dispatch can start") int consumersBeforeDispatch,
                       @Parameter(name = "delayBeforeDispatch", desc = "Delay to wait before dispatching if number of consumers before dispatch is not met") long delayBeforeDispatch,
                       @Parameter(name = "autoCreateAddress", desc = "Create an address with default values should a matching address not be found") boolean autoCreateAddress) throws Exception;
@@ -696,6 +698,7 @@ public interface ActiveMQServerControl {
     * @param maxConsumers       the maximum number of consumers allowed on this queue at any one time
     * @param purgeOnNoConsumers delete this queue when the last consumer disconnects
     * @param exclusive          if the queue should route exclusively to one consumer
+    * @param nonDestructive     If the queue is non-destructive
     * @param consumersBeforeDispatch number of consumers needed before dispatch can start
     * @param delayBeforeDispatch delay to wait before dispatching if number of consumers before dispatch is not met
     * @param user               the user associated with this queue
@@ -709,6 +712,7 @@ public interface ActiveMQServerControl {
                       @Parameter(name = "maxConsumers", desc = "The maximum number of consumers allowed on this queue at any one time") Integer maxConsumers,
                       @Parameter(name = "purgeOnNoConsumers", desc = "Delete this queue when the last consumer disconnects") Boolean purgeOnNoConsumers,
                       @Parameter(name = "exclusive", desc = "If the queue should route exclusively to one consumer") Boolean exclusive,
+                      @Parameter(name = "nonDestructive", desc = "If the queue is non-destructive") Boolean nonDestructive,
                       @Parameter(name = "consumersBeforeDispatch", desc = "Number of consumers needed before dispatch can start") Integer consumersBeforeDispatch,
                       @Parameter(name = "delayBeforeDispatch", desc = "Delay to wait before dispatching if number of consumers before dispatch is not met") Long delayBeforeDispatch,
                       @Parameter(name = "user", desc = "The user associated with this queue") String user) throws Exception;

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/AddressQueryImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/AddressQueryImpl.java
@@ -40,6 +40,14 @@ public class AddressQueryImpl implements ClientSession.AddressQuery {
 
    private final Boolean defaultLastValue;
 
+   private final SimpleString defaultLastValueKey;
+
+   private final Boolean defaultNonDestructive;
+
+   private final Integer defaultConsumersBeforeDispatch;
+
+   private final Long defaultDelayBeforeDispatch;
+
    public AddressQueryImpl(final boolean exists,
                            final List<SimpleString> queueNames,
                            final boolean autoCreateQueues,
@@ -47,7 +55,11 @@ public class AddressQueryImpl implements ClientSession.AddressQuery {
                            final boolean defaultPurgeOnNoConsumers,
                            final int defaultMaxConsumers,
                            final Boolean defaultExclusive,
-                           final Boolean defaultLastValue) {
+                           final Boolean defaultLastValue,
+                           final SimpleString defaultLastValueKey,
+                           final Boolean defaultNonDestructive,
+                           final Integer defaultConsumersBeforeDispatch,
+                           final Long defaultDelayBeforeDispatch) {
       this.exists = exists;
       this.queueNames = new ArrayList<>(queueNames);
       this.autoCreateQueues = autoCreateQueues;
@@ -56,6 +68,10 @@ public class AddressQueryImpl implements ClientSession.AddressQuery {
       this.defaultMaxConsumers = defaultMaxConsumers;
       this.defaultExclusive = defaultExclusive;
       this.defaultLastValue = defaultLastValue;
+      this.defaultLastValueKey = defaultLastValueKey;
+      this.defaultNonDestructive = defaultNonDestructive;
+      this.defaultConsumersBeforeDispatch = defaultConsumersBeforeDispatch;
+      this.defaultDelayBeforeDispatch = defaultDelayBeforeDispatch;
    }
 
    @Override
@@ -96,5 +112,25 @@ public class AddressQueryImpl implements ClientSession.AddressQuery {
    @Override
    public Boolean isDefaultExclusive() {
       return defaultExclusive;
+   }
+
+   @Override
+   public SimpleString getDefaultLastValueKey() {
+      return defaultLastValueKey;
+   }
+
+   @Override
+   public Boolean isDefaultNonDestructive() {
+      return defaultNonDestructive;
+   }
+
+   @Override
+   public Integer getDefaultConsumersBeforeDispatch() {
+      return defaultConsumersBeforeDispatch;
+   }
+
+   @Override
+   public Long getDefaultDelayBeforeDispatch() {
+      return defaultDelayBeforeDispatch;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionImpl.java
@@ -34,6 +34,8 @@ import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
 import org.apache.activemq.artemis.api.core.Message;
+import org.apache.activemq.artemis.api.core.QueueAttributes;
+import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
@@ -46,7 +48,6 @@ import org.apache.activemq.artemis.core.client.ActiveMQClientLogger;
 import org.apache.activemq.artemis.core.client.ActiveMQClientMessageBundle;
 import org.apache.activemq.artemis.core.message.impl.CoreMessageObjectPools;
 import org.apache.activemq.artemis.core.remoting.FailureListener;
-import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
 import org.apache.activemq.artemis.spi.core.remoting.ConsumerContext;
 import org.apache.activemq.artemis.spi.core.remoting.ReadyListener;
@@ -336,7 +337,7 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
 
    @Override
    public void createTemporaryQueue(final SimpleString address, final SimpleString queueName) throws ActiveMQException {
-      createTemporaryQueue(address, queueName, null);
+      createTemporaryQueue(address, queueName, (SimpleString) null);
    }
 
    @Override
@@ -370,13 +371,15 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
                            final boolean durable,
                            final boolean autoCreated) throws ActiveMQException {
       internalCreateQueue(address,
-                          queueName, routingType,
-                          filterString,
-                          durable,
+                          queueName,
                           false,
-                          ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers(),
-                          ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers(),
-                          autoCreated, null, null);
+                          autoCreated,
+                          new QueueAttributes()
+                              .setRoutingType(routingType)
+                              .setFilterString(filterString)
+                              .setDurable(durable)
+                              .setPurgeOnNoConsumers(ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers())
+                              .setMaxConsumers(ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers()));
    }
 
    @Override
@@ -394,28 +397,41 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
    public void createQueue(final SimpleString address, final RoutingType routingType, final SimpleString queueName, final SimpleString filterString,
                            final boolean durable, final boolean autoCreated, final int maxConsumers, final boolean purgeOnNoConsumers) throws ActiveMQException {
       internalCreateQueue(address,
-                          queueName, routingType,
-                          filterString,
-                          durable,
+                          queueName,
                           false,
-                          maxConsumers,
-                          purgeOnNoConsumers,
-                          autoCreated, null, null);
+                          autoCreated,
+                          new QueueAttributes()
+                                  .setRoutingType(routingType)
+                                  .setFilterString(filterString)
+                                  .setDurable(durable)
+                                  .setMaxConsumers(maxConsumers)
+                                  .setPurgeOnNoConsumers(purgeOnNoConsumers));
    }
 
    @Override
    public void createQueue(final SimpleString address, final RoutingType routingType, final SimpleString queueName, final SimpleString filterString,
                            final boolean durable, final boolean autoCreated, final int maxConsumers, final boolean purgeOnNoConsumers, final Boolean exclusive, final Boolean lastValue) throws ActiveMQException {
       internalCreateQueue(address,
-                          queueName, routingType,
-                          filterString,
-                          durable,
+                          queueName,
                           false,
-                          maxConsumers,
-                          purgeOnNoConsumers,
                           autoCreated,
-                          exclusive,
-                          lastValue);
+                          new QueueAttributes()
+                                  .setRoutingType(routingType)
+                                  .setFilterString(filterString)
+                                  .setDurable(durable)
+                                  .setMaxConsumers(maxConsumers)
+                                  .setPurgeOnNoConsumers(purgeOnNoConsumers)
+                                  .setExclusive(exclusive)
+                                  .setLastValue(lastValue));
+   }
+
+   @Override
+   public void createQueue(final SimpleString address, final SimpleString queueName, final boolean autoCreated, final QueueAttributes queueAttributes) throws ActiveMQException {
+      internalCreateQueue(address,
+              queueName,
+              false,
+              autoCreated,
+              queueAttributes);
    }
 
    @Override
@@ -470,13 +486,28 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
                                     final Boolean exclusive,
                                     final Boolean lastValue) throws ActiveMQException {
       internalCreateQueue(address,
-                          queueName, routingType,
-                          filter,
-                          false,
+                          queueName,
                           true,
-                          maxConsumers,
-                          purgeOnNoConsumers,
-                          false, exclusive, lastValue);
+                          false,
+                          new QueueAttributes()
+                                  .setRoutingType(routingType)
+                                  .setFilterString(filter)
+                                  .setDurable(false)
+                                  .setPurgeOnNoConsumers(purgeOnNoConsumers)
+                                  .setMaxConsumers(maxConsumers)
+                                  .setExclusive(exclusive)
+                                  .setLastValue(lastValue));
+   }
+
+   @Override
+   public void createTemporaryQueue(final SimpleString address,
+                                    final SimpleString queueName,
+                                    final QueueAttributes queueAttributes) throws ActiveMQException {
+      internalCreateQueue(address,
+              queueName,
+              true,
+              false,
+              queueAttributes);
    }
 
    @Override
@@ -504,13 +535,15 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
    @Override
    public void createQueue(SimpleString address, RoutingType routingType, SimpleString queueName, boolean durable) throws ActiveMQException {
       internalCreateQueue(address,
-                          queueName, routingType,
-                          null,
-                          durable,
+                          queueName,
                           false,
-                          ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers(),
-                          ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers(),
-                          false, null, null);
+                          false,
+                          new QueueAttributes()
+                                  .setRoutingType(routingType)
+                                  .setFilterString(null)
+                                  .setDurable(durable)
+                                  .setPurgeOnNoConsumers(ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers())
+                                  .setMaxConsumers(ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers()));
    }
 
    /**
@@ -564,11 +597,32 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
    @Override
    public void createSharedQueue(SimpleString address, RoutingType routingType, SimpleString queueName, SimpleString filter,
                                  boolean durable, Integer maxConsumers, Boolean purgeOnNoConsumers, Boolean exclusive, Boolean lastValue) throws ActiveMQException {
+      QueueAttributes queueAttributes = new QueueAttributes()
+              .setRoutingType(routingType)
+              .setFilterString(filter)
+              .setDurable(durable)
+              .setPurgeOnNoConsumers(ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers())
+              .setMaxConsumers(ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers())
+              .setExclusive(exclusive)
+              .setLastValue(lastValue);
+      createSharedQueue(address, queueName, queueAttributes);
+   }
+
+   /**
+    * Creates Shared queue. A queue that will exist as long as there are consumers or is durable.
+    *
+    * @param address      the queue will be bound to this address
+    * @param queueName    the name of the queue
+    * @param queueAttributes attributes for the queue
+    * @throws ActiveMQException in an exception occurs while creating the queue
+    */
+   @Override
+   public void createSharedQueue(SimpleString address, SimpleString queueName, QueueAttributes queueAttributes) throws ActiveMQException {
       checkClosed();
 
       startCall();
       try {
-         sessionContext.createSharedQueue(address, queueName, routingType, filter, durable, maxConsumers, purgeOnNoConsumers, exclusive, lastValue);
+         sessionContext.createSharedQueue(address, queueName, queueAttributes);
       } finally {
          endCall();
       }
@@ -599,13 +653,15 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
    @Override
    public void createQueue(String address, RoutingType routingType, String queueName) throws ActiveMQException {
       internalCreateQueue(SimpleString.toSimpleString(address),
-                          SimpleString.toSimpleString(queueName), routingType,
-                          null,
+                          SimpleString.toSimpleString(queueName),
                           false,
                           false,
-                          ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers(),
-                          ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers(),
-                          false, null, null);
+                          new QueueAttributes()
+                                  .setRoutingType(routingType)
+                                  .setFilterString(null)
+                                  .setDurable(false)
+                                  .setPurgeOnNoConsumers(ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers())
+                                  .setMaxConsumers(ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers()));
    }
 
    /**
@@ -620,13 +676,14 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
    public void createQueue(SimpleString address, RoutingType routingType, SimpleString queueName) throws ActiveMQException {
       internalCreateQueue(address,
                           queueName,
-                          routingType,
-                          null,
                           false,
                           false,
-                          ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers(),
-                          ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers(),
-                          false, null, null);
+                          new QueueAttributes()
+                                  .setRoutingType(routingType)
+                                  .setFilterString(null)
+                                  .setDurable(false)
+                                  .setPurgeOnNoConsumers(ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers())
+                                  .setMaxConsumers(ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers()));
    }
 
    /**
@@ -644,13 +701,14 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
                            boolean durable) throws ActiveMQException {
       internalCreateQueue(address,
                           queueName,
-                          routingType,
-                          filter,
-                          durable,
                           false,
-                          ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers(),
-                          ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers(),
-                          false, null, null);
+                          false,
+                          new QueueAttributes()
+                                  .setRoutingType(routingType)
+                                  .setFilterString(filter)
+                                  .setDurable(durable)
+                                  .setPurgeOnNoConsumers(ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers())
+                                  .setMaxConsumers(ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers()));
    }
 
    /**
@@ -1907,34 +1965,22 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
 
    private void internalCreateQueue(final SimpleString address,
                                     final SimpleString queueName,
-                                    final RoutingType routingType,
-                                    final SimpleString filterString,
-                                    final boolean durable,
                                     final boolean temp,
-                                    final int maxConsumers,
-                                    final boolean purgeOnNoConsumers,
                                     final boolean autoCreated,
-                                    final Boolean exclusive,
-                                    final Boolean lastValue) throws ActiveMQException {
+                                    final QueueAttributes queueAttributes) throws ActiveMQException {
       checkClosed();
 
-      if (durable && temp) {
+      if (queueAttributes.getDurable() && temp) {
          throw ActiveMQClientMessageBundle.BUNDLE.queueMisConfigured();
       }
 
       startCall();
       try {
          sessionContext.createQueue(address,
-                                    routingType,
                                     queueName,
-                                    filterString,
-                                    durable,
                                     temp,
-                                    maxConsumers,
-                                    purgeOnNoConsumers,
                                     autoCreated,
-                                    exclusive,
-                                    lastValue);
+                                    queueAttributes);
       } finally {
          endCall();
       }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/QueueQueryImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/QueueQueryImpl.java
@@ -52,6 +52,15 @@ public class QueueQueryImpl implements ClientSession.QueueQuery {
 
    private final Boolean lastValue;
 
+   private final SimpleString lastValueKey;
+
+   private final Boolean nonDestructive;
+
+   private final Integer consumersBeforeDispatch;
+
+   private final Long delayBeforeDispatch;
+
+
    private final Integer defaultConsumerWindowSize;
 
    public QueueQueryImpl(final boolean durable,
@@ -92,6 +101,7 @@ public class QueueQueryImpl implements ClientSession.QueueQuery {
                          final RoutingType routingType) {
       this(durable, temporary, consumerCount, messageCount, filterString, address, name, exists, autoCreateQueues, maxConsumers, autoCreated, purgeOnNoConsumers, routingType, null, null, null);
    }
+
    public QueueQueryImpl(final boolean durable,
                          final boolean temporary,
                          final int consumerCount,
@@ -108,6 +118,29 @@ public class QueueQueryImpl implements ClientSession.QueueQuery {
                          final Boolean exclusive,
                          final Boolean lastValue,
                          final Integer defaultConsumerWindowSize) {
+      this(durable, temporary, consumerCount, messageCount, filterString, address, name, exists, autoCreateQueues, maxConsumers, autoCreated, purgeOnNoConsumers, routingType, exclusive, lastValue, null, null, null, null, defaultConsumerWindowSize);
+   }
+
+   public QueueQueryImpl(final boolean durable,
+                         final boolean temporary,
+                         final int consumerCount,
+                         final long messageCount,
+                         final SimpleString filterString,
+                         final SimpleString address,
+                         final SimpleString name,
+                         final boolean exists,
+                         final boolean autoCreateQueues,
+                         final int maxConsumers,
+                         final boolean autoCreated,
+                         final boolean purgeOnNoConsumers,
+                         final RoutingType routingType,
+                         final Boolean exclusive,
+                         final Boolean lastValue,
+                         final SimpleString lastValueKey,
+                         final Boolean nonDestructive,
+                         final Integer consumersBeforeDispatch,
+                         final Long delayBeforeDispatch,
+                         final Integer defaultConsumerWindowSize) {
       this.durable = durable;
       this.temporary = temporary;
       this.consumerCount = consumerCount;
@@ -123,6 +156,10 @@ public class QueueQueryImpl implements ClientSession.QueueQuery {
       this.routingType = routingType;
       this.exclusive = exclusive;
       this.lastValue = lastValue;
+      this.lastValueKey = lastValueKey;
+      this.nonDestructive = nonDestructive;
+      this.consumersBeforeDispatch = consumersBeforeDispatch;
+      this.delayBeforeDispatch = delayBeforeDispatch;
       this.defaultConsumerWindowSize = defaultConsumerWindowSize;
    }
 
@@ -199,6 +236,26 @@ public class QueueQueryImpl implements ClientSession.QueueQuery {
    @Override
    public Boolean isLastValue() {
       return lastValue;
+   }
+
+   @Override
+   public SimpleString getLastValueKey() {
+      return lastValueKey;
+   }
+
+   @Override
+   public Boolean isNonDestructive() {
+      return nonDestructive;
+   }
+
+   @Override
+   public Integer getConsumersBeforeDispatch() {
+      return consumersBeforeDispatch;
+   }
+
+   @Override
+   public Long getDelayBeforeDispatch() {
+      return delayBeforeDispatch;
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/CreateQueueMessage_V2.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/CreateQueueMessage_V2.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.api.core.QueueAttributes;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.utils.BufferHelper;
@@ -35,6 +36,40 @@ public class CreateQueueMessage_V2 extends CreateQueueMessage {
 
    private Boolean lastValue;
 
+   private SimpleString lastValueKey;
+
+   private Boolean nonDestructive;
+
+   private Integer consumersBeforeDispatch;
+
+   private Long delayBeforeDispatch;
+
+   public CreateQueueMessage_V2(final SimpleString address,
+                                final SimpleString queueName,
+                                final boolean temporary,
+                                final boolean autoCreated,
+                                final boolean requiresResponse,
+                                final QueueAttributes queueAttributes) {
+      this(
+         address,
+         queueName,
+         queueAttributes.getRoutingType(),
+         queueAttributes.getFilterString(),
+         queueAttributes.getDurable(),
+         temporary,
+         queueAttributes.getMaxConsumers(),
+         queueAttributes.getPurgeOnNoConsumers(),
+         autoCreated,
+         requiresResponse,
+         queueAttributes.getExclusive(),
+         queueAttributes.getLastValue(),
+         queueAttributes.getLastValueKey(),
+         queueAttributes.getNonDestructive(),
+         queueAttributes.getConsumersBeforeDispatch(),
+         queueAttributes.getDelayBeforeDispatch()
+      );
+   }
+
    public CreateQueueMessage_V2(final SimpleString address,
                                 final SimpleString queueName,
                                 final RoutingType routingType,
@@ -46,7 +81,11 @@ public class CreateQueueMessage_V2 extends CreateQueueMessage {
                                 final boolean autoCreated,
                                 final boolean requiresResponse,
                                 final Boolean exclusive,
-                                final Boolean lastValue) {
+                                final Boolean lastValue,
+                                final SimpleString lastValueKey,
+                                final Boolean nonDestructive,
+                                final Integer consumersBeforeDispatch,
+                                final Long delayBeforeDispatch) {
       this();
 
       this.address = address;
@@ -61,6 +100,10 @@ public class CreateQueueMessage_V2 extends CreateQueueMessage {
       this.purgeOnNoConsumers = purgeOnNoConsumers;
       this.exclusive = exclusive;
       this.lastValue = lastValue;
+      this.lastValueKey = lastValueKey;
+      this.nonDestructive = nonDestructive;
+      this.consumersBeforeDispatch = consumersBeforeDispatch;
+      this.delayBeforeDispatch = delayBeforeDispatch;
    }
 
    public CreateQueueMessage_V2() {
@@ -78,6 +121,10 @@ public class CreateQueueMessage_V2 extends CreateQueueMessage {
       buff.append(", purgeOnNoConsumers=" + purgeOnNoConsumers);
       buff.append(", exclusive=" + exclusive);
       buff.append(", lastValue=" + lastValue);
+      buff.append(", lastValueKey=" + lastValue);
+      buff.append(", nonDestructive=" + nonDestructive);
+      buff.append(", consumersBeforeDispatch=" + consumersBeforeDispatch);
+      buff.append(", delayBeforeDispatch=" + delayBeforeDispatch);
       buff.append("]");
       return buff.toString();
    }
@@ -130,6 +177,38 @@ public class CreateQueueMessage_V2 extends CreateQueueMessage {
       this.lastValue = lastValue;
    }
 
+   public SimpleString getLastValueKey() {
+      return lastValueKey;
+   }
+
+   public void setLastValueKey(SimpleString lastValueKey) {
+      this.lastValueKey = lastValueKey;
+   }
+
+   public Boolean isNonDestructive() {
+      return nonDestructive;
+   }
+
+   public void setNonDestructive(Boolean nonDestructive) {
+      this.nonDestructive = nonDestructive;
+   }
+
+   public Integer getConsumersBeforeDispatch() {
+      return consumersBeforeDispatch;
+   }
+
+   public void setConsumersBeforeDispatch(Integer consumersBeforeDispatch) {
+      this.consumersBeforeDispatch = consumersBeforeDispatch;
+   }
+
+   public Long getDelayBeforeDispatch() {
+      return delayBeforeDispatch;
+   }
+
+   public void setDelayBeforeDispatch(Long delayBeforeDispatch) {
+      this.delayBeforeDispatch = delayBeforeDispatch;
+   }
+
    @Override
    public void encodeRest(final ActiveMQBuffer buffer) {
       super.encodeRest(buffer);
@@ -139,6 +218,10 @@ public class CreateQueueMessage_V2 extends CreateQueueMessage {
       buffer.writeBoolean(purgeOnNoConsumers);
       BufferHelper.writeNullableBoolean(buffer, exclusive);
       BufferHelper.writeNullableBoolean(buffer, lastValue);
+      buffer.writeNullableSimpleString(lastValueKey);
+      BufferHelper.writeNullableBoolean(buffer, nonDestructive);
+      BufferHelper.writeNullableInteger(buffer, consumersBeforeDispatch);
+      BufferHelper.writeNullableLong(buffer, delayBeforeDispatch);
    }
 
    @Override
@@ -152,6 +235,12 @@ public class CreateQueueMessage_V2 extends CreateQueueMessage {
          exclusive = BufferHelper.readNullableBoolean(buffer);
          lastValue = BufferHelper.readNullableBoolean(buffer);
       }
+      if (buffer.readableBytes() > 0) {
+         lastValueKey = buffer.readNullableSimpleString();
+         nonDestructive = BufferHelper.readNullableBoolean(buffer);
+         consumersBeforeDispatch = BufferHelper.readNullableInteger(buffer);
+         delayBeforeDispatch = BufferHelper.readNullableLong(buffer);
+      }
    }
 
    @Override
@@ -164,6 +253,10 @@ public class CreateQueueMessage_V2 extends CreateQueueMessage {
       result = prime * result + (purgeOnNoConsumers ? 1231 : 1237);
       result = prime * result + (exclusive == null ? 0 : exclusive ? 1231 : 1237);
       result = prime * result + (lastValue == null ? 0 : lastValue ? 1231 : 1237);
+      result = prime * result + (lastValueKey == null ? 0 : lastValueKey.hashCode());
+      result = prime * result + (nonDestructive == null ? 0 : nonDestructive ? 1231 : 1237);
+      result = prime * result + (consumersBeforeDispatch == null ? 0 : consumersBeforeDispatch.hashCode());
+      result = prime * result + (delayBeforeDispatch == null ? 0 : delayBeforeDispatch.hashCode());
       return result;
    }
 
@@ -191,6 +284,26 @@ public class CreateQueueMessage_V2 extends CreateQueueMessage {
          if (other.lastValue != null)
             return false;
       } else if (!lastValue.equals(other.lastValue))
+         return false;
+      if (lastValueKey == null) {
+         if (other.lastValueKey != null)
+            return false;
+      } else if (!lastValueKey.equals(other.lastValueKey))
+         return false;
+      if (nonDestructive == null) {
+         if (other.nonDestructive != null)
+            return false;
+      } else if (!nonDestructive.equals(other.nonDestructive))
+         return false;
+      if (consumersBeforeDispatch == null) {
+         if (other.consumersBeforeDispatch != null)
+            return false;
+      } else if (!consumersBeforeDispatch.equals(other.consumersBeforeDispatch))
+         return false;
+      if (delayBeforeDispatch == null) {
+         if (other.delayBeforeDispatch != null)
+            return false;
+      } else if (!delayBeforeDispatch.equals(other.delayBeforeDispatch))
          return false;
       if (routingType == null) {
          if (other.routingType != null)

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/CreateSharedQueueMessage_V2.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/CreateSharedQueueMessage_V2.java
@@ -28,6 +28,10 @@ public class CreateSharedQueueMessage_V2 extends CreateSharedQueueMessage {
    Boolean purgeOnNoConsumers;
    private Boolean exclusive;
    private Boolean lastValue;
+   private SimpleString lastValueKey;
+   private Boolean nonDestructive;
+   private Integer consumersBeforeDispatch;
+   private Long delayBeforeDispatch;
 
    public CreateSharedQueueMessage_V2(final SimpleString address,
                                       final SimpleString queueName,
@@ -38,6 +42,10 @@ public class CreateSharedQueueMessage_V2 extends CreateSharedQueueMessage {
                                       final Boolean purgeOnNoConsumers,
                                       final Boolean exclusive,
                                       final Boolean lastValue,
+                                      final SimpleString lastValueKey,
+                                      final Boolean nonDestructive,
+                                      final Integer consumersBeforeDispatch,
+                                      final Long delayBeforeDispatch,
                                       final boolean requiresResponse) {
       this();
 
@@ -50,8 +58,11 @@ public class CreateSharedQueueMessage_V2 extends CreateSharedQueueMessage {
       this.purgeOnNoConsumers = purgeOnNoConsumers;
       this.exclusive = exclusive;
       this.lastValue = lastValue;
+      this.lastValueKey = lastValueKey;
+      this.nonDestructive = nonDestructive;
+      this.consumersBeforeDispatch = consumersBeforeDispatch;
+      this.delayBeforeDispatch = delayBeforeDispatch;
       this.requiresResponse = requiresResponse;
-
    }
 
    public CreateSharedQueueMessage_V2() {
@@ -98,6 +109,38 @@ public class CreateSharedQueueMessage_V2 extends CreateSharedQueueMessage {
       this.lastValue = lastValue;
    }
 
+   public SimpleString getLastValueKey() {
+      return lastValueKey;
+   }
+
+   public void setLastValueKey(SimpleString lastValueKey) {
+      this.lastValueKey = lastValueKey;
+   }
+
+   public Boolean isNonDestructive() {
+      return nonDestructive;
+   }
+
+   public void setNonDestructive(Boolean nonDestructive) {
+      this.nonDestructive = nonDestructive;
+   }
+
+   public Integer getConsumersBeforeDispatch() {
+      return consumersBeforeDispatch;
+   }
+
+   public void setConsumersBeforeDispatch(Integer consumersBeforeDispatch) {
+      this.consumersBeforeDispatch = consumersBeforeDispatch;
+   }
+
+   public Long getDelayBeforeDispatch() {
+      return delayBeforeDispatch;
+   }
+
+   public void setDelayBeforeDispatch(Long delayBeforeDispatch) {
+      this.delayBeforeDispatch = delayBeforeDispatch;
+   }
+
    @Override
    public String toString() {
       StringBuffer buff = new StringBuffer(getParentString());
@@ -110,6 +153,10 @@ public class CreateSharedQueueMessage_V2 extends CreateSharedQueueMessage {
       buff.append(", purgeOnNoConsumers=" + purgeOnNoConsumers);
       buff.append(", exclusive=" + exclusive);
       buff.append(", lastValue=" + lastValue);
+      buff.append(", lastValueKey=" + lastValueKey);
+      buff.append(", nonDestructive=" + nonDestructive);
+      buff.append(", consumersBeforeDispatch=" + consumersBeforeDispatch);
+      buff.append(", delayBeforeDispatch=" + delayBeforeDispatch);
       buff.append(", requiresResponse=" + requiresResponse);
       buff.append("]");
       return buff.toString();
@@ -127,6 +174,10 @@ public class CreateSharedQueueMessage_V2 extends CreateSharedQueueMessage {
       BufferHelper.writeNullableBoolean(buffer, purgeOnNoConsumers);
       BufferHelper.writeNullableBoolean(buffer, exclusive);
       BufferHelper.writeNullableBoolean(buffer, lastValue);
+      buffer.writeNullableSimpleString(lastValueKey);
+      BufferHelper.writeNullableBoolean(buffer, nonDestructive);
+      BufferHelper.writeNullableInteger(buffer, consumersBeforeDispatch);
+      BufferHelper.writeNullableLong(buffer, delayBeforeDispatch);
    }
 
    @Override
@@ -142,6 +193,12 @@ public class CreateSharedQueueMessage_V2 extends CreateSharedQueueMessage {
          purgeOnNoConsumers = BufferHelper.readNullableBoolean(buffer);
          exclusive = BufferHelper.readNullableBoolean(buffer);
          lastValue = BufferHelper.readNullableBoolean(buffer);
+      }
+      if (buffer.readableBytes() > 0) {
+         lastValueKey = buffer.readNullableSimpleString();
+         nonDestructive = BufferHelper.readNullableBoolean(buffer);
+         consumersBeforeDispatch = BufferHelper.readNullableInteger(buffer);
+         delayBeforeDispatch = BufferHelper.readNullableLong(buffer);
       }
    }
 
@@ -159,6 +216,11 @@ public class CreateSharedQueueMessage_V2 extends CreateSharedQueueMessage {
       result = prime * result + (purgeOnNoConsumers == null ? 0 : purgeOnNoConsumers ? 1231 : 1237);
       result = prime * result + (exclusive == null ? 0 : exclusive ? 1231 : 1237);
       result = prime * result + (lastValue == null ? 0 : lastValue ? 1231 : 1237);
+      result = prime * result + (lastValueKey == null ? 0 : lastValueKey.hashCode());
+      result = prime * result + (nonDestructive == null ? 0 : nonDestructive ? 1231 : 1237);
+      result = prime * result + (consumersBeforeDispatch == null ? 0 : consumersBeforeDispatch.hashCode());
+      result = prime * result + (delayBeforeDispatch == null ? 0 : delayBeforeDispatch.hashCode());
+
       return result;
    }
 
@@ -211,6 +273,26 @@ public class CreateSharedQueueMessage_V2 extends CreateSharedQueueMessage {
          if (other.lastValue != null)
             return false;
       } else if (!lastValue.equals(other.lastValue))
+         return false;
+      if (lastValueKey == null) {
+         if (other.lastValueKey != null)
+            return false;
+      } else if (!lastValueKey.equals(other.lastValueKey))
+         return false;
+      if (nonDestructive == null) {
+         if (other.nonDestructive != null)
+            return false;
+      } else if (!nonDestructive.equals(other.nonDestructive))
+         return false;
+      if (consumersBeforeDispatch == null) {
+         if (other.consumersBeforeDispatch != null)
+            return false;
+      } else if (!consumersBeforeDispatch.equals(other.consumersBeforeDispatch))
+         return false;
+      if (delayBeforeDispatch == null) {
+         if (other.delayBeforeDispatch != null)
+            return false;
+      } else if (!delayBeforeDispatch.equals(other.delayBeforeDispatch))
          return false;
       return true;
    }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionBindingQueryResponseMessage_V4.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionBindingQueryResponseMessage_V4.java
@@ -32,6 +32,14 @@ public class SessionBindingQueryResponseMessage_V4 extends SessionBindingQueryRe
 
    private Boolean defaultLastValue;
 
+   private SimpleString defaultLastValueKey;
+
+   private Boolean defaultNonDestructive;
+
+   private Integer defaultConsumersBeforeDispatch;
+
+   private Long defaultDelayBeforeDispatch;
+
    public SessionBindingQueryResponseMessage_V4(final boolean exists,
                                                 final List<SimpleString> queueNames,
                                                 final boolean autoCreateQueues,
@@ -39,7 +47,11 @@ public class SessionBindingQueryResponseMessage_V4 extends SessionBindingQueryRe
                                                 final boolean defaultPurgeOnNoConsumers,
                                                 final int defaultMaxConsumers,
                                                 final Boolean defaultExclusive,
-                                                final Boolean defaultLastValue) {
+                                                final Boolean defaultLastValue,
+                                                final SimpleString defaultLastValueKey,
+                                                final Boolean defaultNonDestructive,
+                                                final Integer defaultConsumersBeforeDispatch,
+                                                final Long defaultDelayBeforeDispatch) {
       super(SESS_BINDINGQUERY_RESP_V4);
 
       this.exists = exists;
@@ -57,6 +69,14 @@ public class SessionBindingQueryResponseMessage_V4 extends SessionBindingQueryRe
       this.defaultExclusive = defaultExclusive;
 
       this.defaultLastValue = defaultLastValue;
+
+      this.defaultLastValueKey = defaultLastValueKey;
+
+      this.defaultNonDestructive = defaultNonDestructive;
+
+      this.defaultConsumersBeforeDispatch = defaultConsumersBeforeDispatch;
+
+      this.defaultDelayBeforeDispatch = defaultDelayBeforeDispatch;
    }
 
    public SessionBindingQueryResponseMessage_V4() {
@@ -79,6 +99,22 @@ public class SessionBindingQueryResponseMessage_V4 extends SessionBindingQueryRe
       return defaultLastValue;
    }
 
+   public SimpleString getDefaultLastValueKey() {
+      return defaultLastValueKey;
+   }
+
+   public Boolean isDefaultNonDestructive() {
+      return defaultNonDestructive;
+   }
+
+   public Integer getDefaultConsumersBeforeDispatch() {
+      return defaultConsumersBeforeDispatch;
+   }
+
+   public Long getDefaultDelayBeforeDispatch() {
+      return defaultDelayBeforeDispatch;
+   }
+
    @Override
    public void encodeRest(final ActiveMQBuffer buffer) {
       super.encodeRest(buffer);
@@ -86,6 +122,10 @@ public class SessionBindingQueryResponseMessage_V4 extends SessionBindingQueryRe
       buffer.writeInt(defaultMaxConsumers);
       BufferHelper.writeNullableBoolean(buffer, defaultExclusive);
       BufferHelper.writeNullableBoolean(buffer, defaultLastValue);
+      buffer.writeNullableSimpleString(defaultLastValueKey);
+      BufferHelper.writeNullableBoolean(buffer, defaultNonDestructive);
+      BufferHelper.writeNullableInteger(buffer, defaultConsumersBeforeDispatch);
+      BufferHelper.writeNullableLong(buffer, defaultDelayBeforeDispatch);
    }
 
    @Override
@@ -97,6 +137,12 @@ public class SessionBindingQueryResponseMessage_V4 extends SessionBindingQueryRe
          defaultExclusive = BufferHelper.readNullableBoolean(buffer);
          defaultLastValue = BufferHelper.readNullableBoolean(buffer);
       }
+      if (buffer.readableBytes() > 0) {
+         defaultLastValueKey = buffer.readNullableSimpleString();
+         defaultNonDestructive = BufferHelper.readNullableBoolean(buffer);
+         defaultConsumersBeforeDispatch = BufferHelper.readNullableInteger(buffer);
+         defaultDelayBeforeDispatch = BufferHelper.readNullableLong(buffer);
+      }
    }
 
    @Override
@@ -107,6 +153,10 @@ public class SessionBindingQueryResponseMessage_V4 extends SessionBindingQueryRe
       result = prime * result + defaultMaxConsumers;
       result = prime * result + (defaultExclusive == null ? 0 : defaultExclusive ? 1231 : 1237);
       result = prime * result + (defaultLastValue == null ? 0 : defaultLastValue ? 1231 : 1237);
+      result = prime * result + (defaultLastValueKey == null ? 0 : defaultLastValueKey.hashCode());
+      result = prime * result + (defaultNonDestructive == null ? 0 : defaultNonDestructive ? 1231 : 1237);
+      result = prime * result + (defaultConsumersBeforeDispatch == null ? 0 : defaultConsumersBeforeDispatch.hashCode());
+      result = prime * result + (defaultDelayBeforeDispatch == null ? 0 : defaultDelayBeforeDispatch.hashCode());
       return result;
    }
 
@@ -124,6 +174,10 @@ public class SessionBindingQueryResponseMessage_V4 extends SessionBindingQueryRe
       buff.append(", defaultMaxConsumers=" + defaultMaxConsumers);
       buff.append(", defaultExclusive=" + defaultExclusive);
       buff.append(", defaultLastValue=" + defaultLastValue);
+      buff.append(", defaultLastValueKey=" + defaultLastValueKey);
+      buff.append(", defaultNonDestructive=" + defaultNonDestructive);
+      buff.append(", defaultConsumersBeforeDispatch=" + defaultConsumersBeforeDispatch);
+      buff.append(", defaultDelayBeforeDispatch=" + defaultDelayBeforeDispatch);
       return buff.toString();
    }
 
@@ -149,6 +203,26 @@ public class SessionBindingQueryResponseMessage_V4 extends SessionBindingQueryRe
          if (other.defaultLastValue != null)
             return false;
       } else if (!defaultLastValue.equals(other.defaultLastValue))
+         return false;
+      if (defaultLastValueKey == null) {
+         if (other.defaultLastValueKey != null)
+            return false;
+      } else if (!defaultLastValueKey.equals(other.defaultLastValueKey))
+         return false;
+      if (defaultNonDestructive == null) {
+         if (other.defaultNonDestructive != null)
+            return false;
+      } else if (!defaultNonDestructive.equals(other.defaultNonDestructive))
+         return false;
+      if (defaultConsumersBeforeDispatch == null) {
+         if (other.defaultConsumersBeforeDispatch != null)
+            return false;
+      } else if (!defaultConsumersBeforeDispatch.equals(other.defaultConsumersBeforeDispatch))
+         return false;
+      if (defaultDelayBeforeDispatch == null) {
+         if (other.defaultDelayBeforeDispatch != null)
+            return false;
+      } else if (!defaultDelayBeforeDispatch.equals(other.defaultDelayBeforeDispatch))
          return false;
       return true;
    }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionQueueQueryResponseMessage_V3.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionQueueQueryResponseMessage_V3.java
@@ -38,14 +38,22 @@ public class SessionQueueQueryResponseMessage_V3 extends SessionQueueQueryRespon
 
    protected Boolean lastValue;
 
+   protected SimpleString lastValueKey;
+
+   protected Boolean nonDestructive;
+
+   private Integer consumersBeforeDispatch;
+
+   private Long delayBeforeDispatch;
+
    protected Integer defaultConsumerWindowSize;
 
    public SessionQueueQueryResponseMessage_V3(final QueueQueryResult result) {
-      this(result.getName(), result.getAddress(), result.isDurable(), result.isTemporary(), result.getFilterString(), result.getConsumerCount(), result.getMessageCount(), result.isExists(), result.isAutoCreateQueues(), result.isAutoCreated(), result.isPurgeOnNoConsumers(), result.getRoutingType(), result.getMaxConsumers(), result.isExclusive(), result.isLastValue(), result.getDefaultConsumerWindowSize());
+      this(result.getName(), result.getAddress(), result.isDurable(), result.isTemporary(), result.getFilterString(), result.getConsumerCount(), result.getMessageCount(), result.isExists(), result.isAutoCreateQueues(), result.isAutoCreated(), result.isPurgeOnNoConsumers(), result.getRoutingType(), result.getMaxConsumers(), result.isExclusive(), result.isLastValue(), result.getLastValueKey(), result.isNonDestructive(), result.getConsumersBeforeDispatch(), result.getDelayBeforeDispatch(), result.getDefaultConsumerWindowSize());
    }
 
    public SessionQueueQueryResponseMessage_V3() {
-      this(null, null, false, false, null, 0, 0, false, false, false, false, RoutingType.MULTICAST, -1, null, null, null);
+      this(null, null, false, false, null, 0, 0, false, false, false, false, RoutingType.MULTICAST, -1, null, null, null, null, null, null, null);
    }
 
    private SessionQueueQueryResponseMessage_V3(final SimpleString name,
@@ -63,6 +71,10 @@ public class SessionQueueQueryResponseMessage_V3 extends SessionQueueQueryRespon
                                                final int maxConsumers,
                                                final Boolean exclusive,
                                                final Boolean lastValue,
+                                               final SimpleString lastValueKey,
+                                               final Boolean nonDestructive,
+                                               final Integer consumersBeforeDispatch,
+                                               final Long delayBeforeDispatch,
                                                final Integer defaultConsumerWindowSize) {
       super(SESS_QUEUEQUERY_RESP_V3);
 
@@ -95,6 +107,14 @@ public class SessionQueueQueryResponseMessage_V3 extends SessionQueueQueryRespon
       this.exclusive = exclusive;
 
       this.lastValue = lastValue;
+
+      this.lastValueKey = lastValueKey;
+
+      this.nonDestructive = nonDestructive;
+
+      this.consumersBeforeDispatch = consumersBeforeDispatch;
+
+      this.delayBeforeDispatch = delayBeforeDispatch;
 
       this.defaultConsumerWindowSize = defaultConsumerWindowSize;
    }
@@ -147,6 +167,38 @@ public class SessionQueueQueryResponseMessage_V3 extends SessionQueueQueryRespon
       this.lastValue = lastValue;
    }
 
+   public SimpleString getLastValueKey() {
+      return lastValueKey;
+   }
+
+   public void setLastValueKey(SimpleString lastValueKey) {
+      this.lastValueKey = lastValueKey;
+   }
+
+   public Boolean isNonDestructive() {
+      return nonDestructive;
+   }
+
+   public void setNonDestructive(Boolean nonDestructive) {
+      this.nonDestructive = nonDestructive;
+   }
+
+   public Integer getConsumersBeforeDispatch() {
+      return consumersBeforeDispatch;
+   }
+
+   public void setConsumersBeforeDispatch(Integer consumersBeforeDispatch) {
+      this.consumersBeforeDispatch = consumersBeforeDispatch;
+   }
+
+   public Long getDelayBeforeDispatch() {
+      return delayBeforeDispatch;
+   }
+
+   public void setDelayBeforeDispatch(Long delayBeforeDispatch) {
+      this.delayBeforeDispatch = delayBeforeDispatch;
+   }
+
    public Integer getDefaultConsumerWindowSize() {
       return defaultConsumerWindowSize;
    }
@@ -165,6 +217,10 @@ public class SessionQueueQueryResponseMessage_V3 extends SessionQueueQueryRespon
       BufferHelper.writeNullableBoolean(buffer, exclusive);
       BufferHelper.writeNullableBoolean(buffer, lastValue);
       BufferHelper.writeNullableInteger(buffer, defaultConsumerWindowSize);
+      buffer.writeNullableSimpleString(lastValueKey);
+      BufferHelper.writeNullableBoolean(buffer, nonDestructive);
+      BufferHelper.writeNullableInteger(buffer, consumersBeforeDispatch);
+      BufferHelper.writeNullableLong(buffer, delayBeforeDispatch);
    }
 
    @Override
@@ -181,6 +237,12 @@ public class SessionQueueQueryResponseMessage_V3 extends SessionQueueQueryRespon
       if (buffer.readableBytes() > 0) {
          defaultConsumerWindowSize = BufferHelper.readNullableInteger(buffer);
       }
+      if (buffer.readableBytes() > 0) {
+         lastValueKey = buffer.readNullableSimpleString();
+         nonDestructive = BufferHelper.readNullableBoolean(buffer);
+         consumersBeforeDispatch = BufferHelper.readNullableInteger(buffer);
+         delayBeforeDispatch = BufferHelper.readNullableLong(buffer);
+      }
    }
 
    @Override
@@ -193,6 +255,10 @@ public class SessionQueueQueryResponseMessage_V3 extends SessionQueueQueryRespon
       result = prime * result + maxConsumers;
       result = prime * result + (exclusive == null ? 0 : exclusive ? 1231 : 1237);
       result = prime * result + (lastValue == null ? 0 : lastValue ? 1231 : 1237);
+      result = prime * result + (lastValueKey == null ? 0 : lastValueKey.hashCode());
+      result = prime * result + (nonDestructive == null ? 0 : nonDestructive ? 1231 : 1237);
+      result = prime * result + (consumersBeforeDispatch == null ? 0 : consumersBeforeDispatch.hashCode());
+      result = prime * result + (delayBeforeDispatch == null ? 0 : delayBeforeDispatch.hashCode());
       result = prime * result + ((defaultConsumerWindowSize == null) ? 0 : defaultConsumerWindowSize.hashCode());
       return result;
    }
@@ -213,13 +279,17 @@ public class SessionQueueQueryResponseMessage_V3 extends SessionQueueQueryRespon
       buff.append(", maxConsumers=" + maxConsumers);
       buff.append(", exclusive=" + exclusive);
       buff.append(", lastValue=" + lastValue);
+      buff.append(", lastValueKey=" + lastValueKey);
+      buff.append(", nonDestructive=" + nonDestructive);
+      buff.append(", consumersBeforeDispatch=" + consumersBeforeDispatch);
+      buff.append(", delayBeforeDispatch=" + delayBeforeDispatch);
       buff.append(", defaultConsumerWindowSize=" + defaultConsumerWindowSize);
       return buff.toString();
    }
 
    @Override
    public ClientSession.QueueQuery toQueueQuery() {
-      return new QueueQueryImpl(isDurable(), isTemporary(), getConsumerCount(), getMessageCount(), getFilterString(), getAddress(), getName(), isExists(), isAutoCreateQueues(), getMaxConsumers(), isAutoCreated(), isPurgeOnNoConsumers(), getRoutingType(), isExclusive(), isLastValue(), getDefaultConsumerWindowSize());
+      return new QueueQueryImpl(isDurable(), isTemporary(), getConsumerCount(), getMessageCount(), getFilterString(), getAddress(), getName(), isExists(), isAutoCreateQueues(), getMaxConsumers(), isAutoCreated(), isPurgeOnNoConsumers(), getRoutingType(), isExclusive(), isLastValue(), getLastValueKey(), isNonDestructive(), getConsumersBeforeDispatch(), getDelayBeforeDispatch(), getDefaultConsumerWindowSize());
    }
 
    @Override
@@ -244,6 +314,26 @@ public class SessionQueueQueryResponseMessage_V3 extends SessionQueueQueryRespon
          if (other.lastValue != null)
             return false;
       } else if (!lastValue.equals(other.lastValue))
+         return false;
+      if (lastValueKey == null) {
+         if (other.lastValueKey != null)
+            return false;
+      } else if (!lastValueKey.equals(other.lastValueKey))
+         return false;
+      if (nonDestructive == null) {
+         if (other.nonDestructive != null)
+            return false;
+      } else if (!nonDestructive.equals(other.nonDestructive))
+         return false;
+      if (consumersBeforeDispatch == null) {
+         if (other.consumersBeforeDispatch != null)
+            return false;
+      } else if (!consumersBeforeDispatch.equals(other.consumersBeforeDispatch))
+         return false;
+      if (delayBeforeDispatch == null) {
+         if (other.delayBeforeDispatch != null)
+            return false;
+      } else if (!delayBeforeDispatch.equals(other.delayBeforeDispatch))
          return false;
       if (defaultConsumerWindowSize == null) {
          if (other.defaultConsumerWindowSize != null)

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/server/QueueQueryResult.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/server/QueueQueryResult.java
@@ -51,6 +51,14 @@ public class QueueQueryResult {
 
    private Boolean lastValue;
 
+   private SimpleString lastValueKey;
+
+   private Boolean nonDestructive;
+
+   private Integer consumersBeforeDispatch;
+
+   private Long delayBeforeDispatch;
+
    private Integer defaultConsumerWindowSize;
 
    public QueueQueryResult(final SimpleString name,
@@ -68,6 +76,10 @@ public class QueueQueryResult {
                            final int maxConsumers,
                            final Boolean exclusive,
                            final Boolean lastValue,
+                           final SimpleString lastValueKey,
+                           final Boolean nonDestructive,
+                           final Integer consumersBeforeDispatch,
+                           final Long delayBeforeDispatch,
                            final Integer defaultConsumerWindowSize) {
       this.durable = durable;
 
@@ -98,6 +110,14 @@ public class QueueQueryResult {
       this.exclusive = exclusive;
 
       this.lastValue = lastValue;
+
+      this.lastValueKey = lastValueKey;
+
+      this.nonDestructive = nonDestructive;
+
+      this.consumersBeforeDispatch = consumersBeforeDispatch;
+
+      this.delayBeforeDispatch = delayBeforeDispatch;
 
       this.defaultConsumerWindowSize = defaultConsumerWindowSize;
    }
@@ -164,6 +184,22 @@ public class QueueQueryResult {
 
    public Boolean isLastValue() {
       return lastValue;
+   }
+
+   public SimpleString getLastValueKey() {
+      return lastValueKey;
+   }
+
+   public Boolean isNonDestructive() {
+      return nonDestructive;
+   }
+
+   public Integer getConsumersBeforeDispatch() {
+      return consumersBeforeDispatch;
+   }
+
+   public Long getDelayBeforeDispatch() {
+      return delayBeforeDispatch;
    }
 
    public Integer getDefaultConsumerWindowSize() {

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/SessionContext.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/SessionContext.java
@@ -26,6 +26,7 @@ import java.util.concurrent.Executor;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.ICoreMessage;
 import org.apache.activemq.artemis.api.core.Message;
+import org.apache.activemq.artemis.api.core.QueueAttributes;
 import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
@@ -186,6 +187,19 @@ public abstract class SessionContext {
                                           Boolean exclusive,
                                           Boolean lastValue) throws ActiveMQException;
 
+   /**
+    * Creates a shared queue using the routing type set by the Address.  If the Address supports more than one type of delivery
+    * then the default delivery mode (MULTICAST) is used.
+    *
+    * @param address
+    * @param queueName
+    * @param queueAttributes
+    * @throws ActiveMQException
+    */
+   public abstract void createSharedQueue(SimpleString address,
+                                          SimpleString queueName,
+                                          QueueAttributes queueAttributes) throws ActiveMQException;
+
    public abstract void createSharedQueue(SimpleString address,
                                           SimpleString queueName,
                                           RoutingType routingType,
@@ -234,6 +248,12 @@ public abstract class SessionContext {
                                     boolean autoCreated,
                                     Boolean exclusive,
                                     Boolean lastVale) throws ActiveMQException;
+
+   public abstract void createQueue(SimpleString address,
+                                    SimpleString queueName,
+                                    boolean temp,
+                                    boolean autoCreated,
+                                    QueueAttributes queueAttributes) throws ActiveMQException;
 
    public abstract ClientSession.QueueQuery queueQuery(SimpleString queueName) throws ActiveMQException;
 

--- a/artemis-protocols/artemis-hqclient-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/hornetq/client/HornetQClientSessionContext.java
+++ b/artemis-protocols/artemis-hqclient-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/hornetq/client/HornetQClientSessionContext.java
@@ -72,7 +72,7 @@ public class HornetQClientSessionContext extends ActiveMQSessionContext {
    public ClientSession.AddressQuery addressQuery(final SimpleString address) throws ActiveMQException {
       SessionBindingQueryResponseMessage response = (SessionBindingQueryResponseMessage) getSessionChannel().sendBlocking(new SessionBindingQueryMessage(address), PacketImpl.SESS_BINDINGQUERY_RESP);
 
-      return new AddressQueryImpl(response.isExists(), response.getQueueNames(), false, false, ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers(), ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers(), ActiveMQDefaultConfiguration.getDefaultExclusive(), ActiveMQDefaultConfiguration.getDefaultLastValue());
+      return new AddressQueryImpl(response.isExists(), response.getQueueNames(), false, false, ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers(), ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers(), ActiveMQDefaultConfiguration.getDefaultExclusive(), ActiveMQDefaultConfiguration.getDefaultLastValue(), ActiveMQDefaultConfiguration.getDefaultLastValueKey(), ActiveMQDefaultConfiguration.getDefaultNonDestructive(), ActiveMQDefaultConfiguration.getDefaultConsumersBeforeDispatch(), ActiveMQDefaultConfiguration.getDefaultDelayBeforeDispatch());
    }
 
    @Override

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQConsumer.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQConsumer.java
@@ -293,7 +293,9 @@ public class AMQConsumer {
       }
 
       boolean removeReferences = !serverConsumer.isBrowseOnly(); // if it's browse only, nothing to be acked, we just remove the lists
-
+      if (serverConsumer.getQueue().isNonDestructive()) {
+         removeReferences = false;
+      }
       if (ack.isRedeliveredAck() || ack.isDeliveredAck() || ack.isExpiredAck()) {
          removeReferences = false;
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/CoreQueueConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/CoreQueueConfiguration.java
@@ -39,6 +39,10 @@ public class CoreQueueConfiguration implements Serializable {
 
    private Boolean lastValue;
 
+   private String lastValueKey;
+
+   private Boolean nonDestructive;
+
    private Integer maxConsumers;
 
    private Integer consumersBeforeDispatch;
@@ -78,6 +82,14 @@ public class CoreQueueConfiguration implements Serializable {
 
    public Boolean isLastValue() {
       return lastValue;
+   }
+
+   public String getLastValueKey() {
+      return lastValueKey;
+   }
+
+   public Boolean isNonDestructive() {
+      return nonDestructive;
    }
 
    public Integer getConsumersBeforeDispatch() {
@@ -170,6 +182,16 @@ public class CoreQueueConfiguration implements Serializable {
       return this;
    }
 
+   public CoreQueueConfiguration setLastValueKey(String lastValueKey) {
+      this.lastValueKey = lastValueKey;
+      return this;
+   }
+
+   public CoreQueueConfiguration setNonDestructive(Boolean nonDestructive) {
+      this.nonDestructive = nonDestructive;
+      return this;
+   }
+
    public boolean getPurgeOnNoConsumers() {
       return purgeOnNoConsumers;
    }
@@ -199,6 +221,8 @@ public class CoreQueueConfiguration implements Serializable {
       result = prime * result + ((purgeOnNoConsumers == null) ? 0 : purgeOnNoConsumers.hashCode());
       result = prime * result + ((exclusive == null) ? 0 : exclusive.hashCode());
       result = prime * result + ((lastValue == null) ? 0 : lastValue.hashCode());
+      result = prime * result + ((lastValueKey == null) ? 0 : lastValueKey.hashCode());
+      result = prime * result + ((nonDestructive == null) ? 0 : nonDestructive.hashCode());
       result = prime * result + ((consumersBeforeDispatch == null) ? 0 : consumersBeforeDispatch.hashCode());
       result = prime * result + ((delayBeforeDispatch == null) ? 0 : delayBeforeDispatch.hashCode());
       result = prime * result + ((routingType == null) ? 0 : routingType.hashCode());
@@ -254,6 +278,18 @@ public class CoreQueueConfiguration implements Serializable {
       } else if (!lastValue.equals(other.lastValue)) {
          return false;
       }
+      if (lastValueKey == null) {
+         if (other.lastValueKey != null)
+            return false;
+      } else if (!lastValueKey.equals(other.lastValueKey)) {
+         return false;
+      }
+      if (nonDestructive == null) {
+         if (other.nonDestructive != null)
+            return false;
+      } else if (!nonDestructive.equals(other.nonDestructive)) {
+         return false;
+      }
       if (consumersBeforeDispatch == null) {
          if (other.consumersBeforeDispatch != null)
             return false;
@@ -287,6 +323,8 @@ public class CoreQueueConfiguration implements Serializable {
          ", purgeOnNoConsumers=" + purgeOnNoConsumers +
          ", exclusive=" + exclusive +
          ", lastValue=" + lastValue +
+         ", lastValueKey=" + lastValueKey +
+         ", nonDestructive=" + nonDestructive +
          ", consumersBeforeDispatch=" + consumersBeforeDispatch +
          ", delayBeforeDispatch=" + delayBeforeDispatch +
          "]";

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -181,6 +181,10 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
    private static final String DEFAULT_LVQ_NODE_NAME = "default-last-value-queue";
 
+   private static final String DEFAULT_LVQ_KEY_NODE_NAME = "default-last-value-key";
+
+   private static final String DEFAULT_NON_DESTRUCTIVE_NODE_NAME = "default-non-destructive";
+
    private static final String DEFAULT_EXCLUSIVE_NODE_NAME = "default-exclusive-queue";
 
    private static final String DEFAULT_CONSUMERS_BEFORE_DISPATCH = "default-consumers-before-dispatch";
@@ -1000,6 +1004,10 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
             addressSettings.setAddressFullMessagePolicy(policy);
          } else if (LVQ_NODE_NAME.equalsIgnoreCase(name) || DEFAULT_LVQ_NODE_NAME.equalsIgnoreCase(name)) {
             addressSettings.setDefaultLastValueQueue(XMLUtil.parseBoolean(child));
+         } else if (DEFAULT_LVQ_KEY_NODE_NAME.equalsIgnoreCase(name)) {
+            addressSettings.setDefaultLastValueKey(SimpleString.toSimpleString(getTrimmedTextContent(child)));
+         } else if (DEFAULT_NON_DESTRUCTIVE_NODE_NAME.equalsIgnoreCase(name)) {
+            addressSettings.setDefaultNonDestructive(XMLUtil.parseBoolean(child));
          } else if (DEFAULT_EXCLUSIVE_NODE_NAME.equalsIgnoreCase(name)) {
             addressSettings.setDefaultExclusiveQueue(XMLUtil.parseBoolean(child));
          } else if (MAX_DELIVERY_ATTEMPTS.equalsIgnoreCase(name)) {
@@ -1109,6 +1117,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       String user = null;
       Boolean exclusive = null;
       Boolean lastValue = null;
+      String lastValueKey = null;
+      Boolean nonDestructive = null;
       Integer consumersBeforeDispatch = null;
       Long delayBeforeDispatch = null;
 
@@ -1124,6 +1134,10 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
             exclusive = Boolean.parseBoolean(item.getNodeValue());
          } else if (item.getNodeName().equals("last-value")) {
             lastValue = Boolean.parseBoolean(item.getNodeValue());
+         } else if (item.getNodeName().equals("last-value-key")) {
+            lastValueKey = item.getNodeValue();
+         } else if (item.getNodeName().equals("non-destructive")) {
+            nonDestructive = Boolean.parseBoolean(item.getNodeValue());
          } else if (item.getNodeName().equals("consumers-before-dispatch")) {
             consumersBeforeDispatch = Integer.parseInt(item.getNodeValue());
          } else if (item.getNodeName().equals("delay-before-dispatch")) {
@@ -1147,7 +1161,7 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       }
 
       return new CoreQueueConfiguration().setAddress(address).setName(name).setFilterString(filterString).setDurable(durable).setMaxConsumers(maxConsumers).setPurgeOnNoConsumers(purgeOnNoConsumers).setUser(user)
-                                         .setExclusive(exclusive).setLastValue(lastValue).setConsumersBeforeDispatch(consumersBeforeDispatch).setDelayBeforeDispatch(delayBeforeDispatch);
+                                         .setExclusive(exclusive).setLastValue(lastValue).setLastValueKey(lastValueKey).setNonDestructive(nonDestructive).setConsumersBeforeDispatch(consumersBeforeDispatch).setDelayBeforeDispatch(delayBeforeDispatch);
    }
 
    protected CoreAddressConfiguration parseAddressConfiguration(final Node node) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/PagedReferenceImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/PagedReferenceImpl.java
@@ -20,6 +20,7 @@ import java.lang.ref.WeakReference;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import org.apache.activemq.artemis.api.core.Message;
+import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.paging.PagedMessage;
 import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
 import org.apache.activemq.artemis.core.server.MessageReference;
@@ -329,6 +330,15 @@ public class PagedReferenceImpl extends LinkedListImpl.Node<PagedReferenceImpl> 
          messageID = getPagedMessage().getMessage().getMessageID();
       }
       return messageID;
+   }
+
+   @Override
+   public SimpleString getLastValueProperty() {
+      SimpleString lastValue = getMessage().getSimpleStringProperty(getQueue().getLastValueKey());
+      if (lastValue == null) {
+         lastValue = getMessage().getLastValueProperty();
+      }
+      return lastValue;
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/QueueBindingInfo.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/QueueBindingInfo.java
@@ -66,6 +66,14 @@ public interface QueueBindingInfo {
 
    void setLastValue(boolean lastValue);
 
+   SimpleString getLastValueKey();
+
+   void setLastValueKey(SimpleString lastValue);
+
+   boolean isNonDestructive();
+
+   void setNonDestructive(boolean nonDestructive);
+
    int getConsumersBeforeDispatch();
 
    void setConsumersBeforeDispatch(int consumersBeforeDispatch);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AbstractJournalStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AbstractJournalStorageManager.java
@@ -1293,7 +1293,7 @@ public abstract class AbstractJournalStorageManager extends CriticalComponentImp
 
       SimpleString filterString = filter == null ? null : filter.getFilterString();
 
-      PersistentQueueBindingEncoding bindingEncoding = new PersistentQueueBindingEncoding(queue.getName(), binding.getAddress(), filterString, queue.getUser(), queue.isAutoCreated(), queue.getMaxConsumers(), queue.isPurgeOnNoConsumers(), queue.isExclusive(), queue.isLastValue(), queue.getConsumersBeforeDispatch(), queue.getDelayBeforeDispatch(), queue.getRoutingType().getType(), queue.isConfigurationManaged());
+      PersistentQueueBindingEncoding bindingEncoding = new PersistentQueueBindingEncoding(queue.getName(), binding.getAddress(), filterString, queue.getUser(), queue.isAutoCreated(), queue.getMaxConsumers(), queue.isPurgeOnNoConsumers(), queue.isExclusive(), queue.isLastValue(), queue.getLastValueKey(), queue.isNonDestructive(), queue.getConsumersBeforeDispatch(), queue.getDelayBeforeDispatch(), queue.getRoutingType().getType(), queue.isConfigurationManaged());
 
       readLock();
       try {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/PersistentQueueBindingEncoding.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/PersistentQueueBindingEncoding.java
@@ -50,6 +50,10 @@ public class PersistentQueueBindingEncoding implements EncodingSupport, QueueBin
 
    public boolean lastValue;
 
+   public SimpleString lastValueKey;
+
+   public boolean nonDestructive;
+
    public int consumersBeforeDispatch;
 
    public long delayBeforeDispatch;
@@ -82,6 +86,10 @@ public class PersistentQueueBindingEncoding implements EncodingSupport, QueueBin
          exclusive +
          ", lastValue=" +
          lastValue +
+         ", lastValueKey=" +
+         lastValueKey +
+         ", nonDestructive=" +
+         nonDestructive +
          ", consumersBeforeDispatch=" +
          consumersBeforeDispatch +
          ", delayBeforeDispatch=" +
@@ -102,6 +110,8 @@ public class PersistentQueueBindingEncoding implements EncodingSupport, QueueBin
                                          final boolean purgeOnNoConsumers,
                                          final boolean exclusive,
                                          final boolean lastValue,
+                                         final SimpleString lastValueKey,
+                                         final boolean nonDestructive,
                                          final int consumersBeforeDispatch,
                                          final long delayBeforeDispatch,
                                          final byte routingType,
@@ -115,6 +125,8 @@ public class PersistentQueueBindingEncoding implements EncodingSupport, QueueBin
       this.purgeOnNoConsumers = purgeOnNoConsumers;
       this.exclusive = exclusive;
       this.lastValue = lastValue;
+      this.lastValueKey = lastValueKey;
+      this.nonDestructive = nonDestructive;
       this.consumersBeforeDispatch = consumersBeforeDispatch;
       this.delayBeforeDispatch = delayBeforeDispatch;
       this.routingType = routingType;
@@ -224,6 +236,26 @@ public class PersistentQueueBindingEncoding implements EncodingSupport, QueueBin
    }
 
    @Override
+   public SimpleString getLastValueKey() {
+      return lastValueKey;
+   }
+
+   @Override
+   public void setLastValueKey(SimpleString lastValueKey) {
+      this.lastValueKey = lastValueKey;
+   }
+
+   @Override
+   public boolean isNonDestructive() {
+      return nonDestructive;
+   }
+
+   @Override
+   public void setNonDestructive(boolean nonDestructive) {
+      this.nonDestructive = nonDestructive;
+   }
+
+   @Override
    public int getConsumersBeforeDispatch() {
       return consumersBeforeDispatch;
    }
@@ -309,6 +341,16 @@ public class PersistentQueueBindingEncoding implements EncodingSupport, QueueBin
       } else {
          configurationManaged = false;
       }
+      if (buffer.readableBytes() > 0) {
+         lastValueKey = buffer.readNullableSimpleString();
+      } else {
+         lastValueKey = ActiveMQDefaultConfiguration.getDefaultLastValueKey();
+      }
+      if (buffer.readableBytes() > 0) {
+         nonDestructive = buffer.readBoolean();
+      } else {
+         nonDestructive = ActiveMQDefaultConfiguration.getDefaultNonDestructive();
+      }
    }
 
    @Override
@@ -326,6 +368,8 @@ public class PersistentQueueBindingEncoding implements EncodingSupport, QueueBin
       buffer.writeInt(consumersBeforeDispatch);
       buffer.writeLong(delayBeforeDispatch);
       buffer.writeBoolean(configurationManaged);
+      buffer.writeNullableSimpleString(lastValueKey);
+      buffer.writeBoolean(nonDestructive);
    }
 
    @Override
@@ -340,6 +384,8 @@ public class PersistentQueueBindingEncoding implements EncodingSupport, QueueBin
          DataConstants.SIZE_BOOLEAN +
          DataConstants.SIZE_INT +
          DataConstants.SIZE_LONG +
+         DataConstants.SIZE_BOOLEAN +
+         SimpleString.sizeofNullableString(lastValueKey) +
          DataConstants.SIZE_BOOLEAN;
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/PostOffice.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/PostOffice.java
@@ -71,6 +71,7 @@ public interface PostOffice extends ActiveMQComponent {
                             Integer maxConsumers,
                             Boolean purgeOnNoConsumers,
                             Boolean exclusive,
+                            Boolean nonDestructive,
                             Integer consumersBeforeDispatch,
                             Long delayBeforeDispatch,
                             SimpleString user,

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -469,6 +469,7 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
                                    Integer maxConsumers,
                                    Boolean purgeOnNoConsumers,
                                    Boolean exclusive,
+                                   Boolean nonDestructive,
                                    Integer consumersBeforeDispatch,
                                    Long delayBeforeDispatch,
                                    SimpleString user,
@@ -515,6 +516,10 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
          if (exclusive != null && queue.isExclusive() != exclusive.booleanValue()) {
             changed = true;
             queue.setExclusive(exclusive);
+         }
+         if (nonDestructive != null && queue.isNonDestructive() != nonDestructive.booleanValue()) {
+            changed = true;
+            queue.setNonDestructive(nonDestructive);
          }
          if (consumersBeforeDispatch != null && !consumersBeforeDispatch.equals(queue.getConsumersBeforeDispatch())) {
             changed = true;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/ServerSessionPacketHandler.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/ServerSessionPacketHandler.java
@@ -362,7 +362,7 @@ public class ServerSessionPacketHandler implements ChannelHandler {
                   CreateQueueMessage_V2 request = (CreateQueueMessage_V2) packet;
                   requiresResponse = request.isRequiresResponse();
                   session.createQueue(request.getAddress(), request.getQueueName(), request.getRoutingType(), request.getFilterString(), request.isTemporary(), request.isDurable(), request.getMaxConsumers(), request.isPurgeOnNoConsumers(),
-                                      request.isExclusive(), request.isLastValue(), request.isAutoCreated());
+                                      request.isExclusive(), request.isLastValue(), request.getLastValueKey(), request.isNonDestructive(), request.getConsumersBeforeDispatch(), request.getDelayBeforeDispatch(), request.isAutoCreated());
                   if (requiresResponse) {
                      response = createNullResponseMessage(packet);
                   }
@@ -385,7 +385,8 @@ public class ServerSessionPacketHandler implements ChannelHandler {
                   requiresResponse = request.isRequiresResponse();
                   QueueQueryResult result = session.executeQueueQuery(request.getQueueName());
                   if (!(result.isExists() && Objects.equals(result.getAddress(), request.getAddress()) && Objects.equals(result.getFilterString(), request.getFilterString()))) {
-                     session.createSharedQueue(request.getAddress(), request.getQueueName(), request.getRoutingType(), request.getFilterString(), request.isDurable(), request.getMaxConsumers(), request.isPurgeOnNoConsumers(), request.isExclusive(), request.isLastValue());
+                     session.createSharedQueue(request.getAddress(), request.getQueueName(), request.getRoutingType(), request.getFilterString(), request.isDurable(), request.getMaxConsumers(), request.isPurgeOnNoConsumers(),
+                                               request.isExclusive(), request.isLastValue(), request.getLastValueKey(), request.isNonDestructive(), request.getConsumersBeforeDispatch(), request.getDelayBeforeDispatch());
                   }
                   if (requiresResponse) {
                      response = createNullResponseMessage(packet);
@@ -432,13 +433,13 @@ public class ServerSessionPacketHandler implements ChannelHandler {
                      if (!queueNames.isEmpty()) {
                         final List<SimpleString> convertedQueueNames = request.convertQueueNames(clientVersion, queueNames);
                         if (convertedQueueNames != queueNames) {
-                           result = new BindingQueryResult(result.isExists(), result.getAddressInfo(), convertedQueueNames, result.isAutoCreateQueues(), result.isAutoCreateAddresses(), result.isDefaultPurgeOnNoConsumers(), result.getDefaultMaxConsumers(), result.isDefaultExclusive(), result.isDefaultLastValue());
+                           result = new BindingQueryResult(result.isExists(), result.getAddressInfo(), convertedQueueNames, result.isAutoCreateQueues(), result.isAutoCreateAddresses(), result.isDefaultPurgeOnNoConsumers(), result.getDefaultMaxConsumers(), result.isDefaultExclusive(), result.isDefaultLastValue(), result.getDefaultLastValueKey(), result.isDefaultNonDestructive(), result.getDefaultConsumersBeforeDispatch(), result.getDefaultDelayBeforeDispatch());
                         }
                      }
                   }
 
                   if (channel.supports(PacketImpl.SESS_BINDINGQUERY_RESP_V4)) {
-                     response = new SessionBindingQueryResponseMessage_V4(result.isExists(), result.getQueueNames(), result.isAutoCreateQueues(), result.isAutoCreateAddresses(), result.isDefaultPurgeOnNoConsumers(), result.getDefaultMaxConsumers(), result.isDefaultExclusive(), result.isDefaultLastValue());
+                     response = new SessionBindingQueryResponseMessage_V4(result.isExists(), result.getQueueNames(), result.isAutoCreateQueues(), result.isAutoCreateAddresses(), result.isDefaultPurgeOnNoConsumers(), result.getDefaultMaxConsumers(), result.isDefaultExclusive(), result.isDefaultLastValue(), result.getDefaultLastValueKey(), result.isDefaultNonDestructive(), result.getDefaultConsumersBeforeDispatch(), result.getDefaultDelayBeforeDispatch());
                   } else if (channel.supports(PacketImpl.SESS_BINDINGQUERY_RESP_V3)) {
                      response = new SessionBindingQueryResponseMessage_V3(result.isExists(), result.getQueueNames(), result.isAutoCreateQueues(), result.isAutoCreateAddresses());
                   } else if (channel.supports(PacketImpl.SESS_BINDINGQUERY_RESP_V2)) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServer.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServer.java
@@ -403,7 +403,7 @@ public interface ActiveMQServer extends ServiceComponent {
 
    void createSharedQueue(SimpleString address, RoutingType routingType, SimpleString name, SimpleString filterString,
                           SimpleString user, boolean durable, int maxConsumers, boolean purgeOnNoConsumers, boolean exclusive, boolean lastValue,
-                          int consumersBeforeDispatch, long delayBeforeDispatch) throws Exception;
+                          SimpleString lastValueKey, boolean nonDestructive, int consumersBeforeDispatch, long delayBeforeDispatch) throws Exception;
 
    Queue createQueue(SimpleString address, RoutingType routingType, SimpleString queueName, SimpleString filter,
                      boolean durable, boolean temporary) throws Exception;
@@ -417,7 +417,7 @@ public interface ActiveMQServer extends ServiceComponent {
 
    Queue createQueue(SimpleString address, RoutingType routingType, SimpleString queueName, SimpleString filter,
                      boolean durable, boolean temporary, int maxConsumers, boolean purgeOnNoConsumers, boolean exclusive,
-                     boolean lastValue, int consumersBeforeDispatch, long delayBeforeDispatch, boolean autoCreateAddress) throws Exception;
+                     boolean lastValue, SimpleString lastValueKey, boolean nonDestructive, int consumersBeforeDispatch, long delayBeforeDispatch, boolean autoCreateAddress) throws Exception;
 
    Queue createQueue(SimpleString address, RoutingType routingType, SimpleString queueName, SimpleString filter,
                      SimpleString user, boolean durable, boolean temporary, boolean autoCreated, Integer maxConsumers,
@@ -433,8 +433,8 @@ public interface ActiveMQServer extends ServiceComponent {
 
    Queue createQueue(AddressInfo addressInfo, SimpleString queueName, SimpleString filter,
                      SimpleString user, boolean durable, boolean temporary, boolean autoCreated, Integer maxConsumers,
-                     Boolean purgeOnNoConsumers, Boolean exclusive, Boolean lastValue, Integer consumersBeforeDispatch,
-                     Long delayBeforeDispatch, boolean autoCreateAddress) throws Exception;
+                     Boolean purgeOnNoConsumers, Boolean exclusive, Boolean lastValue, SimpleString lastValueKey, Boolean nonDestructive,
+                     Integer consumersBeforeDispatch, Long delayBeforeDispatch, boolean autoCreateAddress) throws Exception;
 
    Queue createQueue(SimpleString address, RoutingType routingType, SimpleString queueName, SimpleString filter,
                      SimpleString user, boolean durable, boolean temporary, boolean ignoreIfExists, boolean transientQueue,
@@ -446,8 +446,8 @@ public interface ActiveMQServer extends ServiceComponent {
 
    Queue createQueue(SimpleString address, RoutingType routingType, SimpleString queueName, SimpleString filter,
                      SimpleString user, boolean durable, boolean temporary, boolean ignoreIfExists, boolean transientQueue,
-                     boolean autoCreated, int maxConsumers, boolean purgeOnNoConsumers, boolean exclusive, boolean lastValue, int consumersBeforeDispatch,
-                     long delayBeforeDispatch, boolean autoCreateAddress) throws Exception;
+                     boolean autoCreated, int maxConsumers, boolean purgeOnNoConsumers, boolean exclusive, boolean lastValue, SimpleString lastValueKey, boolean nonDestructive,
+                     int consumersBeforeDispatch, long delayBeforeDispatch, boolean autoCreateAddress) throws Exception;
 
    @Deprecated
    Queue createQueue(SimpleString address, SimpleString queueName, SimpleString filter, boolean durable, boolean temporary) throws Exception;
@@ -541,6 +541,7 @@ public interface ActiveMQServer extends ServiceComponent {
                      Integer maxConsumers,
                      Boolean purgeOnNoConsumers,
                      Boolean exclusive,
+                     Boolean nonDestructive,
                      Integer consumersBeforeDispatch,
                      Long delayBeforeDispatch,
                      String user) throws Exception;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/BindingQueryResult.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/BindingQueryResult.java
@@ -41,6 +41,14 @@ public class BindingQueryResult {
 
    private boolean defaultLastValue;
 
+   private SimpleString defaultLastValueKey;
+
+   private Boolean defaultNonDestructive;
+
+   private Integer defaultConsumersBeforeDispatch;
+
+   private Long defaultDelayBeforeDispatch;
+
    public BindingQueryResult(final boolean exists,
                              final AddressInfo addressInfo,
                              final List<SimpleString> queueNames,
@@ -49,7 +57,11 @@ public class BindingQueryResult {
                              final boolean defaultPurgeOnNoConsumers,
                              final int defaultMaxConsumers,
                              final boolean defaultExclusive,
-                             final boolean defaultLastValue) {
+                             final boolean defaultLastValue,
+                             final SimpleString defaultLastValueKey,
+                             final Boolean defaultNonDestructive,
+                             final Integer defaultConsumersBeforeDispatch,
+                             final Long defaultDelayBeforeDispatch) {
       this.addressInfo = addressInfo;
 
       this.exists = exists;
@@ -67,6 +79,14 @@ public class BindingQueryResult {
       this.defaultExclusive = defaultExclusive;
 
       this.defaultLastValue = defaultLastValue;
+
+      this.defaultLastValueKey = defaultLastValueKey;
+
+      this.defaultNonDestructive = defaultNonDestructive;
+
+      this.defaultConsumersBeforeDispatch = defaultConsumersBeforeDispatch;
+
+      this.defaultDelayBeforeDispatch = defaultDelayBeforeDispatch;
    }
 
    public boolean isExists() {
@@ -103,5 +123,21 @@ public class BindingQueryResult {
 
    public boolean isDefaultLastValue() {
       return defaultLastValue;
+   }
+
+   public SimpleString getDefaultLastValueKey() {
+      return defaultLastValueKey;
+   }
+
+   public Boolean isDefaultNonDestructive() {
+      return defaultNonDestructive;
+   }
+
+   public Integer getDefaultConsumersBeforeDispatch() {
+      return defaultConsumersBeforeDispatch;
+   }
+
+   public Long getDefaultDelayBeforeDispatch() {
+      return defaultDelayBeforeDispatch;
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/MessageReference.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/MessageReference.java
@@ -19,6 +19,7 @@ package org.apache.activemq.artemis.core.server;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.Message;
+import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.server.impl.AckReason;
 import org.apache.activemq.artemis.core.server.impl.MessageReferenceImpl;
 import org.apache.activemq.artemis.core.transaction.Transaction;
@@ -40,6 +41,8 @@ public interface MessageReference {
    Message getMessage();
 
    long getMessageID();
+
+   SimpleString getLastValueProperty();
 
    /**
     * We define this method aggregation here because on paging we need to hold the original estimate,

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/Queue.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/Queue.java
@@ -90,6 +90,12 @@ public interface Queue extends Bindable,CriticalComponent {
 
    boolean isLastValue();
 
+   SimpleString getLastValueKey();
+
+   boolean isNonDestructive();
+
+   void setNonDestructive(boolean nonDestructive);
+
    int getMaxConsumers();
 
    void setMaxConsumer(int maxConsumers);
@@ -104,7 +110,7 @@ public interface Queue extends Bindable,CriticalComponent {
 
    int getConsumerCount();
 
-   /**
+    /**
     * This will set a reference counter for every consumer present on the queue.
     * The ReferenceCounter will know what to do when the counter became zeroed.
     * This is used to control what to do with temporary queues, especially
@@ -227,7 +233,7 @@ public interface Queue extends Bindable,CriticalComponent {
    int deleteMatchingReferences(Filter filter) throws Exception;
 
    default int deleteMatchingReferences(int flushLImit, Filter filter) throws Exception {
-      return deleteMatchingReferences(flushLImit, filter, AckReason.NORMAL);
+      return deleteMatchingReferences(flushLImit, filter, AckReason.KILLED);
    }
 
    int deleteMatchingReferences(int flushLImit, Filter filter, AckReason ackReason) throws Exception;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/QueueConfig.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/QueueConfig.java
@@ -43,6 +43,8 @@ public final class QueueConfig {
    private final int consumersBeforeDispatch;
    private final long delayBeforeDispatch;
    private final boolean configurationManaged;
+   private final SimpleString lastValueKey;
+   private final boolean nonDestructive;
 
    public static final class Builder {
 
@@ -59,6 +61,8 @@ public final class QueueConfig {
       private int maxConsumers;
       private boolean exclusive;
       private boolean lastValue;
+      private SimpleString lastValueKey;
+      private boolean nonDestructive;
       private boolean purgeOnNoConsumers;
       private int consumersBeforeDispatch;
       private long delayBeforeDispatch;
@@ -82,6 +86,8 @@ public final class QueueConfig {
          this.maxConsumers = ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers();
          this.exclusive = ActiveMQDefaultConfiguration.getDefaultExclusive();
          this.lastValue = ActiveMQDefaultConfiguration.getDefaultLastValue();
+         this.lastValueKey = ActiveMQDefaultConfiguration.getDefaultLastValueKey();
+         this.nonDestructive = ActiveMQDefaultConfiguration.getDefaultNonDestructive();
          this.purgeOnNoConsumers = ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers();
          this.consumersBeforeDispatch = ActiveMQDefaultConfiguration.getDefaultConsumersBeforeDispatch();
          this.delayBeforeDispatch = ActiveMQDefaultConfiguration.getDefaultDelayBeforeDispatch();
@@ -152,6 +158,16 @@ public final class QueueConfig {
          return this;
       }
 
+      public Builder lastValueKey(SimpleString lastValueKey) {
+         this.lastValueKey = lastValueKey;
+         return this;
+      }
+
+      public Builder nonDestructive(boolean nonDestructive) {
+         this.nonDestructive = nonDestructive;
+         return this;
+      }
+
       public Builder consumersBeforeDispatch(final int consumersBeforeDispatch) {
          this.consumersBeforeDispatch = consumersBeforeDispatch;
          return this;
@@ -193,7 +209,7 @@ public final class QueueConfig {
          } else {
             pageSubscription = null;
          }
-         return new QueueConfig(id, address, name, filter, pageSubscription, user, durable, temporary, autoCreated, routingType, maxConsumers, exclusive, lastValue, consumersBeforeDispatch, delayBeforeDispatch, purgeOnNoConsumers, configurationManaged);
+         return new QueueConfig(id, address, name, filter, pageSubscription, user, durable, temporary, autoCreated, routingType, maxConsumers, exclusive, lastValue, lastValueKey, nonDestructive, consumersBeforeDispatch, delayBeforeDispatch, purgeOnNoConsumers, configurationManaged);
       }
 
    }
@@ -239,6 +255,8 @@ public final class QueueConfig {
                        final int maxConsumers,
                        final boolean exclusive,
                        final boolean lastValue,
+                       final SimpleString lastValueKey,
+                       final boolean nonDestructive,
                        final int consumersBeforeDispatch,
                        final long delayBeforeDispatch,
                        final boolean purgeOnNoConsumers,
@@ -256,6 +274,8 @@ public final class QueueConfig {
       this.purgeOnNoConsumers = purgeOnNoConsumers;
       this.exclusive = exclusive;
       this.lastValue = lastValue;
+      this.lastValueKey = lastValueKey;
+      this.nonDestructive = nonDestructive;
       this.maxConsumers = maxConsumers;
       this.consumersBeforeDispatch = consumersBeforeDispatch;
       this.delayBeforeDispatch = delayBeforeDispatch;
@@ -314,6 +334,14 @@ public final class QueueConfig {
       return lastValue;
    }
 
+   public SimpleString lastValueKey() {
+      return lastValueKey;
+   }
+
+   public boolean isNonDestructive() {
+      return nonDestructive;
+   }
+
    public RoutingType deliveryMode() {
       return routingType;
    }
@@ -363,6 +391,10 @@ public final class QueueConfig {
          return false;
       if (lastValue != that.lastValue)
          return false;
+      if (lastValueKey != null ? !lastValueKey.equals(that.lastValueKey) : that.lastValueKey != null)
+         return false;
+      if (nonDestructive != that.nonDestructive)
+         return false;
       if (purgeOnNoConsumers != that.purgeOnNoConsumers)
          return false;
       if (consumersBeforeDispatch != that.consumersBeforeDispatch)
@@ -392,6 +424,8 @@ public final class QueueConfig {
       result = 31 * result + maxConsumers;
       result = 31 * result + (exclusive ? 1 : 0);
       result = 31 * result + (lastValue ? 1 : 0);
+      result = 31 * result + (lastValueKey != null ? lastValueKey.hashCode() : 0);
+      result = 31 * result + (nonDestructive ? 1 : 0);
       result = 31 * result + consumersBeforeDispatch;
       result = 31 * result + Long.hashCode(delayBeforeDispatch);
       result = 31 * result + (purgeOnNoConsumers ? 1 : 0);
@@ -415,6 +449,8 @@ public final class QueueConfig {
          + ", maxConsumers=" + maxConsumers
          + ", exclusive=" + exclusive
          + ", lastValue=" + lastValue
+         + ", lastValueKey=" + lastValueKey
+         + ", nonDestructive=" + nonDestructive
          + ", consumersBeforeDispatch=" + consumersBeforeDispatch
          + ", delayBeforeDispatch=" + delayBeforeDispatch
          + ", purgeOnNoConsumers=" + purgeOnNoConsumers

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ServerSession.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ServerSession.java
@@ -167,6 +167,22 @@ public interface ServerSession extends SecurityAuth {
                      SimpleString filterString,
                      boolean temporary,
                      boolean durable,
+                     int maxConsumers,
+                     boolean purgeOnNoConsumers,
+                     Boolean exclusive,
+                     Boolean lastValue,
+                     SimpleString lastValueKey,
+                     Boolean nonDestructive,
+                     Integer consumersBeforeDispatch,
+                     Long delayBeforeDispatch,
+                     boolean autoCreated) throws Exception;
+
+   Queue createQueue(SimpleString address,
+                     SimpleString name,
+                     RoutingType routingType,
+                     SimpleString filterString,
+                     boolean temporary,
+                     boolean durable,
                      boolean autoCreated) throws Exception;
 
    Queue createQueue(AddressInfo addressInfo,
@@ -285,6 +301,20 @@ public interface ServerSession extends SecurityAuth {
                      Boolean purgeOnNoConsumers,
                      Boolean exclusive,
                      Boolean lastValue) throws Exception;
+
+   void createSharedQueue(SimpleString address,
+                          SimpleString name,
+                          RoutingType routingType,
+                          SimpleString filterString,
+                          boolean durable,
+                          Integer maxConsumers,
+                          Boolean purgeOnNoConsumers,
+                          Boolean exclusive,
+                          Boolean lastValue,
+                          SimpleString lastValueKey,
+                          Boolean nonDestructive,
+                          Integer consumersBeforeDispatch,
+                          Long delayBeforeDispatch) throws Exception;
 
    void createSharedQueue(SimpleString address,
                           SimpleString name,

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/AckReason.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/AckReason.java
@@ -18,5 +18,5 @@
 package org.apache.activemq.artemis.core.server.impl;
 
 public enum AckReason {
-   KILLED, EXPIRED, NORMAL
+   KILLED, EXPIRED, NORMAL, REPLACED
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -847,7 +847,11 @@ public class ActiveMQServerImpl implements ActiveMQServer {
       boolean defaultPurgeOnNoConsumers = addressSettings.isDefaultPurgeOnNoConsumers();
       int defaultMaxConsumers = addressSettings.getDefaultMaxConsumers();
       boolean defaultExclusive = addressSettings.isDefaultExclusiveQueue();
-      boolean defaultLastValie = addressSettings.isDefaultLastValueQueue();
+      boolean defaultLastValue = addressSettings.isDefaultLastValueQueue();
+      SimpleString defaultLastValueKey = addressSettings.getDefaultLastValueKey();
+      boolean defaultNonDestructive = addressSettings.isDefaultNonDestructive();
+      int defaultConsumersBeforeDispatch = addressSettings.getDefaultConsumersBeforeDispatch();
+      long defaultDelayBeforeDispatch = addressSettings.getDefaultDelayBeforeDispatch();
 
       List<SimpleString> names = new ArrayList<>();
 
@@ -856,7 +860,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
       SimpleString bindAddress = new SimpleString(realAddress);
       if (managementService != null) {
          if (bindAddress.equals(managementService.getManagementAddress())) {
-            return new BindingQueryResult(true, null, names, autoCreateQeueus, autoCreateAddresses, defaultPurgeOnNoConsumers, defaultMaxConsumers, defaultExclusive, defaultLastValie);
+            return new BindingQueryResult(true, null, names, autoCreateQeueus, autoCreateAddresses, defaultPurgeOnNoConsumers, defaultMaxConsumers, defaultExclusive, defaultLastValue, defaultLastValueKey, defaultNonDestructive, defaultConsumersBeforeDispatch, defaultDelayBeforeDispatch);
          }
       }
 
@@ -874,7 +878,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
 
       AddressInfo info = getAddressInfo(bindAddress);
 
-      return new BindingQueryResult(info != null, info, names, autoCreateQeueus, autoCreateAddresses, defaultPurgeOnNoConsumers, defaultMaxConsumers, defaultExclusive, defaultLastValie);
+      return new BindingQueryResult(info != null, info, names, autoCreateQeueus, autoCreateAddresses, defaultPurgeOnNoConsumers, defaultMaxConsumers, defaultExclusive, defaultLastValue, defaultLastValueKey, defaultNonDestructive, defaultConsumersBeforeDispatch, defaultDelayBeforeDispatch);
    }
 
    @Override
@@ -883,7 +887,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
          throw ActiveMQMessageBundle.BUNDLE.queueNameIsNull();
       }
 
-      QueueQueryResult response;
+      final QueueQueryResult response;
 
       Binding binding = getPostOffice().getBinding(name);
 
@@ -897,6 +901,10 @@ public class ActiveMQServerImpl implements ActiveMQServer {
       int defaultMaxConsumers = addressSettings.getDefaultMaxConsumers();
       boolean defaultExclusiveQueue = addressSettings.isDefaultExclusiveQueue();
       boolean defaultLastValueQueue = addressSettings.isDefaultLastValueQueue();
+      SimpleString defaultLastValueKey = addressSettings.getDefaultLastValueKey();
+      boolean defaultNonDestructive = addressSettings.isDefaultNonDestructive();
+      int defaultConsumersBeforeDispatch = addressSettings.getDefaultConsumersBeforeDispatch();
+      long defaultDelayBeforeDispatch = addressSettings.getDefaultDelayBeforeDispatch();
       int defaultConsumerWindowSize = addressSettings.getDefaultConsumerWindowSize();
 
       SimpleString managementAddress = getManagementService() != null ? getManagementService().getManagementAddress() : null;
@@ -908,14 +916,14 @@ public class ActiveMQServerImpl implements ActiveMQServer {
 
          SimpleString filterString = filter == null ? null : filter.getFilterString();
 
-         response = new QueueQueryResult(name, binding.getAddress(), queue.isDurable(), queue.isTemporary(), filterString, queue.getConsumerCount(), queue.getMessageCount(), autoCreateQueues, true, queue.isAutoCreated(), queue.isPurgeOnNoConsumers(), queue.getRoutingType(), queue.getMaxConsumers(), queue.isExclusive(), queue.isLastValue(), defaultConsumerWindowSize);
+         response = new QueueQueryResult(name, binding.getAddress(), queue.isDurable(), queue.isTemporary(), filterString, queue.getConsumerCount(), queue.getMessageCount(), autoCreateQueues, true, queue.isAutoCreated(), queue.isPurgeOnNoConsumers(), queue.getRoutingType(), queue.getMaxConsumers(), queue.isExclusive(), queue.isLastValue(), queue.getLastValueKey(), queue.isNonDestructive(), queue.getConsumersBeforeDispatch(), queue.getDelayBeforeDispatch(), defaultConsumerWindowSize);
       } else if (name.equals(managementAddress)) {
          // make an exception for the management address (see HORNETQ-29)
-         response = new QueueQueryResult(name, managementAddress, true, false, null, -1, -1, autoCreateQueues, true, false, false, RoutingType.MULTICAST, -1, false, false, defaultConsumerWindowSize);
+         response = new QueueQueryResult(name, managementAddress, true, false, null, -1, -1, autoCreateQueues, true, false, false, RoutingType.MULTICAST, -1, false, false, null, null, null, null, defaultConsumerWindowSize);
       } else if (autoCreateQueues) {
-         response = new QueueQueryResult(name, name, true, false, null, 0, 0, true, false, false, defaultPurgeOnNoConsumers, RoutingType.MULTICAST, defaultMaxConsumers, defaultExclusiveQueue, defaultLastValueQueue, defaultConsumerWindowSize);
+         response = new QueueQueryResult(name, name, true, false, null, 0, 0, true, false, false, defaultPurgeOnNoConsumers, RoutingType.MULTICAST, defaultMaxConsumers, defaultExclusiveQueue, defaultLastValueQueue, defaultLastValueKey, defaultNonDestructive, defaultConsumersBeforeDispatch, defaultDelayBeforeDispatch, defaultConsumerWindowSize);
       } else {
-         response = new QueueQueryResult(null, null, false, false, null, 0, 0, false, false, false, false, RoutingType.MULTICAST, 0, null, null, defaultConsumerWindowSize);
+         response = new QueueQueryResult(null, null, false, false, null, 0, 0, false, false, false, false, RoutingType.MULTICAST, 0, null, null, null, null, null, null, defaultConsumerWindowSize);
       }
 
       return response;
@@ -1702,10 +1710,12 @@ public class ActiveMQServerImpl implements ActiveMQServer {
                             final boolean purgeOnNoConsumers,
                             final boolean exclusive,
                             final boolean lastValue,
+                            final SimpleString lastValueKey,
+                            final boolean nonDestructive,
                             final int consumersBeforeDispatch,
                             final long delayBeforeDispatch,
                             final boolean autoCreateAddress) throws Exception {
-      return createQueue(address, routingType, queueName, filter, null, durable, temporary, false, false, false, maxConsumers, purgeOnNoConsumers, exclusive, lastValue, consumersBeforeDispatch, delayBeforeDispatch, autoCreateAddress);
+      return createQueue(address, routingType, queueName, filter, null, durable, temporary, false, false, false, maxConsumers, purgeOnNoConsumers, exclusive, lastValue, lastValueKey, nonDestructive, consumersBeforeDispatch, delayBeforeDispatch, autoCreateAddress);
    }
 
    @Override
@@ -1727,18 +1737,18 @@ public class ActiveMQServerImpl implements ActiveMQServer {
    @Override
    public Queue createQueue(AddressInfo addressInfo, SimpleString queueName, SimpleString filter, SimpleString user, boolean durable, boolean temporary, boolean autoCreated, Integer maxConsumers, Boolean purgeOnNoConsumers, boolean autoCreateAddress) throws Exception {
       AddressSettings as = getAddressSettingsRepository().getMatch(addressInfo == null ? queueName.toString() : addressInfo.getName().toString());
-      return createQueue(addressInfo, queueName, filter, user, durable, temporary, false, false, autoCreated, maxConsumers, purgeOnNoConsumers, as.isDefaultExclusiveQueue(), as.isDefaultLastValueQueue(), as.getDefaultConsumersBeforeDispatch(), as.getDefaultDelayBeforeDispatch(), autoCreateAddress);
+      return createQueue(addressInfo, queueName, filter, user, durable, temporary, false, false, autoCreated, maxConsumers, purgeOnNoConsumers, as.isDefaultExclusiveQueue(), as.isDefaultLastValueQueue(), as.getDefaultLastValueKey(), as.isDefaultNonDestructive(), as.getDefaultConsumersBeforeDispatch(), as.getDefaultDelayBeforeDispatch(), autoCreateAddress);
    }
 
    @Override
    public Queue createQueue(AddressInfo addressInfo, SimpleString queueName, SimpleString filter, SimpleString user, boolean durable, boolean temporary, boolean autoCreated, Integer maxConsumers, Boolean purgeOnNoConsumers, Boolean exclusive, Boolean lastValue, boolean autoCreateAddress) throws Exception {
       AddressSettings as = getAddressSettingsRepository().getMatch(addressInfo == null ? queueName.toString() : addressInfo.getName().toString());
-      return createQueue(addressInfo, queueName, filter, user, durable, temporary, false, false, autoCreated, maxConsumers, purgeOnNoConsumers, exclusive, lastValue, as.getDefaultConsumersBeforeDispatch(), as.getDefaultDelayBeforeDispatch(), autoCreateAddress);
+      return createQueue(addressInfo, queueName, filter, user, durable, temporary, false, false, autoCreated, maxConsumers, purgeOnNoConsumers, exclusive, lastValue, as.getDefaultLastValueKey(), as.isDefaultNonDestructive(), as.getDefaultConsumersBeforeDispatch(), as.getDefaultDelayBeforeDispatch(), autoCreateAddress);
    }
 
    @Override
-   public Queue createQueue(AddressInfo addressInfo, SimpleString queueName, SimpleString filter, SimpleString user, boolean durable, boolean temporary, boolean autoCreated, Integer maxConsumers, Boolean purgeOnNoConsumers, Boolean exclusive, Boolean lastValue, Integer consumersBeforeDispatch, Long delayBeforeDispatch, boolean autoCreateAddress) throws Exception {
-      return createQueue(addressInfo, queueName, filter, user, durable, temporary, false, false, autoCreated, maxConsumers, purgeOnNoConsumers, exclusive, lastValue, consumersBeforeDispatch, delayBeforeDispatch, autoCreateAddress);
+   public Queue createQueue(AddressInfo addressInfo, SimpleString queueName, SimpleString filter, SimpleString user, boolean durable, boolean temporary, boolean autoCreated, Integer maxConsumers, Boolean purgeOnNoConsumers, Boolean exclusive, Boolean lastValue, SimpleString lastValueKey, Boolean nonDestructive, Integer consumersBeforeDispatch, Long delayBeforeDispatch, boolean autoCreateAddress) throws Exception {
+      return createQueue(addressInfo, queueName, filter, user, durable, temporary, false, false, autoCreated, maxConsumers, purgeOnNoConsumers, exclusive, lastValue, lastValueKey, nonDestructive, consumersBeforeDispatch, delayBeforeDispatch, autoCreateAddress);
    }
 
 
@@ -1747,7 +1757,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
                      SimpleString user, boolean durable, boolean temporary, boolean ignoreIfExists, boolean transientQueue,
                      boolean autoCreated, int maxConsumers, boolean purgeOnNoConsumers, boolean autoCreateAddress) throws Exception {
       AddressSettings as = getAddressSettingsRepository().getMatch(address == null ? queueName.toString() : address.toString());
-      return createQueue(address, routingType, queueName, filter, user, durable, temporary, ignoreIfExists, transientQueue, autoCreated, maxConsumers, purgeOnNoConsumers, as.isDefaultExclusiveQueue(), as.isDefaultLastValueQueue(), as.getDefaultConsumersBeforeDispatch(), as.getDefaultDelayBeforeDispatch(), autoCreateAddress);
+      return createQueue(address, routingType, queueName, filter, user, durable, temporary, ignoreIfExists, transientQueue, autoCreated, maxConsumers, purgeOnNoConsumers, as.isDefaultExclusiveQueue(), as.isDefaultLastValueQueue(), as.getDefaultLastValueKey(), as.isDefaultNonDestructive(), as.getDefaultConsumersBeforeDispatch(), as.getDefaultDelayBeforeDispatch(), autoCreateAddress);
    }
 
    @Override
@@ -1755,7 +1765,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
                             SimpleString user, boolean durable, boolean temporary, boolean ignoreIfExists, boolean transientQueue,
                             boolean autoCreated, int maxConsumers, boolean purgeOnNoConsumers, boolean exclusive, boolean lastValue, boolean autoCreateAddress) throws Exception {
       AddressSettings as = getAddressSettingsRepository().getMatch(address == null ? queueName.toString() : address.toString());
-      return createQueue(address, routingType, queueName, filter, user, durable, temporary, ignoreIfExists, transientQueue, autoCreated, maxConsumers, purgeOnNoConsumers, exclusive, lastValue, as.getDefaultConsumersBeforeDispatch(), as.getDefaultDelayBeforeDispatch(), autoCreateAddress);
+      return createQueue(address, routingType, queueName, filter, user, durable, temporary, ignoreIfExists, transientQueue, autoCreated, maxConsumers, purgeOnNoConsumers, exclusive, lastValue, as.getDefaultLastValueKey(), as.isDefaultNonDestructive(), as.getDefaultConsumersBeforeDispatch(), as.getDefaultDelayBeforeDispatch(), autoCreateAddress);
    }
 
 
@@ -1792,7 +1802,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
                                  boolean exclusive,
                                  boolean lastValue) throws Exception {
       AddressSettings as = getAddressSettingsRepository().getMatch(address == null ? name.toString() : address.toString());
-      createSharedQueue(address, routingType, name, filterString, user, durable, maxConsumers, purgeOnNoConsumers, exclusive, lastValue, as.getDefaultConsumersBeforeDispatch(), as.getDefaultDelayBeforeDispatch());
+      createSharedQueue(address, routingType, name, filterString, user, durable, maxConsumers, purgeOnNoConsumers, exclusive, lastValue, as.getDefaultLastValueKey(), as.isDefaultNonDestructive(), as.getDefaultConsumersBeforeDispatch(), as.getDefaultDelayBeforeDispatch());
    }
 
    @Override
@@ -1806,6 +1816,8 @@ public class ActiveMQServerImpl implements ActiveMQServer {
                                  boolean purgeOnNoConsumers,
                                  boolean exclusive,
                                  boolean lastValue,
+                                 SimpleString lastValueKey,
+                                 boolean nonDestructive,
                                  int consumersBeforeDispatch,
                                  long delayBeforeDispatch) throws Exception {
       //force the old contract about address
@@ -1821,7 +1833,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
          }
       }
 
-      final Queue queue = createQueue(address, routingType, name, filterString, user, durable, !durable, true, !durable, false, maxConsumers, purgeOnNoConsumers, exclusive, lastValue, consumersBeforeDispatch, delayBeforeDispatch, true);
+      final Queue queue = createQueue(address, routingType, name, filterString, user, durable, !durable, true, !durable, false, maxConsumers, purgeOnNoConsumers, exclusive, lastValue, lastValueKey, nonDestructive, consumersBeforeDispatch, delayBeforeDispatch, true);
 
       if (!queue.getAddress().equals(address)) {
          throw ActiveMQMessageBundle.BUNDLE.queueSubscriptionBelongsToDifferentAddress(name);
@@ -2796,15 +2808,17 @@ public class ActiveMQServerImpl implements ActiveMQServer {
             int maxConsumers = config.getMaxConsumers() == null ? as.getDefaultMaxConsumers() : config.getMaxConsumers();
             boolean isExclusive = config.isExclusive() == null ? as.isDefaultExclusiveQueue() : config.isExclusive();
             boolean isLastValue = config.isLastValue() == null ? as.isDefaultLastValueQueue() : config.isLastValue();
+            SimpleString lastValueKey = config.getLastValueKey() == null ? as.getDefaultLastValueKey() : SimpleString.toSimpleString(config.getLastValueKey());
+            boolean isNonDestructive = config.isNonDestructive() == null ? as.isDefaultNonDestructive() : config.isNonDestructive();
             int consumersBeforeDispatch = config.getConsumersBeforeDispatch() == null ? as.getDefaultConsumersBeforeDispatch() : config.getConsumersBeforeDispatch();
             long delayBeforeDispatch = config.getDelayBeforeDispatch() == null ? as.getDefaultDelayBeforeDispatch() : config.getDelayBeforeDispatch();
 
             if (locateQueue(queueName) != null && locateQueue(queueName).getAddress().toString().equals(config.getAddress())) {
-               updateQueue(config.getName(), config.getRoutingType(), config.getFilterString(), maxConsumers, config.getPurgeOnNoConsumers(), isExclusive, consumersBeforeDispatch, delayBeforeDispatch, config.getUser());
+               updateQueue(config.getName(), config.getRoutingType(), config.getFilterString(), maxConsumers, config.getPurgeOnNoConsumers(), isExclusive, isNonDestructive, consumersBeforeDispatch, delayBeforeDispatch, config.getUser(), true);
             } else {
                // if the address::queue doesn't exist then create it
                try {
-                  createQueue(SimpleString.toSimpleString(config.getAddress()), config.getRoutingType(), queueName, SimpleString.toSimpleString(config.getFilterString()), SimpleString.toSimpleString(config.getUser()), config.isDurable(), false, false, false, false, maxConsumers, config.getPurgeOnNoConsumers(), isExclusive, isLastValue, consumersBeforeDispatch, delayBeforeDispatch, true, true);
+                  createQueue(SimpleString.toSimpleString(config.getAddress()), config.getRoutingType(), queueName, SimpleString.toSimpleString(config.getFilterString()), SimpleString.toSimpleString(config.getUser()), config.isDurable(), false, false, false, false, maxConsumers, config.getPurgeOnNoConsumers(), isExclusive, isLastValue, lastValueKey, isNonDestructive, consumersBeforeDispatch, delayBeforeDispatch, true, true);
                } catch (ActiveMQQueueExistsException e) {
                   // the queue may exist on a *different* address
                   ActiveMQServerLogger.LOGGER.warn(e.getMessage());
@@ -2996,6 +3010,8 @@ public class ActiveMQServerImpl implements ActiveMQServer {
                             final boolean purgeOnNoConsumers,
                             final boolean exclusive,
                             final boolean lastValue,
+                            final SimpleString lastValueKey,
+                            final boolean nonDestructive,
                             final int consumersBeforeDispatch,
                             final long delayBeforeDispatch,
                             final boolean autoCreateAddress) throws Exception {
@@ -3052,6 +3068,8 @@ public class ActiveMQServerImpl implements ActiveMQServer {
               .purgeOnNoConsumers(purgeOnNoConsumers)
               .exclusive(exclusive)
               .lastValue(lastValue)
+              .lastValueKey(lastValueKey)
+              .nonDestructive(nonDestructive)
               .consumersBeforeDispatch(consumersBeforeDispatch)
               .delayBeforeDispatch(delayBeforeDispatch)
               .build();
@@ -3126,10 +3144,12 @@ public class ActiveMQServerImpl implements ActiveMQServer {
                             final boolean purgeOnNoConsumers,
                             final boolean exclusive,
                             final boolean lastValue,
+                            final SimpleString lastValueKey,
+                            final boolean nonDestructive,
                             final int consumersBeforeDispatch,
                             final long delayBeforeDispatch,
                             final boolean autoCreateAddress) throws Exception {
-      return createQueue(address, routingType, queueName, filterString, user, durable, temporary, ignoreIfExists, transientQueue, autoCreated, maxConsumers, purgeOnNoConsumers, exclusive, lastValue, consumersBeforeDispatch, delayBeforeDispatch, autoCreateAddress, false);
+      return createQueue(address, routingType, queueName, filterString, user, durable, temporary, ignoreIfExists, transientQueue, autoCreated, maxConsumers, purgeOnNoConsumers, exclusive, lastValue, lastValueKey, nonDestructive, consumersBeforeDispatch, delayBeforeDispatch, autoCreateAddress, false);
    }
 
    private Queue createQueue(final SimpleString address,
@@ -3146,6 +3166,8 @@ public class ActiveMQServerImpl implements ActiveMQServer {
                             final boolean purgeOnNoConsumers,
                             final boolean exclusive,
                             final boolean lastValue,
+                            final SimpleString lastValueKey,
+                            final boolean nonDestructive,
                             final int consumersBeforeDispatch,
                             final long delayBeforeDispatch,
                             final boolean autoCreateAddress,
@@ -3201,6 +3223,8 @@ public class ActiveMQServerImpl implements ActiveMQServer {
               .purgeOnNoConsumers(purgeOnNoConsumers)
               .exclusive(exclusive)
               .lastValue(lastValue)
+              .lastValueKey(lastValueKey)
+              .nonDestructive(nonDestructive)
               .consumersBeforeDispatch(consumersBeforeDispatch)
               .delayBeforeDispatch(delayBeforeDispatch)
               .configurationManaged(configurationManaged)
@@ -3286,7 +3310,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
                             Boolean purgeOnNoConsumers,
                             Boolean exclusive,
                             String user) throws Exception {
-      return updateQueue(name, routingType, null, maxConsumers, purgeOnNoConsumers, exclusive, null, null, user);
+      return updateQueue(name, routingType, null, maxConsumers, purgeOnNoConsumers, exclusive, null, null, null, user);
    }
 
    @Override
@@ -3296,10 +3320,11 @@ public class ActiveMQServerImpl implements ActiveMQServer {
                             Integer maxConsumers,
                             Boolean purgeOnNoConsumers,
                             Boolean exclusive,
+                            Boolean nonDestructive,
                             Integer consumersBeforeDispatch,
                             Long delayBeforeDispatch,
                             String user) throws Exception {
-      return updateQueue(name, routingType, filterString, maxConsumers, purgeOnNoConsumers, exclusive, consumersBeforeDispatch, delayBeforeDispatch, user, null);
+      return updateQueue(name, routingType, filterString, maxConsumers, purgeOnNoConsumers, exclusive, nonDestructive, consumersBeforeDispatch, delayBeforeDispatch, user, null);
    }
 
    private Queue updateQueue(String name,
@@ -3308,12 +3333,13 @@ public class ActiveMQServerImpl implements ActiveMQServer {
                             Integer maxConsumers,
                             Boolean purgeOnNoConsumers,
                             Boolean exclusive,
+                            Boolean nonDestructive,
                             Integer consumersBeforeDispatch,
                             Long delayBeforeDispatch,
                             String user,
                             Boolean configurationManaged) throws Exception {
       final Filter filter = FilterImpl.createFilter(filterString);
-      final QueueBinding queueBinding = this.postOffice.updateQueue(new SimpleString(name), routingType, filter, maxConsumers, purgeOnNoConsumers, exclusive, consumersBeforeDispatch, delayBeforeDispatch, SimpleString.toSimpleString(user), configurationManaged);
+      final QueueBinding queueBinding = this.postOffice.updateQueue(new SimpleString(name), routingType, filter, maxConsumers, purgeOnNoConsumers, exclusive, nonDestructive, consumersBeforeDispatch, delayBeforeDispatch, SimpleString.toSimpleString(user), configurationManaged);
       if (queueBinding != null) {
          final Queue queue = queueBinding.getQueue();
          return queue;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/MessageReferenceImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/MessageReferenceImpl.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.Message;
+import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.server.MessageReference;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.server.ServerConsumer;
@@ -230,6 +231,15 @@ public class MessageReferenceImpl extends LinkedListImpl.Node<MessageReferenceIm
          throw new IllegalStateException("consumerID isn't specified: please check hasConsumerId first");
       }
       return this.consumerID;
+   }
+
+   @Override
+   public SimpleString getLastValueProperty() {
+      SimpleString lastValue = message.getSimpleStringProperty(queue.getLastValueKey());
+      if (lastValue == null) {
+         lastValue = message.getLastValueProperty();
+      }
+      return lastValue;
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/PostOfficeJournalLoader.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/PostOfficeJournalLoader.java
@@ -153,6 +153,8 @@ public class PostOfficeJournalLoader implements JournalLoader {
             .maxConsumers(queueBindingInfo.getMaxConsumers())
             .exclusive(queueBindingInfo.isExclusive())
             .lastValue(queueBindingInfo.isLastValue())
+            .lastValueKey(queueBindingInfo.getLastValueKey())
+            .nonDestructive(queueBindingInfo.isNonDestructive())
             .consumersBeforeDispatch(queueBindingInfo.getConsumersBeforeDispatch())
             .delayBeforeDispatch(queueBindingInfo.getDelayBeforeDispatch())
             .routingType(RoutingType.getType(queueBindingInfo.getRoutingType()))

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
@@ -198,6 +198,8 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
 
    private AtomicLong messagesKilled = new AtomicLong(0);
 
+   private AtomicLong messagesReplaced = new AtomicLong(0);
+
    private boolean paused;
 
    private long pauseStatusRecord = -1;
@@ -285,6 +287,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
 
    private volatile boolean configurationManaged;
 
+   private volatile boolean nonDestructive;
 
    /**
     * This is to avoid multi-thread races on calculating direct delivery,
@@ -353,110 +356,111 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
    }
 
    public QueueImpl(final long id,
-                    final SimpleString address,
-                    final SimpleString name,
-                    final Filter filter,
-                    final SimpleString user,
-                    final boolean durable,
-                    final boolean temporary,
-                    final boolean autoCreated,
-                    final ScheduledExecutorService scheduledExecutor,
-                    final PostOffice postOffice,
-                    final StorageManager storageManager,
-                    final HierarchicalRepository<AddressSettings> addressSettingsRepository,
-                    final ArtemisExecutor executor,
-                    final ActiveMQServer server,
-                    final QueueFactory factory) {
+                     final SimpleString address,
+                     final SimpleString name,
+                     final Filter filter,
+                     final SimpleString user,
+                     final boolean durable,
+                     final boolean temporary,
+                     final boolean autoCreated,
+                     final ScheduledExecutorService scheduledExecutor,
+                     final PostOffice postOffice,
+                     final StorageManager storageManager,
+                     final HierarchicalRepository<AddressSettings> addressSettingsRepository,
+                     final ArtemisExecutor executor,
+                     final ActiveMQServer server,
+                     final QueueFactory factory) {
       this(id, address, name, filter, null, user, durable, temporary, autoCreated, scheduledExecutor, postOffice, storageManager, addressSettingsRepository, executor, server, factory);
    }
 
    public QueueImpl(final long id,
-                    final SimpleString address,
-                    final SimpleString name,
-                    final Filter filter,
-                    final PageSubscription pageSubscription,
-                    final SimpleString user,
-                    final boolean durable,
-                    final boolean temporary,
-                    final boolean autoCreated,
-                    final ScheduledExecutorService scheduledExecutor,
-                    final PostOffice postOffice,
-                    final StorageManager storageManager,
-                    final HierarchicalRepository<AddressSettings> addressSettingsRepository,
-                    final ArtemisExecutor executor,
-                    final ActiveMQServer server,
-                    final QueueFactory factory) {
+                     final SimpleString address,
+                     final SimpleString name,
+                     final Filter filter,
+                     final PageSubscription pageSubscription,
+                     final SimpleString user,
+                     final boolean durable,
+                     final boolean temporary,
+                     final boolean autoCreated,
+                     final ScheduledExecutorService scheduledExecutor,
+                     final PostOffice postOffice,
+                     final StorageManager storageManager,
+                     final HierarchicalRepository<AddressSettings> addressSettingsRepository,
+                     final ArtemisExecutor executor,
+                     final ActiveMQServer server,
+                     final QueueFactory factory) {
       this(id, address, name, filter, pageSubscription, user, durable, temporary, autoCreated, RoutingType.MULTICAST, null, null, scheduledExecutor, postOffice, storageManager, addressSettingsRepository, executor, server, factory);
    }
 
    public QueueImpl(final long id,
-                    final SimpleString address,
-                    final SimpleString name,
-                    final Filter filter,
-                    final PageSubscription pageSubscription,
-                    final SimpleString user,
-                    final boolean durable,
-                    final boolean temporary,
-                    final boolean autoCreated,
-                    final RoutingType routingType,
-                    final Integer maxConsumers,
-                    final Boolean purgeOnNoConsumers,
-                    final ScheduledExecutorService scheduledExecutor,
-                    final PostOffice postOffice,
-                    final StorageManager storageManager,
-                    final HierarchicalRepository<AddressSettings> addressSettingsRepository,
-                    final ArtemisExecutor executor,
-                    final ActiveMQServer server,
-                    final QueueFactory factory) {
+                     final SimpleString address,
+                     final SimpleString name,
+                     final Filter filter,
+                     final PageSubscription pageSubscription,
+                     final SimpleString user,
+                     final boolean durable,
+                     final boolean temporary,
+                     final boolean autoCreated,
+                     final RoutingType routingType,
+                     final Integer maxConsumers,
+                     final Boolean purgeOnNoConsumers,
+                     final ScheduledExecutorService scheduledExecutor,
+                     final PostOffice postOffice,
+                     final StorageManager storageManager,
+                     final HierarchicalRepository<AddressSettings> addressSettingsRepository,
+                     final ArtemisExecutor executor,
+                     final ActiveMQServer server,
+                     final QueueFactory factory) {
       this(id, address, name, filter, pageSubscription, user, durable, temporary, autoCreated, routingType, maxConsumers, null, purgeOnNoConsumers, scheduledExecutor, postOffice, storageManager, addressSettingsRepository, executor, server, factory);
    }
 
    public QueueImpl(final long id,
-                    final SimpleString address,
-                    final SimpleString name,
-                    final Filter filter,
-                    final PageSubscription pageSubscription,
-                    final SimpleString user,
-                    final boolean durable,
-                    final boolean temporary,
-                    final boolean autoCreated,
-                    final RoutingType routingType,
-                    final Integer maxConsumers,
-                    final Boolean exclusive,
-                    final Boolean purgeOnNoConsumers,
-                    final ScheduledExecutorService scheduledExecutor,
-                    final PostOffice postOffice,
-                    final StorageManager storageManager,
-                    final HierarchicalRepository<AddressSettings> addressSettingsRepository,
-                    final ArtemisExecutor executor,
-                    final ActiveMQServer server,
-                    final QueueFactory factory) {
-      this(id, address, name, filter, pageSubscription, user, durable, temporary, autoCreated, routingType, maxConsumers, exclusive, null, null, purgeOnNoConsumers, false, scheduledExecutor, postOffice, storageManager, addressSettingsRepository, executor, server, factory);
+                     final SimpleString address,
+                     final SimpleString name,
+                     final Filter filter,
+                     final PageSubscription pageSubscription,
+                     final SimpleString user,
+                     final boolean durable,
+                     final boolean temporary,
+                     final boolean autoCreated,
+                     final RoutingType routingType,
+                     final Integer maxConsumers,
+                     final Boolean exclusive,
+                     final Boolean purgeOnNoConsumers,
+                     final ScheduledExecutorService scheduledExecutor,
+                     final PostOffice postOffice,
+                     final StorageManager storageManager,
+                     final HierarchicalRepository<AddressSettings> addressSettingsRepository,
+                     final ArtemisExecutor executor,
+                     final ActiveMQServer server,
+                     final QueueFactory factory) {
+      this(id, address, name, filter, pageSubscription, user, durable, temporary, autoCreated, routingType, maxConsumers, exclusive, false, null, null, purgeOnNoConsumers, false, scheduledExecutor, postOffice, storageManager, addressSettingsRepository, executor, server, factory);
    }
 
    public QueueImpl(final long id,
-                    final SimpleString address,
-                    final SimpleString name,
-                    final Filter filter,
-                    final PageSubscription pageSubscription,
-                    final SimpleString user,
-                    final boolean durable,
-                    final boolean temporary,
-                    final boolean autoCreated,
-                    final RoutingType routingType,
-                    final Integer maxConsumers,
-                    final Boolean exclusive,
-                    final Integer consumersBeforeDispatch,
-                    final Long delayBeforeDispatch,
-                    final Boolean purgeOnNoConsumers,
-                    final boolean configurationManaged,
-                    final ScheduledExecutorService scheduledExecutor,
-                    final PostOffice postOffice,
-                    final StorageManager storageManager,
-                    final HierarchicalRepository<AddressSettings> addressSettingsRepository,
-                    final ArtemisExecutor executor,
-                    final ActiveMQServer server,
-                    final QueueFactory factory) {
+                     final SimpleString address,
+                     final SimpleString name,
+                     final Filter filter,
+                     final PageSubscription pageSubscription,
+                     final SimpleString user,
+                     final boolean durable,
+                     final boolean temporary,
+                     final boolean autoCreated,
+                     final RoutingType routingType,
+                     final Integer maxConsumers,
+                     final Boolean exclusive,
+                     final Boolean nonDestructive,
+                     final Integer consumersBeforeDispatch,
+                     final Long delayBeforeDispatch,
+                     final Boolean purgeOnNoConsumers,
+                     final boolean configurationManaged,
+                     final ScheduledExecutorService scheduledExecutor,
+                     final PostOffice postOffice,
+                     final StorageManager storageManager,
+                     final HierarchicalRepository<AddressSettings> addressSettingsRepository,
+                     final ArtemisExecutor executor,
+                     final ActiveMQServer server,
+                     final QueueFactory factory) {
       super(server == null ? EmptyCriticalAnalyzer.getInstance() : server.getCriticalAnalyzer(), CRITICAL_PATHS);
 
       this.id = id;
@@ -482,6 +486,8 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
       this.maxConsumers = maxConsumers == null ? ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers() : maxConsumers;
 
       this.exclusive = exclusive == null ? ActiveMQDefaultConfiguration.getDefaultExclusive() : exclusive;
+
+      this.nonDestructive = nonDestructive == null ? ActiveMQDefaultConfiguration.getDefaultNonDestructive() : nonDestructive;
 
       this.purgeOnNoConsumers = purgeOnNoConsumers == null ? ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers() : purgeOnNoConsumers;
 
@@ -599,6 +605,21 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
    @Override
    public boolean isLastValue() {
       return false;
+   }
+
+   @Override
+   public SimpleString getLastValueKey() {
+      return null;
+   }
+
+   @Override
+   public boolean isNonDestructive() {
+      return nonDestructive;
+   }
+
+   @Override
+   public synchronized void setNonDestructive(boolean nonDestructive) {
+      this.nonDestructive = nonDestructive;
    }
 
    @Override
@@ -1383,30 +1404,38 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
 
    @Override
    public void acknowledge(final MessageReference ref, final AckReason reason, final ServerConsumer consumer) throws Exception {
-      if (ref.isPaged()) {
-         pageSubscription.ack((PagedReference) ref);
-         postAcknowledge(ref);
-      } else {
-         Message message = ref.getMessage();
-
-         boolean durableRef = message.isDurable() && isDurableMessage();
-
-         if (durableRef) {
-            storageManager.storeAcknowledge(id, message.getMessageID());
+      if (nonDestructive && reason == AckReason.NORMAL) {
+         if (logger.isDebugEnabled()) {
+            logger.debug("acknowledge ignored nonDestructive=true and reason=NORMAL");
          }
-         postAcknowledge(ref);
-      }
-
-      if (reason == AckReason.EXPIRED) {
-         messagesExpired.incrementAndGet();
-      } else if (reason == AckReason.KILLED) {
-         messagesKilled.incrementAndGet();
       } else {
-         messagesAcknowledged.incrementAndGet();
-      }
+         if (ref.isPaged()) {
+            pageSubscription.ack((PagedReference) ref);
+            postAcknowledge(ref);
+         } else {
+            Message message = ref.getMessage();
 
-      if (server != null && server.hasBrokerMessagePlugins()) {
-         server.callBrokerMessagePlugins(plugin -> plugin.messageAcknowledged(ref, reason, consumer));
+            boolean durableRef = message.isDurable() && isDurableMessage();
+
+            if (durableRef) {
+               storageManager.storeAcknowledge(id, message.getMessageID());
+            }
+            postAcknowledge(ref);
+         }
+
+         if (reason == AckReason.EXPIRED) {
+            messagesExpired.incrementAndGet();
+         } else if (reason == AckReason.KILLED) {
+            messagesKilled.incrementAndGet();
+         } else if (reason == AckReason.REPLACED) {
+            messagesReplaced.incrementAndGet();
+         } else {
+            messagesAcknowledged.incrementAndGet();
+         }
+
+         if (server != null && server.hasBrokerMessagePlugins()) {
+            server.callBrokerMessagePlugins(plugin -> plugin.messageAcknowledged(ref, reason, consumer));
+         }
       }
    }
 
@@ -1641,7 +1670,11 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
 
    @Override
    public synchronized int deleteMatchingReferences(final int flushLimit, final Filter filter1, AckReason ackReason) throws Exception {
-      return iterQueue(flushLimit, filter1, new QueueIterateAction() {
+      return iterQueue(flushLimit, filter1, createDeleteMatchingAction(ackReason));
+   }
+
+   QueueIterateAction createDeleteMatchingAction(AckReason ackReason) {
+      return new QueueIterateAction() {
          @Override
          public void actMessage(Transaction tx, MessageReference ref) throws Exception {
             actMessage(tx, ref, true);
@@ -1655,7 +1688,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
                refRemoved(ref);
             }
          }
-      });
+      };
    }
 
    /**
@@ -1930,7 +1963,9 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
             if (queueDestroyed) {
                return;
             }
-            logger.debug("Scanning for expires on " + QueueImpl.this.getName());
+            if (logger.isDebugEnabled()) {
+               logger.debug("Scanning for expires on " + QueueImpl.this.getName());
+            }
 
             LinkedListIterator<MessageReference> iter = iterator();
 
@@ -2448,9 +2483,9 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
                   if (logger.isTraceEnabled()) {
                      logger.trace("Reference " + ref + " being expired");
                   }
-                  holder.iter.remove();
+                  removeMessageReference(holder, ref);
 
-                  refRemoved(ref);
+
 
                   handled++;
 
@@ -2485,9 +2520,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
 
                   handledconsumer = consumer;
 
-                  holder.iter.remove();
-
-                  refRemoved(ref);
+                  removeMessageReference(holder, ref);
 
                   if (groupID != null && groupConsumer == null) {
                      groups.put(groupID, consumer);
@@ -2552,6 +2585,13 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
       }
 
       checkDepage();
+   }
+
+   protected void removeMessageReference(ConsumerHolder<? extends Consumer> holder, MessageReference ref) {
+      if (!nonDestructive) {
+         holder.iter.remove();
+         refRemoved(ref);
+      }
    }
 
    private void checkDepage() {
@@ -3312,7 +3352,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
    // Inner classes
    // --------------------------------------------------------------------------
 
-   private static class ConsumerHolder<T extends  Consumer> {
+   protected static class ConsumerHolder<T extends  Consumer> {
 
       ConsumerHolder(final T consumer) {
          this.consumer = consumer;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -559,7 +559,7 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
    @Override
    public Queue createQueue(AddressInfo addressInfo, SimpleString name, SimpleString filterString, boolean temporary, boolean durable) throws Exception {
       AddressSettings as = server.getAddressSettingsRepository().getMatch(addressInfo.getName().toString());
-      return createQueue(addressInfo, name, filterString, temporary, durable, as.getDefaultMaxConsumers(), as.isDefaultPurgeOnNoConsumers(), as.isDefaultExclusiveQueue(), as.isDefaultLastValueQueue(), false);
+      return createQueue(addressInfo, name, filterString, temporary, durable, as.getDefaultMaxConsumers(), as.isDefaultPurgeOnNoConsumers(), as.isDefaultExclusiveQueue(), as.isDefaultLastValueQueue(), as.getDefaultLastValueKey(), as.isDefaultNonDestructive(), as.getDefaultConsumersBeforeDispatch(), as.getDefaultDelayBeforeDispatch(), false);
    }
 
    public Queue createQueue(final AddressInfo addressInfo,
@@ -571,6 +571,10 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
                             final boolean purgeOnNoConsumers,
                             final boolean exclusive,
                             final boolean lastValue,
+                            SimpleString lastValueKey,
+                            final boolean nonDestructive,
+                            final int consumersBeforeDispatch,
+                            final long delayBeforeDispatch,
                             final boolean autoCreated) throws Exception {
       final SimpleString unPrefixedName = removePrefix(name);
 
@@ -591,7 +595,7 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
 
       server.checkQueueCreationLimit(getUsername());
 
-      Queue queue = server.createQueue(art, unPrefixedName, filterString, SimpleString.toSimpleString(getUsername()), durable, temporary, autoCreated, maxConsumers, purgeOnNoConsumers, exclusive, lastValue, as.isAutoCreateAddresses());
+      Queue queue = server.createQueue(art, unPrefixedName, filterString, SimpleString.toSimpleString(getUsername()), durable, temporary, autoCreated, maxConsumers, purgeOnNoConsumers, exclusive, lastValue, lastValueKey, nonDestructive, consumersBeforeDispatch, delayBeforeDispatch, as.isAutoCreateAddresses());
 
       if (temporary) {
          // Temporary queue in core simply means the queue will be deleted if
@@ -631,7 +635,7 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
                             final boolean purgeOnNoConsumers,
                             final boolean autoCreated) throws Exception {
       AddressSettings as = server.getAddressSettingsRepository().getMatch(address.toString());
-      return createQueue(new AddressInfo(address, routingType), name, filterString, temporary, durable, maxConsumers, purgeOnNoConsumers, as.isDefaultExclusiveQueue(), as.isDefaultLastValueQueue(), autoCreated);
+      return createQueue(new AddressInfo(address, routingType), name, filterString, temporary, durable, maxConsumers, purgeOnNoConsumers, as.isDefaultExclusiveQueue(), as.isDefaultLastValueQueue(), as.getDefaultLastValueKey(), as.isDefaultNonDestructive(), as.getDefaultConsumersBeforeDispatch(), as.getDefaultDelayBeforeDispatch(), autoCreated);
    }
 
    @Override
@@ -646,13 +650,38 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
                             final Boolean exclusive,
                             final Boolean lastValue,
                             final boolean autoCreated) throws Exception {
-      if (exclusive == null || lastValue == null) {
+      return createQueue(address, name, routingType, filterString, temporary, durable, maxConsumers, purgeOnNoConsumers, exclusive, lastValue, null, null, null, null, autoCreated);
+   }
+
+   @Override
+   public Queue createQueue(final SimpleString address,
+                            final SimpleString name,
+                            final RoutingType routingType,
+                            final SimpleString filterString,
+                            final boolean temporary,
+                            final boolean durable,
+                            final int maxConsumers,
+                            final boolean purgeOnNoConsumers,
+                            final Boolean exclusive,
+                            final Boolean lastValue,
+                            final SimpleString lastValueKey,
+                            final Boolean nonDestructive,
+                            final Integer consumersBeforeDispatch,
+                            final Long delayBeforeDispatch,
+                            final boolean autoCreated) throws Exception {
+      if (exclusive == null || lastValue == null || lastValueKey == null || nonDestructive == null || consumersBeforeDispatch == null || delayBeforeDispatch == null) {
          AddressSettings as = server.getAddressSettingsRepository().getMatch(address.toString());
          return createQueue(new AddressInfo(address, routingType), name, filterString, temporary, durable, maxConsumers, purgeOnNoConsumers,
-                            exclusive == null ? as.isDefaultExclusiveQueue() : exclusive, lastValue == null ? as.isDefaultLastValueQueue() : lastValue, autoCreated);
+                 exclusive == null ? as.isDefaultExclusiveQueue() : exclusive,
+                 lastValue == null ? as.isDefaultLastValueQueue() : lastValue,
+                 lastValueKey == null ? as.getDefaultLastValueKey() : lastValueKey,
+                 nonDestructive == null ? as.isDefaultNonDestructive() : nonDestructive,
+                 consumersBeforeDispatch == null ? as.getDefaultConsumersBeforeDispatch() : consumersBeforeDispatch,
+                 delayBeforeDispatch == null ? as.getDefaultDelayBeforeDispatch() : delayBeforeDispatch,
+                 autoCreated);
       } else {
          return createQueue(new AddressInfo(address, routingType), name, filterString, temporary, durable, maxConsumers, purgeOnNoConsumers,
-                            exclusive, lastValue, autoCreated);
+                 exclusive, lastValue, lastValueKey, nonDestructive, consumersBeforeDispatch, delayBeforeDispatch, autoCreated);
       }
    }
 
@@ -671,14 +700,14 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
    @Override
    public Queue createQueue(AddressInfo addressInfo, SimpleString name, SimpleString filterString, boolean temporary, boolean durable, boolean autoCreated) throws Exception {
       AddressSettings as = server.getAddressSettingsRepository().getMatch(addressInfo.getName().toString());
-      return createQueue(addressInfo, name, filterString, temporary, durable, as.getDefaultMaxConsumers(), as.isDefaultPurgeOnNoConsumers(), as.isDefaultExclusiveQueue(), as.isDefaultLastValueQueue(), autoCreated);
+      return createQueue(addressInfo, name, filterString, temporary, durable, as.getDefaultMaxConsumers(), as.isDefaultPurgeOnNoConsumers(), as.isDefaultExclusiveQueue(), as.isDefaultLastValueQueue(), as.getDefaultLastValueKey(), as.isDefaultNonDestructive(), as.getDefaultConsumersBeforeDispatch(), as.getDefaultDelayBeforeDispatch(), autoCreated);
    }
 
    @Override
    public Queue createQueue(AddressInfo addressInfo, SimpleString name, SimpleString filterString, boolean temporary, boolean durable, Boolean exclusive, Boolean lastValue, boolean autoCreated) throws Exception {
       AddressSettings as = server.getAddressSettingsRepository().getMatch(addressInfo.getName().toString());
       return createQueue(addressInfo, name, filterString, temporary, durable, as.getDefaultMaxConsumers(), as.isDefaultPurgeOnNoConsumers(),
-                         exclusive == null ? as.isDefaultExclusiveQueue() : exclusive, lastValue == null ? as.isDefaultLastValueQueue() : lastValue, autoCreated);
+                         exclusive == null ? as.isDefaultExclusiveQueue() : exclusive, lastValue == null ? as.isDefaultLastValueQueue() : lastValue, as.getDefaultLastValueKey(), as.isDefaultNonDestructive(), as.getDefaultConsumersBeforeDispatch(), as.getDefaultDelayBeforeDispatch(), autoCreated);
    }
 
    @Override
@@ -716,6 +745,23 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
                                  Boolean purgeOnNoConsumers,
                                  Boolean exclusive,
                                  Boolean lastValue) throws Exception {
+      createSharedQueue(address, name, routingType, filterString, durable, maxConsumers, purgeOnNoConsumers, exclusive, lastValue, null, null, null, null);
+   }
+
+   @Override
+   public void createSharedQueue(SimpleString address,
+                                 SimpleString name,
+                                 RoutingType routingType,
+                                 SimpleString filterString,
+                                 boolean durable,
+                                 Integer maxConsumers,
+                                 Boolean purgeOnNoConsumers,
+                                 Boolean exclusive,
+                                 Boolean lastValue,
+                                 SimpleString lastValueKey,
+                                 Boolean nonDestructive,
+                                 Integer consumersBeforeDispatch,
+                                 Long delayBeforeDispatch) throws Exception {
       address = removePrefix(address);
 
       securityCheck(address, name, durable ? CheckType.CREATE_DURABLE_QUEUE : CheckType.CREATE_NON_DURABLE_QUEUE, this);
@@ -728,7 +774,11 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
                                maxConsumers == null ? as.getDefaultMaxConsumers() : maxConsumers,
                                purgeOnNoConsumers == null ? as.isDefaultPurgeOnNoConsumers() : purgeOnNoConsumers,
                                exclusive == null ? as.isDefaultExclusiveQueue() : exclusive,
-                               lastValue == null ? as.isDefaultLastValueQueue() : lastValue);
+                               lastValue == null ? as.isDefaultLastValueQueue() : lastValue,
+                               lastValueKey == null ? as.getDefaultLastValueKey() : lastValueKey,
+                               nonDestructive == null ? as.isDefaultNonDestructive() : nonDestructive,
+                               consumersBeforeDispatch == null ? as.getDefaultConsumersBeforeDispatch() : consumersBeforeDispatch,
+                               delayBeforeDispatch == null ? as.getDefaultDelayBeforeDispatch() : delayBeforeDispatch);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
@@ -127,6 +127,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
    private Boolean defaultLastValueQueue = null;
 
+   private SimpleString defaultLastValueKey = null;
+
+   private Boolean defaultNonDestructive = null;
+
    private Boolean defaultExclusiveQueue = null;
 
    private Long redistributionDelay = null;
@@ -200,6 +204,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       this.expiryAddress = other.expiryAddress;
       this.expiryDelay = other.expiryDelay;
       this.defaultLastValueQueue = other.defaultLastValueQueue;
+      this.defaultLastValueKey = other.defaultLastValueKey;
+      this.defaultNonDestructive = other.defaultNonDestructive;
       this.defaultExclusiveQueue = other.defaultExclusiveQueue;
       this.redistributionDelay = other.redistributionDelay;
       this.sendToDLAOnNoRoute = other.sendToDLAOnNoRoute;
@@ -389,6 +395,24 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
    public AddressSettings setDefaultLastValueQueue(final boolean defaultLastValueQueue) {
       this.defaultLastValueQueue = defaultLastValueQueue;
+      return this;
+   }
+
+   public SimpleString getDefaultLastValueKey() {
+      return defaultLastValueKey != null ? defaultLastValueKey : ActiveMQDefaultConfiguration.getDefaultLastValueKey();
+   }
+
+   public AddressSettings setDefaultLastValueKey(final SimpleString defaultLastValueKey) {
+      this.defaultLastValueKey = defaultLastValueKey;
+      return this;
+   }
+
+   public boolean isDefaultNonDestructive() {
+      return defaultNonDestructive != null ? defaultNonDestructive : ActiveMQDefaultConfiguration.getDefaultNonDestructive();
+   }
+
+   public AddressSettings setDefaultNonDestructive(final boolean defaultNonDestructive) {
+      this.defaultNonDestructive = defaultNonDestructive;
       return this;
    }
 
@@ -719,6 +743,12 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       if (defaultLastValueQueue == null) {
          defaultLastValueQueue = merged.defaultLastValueQueue;
       }
+      if (defaultLastValueKey == null) {
+         defaultLastValueKey = merged.defaultLastValueKey;
+      }
+      if (defaultNonDestructive == null) {
+         defaultNonDestructive = merged.defaultNonDestructive;
+      }
       if (defaultConsumersBeforeDispatch == null) {
          defaultConsumersBeforeDispatch = merged.defaultConsumersBeforeDispatch;
       }
@@ -848,6 +878,14 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       if (buffer.readableBytes() > 0) {
          defaultConsumerWindowSize = BufferHelper.readNullableInteger(buffer);
       }
+
+      if (buffer.readableBytes() > 0) {
+         defaultLastValueKey = buffer.readNullableSimpleString();
+      }
+
+      if (buffer.readableBytes() > 0) {
+         defaultNonDestructive = BufferHelper.readNullableBoolean(buffer);
+      }
    }
 
    @Override
@@ -889,7 +927,9 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
          BufferHelper.sizeOfNullableBoolean(defaultExclusiveQueue) +
          BufferHelper.sizeOfNullableInteger(defaultConsumersBeforeDispatch) +
          BufferHelper.sizeOfNullableLong(defaultDelayBeforeDispatch) +
-         BufferHelper.sizeOfNullableInteger(defaultConsumerWindowSize);
+         BufferHelper.sizeOfNullableInteger(defaultConsumerWindowSize) +
+         SimpleString.sizeofNullableString(defaultLastValueKey) +
+         BufferHelper.sizeOfNullableBoolean(defaultNonDestructive);
    }
 
    @Override
@@ -972,6 +1012,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
       BufferHelper.writeNullableInteger(buffer, defaultConsumerWindowSize);
 
+      buffer.writeNullableSimpleString(defaultLastValueKey);
+
+      BufferHelper.writeNullableBoolean(buffer, defaultNonDestructive);
+
    }
 
    /* (non-Javadoc)
@@ -987,6 +1031,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       result = prime * result + ((expiryAddress == null) ? 0 : expiryAddress.hashCode());
       result = prime * result + ((expiryDelay == null) ? 0 : expiryDelay.hashCode());
       result = prime * result + ((defaultLastValueQueue == null) ? 0 : defaultLastValueQueue.hashCode());
+      result = prime * result + ((defaultLastValueKey == null) ? 0 : defaultLastValueKey.hashCode());
+      result = prime * result + ((defaultNonDestructive == null) ? 0 : defaultNonDestructive.hashCode());
       result = prime * result + ((defaultExclusiveQueue == null) ? 0 : defaultExclusiveQueue.hashCode());
       result = prime * result + ((maxDeliveryAttempts == null) ? 0 : maxDeliveryAttempts.hashCode());
       result = prime * result + ((maxSizeBytes == null) ? 0 : maxSizeBytes.hashCode());
@@ -1065,6 +1111,16 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
          if (other.defaultLastValueQueue != null)
             return false;
       } else if (!defaultLastValueQueue.equals(other.defaultLastValueQueue))
+         return false;
+      if (defaultLastValueKey == null) {
+         if (other.defaultLastValueKey != null)
+            return false;
+      } else if (!defaultLastValueKey.equals(other.defaultLastValueKey))
+         return false;
+      if (defaultNonDestructive == null) {
+         if (other.defaultNonDestructive != null)
+            return false;
+      } else if (!defaultNonDestructive.equals(other.defaultNonDestructive))
          return false;
       if (defaultExclusiveQueue == null) {
          if (other.defaultExclusiveQueue != null)
@@ -1263,6 +1319,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
          expiryDelay +
          ", defaultLastValueQueue=" +
          defaultLastValueQueue +
+         ", defaultLastValueKey=" +
+         defaultLastValueKey +
+         ", defaultNonDestructive=" +
+         defaultNonDestructive +
          ", defaultExclusiveQueue=" +
          defaultExclusiveQueue +
          ", maxDeliveryAttempts=" +

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -510,6 +510,8 @@
                         <xsd:attribute name="purge-on-no-consumers" type="xsd:boolean" use="optional"/>
                         <xsd:attribute name="exclusive" type="xsd:boolean" use="optional"/>
                         <xsd:attribute name="last-value" type="xsd:boolean" use="optional"/>
+                        <xsd:attribute name="last-value-key" type="xsd:string" use="optional"/>
+                        <xsd:attribute name="non-destructive" type="xsd:boolean" use="optional"/>
                         <xsd:attribute name="consumers-before-dispatch" type="xsd:int" use="optional"/>
                         <xsd:attribute name="delay-before-dispatch" type="xsd:long" use="optional"/>
                         <xsd:attributeGroup ref="xml:specialAttrs"/>
@@ -2810,6 +2812,22 @@
                </xsd:annotation>
             </xsd:element>
 
+            <xsd:element name="default-last-value-key" type="xsd:string" maxOccurs="1" minOccurs="0">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     the property to use as the key for a last value queue by default
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
+            <xsd:element name="default-non-destructive" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     whether the queue should be non-destructive by default
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
             <xsd:element name="default-exclusive-queue" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
                <xsd:annotation>
                   <xsd:documentation>
@@ -3160,6 +3178,8 @@
       <xsd:attribute name="purge-on-no-consumers" type="xsd:boolean" use="optional"/>
       <xsd:attribute name="exclusive" type="xsd:boolean" use="optional"/>
       <xsd:attribute name="last-value" type="xsd:boolean" use="optional"/>
+      <xsd:attribute name="last-value-key" type="xsd:string" use="optional"/>
+      <xsd:attribute name="non-destructive" type="xsd:boolean" use="optional"/>
       <xsd:attribute name="consumers-before-dispatch" type="xsd:int" use="optional"/>
       <xsd:attribute name="delay-before-dispatch" type="xsd:long" use="optional"/>
       <xsd:attributeGroup ref="xml:specialAttrs"/>

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/ScheduledDeliveryHandlerTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/ScheduledDeliveryHandlerTest.java
@@ -1454,6 +1454,21 @@ public class ScheduledDeliveryHandlerTest extends Assert {
       }
 
       @Override
+      public SimpleString getLastValueKey() {
+         return null;
+      }
+
+      @Override
+      public boolean isNonDestructive() {
+         return false;
+      }
+
+      @Override
+      public void setNonDestructive(boolean nonDestructive) {
+
+      }
+
+      @Override
       public boolean isExclusive() {
          return false;
       }

--- a/artemis-tools/src/test/resources/artemis-configuration.xsd
+++ b/artemis-tools/src/test/resources/artemis-configuration.xsd
@@ -491,6 +491,8 @@
                         <xsd:attribute name="purge-on-no-consumers" type="xsd:boolean" use="optional"/>
                         <xsd:attribute name="exclusive" type="xsd:boolean" use="optional"/>
                         <xsd:attribute name="last-value" type="xsd:boolean" use="optional"/>
+                        <xsd:attribute name="last-value-key" type="xsd:string" use="optional"/>
+                        <xsd:attribute name="non-destructive" type="xsd:boolean" use="optional"/>
                         <xsd:attribute name="consumers-before-dispatch" type="xsd:int" use="optional"/>
                         <xsd:attribute name="delay-before-dispatch" type="xsd:long" use="optional"/>
                         <xsd:attributeGroup ref="xml:specialAttrs"/>
@@ -2492,6 +2494,22 @@
                </xsd:annotation>
             </xsd:element>
 
+            <xsd:element name="default-last-value-key" type="xsd:string" maxOccurs="1" minOccurs="0">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     the property to use as the key for a last value queue by default
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
+            <xsd:element name="default-non-destructive" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+               <xsd:annotation>
+                  <xsd:documentation>
+                      whether the queue should be non-destructive by default
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
             <xsd:element name="default-exclusive-queue" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
                <xsd:annotation>
                   <xsd:documentation>
@@ -2787,6 +2805,8 @@
       <xsd:attribute name="purge-on-no-consumers" type="xsd:boolean" use="optional"/>
       <xsd:attribute name="exclusive" type="xsd:boolean" use="optional"/>
       <xsd:attribute name="last-value" type="xsd:boolean" use="optional"/>
+      <xsd:attribute name="last-value-key" type="xsd:string" use="optional"/>
+      <xsd:attribute name="non-destructive" type="xsd:boolean" use="optional"/>
       <xsd:attribute name="consumers-before-dispatch" type="xsd:int" use="optional"/>
       <xsd:attribute name="delay-before-dispatch" type="xsd:long" use="optional"/>
       <xsd:attributeGroup ref="xml:specialAttrs"/>

--- a/docs/user-manual/en/last-value-queues.md
+++ b/docs/user-manual/en/last-value-queues.md
@@ -8,15 +8,53 @@ last value.
 A typical example for Last-Value queue is for stock prices, where you
 are only interested by the latest value for a particular stock.
 
+Messages sent to an Last-Value queue without the specified property will be delivered as normal and will never be "replaced".
+
 ## Configuration
 
-Last-Value queues can be statically configured via the `last-value` 
-boolean property:
+#### Last Value Key Configuration
+Last-Value queues can be statically configured in broker.xml via the `last-value-key`
 
 ```xml
 <address name="foo.bar">
    <multicast>
-      <queue name="orders1" last-value="true"/>
+      <queue name="orders1" last-value-key="reuters_code" />
+   </multicast>
+</address>
+```
+
+Specified on creating a queue by using the CORE api specifying the parameter 
+`lastValue` to `true`. 
+
+Or on auto-create when using the JMS Client by using address parameters when 
+creating the destination used by the consumer.
+
+```java
+Queue queue = session.createQueue("my.destination.name?last-value-key=reuters_code");
+Topic topic = session.createTopic("my.destination.name?last-value-key=reuters_code");
+```
+
+Address wildcards can be used to configure Last-Value queues 
+for a set of addresses (see [here](wildcard-syntax.md)).
+
+```xml
+<address-setting match="lastValueQueue">
+   <default-last-value-key>reuters_code</default-last-value-key>
+</address-setting>
+```
+
+By default, `default-last-value-key` is null.
+
+
+#### Legacy Last Value Configuration
+
+Last-Value queues can also just be configured via the `last-value` boolean property, doing so it will default the last-value-key to `"_AMQ_LVQ_NAME"`.
+
+
+```xml
+<address name="foo.bar">
+   <multicast>
+      <queue name="orders1" last-value="true" />
    </multicast>
 </address>
 ```
@@ -42,30 +80,43 @@ Also the default for all queues under and address can be defaulted using the
 ```
 
 By default, `default-last-value-queue` is false. 
-Address wildcards can be used to configure Last-Value queues 
-for a set of addresses (see [here](wildcard-syntax.md)).
 
 Note that `address-setting` `last-value-queue` config is deprecated, please use
 `default-last-value-queue` instead.
 
+
+
 ## Last-Value Property
 
-The property name used to identify the last value is `"_AMQ_LVQ_NAME"`
+The property name used to identify the last value is configurable 
+at the queue level mentioned above.
+
+If using the legacy setting to configure an LVQ then the default property `"_AMQ_LVQ_NAME"` is used
 (or the constant `Message.HDR_LAST_VALUE_NAME` from the Core API).
 
-For example, if two messages with the same value for the Last-Value
+For example, using the sample configuration 
+
+```xml
+<address name="foo.bar">
+   <multicast>
+      <queue name="orders1" last-value-key="reuters_code" />
+   </multicast>
+</address>
+```
+
+if two messages with the same value for the Last-Value
 property are sent to a Last-Value queue, only the latest message will be
 kept in the queue:
 
 ```java
-// send 1st message with Last-Value property set to STOCK_NAME
+// send 1st message with Last-Value property `reuters_code` set to `VOD`
 TextMessage message = session.createTextMessage("1st message with Last-Value property set");
-message.setStringProperty("_AMQ_LVQ_NAME", "STOCK_NAME");
+message.setStringProperty("reuters_code", "VOD");
 producer.send(message);
 
-// send 2nd message with Last-Value property set to STOCK_NAME
+// send 2nd message with Last-Value property `reuters_code` set to `VOD`
 message = session.createTextMessage("2nd message with Last-Value property set");
-message.setStringProperty("_AMQ_LVQ_NAME", "STOCK_NAME");
+message.setStringProperty("reuters_code", "VOD");
 producer.send(message);
 
 ...
@@ -75,6 +126,53 @@ producer.send(message);
 TextMessage messageReceived = (TextMessage)messageConsumer.receive(5000);
 System.out.format("Received message: %s\n", messageReceived.getText());
 ```
+
+
+## Forcing all consumers to be non-destructive
+When a consumer attaches to a queue, the normal behaviour is that messages are sent to that consumer are acquired exclusively by that consumer, and when the consumer acknowledges them, the messages are removed from the queue.
+
+Another common pattern is to have queue "browsers" which send all messages to the browser, but do not prevent other consumers from receiving the messages, and do not remove them from the queue when the browser is done with them. Such a browser is an instance of a "non-destructive" consumer.
+
+If every consumer on a queue is non destructive then we can obtain some interesting behaviours. In the case of a LVQ then the queue will always contain the most up to date value for every key. 
+
+A queue can be created to enforce all consumers are non-destructive for last value queue. This can be be achieved using the following queue configuration:
+
+
+```xml
+<address name="foo.bar">
+   <multicast>
+      <queue name="orders1" last-value-key="reuters_code" non-destructive="true" />
+   </multicast>
+</address>
+```
+
+Or on auto-create when using the JMS Client by using address parameters when 
+creating the destination used by the consumer.
+
+```java
+Queue queue = session.createQueue("my.destination.name?last-value-key=reuters_code&non-destructive=true");
+Topic topic = session.createTopic("my.destination.name?last-value-key=reuters_code&non-destructive=true");
+```
+
+Also the default for all queues under and address can be defaulted using the 
+`address-setting` configuration:
+
+```xml
+<address-setting match="lastValueQueue">
+   <default-last-value-key>reuters_code</default-last-value-key>
+   <default-non-destructive>true</default-non-destructive>
+</address-setting>
+```
+
+By default, `default-non-destructive` is false.
+
+
+#### Bounding size using expiry-delay
+For queues other than LVQs, having only non-destructive consumers could mean that messages would never get deleted, leaving the queue to grow unconstrainedly. To prevent this you can use the ability to set a default `expiry-delay`.
+
+See [expiry-delay](message-expiry.md#configuring-expiry-delay) for more details on this.
+ 
+
 
 ## Example
 

--- a/docs/user-manual/en/message-expiry.md
+++ b/docs/user-manual/en/message-expiry.md
@@ -45,6 +45,27 @@ properties:
 
   a Long property containing the *actual expiration time* of the
   expired message
+  
+## Configuring Expiry Delay
+
+Default Expiry delay can be configured in the address-setting configuration:
+
+```xml
+<!-- expired messages in exampleQueue will be sent to the expiry address expiryQueue -->
+<address-setting match="exampleQueue">
+   <expiry-delay>10</expiry-delay>
+</address-setting>
+```
+
+`expiry-delay` defines the expiration time in milliseconds that will be used for messages 
+which are using the default expiration time (i.e. 0). 
+  
+For example, if `expiry-delay` is set to "10" and a message which is using the default 
+expiration time (i.e.10) arrives then its expiration time of "0" will be changed to "10." 
+However, if a message which is using an expiration time of "20" arrives then its expiration
+time will remain unchanged. Setting `expiry-delay` to "-1" will disable this feature. 
+  
+The default is "-1".
 
 ## Configuring Expiry Addresses
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/DuplicateDetectionTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/DuplicateDetectionTest.java
@@ -168,7 +168,7 @@ public class DuplicateDetectionTest extends ActiveMQTestBase {
          final SimpleString queueName = new SimpleString("DuplicateDetectionTestQueue_" + i);
 
          if (temporary) {
-            session.createTemporaryQueue(addressName, queueName, null);
+            session.createTemporaryQueue(addressName, queueName, (SimpleString) null);
          } else {
             session.createQueue(addressName, queueName, null, true);
          }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSClientTestSupport.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSClientTestSupport.java
@@ -259,4 +259,8 @@ public abstract class JMSClientTestSupport extends AmqpClientTestSupport {
 
       return connection;
    }
+
+   interface ConnectionSupplier {
+      Connection createConnection() throws JMSException;
+   }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSLVQTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSLVQTest.java
@@ -16,25 +16,32 @@
  */
 package org.apache.activemq.artemis.tests.integration.amqp;
 
+
 import javax.jms.Connection;
+import javax.jms.JMSException;
 import javax.jms.MessageConsumer;
 import javax.jms.MessageProducer;
 import javax.jms.Queue;
 import javax.jms.Session;
 import javax.jms.TextMessage;
-
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.impl.AddressInfo;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
-import org.apache.activemq.artemis.protocol.amqp.broker.AMQPMessage;
 import org.junit.Test;
 
 public class JMSLVQTest extends JMSClientTestSupport {
 
+   private static final String NORMAL_QUEUE_NAME = "NORMAL";
    private static final String LVQ_QUEUE_NAME = "LVQ";
+   private static final String LVQ_CUSTOM_KEY_QUEUE_NAME = "LVQ_CUSTOM_KEY_QUEUE";
+   private static final String CUSTOM_KEY = "KEY";
+
+   private ConnectionSupplier AMQPConnection = () -> createConnection();
+   private ConnectionSupplier CoreConnection = () -> createCoreConnection();
+   private ConnectionSupplier OpenWireConnection = () -> createOpenWireConnection();
 
    @Override
    protected String getConfiguredProtocols() {
@@ -43,110 +50,132 @@ public class JMSLVQTest extends JMSClientTestSupport {
 
    @Override
    protected void addConfiguration(ActiveMQServer server) {
+      server.getConfiguration().setPersistenceEnabled(false);
+      server.getConfiguration().setMessageExpiryScanPeriod(1000);
+      server.getAddressSettingsRepository().addMatch(NORMAL_QUEUE_NAME, new AddressSettings());
       server.getAddressSettingsRepository().addMatch(LVQ_QUEUE_NAME, new AddressSettings().setDefaultLastValueQueue(true));
+      server.getAddressSettingsRepository().addMatch(LVQ_CUSTOM_KEY_QUEUE_NAME, new AddressSettings().setDefaultLastValueQueue(true).setDefaultLastValueKey(SimpleString.toSimpleString(CUSTOM_KEY)));
+
    }
+
    @Override
    protected void createAddressAndQueues(ActiveMQServer server) throws Exception {
       super.createAddressAndQueues(server);
+
+      //Add Standard Queue
+      server.addAddressInfo(new AddressInfo(SimpleString.toSimpleString(NORMAL_QUEUE_NAME), RoutingType.ANYCAST));
+      server.createQueue(SimpleString.toSimpleString(NORMAL_QUEUE_NAME), RoutingType.ANYCAST, SimpleString.toSimpleString(NORMAL_QUEUE_NAME), null, true, false, -1, false, true);
+
+
+      //Add LVQ using Default Message.HDR_LAST_VALUE_NAME
       server.addAddressInfo(new AddressInfo(SimpleString.toSimpleString(LVQ_QUEUE_NAME), RoutingType.ANYCAST));
-      server.createQueue(SimpleString.toSimpleString(LVQ_QUEUE_NAME), RoutingType.ANYCAST, SimpleString.toSimpleString("LVQ"), null, true, false, -1, false, true);
+      server.createQueue(SimpleString.toSimpleString(LVQ_QUEUE_NAME), RoutingType.ANYCAST, SimpleString.toSimpleString(LVQ_QUEUE_NAME), null, true, false, -1, false, true);
+
+      //Add LVQ using Custom Key
+      server.addAddressInfo(new AddressInfo(SimpleString.toSimpleString(LVQ_CUSTOM_KEY_QUEUE_NAME), RoutingType.ANYCAST));
+      server.createQueue(SimpleString.toSimpleString(LVQ_CUSTOM_KEY_QUEUE_NAME), RoutingType.ANYCAST, SimpleString.toSimpleString(LVQ_CUSTOM_KEY_QUEUE_NAME), null, true, false, -1, false, true);
    }
 
 
    @Test
    public void testLVQAMQPProducerAMQPConsumer() throws Exception {
-      Connection producerConnection = createConnection();
-      Connection consumerConnection = createConnection();
-      testLVQ(producerConnection, consumerConnection);
+      testLVQ(AMQPConnection, AMQPConnection);
    }
 
    @Test
    public void testLVQCoreProducerCoreConsumer() throws Exception {
-      Connection producerConnection = createCoreConnection();
-      Connection consumerConnection = createCoreConnection();
-      testLVQ(producerConnection, consumerConnection);
+      testLVQ(CoreConnection, CoreConnection);
    }
 
    @Test
    public void testLVQCoreProducerAMQPConsumer() throws Exception {
-      Connection producerConnection = createCoreConnection();
-      Connection consumerConnection = createConnection();
-      testLVQ(producerConnection, consumerConnection);
+      testLVQ(CoreConnection, AMQPConnection);
    }
 
    @Test
    public void testLVQAMQPProducerCoreConsumer() throws Exception {
-      Connection producerConnection = createConnection();
-      Connection consumerConnection = createCoreConnection();
-      testLVQ(producerConnection, consumerConnection);
+      testLVQ(AMQPConnection, CoreConnection);
    }
 
    @Test
    public void testLVQOpenWireProducerOpenWireConsumer() throws Exception {
-      Connection producerConnection = createOpenWireConnection();
-      Connection consumerConnection = createOpenWireConnection();
-      testLVQ(producerConnection, consumerConnection);
+      testLVQ(OpenWireConnection, OpenWireConnection);
    }
 
    @Test
    public void testLVQCoreProducerOpenWireConsumer() throws Exception {
-      Connection producerConnection = createCoreConnection();
-      Connection consumerConnection = createOpenWireConnection();
-      testLVQ(producerConnection, consumerConnection);
+      testLVQ(CoreConnection, OpenWireConnection);
    }
 
    @Test
    public void testLVQOpenWireProducerCoreConsumer() throws Exception {
-      Connection producerConnection = createOpenWireConnection();
-      Connection consumerConnection = createCoreConnection();
-      testLVQ(producerConnection, consumerConnection);
+      testLVQ(OpenWireConnection, CoreConnection);
    }
 
    @Test
    public void testLVQAMQPProducerOpenWireConsumer() throws Exception {
-      Connection producerConnection = createConnection();
-      Connection consumerConnection = createOpenWireConnection();
-      testLVQ(producerConnection, consumerConnection);
+      testLVQ(AMQPConnection, OpenWireConnection);
    }
 
    @Test
    public void testLVQOpenWireProducerAMQPConsumer() throws Exception {
-      Connection producerConnection = createOpenWireConnection();
-      Connection consumerConnection = createConnection();
-      testLVQ(producerConnection, consumerConnection);
+      testLVQ(OpenWireConnection, AMQPConnection);
    }
 
-   public void testLVQ(Connection producerConnection, Connection consumerConnection) throws Exception {
+   public void testLVQ(ConnectionSupplier producerConnectionSupplier, ConnectionSupplier consumerConnectionSupplier) throws Exception {
+      testLVQDefaultKey(producerConnectionSupplier, consumerConnectionSupplier);
+      testLVQCustomKey(producerConnectionSupplier, consumerConnectionSupplier);
+   }
 
-      try {
+
+
+   public void testLVQDefaultKey(ConnectionSupplier producerConnectionSupplier, ConnectionSupplier consumerConnectionSupplier) throws Exception {
+      testLVQ(producerConnectionSupplier, consumerConnectionSupplier, LVQ_QUEUE_NAME, Message.HDR_LAST_VALUE_NAME.toString());
+   }
+
+   public void testLVQCustomKey(ConnectionSupplier producerConnectionSupplier, ConnectionSupplier consumerConnectionSupplier) throws Exception {
+      testLVQ(producerConnectionSupplier, consumerConnectionSupplier, LVQ_CUSTOM_KEY_QUEUE_NAME, CUSTOM_KEY);
+   }
+
+   public void testLVQ(ConnectionSupplier producerConnectionSupplier, ConnectionSupplier consumerConnectionSupplier, String queueName, String lastValueKey) throws Exception {
+
+      sendLVQ(producerConnectionSupplier, queueName, lastValueKey);
+
+      //Simulate a small pause, else both messages could be consumed if consumer is fast enough
+      Thread.sleep(10);
+
+      receiveLVQ(consumerConnectionSupplier, queueName, lastValueKey);
+   }
+
+   private void receiveLVQ(ConnectionSupplier consumerConnectionSupplier, String queueName, String lastValueKey) throws JMSException {
+      try (Connection consumerConnection = consumerConnectionSupplier.createConnection()) {
+
+         Session consumerSession = consumerConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+         Queue consumerQueue = consumerSession.createQueue(queueName);
+         MessageConsumer consumer = consumerSession.createConsumer(consumerQueue);
+         TextMessage msg = (TextMessage) consumer.receive(1000);
+         assertNotNull(msg);
+         assertEquals("KEY", msg.getStringProperty(lastValueKey));
+         assertEquals("how are you", msg.getText());
+         consumer.close();
+      }
+   }
+
+   private void sendLVQ(ConnectionSupplier producerConnectionSupplier, String queueName, String lastValueKey) throws JMSException {
+      try (Connection producerConnection = producerConnectionSupplier.createConnection()) {
          Session producerSession = producerConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
-         Queue queue1 = producerSession.createQueue(LVQ_QUEUE_NAME);
+         Queue queue1 = producerSession.createQueue(queueName);
          MessageProducer p = producerSession.createProducer(null);
 
          TextMessage message1 = producerSession.createTextMessage();
-         message1.setStringProperty(Message.HDR_LAST_VALUE_NAME.toString(), "KEY");
+         message1.setStringProperty(lastValueKey, "KEY");
          message1.setText("hello");
          p.send(queue1, message1);
 
          TextMessage message2 = producerSession.createTextMessage();
-         message2.setStringProperty(Message.HDR_LAST_VALUE_NAME.toString(), "KEY");
+         message2.setStringProperty(lastValueKey, "KEY");
          message2.setText("how are you");
          p.send(queue1, message2);
-
-         //Simulate a small pause, else both messages could be consumed if consumer is fast enough
-         Thread.sleep(10);
-
-         Session consumerSession = consumerConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
-         Queue consumerQueue = consumerSession.createQueue(LVQ_QUEUE_NAME);
-         MessageConsumer consumer = consumerSession.createConsumer(consumerQueue);
-         TextMessage msg = (TextMessage) consumer.receive(1000);
-         assertNotNull(msg);
-         assertEquals("KEY", msg.getStringProperty(AMQPMessage.HDR_LAST_VALUE_NAME.toString()));
-         assertEquals("how are you", msg.getText());
-         consumer.close();
-      } finally {
-         producerConnection.close();
-         consumerConnection.close();
       }
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSNonDestructiveTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSNonDestructiveTest.java
@@ -1,0 +1,467 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.amqp;
+
+
+import javax.jms.Connection;
+import javax.jms.JMSException;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import org.apache.activemq.artemis.api.core.Message;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.api.core.management.QueueControl;
+import org.apache.activemq.artemis.api.core.management.ResourceNames;
+import org.apache.activemq.artemis.core.postoffice.QueueBinding;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.impl.AddressInfo;
+import org.apache.activemq.artemis.core.server.impl.LastValueQueue;
+import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
+import org.junit.Test;
+
+public class JMSNonDestructiveTest extends JMSClientTestSupport {
+
+   private static final String NON_DESTRUCTIVE_QUEUE_NAME = "NON_DESTRUCTIVE_QUEUE";
+   private static final String NON_DESTRUCTIVE_EXPIRY_QUEUE_NAME = "NON_DESTRUCTIVE_EXPIRY_QUEUE";
+   private static final String NON_DESTRUCTIVE_LVQ_QUEUE_NAME = "NON_DESTRUCTIVE_LVQ_QUEUE";
+   private static final String NON_DESTRUCTIVE_TOMBSTONE_LVQ_QUEUE_NAME = "NON_DESTRUCTIVE_LVQ_TOMBSTONE_QUEUE";
+
+   private ConnectionSupplier AMQPConnection = () -> createConnection();
+   private ConnectionSupplier CoreConnection = () -> createCoreConnection();
+
+   @Override
+   protected String getConfiguredProtocols() {
+      return "AMQP,OPENWIRE,CORE";
+   }
+
+   @Override
+   protected void addConfiguration(ActiveMQServer server) {
+      server.getConfiguration().setPersistenceEnabled(false);
+      server.getConfiguration().setMessageExpiryScanPeriod(100);
+      server.getAddressSettingsRepository().addMatch(NON_DESTRUCTIVE_QUEUE_NAME, new AddressSettings().setDefaultNonDestructive(true));
+      server.getAddressSettingsRepository().addMatch(NON_DESTRUCTIVE_EXPIRY_QUEUE_NAME, new AddressSettings().setDefaultNonDestructive(true).setExpiryDelay(100L));
+      server.getAddressSettingsRepository().addMatch(NON_DESTRUCTIVE_LVQ_QUEUE_NAME, new AddressSettings().setDefaultLastValueQueue(true).setDefaultNonDestructive(true));
+      server.getAddressSettingsRepository().addMatch(NON_DESTRUCTIVE_TOMBSTONE_LVQ_QUEUE_NAME, new AddressSettings().setDefaultLastValueQueue(true).setDefaultNonDestructive(true));
+   }
+   @Override
+   protected void createAddressAndQueues(ActiveMQServer server) throws Exception {
+      super.createAddressAndQueues(server);
+
+      //Add Non Destructive Queue
+      server.addAddressInfo(new AddressInfo(SimpleString.toSimpleString(NON_DESTRUCTIVE_QUEUE_NAME), RoutingType.ANYCAST));
+      server.createQueue(SimpleString.toSimpleString(NON_DESTRUCTIVE_QUEUE_NAME), RoutingType.ANYCAST, SimpleString.toSimpleString(NON_DESTRUCTIVE_QUEUE_NAME), null, true, false, -1, false, true);
+
+      //Add Non Destructive Expiry Queue
+      server.addAddressInfo(new AddressInfo(SimpleString.toSimpleString(NON_DESTRUCTIVE_EXPIRY_QUEUE_NAME), RoutingType.ANYCAST));
+      server.createQueue(SimpleString.toSimpleString(NON_DESTRUCTIVE_EXPIRY_QUEUE_NAME), RoutingType.ANYCAST, SimpleString.toSimpleString(NON_DESTRUCTIVE_EXPIRY_QUEUE_NAME), null, true, false, -1, false, true);
+
+      //Add Non Destructive Last Value Queue
+      server.addAddressInfo(new AddressInfo(SimpleString.toSimpleString(NON_DESTRUCTIVE_LVQ_QUEUE_NAME), RoutingType.ANYCAST));
+      server.createQueue(SimpleString.toSimpleString(NON_DESTRUCTIVE_LVQ_QUEUE_NAME), RoutingType.ANYCAST, SimpleString.toSimpleString(NON_DESTRUCTIVE_LVQ_QUEUE_NAME), null, true, false, -1, false, true);
+
+      //Add  Non Destructive Last Value Queue for Tombstone Test
+      server.addAddressInfo(new AddressInfo(SimpleString.toSimpleString(NON_DESTRUCTIVE_TOMBSTONE_LVQ_QUEUE_NAME), RoutingType.ANYCAST));
+      server.createQueue(SimpleString.toSimpleString(NON_DESTRUCTIVE_TOMBSTONE_LVQ_QUEUE_NAME), RoutingType.ANYCAST, SimpleString.toSimpleString(NON_DESTRUCTIVE_TOMBSTONE_LVQ_QUEUE_NAME), null, true, false, -1, false, true);
+
+   }
+
+
+   @Test
+   public void testNonDestructiveAMQPProducerAMQPConsumer() throws Exception {
+      testNonDestructive(AMQPConnection, AMQPConnection);
+   }
+
+   @Test
+   public void testNonDestructiveCoreProducerCoreConsumer() throws Exception {
+      testNonDestructive(CoreConnection, CoreConnection);
+   }
+
+   @Test
+   public void testNonDestructiveCoreProducerAMQPConsumer() throws Exception {
+      testNonDestructive(CoreConnection, AMQPConnection);
+   }
+
+   @Test
+   public void testNonDestructiveAMQPProducerCoreConsumer() throws Exception {
+      testNonDestructive(AMQPConnection, CoreConnection);
+   }
+
+   public void testNonDestructive(ConnectionSupplier producerConnectionSupplier, ConnectionSupplier consumerConnectionSupplier) throws Exception {
+      testNonDestructiveSingle(producerConnectionSupplier, consumerConnectionSupplier);
+      testNonDestructiveDualConsumer(producerConnectionSupplier, consumerConnectionSupplier);
+      testNonDestructiveExpiry(producerConnectionSupplier, consumerConnectionSupplier);
+      testNonDestructiveMulitpleMessages(producerConnectionSupplier, consumerConnectionSupplier);
+      testNonDestructiveMulitpleMessagesDualConsumer(producerConnectionSupplier, consumerConnectionSupplier);
+      testNonDestructiveLVQ(producerConnectionSupplier, consumerConnectionSupplier);
+      testNonDestructiveLVQTombstone(producerConnectionSupplier, consumerConnectionSupplier);
+
+   }
+
+
+   public void testNonDestructiveSingle(ConnectionSupplier producerConnectionSupplier, ConnectionSupplier consumerConnectionSupplier) throws Exception {
+      sendMessage(producerConnectionSupplier, NON_DESTRUCTIVE_QUEUE_NAME);
+
+      QueueBinding queueBinding = (QueueBinding) server.getPostOffice().getBinding(SimpleString.toSimpleString(NON_DESTRUCTIVE_QUEUE_NAME));
+      assertEquals("Ensure Message count", 1, queueBinding.getQueue().getMessageCount());
+
+
+      //Consume Once
+      receive(consumerConnectionSupplier, NON_DESTRUCTIVE_QUEUE_NAME);
+      assertEquals("Ensure Message count", 1, queueBinding.getQueue().getMessageCount());
+
+      //Consume Again as should be non-destructive
+      receive(consumerConnectionSupplier, NON_DESTRUCTIVE_QUEUE_NAME);
+      assertEquals("Ensure Message count", 1, queueBinding.getQueue().getMessageCount());
+
+      QueueControl control = (QueueControl) server.getManagementService().getResource(ResourceNames.QUEUE + NON_DESTRUCTIVE_QUEUE_NAME);
+      control.removeAllMessages();
+
+      assertEquals("Message count after clearing queue via queue control should be 0", 0, queueBinding.getQueue().getMessageCount());
+   }
+
+   public void testNonDestructiveDualConsumer(ConnectionSupplier producerConnectionSupplier, ConnectionSupplier consumerConnectionSupplier) throws Exception {
+      sendMessage(producerConnectionSupplier, NON_DESTRUCTIVE_QUEUE_NAME);
+
+      QueueBinding queueBinding = (QueueBinding) server.getPostOffice().getBinding(SimpleString.toSimpleString(NON_DESTRUCTIVE_QUEUE_NAME));
+      assertEquals("Ensure Message count", 1, queueBinding.getQueue().getMessageCount());
+
+
+      //Consume Once
+      receiveDualConsumer(consumerConnectionSupplier, NON_DESTRUCTIVE_QUEUE_NAME);
+      assertEquals("Ensure Message count", 1, queueBinding.getQueue().getMessageCount());
+
+      //Consume Again as should be non-destructive
+      receiveDualConsumer(consumerConnectionSupplier, NON_DESTRUCTIVE_QUEUE_NAME);
+      assertEquals("Ensure Message count", 1, queueBinding.getQueue().getMessageCount());
+
+      QueueControl control = (QueueControl) server.getManagementService().getResource(ResourceNames.QUEUE + NON_DESTRUCTIVE_QUEUE_NAME);
+      control.removeAllMessages();
+
+      assertEquals("Message count after clearing queue via queue control should be 0", 0, queueBinding.getQueue().getMessageCount());
+   }
+
+   public void testNonDestructiveExpiry(ConnectionSupplier producerConnectionSupplier, ConnectionSupplier consumerConnectionSupplier) throws Exception {
+      sendMessage(producerConnectionSupplier, NON_DESTRUCTIVE_EXPIRY_QUEUE_NAME);
+
+      QueueBinding queueBinding = (QueueBinding) server.getPostOffice().getBinding(SimpleString.toSimpleString(NON_DESTRUCTIVE_EXPIRY_QUEUE_NAME));
+      assertEquals("Ensure Message count", 1, queueBinding.getQueue().getMessageCount());
+
+
+      //Consume Once
+      receive(consumerConnectionSupplier, NON_DESTRUCTIVE_EXPIRY_QUEUE_NAME);
+      assertEquals("Ensure Message count", 1, queueBinding.getQueue().getMessageCount());
+
+      Thread.sleep(500);
+
+      //Consume Again this time we expect the message to be expired, so nothing delivered
+      receiveNull(consumerConnectionSupplier, NON_DESTRUCTIVE_EXPIRY_QUEUE_NAME);
+      assertEquals("Ensure Message count", 0, queueBinding.getQueue().getMessageCount());
+
+      QueueControl control = (QueueControl) server.getManagementService().getResource(ResourceNames.QUEUE + NON_DESTRUCTIVE_EXPIRY_QUEUE_NAME);
+      control.removeAllMessages();
+
+      assertEquals("Message count after clearing queue via queue control should be 0", 0, queueBinding.getQueue().getMessageCount());
+   }
+
+   public void testNonDestructiveMulitpleMessages(ConnectionSupplier producerConnectionSupplier, ConnectionSupplier consumerConnectionSupplier) throws Exception {
+      sendMessage(producerConnectionSupplier, NON_DESTRUCTIVE_QUEUE_NAME, 0);
+      sendMessage(producerConnectionSupplier, NON_DESTRUCTIVE_QUEUE_NAME, 1);
+      sendMessage(producerConnectionSupplier, NON_DESTRUCTIVE_QUEUE_NAME, 2);
+
+      QueueBinding queueBinding = (QueueBinding) server.getPostOffice().getBinding(SimpleString.toSimpleString(NON_DESTRUCTIVE_QUEUE_NAME));
+      assertEquals("Ensure Message count", 3, queueBinding.getQueue().getMessageCount());
+
+
+      //Consume Once
+      receive(consumerConnectionSupplier, NON_DESTRUCTIVE_QUEUE_NAME, 3);
+
+      //Consume Again as should be non-destructive
+      receive(consumerConnectionSupplier, NON_DESTRUCTIVE_QUEUE_NAME, 3);
+
+      QueueControl control = (QueueControl) server.getManagementService().getResource(ResourceNames.QUEUE + NON_DESTRUCTIVE_QUEUE_NAME);
+      control.removeAllMessages();
+
+      assertEquals("Message count after clearing queue via queue control should be 0", 0, queueBinding.getQueue().getMessageCount());
+   }
+
+   public void testNonDestructiveMulitpleMessagesDualConsumer(ConnectionSupplier producerConnectionSupplier, ConnectionSupplier consumerConnectionSupplier) throws Exception {
+      sendMessage(producerConnectionSupplier, NON_DESTRUCTIVE_QUEUE_NAME, 0);
+      sendMessage(producerConnectionSupplier, NON_DESTRUCTIVE_QUEUE_NAME, 1);
+      sendMessage(producerConnectionSupplier, NON_DESTRUCTIVE_QUEUE_NAME, 2);
+
+      QueueBinding queueBinding = (QueueBinding) server.getPostOffice().getBinding(SimpleString.toSimpleString(NON_DESTRUCTIVE_QUEUE_NAME));
+      assertEquals("Ensure Message count", 3, queueBinding.getQueue().getMessageCount());
+
+
+      //Consume Once
+      receiveDualConsumer(consumerConnectionSupplier, NON_DESTRUCTIVE_QUEUE_NAME, 3);
+
+      //Consume Again as should be non-destructive
+      receiveDualConsumer(consumerConnectionSupplier, NON_DESTRUCTIVE_QUEUE_NAME, 3);
+
+      QueueControl control = (QueueControl) server.getManagementService().getResource(ResourceNames.QUEUE + NON_DESTRUCTIVE_QUEUE_NAME);
+      control.removeAllMessages();
+
+      assertEquals("Message count after clearing queue via queue control should be 0", 0, queueBinding.getQueue().getMessageCount());
+   }
+
+   public void testNonDestructiveLVQ(ConnectionSupplier producerConnectionSupplier, ConnectionSupplier consumerConnectionSupplier) throws Exception {
+      sendLVQ(producerConnectionSupplier, NON_DESTRUCTIVE_LVQ_QUEUE_NAME, Message.HDR_LAST_VALUE_NAME.toString());
+
+      QueueBinding queueBinding = (QueueBinding) server.getPostOffice().getBinding(SimpleString.toSimpleString(NON_DESTRUCTIVE_LVQ_QUEUE_NAME));
+      assertEquals("Ensure Message count", 1, queueBinding.getQueue().getMessageCount());
+
+      //Simulate a small pause, else both messages could be consumed if consumer is fast enough
+      Thread.sleep(10);
+
+      //Consume Once
+      receiveLVQ(consumerConnectionSupplier, NON_DESTRUCTIVE_LVQ_QUEUE_NAME, Message.HDR_LAST_VALUE_NAME.toString());
+      assertEquals("Ensure Message count", 1, queueBinding.getQueue().getMessageCount());
+
+      //Consume Again as should be non-destructive
+      receiveLVQ(consumerConnectionSupplier, NON_DESTRUCTIVE_LVQ_QUEUE_NAME, Message.HDR_LAST_VALUE_NAME.toString());
+      assertEquals("Ensure Message count", 1, queueBinding.getQueue().getMessageCount());
+
+      //Send again
+      sendLVQ(producerConnectionSupplier, NON_DESTRUCTIVE_LVQ_QUEUE_NAME, Message.HDR_LAST_VALUE_NAME.toString());
+
+      assertEquals("Ensure Message count", 1, queueBinding.getQueue().getMessageCount());
+
+      //Simulate a small pause, else both messages could be consumed if consumer is fast enough
+      Thread.sleep(10);
+
+      //Consume Once More
+      receiveLVQ(consumerConnectionSupplier, NON_DESTRUCTIVE_LVQ_QUEUE_NAME, Message.HDR_LAST_VALUE_NAME.toString());
+
+      assertEquals("Ensure Message count", 1, queueBinding.getQueue().getMessageCount());
+
+      QueueControl control = (QueueControl) server.getManagementService().getResource(ResourceNames.QUEUE + NON_DESTRUCTIVE_LVQ_QUEUE_NAME);
+      control.removeAllMessages();
+
+      assertEquals("Message count after clearing queue via queue control should be 0", 0, queueBinding.getQueue().getMessageCount());
+   }
+
+   public void testNonDestructiveLVQTombstone(ConnectionSupplier producerConnectionSupplier, ConnectionSupplier consumerConnectionSupplier) throws Exception {
+      int tombstoneTimeToLive = 500;
+
+      QueueBinding queueBinding = (QueueBinding) server.getPostOffice().getBinding(SimpleString.toSimpleString(NON_DESTRUCTIVE_TOMBSTONE_LVQ_QUEUE_NAME));
+      LastValueQueue lastValueQueue = (LastValueQueue)queueBinding.getQueue();
+      //Send again
+      sendLVQ(producerConnectionSupplier, NON_DESTRUCTIVE_TOMBSTONE_LVQ_QUEUE_NAME, Message.HDR_LAST_VALUE_NAME.toString());
+
+      assertEquals("Ensure Message count", 1, lastValueQueue.getMessageCount());
+
+      //Simulate a small pause, else both messages could be consumed if consumer is fast enough
+      Thread.sleep(10);
+
+      //Consume Once More
+      receiveLVQ(consumerConnectionSupplier, NON_DESTRUCTIVE_TOMBSTONE_LVQ_QUEUE_NAME, Message.HDR_LAST_VALUE_NAME.toString());
+
+      //Send Tombstone
+      sendLVQTombstone(producerConnectionSupplier, NON_DESTRUCTIVE_TOMBSTONE_LVQ_QUEUE_NAME, Message.HDR_LAST_VALUE_NAME.toString(), tombstoneTimeToLive);
+
+      assertEquals("Ensure Message count", 1, lastValueQueue.getMessageCount());
+
+      //Simulate a small pause, else both messages could be consumed if consumer is fast enough
+      Thread.sleep(10);
+
+      //Consume Tombstone ensuring Tombstone exists
+      receiveLVQTombstone(consumerConnectionSupplier, NON_DESTRUCTIVE_TOMBSTONE_LVQ_QUEUE_NAME, Message.HDR_LAST_VALUE_NAME.toString());
+
+      //Consume Again ensuring Tombstone exists as should not have expired
+      receiveLVQTombstone(consumerConnectionSupplier, NON_DESTRUCTIVE_TOMBSTONE_LVQ_QUEUE_NAME, Message.HDR_LAST_VALUE_NAME.toString());
+
+      assertEquals("Ensure Message count", 1, lastValueQueue.getLastValueKeys().size());
+
+      //Ensure enough time elapsed for expiration and expiry thread to have run.
+      Thread.sleep(tombstoneTimeToLive * 3);
+
+      // Consume again testing tombstone has been removed
+      receiveLVQAssertEmpty(consumerConnectionSupplier, NON_DESTRUCTIVE_TOMBSTONE_LVQ_QUEUE_NAME);
+      assertEquals("Ensure Message count", 0, lastValueQueue.getMessageCount());
+      assertEquals("Ensure Message count", 0, lastValueQueue.getLastValueKeys().size());
+
+   }
+
+
+   private void receive(ConnectionSupplier consumerConnectionSupplier, String queueName, int i) throws JMSException {
+      try (Connection consumerConnection = consumerConnectionSupplier.createConnection()) {
+
+         Session consumerSession = consumerConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+         Queue consumerQueue = consumerSession.createQueue(queueName);
+         MessageConsumer consumer = consumerSession.createConsumer(consumerQueue);
+         for (int j = 0; j < i; j++) {
+            TextMessage msg = (TextMessage) consumer.receive(200);
+            assertNotNull(msg);
+            assertEquals(Integer.toString(j), msg.getText());
+         }
+         TextMessage msg = (TextMessage) consumer.receive(200);
+         assertNull(msg);
+         consumer.close();
+      }
+   }
+
+   private void receive(ConnectionSupplier consumerConnectionSupplier, String queueName) throws JMSException {
+      try (Connection consumerConnection = consumerConnectionSupplier.createConnection()) {
+
+         Session consumerSession = consumerConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+         Queue consumerQueue = consumerSession.createQueue(queueName);
+         MessageConsumer consumer = consumerSession.createConsumer(consumerQueue);
+         TextMessage msg = (TextMessage) consumer.receive(200);
+         assertNotNull(msg);
+         consumer.close();
+      }
+   }
+
+   private void receiveNull(ConnectionSupplier consumerConnectionSupplier, String queueName) throws JMSException {
+      try (Connection consumerConnection = consumerConnectionSupplier.createConnection()) {
+
+         Session consumerSession = consumerConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+         Queue consumerQueue = consumerSession.createQueue(queueName);
+         MessageConsumer consumer = consumerSession.createConsumer(consumerQueue);
+         TextMessage msg = (TextMessage) consumer.receive(200);
+         assertNull(msg);
+         consumer.close();
+      }
+   }
+
+   private void receiveDualConsumer(ConnectionSupplier consumerConnectionSupplier, String queueName) throws JMSException {
+      try (Connection consumerConnection = consumerConnectionSupplier.createConnection();
+           Connection consumerConnection2 = consumerConnectionSupplier.createConnection()) {
+
+         MessageConsumer consumer = createConsumer(consumerConnection, queueName);
+         MessageConsumer consumer2 = createConsumer(consumerConnection2, queueName);
+
+         TextMessage msg = (TextMessage) consumer.receive(200);
+         TextMessage msg2 = (TextMessage) consumer2.receive(200);
+
+         assertNotNull(msg);
+         assertNotNull(msg2);
+         consumer.close();
+         consumer2.close();
+      }
+   }
+
+   private void receiveDualConsumer(ConnectionSupplier consumerConnectionSupplier, String queueName, int i) throws JMSException {
+      try (Connection consumerConnection = consumerConnectionSupplier.createConnection();
+           Connection consumerConnection2 = consumerConnectionSupplier.createConnection()) {
+
+         MessageConsumer consumer = createConsumer(consumerConnection, queueName);
+         MessageConsumer consumer2 = createConsumer(consumerConnection2, queueName);
+
+
+         for (int j = 0; j < i; j++) {
+            TextMessage msg = (TextMessage) consumer.receive(200);
+            TextMessage msg2 = (TextMessage) consumer2.receive(200);
+            assertNotNull(msg);
+            assertNotNull(msg2);
+            assertEquals(Integer.toString(j), msg.getText());
+            assertEquals(Integer.toString(j), msg2.getText());
+         }
+         TextMessage msg = (TextMessage) consumer.receive(200);
+         assertNull(msg);
+         TextMessage msg2 = (TextMessage) consumer2.receive(200);
+         assertNull(msg2);
+         consumer.close();
+         consumer2.close();
+      }
+   }
+
+   private MessageConsumer createConsumer(Connection connection, String queueName) throws JMSException {
+      connection.start();
+      Session consumerSession = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+      Queue consumerQueue = consumerSession.createQueue(queueName);
+      return consumerSession.createConsumer(consumerQueue);
+   }
+
+   private void sendMessage(ConnectionSupplier producerConnectionSupplier, String queueName) throws JMSException {
+      sendMessage(producerConnectionSupplier, queueName, 0);
+   }
+
+   private void sendMessage(ConnectionSupplier producerConnectionSupplier, String queueName, int i) throws JMSException {
+      try (Connection connection = producerConnectionSupplier.createConnection();
+           Session session = connection.createSession();
+           MessageProducer producer = session.createProducer(session.createQueue(queueName))) {
+         TextMessage message1 = session.createTextMessage();
+         message1.setText(Integer.toString(i));
+         producer.send(message1);
+      }
+   }
+
+   private void receiveLVQ(ConnectionSupplier consumerConnectionSupplier, String queueName, String lastValueKey) throws JMSException {
+      try (Connection connection = consumerConnectionSupplier.createConnection();
+           Session session = connection.createSession();
+           MessageConsumer consumer = session.createConsumer(session.createQueue(queueName))) {
+         TextMessage msg = (TextMessage) consumer.receive(1000);
+         assertNotNull(msg);
+         assertEquals("KEY", msg.getStringProperty(lastValueKey));
+         assertEquals("how are you", msg.getText());
+      }
+   }
+
+   private void sendLVQ(ConnectionSupplier producerConnectionSupplier, String queueName, String lastValueKey) throws JMSException {
+      try (Connection connection = producerConnectionSupplier.createConnection();
+           Session session = connection.createSession();
+           MessageProducer producer = session.createProducer(session.createQueue(queueName))) {
+
+         TextMessage message1 = session.createTextMessage();
+         message1.setStringProperty(lastValueKey, "KEY");
+         message1.setText("hello");
+         producer.send(message1);
+
+         TextMessage message2 = session.createTextMessage();
+         message2.setStringProperty(lastValueKey, "KEY");
+         message2.setText("how are you");
+         producer.send(message2);
+      }
+   }
+
+   private void receiveLVQTombstone(ConnectionSupplier consumerConnectionSupplier, String queueName, String lastValueKey) throws JMSException {
+      try (Connection connection = consumerConnectionSupplier.createConnection();
+           Session session = connection.createSession();
+           MessageConsumer consumer = session.createConsumer(session.createQueue(queueName))) {
+         TextMessage msg = (TextMessage) consumer.receive(1000);
+         assertNotNull(msg);
+         assertEquals("KEY", msg.getStringProperty(lastValueKey));
+         assertEquals("tombstone", msg.getText());
+      }
+   }
+
+   private void receiveLVQAssertEmpty(ConnectionSupplier consumerConnectionSupplier, String queueName) throws JMSException {
+      try (Connection connection = consumerConnectionSupplier.createConnection();
+           Session session = connection.createSession();
+           MessageConsumer consumer = session.createConsumer(session.createQueue(queueName))) {
+         TextMessage msg = (TextMessage) consumer.receive(1000);
+         assertNull(msg);
+      }
+   }
+
+
+   private void sendLVQTombstone(ConnectionSupplier producerConnectionSupplier, String queueName, String lastValueKey, int tombstoneTimeToLive) throws JMSException {
+      try (Connection connection = producerConnectionSupplier.createConnection();
+           Session session = connection.createSession();
+           MessageProducer producer = session.createProducer(session.createQueue(queueName))) {
+         TextMessage message1 = session.createTextMessage();
+         message1.setStringProperty(lastValueKey, "KEY");
+         message1.setText("tombstone");
+         producer.send(message1, javax.jms.Message.DEFAULT_DELIVERY_MODE, javax.jms.Message.DEFAULT_PRIORITY, tombstoneTimeToLive);
+      }
+   }
+}

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/ConsumerDelayDispatchTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/ConsumerDelayDispatchTest.java
@@ -46,8 +46,8 @@ public class ConsumerDelayDispatchTest extends JMSTestBase {
    @Before
    public void setUp() throws Exception {
       super.setUp();
-      server.createQueue(queueName, RoutingType.ANYCAST, queueName, null, null, true, false, false, false, false, -1, false, true, false, 2, DELAY_BEFORE_DISPATCH, true);
-      server.createQueue(normalQueueName, RoutingType.ANYCAST, normalQueueName, null, null, true, false, false, false, false, -1, false, true, false, 0, -1, true);
+      server.createQueue(queueName, RoutingType.ANYCAST, queueName, null, null, true, false, false, false, false, -1, false, true, false, null, false, 2, DELAY_BEFORE_DISPATCH, true);
+      server.createQueue(normalQueueName, RoutingType.ANYCAST, normalQueueName, null, null, true, false, false, false, false, -1, false, true, false, null, false, 0, -1, true);
 
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
@@ -162,10 +162,11 @@ public class ActiveMQServerControlUsingCoreTest extends ActiveMQServerControlTes
                                    @Parameter(name = "maxConsumers", desc = "The maximum number of consumers allowed on this queue at any one time") Integer maxConsumers,
                                    @Parameter(name = "purgeOnNoConsumers", desc = "Delete this queue when the last consumer disconnects") Boolean purgeOnNoConsumers,
                                    @Parameter(name = "exclusive", desc = "If the queue should route exclusively to one consumer") Boolean exclusive,
+                                   @Parameter(name = "nonDestructive", desc = "If the queue should be nonDestructive") Boolean nonDestructive,
                                    @Parameter(name = "consumersBeforeDispatch", desc = "Number of consumers needed before dispatch can start") Integer consumersBeforeDispatch,
                                    @Parameter(name = "delayBeforeDispatch", desc = "Delay to wait before dispatching if number of consumers before dispatch is not met") Long delayBeforeDispatch,
                                    @Parameter(name = "user", desc = "The user associated with this queue") String user) throws Exception {
-            return (String) proxy.invokeOperation("updateQueue", name, routingType, filter, maxConsumers, purgeOnNoConsumers, exclusive, consumersBeforeDispatch, delayBeforeDispatch, user);
+            return (String) proxy.invokeOperation("updateQueue", name, routingType, filter, maxConsumers, purgeOnNoConsumers, exclusive, nonDestructive, consumersBeforeDispatch, delayBeforeDispatch, user);
          }
 
          @Override
@@ -202,8 +203,8 @@ public class ActiveMQServerControlUsingCoreTest extends ActiveMQServerControlTes
          }
 
          @Override
-         public String createQueue(String address, String routingType, String name, String filterStr, boolean durable, int maxConsumers, boolean purgeOnNoConsumers, boolean exclusive, boolean lastValue, int consumersBeforeDispatch, long delayBeforeDispatch, boolean autoCreateAddress) throws Exception {
-            return null;
+         public String createQueue(String address, String routingType, String name, String filter, boolean durable, int maxConsumers, boolean purgeOnNoConsumers, boolean exclusive, boolean lastValue, String lastValueKey, boolean nonDestructive, int consumersBeforeDispatch, long delayBeforeDispatch, boolean autoCreateAddress) throws Exception {
+            return (String) proxy.invokeOperation("createQueue", address, routingType, name, filter, durable, maxConsumers, purgeOnNoConsumers, exclusive, lastValue, lastValueKey, nonDestructive, consumersBeforeDispatch, delayBeforeDispatch, autoCreateAddress);
          }
 
          @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/QueueConfigRestartTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/QueueConfigRestartTest.java
@@ -115,7 +115,7 @@ public class QueueConfigRestartTest extends ActiveMQTestBase {
       SimpleString address = new SimpleString("test.address");
       SimpleString queue = new SimpleString("test.queue");
 
-      server.createQueue(address, RoutingType.MULTICAST, queue, null, null, true, false, false, false,false, 10, true, true, true, consumersBeforeDispatch, -1, true);
+      server.createQueue(address, RoutingType.MULTICAST, queue, null, null, true, false, false, false,false, 10, true, true, true, null, false, consumersBeforeDispatch, -1, true);
 
       QueueBinding queueBinding1 = (QueueBinding)server.getPostOffice().getBinding(queue);
       Assert.assertEquals(consumersBeforeDispatch, queueBinding1.getQueue().getConsumersBeforeDispatch());
@@ -138,7 +138,7 @@ public class QueueConfigRestartTest extends ActiveMQTestBase {
       SimpleString address = new SimpleString("test.address");
       SimpleString queue = new SimpleString("test.queue");
 
-      server.createQueue(address, RoutingType.MULTICAST, queue, null, null, true, false, false, false,false, 10, true, true, true, 0, delayBeforeDispatch, true);
+      server.createQueue(address, RoutingType.MULTICAST, queue, null, null, true, false, false, false,false, 10, true, true, true, null, false,0, delayBeforeDispatch, true);
 
       QueueBinding queueBinding1 = (QueueBinding)server.getPostOffice().getBinding(queue);
       Assert.assertEquals(delayBeforeDispatch, queueBinding1.getQueue().getDelayBeforeDispatch());

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/MessageHeaderTest.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/MessageHeaderTest.java
@@ -39,6 +39,8 @@ import java.util.Set;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.QueueAttributes;
+import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
@@ -50,7 +52,6 @@ import org.apache.activemq.artemis.api.core.client.SendAcknowledgementHandler;
 import org.apache.activemq.artemis.api.core.client.SessionFailureListener;
 import org.apache.activemq.artemis.core.client.impl.ClientMessageImpl;
 import org.apache.activemq.artemis.core.remoting.FailureListener;
-import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.jms.client.ActiveMQBytesMessage;
 import org.apache.activemq.artemis.jms.client.ActiveMQMapMessage;
 import org.apache.activemq.artemis.jms.client.ActiveMQMessage;
@@ -923,6 +924,11 @@ public class MessageHeaderTest extends MessageHeaderTestBase {
 
       }
 
+      @Override
+      public void createSharedQueue(SimpleString address, SimpleString queueName, QueueAttributes queueAttributes) throws ActiveMQException {
+
+      }
+
       /**
        * Creates a <em>non-temporary</em> queue.
        *
@@ -1031,6 +1037,11 @@ public class MessageHeaderTest extends MessageHeaderTestBase {
 
       }
 
+      @Override
+      public void createQueue(SimpleString address, SimpleString queueName, boolean autoCreated, QueueAttributes queueAttributes) throws ActiveMQException {
+
+      }
+
       /**
        * Creates a <em>non-temporary</em>queue.
        *
@@ -1098,6 +1109,11 @@ public class MessageHeaderTest extends MessageHeaderTestBase {
       public void createTemporaryQueue(SimpleString address, RoutingType routingType, SimpleString queueName, SimpleString filter,
                                        int maxConsumers, boolean purgeOnNoConsumers, Boolean exclusive, Boolean lastValue)
          throws ActiveMQException {
+
+      }
+
+      @Override
+      public void createTemporaryQueue(SimpleString address, SimpleString queueName, QueueAttributes queueAttributes) throws ActiveMQException {
 
       }
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/FakeQueue.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/FakeQueue.java
@@ -101,6 +101,21 @@ public class FakeQueue extends CriticalComponentImpl implements Queue {
    }
 
    @Override
+   public SimpleString getLastValueKey() {
+      return null;
+   }
+
+   @Override
+   public boolean isNonDestructive() {
+      return false;
+   }
+
+   @Override
+   public void setNonDestructive(boolean nonDestructive) {
+
+   }
+
+   @Override
    public void setMaxConsumer(int maxConsumers) {
 
    }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/impl/fakes/FakePostOffice.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/impl/fakes/FakePostOffice.java
@@ -51,6 +51,7 @@ public class FakePostOffice implements PostOffice {
                                    Integer maxConsumers,
                                    Boolean purgeOnNoConsumers,
                                    Boolean exclusive,
+                                   Boolean lastValue,
                                    Integer consumersBeforeDispatch,
                                    Long delayBeforeDispatch,
                                    SimpleString user,
@@ -66,7 +67,6 @@ public class FakePostOffice implements PostOffice {
 
    @Override
    public boolean isStarted() {
-
       return false;
    }
 


### PR DESCRIPTION
Implement custom LVQ Key and Non-Destructive in broker - protocol agnostic
Make feature configurable via broker.xml, core apis and activemqservercontrol 
Add last-value-key test cases
Add non-destructive with lvq test cases 
Add non-destructive with expiry-delay test cases
Update documents
Add new methods to support create, update with new attributes
Refactor to pass through queue-attributes in client side methods to reduce further method changes for adding new attributes in future and avoid methods with endless parameters. (note: in future this should prob be done server side too)


Update existing test cases and fake impls for new methods/attributes