### PR TITLE
ARTEMIS-2197 Page deleted before transaction finishes

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/PageSubscription.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/PageSubscription.java
@@ -170,4 +170,5 @@ public interface PageSubscription {
 
    void incrementDeliveredSize(long size);
 
+   void removePendingDelivery(PagePosition position);
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/PagedReference.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/PagedReference.java
@@ -28,4 +28,20 @@ public interface PagedReference extends MessageReference {
    boolean isLargeMessage();
 
    long getTransactionID();
+
+   /** this method affects paging clean up
+       It adds to the flag that prevents its page from cleanup.
+       It's a helper method to call the proper {@link PageSubscription#addPendingDelivery(PagePosition)}
+
+    @see PageSubscription#addPendingDelivery(PagePosition)
+    */
+   void addPendingFlag();
+
+   /** this method affects paging clean up
+    It adds to the flag that prevents its page from cleanup.
+    It's a helper method to call the proper {@link PageSubscription#addPendingDelivery(PagePosition)}
+
+    @see PageSubscription#addPendingDelivery(PagePosition)
+    */
+   void removePendingFlag();
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/PagedReferenceImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/PagedReferenceImpl.java
@@ -324,6 +324,16 @@ public class PagedReferenceImpl extends LinkedListImpl.Node<PagedReferenceImpl> 
    }
 
    @Override
+   public void addPendingFlag() {
+      subscription.addPendingDelivery(position);
+   }
+
+   @Override
+   public void removePendingFlag() {
+      subscription.removePendingDelivery(position);
+   }
+
+   @Override
    public long getMessageID() {
       if (messageID < 0) {
          messageID = getPagedMessage().getMessage().getMessageID();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageSubscriptionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageSubscriptionImpl.java
@@ -59,7 +59,7 @@ import org.apache.activemq.artemis.utils.actors.ArtemisExecutor;
 import org.apache.activemq.artemis.utils.collections.ConcurrentHashSet;
 import org.jboss.logging.Logger;
 
-final class PageSubscriptionImpl implements PageSubscription {
+public final class PageSubscriptionImpl implements PageSubscription {
 
    private static final Logger logger = Logger.getLogger(PageSubscriptionImpl.class);
 
@@ -556,6 +556,15 @@ final class PageSubscriptionImpl implements PageSubscription {
    }
 
    @Override
+   public void removePendingDelivery(final PagePosition position) {
+      PageCursorInfo info = getPageInfo(position);
+
+      if (info != null) {
+         info.decrementPendingTX();
+      }
+   }
+
+   @Override
    public void redeliver(final PageIterator iterator, final PagePosition position) {
       iterator.redeliver(position);
 
@@ -780,7 +789,7 @@ final class PageSubscriptionImpl implements PageSubscription {
       return getPageInfo(pos.getPageNr());
    }
 
-   private PageCursorInfo getPageInfo(final long pageNr) {
+   public PageCursorInfo getPageInfo(final long pageNr) {
       synchronized (consumedPages) {
          PageCursorInfo pageInfo = consumedPages.get(pageNr);
 
@@ -916,7 +925,7 @@ final class PageSubscriptionImpl implements PageSubscription {
     * This instance will be released as soon as the entire page is consumed, releasing the memory at
     * that point The ref counts are increased also when a message is ignored for any reason.
     */
-   private final class PageCursorInfo {
+   public final class PageCursorInfo {
 
       // Number of messages existent on this page
       private final int numberOfMessages;
@@ -934,6 +943,7 @@ final class PageSubscriptionImpl implements PageSubscription {
       private final boolean wasLive;
 
       // There's a pending TX to add elements on this page
+      // also can be used to prevent the page from being deleted too soon.
       private final AtomicInteger pendingTX = new AtomicInteger(0);
 
       // There's a pending delete on the async IO pipe
@@ -1108,6 +1118,9 @@ final class PageSubscriptionImpl implements PageSubscription {
          return cache != null ? cache.get() : null;
       }
 
+      public int getPendingTx() {
+         return pendingTX.get();
+      }
    }
 
    private final class PageCursorTX extends TransactionOperationAbstract {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/RefsOperation.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/RefsOperation.java
@@ -132,14 +132,14 @@ public class RefsOperation extends TransactionOperationAbstract {
                message.incrementRefCount();
             }
             ackedTX.commit(true);
-
-            if (pagedMessagesToPostACK != null) {
-               for (MessageReference refmsg : pagedMessagesToPostACK) {
-                  ((PagedReference)refmsg).removePendingFlag();
-               }
-            }
          } catch (Exception e) {
             ActiveMQServerLogger.LOGGER.failedToProcessMessageReferenceAfterRollback(e);
+         }
+      }
+
+      if (pagedMessagesToPostACK != null) {
+         for (MessageReference refmsg : pagedMessagesToPostACK) {
+            ((PagedReference)refmsg).removePendingFlag();
          }
       }
    }


### PR DESCRIPTION

When a receiving transaction is committed in a paging situation,
if a page happens to be completed and it will be deleted in a
transaction operation (PageCursorTx). The other tx operation
RefsOperation needs to access the page (in PageCache) to finish
its job. There is a chance that the PageCursorTx removes the
page before RefsOperation and it will cause the RefsOperation
failed to find a message in a page.

(cherry picked from b36dc37c152cabe3a0d9af178db043f842bfcdc0)
(cherry picked from 2bd8fa7c5dcfb2c29a5c5f61ff433bf161b1b86e) (Fix regression)
