### PR TITLE
[ARTEMIS-2166]Unable to delete queue with single quote from console

### DIFF
--- a/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/queue.js
+++ b/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/queue.js
@@ -102,7 +102,6 @@ var ARTEMIS = (function(ARTEMIS) {
                 if (selection && jolokia && entries) {
                     var domain = selection.domain;
                     var name = entries["Destination"] || entries["destinationName"] || selection.title;
-                    name = name.replace(/['"]+/g, '');
                     name = ARTEMISService.artemisConsole.ownUnescape(name);
                     ARTEMIS.log.info(name);
                     var operation;


### PR DESCRIPTION
JIRA:- https://issues.apache.org/jira/browse/ARTEMIS-2166

I assume a single quote(') is not a reserved character so queue name with the single quote is valid. Currently, the replace logic is only applied to the console; I think it's not required. If yes then we will have to apply the same replace logic for address and CLI delete command.