### PR TITLE
ARTEMIS-2206 The MQTT consumer reconnection caused the queue to not be cle…

### DIFF
--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTConnectionManager.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTConnectionManager.java
@@ -58,15 +58,15 @@ public class MQTTConnectionManager {
    /**
     * Handles the connect packet.  See spec for details on each of parameters.
     */
-   synchronized void connect(String cId,
-                             String username,
-                             byte[] passwordInBytes,
-                             boolean will,
-                             byte[] willMessage,
-                             String willTopic,
-                             boolean willRetain,
-                             int willQosLevel,
-                             boolean cleanSession) throws Exception {
+   void connect(String cId,
+                String username,
+                byte[] passwordInBytes,
+                boolean will,
+                byte[] willMessage,
+                String willTopic,
+                boolean willRetain,
+                int willQosLevel,
+                boolean cleanSession) throws Exception {
       String clientId = validateClientId(cId, cleanSession);
       if (clientId == null) {
          session.getProtocolHandler().sendConnack(MqttConnectReturnCode.CONNECTION_REFUSED_IDENTIFIER_REJECTED);
@@ -74,34 +74,36 @@ public class MQTTConnectionManager {
          return;
       }
 
-      String password = passwordInBytes == null ? null : new String(passwordInBytes, CharsetUtil.UTF_8);
-      session.getConnection().setClientID(clientId);
-      ServerSessionImpl serverSession = createServerSession(username, password);
-      serverSession.start();
-      session.setServerSession(serverSession);
+      MQTTSessionState sessionState = getSessionState(clientId);
+      synchronized (sessionState) {
+         session.setSessionState(sessionState);
+         String password = passwordInBytes == null ? null : new String(passwordInBytes, CharsetUtil.UTF_8);
+         session.getConnection().setClientID(clientId);
+         ServerSessionImpl serverSession = createServerSession(username, password);
+         serverSession.start();
+         session.setServerSession(serverSession);
 
-      session.setSessionState(getSessionState(clientId));
+         if (cleanSession) {
+            /* [MQTT-3.1.2-6] If CleanSession is set to 1, the Client and Server MUST discard any previous Session and
+             * start a new one. This Session lasts as long as the Network Connection. State data associated with this Session
+             * MUST NOT be reused in any subsequent Session */
+            session.clean();
+            session.setClean(true);
+         }
 
-      if (cleanSession) {
-         /* [MQTT-3.1.2-6] If CleanSession is set to 1, the Client and Server MUST discard any previous Session and
-          * start a new one. This Session lasts as long as the Network Connection. State data associated with this Session
-          * MUST NOT be reused in any subsequent Session */
-         session.clean();
-         session.setClean(true);
+         if (will) {
+            isWill = true;
+            this.willMessage = ByteBufAllocator.DEFAULT.buffer(willMessage.length);
+            this.willMessage.writeBytes(willMessage);
+            this.willQoSLevel = willQosLevel;
+            this.willRetain = willRetain;
+            this.willTopic = willTopic;
+         }
+
+         session.getConnection().setConnected(true);
+         session.start();
+         session.getProtocolHandler().sendConnack(MqttConnectReturnCode.CONNECTION_ACCEPTED);
       }
-
-      if (will) {
-         isWill = true;
-         this.willMessage = ByteBufAllocator.DEFAULT.buffer(willMessage.length);
-         this.willMessage.writeBytes(willMessage);
-         this.willQoSLevel = willQosLevel;
-         this.willRetain = willRetain;
-         this.willTopic = willTopic;
-      }
-
-      session.getConnection().setConnected(true);
-      session.start();
-      session.getProtocolHandler().sendConnack(MqttConnectReturnCode.CONNECTION_ACCEPTED);
    }
 
    /**
@@ -133,35 +135,37 @@ public class MQTTConnectionManager {
       return (ServerSessionImpl) serverSession;
    }
 
-   synchronized void disconnect(boolean failure) {
+   void disconnect(boolean failure) {
       if (session == null || session.getStopped()) {
          return;
       }
 
-      try {
-         if (isWill && failure) {
-            session.getMqttPublishManager().sendInternal(0, willTopic, willQoSLevel, willMessage, willRetain, true);
-         }
-         session.stop();
-         session.getConnection().destroy();
-      } catch (Exception e) {
-         log.error("Error disconnecting client: " + e.getMessage());
-      } finally {
-         if (session.getSessionState() != null) {
-            session.getSessionState().setAttached(false);
-            String clientId = session.getSessionState().getClientId();
-            /**
-             *  ensure that the connection for the client ID matches *this* connection otherwise we could remove the
-             *  entry for the client who "stole" this client ID via [MQTT-3.1.4-2]
-             */
-            if (clientId != null && session.getProtocolManager().isClientConnected(clientId, session.getConnection())) {
-               session.getProtocolManager().removeConnectedClient(clientId);
+      synchronized (session.getSessionState()) {
+         try {
+            if (isWill && failure) {
+               session.getMqttPublishManager().sendInternal(0, willTopic, willQoSLevel, willMessage, willRetain, true);
+            }
+            session.stop();
+            session.getConnection().destroy();
+         } catch (Exception e) {
+            log.error("Error disconnecting client: " + e.getMessage());
+         } finally {
+            if (session.getSessionState() != null) {
+               session.getSessionState().setAttached(false);
+               String clientId = session.getSessionState().getClientId();
+               /**
+                *  ensure that the connection for the client ID matches *this* connection otherwise we could remove the
+                *  entry for the client who "stole" this client ID via [MQTT-3.1.4-2]
+                */
+               if (clientId != null && session.getProtocolManager().isClientConnected(clientId, session.getConnection())) {
+                  session.getProtocolManager().removeConnectedClient(clientId);
+               }
             }
          }
       }
    }
 
-   private MQTTSessionState getSessionState(String clientId) {
+   private synchronized MQTTSessionState getSessionState(String clientId) {
       /* [MQTT-3.1.2-4] Attach an existing session if one exists otherwise create a new one. */
       MQTTSessionState state = MQTTSession.SESSIONS.get(clientId);
       if (state == null) {

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTProtocolManager.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTProtocolManager.java
@@ -179,7 +179,10 @@ class MQTTProtocolManager extends AbstractProtocolManager<MqttMessage, MQTTInter
    }
 
    public boolean isClientConnected(String clientId, MQTTConnection connection) {
-      return connectedClients.get(clientId).equals(connection);
+      MQTTConnection connectedClient = connectedClients.get(clientId);
+      if (connectedClient != null)
+         return connectedClients.get(clientId).equals(connection);
+      return false;
    }
 
    public void removeConnectedClient(String clientId) {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/imported/MQTTQueueCleanTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/imported/MQTTQueueCleanTest.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.tests.integration.mqtt.imported;
+
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.tests.util.Wait;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+
+public class MQTTQueueCleanTest extends MQTTTestSupport {
+
+   private static final Logger LOG = LoggerFactory.getLogger(MQTTQueueCleanTest.class);
+
+   @Test
+   public void testQueueCleanWhenConnectionSynExeConnectAndDisconnect() throws Exception {
+      Random random = new Random();
+      Set<MQTTClientProvider> clientProviders = new HashSet<>(11);
+      int repeatCount = 0;
+      String address = "clean/test";
+      String clientId = "sameClientId";
+      String queueName = "::sameClientId.clean.test";
+      //The abnormal scene does not necessarily occur, repeating 100 times to ensure the recurrence of the abnormality
+      while (repeatCount < 100) {
+         repeatCount++;
+         int subConnectionCount = random.nextInt(50) + 1;
+         int sC = 0;
+         try {
+            //Reconnect at least twice to reproduce the problem
+            while (sC < subConnectionCount) {
+               sC++;
+               MQTTClientProvider clientProvider = getMQTTClientProvider();
+               clientProvider.setClientId(clientId);
+               initializeConnection(clientProvider);
+               clientProviders.add(clientProvider);
+               clientProvider.subscribe(address, AT_LEAST_ONCE);
+            }
+         } catch (Throwable e) {
+            LOG.error(e.getMessage(), e);
+         } finally {
+            for (MQTTClientProvider clientProvider : clientProviders) {
+               clientProvider.disconnect();
+            }
+            clientProviders.clear();
+            assertTrue(Wait.waitFor(() -> server.locateQueue(SimpleString.toSimpleString(queueName)) == null, 5000, 10));
+         }
+      }
+   }
+
+}


### PR DESCRIPTION
### Test environment

1. Use 10,000 (9 thousand senders, 1 thousand consumers) MQTT connection on one server to test Artemis, set the 'cleanSession' property to true；
2. MQTT client: paho 1.2.0;
3. Server: CPU Cores:32, Mem:64G, SSD:250G, HDD:1T

### Issue

**Issue 1**
Artemis broker has the following exception log:
`[Thread-0 (ActiveMQ-remoting-threads-ActiveMQServerImpl::serverUUID=fb358579-feb3-11e8-bc7c-141877a7fd13-1409545055)] 17:27:59,035 WARN  [org.apache.activemq.artemis.utils.actors.OrderedExecutor] null: java.lang.NullPointerException
	at org.apache.activemq.artemis.core.protocol.mqtt.MQTTProtocolManager.isClientConnected(MQTTProtocolManager.java:182) [:]
	at org.apache.activemq.artemis.core.protocol.mqtt.MQTTConnectionManager.disconnect(MQTTConnectionManager.java:150) [:]
	at org.apache.activemq.artemis.core.protocol.mqtt.MQTTFailureListener.connectionFailed(MQTTFailureListener.java:37) [:]
	at org.apache.activemq.artemis.core.protocol.mqtt.MQTTConnection.fail(MQTTConnection.java:147) [:]
	at org.apache.activemq.artemis.core.remoting.server.impl.RemotingServiceImpl.issueFailure(RemotingServiceImpl.java:561) [:]
	at org.apache.activemq.artemis.core.remoting.server.impl.RemotingServiceImpl.connectionDestroyed(RemotingServiceImpl.java:542) [:]
	at org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptor$Listener.connectionDestroyed(NettyAcceptor.java:858) [:]
	at org.apache.activemq.artemis.core.remoting.impl.netty.ActiveMQChannelHandler.lambda$channelInactive$0(ActiveMQChannelHandler.java:83) [:]
	at org.apache.activemq.artemis.utils.actors.OrderedExecutor.doTask(OrderedExecutor.java:42) [:]
	at org.apache.activemq.artemis.utils.actors.OrderedExecutor.doTask(OrderedExecutor.java:31) [:]
	at org.apache.activemq.artemis.utils.actors.ProcessorBase.executePendingTasks(ProcessorBase.java:66) [:]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [rt.jar:1.8.0_101]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [rt.jar:1.8.0_101]
at org.apache.activemq.artemis.utils.ActiveMQThreadFactory$1.run(ActiveMQThreadFactory.java:118) [:]`

**Issue 2**
After closing all client connections, 64 queues were not cleaned up。

### Analysis and simulation reproduction

  When the MQTT consumer client (cleanSession property set to true) reconnected,There is a certain probability that the queue will not be automatically cleared and a NullPointerException will be thrown.
  This is because the MQTT consumer client thinks that its connection has been disconnected and triggers reconnection, but the MQTT connection is still alive at Artemis broker. This bug occurs when the Artemis broker to start processing a ‘new MQTT connection’ while closing the ‘old MQTT connection’.
  Create an MQTT consumer (cleanSession: true, clientID: superConsumer, topic: mit.test) and connect to the Artemis broker. Create another MQTT consumer to set the same cleanSession, clientID, and topic, then start connecting with the Artemis broker. Close the two MQTT connections, and so many times after repeated trials, there is a probability to reproduce the two problems mentioned above.

### Solution

**Issue 1**

  When 'session.getProtocolManager().isClientConnected(clientId, session.getConnection())' is called, if the 'MQTTConnection' instance retrieved from 'connectedClients' is 'null', a NullPointerException is thrown. Add a non-null decision in the 'MQTTProtocolManager.isClientConnected' method.

**Issue 2** 

1. Remove ‘InterruptedException’ from the ‘MQTTConnectionManager.getSessionState’ method because the ‘InterruptedException’ exception will never be thrown in this method;
2. 'MQTTConnectionManager.connect' and 'MQTTConnectionManager.disconnect' methods add 'synchronized' with the MQTTSessionState instance as a lock.In the Artemis broker, all MQTT connections using the same clientId share the same MQTTSessionState instance. After adding this lock, you can avoid calling the 'connect' and 'disconnect' methods on the MQTT connections with the same clientId.
3. For the MQTT protocol, there is one and only one consumer connection per queue, which is a good choice for closing the old MQTT consumer before the new MQTT consumer connects.
    The original code could not effectively clean up the 'old consumer' in the queue when the 'new MQTT connection' was connected to the Artemis broker. Modify ‘MQTTSubscriptionManager.removeSubscription’ to get the queue consumer collection from the ‘QueueImpl’ instance and close them.
