### PR TITLE
ARTEMIS-1058 Jars in web tmp dir locked on Windows

### DIFF
--- a/artemis-boot/src/main/java/org/apache/activemq/artemis/boot/WebTmpCleaner.java
+++ b/artemis-boot/src/main/java/org/apache/activemq/artemis/boot/WebTmpCleaner.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.boot;
+
+import java.io.File;
+
+/**
+ * This class is used to remove the jar files
+ * in temp web dir on Windows platform where
+ * handles of the jar files are never released
+ * by URLClassLoader until the whole VM exits.
+ */
+public class WebTmpCleaner {
+
+   public static void main(String[] args) throws Exception {
+
+      String[] filesToClean = args[0].split(",");
+
+      //It needs to retry a bit as we are not sure
+      //when the main VM exists.
+      boolean allCleaned = false;
+      int maxRetries = 100;
+      while (!allCleaned && maxRetries-- > 0) {
+         allCleaned = true;
+         for (String f : filesToClean) {
+            if (!f.trim().isEmpty()) {
+               File file = new File(f);
+               if (file.exists()) {
+                  deleteFile(file);
+                  allCleaned = false;
+               }
+            }
+         }
+         Thread.sleep(200);
+      }
+   }
+
+
+   public static final void deleteFile(final File file) {
+      if (file.isDirectory()) {
+         String[] files = file.list();
+         for (String path : files) {
+            File f = new File(file, path);
+            deleteFile(f);
+         }
+      }
+      file.delete();
+   }
+
+}


### PR DESCRIPTION
Because Sun's URLClassLoader never closes it's jar file handles
Jetty doesn't cleanup is temp web dir after Artemis broker shut
down normally on Windows.

To work around this a new process is forked before broker VM
exits to clean up the tmp dir if they are not deleted. The
new process out lives the main VM so that those jar's handles
are released and the temp dir can be cleaned up.