### PR TITLE
ARTEMIS-1952 NPE logged at warn if MQTT subscriber disconnects abruptly

### DIFF
--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTProtocolManager.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTProtocolManager.java
@@ -179,7 +179,13 @@ class MQTTProtocolManager extends AbstractProtocolManager<MqttMessage, MQTTInter
    }
 
    public boolean isClientConnected(String clientId, MQTTConnection connection) {
-      return connectedClients.get(clientId).equals(connection);
+      MQTTConnection connectedConn = connectedClients.get(clientId);
+
+      if (connectedConn != null) {
+         return connectedConn.equals(connection);
+      }
+
+      return false;
    }
 
    public void removeConnectedClient(String clientId) {


### PR DESCRIPTION
Prevent a NullPointerException if no connection by the given clientId is found on the cache of stored sessions