### PR TITLE
ARTEMIS-2269 Using karaf.etc for config location

### DIFF
--- a/artemis-features/src/main/resources/org.apache.activemq.artemis.cfg
+++ b/artemis-features/src/main/resources/org.apache.activemq.artemis.cfg
@@ -1,4 +1,4 @@
-config=file:etc/artemis.xml
+config=file:${karaf.etc}/artemis.xml
 name=local
 domain=karaf
 rolePrincipalClass=org.apache.karaf.jaas.boot.principal.RolePrincipal


### PR DESCRIPTION
Karaf config should use predefined etc-dir instead of hard-coded etc