### PR TITLE
NO-JIRA: Clarify journal-buffer-timeout documentation

### DIFF
--- a/docs/user-manual/en/persistence.md
+++ b/docs/user-manual/en/persistence.md
@@ -266,6 +266,9 @@ The message journal is configured using the following attributes in
   nanoseconds - 300 times per second, default for ASYNCIO is 500000
   nanoseconds - ie. 2000 times per second).
 
+  Setting this property to 0 will disable the internal buffer and writes will
+  be directly written to the journal file immediately.
+  
   > **Note:**
   >
   > By increasing the timeout, you may be able to increase system


### PR DESCRIPTION
Clarify how to disable the buffer timeout.  On one of my test brokers I disabled journal-sync-transactional and journal-sync-non-transactional as data loss is not a big deal.  In this scenario I just want to write directly to the file and not use a timed buffer and let the OS handle data syncing, however it was not clear on how to accomplish this.  Looking at the code I discovered setting the timeout to 0 will disable the buffer so I'm adding a comment in case others want to do the same.