### PR TITLE
Native library fixes

### DIFF
--- a/artemis-native/src/main/c/org_apache_activemq_artemis_jlibaio_LibaioContext.c
+++ b/artemis-native/src/main/c/org_apache_activemq_artemis_jlibaio_LibaioContext.c
@@ -421,6 +421,12 @@ JNIEXPORT jobject JNICALL Java_org_apache_activemq_artemis_jlibaio_LibaioContext
     }
 
     struct io_event * events = (struct io_event *)malloc(sizeof(struct io_event) * (size_t)queueSize);
+    if (events == NULL) {
+        free(theControl);
+        free(libaioContext);
+        throwRuntimeExceptionErrorNo(env, "Can't initialize mutext (not enough memory for the events member): ", res);
+        return NULL;
+    }
 
     theControl->ioContext = libaioContext;
     theControl->events = events;

--- a/artemis-native/src/main/c/org_apache_activemq_artemis_jlibaio_LibaioContext.c
+++ b/artemis-native/src/main/c/org_apache_activemq_artemis_jlibaio_LibaioContext.c
@@ -374,7 +374,7 @@ JNIEXPORT jobject JNICALL Java_org_apache_activemq_artemis_jlibaio_LibaioContext
     int res = io_queue_init(queueSize, &libaioContext);
     if (res) {
         // Error, so need to release whatever was done before
-        free(libaioContext);
+        io_queue_release(libaioContext);
 
         throwRuntimeExceptionErrorNo(env, "Cannot initialize queue:", res);
         return NULL;
@@ -407,7 +407,7 @@ JNIEXPORT jobject JNICALL Java_org_apache_activemq_artemis_jlibaio_LibaioContext
     res = pthread_mutex_init(&(theControl->iocbLock), 0);
     if (res) {
         free(theControl);
-        free(libaioContext);
+        io_queue_release(libaioContext);
         throwRuntimeExceptionErrorNo(env, "Can't initialize mutext:", res);
         return NULL;
     }
@@ -415,7 +415,7 @@ JNIEXPORT jobject JNICALL Java_org_apache_activemq_artemis_jlibaio_LibaioContext
     res = pthread_mutex_init(&(theControl->pollLock), 0);
     if (res) {
         free(theControl);
-        free(libaioContext);
+        io_queue_release(libaioContext);
         throwRuntimeExceptionErrorNo(env, "Can't initialize mutext:", res);
         return NULL;
     }
@@ -423,7 +423,8 @@ JNIEXPORT jobject JNICALL Java_org_apache_activemq_artemis_jlibaio_LibaioContext
     struct io_event * events = (struct io_event *)malloc(sizeof(struct io_event) * (size_t)queueSize);
     if (events == NULL) {
         free(theControl);
-        free(libaioContext);
+        io_queue_release(libaioContext);
+
         throwRuntimeExceptionErrorNo(env, "Can't initialize mutext (not enough memory for the events member): ", res);
         return NULL;
     }

--- a/artemis-native/src/main/c/org_apache_activemq_artemis_jlibaio_LibaioContext.c
+++ b/artemis-native/src/main/c/org_apache_activemq_artemis_jlibaio_LibaioContext.c
@@ -113,10 +113,12 @@ char* exceptionMessage(char* msg, int error) {
         error = error * -1;
     }
     //strerror is returning a constant, so no need to free anything coming from strerror
-    char* err = strerror(error);
-    char* result = malloc(strlen(msg) + strlen(err) + 1);
-    strcpy(result, msg);
-    strcat(result, err);
+    char *result = NULL;
+
+    if (asprintf(&result, "%s%s", msg, strerror(error)) == -1) {
+    	fprintf(stderr, "Could not allocate enough memory for the error message: %s/%s\n", msg, strerror(error));
+    }
+
     return result;
 }
 


### PR DESCRIPTION
These are small fixes to the native library that:

1) prevent a NULL pointer dereference. Although rare, it is still possible that a call to malloc fails and returns null. In that case, it could potentially bring down the whole process. It replaces the first malloc call on exceptionMessage with a call to asprintf which performs the allocation of a string large enough to hold both the err and result string plus the NULL pointer. 

2) Handles failure to initialize the events structure

3) Fix a cleanup error caused by trying to deallocate stack memory with free

4) Ensure proper memory cleanup of IOCB structure on error