### PR TITLE
Add CR in sanity check

### DIFF
--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompDecoder.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompDecoder.java
@@ -527,7 +527,7 @@ public class StompDecoder {
       }
 
       // Sanity check
-      if (workingBuffer[pos - 1] != NEW_LINE) {
+      if (workingBuffer[pos - 1] != NEW_LINE && workingBuffer[pos - 1] != CR) {
          //give a signal to try other versions
          ActiveMQStompException error = BUNDLE.notValidNewLine(workingBuffer[pos - 1]).setHandler(handler);
          error.setCode(ActiveMQStompException.INVALID_EOL_V10);


### PR DESCRIPTION
Specified in https://stomp.github.io/stomp-specification-1.2.html#STOMP_Frames also carriage return (octet 13) is allowed:

> The frame starts with a command string terminated by an end-of-line (EOL), which consists of an OPTIONAL carriage return (octet 13) followed by a REQUIRED line feed (octet 10).