### PR TITLE
ARTEMIS-2168 Fix "populate-validated-user" feature for AMQP messages

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/Message.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/Message.java
@@ -250,8 +250,20 @@ public interface Message {
       return null;
    }
 
-   default int getGroupSequence() {
-      return 0;
+   default Message setGroupID(SimpleString groupID) {
+      return this;
+   }
+
+   default Message setGroupID(String groupID) {
+      return setGroupID(SimpleString.toSimpleString(groupID));
+   }
+
+   default Integer getGroupSequence() {
+      return null;
+   }
+
+   default Message setGroupSequence(int sequence) {
+      return this;
    }
 
    SimpleString getReplyTo();

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessage.java
@@ -290,9 +290,23 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
    }
 
    @Override
-   public int getGroupSequence() {
-      final Integer integer = this.getIntProperty(Message.HDR_GROUP_SEQUENCE);
-      return integer == null ? 0 : integer;
+   public CoreMessage setGroupID(SimpleString groupId) {
+      return this.putStringProperty(Message.HDR_GROUP_ID, groupId);
+   }
+
+   @Override
+   public CoreMessage setGroupID(String groupId) {
+      return this.setGroupID(SimpleString.toSimpleString(groupId, coreMessageObjectPools == null ? null : coreMessageObjectPools.getGroupIdStringSimpleStringPool()));
+   }
+
+   @Override
+   public Integer getGroupSequence() {
+      return containsProperty(Message.HDR_GROUP_SEQUENCE) ? getIntProperty(Message.HDR_GROUP_SEQUENCE) : null;
+   }
+
+   @Override
+   public CoreMessage setGroupSequence(int sequence) {
+      return this.putIntProperty(Message.HDR_GROUP_SEQUENCE, sequence);
    }
 
    /**

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/reader/MessageUtil.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/reader/MessageUtil.java
@@ -19,6 +19,7 @@ package org.apache.activemq.artemis.reader;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.ActiveMQPropertyConversionException;
@@ -174,5 +175,104 @@ public class MessageUtil {
          (MessageUtil.JMSXGROUPID.equals(name) && message.containsProperty(Message.HDR_GROUP_ID)) ||
          (MessageUtil.JMSXGROUPSEQ.equals(name) && message.containsProperty(Message.HDR_GROUP_SEQUENCE)) ||
          (MessageUtil.JMSXUSERID.equals(name) && message.containsProperty(Message.HDR_VALIDATED_USER));
+   }
+
+
+   public static String getStringProperty(final Message message, final String name) {
+      if (MessageUtil.JMSXGROUPID.equals(name)) {
+         return Objects.toString(message.getGroupID(), null);
+      } else if (MessageUtil.JMSXGROUPSEQ.equals(name)) {
+         return Integer.toString(message.getGroupSequence());
+      } else if (MessageUtil.JMSXUSERID.equals(name)) {
+         return message.getValidatedUserID();
+      } else {
+         return message.getStringProperty(name);
+      }
+   }
+
+   public static Object getObjectProperty(final Message message, final String name) {
+      final Object val;
+      if (MessageUtil.JMSXGROUPID.equals(name)) {
+         val = message.getGroupID();
+      } else if (MessageUtil.JMSXGROUPSEQ.equals(name)) {
+         val = message.getGroupSequence();
+      } else if (MessageUtil.JMSXUSERID.equals(name)) {
+         val = message.getValidatedUserID();
+      } else {
+         val = message.getObjectProperty(name);
+      }
+      if (val instanceof SimpleString) {
+         return val.toString();
+      }
+      return val;
+   }
+
+   public static long getLongProperty(final Message message, final String name) {
+      if (MessageUtil.JMSXGROUPSEQ.equals(name)) {
+         return message.getGroupSequence();
+      } else {
+         return message.getLongProperty(name);
+      }
+   }
+
+   public static int getIntProperty(final Message message, final String name) {
+      if (MessageUtil.JMSXGROUPSEQ.equals(name)) {
+         return message.getGroupSequence();
+      } else {
+         return message.getIntProperty(name);
+      }
+   }
+
+   public static void setIntProperty(final Message message, final String name, final int value) {
+      if (MessageUtil.JMSXGROUPSEQ.equals(name)) {
+         message.setGroupSequence(value);
+      } else {
+         message.putIntProperty(name, value);
+      }
+   }
+
+   public static void setLongProperty(final Message message, final String name, final long value) {
+      if (MessageUtil.JMSXGROUPSEQ.equals(name)) {
+         message.setGroupSequence((int) value);
+      } else {
+         message.putLongProperty(name, value);
+      }
+   }
+
+   public static void setStringProperty(final Message message, final String name, final String value) {
+      if (MessageUtil.JMSXGROUPID.equals(name)) {
+         message.setGroupID(value);
+      } else if (MessageUtil.JMSXGROUPSEQ.equals(name)) {
+         message.setGroupSequence(getInteger(value));
+      } else if (MessageUtil.JMSXUSERID.equals(name)) {
+         message.setValidatedUserID(value);
+      } else {
+         message.putStringProperty(name, value);
+      }
+   }
+
+   public static void setObjectProperty(final Message message,  final String name, final Object value) {
+      if (MessageUtil.JMSXGROUPID.equals(name)) {
+         message.setGroupID(value == null ? null : value.toString());
+      } else if (MessageUtil.JMSXGROUPSEQ.equals(name)) {
+         message.setGroupSequence(getInteger(value));
+      } else if (MessageUtil.JMSXUSERID.equals(name)) {
+         message.setValidatedUserID(value == null ? null : value.toString());
+      } else {
+         message.putObjectProperty(name, value);
+      }
+   }
+
+   private static int getInteger(final Object value) {
+      Objects.requireNonNull(value);
+      final int integer;
+      if (value instanceof Integer) {
+         integer = (Integer) value;
+      } else if (value instanceof Number) {
+         integer = ((Number) value).intValue();
+      } else {
+         integer = Integer.parseInt(value.toString());
+      }
+      return integer;
    }
 }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
@@ -918,7 +918,7 @@ public class AMQPMessage extends RefCountMessage {
     *
     * @return the UserID value in the AMQP Properties if one is present.
     */
-   public Object getAMQPUserID() {
+   public String getAMQPUserID() {
       if (properties != null && properties.getUserId() != null) {
          Binary binary = properties.getUserId();
          return new String(binary.getArray(), binary.getArrayOffset(), binary.getLength(), StandardCharsets.UTF_8);
@@ -928,8 +928,13 @@ public class AMQPMessage extends RefCountMessage {
    }
 
    @Override
+   public String getValidatedUserID() {
+      return getAMQPUserID();
+   }
+
+   @Override
    public org.apache.activemq.artemis.api.core.Message setUserID(Object userID) {
-      return null;
+      return this;
    }
 
    @Override
@@ -1100,13 +1105,13 @@ public class AMQPMessage extends RefCountMessage {
    }
 
    @Override
-   public int getGroupSequence() {
+   public Integer getGroupSequence() {
       ensureMessageDataScanned();
 
       if (properties != null && properties.getGroupSequence() != null) {
          return properties.getGroupSequence().intValue();
       } else {
-         return 0;
+         return null;
       }
    }
 
@@ -1219,6 +1224,8 @@ public class AMQPMessage extends RefCountMessage {
          return getConnectionID();
       } else if (key.equals(MessageUtil.JMSXGROUPID)) {
          return getGroupID();
+      } else if (key.equals(MessageUtil.JMSXGROUPSEQ)) {
+         return getGroupSequence();
       } else if (key.equals(MessageUtil.JMSXUSERID)) {
          return getAMQPUserID();
       } else if (key.equals(MessageUtil.CORRELATIONID_HEADER_NAME.toString())) {

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/converter/CoreAmqpConverter.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/converter/CoreAmqpConverter.java
@@ -209,15 +209,17 @@ public class CoreAmqpConverter {
          if (key.startsWith("JMSX")) {
             if (key.equals("JMSXUserID")) {
                String value = message.getStringProperty(key);
-               properties.setUserId(new Binary(value.getBytes(StandardCharsets.UTF_8)));
+               if (value != null) {
+                  properties.setUserId(Binary.create(StandardCharsets.UTF_8.encode(value)));
+               }
                continue;
             } else if (key.equals("JMSXGroupID")) {
                String value = message.getStringProperty(key);
                properties.setGroupId(value);
                continue;
             } else if (key.equals("JMSXGroupSeq")) {
-               UnsignedInteger value = new UnsignedInteger(message.getIntProperty(key));
-               properties.setGroupSequence(value);
+               int value = message.getIntProperty(key);
+               properties.setGroupSequence(UnsignedInteger.valueOf(value));
                continue;
             }
          } else if (key.startsWith(JMS_AMQP_PREFIX)) {
@@ -281,9 +283,13 @@ public class CoreAmqpConverter {
                footerMap.put(name, message.getObjectProperty(key));
                continue;
             }
-         } else if (key.equals("_AMQ_GROUP_ID")) {
+         } else if (key.equals(Message.HDR_GROUP_ID)) {
             String value = message.getStringProperty(key);
             properties.setGroupId(value);
+            continue;
+         } else if (key.equals(Message.HDR_GROUP_SEQUENCE)) {
+            int value = message.getIntProperty(key);
+            properties.setGroupSequence(UnsignedInteger.valueOf(value));
             continue;
          } else if (key.equals(NATIVE_MESSAGE_ID)) {
             // skip..internal use only

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/converter/jms/ServerJMSMessage.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/converter/jms/ServerJMSMessage.java
@@ -266,12 +266,12 @@ public class ServerJMSMessage implements Message {
 
    @Override
    public final int getIntProperty(String name) throws JMSException {
-      return message.getIntProperty(name);
+      return MessageUtil.getIntProperty(message, name);
    }
 
    @Override
    public final long getLongProperty(String name) throws JMSException {
-      return message.getLongProperty(name);
+      return MessageUtil.getLongProperty(message, name);
    }
 
    @Override
@@ -286,16 +286,12 @@ public class ServerJMSMessage implements Message {
 
    @Override
    public final String getStringProperty(String name) throws JMSException {
-      return message.getStringProperty(name);
+      return MessageUtil.getStringProperty(message, name);
    }
 
    @Override
    public final Object getObjectProperty(String name) throws JMSException {
-      Object val = message.getObjectProperty(name);
-      if (val instanceof SimpleString) {
-         val = ((SimpleString) val).toString();
-      }
-      return val;
+      return MessageUtil.getObjectProperty(message, name);
    }
 
    @Override
@@ -320,12 +316,12 @@ public class ServerJMSMessage implements Message {
 
    @Override
    public final void setIntProperty(String name, int value) throws JMSException {
-      message.putIntProperty(name, value);
+      MessageUtil.setIntProperty(message, name, value);
    }
 
    @Override
    public final void setLongProperty(String name, long value) throws JMSException {
-      message.putLongProperty(name, value);
+      MessageUtil.setLongProperty(message, name, value);
    }
 
    @Override
@@ -340,12 +336,12 @@ public class ServerJMSMessage implements Message {
 
    @Override
    public final void setStringProperty(String name, String value) throws JMSException {
-      message.putStringProperty(name, value);
+      MessageUtil.setStringProperty(message, name, value);
    }
 
    @Override
    public final void setObjectProperty(String name, Object value) throws JMSException {
-      message.putObjectProperty(name, value);
+      MessageUtil.setObjectProperty(message, name, value);
    }
 
    @Override

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireMessageConverter.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireMessageConverter.java
@@ -173,9 +173,9 @@ public final class OpenWireMessageConverter {
       }
       final String groupId = messageSend.getGroupID();
       if (groupId != null) {
-         coreMessage.putStringProperty(AMQ_MSG_GROUP_ID, coreMessageObjectPools.getGroupIdStringSimpleStringPool().getOrCreate(groupId));
+         coreMessage.setGroupID(groupId);
       }
-      coreMessage.putIntProperty(AMQ_MSG_GROUP_SEQUENCE, messageSend.getGroupSequence());
+      coreMessage.setGroupSequence(messageSend.getGroupSequence());
 
       final MessageId messageId = messageSend.getMessageId();
 
@@ -614,11 +614,10 @@ public final class OpenWireMessageConverter {
          amqMsg.setGroupID(groupId);
       }
 
-      Integer groupSequence = (Integer) coreMessage.getObjectProperty(AMQ_MSG_GROUP_SEQUENCE);
-      if (groupSequence == null) {
-         groupSequence = 0;
+      Integer groupSequence = coreMessage.getGroupSequence();
+      if (groupSequence != null) {
+         amqMsg.setGroupSequence(groupSequence);
       }
-      amqMsg.setGroupSequence(groupSequence);
 
       final MessageId mid;
       final byte[] midBytes = (byte[]) coreMessage.getObjectProperty(AMQ_MSG_MESSAGE_ID);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
@@ -2635,16 +2635,16 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
       }
    }
 
-   private int extractGroupSequence(MessageReference ref) {
+   private Integer extractGroupSequence(MessageReference ref) {
       if (internalQueue) {
-         return 0;
+         return null;
       } else {
          try {
             // But we don't use the groupID on internal queues (clustered queues) otherwise the group map would leak forever
             return ref.getMessage().getGroupSequence();
          } catch (Throwable e) {
             ActiveMQServerLogger.LOGGER.unableToExtractGroupSequence(e);
-            return 0;
+            return null;
          }
       }
    }
@@ -3147,7 +3147,8 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
 
    private void handleMessageGroup(MessageReference ref, Consumer consumer, Consumer groupConsumer, SimpleString groupID) {
       if (groupID != null) {
-         if (extractGroupSequence(ref) == -1) {
+         Integer groupSequence = extractGroupSequence(ref);
+         if (groupSequence != null && groupSequence == -1) {
             groups.remove(groupID);
          }
          if (groupConsumer == null) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -1844,8 +1844,12 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
          throw e;
       }
 
+      final Message message;
       if (server.getConfiguration().isPopulateValidatedUser() && validatedUser != null) {
-         msg.setValidatedUserID(validatedUser);
+         message = msg.toCore();
+         message.setValidatedUserID(validatedUser);
+      } else {
+         message = msg;
       }
 
       if (tx == null || autoCommitSends) {
@@ -1857,14 +1861,14 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
          routingContext.setAddress(art.getName());
          routingContext.setRoutingType(art.getRoutingType());
 
-         result = postOffice.route(msg, routingContext, direct);
+         result = postOffice.route(message, routingContext, direct);
 
-         Pair<Object, AtomicLong> value = targetAddressInfos.get(msg.getAddressSimpleString());
+         Pair<Object, AtomicLong> value = targetAddressInfos.get(message.getAddressSimpleString());
 
          if (value == null) {
-            targetAddressInfos.put(msg.getAddressSimpleString(), new Pair<>(msg.getUserID(), new AtomicLong(1)));
+            targetAddressInfos.put(message.getAddressSimpleString(), new Pair<>(message.getUserID(), new AtomicLong(1)));
          } else {
-            value.setA(msg.getUserID());
+            value.setA(message.getUserID());
             value.getB().incrementAndGet();
          }
       } finally {


### PR DESCRIPTION
When populate-validated-user is true, force conversion to CORE as AMQP messages are immutable.
Note, this fixes feature: https://issues.apache.org/jira/browse/ARTEMIS-584 for AMQP produced messages.
Add additional test cases to cover AMQP for feature.