### PR TITLE
ARTEMIS-2244 checkDepage method placed outside CRITICAL_DELIVER avoid critical analyzer timeout

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
@@ -2409,7 +2409,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
     * This method will deliver as many messages as possible until all consumers are busy or there
     * are no more matching or available messages.
     */
-   private void deliver() {
+   private boolean deliver() {
       if (logger.isDebugEnabled()) {
          logger.debug(this + " doing deliver. messageReferences=" + messageReferences.size());
       }
@@ -2430,7 +2430,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
 
             deliverAsync();
 
-            return;
+            return false;
          }
 
          if (System.currentTimeMillis() > timeout) {
@@ -2440,7 +2440,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
 
             deliverAsync();
 
-            return;
+            return false;
          }
 
          MessageReference ref;
@@ -2451,7 +2451,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
 
             // Need to do these checks inside the synchronized
             if (paused || !canDispatch() && redistributor == null) {
-               return;
+               return false;
             }
 
             if (messageReferences.size() == 0) {
@@ -2571,7 +2571,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
          }
       }
 
-      checkDepage();
+      return true;
    }
 
    protected void removeMessageReference(ConsumerHolder<? extends Consumer> holder, MessageReference ref) {
@@ -3423,13 +3423,19 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
             // We will be using the deliverRunner instance as the guard object to avoid multiple threads executing
             // an asynchronous delivery
             enterCritical(CRITICAL_DELIVER);
+            boolean needCheckDepage = false;
             try {
                synchronized (QueueImpl.this.deliverRunner) {
-                  deliver();
+                  needCheckDepage = deliver();
                }
             } finally {
                leaveCritical(CRITICAL_DELIVER);
             }
+
+            if (needCheckDepage) {
+               checkDepage();
+            }
+
          } catch (Exception e) {
             ActiveMQServerLogger.LOGGER.errorDelivering(e);
          } finally {


### PR DESCRIPTION
We found server crash becauseof critical analyzer timeout, thread dump can be seen in attachment.	
Suppose that there is a topic t with two subscriber ta and tb. Some messages were routed to subscriber ta, not to tb. When a consumer that subscribe tb is created and send ConsumerCredits to server, ServerConsumerImpl will call promptDelivery method, then forceDelivery() -> messageQueue.deliverAsync() -> deliverRunner will executed in the pageSubscription's executor(step1), then checkDepage(step2) -> pageIterator.hasNext(synchronized method) -> next -> moveNext, moveNext method will iterate through queue until find a matching message. At this time(step1), DeliverRunner call deliver method -> checkDepage -> pageIterator.hasNext, this step blocked on CursorIterator which was locked by step2, then critical analyzer timeout.
thread dump can be seen in attachment.
[threaddump.txt](https://github.com/apache/activemq-artemis/files/2820006/threaddump.txt)
