### PR TITLE
[ARTEMIS-2234]: Incorrect warning from LoggingConfigurationFileReloader

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/LoggingConfigurationFileReloader.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/LoggingConfigurationFileReloader.java
@@ -81,6 +81,9 @@ public class LoggingConfigurationFileReloader implements ReloadCallback {
       if (configurator instanceof PropertyConfigurator) {
          return ((PropertyConfigurator) configurator).getLogContextConfiguration();
       }
+      if(configurator instanceof LogContextConfiguration) {
+          return (LogContextConfiguration) configurator;
+      }
       return null;
    }
 }


### PR DESCRIPTION
* returning the LogContextConfiguration if we have one.

Jira: https://issues.apache.org/jira/browse/ARTEMIS-2234