### PR TITLE
ARTEMIS-2192 LegacyLDAPSecuritySettingPlugin uses hard-coded RDN types

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/security/LegacyLDAPSecuritySettingPluginTest2.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/security/LegacyLDAPSecuritySettingPluginTest2.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.security;
+
+import javax.naming.Context;
+import javax.naming.NameClassPair;
+import javax.naming.NamingEnumeration;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.InitialDirContext;
+import java.io.File;
+import java.lang.management.ManagementFactory;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Hashtable;
+import java.util.Map;
+
+import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
+import org.apache.activemq.artemis.api.core.client.ClientProducer;
+import org.apache.activemq.artemis.api.core.client.ClientSession;
+import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
+import org.apache.activemq.artemis.api.core.client.ServerLocator;
+import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
+import org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory;
+import org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnectorFactory;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.ActiveMQServers;
+import org.apache.activemq.artemis.core.server.impl.LegacyLDAPSecuritySettingPlugin;
+import org.apache.activemq.artemis.spi.core.security.ActiveMQJAASSecurityManager;
+import org.apache.activemq.artemis.spi.core.security.jaas.LDAPLoginModule;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.apache.directory.server.annotations.CreateLdapServer;
+import org.apache.directory.server.annotations.CreateTransport;
+import org.apache.directory.server.core.annotations.ApplyLdifFiles;
+import org.apache.directory.server.core.integ.AbstractLdapTestUnit;
+import org.apache.directory.server.core.integ.FrameworkRunner;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+
+@RunWith(FrameworkRunner.class)
+@CreateLdapServer(transports = {@CreateTransport(protocol = "LDAP", port = 1024)})
+@ApplyLdifFiles("AMQauth2.ldif")
+public class LegacyLDAPSecuritySettingPluginTest2 extends AbstractLdapTestUnit {
+
+   static {
+      String path = System.getProperty("java.security.auth.login.config");
+      if (path == null) {
+         URL resource = LegacyLDAPSecuritySettingPluginTest2.class.getClassLoader().getResource("login.config");
+         if (resource != null) {
+            path = resource.getFile();
+            System.setProperty("java.security.auth.login.config", path);
+         }
+      }
+   }
+
+   private ServerLocator locator;
+   ActiveMQServer server;
+
+   public static final String TARGET_TMP = "./target/tmp";
+   private static final String PRINCIPAL = "uid=admin,ou=system";
+   private static final String CREDENTIALS = "secret";
+
+   public LegacyLDAPSecuritySettingPluginTest2() {
+      File parent = new File(TARGET_TMP);
+      parent.mkdirs();
+      temporaryFolder = new TemporaryFolder(parent);
+   }
+
+   @Rule
+   public TemporaryFolder temporaryFolder;
+   private String testDir;
+
+   @Before
+   public void setUp() throws Exception {
+      locator = ActiveMQClient.createServerLocatorWithoutHA(new TransportConfiguration(InVMConnectorFactory.class.getCanonicalName()));
+      testDir = temporaryFolder.getRoot().getAbsolutePath();
+
+      Map<String, String> init = new HashMap<>();
+      init.put("destinationBase", "ou=Destination,ou=ActiveMQ,o=example,ou=system");
+      init.put("roleAttribute", "member");
+
+      LegacyLDAPSecuritySettingPlugin legacyLDAPSecuritySettingPlugin = new LegacyLDAPSecuritySettingPlugin()
+         .setInitialContextFactory("com.sun.jndi.ldap.LdapCtxFactory")
+         .setConnectionURL("ldap://localhost:1024")
+         .setConnectionUsername("uid=admin,ou=system")
+         .setConnectionPassword("secret")
+         .setConnectionProtocol("s")
+         .setAuthentication("simple")
+         .init(init);
+
+      ActiveMQJAASSecurityManager securityManager = new ActiveMQJAASSecurityManager("LDAPLogin2");
+      Configuration configuration = new ConfigurationImpl()
+         .setSecurityEnabled(true)
+         .addAcceptorConfiguration(new TransportConfiguration(InVMAcceptorFactory.class.getCanonicalName()))
+         .setJournalDirectory(ActiveMQTestBase.getJournalDir(testDir, 0, false))
+         .setBindingsDirectory(ActiveMQTestBase.getBindingsDir(testDir, 0, false))
+         .setPagingDirectory(ActiveMQTestBase.getPageDir(testDir, 0, false))
+         .setLargeMessagesDirectory(ActiveMQTestBase.getLargeMessagesDir(testDir, 0, false))
+         .setPersistenceEnabled(false)
+         .addSecuritySettingPlugin(legacyLDAPSecuritySettingPlugin);
+
+      server = ActiveMQServers.newActiveMQServer(configuration, ManagementFactory.getPlatformMBeanServer(), securityManager, false);
+   }
+
+   @After
+   public void tearDown() throws Exception {
+      locator.close();
+      server.stop();
+   }
+
+   @Test
+   public void testRunning() throws Exception {
+      Hashtable<String, String> env = new Hashtable<>();
+      env.put(Context.PROVIDER_URL, "ldap://localhost:1024");
+      env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
+      env.put(Context.SECURITY_AUTHENTICATION, "simple");
+      env.put(Context.SECURITY_PRINCIPAL, PRINCIPAL);
+      env.put(Context.SECURITY_CREDENTIALS, CREDENTIALS);
+      DirContext ctx = new InitialDirContext(env);
+
+      HashSet<String> set = new HashSet<>();
+
+      NamingEnumeration<NameClassPair> list = ctx.list("ou=system");
+
+      while (list.hasMore()) {
+         NameClassPair ncp = list.next();
+         set.add(ncp.getName());
+      }
+
+      Assert.assertTrue(set.contains("uid=admin"));
+      Assert.assertTrue(set.contains("ou=users"));
+      Assert.assertTrue(set.contains("ou=groups"));
+      Assert.assertTrue(set.contains("ou=configuration"));
+      Assert.assertTrue(set.contains("prefNodeName=sysPrefRoot"));
+   }
+
+   @Test
+   public void testBasicPluginAuthorization() throws Exception {
+      org.jboss.logmanager.Logger.getLogger(LDAPLoginModule.class.getName()).setLevel(org.jboss.logmanager.Level.DEBUG);
+      org.jboss.logmanager.Logger.getLogger(LegacyLDAPSecuritySettingPlugin.class.getName()).setLevel(org.jboss.logmanager.Level.DEBUG);
+      server.start();
+      ClientSessionFactory cf = locator.createSessionFactory();
+      String name = "TEST.FOO";
+
+      try {
+         ClientSession session = cf.createSession("admin", "secret", false, true, true, false, 0);
+         session.createQueue(SimpleString.toSimpleString(name), SimpleString.toSimpleString(name));
+         ClientProducer producer = session.createProducer();
+         producer.send(name, session.createMessage(false));
+         session.close();
+      } catch (ActiveMQException e) {
+         e.printStackTrace();
+         Assert.fail("should not throw exception");
+      }
+
+      cf.close();
+   }
+}

--- a/tests/integration-tests/src/test/resources/AMQauth2.ldif
+++ b/tests/integration-tests/src/test/resources/AMQauth2.ldif
@@ -1,0 +1,335 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+
+##########################
+## Define basic objects ##
+##########################
+
+dn: o=example,ou=system
+#objectClass: dcObject
+#objectClass: container
+objectClass: organization
+objectClass: top
+#cn: activemq
+#o: activemq
+o: example
+
+dn: ou=ActiveMQ,o=example,ou=system
+objectClass: organizationalUnit
+objectClass: top
+ou: ActiveMQ
+
+dn: ou=Services,o=example,ou=system
+ou: Services
+objectClass: organizationalUnit
+objectClass: top
+
+dn: cn=mqbroker,ou=Services,o=example,ou=system
+cn: mqbroker
+objectClass: organizationalRole
+objectClass: top
+objectClass: simpleSecurityObject
+userPassword: {SSHA}YvMAkkd66cDecNoejo8jnw5uUUBziyl0
+description: Bind user for MQ broker
+
+
+###################
+## Define groups ##
+###################
+
+
+dn: ou=Group,ou=ActiveMQ,o=example,ou=system
+objectClass: organizationalUnit
+objectClass: top
+ou: Group
+
+dn: cn=admins,ou=Group,ou=ActiveMQ,o=example,ou=system
+cn: admins
+member: uid=admin
+objectClass: groupOfNames
+objectClass: top
+
+dn: cn=users,ou=Group,ou=ActiveMQ,o=example,ou=system
+cn: users
+member: uid=jdoe
+objectClass: groupOfNames
+objectClass: top
+
+
+##################
+## Define users ##
+##################
+
+
+dn: ou=User,ou=ActiveMQ,o=example,ou=system
+objectClass: organizationalUnit
+objectClass: top
+ou: User
+
+dn: uid=admin,ou=User,ou=ActiveMQ,o=example,ou=system
+uid: admin
+userPassword: secret
+objectclass: uidObject
+objectclass: organizationalPerson
+objectclass: person
+objectclass: top
+cn: Admin
+sn: Admin
+
+
+dn: uid=jdoe,ou=User,ou=ActiveMQ,o=example,ou=system
+uid: jdoe
+userPassword: secret
+objectclass: uidObject
+objectclass: organizationalPerson
+objectclass: person
+objectclass: top
+cn: Jane Doe
+sn: Doe
+
+
+#########################
+## Define destinations ##
+#########################
+
+dn: ou=Destination,ou=ActiveMQ,o=example,ou=system
+objectClass: organizationalUnit
+objectClass: top
+ou: Destination
+
+dn: ou=Topic,ou=Destination,ou=ActiveMQ,o=example,ou=system
+objectClass: organizationalUnit
+objectClass: top
+ou: Topic
+
+dn: ou=Queue,ou=Destination,ou=ActiveMQ,o=example,ou=system
+objectClass: organizationalUnit
+objectClass: top
+ou: Queue
+
+## TEST.FOO
+
+dn: uid=TEST.FOO,ou=Queue,ou=Destination,ou=ActiveMQ,o=example,ou=system
+uid: TEST.FOO
+description: A queue
+objectClass: applicationProcess
+objectclass: uidObject
+objectClass: top
+cn: TEST.FOO
+
+dn: cn=admin,uid=TEST.FOO,ou=Queue,ou=Destination,ou=ActiveMQ,o=example,ou=system
+cn: admin
+description: Admin privilege group, members are roles
+member: cn=admins,ou=Group,ou=ActiveMQ,o=example,ou=system
+member: cn=users,ou=Group,ou=ActiveMQ,o=example,ou=system
+objectClass: groupOfNames
+objectClass: top
+
+dn: cn=read,uid=TEST.FOO,ou=Queue,ou=Destination,ou=ActiveMQ,o=example,ou=system
+cn: read
+member: cn=users,ou=Group,ou=ActiveMQ,o=example,ou=system
+member: cn=admins,ou=Group,ou=ActiveMQ,o=example,ou=system
+objectClass: groupOfNames
+objectClass: top
+
+dn: cn=write,uid=TEST.FOO,ou=Queue,ou=Destination,ou=ActiveMQ,o=example,ou=system
+cn: write
+objectClass: groupOfNames
+objectClass: top
+member: cn=users,ou=Group,ou=ActiveMQ,o=example,ou=system
+member: cn=admins,ou=Group,ou=ActiveMQ,o=example,ou=system
+
+## TEST.FOOBAR
+
+dn: cn=TEST.FOOBAR,ou=Queue,ou=Destination,ou=ActiveMQ,o=example,ou=system
+cn: TEST.FOOBAR
+description: A queue
+objectClass: applicationProcess
+objectClass: top
+
+dn: cn=admin,cn=TEST.FOOBAR,ou=Queue,ou=Destination,ou=ActiveMQ,o=example,ou=system
+cn: admin
+description: Admin privilege group, members are roles
+member: cn=admins,ou=Group,ou=ActiveMQ,o=example,ou=system
+member: cn=users,ou=Group,ou=ActiveMQ,o=example,ou=system
+objectClass: groupOfNames
+objectClass: top
+
+dn: cn=read,cn=TEST.FOOBAR,ou=Queue,ou=Destination,ou=ActiveMQ,o=example,ou=system
+cn: read
+member: cn=users,ou=Group,ou=ActiveMQ,o=example,ou=system
+member: cn=admins,ou=Group,ou=ActiveMQ,o=example,ou=system
+member: uid=jdoe,ou=User,ou=ActiveMQ,o=example,ou=system
+objectClass: groupOfNames
+objectClass: top
+
+dn: cn=write,cn=TEST.FOOBAR,ou=Queue,ou=Destination,ou=ActiveMQ,o=example,ou=system
+cn: write
+objectClass: groupOfNames
+objectClass: top
+member: cn=users,ou=Group,ou=ActiveMQ,o=example,ou=system
+member: cn=admins,ou=Group,ou=ActiveMQ,o=example,ou=system
+member: uid=jdoe,ou=User,ou=ActiveMQ,o=example,ou=system
+
+## FOO.>
+
+dn: cn=FOO.$,ou=Queue,ou=Destination,ou=ActiveMQ,o=example,ou=system
+cn: FOO.$
+description: A queue
+objectClass: applicationProcess
+objectClass: top
+
+dn: cn=admin,cn=FOO.$,ou=Queue,ou=Destination,ou=ActiveMQ,o=example,ou=system
+cn: admin
+description: Admin privilege group, members are roles
+member: cn=admins,ou=Group,ou=ActiveMQ,o=example,ou=system
+member: cn=users,ou=Group,ou=ActiveMQ,o=example,ou=system
+objectClass: groupOfNames
+objectClass: top
+
+dn: cn=read,cn=FOO.$,ou=Queue,ou=Destination,ou=ActiveMQ,o=example,ou=system
+cn: read
+member: cn=users,ou=Group,ou=ActiveMQ,o=example,ou=system
+member: cn=admins,ou=Group,ou=ActiveMQ,o=example,ou=system
+objectClass: groupOfNames
+objectClass: top
+
+dn: cn=write,cn=FOO.$,ou=Queue,ou=Destination,ou=ActiveMQ,o=example,ou=system
+cn: write
+objectClass: groupOfNames
+objectClass: top
+member: cn=users,ou=Group,ou=ActiveMQ,o=example,ou=system
+member: cn=admins,ou=Group,ou=ActiveMQ,o=example,ou=system
+
+## BAR.*
+
+dn: cn=BAR.*,ou=Queue,ou=Destination,ou=ActiveMQ,o=example,ou=system
+cn: BAR.*
+description: A queue
+objectClass: applicationProcess
+objectClass: top
+
+dn: cn=admin,cn=BAR.*,ou=Queue,ou=Destination,ou=ActiveMQ,o=example,ou=system
+cn: admin
+description: Admin privilege group, members are roles
+member: cn=admins,ou=Group,ou=ActiveMQ,o=example,ou=system
+member: cn=users,ou=Group,ou=ActiveMQ,o=example,ou=system
+objectClass: groupOfNames
+objectClass: top
+
+dn: cn=read,cn=BAR.*,ou=Queue,ou=Destination,ou=ActiveMQ,o=example,ou=system
+cn: read
+member: cn=users,ou=Group,ou=ActiveMQ,o=example,ou=system
+member: cn=admins,ou=Group,ou=ActiveMQ,o=example,ou=system
+objectClass: groupOfNames
+objectClass: top
+
+dn: cn=write,cn=BAR.*,ou=Queue,ou=Destination,ou=ActiveMQ,o=example,ou=system
+cn: write
+objectClass: groupOfNames
+objectClass: top
+member: cn=users,ou=Group,ou=ActiveMQ,o=example,ou=system
+member: cn=admins,ou=Group,ou=ActiveMQ,o=example,ou=system
+
+## $
+
+dn: cn=$,ou=Queue,ou=Destination,ou=ActiveMQ,o=example,ou=system
+cn: $
+description: A queue
+objectclass: applicationProcess
+objectclass: top
+
+dn: cn=admin,cn=$,ou=Queue,ou=Destination,ou=ActiveMQ,o=example,ou=system
+cn: admin
+description: Admin privilege group, members are roles
+member: cn=admins,ou=Group,ou=ActiveMQ,o=example,ou=system
+objectclass: groupOfNames
+objectclass: top
+
+dn: cn=read,cn=$,ou=Queue,ou=Destination,ou=ActiveMQ,o=example,ou=system
+cn: read
+member: cn=admins,ou=Group,ou=ActiveMQ,o=example,ou=system
+objectclass: groupOfNames
+objectclass: top
+
+dn: cn=write,cn=$,ou=Queue,ou=Destination,ou=ActiveMQ,o=example,ou=system
+cn: write
+member: cn=admins,ou=Group,ou=ActiveMQ,o=example,ou=system
+objectclass: groupOfNames
+objectclass: top
+
+#######################
+## Define advisories ##
+#######################
+
+dn: cn=ActiveMQ.Advisory.$,ou=Topic,ou=Destination,ou=ActiveMQ,o=example,ou=system
+cn: ActiveMQ.Advisory.$
+objectClass: applicationProcess
+objectClass: top
+description: Advisory topics
+
+dn: cn=read,cn=ActiveMQ.Advisory.$,ou=Topic,ou=Destination,ou=ActiveMQ,o=example,ou=system
+cn: read
+member: cn=admins,ou=Group,ou=ActiveMQ,o=example,ou=system
+member: cn=users,ou=Group,ou=ActiveMQ,o=example,ou=system
+objectClass: groupOfNames
+objectClass: top
+
+dn: cn=write,cn=ActiveMQ.Advisory.$,ou=Topic,ou=Destination,ou=ActiveMQ,o=example,ou=system
+cn: write
+member: cn=admins,ou=Group,ou=ActiveMQ,o=example,ou=system
+member: cn=users,ou=Group,ou=ActiveMQ,o=example,ou=system
+objectClass: groupOfNames
+objectClass: top
+
+dn: cn=admin,cn=ActiveMQ.Advisory.$,ou=Topic,ou=Destination,ou=ActiveMQ,o=example,ou=system
+cn: admin
+member: cn=admins,ou=Group,ou=ActiveMQ,o=example,ou=system
+member: cn=users,ou=Group,ou=ActiveMQ,o=example,ou=system
+objectClass: groupOfNames
+objectClass: top
+
+######################
+## Define temporary ##
+######################
+
+dn: ou=Temp,ou=Destination,ou=ActiveMQ,o=example,ou=system
+objectClass: organizationalUnit
+objectClass: top
+ou: Temp
+
+dn: cn=read,ou=Temp,ou=Destination,ou=ActiveMQ,o=example,ou=system
+cn: read
+member: cn=admins,ou=Group,ou=ActiveMQ,o=example,ou=system
+member: cn=users,ou=Group,ou=ActiveMQ,o=example,ou=system
+objectClass: groupOfNames
+objectClass: top
+
+dn: cn=write,ou=Temp,ou=Destination,ou=ActiveMQ,o=example,ou=system
+cn: write
+member: cn=admins,ou=Group,ou=ActiveMQ,o=example,ou=system
+member: cn=users,ou=Group,ou=ActiveMQ,o=example,ou=system
+objectClass: groupOfNames
+objectClass: top
+
+dn: cn=admin,ou=Temp,ou=Destination,ou=ActiveMQ,o=example,ou=system
+cn: admin
+member: cn=admins,ou=Group,ou=ActiveMQ,o=example,ou=system
+member: cn=users,ou=Group,ou=ActiveMQ,o=example,ou=system
+objectClass: groupOfNames
+objectClass: top

--- a/tests/integration-tests/src/test/resources/login.config
+++ b/tests/integration-tests/src/test/resources/login.config
@@ -21,6 +21,7 @@ PropertiesLogin {
         org.apache.activemq.jaas.properties.role="roles.properties";
 };
 
+
 LDAPLogin {
     org.apache.activemq.artemis.spi.core.security.jaas.LDAPLoginModule required
         debug=true
@@ -37,6 +38,25 @@ LDAPLogin {
         roleName=cn
         roleSearchMatching="(member=uid={1},ou=system)"
         roleSearchSubtree=false
+        ;
+};
+
+LDAPLogin2 {
+    org.apache.activemq.artemis.spi.core.security.jaas.LDAPLoginModule required
+        debug=true
+        initialContextFactory=com.sun.jndi.ldap.LdapCtxFactory
+        connectionURL="ldap://localhost:1024"
+        connectionUsername="uid=admin,ou=system"
+        connectionPassword=secret
+        connectionProtocol=s
+        authentication=simple
+        userBase="ou=User,ou=ActiveMQ,o=example,ou=system"
+        userSearchMatching="(uid={0})"
+        userSearchSubtree=true
+        roleBase="ou=Group,ou=ActiveMQ,o=example,ou=system"
+        roleName=cn
+        roleSearchMatching="(member=uid={1})"
+        roleSearchSubtree=true
         ;
 };
 


### PR DESCRIPTION
Change the LegacyLDAPSecuritySettingPlugin to interpret the search
results based on the order of the returned RDNs rather than hard-coded
types.