### PR TITLE
ARTEMIS-2199 PagingStore leak when deleting queue

### DIFF
--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/NetworkHealthTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/NetworkHealthTest.java
@@ -144,9 +144,8 @@ public class NetworkHealthTest {
       NetworkHealthCheck check = addCheck(new NetworkHealthCheck(null, 100, 100));
 
       // using two addresses for URI and localhost
-      check.parseAddressList("localhost, , 127.0.0.2").parseURIList("http://www.redhat.com, , http://www.apache.org");
+      check.parseAddressList("localhost, , 127.0.0.2");
       Assert.assertEquals(2, check.getAddresses().size());
-      Assert.assertEquals(2, check.getUrls().size());
    }
 
    @Test
@@ -154,9 +153,9 @@ public class NetworkHealthTest {
       NetworkHealthCheck check = addCheck(new NetworkHealthCheck(null, 100, 100));
 
       // using two addresses for URI and localhost
-      check.parseAddressList("localhost, , 127.0.0.2").parseURIList("http://www.redhat.com, , http://www.apache.org");
+      check.parseAddressList("localhost, , 127.0.0.2");
       Assert.assertEquals(2, check.getAddresses().size());
-      Assert.assertEquals(2, check.getUrls().size());
+      Assert.assertEquals(0, check.getUrls().size());
    }
 
    @Test

--- a/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/impl/JMSServerManagerImpl.java
+++ b/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/impl/JMSServerManagerImpl.java
@@ -51,6 +51,7 @@ import org.apache.activemq.artemis.api.jms.JMSFactoryType;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.postoffice.Binding;
 import org.apache.activemq.artemis.core.postoffice.BindingType;
+import org.apache.activemq.artemis.core.postoffice.Bindings;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory;
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.core.security.Role;
@@ -1719,11 +1720,11 @@ public class JMSServerManagerImpl implements JMSServerManager, ActivateCallback 
       @Override
       public void callback(SimpleString address, SimpleString queueName) throws Exception {
          Queue queue = server.locateQueue(address);
-         Collection<Binding> bindings = server.getPostOffice().getBindingsForAddress(address).getBindings();
+         Bindings bindings = server.getPostOffice().lookupBindingsForAddress(address);
 
          AddressSettings settings = server.getAddressSettingsRepository().getMatch(address.toString());
 
-         if (address.toString().startsWith(ActiveMQDestination.JMS_TOPIC_ADDRESS_PREFIX) && settings.isAutoDeleteJmsTopics() && bindings.size() == 1 && queue != null && queue.isAutoCreated()) {
+         if (address.toString().startsWith(ActiveMQDestination.JMS_TOPIC_ADDRESS_PREFIX) && settings.isAutoDeleteJmsTopics() && bindings != null && bindings.getBindings().size() == 1 && queue != null && queue.isAutoCreated()) {
             try {
                destroyTopic(address.toString().substring(ActiveMQDestination.JMS_TOPIC_ADDRESS_PREFIX.length()));
             } catch (IllegalStateException e) {

--- a/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/impl/JMSServerManagerImpl.java
+++ b/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/impl/JMSServerManagerImpl.java
@@ -28,7 +28,6 @@ import java.net.InetAddress;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/TemporaryDestinationTest.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/TemporaryDestinationTest.java
@@ -26,7 +26,9 @@ import javax.jms.TemporaryQueue;
 import javax.jms.TemporaryTopic;
 import javax.jms.TextMessage;
 import javax.naming.NamingException;
+import java.util.Arrays;
 
+import org.apache.activemq.artemis.jms.client.ActiveMQTemporaryQueue;
 import org.apache.activemq.artemis.jms.tests.util.ProxyAssertSupport;
 import org.junit.Test;
 
@@ -119,6 +121,27 @@ public class TemporaryDestinationTest extends JMSTestCase {
          ProxyAssertSupport.assertNotNull(m2);
 
          ProxyAssertSupport.assertEquals(messageText, m2.getText());
+      } finally {
+         if (conn != null) {
+            conn.close();
+         }
+      }
+   }
+
+   @Test
+   public void testTemporaryQueuePagingStoreLeak() throws Exception {
+      Connection conn = null;
+
+      try {
+         conn = createConnection();
+
+         Session session = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+         TemporaryQueue tempQueue = session.createTemporaryQueue();
+
+         tempQueue.delete();
+
+         ProxyAssertSupport.assertFalse(Arrays.asList(servers.get(0).getActiveMQServer().getPagingManager().getStoreNames()).contains(((ActiveMQTemporaryQueue)tempQueue).getSimpleAddress()));
       } finally {
          if (conn != null) {
             conn.close();

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/JournalFileRepositoryOrderTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/JournalFileRepositoryOrderTest.java
@@ -51,6 +51,7 @@ public class JournalFileRepositoryOrderTest extends ActiveMQTestBase {
 
          // this is simulating how compating would return files into the journal
          t = new Thread() {
+            @Override
             public void run() {
                while (running.get()) {
                   try {


### PR DESCRIPTION
When deleting a queue the JMSPostQueueDeletionCallback#callback will
invoke PostOfficeImpl#getBindingsForAddress which will *create* a
Bindings instance if one doesn't exist. This will trigger the creation
of a PagingStore instance which will be stored by the PagingManager
and may never be deleted. This is particularly problematic for use-cases
involving temporary JMS queues.

This change uses the lookupBindingsForAddress instead of
getBindingsForAddress which doesn't implicitly create a Bindings
instance.

This problem doesn't exist on the master branch as the
JMSPostQueueDeletionCallback no longer exists there.