### PR TITLE
ARTEMIS-2214 Cache durable&deliveryTime in PagedReference

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/MessageReference.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/MessageReference.java
@@ -44,6 +44,8 @@ public interface MessageReference {
 
    long getMessageID();
 
+   boolean isDurable();
+
    SimpleString getLastValueProperty();
 
    /**

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/LastValueQueue.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/LastValueQueue.java
@@ -306,6 +306,11 @@ public class LastValueQueue extends QueueImpl {
       }
 
       @Override
+      public boolean isDurable() {
+         return getMessage().isDurable();
+      }
+
+      @Override
       public SimpleString getLastValueProperty() {
          return prop;
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/MessageReferenceImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/MessageReferenceImpl.java
@@ -190,6 +190,11 @@ public class MessageReferenceImpl extends LinkedListImpl.Node<MessageReferenceIm
    }
 
    @Override
+   public boolean isDurable() {
+      return getMessage().isDurable();
+   }
+
+   @Override
    public void handled() {
       queue.referenceHandled(this);
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
@@ -2767,7 +2767,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
          return true;
       }
 
-      if (!internalQueue && message.isDurable() && isDurableMessage() && !reference.isPaged()) {
+      if (!internalQueue && reference.isDurable() && isDurableMessage() && !reference.isPaged()) {
          storageManager.updateDeliveryCount(reference);
       }
 
@@ -2796,7 +2796,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
 
             reference.setScheduledDeliveryTime(timeBase + redeliveryDelay);
 
-            if (!reference.isPaged() && message.isDurable() && isDurableMessage()) {
+            if (!reference.isPaged() && reference.isDurable() && isDurableMessage()) {
                storageManager.updateScheduledDeliveryTime(reference);
             }
          }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueuePendingMessageMetrics.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueuePendingMessageMetrics.java
@@ -58,7 +58,7 @@ public class QueuePendingMessageMetrics {
       long size = getPersistentSize(reference);
       COUNT_UPDATER.incrementAndGet(this);
       SIZE_UPDATER.addAndGet(this, size);
-      if (queue.isDurable() && reference.getMessage().isDurable()) {
+      if (queue.isDurable() && reference.isDurable()) {
          DURABLE_COUNT_UPDATER.incrementAndGet(this);
          DURABLE_SIZE_UPDATER.addAndGet(this, size);
       }
@@ -68,7 +68,7 @@ public class QueuePendingMessageMetrics {
       long size = -getPersistentSize(reference);
       COUNT_UPDATER.decrementAndGet(this);
       SIZE_UPDATER.addAndGet(this, size);
-      if (queue.isDurable() && reference.getMessage().isDurable()) {
+      if (queue.isDurable() && reference.isDurable()) {
          DURABLE_COUNT_UPDATER.decrementAndGet(this);
          DURABLE_SIZE_UPDATER.addAndGet(this, size);
       }


### PR DESCRIPTION
We recently performed a test on artemis broker and found a severe performance issue.

When paged messages are being consumed, decrementMetrics in QueuePendingMessageMetrics will try to ‘getMessage’ to check whether they are durable or not. In this way queue will be locked for a long time because page may be GCed and need to be reload entirely. Other operations rely on queue will be blocked at this time, which cause a significant TPS drop. Detailed stacks are attached below.

This also happens when consumer is closed and messages are pushed back to the queue, artemis will check priority on return if these messages are paged.

To solve the issue, durable and priority need to be cached in PagedReference just like messageID, transactionID and so on. I have applied a patch to fix the issue. Any review is appreciated.

jira issue:https://issues.apache.org/jira/projects/ARTEMIS/issues/ARTEMIS-2214