### PR TITLE
ARTEMIS-2220 Fix PageCursorStressTest::testSimpleCursorWithFilter NPE

### DIFF
--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/FakeQueue.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/FakeQueue.java
@@ -735,6 +735,9 @@ public class FakeQueue extends CriticalComponentImpl implements Queue {
 
    public void setPageSubscription(PageSubscription sub) {
       this.subs = sub;
+      if (subs != null) {
+         sub.setQueue(this);
+      }
    }
 
    @Override


### PR DESCRIPTION
FakeQueue is not correctly setting the queue on its PageSubscription,
leading to fail the test due to NPEs when PageSubscription::getQueue
is being used.