### PR TITLE
ARTEMIS-2097 Pause and Block Producers

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/ActiveMQAddressBlockedException.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/ActiveMQAddressBlockedException.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.api.core;
+
+public class ActiveMQAddressBlockedException extends ActiveMQException {
+
+   public ActiveMQAddressBlockedException(String address) {
+      super(ActiveMQExceptionType.ADDRESS_BLOCKED, "Sending is blocked on address: " + address);
+   }
+
+   @Override
+   public Throwable fillInStackTrace() {
+      return this;
+   }
+}

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/ActiveMQExceptionType.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/ActiveMQExceptionType.java
@@ -255,6 +255,12 @@ public enum ActiveMQExceptionType {
       public ActiveMQException createException(String msg) {
          return new ActiveMQShutdownException(msg);
       }
+   },
+   ADDRESS_BLOCKED(220) {
+      @Override
+      public ActiveMQException createException(String msg) {
+         return new ActiveMQAddressBlockedException(msg);
+      }
    };
 
    private static final Map<Integer, ActiveMQExceptionType> TYPE_MAP;

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
@@ -1331,5 +1331,9 @@ public interface ActiveMQServerControl {
     */
    @Operation(desc = "Names of the queues created on this server with the given routing-type (i.e. ANYCAST or MULTICAST)", impact = MBeanOperationInfo.INFO)
    String[] getQueueNames(@Parameter(name = "routingType", desc = "The routing type, MULTICAST or ANYCAST") String routingType);
+
+   @Operation(desc = "Block sending on multiple addresses", impact = MBeanOperationInfo.ACTION)
+   void blockSendingOnAddresses(@Parameter(name = "blocking", desc = "Whether to block or to unblock") boolean blocking,
+                                @Parameter(name = "addresses", desc = "The target addresses to block or unblock") String... addresses) throws Exception;
 }
 

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/AddressControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/AddressControl.java
@@ -133,4 +133,7 @@ public interface AddressControl {
                       @Parameter(name = "durable", desc = "Whether the message is durable") boolean durable,
                       @Parameter(name = "user", desc = "The user to authenticate with") String user,
                       @Parameter(name = "password", desc = "The users password to authenticate with") String password) throws Exception;
+
+   @Operation(desc = "blocking/unblocking message sending to this address")
+   void blockSending(@Parameter(name = "block", desc = "Whether to block or unblock message sending on the address") boolean block) throws Exception;
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -926,6 +926,11 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
    }
 
    @Override
+   public void blockSendingOnAddresses(boolean blocking, String... addresses) throws Exception {
+      server.blockSendingOnAddresses(blocking, addresses);
+   }
+
+   @Override
    public String getUptime() {
       checkStarted();
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/AddressControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/AddressControlImpl.java
@@ -327,6 +327,12 @@ public class AddressControlImpl extends AbstractControl implements AddressContro
    }
 
    @Override
+   public void blockSending(boolean block) {
+      postOffice.blockSendingOnAddress(block, this.getAddress());
+   }
+
+
+   @Override
    protected MBeanOperationInfo[] fillMBeanOperationInfo() {
       return MBeanInfoHelper.getMBeanOperationsInfo(AddressControl.class);
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/PostOffice.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/PostOffice.java
@@ -161,4 +161,10 @@ public interface PostOffice extends ActiveMQComponent {
    Set<SimpleString> getAddresses();
 
    void updateMessageLoadBalancingTypeForAddress(SimpleString  address, MessageLoadBalancingType messageLoadBalancingType) throws Exception;
+
+   void blockSendingOnAddress(boolean blocking, String address);
+
+   boolean isAddressBlocked(SimpleString address);
+
+   List<Pair<String, Boolean>> getAddressBlockRules();
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServer.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServer.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import javax.management.MBeanServer;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.Pair;
 import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.config.BridgeConfiguration;
@@ -81,7 +82,6 @@ import org.apache.activemq.artemis.utils.critical.CriticalAnalyzer;
  * This is not part of our public API.
  */
 public interface ActiveMQServer extends ServiceComponent {
-
 
    enum SERVER_STATE {
       /**
@@ -636,4 +636,20 @@ public interface ActiveMQServer extends ServiceComponent {
 
    String getInternalNamingPrefix();
 
+   /**
+    * Block message sending on the address. Clients
+    * sending messages to this address will be blocked
+    * untill it is unblocked.
+    * @param blocking whether to block or unblock the address
+    * @param address the target address
+    */
+   void blockSendingOnSingleAddress(boolean blocking, String address) throws Exception;
+
+   default void blockSendingOnAddresses(boolean blocking, String... addresses) throws Exception {
+      for (String address : addresses) {
+         blockSendingOnSingleAddress(blocking, address);
+      }
+   }
+
+   List<Pair<String, Boolean>> getAddressBlockRules();
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -2990,6 +2990,16 @@ public class ActiveMQServerImpl implements ActiveMQServer {
    }
 
    @Override
+   public void blockSendingOnSingleAddress(boolean blocking, String address) throws Exception {
+      postOffice.blockSendingOnAddress(blocking, address);
+   }
+
+   @Override
+   public List<Pair<String, Boolean>> getAddressBlockRules() {
+      return postOffice.getAddressBlockRules();
+   }
+
+   @Override
    public AddressInfo getAddressInfo(SimpleString address) {
       return postOffice.getAddressInfo(address);
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.activemq.artemis.Closeable;
+import org.apache.activemq.artemis.api.core.ActiveMQAddressBlockedException;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.ActiveMQIOErrorException;
@@ -1788,6 +1789,11 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
          } */
 
       AddressInfo art = getAddressAndRoutingType(new AddressInfo(msg.getAddressSimpleString(), routingType));
+
+      if (postOffice.isAddressBlocked(msg.getAddressSimpleString())) {
+         //throw an exception telling clients that it's blocked
+         throw new ActiveMQAddressBlockedException(msg.getAddress());
+      }
 
       // Consumer
       // check the user has write access to this address.

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
@@ -324,6 +324,11 @@ public class ActiveMQServerControlUsingCoreTest extends ActiveMQServerControlTes
          }
 
          @Override
+         public void blockSendingOnAddresses(boolean blocking, String... addresses) throws Exception {
+
+         }
+
+         @Override
          public String getUptime() {
             return null;
          }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/AddressControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/AddressControlTest.java
@@ -392,6 +392,10 @@ public class AddressControlTest extends ManagementTestBase {
       assertEquals("test", new String(buffer));
    }
 
+   @Test
+   public void testBlockingSendMessage() throws Exception {
+
+   }
    // Package protected ---------------------------------------------
 
    // Protected -----------------------------------------------------

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/AddressControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/AddressControlUsingCoreTest.java
@@ -122,6 +122,11 @@ public class AddressControlUsingCoreTest extends AddressControlTest {
                                    String password) throws Exception {
             return (String) proxy.invokeOperation("sendMessage", headers, type, body, durable, user, password);
          }
+
+         @Override
+         public void blockSending(boolean block) throws Exception {
+            proxy.invokeOperation("blockSending", block);
+         }
       };
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/BlockingSendTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/BlockingSendTest.java
@@ -1,0 +1,545 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.management;
+
+import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.api.core.client.ClientMessage;
+import org.apache.activemq.artemis.api.core.client.ClientProducer;
+import org.apache.activemq.artemis.api.core.client.ClientSession;
+import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
+import org.apache.activemq.artemis.api.core.client.ServerLocator;
+import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl;
+import org.apache.activemq.artemis.api.core.management.AddressControl;
+import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.postoffice.PostOffice;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.Queue;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.apache.activemq.artemis.junit.Wait;
+import org.apache.qpid.jms.JmsConnectionFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class BlockingSendTest extends ManagementTestBase {
+
+   private static final String BLOCK_ADDRESS1 = "BLOCK.ADDRESS.1";
+   private static final String BLOCK_ADDRESS2 = "BLOCK.ADDRESS.2";
+   private static final String NORMAL_ADDRESS1 = "NORMAL.ADDRESS.1";
+   private static final String NORMAL_ADDRESS2 = "NORMAL.ADDRESS.2";
+   private static final String BLOCK_ADDRESS_ALL = "BLOCK.ADDRESS.#";
+   private static final String NORMAL_ADDRESS_ALL = "NORMAL.ADDRESS.#";
+
+   private static final String KEY_PRODUCER_ID = "producer_id";
+
+   private ActiveMQServer server;
+
+   Queue blockQueue1;
+   Queue blockQueue2;
+   Queue normalQueue1;
+   Queue normalQueue2;
+
+   TestProducer[] blockProducers1 = null;
+   TestProducer[] blockProducers2 = null;
+   TestProducer[] normalProducers1 = null;
+   TestProducer[] normalProducers2 = null;
+
+   @Override
+   @Before
+   public void setUp() throws Exception {
+      super.setUp();
+
+      leakCheckRule.disable();//tmp disable
+
+      Configuration config = createDefaultConfig(true).setJMXManagementEnabled(true);
+      server = createServer(true, config);
+      server.setMBeanServer(mbeanServer);
+      server.start();
+
+      blockQueue1 = server.createQueue(new SimpleString(BLOCK_ADDRESS1), RoutingType.ANYCAST, new SimpleString(BLOCK_ADDRESS1), null, true, false);
+      blockProducers1 = createTestProducers(BLOCK_ADDRESS1);
+      blockQueue2 = server.createQueue(new SimpleString(BLOCK_ADDRESS2), RoutingType.ANYCAST, new SimpleString(BLOCK_ADDRESS2), null, true, false);
+      blockProducers2 = createTestProducers(BLOCK_ADDRESS2);
+      normalQueue1 = server.createQueue(new SimpleString(NORMAL_ADDRESS1), RoutingType.ANYCAST, new SimpleString(NORMAL_ADDRESS1), null, true, false);
+      normalProducers1 = createTestProducers(NORMAL_ADDRESS1);
+      normalQueue2 = server.createQueue(new SimpleString(NORMAL_ADDRESS2), RoutingType.ANYCAST, new SimpleString(NORMAL_ADDRESS2), null, true, false);
+      normalProducers2 = createTestProducers(NORMAL_ADDRESS2);
+
+      for (TestProducer producer : blockProducers1) {
+         producer.start();
+      }
+      for (TestProducer producer : blockProducers2) {
+         producer.start();
+      }
+      for (TestProducer producer : normalProducers1) {
+         producer.start();
+      }
+      for (TestProducer producer : normalProducers2) {
+         producer.start();
+      }
+   }
+
+   @Override
+   @After
+   public void tearDown() throws Exception {
+      stopAllProducers();
+      server.destroyQueue(blockQueue1.getName());
+      server.destroyQueue(blockQueue2.getName());
+      server.destroyQueue(normalQueue1.getName());
+      server.destroyQueue(normalQueue2.getName());
+      server.stop();
+   }
+
+   private void checkProducersNotBlocked(TestProducer[]... producers) throws Exception {
+      checkProducerBlockStatus(false, producers);
+   }
+
+   private void checkProducersBlocked(TestProducer[]... producers) throws Exception {
+      checkProducerBlockStatus(true, producers);
+   }
+
+   private void checkProducerBlockStatus(boolean expected, TestProducer[]... producers) throws Exception {
+      for (TestProducer[] producerGroup : producers) {
+         for (TestProducer producer : producerGroup) {
+            assertTrue("producer " + (expected ? "should" : "shouldn't") + " be blocked: " + producer, producer.checkSendingBlocked(expected, 1000));
+         }
+      }
+   }
+
+   @Test
+   public void testBlockSendingOnOneAddress() throws Exception {
+
+      checkProducersNotBlocked(blockProducers1);
+
+      server.blockSendingOnAddresses(true, BLOCK_ADDRESS1);
+
+      checkProducersBlocked(blockProducers1);
+
+      checkQueueEmpty(blockQueue1);
+
+      checkProducersNotBlocked(blockProducers2, normalProducers1, normalProducers2);
+
+      server.blockSendingOnAddresses(true, BLOCK_ADDRESS2);
+
+      checkProducersBlocked(blockProducers1, blockProducers2);
+      checkQueueEmpty(blockQueue2);
+
+      checkProducersNotBlocked(normalProducers1, normalProducers2);
+
+      server.blockSendingOnAddresses(true, NORMAL_ADDRESS1);
+
+      checkProducersBlocked(blockProducers1, blockProducers2, normalProducers1);
+
+      checkQueueEmpty(normalQueue1);
+
+      checkProducersNotBlocked(normalProducers2);
+
+      server.blockSendingOnAddresses(true, NORMAL_ADDRESS2);
+
+      checkProducersBlocked(blockProducers1, blockProducers2, normalProducers1, normalProducers2);
+      checkQueueEmpty(normalQueue2);
+
+      //unblocking
+      server.blockSendingOnAddresses(false, BLOCK_ADDRESS1);
+
+      checkProducersNotBlocked(blockProducers1);
+      checkProducersBlocked(blockProducers2, normalProducers1, normalProducers2);
+
+      server.blockSendingOnAddresses(false, BLOCK_ADDRESS2);
+
+      checkProducersNotBlocked(blockProducers1, blockProducers2);
+      checkProducersBlocked(normalProducers1, normalProducers2);
+
+      server.blockSendingOnAddresses(false, NORMAL_ADDRESS1);
+
+      checkProducersNotBlocked(blockProducers1, blockProducers2, normalProducers1);
+      checkProducersBlocked(normalProducers2);
+
+      server.blockSendingOnAddresses(false, NORMAL_ADDRESS2);
+
+      checkProducersNotBlocked(blockProducers1, blockProducers2, normalProducers1, normalProducers2);
+      assertNull(server.getAddressBlockRules());
+   }
+
+   @Test
+   public void testBlockSendingOnWildcardAddress() throws Exception {
+
+      server.blockSendingOnAddresses(true, BLOCK_ADDRESS_ALL);
+
+      checkProducersBlocked(blockProducers1, blockProducers2);
+      checkQueueEmpty(blockQueue1);
+      checkQueueEmpty(blockQueue2);
+
+      checkProducersNotBlocked(normalProducers1, normalProducers2);
+
+      server.blockSendingOnAddresses(true, NORMAL_ADDRESS_ALL);
+
+      checkProducersBlocked(blockProducers1, blockProducers2, normalProducers1, normalProducers2);
+      checkQueueEmpty(normalQueue1);
+      checkQueueEmpty(normalQueue2);
+
+      server.blockSendingOnAddresses(false, BLOCK_ADDRESS_ALL);
+
+      checkProducersNotBlocked(blockProducers1, blockProducers2);
+      checkProducersBlocked(normalProducers1, normalProducers2);
+
+      server.blockSendingOnAddresses(false, NORMAL_ADDRESS_ALL);
+
+      checkProducersNotBlocked(blockProducers1, blockProducers2, normalProducers1, normalProducers2);
+
+      server.blockSendingOnAddresses(true, "#");
+
+      checkProducersBlocked(blockProducers1, blockProducers2, normalProducers1, normalProducers2);
+      checkQueueEmpty(blockQueue1);
+      checkQueueEmpty(blockQueue2);
+      checkQueueEmpty(normalQueue1);
+      checkQueueEmpty(normalQueue2);
+
+      server.blockSendingOnAddresses(false, "#");
+
+      checkProducersNotBlocked(blockProducers1, blockProducers2, normalProducers1, normalProducers2);
+      assertNull(server.getAddressBlockRules());
+   }
+
+   @Test
+   public void testBlockSendingOnMultiAddresses() throws Exception {
+
+      server.blockSendingOnAddresses(true, BLOCK_ADDRESS1, BLOCK_ADDRESS2, NORMAL_ADDRESS1);
+
+      checkProducersBlocked(blockProducers1, blockProducers2, normalProducers1);
+      checkQueueEmpty(normalQueue1);
+      checkProducersNotBlocked(normalProducers2);
+
+      server.blockSendingOnAddresses(false, BLOCK_ADDRESS_ALL, NORMAL_ADDRESS1);
+
+      checkProducersNotBlocked(blockProducers1, blockProducers2, normalProducers1, normalProducers2);
+
+      server.blockSendingOnAddresses(true, NORMAL_ADDRESS_ALL, BLOCK_ADDRESS_ALL);
+
+      checkProducersBlocked(blockProducers1, blockProducers2, normalProducers1, normalProducers2);
+      checkQueueEmpty(blockQueue1);
+      checkQueueEmpty(blockQueue2);
+      checkQueueEmpty(normalQueue1);
+      checkQueueEmpty(normalQueue2);
+
+      server.blockSendingOnAddresses(false, NORMAL_ADDRESS_ALL, BLOCK_ADDRESS_ALL);
+
+      checkProducersNotBlocked(blockProducers1, blockProducers2, normalProducers1, normalProducers2);
+      assertNull(server.getAddressBlockRules());
+   }
+
+   @Test
+   public void testManagementAPI() throws Exception {
+      //we just need to verify that management api can reach the actual code.
+      stopAllProducers();
+
+      PostOffice po = server.getPostOffice();
+
+      AddressControl addressControl1 = ManagementControlHelper.createAddressControl(new SimpleString(BLOCK_ADDRESS1), mbeanServer);
+
+      addressControl1.blockSending(true);
+      assertTrue(po.isAddressBlocked(new SimpleString(BLOCK_ADDRESS1)));
+
+      addressControl1.blockSending(false);
+      assertFalse(po.isAddressBlocked(new SimpleString(BLOCK_ADDRESS1)));
+
+      ActiveMQServerControl serverControl = ManagementControlHelper.createActiveMQServerControl(mbeanServer);
+
+      serverControl.blockSendingOnAddresses(true, BLOCK_ADDRESS1, BLOCK_ADDRESS2, NORMAL_ADDRESS1, NORMAL_ADDRESS2);
+      assertTrue(po.isAddressBlocked(new SimpleString(BLOCK_ADDRESS1)));
+      assertTrue(po.isAddressBlocked(new SimpleString(BLOCK_ADDRESS2)));
+      assertTrue(po.isAddressBlocked(new SimpleString(NORMAL_ADDRESS1)));
+      assertTrue(po.isAddressBlocked(new SimpleString(NORMAL_ADDRESS2)));
+
+      serverControl.blockSendingOnAddresses(false, BLOCK_ADDRESS_ALL);
+      assertFalse(po.isAddressBlocked(new SimpleString(BLOCK_ADDRESS1)));
+      assertFalse(po.isAddressBlocked(new SimpleString(BLOCK_ADDRESS2)));
+      assertTrue(po.isAddressBlocked(new SimpleString(NORMAL_ADDRESS1)));
+      assertTrue(po.isAddressBlocked(new SimpleString(NORMAL_ADDRESS2)));
+
+      serverControl.blockSendingOnAddresses(false, NORMAL_ADDRESS1);
+      assertFalse(po.isAddressBlocked(new SimpleString(BLOCK_ADDRESS1)));
+      assertFalse(po.isAddressBlocked(new SimpleString(BLOCK_ADDRESS2)));
+      assertFalse(po.isAddressBlocked(new SimpleString(NORMAL_ADDRESS1)));
+      assertTrue(po.isAddressBlocked(new SimpleString(NORMAL_ADDRESS2)));
+
+      serverControl.blockSendingOnAddresses(false, NORMAL_ADDRESS2);
+      assertFalse(po.isAddressBlocked(new SimpleString(BLOCK_ADDRESS1)));
+      assertFalse(po.isAddressBlocked(new SimpleString(BLOCK_ADDRESS2)));
+      assertFalse(po.isAddressBlocked(new SimpleString(NORMAL_ADDRESS1)));
+      assertFalse(po.isAddressBlocked(new SimpleString(NORMAL_ADDRESS2)));
+
+      assertNull(po.getAddressBlockRules());
+   }
+
+   private TestProducer[] createTestProducers(String address) throws Exception {
+      //core, jms, openwire, amqp
+      TestProducer[] producers = new TestProducer[4];
+      producers[0] = new CoreTestProducer(address);
+      producers[1] = new JmsTestProducer(address);
+      producers[2] = new OpenwireTestProducer(address);
+      producers[3] = new AmqpTestProducer(address);
+      return producers;
+   }
+
+   private void stopAllProducers() {
+      for (TestProducer producer : blockProducers1) {
+         producer.discard();
+      }
+      for (TestProducer producer : blockProducers2) {
+         producer.discard();
+      }
+      for (TestProducer producer : normalProducers1) {
+         producer.discard();
+      }
+      for (TestProducer producer : normalProducers2) {
+         producer.discard();
+      }
+   }
+
+   private void checkQueueEmpty(Queue queue) throws Exception {
+      queue.deleteAllReferences();
+      boolean result = Wait.waitFor(new Wait.Condition() {
+         @Override
+         public boolean isSatisfied() throws Exception {
+            return queue.getMessageCount() == 0;
+         }
+      }, 2000, 200);
+      assertTrue("queue not empty: " + queue.getMessageCount(), result);
+   }
+
+   private abstract class TestProducer extends Thread {
+
+      protected static final long SEND_INTERVAL = 100;
+
+      protected String address;
+      protected volatile boolean running = true;
+      protected AtomicBoolean blocked = new AtomicBoolean(false);
+
+      TestProducer(String address) throws Exception {
+         this.address = address;
+      }
+
+      public void discard() {
+         running = false;
+         try {
+            this.join();
+         } catch (InterruptedException e) {
+         }
+         cleanupProducer();
+      }
+
+      public abstract void createProducer() throws Exception;
+      public abstract void cleanupProducer();
+      public abstract void sendMessage() throws Exception;
+
+      public boolean checkSendingBlocked(boolean expected, long timeout) throws Exception {
+
+         if (!running) {
+            throw new Exception(this + " producer already stopped");
+         }
+
+         boolean result = Wait.waitFor(() -> blocked.get() == expected, timeout);
+
+         return result;
+      }
+
+      @Override
+      public void run() {
+         try {
+            createProducer();
+         } catch (Throwable e) {
+            System.err.println(this + " error creating producer: " + e.getMessage());
+            e.printStackTrace();
+            return;
+         }
+
+         while (running) {
+            try {
+               sendMessage();
+               blocked.set(false);
+               try {
+                  Thread.sleep(SEND_INTERVAL);
+               } catch (InterruptedException e) {
+               }
+            } catch (Exception e) {
+               System.err.println(this + " error sending message: " + e.getMessage());
+
+               if (e.getMessage().contains("Sending is blocked on address")) {
+                  blocked.set(true);
+                  try {
+                     cleanupProducer();
+                     createProducer();
+                  } catch (Exception e1) {
+                     running = false;
+                     discard();
+                  }
+               } else {
+                  running = false;
+                  discard();
+               }
+            }
+         }
+      }
+   }
+
+   private class CoreTestProducer extends TestProducer {
+
+      private ServerLocator locator;
+      private ClientSessionFactory sf;
+      private ClientSession session;
+      private ClientProducer producer;
+
+      CoreTestProducer(String address) throws Exception {
+         super(address);
+      }
+
+      @Override
+      public void createProducer() throws Exception {
+         locator = createNettyNonHALocator();
+         sf = locator.createSessionFactory();
+         session = sf.createSession(true, true);
+         producer = session.createProducer(address);
+      }
+
+      @Override
+      public void cleanupProducer() {
+         if (producer == null) {
+            return;
+         }
+         try {
+            producer.close();
+            session.close();
+         } catch (ActiveMQException e) {
+            System.err.println("failed to close resource: " + e.getMessage());
+            e.printStackTrace();
+         }
+         sf.close();
+         locator.close();
+      }
+
+      @Override
+      public void sendMessage() throws Exception {
+         ClientMessage message = session.createMessage(true);
+         message.putStringProperty(KEY_PRODUCER_ID, "CoreProducer@" + address);
+         producer.send(message);
+      }
+
+      @Override
+      public String toString() {
+         return "CoreProducer@" + address;
+      }
+   }
+
+   private class JmsTestProducer extends TestProducer {
+
+      private Connection connection;
+      private Session session;
+      private javax.jms.Queue dest;
+      private MessageProducer producer;
+
+      JmsTestProducer(String address) throws Exception {
+         super(address);
+      }
+
+      @Override
+      public void createProducer() throws Exception {
+         ConnectionFactory cf = createCF();
+         connection = cf.createConnection();
+         session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+         dest = session.createQueue(address);
+         producer = session.createProducer(dest);
+      }
+
+      protected ConnectionFactory createCF() {
+         return new ActiveMQConnectionFactory("tcp://localhost:61616");
+      }
+
+      @Override
+      public void cleanupProducer() {
+         try {
+            producer.close();
+            session.close();
+            connection.close();
+         } catch (JMSException e) {
+            System.err.println("failed to close resources: " + e.getMessage());
+            e.printStackTrace();
+         }
+      }
+
+      @Override
+      public void sendMessage() throws Exception {
+         Message message = session.createMessage();
+         message.setStringProperty(KEY_PRODUCER_ID, "JMSProducer@" + address);
+         producer.send(message);
+      }
+
+      @Override
+      public String toString() {
+         return "JmsProducer@" + address;
+      }
+   }
+
+   private class OpenwireTestProducer extends JmsTestProducer {
+      private org.apache.activemq.ActiveMQConnectionFactory cf;
+      private Connection connection;
+      private Session session;
+      private javax.jms.Queue dest;
+      private MessageProducer producer;
+
+      OpenwireTestProducer(String address) throws Exception {
+         super(address);
+      }
+
+      @Override
+      protected ConnectionFactory createCF() {
+         return new org.apache.activemq.ActiveMQConnectionFactory("tcp://localhost:61616");
+      }
+
+      @Override
+      public String toString() {
+         return "OpenwireProducer@" + address;
+      }
+   }
+
+   private class AmqpTestProducer extends JmsTestProducer {
+
+      AmqpTestProducer(String address) throws Exception {
+         super(address);
+      }
+
+      @Override
+      public String toString() {
+         return "AmqpProducer@" + address;
+      }
+
+      @Override
+      public ConnectionFactory createCF() {
+         return new JmsConnectionFactory("amqp://127.0.0.1:61616");
+      }
+   }
+}

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/impl/fakes/FakePostOffice.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/impl/fakes/FakePostOffice.java
@@ -81,6 +81,21 @@ public class FakePostOffice implements PostOffice {
    }
 
    @Override
+   public void blockSendingOnAddress(boolean blocking, String address) {
+
+   }
+
+   @Override
+   public boolean isAddressBlocked(SimpleString address) {
+      return false;
+   }
+
+   @Override
+   public List<Pair<String, Boolean>> getAddressBlockRules() {
+      return null;
+   }
+
+   @Override
    public SimpleString getMatchingQueue(SimpleString address, RoutingType routingType) {
 
       return null;


### PR DESCRIPTION
Added new methods to AddressControl and ServerControl to allow users
to block sending on addresses. Once blocked, any messages sending
to the blocked addresses will get rejected with an exception. The
senders can catch the corresponding exception and handle properly.
For example, keep resending or send messages to some alternative
addresses.