### PR TITLE
ARTEMIS-2183 Useless statement in public synchronized List

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/RefsOperation.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/RefsOperation.java
@@ -190,9 +190,7 @@ public class RefsOperation extends TransactionOperationAbstract {
 
    @Override
    public synchronized List<MessageReference> getRelatedMessageReferences() {
-      List<MessageReference> listRet = new LinkedList<>();
-      listRet.addAll(listRet);
-      return listRet;
+      return refsToAck;
    }
 
    @Override


### PR DESCRIPTION
Removes the seemingly unnecessary call to addAll to self.