### PR TITLE
ARTEMIS-2133 Artemis tab not showing on IE browser

### DIFF
--- a/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/artemisPlugin.js
+++ b/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/artemisPlugin.js
@@ -362,7 +362,7 @@ var ARTEMIS = (function(ARTEMIS) {
 
       workspace.subLevelTabs = subLevelTabs;
 
-      preLogoutTasks.addTask("clearArtemisCredentials", () => {
+      preLogoutTasks.addTask("clearArtemisCredentials", function () {
           localStorage.removeItem('artemisUserName');
           localStorage.removeItem('artemisPassword');
       });


### PR DESCRIPTION
The web console on IE doesn't have 'Artemis' showed up because
it doesn't support javascripts => function.