### PR TITLE
ARTEMIS-2217 ‘MQTTSessionState’ in the ‘SESSIONS ConcurrentHashMap’ n…

### DIFF
--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTSession.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTSession.java
@@ -106,7 +106,7 @@ public class MQTTSession {
          }
 
          if (isClean()) {
-            clean();
+            clean(true);
          }
       }
       stopped = true;
@@ -123,7 +123,7 @@ public class MQTTSession {
    void setIsClean(boolean isClean) throws Exception {
       this.isClean = isClean;
       if (isClean) {
-         clean();
+         clean(false);
       }
    }
 
@@ -184,10 +184,13 @@ public class MQTTSession {
       return protocolManager;
    }
 
-   void clean() throws Exception {
+   void clean(boolean isCleanSessionState) throws Exception {
       subscriptionManager.clean();
       mqttPublishManager.clean();
       state.clear();
+      //when cleanSession is true,MQTTSessionState should be removed
+      if (isCleanSessionState)
+         SESSIONS.remove(connection.getClientID());
    }
 
    public WildcardConfiguration getWildcardConfiguration() {


### PR DESCRIPTION
…ever be removed

‘MQTTSessionState’ in the ‘SESSIONS ConcurrentHashMap’ should be removed when the conusmer （cleanSession is true） connection is closed