### PR TITLE
ARTEMIS-2262: Correlate management response messages with the request

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/Message.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/Message.java
@@ -266,6 +266,15 @@ public interface Message {
       return this;
    }
 
+   default Object getCorrelationID() {
+      return null;
+   }
+
+   default Message setCorrelationID(Object correlationID) {
+
+      return this;
+   }
+
    SimpleString getReplyTo();
 
    Message setReplyTo(SimpleString address);

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessage.java
@@ -297,6 +297,17 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
       return this.putIntProperty(Message.HDR_GROUP_SEQUENCE, sequence);
    }
 
+   @Override
+   public Object getCorrelationID() {
+      return getObjectProperty(MessageUtil.CORRELATIONID_HEADER_NAME);
+   }
+
+   @Override
+   public Message setCorrelationID(final Object correlationID) {
+      putObjectProperty(MessageUtil.CORRELATIONID_HEADER_NAME, correlationID);
+      return this;
+   }
+
    /**
     * @param sendBuffer
     * @param deliveryCount Some protocols (AMQP) will have this as part of the message. ignored on core

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
@@ -1148,6 +1148,21 @@ public class AMQPMessage extends RefCountMessage {
    }
 
    @Override
+   public Object getCorrelationID() {
+      return properties != null ? properties.getCorrelationId() : null;
+   }
+
+   @Override
+   public org.apache.activemq.artemis.api.core.Message setCorrelationID(final Object correlationID) {
+      if (properties == null) {
+         properties = new Properties();
+      }
+
+      properties.setCorrelationId(correlationID);
+      return this;
+   }
+
+   @Override
    public Long getScheduledDeliveryTime() {
       if (scheduledTime < 0) {
          Object objscheduledTime = getMessageAnnotation(AMQPMessageSupport.SCHEDULED_DELIVERY_TIME);

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/converter/AmqpCoreConverter.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/converter/AmqpCoreConverter.java
@@ -325,8 +325,13 @@ public class AmqpCoreConverter {
          if (properties.getReplyTo() != null) {
             jms.setJMSReplyTo(new ServerDestination(properties.getReplyTo()));
          }
-         if (properties.getCorrelationId() != null) {
-            jms.setJMSCorrelationID(AMQPMessageIdHelper.INSTANCE.toCorrelationIdString(properties.getCorrelationId()));
+         Object correlationID = properties.getCorrelationId();
+         if (correlationID != null) {
+            try {
+               jms.getInnerMessage().setCorrelationID(AMQPMessageIdHelper.INSTANCE.toCorrelationIdString(correlationID));
+            } catch (IllegalArgumentException e) {
+               jms.getInnerMessage().setCorrelationID(String.valueOf(correlationID));
+            }
          }
          if (properties.getContentType() != null) {
             jms.setStringProperty(JMS_AMQP_CONTENT_TYPE, properties.getContentType().toString());

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/converter/jms/ServerJMSMessage.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/converter/jms/ServerJMSMessage.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.Enumeration;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
-import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.ICoreMessage;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.jms.client.ActiveMQDestination;
@@ -118,21 +117,29 @@ public class ServerJMSMessage implements Message {
 
    @Override
    public final void setJMSCorrelationIDAsBytes(byte[] correlationID) throws JMSException {
-      try {
-         MessageUtil.setJMSCorrelationIDAsBytes(message, correlationID);
-      } catch (ActiveMQException e) {
-         throw new JMSException(e.getMessage());
+      if (correlationID == null || correlationID.length == 0) {
+         throw new JMSException("Please specify a non-zero length byte[]");
       }
+      message.setCorrelationID(correlationID);
    }
 
    @Override
    public final String getJMSCorrelationID() throws JMSException {
-      return MessageUtil.getJMSCorrelationID(message);
+
+      Object correlationID = message.getCorrelationID();
+      if (correlationID instanceof String) {
+
+         return ((String) correlationID);
+      } else if (correlationID != null) {
+         return String.valueOf(correlationID);
+      } else {
+         return null;
+      }
    }
 
    @Override
    public final void setJMSCorrelationID(String correlationID) throws JMSException {
-      MessageUtil.setJMSCorrelationID(message, correlationID);
+      message.setCorrelationID(correlationID);
    }
 
    @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpManagementTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpManagementTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.activemq.artemis.tests.integration.amqp;
 
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -28,6 +29,8 @@ import org.apache.activemq.transport.amqp.client.AmqpMessage;
 import org.apache.activemq.transport.amqp.client.AmqpReceiver;
 import org.apache.activemq.transport.amqp.client.AmqpSender;
 import org.apache.activemq.transport.amqp.client.AmqpSession;
+
+import org.apache.qpid.proton.amqp.Binary;
 import org.apache.qpid.proton.amqp.UnsignedByte;
 import org.apache.qpid.proton.amqp.UnsignedInteger;
 import org.apache.qpid.proton.amqp.UnsignedLong;
@@ -39,6 +42,8 @@ import org.junit.Test;
 import static org.apache.activemq.artemis.protocol.amqp.converter.AMQPMessageSupport.createMapMessage;
 
 public class AmqpManagementTest extends AmqpClientTestSupport {
+
+   private static final Binary BINARY_CORRELATION_ID = new Binary("mystring".getBytes(StandardCharsets.UTF_8));
 
    @Test(timeout = 60000)
    public void testManagementQueryOverAMQP() throws Throwable {
@@ -75,68 +80,6 @@ public class AmqpManagementTest extends AmqpClientTestSupport {
       }
    }
 
-   @Test(timeout = 60000)
-   public void testCorrelationByMessageID() throws Throwable {
-      AmqpClient client = createAmqpClient();
-      AmqpConnection connection = addConnection(client.connect());
-
-      try {
-         String destinationAddress = getQueueName(1);
-         AmqpSession session = connection.createSession();
-         AmqpSender sender = session.createSender("activemq.management");
-         AmqpReceiver receiver = session.createReceiver(destinationAddress);
-         receiver.flow(10);
-
-         // Create request message for getQueueNames query
-         UUID messageId = UUID.randomUUID();
-         AmqpMessage request = new AmqpMessage();
-         request.setApplicationProperty("_AMQ_ResourceName", ResourceNames.BROKER);
-         request.setApplicationProperty("_AMQ_OperationName", "getQueueNames");
-         request.setReplyToAddress(destinationAddress);
-         request.setRawMessageId(messageId);
-         request.setText("[]");
-
-         sender.send(request);
-         AmqpMessage response = receiver.receive(5, TimeUnit.SECONDS);
-         Assert.assertNotNull(response);
-         Assert.assertEquals(messageId, response.getRawCorrelationId());
-         response.accept();
-      } finally {
-         connection.close();
-      }
-   }
-
-   @Test(timeout = 60000)
-   public void testCorrelationByCorrelationID() throws Throwable {
-      AmqpClient client = createAmqpClient();
-      AmqpConnection connection = addConnection(client.connect());
-
-      try {
-         String destinationAddress = getQueueName(1);
-         AmqpSession session = connection.createSession();
-         AmqpSender sender = session.createSender("activemq.management");
-         AmqpReceiver receiver = session.createReceiver(destinationAddress);
-         receiver.flow(10);
-
-         // Create request message for getQueueNames query
-         UUID correlationId = UUID.randomUUID();
-         AmqpMessage request = new AmqpMessage();
-         request.setApplicationProperty("_AMQ_ResourceName", ResourceNames.BROKER);
-         request.setApplicationProperty("_AMQ_OperationName", "getQueueNames");
-         request.setReplyToAddress(destinationAddress);
-         request.setRawCorrelationId(correlationId);
-         request.setText("[]");
-
-         sender.send(request);
-         AmqpMessage response = receiver.receive(5, TimeUnit.SECONDS);
-         Assert.assertNotNull(response);
-         Assert.assertEquals(correlationId, response.getRawCorrelationId());
-         response.accept();
-      } finally {
-         connection.close();
-      }
-   }
-
    /**
     * Some clients use Unsigned types from org.apache.qpid.proton.amqp
     * @throws Exception
@@ -163,5 +106,68 @@ public class AmqpManagementTest extends AmqpClientTestSupport {
       map.put("sequence", new UnsignedByte((byte) sequence));
       msg = createMapMessage(1, map, null);
       assertEquals(msg.getByte("sequence"), sequence);
+   }
+
+   @Test(timeout = 60000)
+   public void testCorrelationByMessageIDUUID() throws Throwable {
+      doTestReplyCorrelation(UUID.randomUUID(), false);
+   }
+
+   @Test(timeout = 60000)
+   public void testCorrelationByMessageIDString() throws Throwable {
+      doTestReplyCorrelation("mystring", false);
+   }
+
+   @Test(timeout = 60000)
+   public void testCorrelationByMessageIDBinary() throws Throwable {
+      doTestReplyCorrelation(BINARY_CORRELATION_ID, false);
+   }
+
+   @Test(timeout = 60000)
+   public void testCorrelationByCorrelationIDUUID() throws Throwable {
+      doTestReplyCorrelation(UUID.randomUUID(), true);
+   }
+
+   @Test(timeout = 60000)
+   public void testCorrelationByCorrelationIDString() throws Throwable {
+      doTestReplyCorrelation("mystring", true);
+   }
+
+   @Test(timeout = 60000)
+   public void testCorrelationByCorrelationIDBinary() throws Throwable {
+      doTestReplyCorrelation(BINARY_CORRELATION_ID, true);
+   }
+
+   private void doTestReplyCorrelation(final Object correlationId, final boolean sendCorrelAsCorrelation) throws Exception {
+      AmqpClient client = createAmqpClient();
+      AmqpConnection connection = addConnection(client.connect());
+
+      try {
+         String destinationAddress = getQueueName(1);
+         AmqpSession session = connection.createSession();
+         AmqpSender sender = session.createSender("activemq.management");
+         AmqpReceiver receiver = session.createReceiver(destinationAddress);
+         receiver.flow(10);
+
+         // Create request message for getQueueNames query
+         AmqpMessage request = new AmqpMessage();
+         request.setApplicationProperty("_AMQ_ResourceName", ResourceNames.BROKER);
+         request.setApplicationProperty("_AMQ_OperationName", "getQueueNames");
+         request.setReplyToAddress(destinationAddress);
+         if (sendCorrelAsCorrelation) {
+            request.setRawCorrelationId(correlationId);
+         } else {
+            request.setRawMessageId(correlationId);
+         }
+         request.setText("[]");
+
+         sender.send(request);
+         AmqpMessage response = receiver.receive(5, TimeUnit.SECONDS);
+         Assert.assertNotNull(response);
+         Assert.assertEquals(correlationId, response.getRawCorrelationId());
+         response.accept();
+      } finally {
+         connection.close();
+      }
    }
 }


### PR DESCRIPTION
This change correlates management response messages with the message request that caused them.  It uses either the Correlation ID pattern (if the request message carried a correlation id), or Message ID pattern (if the request carried a message ID but no correlation id).    If the request carried neither, no correlation is performed.

This change would cause a user-visible change to existing users of the management API over messaging.  It is probably unlikely to be breaking for most valid uses, but a switch might be considered for caution's sake.  Feedback welcome.