### PR TITLE
NO-JIRA close connection factory in CLI

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/Browse.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/Browse.java
@@ -69,6 +69,10 @@ public class Browse extends DestAbstract {
          }
 
          return received;
+      } finally {
+         if (factory instanceof AutoCloseable) {
+            ((AutoCloseable) factory).close();
+         }
       }
    }
 

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/Consumer.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/Consumer.java
@@ -55,8 +55,6 @@ public class Consumer extends DestAbstract {
 
       System.out.println("Consumer:: filter = " + filter);
 
-      ConnectionFactory factory = createConnectionFactory();
-
       SerialiserMessageListener listener = null;
       MessageSerializer messageSerializer = null;
       if (file != null) {
@@ -82,6 +80,8 @@ public class Consumer extends DestAbstract {
       }
 
       if (messageSerializer != null) messageSerializer.start();
+
+      ConnectionFactory factory = createConnectionFactory();
 
       try (Connection connection = factory.createConnection()) {
          // We read messages in a single thread when persisting to file.
@@ -118,6 +118,10 @@ public class Consumer extends DestAbstract {
          if (messageSerializer != null) messageSerializer.stop();
 
          return received;
+      } finally {
+         if (factory instanceof AutoCloseable) {
+            ((AutoCloseable) factory).close();
+         }
       }
    }
 

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/Producer.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/Producer.java
@@ -137,6 +137,10 @@ public class Producer extends DestAbstract {
             }
             return messagesProduced;
          }
+      } finally {
+         if (factory instanceof AutoCloseable) {
+            ((AutoCloseable) factory).close();
+         }
       }
    }
 


### PR DESCRIPTION
Fix warning seen in logs during test case runs, caused by CF not being closed.

Oct 10, 2018 8:53:18 PM org.apache.activemq.artemis.core.client.impl.ClientSessionFactoryImpl finalize
WARN: AMQ212008: I am closing a core ClientSessionFactory you left open. Please make sure you close all ClientSessionFactories explicitly before letting them go out of scope! 639,542,871
java.lang.Exception
	at org.apache.activemq.artemis.core.client.impl.ClientSessionFactoryImpl.<init>(ClientSessionFactoryImpl.java:171)
	at org.apache.activemq.artemis.core.client.impl.ServerLocatorImpl.createSessionFactory(ServerLocatorImpl.java:779)
	at org.apache.activemq.artemis.cli.commands.messages.DestAbstract.getManagementSession(DestAbstract.java:103)
	at org.apache.activemq.artemis.cli.commands.messages.DestAbstract.getQueueAttribute(DestAbstract.java:127)
	at org.apache.activemq.artemis.cli.commands.messages.DestAbstract.getQueueIdFromName(DestAbstract.java:116)
	at org.apache.activemq.artemis.cli.commands.messages.Producer.execute(Producer.java:75)
	at org.apache.activemq.artemis.cli.Artemis.internalExecute(Artemis.java:150)
	at org.apache.activemq.artemis.cli.Artemis.execute(Artemis.java:98)
	at org.apache.activemq.artemis.cli.Artemis.execute(Artemis.java:125)
	at org.apache.activemq.artemis.cli.Artemis.main(Artemis.java:81)