### PR TITLE
ARTEMIS-2223 when a new consumer is created, no subscription is called.

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/imported/MQTTTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/imported/MQTTTest.java
@@ -1114,9 +1114,9 @@ public class MQTTTest extends MQTTTestSupport {
       final MQTT mqttClean = createMQTTConnection(CLIENTID, true);
       final BlockingConnection clean = mqttClean.blockingConnection();
       clean.connect();
+      clean.subscribe(new Topic[]{new Topic(TOPIC, QoS.EXACTLY_ONCE)});
       msg = clean.receive(10000, TimeUnit.MILLISECONDS);
       assertNull(msg);
-      clean.subscribe(new Topic[]{new Topic(TOPIC, QoS.EXACTLY_ONCE)});
       clean.publish(TOPIC, TOPIC.getBytes(), QoS.EXACTLY_ONCE, false);
       clean.disconnect();
 


### PR DESCRIPTION
In the 'MQTTTest.testCleanSession()' test method, when a new consumer is created, no subscription is called.Consumers need to subscribe before they consume the news.