### PR TITLE
ARTEMIS-2188 fix address size leak caused by large page message

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/LargeServerMessageImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/LargeServerMessageImpl.java
@@ -25,6 +25,7 @@ import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
 import org.apache.activemq.artemis.api.core.ActiveMQIOErrorException;
 import org.apache.activemq.artemis.api.core.ActiveMQInternalErrorException;
 import org.apache.activemq.artemis.api.core.Message;
+import org.apache.activemq.artemis.api.core.RefCountMessageListener;
 import org.apache.activemq.artemis.core.buffers.impl.ChannelBufferWrapper;
 import org.apache.activemq.artemis.core.io.SequentialFile;
 import org.apache.activemq.artemis.core.message.LargeBodyEncoder;
@@ -161,7 +162,15 @@ public final class LargeServerMessageImpl extends CoreMessage implements LargeSe
    public synchronized void incrementDelayDeletionCount() {
       delayDeletionCount.incrementAndGet();
       try {
-         incrementRefCount();
+         if (paged) {
+            RefCountMessageListener tmpContext = super.getContext();
+            setContext(null);
+            incrementRefCount();
+            setContext(tmpContext);
+         } else {
+            incrementRefCount();
+         }
+
       } catch (Exception e) {
          ActiveMQServerLogger.LOGGER.errorIncrementDelayDeletionCount(e);
       }
@@ -200,7 +209,15 @@ public final class LargeServerMessageImpl extends CoreMessage implements LargeSe
 
    @Override
    public synchronized int decrementRefCount() throws Exception {
-      int currentRefCount = super.decrementRefCount();
+      int currentRefCount;
+      if (paged) {
+         RefCountMessageListener tmpContext = super.getContext();
+         setContext(null);
+         currentRefCount = super.decrementRefCount();
+         setContext(tmpContext);
+      } else {
+         currentRefCount = super.decrementRefCount();
+      }
 
       // We use <= as this could be used by load.
       // because of a failure, no references were loaded, so we have 0... and we still need to delete the associated
@@ -208,7 +225,6 @@ public final class LargeServerMessageImpl extends CoreMessage implements LargeSe
       if (delayDeletionCount.get() <= 0) {
          checkDelete();
       }
-
       return currentRefCount;
    }
 
@@ -507,6 +523,5 @@ public final class LargeServerMessageImpl extends CoreMessage implements LargeSe
          return getBodySize();
       }
    }
-
 
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/LargeMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/LargeMessageTest.java
@@ -40,6 +40,7 @@ import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.client.impl.ClientConsumerInternal;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.StoreConfiguration;
+import org.apache.activemq.artemis.core.paging.PagingStore;
 import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager;
 import org.apache.activemq.artemis.core.persistence.impl.journal.LargeServerMessageImpl;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
@@ -2473,6 +2474,84 @@ public class LargeMessageTest extends LargeMessageTestBase {
       // printBuffer("message received : ", message2.getBody());
 
       session.close();
+   }
+
+   @Test
+   public void testGlobalSizeBytesAndAddressSizeOnPage() throws Exception {
+      testGlobalSizeBytesAndAddressSize(true);
+   }
+
+   @Test
+   public void testGlobalSizeBytesAndAddressSize() throws Exception {
+      testGlobalSizeBytesAndAddressSize(false);
+   }
+
+   public void testGlobalSizeBytesAndAddressSize(boolean isPage) throws Exception {
+      ActiveMQServer server = createServer(true, isNetty(), storeType);
+
+      server.start();
+
+      ClientSessionFactory sf = addSessionFactory(createSessionFactory(locator));
+
+      ClientSession session = sf.createSession(false, false);
+
+      LargeServerMessageImpl fileMessage = new LargeServerMessageImpl((JournalStorageManager) server.getStorageManager());
+
+      fileMessage.setMessageID(1005);
+
+      for (int i = 0; i < largeMessageSize; i++) {
+         fileMessage.addBytes(new byte[]{ActiveMQTestBase.getSamplebyte(i)});
+      }
+
+      fileMessage.releaseResources();
+
+      session.createQueue(ADDRESS, ADDRESS, true);
+
+      PagingStore store = server.getPagingManager().getPageStore(ADDRESS);
+
+      if (isPage) {
+         store.startPaging();
+      }
+
+      ClientProducer prod = session.createProducer(ADDRESS);
+
+      prod.send(fileMessage);
+
+      fileMessage.deleteFile();
+
+      session.commit();
+
+      if (isPage) {
+         server.getPagingManager().getPageStore(ADDRESS).getCursorProvider().clearCache();
+      }
+
+      if (isPage) {
+         Assert.assertEquals(0, server.getPagingManager().getPageStore(ADDRESS).getAddressSize());
+         Assert.assertEquals(0, server.getPagingManager().getGlobalSize());
+      } else {
+         Assert.assertNotEquals(0, server.getPagingManager().getPageStore(ADDRESS).getAddressSize());
+         Assert.assertNotEquals(0, server.getPagingManager().getGlobalSize());
+      }
+
+      session.start();
+
+      ClientConsumer cons = session.createConsumer(ADDRESS);
+
+      ClientMessage msg = cons.receive(5000);
+
+      Assert.assertNotNull(msg);
+
+      msg.acknowledge();
+
+      session.commit();
+
+      Assert.assertEquals(0, server.getPagingManager().getPageStore(ADDRESS).getAddressSize());
+
+      Assert.assertEquals(0, server.getPagingManager().getGlobalSize());
+
+      session.close();
+
+      cons.close();
    }
 
    // Private -------------------------------------------------------


### PR DESCRIPTION
When we write a paged large message, addLiveMessage->incrementDelayDeletionCount->

incrementRefCount->onDurableUp is called where pagingstore size and global size is added.

The page where the large message resides maybe evicted from cache.

When the page is deleted, LargeServerMessageImpl::decrementDelayDeletionCount is called the last time but the large message is not the original one which means context is null and nonDurableDown is not called resulting in pagingstore size and global size not properly subtracted.

Writing large paged message should be handled like regular paged message. The large paged message doesn't account for the memory size, we don't need to call PagingStoreImpl::onDurableUp.