### PR TITLE
NO-JIRA Fix a "Dereference null return value" Coverity Scan warning

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/SpawnedVMSupport.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/SpawnedVMSupport.java
@@ -146,7 +146,7 @@ public class SpawnedVMSupport {
       if (files == null) {
          return getClassPath();
       } else {
-         for (File f : libfolder.listFiles()) {
+         for (File f : files) {
             if (f.getName().endsWith(".jar") || f.getName().endsWith(".zip")) {
                if (!empty) {
                   stringBuilder.append(File.pathSeparator);

--- a/artemis-web/src/main/java/org/apache/activemq/artemis/component/WebTmpCleaner.java
+++ b/artemis-web/src/main/java/org/apache/activemq/artemis/component/WebTmpCleaner.java
@@ -65,9 +65,11 @@ public class WebTmpCleaner {
    public static final void deleteFolder(final File file) {
       if (file.isDirectory()) {
          String[] files = file.list();
-         for (String path : files) {
-            File f = new File(file, path);
-            deleteFolder(f);
+         if (files != null) {
+            for (String path : files) {
+               File f = new File(file, path);
+               deleteFolder(f);
+            }
          }
       }
       file.delete();


### PR DESCRIPTION
The value checked for null was not the one that was subsequently used.