### PR TITLE
[ARTEMIS-2130]Web console display blank ClientID for the core client

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/ConnectionView.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/ConnectionView.java
@@ -51,10 +51,14 @@ public class ConnectionView extends ActiveMQAbstractView<RemotingConnection> {
 
       List<ServerSession> sessions = server.getSessions(connection.getID().toString());
       Set<String> users = new HashSet<>();
+      String clientID = null;
 
       for (ServerSession session : sessions) {
          String username = session.getUsername() == null ? "" : session.getUsername();
          users.add(username);
+         if (clientID == null) {
+            clientID = session.getMetaData("jms-client-id") == null ? connection.getClientID() : session.getMetaData("jms-client-id");
+         }
       }
 
       return JsonLoader.createObjectBuilder().add("connectionID", toString(connection.getID()))
@@ -63,7 +67,7 @@ public class ConnectionView extends ActiveMQAbstractView<RemotingConnection> {
          .add("creationTime", new Date(connection.getCreationTime()).toString())
          .add("implementation", toString(connection.getClass().getSimpleName()))
          .add("protocol", toString(connection.getProtocolName()))
-         .add("clientID", toString(connection.getClientID()))
+         .add("clientID", toString(clientID))
          .add("localAddress", toString(connection.getTransportLocalAddress()))
          .add("sessionCount", server.getSessions(connection.getID().toString()).size());
    }
@@ -91,7 +95,14 @@ public class ConnectionView extends ActiveMQAbstractView<RemotingConnection> {
          case "protocol":
             return connection.getProtocolName();
          case "clientID":
-            return connection.getClientID();
+            String clientID = null;
+            for (ServerSession session : sessions) {
+               if (clientID == null) {
+                  clientID = session.getMetaData("jms-client-id") == null ? connection.getClientID() : session.getMetaData("jms-client-id");
+                  break;
+               }
+            }
+            return clientID;
          case "localAddress":
             return connection.getTransportLocalAddress();
          case "sessionCount":

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/ConsumerView.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/ConsumerView.java
@@ -53,7 +53,7 @@ public class ConsumerView extends ActiveMQAbstractView<ServerConsumer> {
 
       JsonObjectBuilder obj = JsonLoader.createObjectBuilder().add("id", toString(consumer.getSequentialID()))
          .add("session", toString(consumer.getSessionName()))
-         .add("clientID", toString(consumer.getConnectionClientID()))
+         .add("clientID", toString(session.getMetaData("jms-client-id") == null ? consumer.getConnectionClientID() : session.getMetaData("jms-client-id")))
          .add("user", toString(session.getUsername()))
          .add("protocol", toString(consumer.getConnectionProtocolName()))
          .add("queue", toString(consumer.getQueueName()))
@@ -82,7 +82,7 @@ public class ConsumerView extends ActiveMQAbstractView<ServerConsumer> {
          case "user":
             return session.getUsername();
          case "clientID":
-            return consumer.getConnectionClientID();
+            return session.getMetaData("jms-client-id") == null ? consumer.getConnectionClientID() : session.getMetaData("jms-client-id");
          case "protocol":
             return consumer.getConnectionProtocolName();
          case "queue":

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/ProducerView.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/ProducerView.java
@@ -52,7 +52,7 @@ public class ProducerView extends ActiveMQAbstractView<ServerProducer> {
 
       JsonObjectBuilder obj = JsonLoader.createObjectBuilder().add("id", toString(producer.getID()))
          .add("session", toString(session.getName()))
-         .add("clientID", toString(session.getRemotingConnection().getClientID()))
+         .add("clientID", toString(session.getMetaData("jms-client-id") == null ? session.getRemotingConnection().getClientID() : session.getMetaData("jms-client-id")))
          .add("user", toString(session.getUsername()))
          .add("protocol", toString(session.getRemotingConnection().getProtocolName()))
          .add("address", toString(producer.getAddress() != null ? producer.getAddress() : session.getDefaultAddress()))
@@ -79,7 +79,7 @@ public class ProducerView extends ActiveMQAbstractView<ServerProducer> {
          case "user":
             return session.getUsername();
          case "clientID":
-            return session.getRemotingConnection().getClientID();
+            return session.getMetaData("jms-client-id") == null ? session.getRemotingConnection().getClientID() : session.getMetaData("jms-client-id");
          case "protocol":
             return session.getRemotingConnection().getProtocolName();
          case "address":


### PR DESCRIPTION
JIRA:- https://issues.apache.org/jira/browse/ARTEMIS-2130

While using core client. Connection.setClientID(String) , set the ServerSession metadata using the key "jms-client-id"