### PR TITLE
ARTEMIS-2222 why the position remains unchanged if ignored is set to true

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageSubscriptionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageSubscriptionImpl.java
@@ -1315,9 +1315,7 @@ public final class PageSubscriptionImpl implements PageSubscription {
                   }
                }
 
-               if (!ignored) {
-                  position = message.getPosition();
-               }
+               position = message.getPosition();
 
                if (valid) {
                   match = match(message.getMessage());


### PR DESCRIPTION
I am a bit confused about this, When CursorIterator:next is called during queue depage, if ignored is set to true, why the position remains unchanged. 		
if (!ignored) {
    position = message.getPosition();
}		
For example, the client sends some messages to the topic subscriber ta (this topic has two subscribers ta and tb), every time tb depage continuous PagePositions that ignored are set to true will be traversed again.