### PR TITLE
Added Javadoc reference to the documentation

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
@@ -357,6 +357,7 @@ public interface Configuration {
     * @param uri  the URI of the acceptor
     * @return this
     * @throws Exception in case of Parsing errors on the URI
+    * @see <a href="https://activemq.apache.org/artemis/docs/latest/configuring-transports.html">Configuring the Transport</a>
     */
    Configuration addAcceptorConfiguration(String name, String uri) throws Exception;
 


### PR DESCRIPTION
I would have preferred the link to point to https://activemq.apache.org/artemis/docs/2.7.0/configuring-transports.html but I'm not super-familiar with Javadoc and there seems to be some extra work involved in getting Javadocs to reflect the Maven project version automatically.