### PR TITLE
[ARTEMIS-2171]: ThreadPoolExecutor leak under SM due to lack of privileged block.

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQScheduledComponent.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQScheduledComponent.java
@@ -153,7 +153,12 @@ public abstract class ActiveMQScheduledComponent implements ActiveMQComponent, R
    }
 
    protected ActiveMQThreadFactory getThreadFactory() {
-      return new ActiveMQThreadFactory(this.getClass().getSimpleName() + "-scheduled-threads", false, getThisClassLoader());
+      return AccessController.doPrivileged(new PrivilegedAction<ActiveMQThreadFactory>() {
+         @Override
+         public ActiveMQThreadFactory run() {
+            return new ActiveMQThreadFactory(this.getClass().getSimpleName() + "-scheduled-threads", false, getThisClassLoader());
+         }
+      });
    }
 
    private ClassLoader getThisClassLoader() {

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/core/server/NetworkHealthCheck.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/core/server/NetworkHealthCheck.java
@@ -157,7 +157,12 @@ public class NetworkHealthCheck extends ActiveMQScheduledComponent {
 
    @Override
    protected ActiveMQThreadFactory getThreadFactory() {
-      return new ActiveMQThreadFactory("NetworkChecker", "Network-Checker-", false, getThisClassLoader());
+      return AccessController.doPrivileged(new PrivilegedAction<ActiveMQThreadFactory>() {
+         @Override
+         public ActiveMQThreadFactory run() {
+            return new ActiveMQThreadFactory("NetworkChecker", "Network-Checker-", false, getThisClassLoader());
+         }
+      });
    }
 
 

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/ActiveMQThreadFactory.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/ActiveMQThreadFactory.java
@@ -128,8 +128,13 @@ public final class ActiveMQThreadFactory implements ThreadFactory {
    }
 
    public static ActiveMQThreadFactory defaultThreadFactory() {
-      String callerClassName = Thread.currentThread().getStackTrace()[2].getClassName();
-      return new ActiveMQThreadFactory(callerClassName, false, null);
+      final String callerClassName = Thread.currentThread().getStackTrace()[2].getClassName();
+      return AccessController.doPrivileged(new PrivilegedAction<ActiveMQThreadFactory>() {
+         @Override
+         public ActiveMQThreadFactory run() {
+            return new ActiveMQThreadFactory(callerClassName, false, null);
+         }
+      });
    }
 
 }

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQActivation.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQActivation.java
@@ -31,6 +31,7 @@ import javax.resource.spi.work.WorkManager;
 import javax.transaction.xa.XAResource;
 import java.lang.reflect.Method;
 import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -638,8 +639,13 @@ public class ActiveMQActivation {
          logger.warn(e.getMessage(), e);
          tccl = null;
       }
-
-      ActiveMQThreadFactory factory = new ActiveMQThreadFactory(name, true, tccl);
+      final ClassLoader loader = tccl;
+      ActiveMQThreadFactory factory = AccessController.doPrivileged(new PrivilegedAction<ActiveMQThreadFactory>() {
+         @Override
+         public ActiveMQThreadFactory run() {
+            return new ActiveMQThreadFactory(name, true, loader);
+         }
+      });
       Thread t = factory.newThread(run);
       t.start();
       return t;


### PR DESCRIPTION
* Ensuring that all threadPoolFactories are created under a privileged
block so the threads created are under the same AccessControlContext.

Jira: https://issues.apache.org/jira/browse/ARTEMIS-2171