### PR TITLE
NO-JIRA Prevent maven-source-plugin being executed twice

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1403,8 +1403,9 @@
                <executions>
                   <execution>
                      <id>attach-sources</id>
+                     <phase>verify</phase>
                      <goals>
-                        <goal>jar</goal>
+                        <goal>jar-no-fork</goal>
                      </goals>
                   </execution>
                </executions>
@@ -1518,14 +1519,6 @@
          </plugin>
          <plugin>
             <artifactId>maven-source-plugin</artifactId>
-            <executions>
-               <execution>
-                  <phase>verify</phase>
-                  <goals>
-                     <goal>jar</goal>
-                  </goals>
-               </execution>
-            </executions>
          </plugin>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
With the current Maven config, the maven-source-plugin is executed twice, this results in the sources-jars being attached twice which leads the deploy goal in trying to upload the same sources jars twice to the repository. This slows down the build process and also fails on repositories that disallow updating of existing artifacts. 

Additionally the "jar" goal is now replaced with "jar-no-fork" which prevents the maven life cycle being executed twice too.