### PR TITLE
ARTEMIS-2245 Cleaning up Docker images preparation, run and docs

### DIFF
--- a/artemis-docker/Dockerfile-centos
+++ b/artemis-docker/Dockerfile-centos
@@ -31,10 +31,8 @@ ENV CREATE_ARGUMENTS --user ${ARTEMIS_USER} --password ${ARTEMIS_PASSWORD} --sil
 USER root
 
 # add user and group for artemis
-RUN groupadd -g 1001 -r artemis && useradd -r -u 1001 -g artemis artemis
-
-RUN yum install -y libaio && \
-    yum -y clean all
+RUN groupadd -g 1001 -r artemis && useradd -r -u 1001 -g artemis artemis \
+ && yum install -y libaio && yum -y clean all
 
 USER artemis
 
@@ -68,4 +66,4 @@ VOLUME ["/var/lib/artemis-instance"]
 WORKDIR /var/lib/artemis-instance
 
 ENTRYPOINT ["/docker-run.sh"]
-CMD ["artemis-server"]
+CMD ["run"]

--- a/artemis-docker/Dockerfile-ubuntu
+++ b/artemis-docker/Dockerfile-ubuntu
@@ -29,10 +29,9 @@ ENV ANONYMOUS_LOGIN false
 ENV CREATE_ARGUMENTS --user ${ARTEMIS_USER} --password ${ARTEMIS_PASSWORD} --silent --http-host 0.0.0.0 --relax-jolokia
 
 # add user and group for artemis
-RUN groupadd -g 1000 -r artemis && useradd -r -u 1000 -g artemis artemis
-
-RUN apt-get -qq -o=Dpkg::Use-Pty=0 update && \
-  apt-get -qq -o=Dpkg::Use-Pty=0 install -y --no-install-recommends \
+RUN groupadd -g 1000 -r artemis && useradd -r -u 1000 -g artemis artemis \
+ && apt-get -qq -o=Dpkg::Use-Pty=0 update && \
+    apt-get -qq -o=Dpkg::Use-Pty=0 install -y --no-install-recommends \
     libaio1=0.3.110-3 && \
     rm -rf /var/lib/apt/lists/*
 
@@ -68,4 +67,4 @@ VOLUME ["/var/lib/artemis-instance"]
 WORKDIR /var/lib/artemis-instance
 
 ENTRYPOINT ["/docker-run.sh"]
-CMD ["artemis-server"]
+CMD ["run"]

--- a/artemis-docker/docker-run.sh
+++ b/artemis-docker/docker-run.sh
@@ -36,6 +36,6 @@ else
     echo "broker already created, ignoring creation"
 fi
 
-./bin/artemis run
+exec ./bin/artemis "$@"
 
 

--- a/artemis-docker/prepare-docker.sh
+++ b/artemis-docker/prepare-docker.sh
@@ -29,7 +29,7 @@ error () {
    echo "Usage: ./prepare-docker.sh ARTEMIS_HOME_LOCATION"
    echo ""
    echo "example:"
-   echo "./prepare-release.sh https://repo1.maven.org/maven2 2.5.0"
+   echo "./prepare-docker.sh ../artemis-distribution/target/apache-artemis-2.7.0-SNAPSHOT-bin/apache-artemis-2.7.0-SNAPSHOT"
    echo ""
    exit 64
 }
@@ -51,6 +51,6 @@ then
   rm -rf $target/docker
 fi
 mkdir $target/docker
-cp * $target/docker
+cp ./{Dockerfile-centos,Dockerfile-ubuntu,docker-run.sh} $target/docker
 
 echo "Docker file support files at : $target/docker"

--- a/artemis-docker/readme.md
+++ b/artemis-docker/readme.md
@@ -1,4 +1,4 @@
-# Docker Image Example *
+# Docker Image Example
 
 This is an example on how you could create your own Docker Image For Apache ActiveMQ Artemis based on CentOS or Ubuntu.
 # Preparing
@@ -6,29 +6,29 @@ This is an example on how you could create your own Docker Image For Apache Acti
 Use the script ./prepare-docker.sh as it will copy the docker files under the binary distribution.
 
 ```
-$ ./prepare.sh $ARTEMIS_HOME
+$ ./prepare-docker.sh $ARTEMIS_HOME
 ```
 
 # Building
 
-Go to $ARTEMIS_HOME where you prepared the binary with Docker files.
+Go to `$ARTEMIS_HOME` where you prepared the binary with Docker files.
 
 ## For Ubuntu:
 
-From within the $ARTEMIS_HOME
+From within the `$ARTEMIS_HOME` folder:
 ```
 $ docker build -f ./docker/Dockerfile-ubuntu -t artemis-ubuntu .
 ```
 
-**Note:**
--t artemis-ubuntu` is just a tag name for the purpose of this guide
-
 ## For CentOS
 
-From within the binary distribution folder:
+From within the `$ARTEMIS_HOME` folder:
 ```
 $ docker build -f ./docker/Dockerfile-centos -t artemis-centos .
 ```
+
+**Note:**
+`-t artemis-ubuntu`,`-t artemis-centos` are just tag names for the purpose of this guide
 
 # Variables:
 
@@ -40,15 +40,15 @@ Default here is FALSE. If you set this to true, it will change security settings
 
 - CREATE_ARGUMENTS
 
-Default here is " --user ${ARTEMIS_USER} --password ${ARTEMIS_PASSWORD} --silent --http-host 0.0.0.0 --relax-jolokia"
+Default here is `--user ${ARTEMIS_USER} --password ${ARTEMIS_PASSWORD} --silent --http-host 0.0.0.0 --relax-jolokia"`
 
 
-This will be passed straight to ./artemis create during the execution.
+This will be passed straight to `./artemis create` during the execution.
 
 
 # Mapping point
 
-- /var/lib/artemis-instance
+- `/var/lib/artemis-instance`
 
 It's possible to map a folder as the instance broker.
 This will hold the configuration and the data of the running broker. This is useful for when you want the data persisted outside of a container.
@@ -56,7 +56,7 @@ This will hold the configuration and the data of the running broker. This is use
 
 # Lifecycle of the execution
 
-A broker instance will be created during the execution of the instance. If you pass a mapped folder for /var/lib/artemis-instance an image will be created or reused depending on the contents of the folder.
+A broker instance will be created during the execution of the instance. If you pass a mapped folder for `/var/lib/artemis-instance` an image will be created or reused depending on the contents of the folder.
 
 
 


### PR DESCRIPTION
I've included:

- doc fixes on both the docker image preparation and guide
- allowed users to run other artemis commands on docker CMD
- cleaned up docker image building by reducing the RUN calls
- avoided useless copies on docker preparation