### PR TITLE
ARTEMIS-2183 Useless statement in public synchronized List

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/RefsOperation.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/RefsOperation.java
@@ -191,7 +191,11 @@ public class RefsOperation extends TransactionOperationAbstract {
    @Override
    public synchronized List<MessageReference> getRelatedMessageReferences() {
       List<MessageReference> listRet = new LinkedList<>();
-      listRet.addAll(listRet);
+
+      if (refsToAck != null && !refsToAck.isEmpty()) {
+         listRet.addAll(refsToAck);
+      }
+
       return listRet;
    }
 


### PR DESCRIPTION
Sending this PR again based feedback from @clebertsuconic. 

Ensures that the returned list returns the refsToAck list instead of trying to add all items of itself. 

