### PR TITLE
ARTEMIS-2187 remove page from softcache before consumedpage

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageCursorProviderImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageCursorProviderImpl.java
@@ -473,11 +473,10 @@ public class PageCursorProviderImpl implements PageCursorProvider {
             }
 
             depagedPage.delete(pgdMessages);
-            onDeletePage(depagedPage);
-
             synchronized (softCache) {
                softCache.remove((long) depagedPage.getPageId());
             }
+            onDeletePage(depagedPage);
          }
       } catch (Exception ex) {
          ActiveMQServerLogger.LOGGER.problemCleaningPageAddress(ex, pagingStore.getAddress());


### PR DESCRIPTION
We found some PageCursorInfo in consumedPage map even if these corresponding page file is deleted.

Suppose that there is a topic t with some messages not routed to subscriber ta. When calling ta.deliverAsync(), DeliverRunner->deliver->checkDepage->pageIterator.hasNext->

processACK->cleanup is called in the pageSubscription's executor(step1), then checkDepage->pageIterator.hasNext->processACK->getPageInfo is called(step2). At this time(step2) pageCursorInfo maybe again put into consumedPage when the page is removed from consumedPage but not from softCache(int step1).