### PR TITLE
ARTEMIS-2200 NPE while dropping/failing large messages on paging

### DIFF
--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalImpl.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalImpl.java
@@ -974,6 +974,7 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
             } catch (Throwable e) {
                result.fail(e);
                logger.error("appendDeleteRecord:" + e, e);
+               setErrorCondition(callback, null, e);
             } finally {
                journalLock.readLock().unlock();
             }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AbstractJournalStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AbstractJournalStorageManager.java
@@ -1653,12 +1653,14 @@ public abstract class AbstractJournalStorageManager extends CriticalComponentImp
    // Package protected ---------------------------------------------
 
    protected void confirmLargeMessage(final LargeServerMessage largeServerMessage) {
-      if (largeServerMessage.getPendingRecordID() >= 0) {
-         try {
-            confirmPendingLargeMessage(largeServerMessage.getPendingRecordID());
-            largeServerMessage.setPendingRecordID(LargeServerMessage.NO_PENDING_ID);
-         } catch (Exception e) {
-            ActiveMQServerLogger.LOGGER.warn(e.getMessage(), e);
+      synchronized (largeServerMessage) {
+         if (largeServerMessage.getPendingRecordID() >= 0) {
+            try {
+               confirmPendingLargeMessage(largeServerMessage.getPendingRecordID());
+               largeServerMessage.setPendingRecordID(LargeServerMessage.NO_PENDING_ID);
+            } catch (Exception e) {
+               ActiveMQServerLogger.LOGGER.warn(e.getMessage(), e);
+            }
          }
       }
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalStorageManager.java
@@ -440,15 +440,17 @@ public class JournalStorageManager extends AbstractJournalStorageManager {
 
    // This should be accessed from this package only
    void deleteLargeMessageFile(final LargeServerMessage largeServerMessage) throws ActiveMQException {
-      if (largeServerMessage.getPendingRecordID() < 0) {
-         try {
-            // The delete file happens asynchronously
-            // And the client won't be waiting for the actual file to be deleted.
-            // We set a temporary record (short lived) on the journal
-            // to avoid a situation where the server is restarted and pending large message stays on forever
-            largeServerMessage.setPendingRecordID(storePendingLargeMessage(largeServerMessage.getMessageID(), largeServerMessage.getPendingRecordID()));
-         } catch (Exception e) {
-            throw new ActiveMQInternalErrorException(e.getMessage(), e);
+      synchronized (largeServerMessage) {
+         if (largeServerMessage.getPendingRecordID() < 0) {
+            try {
+               // The delete file happens asynchronously
+               // And the client won't be waiting for the actual file to be deleted.
+               // We set a temporary record (short lived) on the journal
+               // to avoid a situation where the server is restarted and pending large message stays on forever
+               largeServerMessage.setPendingRecordID(storePendingLargeMessage(largeServerMessage.getMessageID(), largeServerMessage.getPendingRecordID()));
+            } catch (Exception e) {
+               throw new ActiveMQInternalErrorException(e.getMessage(), e);
+            }
          }
       }
       final SequentialFile file = largeServerMessage.getFile();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -1354,13 +1354,15 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
     */
    private void confirmLargeMessageSend(Transaction tx, final Message message) throws Exception {
       LargeServerMessage largeServerMessage = (LargeServerMessage) message;
-      if (largeServerMessage.getPendingRecordID() >= 0) {
-         if (tx == null) {
-            storageManager.confirmPendingLargeMessage(largeServerMessage.getPendingRecordID());
-         } else {
-            storageManager.confirmPendingLargeMessageTX(tx, largeServerMessage.getMessageID(), largeServerMessage.getPendingRecordID());
+      synchronized (largeServerMessage) {
+         if (largeServerMessage.getPendingRecordID() >= 0) {
+            if (tx == null) {
+               storageManager.confirmPendingLargeMessage(largeServerMessage.getPendingRecordID());
+            } else {
+               storageManager.confirmPendingLargeMessageTX(tx, largeServerMessage.getMessageID(), largeServerMessage.getPendingRecordID());
+            }
+            largeServerMessage.setPendingRecordID(-1);
          }
-         largeServerMessage.setPendingRecordID(-1);
       }
    }
 


### PR DESCRIPTION
Large messages pendingRecordID is not accessed atomically, leading
to races that would lead to records that cannot been found on the
journal for deletion: it would lead to cause NPE that won't clean
the pending tasks on the current OperationContextImpl.
Adding a cleanup on error of those tasks and avoiding the race
to happen by adding proper synchronization will both enforce
correct clean up when something bad happen and avoid NPE.