### PR TITLE
ARTEMIS-1938 Update proton-j to 0.30.0 and Qpid JMS 0.37.0

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/util/NettyWritable.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/util/NettyWritable.java
@@ -86,6 +86,11 @@ public class NettyWritable implements WritableBuffer {
    }
 
    @Override
+   public void ensureRemaining(int remaining) {
+      nettyBuffer.ensureWritable(remaining);
+   }
+
+   @Override
    public int position() {
       return nettyBuffer.writerIndex();
    }

--- a/pom.xml
+++ b/pom.xml
@@ -92,10 +92,10 @@
       <mockito.version>2.8.47</mockito.version>
       <netty.version>4.1.28.Final</netty.version>
       <netty-tcnative-version>2.0.12.Final</netty-tcnative-version>
-      <proton.version>0.29.0</proton.version>
+      <proton.version>0.30.0</proton.version>
       <resteasy.version>3.0.19.Final</resteasy.version>
       <slf4j.version>1.7.21</slf4j.version>
-      <qpid.jms.version>0.36.0</qpid.jms.version>
+      <qpid.jms.version>0.37.0</qpid.jms.version>
       <johnzon.version>0.9.5</johnzon.version>
       <json-p.spec.version>1.0-alpha-1</json-p.spec.version>
       <javax.inject.version>1</javax.inject.version>


### PR DESCRIPTION
Update to latest proton-j release and refactor the dispostion code to use
the new type enums to better deal with the dispistions.  Updates to Qpid JMS
0.37.0 which still uses the current netty 4.1.28.Final dependency.