### PR TITLE
Patched with live lock evaluation

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/PrintData.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/PrintData.java
@@ -26,9 +26,8 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
 import org.apache.activemq.artemis.api.core.SimpleString;
@@ -61,6 +60,9 @@ import org.apache.activemq.artemis.spi.core.protocol.MessagePersister;
 import org.apache.activemq.artemis.utils.ActiveMQThreadFactory;
 import org.apache.activemq.artemis.utils.ExecutorFactory;
 import org.apache.activemq.artemis.utils.actors.ArtemisExecutor;
+
+import io.airlift.airline.Command;
+import io.airlift.airline.Option;
 
 @Command(name = "print", description = "Print data records information (WARNING: don't use while a production server is running)")
 public class PrintData extends DBOption {
@@ -129,7 +131,7 @@ public class PrintData extends DBOption {
 
       if (serverLockFile.isFile()) {
          try {
-            FileLockNodeManager fileLock = new FileLockNodeManager(messagesDirectory, false);
+            FileLockNodeManager fileLock = new FileLockNodeManager(messagesDirectory, false, new ScheduledThreadPoolExecutor(1));
             fileLock.start();
             printBanner(out, "Server's ID=" + fileLock.getNodeId().toString());
             fileLock.stop();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -479,12 +479,12 @@ public class ActiveMQServerImpl implements ActiveMQServer {
                logger.debug("Detected no Shared Store HA options on JDBC store");
             }
             //LIVE_ONLY should be the default HA option when HA isn't configured
-            manager = new FileLockNodeManager(directory, replicatingBackup, configuration.getJournalLockAcquisitionTimeout());
+            manager = new FileLockNodeManager(directory, replicatingBackup, configuration.getJournalLockAcquisitionTimeout(), scheduledPool);
          } else {
             throw new IllegalArgumentException("JDBC persistence allows only Shared Store HA options");
          }
       } else {
-         manager = new FileLockNodeManager(directory, replicatingBackup, configuration.getJournalLockAcquisitionTimeout());
+         manager = new FileLockNodeManager(directory, replicatingBackup, configuration.getJournalLockAcquisitionTimeout(), scheduledPool);
       }
       return manager;
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/SharedStoreLiveActivation.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/SharedStoreLiveActivation.java
@@ -16,19 +16,25 @@
  */
 package org.apache.activemq.artemis.core.server.impl;
 
+import org.apache.activemq.artemis.core.server.ActivateCallback;
 import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
 import org.apache.activemq.artemis.core.server.NodeManager;
 import org.apache.activemq.artemis.core.server.cluster.ha.SharedStoreMasterPolicy;
+import org.apache.activemq.artemis.core.server.impl.FileLockNodeManager.LockListener;
 import org.jboss.logging.Logger;
 
 public final class SharedStoreLiveActivation extends LiveActivation {
 
    private static final Logger logger = Logger.getLogger(SharedStoreLiveActivation.class);
 
-   //this is how we act when we initially start as live
+   // this is how we act when we initially start as live
    private SharedStoreMasterPolicy sharedStoreMasterPolicy;
 
    private ActiveMQServerImpl activeMQServer;
+
+   private volatile FileLockNodeManager.LockListener activeLockListener;
+
+   private volatile ActivateCallback nodeManagerActivateCallback;
 
    public SharedStoreLiveActivation(ActiveMQServerImpl server, SharedStoreMasterPolicy sharedStoreMasterPolicy) {
       this.activeMQServer = server;
@@ -51,8 +57,8 @@ public final class SharedStoreLiveActivation extends LiveActivation {
 
          if (activeMQServer.getNodeManager().isBackupLive()) {
             /*
-             * looks like we've failed over at some point need to inform that we are the backup
-             * so when the current live goes down they failover to us
+             * looks like we've failed over at some point need to inform that we are the
+             * backup so when the current live goes down they failover to us
              */
             if (logger.isDebugEnabled()) {
                logger.debug("announcing backup to the former live" + this);
@@ -65,9 +71,12 @@ public final class SharedStoreLiveActivation extends LiveActivation {
             activeMQServer.getBackupManager().announceBackup();
          }
 
-         activeMQServer.registerActivateCallback(activeMQServer.getNodeManager().startLiveNode());
+         nodeManagerActivateCallback = activeMQServer.getNodeManager().startLiveNode();
+         activeMQServer.registerActivateCallback(nodeManagerActivateCallback);
+         addLockListener(activeMQServer, activeMQServer.getNodeManager());
 
-         if (activeMQServer.getState() == ActiveMQServerImpl.SERVER_STATE.STOPPED || activeMQServer.getState() == ActiveMQServerImpl.SERVER_STATE.STOPPING) {
+         if (activeMQServer.getState() == ActiveMQServerImpl.SERVER_STATE.STOPPED
+               || activeMQServer.getState() == ActiveMQServerImpl.SERVER_STATE.STOPPING) {
             return;
          }
 
@@ -82,17 +91,76 @@ public final class SharedStoreLiveActivation extends LiveActivation {
       }
    }
 
+   private void addLockListener(ActiveMQServerImpl activeMQServer, NodeManager nodeManager) {
+      if (nodeManager instanceof FileLockNodeManager) {
+         FileLockNodeManager fileNodeManager = (FileLockNodeManager) nodeManager;
+
+         activeLockListener = fileNodeManager.new LockListener() {
+
+            @Override
+            public void lostLock() {
+               stopStartServerInSeperateThread(activeMQServer);
+            }
+
+         };
+         fileNodeManager.registerLockListener(activeLockListener);
+      } // else no business registering a listener
+   }
+
+   /**
+    * We need to do this in a new thread because this takes to long to finish in
+    * the scheduled thread Also this is not the responsibility of the scheduled
+    * thread
+    * @param activeMQServer
+    */
+   private void stopStartServerInSeperateThread(ActiveMQServerImpl activeMQServer) {
+      try {
+
+         Runnable startServerRunnable = new Runnable() {
+
+            @Override
+            public void run() {
+               try {
+                  activeMQServer.stop(true, false);
+               } catch (Exception e) {
+                  logger.warn("Failed to stop artemis server after loosing the lock", e);
+               }
+
+               try {
+                  activeMQServer.start();
+               } catch (Exception e) {
+                  logger.error("Failed to start artemis server after recovering from loosing the lock", e);
+               }
+            }
+
+         };
+         Thread startServer = new Thread(startServerRunnable);
+         startServer.start();
+      } catch (Exception e) {
+         logger.error(e.getMessage());
+      }
+   }
+
    @Override
    public void close(boolean permanently, boolean restarting) throws Exception {
       // TO avoid a NPE from stop
       NodeManager nodeManagerInUse = activeMQServer.getNodeManager();
 
       if (nodeManagerInUse != null) {
+         LockListener closeLockListener = activeLockListener;
+         if (closeLockListener != null) {
+            closeLockListener.unregisterListener();
+         }
+         ActivateCallback activateCallback = nodeManagerActivateCallback;
+         if (activateCallback != null) {
+            activeMQServer.unregisterActivateCallback(activateCallback);
+         }
          if (sharedStoreMasterPolicy.isFailoverOnServerShutdown() || permanently) {
             nodeManagerInUse.crashLiveServer();
          } else {
             nodeManagerInUse.pauseLiveServer();
          }
+
       }
    }
 }

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/FileLockMonitorTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/FileLockMonitorTest.java
@@ -1,0 +1,131 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.tests.extras.byteman;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+import org.apache.activemq.artemis.core.server.ActivateCallback;
+import org.apache.activemq.artemis.core.server.impl.FileLockNodeManager;
+import org.apache.activemq.artemis.core.server.impl.FileLockNodeManager.LockListener;
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.jboss.byteman.contrib.bmunit.BMRules;
+import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(BMUnitRunner.class)
+public class FileLockMonitorTest {
+
+   private File sharedDir;
+   private volatile boolean lostLock = false;
+   private volatile FileLockNodeManager nodeManager;
+   private ScheduledThreadPoolExecutor executor;
+
+   @Before
+   public void handleLockFile() throws IOException {
+      sharedDir = File.createTempFile("shared-dir", "");
+      sharedDir.delete();
+      Assert.assertTrue(sharedDir.mkdir());
+      lostLock = false;
+   }
+
+   @Test
+   @BMRules(rules = {
+         @BMRule(name = "lock is invalid", targetClass = "sun.nio.ch.FileLockImpl", targetMethod = "isValid", action = "return false;") })
+   public void testLockMonitorInvalid() throws Exception {
+      lostLock = false;
+      startServer();
+      Thread.sleep(5000);
+      if (!lostLock) {
+         throw new Exception("The FileLockNodeManager should have lost the lock");
+      }
+      nodeManager.isStarted();
+      nodeManager.crashLiveServer();
+      executor.shutdown();
+   }
+
+   @Test
+   @BMRules(rules = {
+         @BMRule(name = "lock is invalid", targetClass = "org.apache.activemq.artemis.core.server.impl.FileLockNodeManager", targetMethod = "getState", action = "throw new java.io.IOException(\"EFS is disconnected\");") })
+   public void testLockMonitorIOException() throws Exception {
+      lostLock = false;
+      startServer();
+      Thread.sleep(5000);
+      if (!lostLock) {
+         throw new Exception("The FileLockNodeManager should have lost the lock");
+      }
+      nodeManager.crashLiveServer();
+      executor.shutdown();
+   }
+
+   @Test
+   public void testLockMonitorHasCorrectLockAndState() throws Exception {
+      lostLock = false;
+      startServer();
+      Thread.sleep(5000);
+      if (lostLock) {
+         throw new Exception("The FileLockNodeManager should not have lost the lock");
+      }
+      nodeManager.crashLiveServer();
+      executor.shutdown();
+   }
+
+   @Test
+   @BMRules(rules = {
+         @BMRule(name = "lock is invalid", targetClass = "org.apache.activemq.artemis.core.server.impl.FileLockNodeManager", targetMethod = "getState", action = "return 70;") })
+   public void testLockMonitorHasLockWrongState() throws Exception {
+      lostLock = false;
+      startServer();
+      Thread.sleep(5000);
+      if (lostLock) {
+         throw new Exception("The FileLockNodeManager should not notice a state difference");
+      }
+      nodeManager.crashLiveServer();
+      executor.shutdown();
+   }
+
+   public LockListener startServer() throws Exception {
+      executor = new ScheduledThreadPoolExecutor(2);
+      nodeManager = new FileLockNodeManager(sharedDir, false, executor);
+      LockListener listener = nodeManager.new LockListener() {
+
+         @Override
+         protected void lostLock() throws Exception {
+            lostLock = true;
+            nodeManager.crashLiveServer();
+         }
+
+      };
+      nodeManager.registerLockListener(listener);
+
+      try {
+         nodeManager.start();
+         ActivateCallback startLiveNode = nodeManager.startLiveNode();
+         startLiveNode.activationComplete();
+
+      } catch (Exception exception) {
+         exception.printStackTrace();
+      }
+
+      return listener;
+   }
+}


### PR DESCRIPTION
When using the shared store the live server can loose the lock on the journal but does not notice it. This can happen when a shared file system is being used like in AWS where we use EFS.

This can cause problems when the live server regains the network file system connection and just continues to process messages. At some point the live or the backup quits because it notices changes on the filesystems which it did not do itself.

We were able to prevent the occurence by tweaking EFS connection settings so it does not occur anymore in our setup.

For artemis we would like to show our change maybe someone can review the change and see if it can be improved and adapted in artemis.

Patch is here for master:
https://github.com/emagiz/activemq-artemis/commit/788adfbd3e5a54c63eed0810b7377641684b6fe1.patch