### PR TITLE
NO-JIRA fix writableBuffer so that its only visible after sub statements

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessage.java
@@ -386,11 +386,12 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
       if (writableBuffer == null) {
          synchronized (this) {
             if (writableBuffer == null) {
-               writableBuffer = new ResetLimitWrappedActiveMQBuffer(BODY_OFFSET, buffer.duplicate(), this);
+               ResetLimitWrappedActiveMQBuffer writableBuffer = new ResetLimitWrappedActiveMQBuffer(BODY_OFFSET, buffer.duplicate(), this);
                if (endOfBodyPosition > 0) {
                   writableBuffer.byteBuf().setIndex(BODY_OFFSET, endOfBodyPosition - BUFFER_HEADER_SPACE + BODY_OFFSET);
                   writableBuffer.resetReaderIndex();
                }
+               this.writableBuffer = writableBuffer;
             }
          }
       }


### PR DESCRIPTION
Potential race condition. This assignment to writableBuffer is visible to other threads before the subsequent statements are executed.