### PR TITLE
ARTEMIS-2273 Adding Audit Log

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/logs/AuditLogger.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/logs/AuditLogger.java
@@ -1,0 +1,2255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.logs;
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
+
+import javax.security.auth.Subject;
+import java.security.AccessController;
+import java.security.Principal;
+import java.util.Arrays;
+
+/**
+ * Logger Code 60
+ *
+ * each message id must be 6 digits long starting with 22, the 3rd digit donates the level so
+ *
+ * INF0  1
+ * WARN  2
+ * DEBUG 3
+ * ERROR 4
+ * TRACE 5
+ * FATAL 6
+ *
+ * so an INFO message would be 601000 to 601999
+ */
+@MessageLogger(projectCode = "AMQ")
+public interface AuditLogger extends BasicLogger {
+
+   AuditLogger LOGGER = Logger.getMessageLogger(AuditLogger.class, "org.apache.activemq.audit.base");
+   AuditLogger MESSAGE_LOGGER = Logger.getMessageLogger(AuditLogger.class, "org.apache.activemq.audit.message");
+
+   static boolean isEnabled() {
+      return LOGGER.isEnabled(Logger.Level.INFO);
+   }
+
+   static boolean isMessageEnabled() {
+      return MESSAGE_LOGGER.isEnabled(Logger.Level.INFO);
+   }
+
+   static String getCaller() {
+      Subject subject = Subject.getSubject(AccessController.getContext());
+      String caller = "anonymous";
+      if (subject != null) {
+         caller = "";
+         for (Principal principal : subject.getPrincipals()) {
+            caller += principal.getName() + "|";
+         }
+      }
+      return caller;
+   }
+
+   static String arrayToString(Object value) {
+      if (value == null) return "";
+
+      final String prefix = "with parameters: ";
+
+      if (value instanceof long[]) {
+         return prefix + Arrays.toString((long[])value);
+      } else if (value instanceof int[]) {
+         return prefix + Arrays.toString((int[])value);
+      } else if (value instanceof char[]) {
+         return prefix + Arrays.toString((char[])value);
+      } else if (value instanceof byte[]) {
+         return prefix + Arrays.toString((byte[])value);
+      } else if (value instanceof float[]) {
+         return prefix + Arrays.toString((float[])value);
+      } else if (value instanceof short[]) {
+         return prefix + Arrays.toString((short[])value);
+      } else if (value instanceof double[]) {
+         return prefix + Arrays.toString((double[])value);
+      } else if (value instanceof boolean[]) {
+         return prefix + Arrays.toString((boolean[])value);
+      } else if (value instanceof Object[]) {
+         return prefix + Arrays.toString((Object[])value);
+      } else {
+         return prefix + value.toString();
+      }
+   }
+
+   static void getRoutingTypes(Object source) {
+      LOGGER.getRoutingTypes(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601000, value = "User {0} is getting routing type property on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getRoutingTypes(String user, Object source, Object... args);
+
+   static void getRoutingTypesAsJSON(Object source) {
+      LOGGER.getRoutingTypesAsJSON(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601001, value = "User {0} is getting routing type property as json on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getRoutingTypesAsJSON(String user, Object source, Object... args);
+
+   static void getQueueNames(Object source, Object... args) {
+      LOGGER.getQueueNames(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601002, value = "User {0} is getting queue names on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getQueueNames(String user, Object source, Object... args);
+
+   static void getBindingNames(Object source) {
+      LOGGER.getBindingNames(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601003, value = "User {0} is getting binding names on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getBindingNames(String user, Object source, Object... args);
+
+   static void getRoles(Object source, Object... args) {
+      LOGGER.getRoles(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601004, value = "User {0} is getting roles on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getRoles(String user, Object source, Object... args);
+
+   static void getRolesAsJSON(Object source, Object... args) {
+      LOGGER.getRolesAsJSON(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601005, value = "User {0} is getting roles as json on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getRolesAsJSON(String user, Object source, Object... args);
+
+   static void getNumberOfBytesPerPage(Object source) {
+      LOGGER.getNumberOfBytesPerPage(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601006, value = "User {0} is getting number of bytes per page on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getNumberOfBytesPerPage(String user, Object source, Object... args);
+
+   static void getAddressSize(Object source) {
+      LOGGER.getAddressSize(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601007, value = "User {0} is getting address size on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getAddressSize(String user, Object source, Object... args);
+
+   static void getNumberOfMessages(Object source) {
+      LOGGER.getNumberOfMessages(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601008, value = "User {0} is getting number of messages on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getNumberOfMessages(String user, Object source, Object... args);
+
+   static void isPaging(Object source) {
+      LOGGER.isPaging(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601009, value = "User {0} is getting isPaging on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void isPaging(String user, Object source, Object... args);
+
+   static void getNumberOfPages(Object source) {
+      LOGGER.getNumberOfPages(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601010, value = "User {0} is getting number of pages on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getNumberOfPages(String user, Object source, Object... args);
+
+   static void getRoutedMessageCount(Object source) {
+      LOGGER.getRoutedMessageCount(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601011, value = "User {0} is getting routed message count on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getRoutedMessageCount(String user, Object source, Object... args);
+
+   static void getUnRoutedMessageCount(Object source) {
+      LOGGER.getUnRoutedMessageCount(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601012, value = "User {0} is getting unrouted message count on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getUnRoutedMessageCount(String user, Object source, Object... args);
+
+   static void sendMessage(Object source, String user, Object... args) {
+      LOGGER.sendMessage(user == null ? getCaller() : user, source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601013, value = "User {0} is sending a message on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void sendMessage(String user, Object source, Object... args);
+
+   static void getName(Object source) {
+      LOGGER.getName(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601014, value = "User {0} is getting name on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getName(String user, Object source, Object... args);
+
+   static void getAddress(Object source) {
+      LOGGER.getAddress(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601015, value = "User {0} is getting address on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getAddress(String user, Object source, Object... args);
+
+   static void getFilter(Object source) {
+      LOGGER.getFilter(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601016, value = "User {0} is getting filter on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getFilter(String user, Object source, Object... args);
+
+   static void isDurable(Object source) {
+      LOGGER.isDurable(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601017, value = "User {0} is getting durable property on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void isDurable(String user, Object source, Object... args);
+
+   static void getMessageCount(Object source) {
+      LOGGER.getMessageCount(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601018, value = "User {0} is getting message count on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getMessageCount(String user, Object source, Object... args);
+
+   static void getMBeanInfo(Object source) {
+      LOGGER.getMBeanInfo(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601019, value = "User {0} is getting mbean info on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getMBeanInfo(String user, Object source, Object... args);
+
+   static void getFactoryClassName(Object source) {
+      LOGGER.getFactoryClassName(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601020, value = "User {0} is getting factory class name on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getFactoryClassName(String user, Object source, Object... args);
+
+   static void getParameters(Object source) {
+      LOGGER.getParameters(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601021, value = "User {0} is getting parameters on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getParameters(String user, Object source, Object... args);
+
+   static void reload(Object source) {
+      LOGGER.reload(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601022, value = "User {0} is doing reload on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void reload(String user, Object source, Object... args);
+
+   static void isStarted(Object source) {
+      LOGGER.isStarted(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601023, value = "User {0} is querying isStarted on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void isStarted(String user, Object source, Object... args);
+
+   static void startAcceptor(Object source) {
+      LOGGER.startAcceptor(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601024, value = "User {0} is starting an acceptor on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void startAcceptor(String user, Object source, Object... args);
+
+   static void stopAcceptor(Object source) {
+      LOGGER.stopAcceptor(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601025, value = "User {0} is stopping an acceptor on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void stopAcceptor(String user, Object source, Object... args);
+
+   static void getVersion(Object source) {
+      LOGGER.getVersion(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601026, value = "User {0} is getting version on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getVersion(String user, Object source, Object... args);
+
+   static void isBackup(Object source) {
+      LOGGER.isBackup(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601027, value = "User {0} is querying isBackup on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void isBackup(String user, Object source, Object... args);
+
+   static void isSharedStore(Object source) {
+      LOGGER.isSharedStore(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601028, value = "User {0} is querying isSharedStore on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void isSharedStore(String user, Object source, Object... args);
+
+   static void getBindingsDirectory(Object source) {
+      LOGGER.getBindingsDirectory(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601029, value = "User {0} is getting bindings directory on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getBindingsDirectory(String user, Object source, Object... args);
+
+   static void getIncomingInterceptorClassNames(Object source) {
+      LOGGER.getIncomingInterceptorClassNames(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601030, value = "User {0} is getting incoming interceptor class names on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getIncomingInterceptorClassNames(String user, Object source, Object... args);
+
+   static void getOutgoingInterceptorClassNames(Object source) {
+      LOGGER.getOutgoingInterceptorClassNames(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601031, value = "User {0} is getting outgoing interceptor class names on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getOutgoingInterceptorClassNames(String user, Object source, Object... args);
+
+   static void getJournalBufferSize(Object source) {
+      LOGGER.getJournalBufferSize(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601032, value = "User {0} is getting journal buffer size on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getJournalBufferSize(String user, Object source, Object... args);
+
+   static void getJournalBufferTimeout(Object source) {
+      LOGGER.getJournalBufferTimeout(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601033, value = "User {0} is getting journal buffer timeout on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getJournalBufferTimeout(String user, Object source, Object... args);
+
+   static void setFailoverOnServerShutdown(Object source, Object... args) {
+      LOGGER.setFailoverOnServerShutdown(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601034, value = "User {0} is setting failover on server shutdown on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void setFailoverOnServerShutdown(String user, Object source, Object... args);
+
+   static void isFailoverOnServerShutdown(Object source) {
+      LOGGER.isFailoverOnServerShutdown(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601035, value = "User {0} is querying is-failover-on-server-shutdown on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void isFailoverOnServerShutdown(String user, Object source, Object... args);
+
+   static void getJournalMaxIO(Object source) {
+      LOGGER.getJournalMaxIO(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601036, value = "User {0} is getting journal's max io on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getJournalMaxIO(String user, Object source, Object... args);
+
+   static void getJournalDirectory(Object source) {
+      LOGGER.getJournalDirectory(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601037, value = "User {0} is getting journal directory on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getJournalDirectory(String user, Object source, Object... args);
+
+   static void getJournalFileSize(Object source) {
+      LOGGER.getJournalFileSize(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601038, value = "User {0} is getting journal file size on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getJournalFileSize(String user, Object source, Object... args);
+
+   static void getJournalMinFiles(Object source) {
+      LOGGER.getJournalMinFiles(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601039, value = "User {0} is getting journal min files on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getJournalMinFiles(String user, Object source, Object... args);
+
+   static void getJournalCompactMinFiles(Object source) {
+      LOGGER.getJournalCompactMinFiles(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601040, value = "User {0} is getting journal compact min files on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getJournalCompactMinFiles(String user, Object source, Object... args);
+
+   static void getJournalCompactPercentage(Object source) {
+      LOGGER.getJournalCompactPercentage(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601041, value = "User {0} is getting journal compact percentage on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getJournalCompactPercentage(String user, Object source, Object... args);
+
+   static void isPersistenceEnabled(Object source) {
+      LOGGER.isPersistenceEnabled(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601042, value = "User {0} is querying persistence enabled on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void isPersistenceEnabled(String user, Object source, Object... args);
+
+   static void getJournalType(Object source) {
+      LOGGER.getJournalType(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601043, value = "User {0} is getting journal type on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getJournalType(String user, Object source, Object... args);
+
+   static void getPagingDirectory(Object source) {
+      LOGGER.getPagingDirectory(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601044, value = "User {0} is getting paging directory on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getPagingDirectory(String user, Object source, Object... args);
+
+   static void getScheduledThreadPoolMaxSize(Object source) {
+      LOGGER.getScheduledThreadPoolMaxSize(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601045, value = "User {0} is getting scheduled threadpool max size on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getScheduledThreadPoolMaxSize(String user, Object source, Object... args);
+
+   static void getThreadPoolMaxSize(Object source) {
+      LOGGER.getThreadPoolMaxSize(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601046, value = "User {0} is getting threadpool max size on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getThreadPoolMaxSize(String user, Object source, Object... args);
+
+   static void getSecurityInvalidationInterval(Object source) {
+      LOGGER.getSecurityInvalidationInterval(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601047, value = "User {0} is getting security invalidation interval on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getSecurityInvalidationInterval(String user, Object source, Object... args);
+
+   static void isClustered(Object source) {
+      LOGGER.isClustered(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601048, value = "User {0} is querying is-clustered on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void isClustered(String user, Object source, Object... args);
+
+   static void isCreateBindingsDir(Object source) {
+      LOGGER.isCreateBindingsDir(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601049, value = "User {0} is querying is-create-bindings-dir on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void isCreateBindingsDir(String user, Object source, Object... args);
+
+   static void isCreateJournalDir(Object source) {
+      LOGGER.isCreateJournalDir(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601050, value = "User {0} is querying is-create-journal-dir on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void isCreateJournalDir(String user, Object source, Object... args);
+
+   static void isJournalSyncNonTransactional(Object source) {
+      LOGGER.isJournalSyncNonTransactional(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601051, value = "User {0} is querying is-journal-sync-non-transactional on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void isJournalSyncNonTransactional(String user, Object source, Object... args);
+
+   static void isJournalSyncTransactional(Object source) {
+      LOGGER.isJournalSyncTransactional(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601052, value = "User {0} is querying is-journal-sync-transactional on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void isJournalSyncTransactional(String user, Object source, Object... args);
+
+   static void isSecurityEnabled(Object source) {
+      LOGGER.isSecurityEnabled(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601053, value = "User {0} is querying is-security-enabled on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void isSecurityEnabled(String user, Object source, Object... args);
+
+   static void isAsyncConnectionExecutionEnabled(Object source) {
+      LOGGER.isAsyncConnectionExecutionEnabled(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601054, value = "User {0} is query is-async-connection-execution-enabled on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void isAsyncConnectionExecutionEnabled(String user, Object source, Object... args);
+
+   static void getDiskScanPeriod(Object source) {
+      LOGGER.getDiskScanPeriod(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601055, value = "User {0} is getting disk scan period on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getDiskScanPeriod(String user, Object source, Object... args);
+
+   static void getMaxDiskUsage(Object source) {
+      LOGGER.getMaxDiskUsage(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601056, value = "User {0} is getting max disk usage on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getMaxDiskUsage(String user, Object source, Object... args);
+
+   static void getGlobalMaxSize(Object source) {
+      LOGGER.getGlobalMaxSize(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601057, value = "User {0} is getting global max size on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getGlobalMaxSize(String user, Object source, Object... args);
+
+   static void getAddressMemoryUsage(Object source) {
+      LOGGER.getAddressMemoryUsage(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601058, value = "User {0} is getting address memory usage on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getAddressMemoryUsage(String user, Object source, Object... args);
+
+   static void getAddressMemoryUsagePercentage(Object source) {
+      LOGGER.getAddressMemoryUsagePercentage(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601059, value = "User {0} is getting address memory usage percentage on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getAddressMemoryUsagePercentage(String user, Object source, Object... args);
+
+   static void freezeReplication(Object source) {
+      LOGGER.freezeReplication(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601060, value = "User {0} is freezing replication on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void freezeReplication(String user, Object source, Object... args);
+
+   static void createAddress(Object source, Object... args) {
+      LOGGER.createAddress(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601061, value = "User {0} is creating an address on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void createAddress(String user, Object source, Object... args);
+
+   static void updateAddress(Object source, Object... args) {
+      LOGGER.updateAddress(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601062, value = "User {0} is updating an address on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void updateAddress(String user, Object source, Object... args);
+
+   static void deleteAddress(Object source, Object... args) {
+      LOGGER.deleteAddress(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601063, value = "User {0} is deleting an address on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void deleteAddress(String user, Object source, Object... args);
+
+   static void deployQueue(Object source, Object... args) {
+      LOGGER.deployQueue(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601064, value = "User {0} is creating a queue on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void deployQueue(String user, Object source, Object... args);
+
+   static void createQueue(Object source, String user, Object... args) {
+      LOGGER.createQueue(user == null ? getCaller() : user, source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601065, value = "User {0} is creating a queue on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void createQueue(String user, Object source, Object... args);
+
+   static void updateQueue(Object source, Object... args) {
+      LOGGER.updateQueue(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601066, value = "User {0} is updating a queue on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void updateQueue(String user, Object source, Object... args);
+
+   static void getClusterConnectionNames(Object source) {
+      LOGGER.getClusterConnectionNames(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601067, value = "User {0} is getting cluster connection names on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getClusterConnectionNames(String user, Object source, Object... args);
+
+   static void getUptime(Object source) {
+      LOGGER.getUptime(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601068, value = "User {0} is getting uptime on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getUptime(String user, Object source, Object... args);
+
+   static void getUptimeMillis(Object source) {
+      LOGGER.getUptimeMillis(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601069, value = "User {0} is getting uptime in milliseconds on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getUptimeMillis(String user, Object source, Object... args);
+
+   static void isReplicaSync(Object source) {
+      LOGGER.isReplicaSync(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601070, value = "User {0} is querying is-replica-sync on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void isReplicaSync(String user, Object source, Object... args);
+
+   static void getAddressNames(Object source) {
+      LOGGER.getAddressNames(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601071, value = "User {0} is getting address names on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getAddressNames(String user, Object source, Object... args);
+
+   static void destroyQueue(Object source, String user, Object... args) {
+      LOGGER.destroyQueue(user == null ? getCaller() : user, source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601072, value = "User {0} is deleting a queue on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void destroyQueue(String user, Object source, Object... args);
+
+   static void getAddressInfo(Object source, Object... args) {
+      LOGGER.getAddressInfo(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601073, value = "User {0} is getting address info on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getAddressInfo(String user, Object source, Object... args);
+
+   static void listBindingsForAddress(Object source, Object... args) {
+      LOGGER.listBindingsForAddress(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601074, value = "User {0} is listing bindings for address on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listBindingsForAddress(String user, Object source, Object... args);
+
+   static void listAddresses(Object source, Object... args) {
+      LOGGER.listAddresses(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601075, value = "User {0} is listing addresses on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listAddresses(String user, Object source, Object... args);
+
+   static void getConnectionCount(Object source, Object... args) {
+      LOGGER.getConnectionCount(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601076, value = "User {0} is getting connection count on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getConnectionCount(String user, Object source, Object... args);
+
+   static void getTotalConnectionCount(Object source) {
+      LOGGER.getTotalConnectionCount(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601077, value = "User {0} is getting total connection count on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getTotalConnectionCount(String user, Object source, Object... args);
+
+   static void getTotalMessageCount(Object source) {
+      LOGGER.getTotalMessageCount(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601078, value = "User {0} is getting total message count on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getTotalMessageCount(String user, Object source, Object... args);
+
+   static void getTotalMessagesAdded(Object source) {
+      LOGGER.getTotalMessagesAdded(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601079, value = "User {0} is getting total messages added on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getTotalMessagesAdded(String user, Object source, Object... args);
+
+   static void getTotalMessagesAcknowledged(Object source) {
+      LOGGER.getTotalMessagesAcknowledged(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601080, value = "User {0} is getting total messages acknowledged on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getTotalMessagesAcknowledged(String user, Object source, Object... args);
+
+   static void getTotalConsumerCount(Object source) {
+      LOGGER.getTotalConsumerCount(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601081, value = "User {0} is getting total consumer count on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getTotalConsumerCount(String user, Object source, Object... args);
+
+   static void enableMessageCounters(Object source) {
+      LOGGER.enableMessageCounters(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601082, value = "User {0} is enabling message counters on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void enableMessageCounters(String user, Object source, Object... args);
+
+   static void disableMessageCounters(Object source) {
+      LOGGER.disableMessageCounters(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601083, value = "User {0} is disabling message counters on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void disableMessageCounters(String user, Object source, Object... args);
+
+   static void resetAllMessageCounters(Object source) {
+      LOGGER.resetAllMessageCounters(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601084, value = "User {0} is resetting all message counters on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void resetAllMessageCounters(String user, Object source, Object... args);
+
+   static void resetAllMessageCounterHistories(Object source) {
+      LOGGER.resetAllMessageCounterHistories(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601085, value = "User {0} is resetting all message counter histories on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void resetAllMessageCounterHistories(String user, Object source, Object... args);
+
+   static void isMessageCounterEnabled(Object source) {
+      LOGGER.isMessageCounterEnabled(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601086, value = "User {0} is querying is-message-counter-enabled on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void isMessageCounterEnabled(String user, Object source, Object... args);
+
+   static void getMessageCounterSamplePeriod(Object source) {
+      LOGGER.getMessageCounterSamplePeriod(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601087, value = "User {0} is getting message counter sample period on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getMessageCounterSamplePeriod(String user, Object source, Object... args);
+
+   static void setMessageCounterSamplePeriod(Object source, Object... args) {
+      LOGGER.setMessageCounterSamplePeriod(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601088, value = "User {0} is setting message counter sample period on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void setMessageCounterSamplePeriod(String user, Object source, Object... args);
+
+   static void getMessageCounterMaxDayCount(Object source) {
+      LOGGER.getMessageCounterMaxDayCount(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601089, value = "User {0} is getting message counter max day count on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getMessageCounterMaxDayCount(String user, Object source, Object... args);
+
+   static void setMessageCounterMaxDayCount(Object source, Object... args) {
+      LOGGER.setMessageCounterMaxDayCount(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601090, value = "User {0} is setting message counter max day count on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void setMessageCounterMaxDayCount(String user, Object source, Object... args);
+
+   static void listPreparedTransactions(Object source) {
+      LOGGER.listPreparedTransactions(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601091, value = "User {0} is listing prepared transactions on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listPreparedTransactions(String user, Object source, Object... args);
+
+   static void listPreparedTransactionDetailsAsJSON(Object source) {
+      LOGGER.listPreparedTransactionDetailsAsJSON(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601092, value = "User {0} is listing prepared transaction details as json on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listPreparedTransactionDetailsAsJSON(String user, Object source, Object... args);
+
+   static void listPreparedTransactionDetailsAsHTML(Object source, Object... args) {
+      LOGGER.listPreparedTransactionDetailsAsHTML(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601093, value = "User {0} is listing prepared transaction details as HTML on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listPreparedTransactionDetailsAsHTML(String user, Object source, Object... args);
+
+   static void listHeuristicCommittedTransactions(Object source) {
+      LOGGER.listHeuristicCommittedTransactions(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601094, value = "User {0} is listing heuristic committed transactions on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listHeuristicCommittedTransactions(String user, Object source, Object... args);
+
+   static void listHeuristicRolledBackTransactions(Object source) {
+      LOGGER.listHeuristicRolledBackTransactions(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601095, value = "User {0} is listing heuristic rolled back transactions on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listHeuristicRolledBackTransactions(String user, Object source, Object... args);
+
+   static void commitPreparedTransaction(Object source, Object... args) {
+      LOGGER.commitPreparedTransaction(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601096, value = "User {0} is commiting prepared transaction on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void commitPreparedTransaction(String user, Object source, Object... args);
+
+   static void rollbackPreparedTransaction(Object source, Object... args) {
+      LOGGER.rollbackPreparedTransaction(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601097, value = "User {0} is rolling back prepared transaction on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void rollbackPreparedTransaction(String user, Object source, Object... args);
+
+   static void listRemoteAddresses(Object source, Object... args) {
+      LOGGER.listRemoteAddresses(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601098, value = "User {0} is listing remote addresses on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listRemoteAddresses(String user, Object source, Object... args);
+
+   static void closeConnectionsForAddress(Object source, Object... args) {
+      LOGGER.closeConnectionsForAddress(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601099, value = "User {0} is closing connections for address on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void closeConnectionsForAddress(String user, Object source, Object... args);
+
+   static void closeConsumerConnectionsForAddress(Object source, Object... args) {
+      LOGGER.closeConsumerConnectionsForAddress(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601100, value = "User {0} is closing consumer connections for address on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void closeConsumerConnectionsForAddress(String user, Object source, Object... args);
+
+   static void closeConnectionsForUser(Object source, Object... args) {
+      LOGGER.closeConnectionsForUser(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601101, value = "User {0} is closing connections for user on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void closeConnectionsForUser(String user, Object source, Object... args);
+
+   static void closeConnectionWithID(Object source, Object... args) {
+      LOGGER.closeConnectionWithID(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601102, value = "User {0} is closing a connection by ID on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void closeConnectionWithID(String user, Object source, Object... args);
+
+   static void closeSessionWithID(Object source, Object... args) {
+      LOGGER.closeSessionWithID(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601103, value = "User {0} is closing session with id on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void closeSessionWithID(String user, Object source, Object... args);
+
+   static void closeConsumerWithID(Object source, Object... args) {
+      LOGGER.closeConsumerWithID(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601104, value = "User {0} is closing consumer with id on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void closeConsumerWithID(String user, Object source, Object... args);
+
+   static void listConnectionIDs(Object source) {
+      LOGGER.listConnectionIDs(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601105, value = "User {0} is listing connection IDs on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listConnectionIDs(String user, Object source, Object... args);
+
+   static void listSessions(Object source, Object... args) {
+      LOGGER.listSessions(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601106, value = "User {0} is listing sessions on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listSessions(String user, Object source, Object... args);
+
+   static void listProducersInfoAsJSON(Object source) {
+      LOGGER.listProducersInfoAsJSON(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601107, value = "User {0} is listing producers info as json on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listProducersInfoAsJSON(String user, Object source, Object... args);
+
+   static void listConnections(Object source, Object... args) {
+      LOGGER.listConnections(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601108, value = "User {0} is listing connections on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listConnections(String user, Object source, Object... args);
+
+   static void listConsumers(Object source, Object... args) {
+      LOGGER.listConsumers(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601109, value = "User {0} is listing consumers on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listConsumers(String user, Object source, Object... args);
+
+   static void listQueues(Object source, Object... args) {
+      LOGGER.listQueues(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601110, value = "User {0} is listing queues on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listQueues(String user, Object source, Object... args);
+
+   static void listProducers(Object source, Object... args) {
+      LOGGER.listProducers(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601111, value = "User {0} is listing producers on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listProducers(String user, Object source, Object... args);
+
+   static void listConnectionsAsJSON(Object source) {
+      LOGGER.listConnectionsAsJSON(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601112, value = "User {0} is listing connections as json on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listConnectionsAsJSON(String user, Object source, Object... args);
+
+   static void listSessionsAsJSON(Object source, Object... args) {
+      LOGGER.listSessionsAsJSON(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601113, value = "User {0} is listing sessions as json on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listSessionsAsJSON(String user, Object source, Object... args);
+
+   static void listAllSessionsAsJSON(Object source) {
+      LOGGER.listAllSessionsAsJSON(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601114, value = "User {0} is listing all sessions as json on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listAllSessionsAsJSON(String user, Object source, Object... args);
+
+   static void listConsumersAsJSON(Object source, Object... args) {
+      LOGGER.listConsumersAsJSON(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601115, value = "User {0} is listing consumers as json on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listConsumersAsJSON(String user, Object source, Object... args);
+
+   static void listAllConsumersAsJSON(Object source) {
+      LOGGER.listAllConsumersAsJSON(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601116, value = "User {0} is listing all consumers as json on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listAllConsumersAsJSON(String user, Object source, Object... args);
+
+   static void getConnectors(Object source) {
+      LOGGER.getConnectors(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601117, value = "User {0} is getting connectors on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getConnectors(String user, Object source, Object... args);
+
+   static void getConnectorsAsJSON(Object source) {
+      LOGGER.getConnectorsAsJSON(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601118, value = "User {0} is getting connectors as json on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getConnectorsAsJSON(String user, Object source, Object... args);
+
+   static void addSecuritySettings(Object source, Object... args) {
+      LOGGER.addSecuritySettings(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601119, value = "User {0} is adding security settings on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void addSecuritySettings(String user, Object source, Object... args);
+
+   static void removeSecuritySettings(Object source, Object... args) {
+      LOGGER.removeSecuritySettings(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601120, value = "User {0} is removing security settings on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void removeSecuritySettings(String user, Object source, Object... args);
+
+   static void getAddressSettingsAsJSON(Object source, Object... args) {
+      LOGGER.getAddressSettingsAsJSON(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601121, value = "User {0} is getting address settings as json on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getAddressSettingsAsJSON(String user, Object source, Object... args);
+
+   static void addAddressSettings(Object source, Object... args) {
+      LOGGER.addAddressSettings(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601122, value = "User {0} is adding addressSettings on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void addAddressSettings(String user, Object source, Object... args);
+
+   static void removeAddressSettings(Object source, Object... args) {
+      LOGGER.removeAddressSettings(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601123, value = "User {0} is removing address settings on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void removeAddressSettings(String user, Object source, Object... args);
+
+   static void getDivertNames(Object source) {
+      LOGGER.getDivertNames(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601124, value = "User {0} is getting divert names on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getDivertNames(String user, Object source, Object... args);
+
+   static void createDivert(Object source, Object... args) {
+      LOGGER.createDivert(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601125, value = "User {0} is creating a divert on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void createDivert(String user, Object source, Object... args);
+
+   static void destroyDivert(Object source, Object... args) {
+      LOGGER.destroyDivert(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601126, value = "User {0} is destroying a divert on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void destroyDivert(String user, Object source, Object... args);
+
+   static void getBridgeNames(Object source) {
+      LOGGER.getBridgeNames(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601127, value = "User {0} is getting bridge names on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getBridgeNames(String user, Object source, Object... args);
+
+   static void createBridge(Object source, Object... args) {
+      LOGGER.createBridge(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601128, value = "User {0} is creating a bridge on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void createBridge(String user, Object source, Object... args);
+
+   static void destroyBridge(Object source, Object... args) {
+      LOGGER.destroyBridge(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601129, value = "User {0} is destroying a bridge on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void destroyBridge(String user, Object source, Object... args);
+
+   static void createConnectorService(Object source, Object... args) {
+      LOGGER.createConnectorService(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601130, value = "User {0} is creating connector service on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void createConnectorService(String user, Object source, Object... args);
+
+   static void destroyConnectorService(Object source, Object... args) {
+      LOGGER.destroyConnectorService(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601131, value = "User {0} is destroying connector service on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void destroyConnectorService(String user, Object source, Object... args);
+
+   static void getConnectorServices(Object source, Object... args) {
+      LOGGER.getConnectorServices(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601132, value = "User {0} is getting connector services on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getConnectorServices(String user, Object source, Object... args);
+
+   static void forceFailover(Object source) {
+      LOGGER.forceFailover(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601133, value = "User {0} is forceing a failover on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void forceFailover(String user, Object source, Object... args);
+
+   static void scaleDown(Object source, Object... args) {
+      LOGGER.scaleDown(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601134, value = "User {0} is performing scale down on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void scaleDown(String user, Object source, Object... args);
+
+   static void listNetworkTopology(Object source) {
+      LOGGER.listNetworkTopology(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601135, value = "User {0} is listing network topology on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listNetworkTopology(String user, Object source, Object... args);
+
+   static void removeNotificationListener(Object source, Object... args) {
+      LOGGER.removeNotificationListener(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601136, value = "User {0} is removing notification listener on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void removeNotificationListener(String user, Object source, Object... args);
+
+   static void addNotificationListener(Object source, Object... args) {
+      LOGGER.addNotificationListener(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601137, value = "User {0} is adding notification listener on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void addNotificationListener(String user, Object source, Object... args);
+
+   static void getNotificationInfo(Object source) {
+      LOGGER.getNotificationInfo(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601138, value = "User {0} is getting notification info on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getNotificationInfo(String user, Object source, Object... args);
+
+   static void getConnectionTTLOverride(Object source) {
+      LOGGER.getConnectionTTLOverride(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601139, value = "User {0} is getting connection ttl override on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getConnectionTTLOverride(String user, Object source, Object... args);
+
+   static void getIDCacheSize(Object source) {
+      LOGGER.getIDCacheSize(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601140, value = "User {0} is getting ID cache size on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getIDCacheSize(String user, Object source, Object... args);
+
+   static void getLargeMessagesDirectory(Object source) {
+      LOGGER.getLargeMessagesDirectory(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601141, value = "User {0} is getting large message directory on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getLargeMessagesDirectory(String user, Object source, Object... args);
+
+   static void getManagementAddress(Object source) {
+      LOGGER.getManagementAddress(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601142, value = "User {0} is getting management address on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getManagementAddress(String user, Object source, Object... args);
+
+   static void getNodeID(Object source) {
+      LOGGER.getNodeID(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601143, value = "User {0} is getting node ID on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getNodeID(String user, Object source, Object... args);
+
+   static void getManagementNotificationAddress(Object source) {
+      LOGGER.getManagementNotificationAddress(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601144, value = "User {0} is getting management notification address on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getManagementNotificationAddress(String user, Object source, Object... args);
+
+   static void getMessageExpiryScanPeriod(Object source) {
+      LOGGER.getMessageExpiryScanPeriod(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601145, value = "User {0} is getting message expiry scan period on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getMessageExpiryScanPeriod(String user, Object source, Object... args);
+
+   static void getMessageExpiryThreadPriority(Object source) {
+      LOGGER.getMessageExpiryThreadPriority(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601146, value = "User {0} is getting message expiry thread priority on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getMessageExpiryThreadPriority(String user, Object source, Object... args);
+
+   static void getTransactionTimeout(Object source) {
+      LOGGER.getTransactionTimeout(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601147, value = "User {0} is getting transaction timeout on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getTransactionTimeout(String user, Object source, Object... args);
+
+   static void getTransactionTimeoutScanPeriod(Object source) {
+      LOGGER.getTransactionTimeoutScanPeriod(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601148, value = "User {0} is getting transaction timeout scan period on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getTransactionTimeoutScanPeriod(String user, Object source, Object... args);
+
+   static void isPersistDeliveryCountBeforeDelivery(Object source) {
+      LOGGER.isPersistDeliveryCountBeforeDelivery(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601149, value = "User {0} is querying is-persist-delivery-before-delivery on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void isPersistDeliveryCountBeforeDelivery(String user, Object source, Object... args);
+
+   static void isPersistIDCache(Object source) {
+      LOGGER.isPersistIDCache(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601150, value = "User {0} is querying is-persist-id-cache on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void isPersistIDCache(String user, Object source, Object... args);
+
+   static void isWildcardRoutingEnabled(Object source) {
+      LOGGER.isWildcardRoutingEnabled(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601151, value = "User {0} is querying is-wildcard-routing-enabled on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void isWildcardRoutingEnabled(String user, Object source, Object... args);
+
+   static void addUser(Object source, Object... args) {
+      LOGGER.addUser(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601152, value = "User {0} is adding a user on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void addUser(String user, Object source, Object... args);
+
+   static void listUser(Object source, Object... args) {
+      LOGGER.listUser(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601153, value = "User {0} is listing a user on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listUser(String user, Object source, Object... args);
+
+   static void removeUser(Object source, Object... args) {
+      LOGGER.removeUser(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601154, value = "User {0} is removing a user on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void removeUser(String user, Object source, Object... args);
+
+   static void resetUser(Object source, Object... args) {
+      LOGGER.resetUser(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601155, value = "User {0} is resetting a user on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void resetUser(String user, Object source, Object... args);
+
+   static void getUser(Object source) {
+      LOGGER.getUser(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601156, value = "User {0} is getting user property on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getUser(String user, Object source, Object... args);
+
+   static void getRoutingType(Object source) {
+      LOGGER.getRoutingType(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601157, value = "User {0} is getting routing type property on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getRoutingType(String user, Object source, Object... args);
+
+   static void isTemporary(Object source) {
+      LOGGER.isTemporary(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601158, value = "User {0} is getting temporary property on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void isTemporary(String user, Object source, Object... args);
+
+   static void getPersistentSize(Object source) {
+      LOGGER.getPersistentSize(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601159, value = "User {0} is getting persistent size on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getPersistentSize(String user, Object source, Object... args);
+
+   static void getDurableMessageCount(Object source) {
+      LOGGER.getDurableMessageCount(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601160, value = "User {0} is getting durable message count on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getDurableMessageCount(String user, Object source, Object... args);
+
+   static void getDurablePersistSize(Object source) {
+      LOGGER.getDurablePersistSize(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601161, value = "User {0} is getting durable persist size on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getDurablePersistSize(String user, Object source, Object... args);
+
+   static void getConsumerCount(Object source) {
+      LOGGER.getConsumerCount(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601162, value = "User {0} is getting consumer count on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getConsumerCount(String user, Object source, Object... args);
+
+   static void getDeliveringCount(Object source) {
+      LOGGER.getDeliveringCount(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601163, value = "User {0} is getting delivering count on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getDeliveringCount(String user, Object source, Object... args);
+
+   static void getDeliveringSize(Object source) {
+      LOGGER.getDeliveringSize(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601164, value = "User {0} is getting delivering size on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getDeliveringSize(String user, Object source, Object... args);
+
+   static void getDurableDeliveringCount(Object source) {
+      LOGGER.getDurableDeliveringCount(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601165, value = "User {0} is getting durable delivering count on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getDurableDeliveringCount(String user, Object source, Object... args);
+
+   static void getDurableDeliveringSize(Object source) {
+      LOGGER.getDurableDeliveringSize(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601166, value = "User {0} is getting durable delivering size on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getDurableDeliveringSize(String user, Object source, Object... args);
+
+   static void getMessagesAdded(Object source) {
+      LOGGER.getMessagesAdded(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601167, value = "User {0} is getting messages added on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getMessagesAdded(String user, Object source, Object... args);
+
+   static void getMessagesAcknowledged(Object source) {
+      LOGGER.getMessagesAcknowledged(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601168, value = "User {0} is getting messages acknowledged on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getMessagesAcknowledged(String user, Object source, Object... args);
+
+   static void getMessagesExpired(Object source) {
+      LOGGER.getMessagesExpired(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601169, value = "User {0} is getting messages expired on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getMessagesExpired(String user, Object source, Object... args);
+
+   static void getMessagesKilled(Object source) {
+      LOGGER.getMessagesKilled(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601170, value = "User {0} is getting messages killed on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getMessagesKilled(String user, Object source, Object... args);
+
+   static void getID(Object source) {
+      LOGGER.getID(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601171, value = "User {0} is getting ID on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getID(String user, Object source, Object... args);
+
+   static void getScheduledCount(Object source) {
+      LOGGER.getScheduledCount(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601172, value = "User {0} is getting scheduled count on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getScheduledCount(String user, Object source, Object... args);
+
+   static void getScheduledSize(Object source) {
+      LOGGER.getScheduledSize(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601173, value = "User {0} is getting scheduled size on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getScheduledSize(String user, Object source, Object... args);
+
+   static void getDurableScheduledCount(Object source) {
+      LOGGER.getDurableScheduledCount(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601174, value = "User {0} is getting durable scheduled count on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getDurableScheduledCount(String user, Object source, Object... args);
+
+   static void getDurableScheduledSize(Object source) {
+      LOGGER.getDurableScheduledSize(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601175, value = "User {0} is getting durable scheduled size on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getDurableScheduledSize(String user, Object source, Object... args);
+
+   static void getDeadLetterAddress(Object source) {
+      LOGGER.getDeadLetterAddress(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601176, value = "User {0} is getting dead letter address on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getDeadLetterAddress(String user, Object source, Object... args);
+
+   static void getExpiryAddress(Object source) {
+      LOGGER.getExpiryAddress(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601177, value = "User {0} is getting expiry address on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getExpiryAddress(String user, Object source, Object... args);
+
+   static void getMaxConsumers(Object source) {
+      LOGGER.getMaxConsumers(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601178, value = "User {0} is getting max consumers on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getMaxConsumers(String user, Object source, Object... args);
+
+   static void isPurgeOnNoConsumers(Object source) {
+      LOGGER.isPurgeOnNoConsumers(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601179, value = "User {0} is getting purge-on-consumers property on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void isPurgeOnNoConsumers(String user, Object source, Object... args);
+
+   static void isConfigurationManaged(Object source) {
+      LOGGER.isConfigurationManaged(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601180, value = "User {0} is getting configuration-managed property on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void isConfigurationManaged(String user, Object source, Object... args);
+
+   static void isExclusive(Object source) {
+      LOGGER.isExclusive(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601181, value = "User {0} is getting exclusive property on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void isExclusive(String user, Object source, Object... args);
+
+   static void isLastValue(Object source) {
+      LOGGER.isLastValue(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601182, value = "User {0} is getting last-value property on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void isLastValue(String user, Object source, Object... args);
+
+   static void listScheduledMessages(Object source) {
+      LOGGER.listScheduledMessages(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601183, value = "User {0} is listing scheduled messages on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listScheduledMessages(String user, Object source, Object... args);
+
+   static void listScheduledMessagesAsJSON(Object source) {
+      LOGGER.listScheduledMessagesAsJSON(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601184, value = "User {0} is listing scheduled messages as json on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listScheduledMessagesAsJSON(String user, Object source, Object... args);
+
+   static void listDeliveringMessages(Object source) {
+      LOGGER.listDeliveringMessages(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601185, value = "User {0} is listing delivering messages on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listDeliveringMessages(String user, Object source, Object... args);
+
+   static void listDeliveringMessagesAsJSON(Object source) {
+      LOGGER.listDeliveringMessagesAsJSON(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601186, value = "User {0} is listing delivering messages as json on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listDeliveringMessagesAsJSON(String user, Object source, Object... args);
+
+   static void listMessages(Object source, Object... args) {
+      LOGGER.listMessages(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601187, value = "User {0} is listing messages on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listMessages(String user, Object source, Object... args);
+
+   static void listMessagesAsJSON(Object source) {
+      LOGGER.listMessagesAsJSON(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601188, value = "User {0} is listing messages as json on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listMessagesAsJSON(String user, Object source, Object... args);
+
+   static void getFirstMessage(Object source) {
+      LOGGER.getFirstMessage(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601189, value = "User {0} is getting first message on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getFirstMessage(String user, Object source, Object... args);
+
+   static void getFirstMessageAsJSON(Object source) {
+      LOGGER.getFirstMessageAsJSON(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601190, value = "User {0} is getting first message as json on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getFirstMessageAsJSON(String user, Object source, Object... args);
+
+   static void getFirstMessageTimestamp(Object source) {
+      LOGGER.getFirstMessageTimestamp(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601191, value = "User {0} is getting first message's timestamp on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getFirstMessageTimestamp(String user, Object source, Object... args);
+
+   static void getFirstMessageAge(Object source) {
+      LOGGER.getFirstMessageAge(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601192, value = "User {0} is getting first message's age on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getFirstMessageAge(String user, Object source, Object... args);
+
+   static void countMessages(Object source, Object... args) {
+      LOGGER.countMessages(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601193, value = "User {0} is counting messages on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void countMessages(String user, Object source, Object... args);
+
+   static void countDeliveringMessages(Object source, Object... args) {
+      LOGGER.countDeliveringMessages(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601194, value = "User {0} is counting delivery messages on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void countDeliveringMessages(String user, Object source, Object... args);
+
+   static void removeMessage(Object source, Object... args) {
+      LOGGER.removeMessage(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601195, value = "User {0} is removing a message on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void removeMessage(String user, Object source, Object... args);
+
+   static void removeMessages(Object source, Object... args) {
+      LOGGER.removeMessages(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601196, value = "User {0} is removing messages on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void removeMessages(String user, Object source, Object... args);
+
+   static void expireMessage(Object source, Object... args) {
+      LOGGER.expireMessage(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601197, value = "User {0} is expiring messages on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void expireMessage(String user, Object source, Object... args);
+
+   static void expireMessages(Object source, Object... args) {
+      LOGGER.expireMessages(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601198, value = "User {0} is expiring messages on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void expireMessages(String user, Object source, Object... args);
+
+   static void retryMessage(Object source, Object... args) {
+      LOGGER.retryMessage(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601199, value = "User {0} is retry sending message on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void retryMessage(String user, Object source, Object... args);
+
+   static void retryMessages(Object source) {
+      LOGGER.retryMessages(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601200, value = "User {0} is retry sending messages on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void retryMessages(String user, Object source, Object... args);
+
+   static void moveMessage(Object source, Object... args) {
+      LOGGER.moveMessage(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601201, value = "User {0} is moving a message to another queue on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void moveMessage(String user, Object source, Object... args);
+
+   static void moveMessages(Object source, Object... args) {
+      LOGGER.moveMessages(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601202, value = "User {0} is moving messages to another queue on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void moveMessages(String user, Object source, Object... args);
+
+   static void sendMessagesToDeadLetterAddress(Object source, Object... args) {
+      LOGGER.sendMessagesToDeadLetterAddress(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601203, value = "User {0} is sending messages to dead letter address on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void sendMessagesToDeadLetterAddress(String user, Object source, Object... args);
+
+   static void sendMessageToDeadLetterAddress(Object source, Object... args) {
+      LOGGER.sendMessageToDeadLetterAddress(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601204, value = "User {0} is sending messages to dead letter address on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void sendMessageToDeadLetterAddress(String user, Object source, Object... args);
+
+   static void changeMessagesPriority(Object source, Object... args) {
+      LOGGER.changeMessagesPriority(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601205, value = "User {0} is changing message's priority on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void changeMessagesPriority(String user, Object source, Object... args);
+
+   static void changeMessagePriority(Object source, Object... args) {
+      LOGGER.changeMessagePriority(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601206, value = "User {0} is changing a message's priority on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void changeMessagePriority(String user, Object source, Object... args);
+
+   static void listMessageCounter(Object source) {
+      LOGGER.listMessageCounter(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601207, value = "User {0} is listing message counter on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listMessageCounter(String user, Object source, Object... args);
+
+   static void resetMessageCounter(Object source) {
+      LOGGER.resetMessageCounter(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601208, value = "User {0} is resetting message counter on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void resetMessageCounter(String user, Object source, Object... args);
+
+   static void listMessageCounterAsHTML(Object source) {
+      LOGGER.listMessageCounterAsHTML(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601209, value = "User {0} is listing message counter as HTML on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listMessageCounterAsHTML(String user, Object source, Object... args);
+
+   static void listMessageCounterHistory(Object source) {
+      LOGGER.listMessageCounterHistory(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601210, value = "User {0} is listing message counter history on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listMessageCounterHistory(String user, Object source, Object... args);
+
+   static void listMessageCounterHistoryAsHTML(Object source) {
+      LOGGER.listMessageCounterHistoryAsHTML(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601211, value = "User {0} is listing message counter history as HTML on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listMessageCounterHistoryAsHTML(String user, Object source, Object... args);
+
+   static void pause(Object source, Object... args) {
+      LOGGER.pause(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601212, value = "User {0} is pausing on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void pause(String user, Object source, Object... args);
+
+   static void resume(Object source) {
+      LOGGER.resume(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601213, value = "User {0} is resuming on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void resume(String user, Object source, Object... args);
+
+   static void isPaused(Object source) {
+      LOGGER.isPaused(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601214, value = "User {0} is getting paused property on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void isPaused(String user, Object source, Object... args);
+
+   static void browse(Object source, Object... args) {
+      LOGGER.browse(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601215, value = "User {0} is browsing a queue on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void browse(String user, Object source, Object... args);
+
+   static void flushExecutor(Object source) {
+      LOGGER.flushExecutor(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601216, value = "User {0} is flushing executor on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void flushExecutor(String user, Object source, Object... args);
+
+   static void resetAllGroups(Object source) {
+      LOGGER.resetAllGroups(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601217, value = "User {0} is resetting all groups on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void resetAllGroups(String user, Object source, Object... args);
+
+   static void resetGroup(Object source, Object... args) {
+      LOGGER.resetGroup(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601218, value = "User {0} is resetting group on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void resetGroup(String user, Object source, Object... args);
+
+   static void getGroupCount(Object source, Object... args) {
+      LOGGER.getGroupCount(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601219, value = "User {0} is getting group count on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getGroupCount(String user, Object source, Object... args);
+
+   static void listGroupsAsJSON(Object source) {
+      LOGGER.listGroupsAsJSON(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601220, value = "User {0} is listing groups as json on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void listGroupsAsJSON(String user, Object source, Object... args);
+
+   static void resetMessagesAdded(Object source) {
+      LOGGER.resetMessagesAdded(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601221, value = "User {0} is resetting added messages on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void resetMessagesAdded(String user, Object source, Object... args);
+
+   static void resetMessagesAcknowledged(Object source) {
+      LOGGER.resetMessagesAcknowledged(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601222, value = "User {0} is resetting acknowledged messages on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void resetMessagesAcknowledged(String user, Object source, Object... args);
+
+   static void resetMessagesExpired(Object source) {
+      LOGGER.resetMessagesExpired(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601223, value = "User {0} is resetting expired messages on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void resetMessagesExpired(String user, Object source, Object... args);
+
+   static void resetMessagesKilled(Object source) {
+      LOGGER.resetMessagesKilled(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601224, value = "User {0} is resetting killed messages on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void resetMessagesKilled(String user, Object source, Object... args);
+
+   static void getStaticConnectors(Object source) {
+      LOGGER.getStaticConnectors(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601225, value = "User {0} is getting static connectors on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getStaticConnectors(String user, Object source, Object... args);
+
+   static void getForwardingAddress(Object source) {
+      LOGGER.getForwardingAddress(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601226, value = "User {0} is getting forwarding address on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getForwardingAddress(String user, Object source, Object... args);
+
+   static void getQueueName(Object source) {
+      LOGGER.getQueueName(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601227, value = "User {0} is getting the queue name on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getQueueName(String user, Object source, Object... args);
+
+   static void getDiscoveryGroupName(Object source) {
+      LOGGER.getDiscoveryGroupName(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601228, value = "User {0} is getting discovery group name on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getDiscoveryGroupName(String user, Object source, Object... args);
+
+   static void getFilterString(Object source) {
+      LOGGER.getFilterString(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601229, value = "User {0} is getting filter string on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getFilterString(String user, Object source, Object... args);
+
+   static void getReconnectAttempts(Object source) {
+      LOGGER.getReconnectAttempts(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601230, value = "User {0} is getting reconnect attempts on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getReconnectAttempts(String user, Object source, Object... args);
+
+   static void getRetryInterval(Object source) {
+      LOGGER.getRetryInterval(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601231, value = "User {0} is getting retry interval on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getRetryInterval(String user, Object source, Object... args);
+
+   static void getRetryIntervalMultiplier(Object source) {
+      LOGGER.getRetryIntervalMultiplier(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601232, value = "User {0} is getting retry interval multiplier on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getRetryIntervalMultiplier(String user, Object source, Object... args);
+
+   static void getTransformerClassName(Object source) {
+      LOGGER.getTransformerClassName(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601233, value = "User {0} is getting transformer class name on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getTransformerClassName(String user, Object source, Object... args);
+
+   static void getTransformerPropertiesAsJSON(Object source) {
+      LOGGER.getTransformerPropertiesAsJSON(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601234, value = "User {0} is getting transformer properties as json on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getTransformerPropertiesAsJSON(String user, Object source, Object... args);
+
+   static void getTransformerProperties(Object source) {
+      LOGGER.getTransformerProperties(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601235, value = "User {0} is getting transformer properties on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getTransformerProperties(String user, Object source, Object... args);
+
+   static void isStartedBridge(Object source) {
+      LOGGER.isStartedBridge(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601236, value = "User {0} is checking if bridge started on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void isStartedBridge(String user, Object source, Object... args);
+
+   static void isUseDuplicateDetection(Object source) {
+      LOGGER.isUseDuplicateDetection(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601237, value = "User {0} is querying use duplicate detection on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void isUseDuplicateDetection(String user, Object source, Object... args);
+
+   static void isHA(Object source) {
+      LOGGER.isHA(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601238, value = "User {0} is querying isHA on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void isHA(String user, Object source, Object... args);
+
+   static void startBridge(Object source) {
+      LOGGER.startBridge(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601239, value = "User {0} is starting a bridge on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void startBridge(String user, Object source, Object... args);
+
+   static void stopBridge(Object source) {
+      LOGGER.stopBridge(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601240, value = "User {0} is stopping a bridge on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void stopBridge(String user, Object source, Object... args);
+
+   static void getMessagesPendingAcknowledgement(Object source) {
+      LOGGER.getMessagesPendingAcknowledgement(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601241, value = "User {0} is getting messages pending acknowledgement on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getMessagesPendingAcknowledgement(String user, Object source, Object... args);
+
+   static void getMetrics(Object source) {
+      LOGGER.getMetrics(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601242, value = "User {0} is getting metrics on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getMetrics(String user, Object source, Object... args);
+
+   static void getBroadcastPeriod(Object source) {
+      LOGGER.getBroadcastPeriod(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601243, value = "User {0} is getting broadcast period on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getBroadcastPeriod(String user, Object source, Object... args);
+
+   static void getConnectorPairs(Object source) {
+      LOGGER.getConnectorPairs(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601244, value = "User {0} is getting connector pairs on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getConnectorPairs(String user, Object source, Object... args);
+
+   static void getConnectorPairsAsJSON(Object source) {
+      LOGGER.getConnectorPairsAsJSON(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601245, value = "User {0} is getting connector pairs as json on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getConnectorPairsAsJSON(String user, Object source, Object... args);
+
+   static void getGroupAddress(Object source) {
+      LOGGER.getGroupAddress(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601246, value = "User {0} is getting group address on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getGroupAddress(String user, Object source, Object... args);
+
+   static void getGroupPort(Object source) {
+      LOGGER.getGroupPort(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601247, value = "User {0} is getting group port on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getGroupPort(String user, Object source, Object... args);
+
+   static void getLocalBindPort(Object source) {
+      LOGGER.getLocalBindPort(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601248, value = "User {0} is getting local binding port on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getLocalBindPort(String user, Object source, Object... args);
+
+   static void startBroadcastGroup(Object source) {
+      LOGGER.startBroadcastGroup(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601249, value = "User {0} is starting broadcasting group on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void startBroadcastGroup(String user, Object source, Object... args);
+
+   static void stopBroadcastGroup(Object source) {
+      LOGGER.stopBroadcastGroup(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601250, value = "User {0} is stopping broadcasting group on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void stopBroadcastGroup(String user, Object source, Object... args);
+
+   static void getMaxHops(Object source) {
+      LOGGER.getMaxHops(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601251, value = "User {0} is getting max hops on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getMaxHops(String user, Object source, Object... args);
+
+   static void getStaticConnectorsAsJSON(Object source) {
+      LOGGER.getStaticConnectorsAsJSON(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601252, value = "User {0} is geting static connectors as json on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getStaticConnectorsAsJSON(String user, Object source, Object... args);
+
+   static void isDuplicateDetection(Object source) {
+      LOGGER.isDuplicateDetection(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601253, value = "User {0} is querying use duplicate detection on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void isDuplicateDetection(String user, Object source, Object... args);
+
+   static void getMessageLoadBalancingType(Object source) {
+      LOGGER.getMessageLoadBalancingType(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601254, value = "User {0} is getting message loadbalancing type on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getMessageLoadBalancingType(String user, Object source, Object... args);
+
+   static void getTopology(Object source) {
+      LOGGER.getTopology(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601255, value = "User {0} is getting topology on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getTopology(String user, Object source, Object... args);
+
+   static void getNodes(Object source) {
+      LOGGER.getNodes(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601256, value = "User {0} is getting nodes on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getNodes(String user, Object source, Object... args);
+
+   static void startClusterConnection(Object source) {
+      LOGGER.startClusterConnection(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601257, value = "User {0} is start cluster connection on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void startClusterConnection(String user, Object source, Object... args);
+
+   static void stopClusterConnection(Object source) {
+      LOGGER.stopClusterConnection(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601258, value = "User {0} is stop cluster connection on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void stopClusterConnection(String user, Object source, Object... args);
+
+   static void getBridgeMetrics(Object source, Object... args) {
+      LOGGER.getBridgeMetrics(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601259, value = "User {0} is getting bridge metrics on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getBridgeMetrics(String user, Object source, Object... args);
+
+   static void getRoutingName(Object source) {
+      LOGGER.getRoutingName(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601260, value = "User {0} is getting routing name on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getRoutingName(String user, Object source, Object... args);
+
+   static void getUniqueName(Object source) {
+      LOGGER.getUniqueName(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601261, value = "User {0} is getting unique name on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getUniqueName(String user, Object source, Object... args);
+
+   static void serverSessionCreateAddress(Object source, String user, Object... args) {
+      LOGGER.serverSessionCreateAddress2(user == null ? getCaller() : user, source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601262, value = "User {0} is creating address on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void serverSessionCreateAddress2(String user, Object source, Object... args);
+
+   static void handleManagementMessage(Object source, String user, Object... args) {
+      LOGGER.handleManagementMessage2(user == null ? getCaller() : user, source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601263, value = "User {0} is handling a management message on target resource {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void handleManagementMessage2(String user, Object source, Object... args);
+
+
+   static void securityFailure(Exception cause) {
+      LOGGER.securityFailure(getCaller(), cause);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601264, value = "User {0} gets security check failure", format = Message.Format.MESSAGE_FORMAT)
+   void securityFailure(String user, @Cause Throwable cause);
+
+
+   static void createCoreConsumer(Object source, String user, Object... args) {
+      LOGGER.createCoreConsumer(user == null ? getCaller() : user, source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601265, value = "User {0} is creating a core consumer on target resource {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void createCoreConsumer(String user, Object source, Object... args);
+
+   static void createSharedQueue(Object source, String user, Object... args) {
+      LOGGER.createSharedQueue(user == null ? getCaller() : user, source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601266, value = "User {0} is creating a shared queue on target resource {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void createSharedQueue(String user, Object source, Object... args);
+
+   static void createCoreSession(Object source, Object... args) {
+      LOGGER.createCoreSession(getCaller(), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601267, value = "User {0} is creating a core session on target resource {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void createCoreSession(String user, Object source, Object... args);
+
+
+   //hot path log using a different logger
+   static void coreSendMessage(Object source, String user, Object... args) {
+      MESSAGE_LOGGER.coreSendMessage(user == null ? getCaller() : user, source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601500, value = "User {0} is sending a core message on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void coreSendMessage(String user, Object source, Object... args);
+
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/AbstractControl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/AbstractControl.java
@@ -33,6 +33,7 @@ import org.apache.activemq.artemis.core.persistence.StorageManager;
 import org.apache.activemq.artemis.core.persistence.impl.journal.DummyOperationContext;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ServerSession;
+import org.apache.activemq.artemis.logs.AuditLogger;
 import org.apache.activemq.artemis.utils.Base64;
 import org.apache.activemq.artemis.utils.RunnableEx;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
@@ -106,6 +107,9 @@ public abstract class AbstractControl extends StandardMBean {
 
    @Override
    public MBeanInfo getMBeanInfo() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getMBeanInfo(this);
+      }
       MBeanInfo info = super.getMBeanInfo();
       return new MBeanInfo(info.getClassName(), info.getDescription(), fillMBeanAttributeInfo(), info.getConstructors(), fillMBeanOperationInfo(), info.getNotifications());
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/AcceptorControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/AcceptorControlImpl.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.management.AcceptorControl;
 import org.apache.activemq.artemis.core.persistence.StorageManager;
+import org.apache.activemq.artemis.logs.AuditLogger;
 import org.apache.activemq.artemis.spi.core.remoting.Acceptor;
 
 public class AcceptorControlImpl extends AbstractControl implements AcceptorControl {
@@ -52,6 +53,9 @@ public class AcceptorControlImpl extends AbstractControl implements AcceptorCont
 
    @Override
    public String getFactoryClassName() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getFactoryClassName(this.acceptor);
+      }
       clearIO();
       try {
          return configuration.getFactoryClassName();
@@ -62,6 +66,9 @@ public class AcceptorControlImpl extends AbstractControl implements AcceptorCont
 
    @Override
    public String getName() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getName(this.acceptor);
+      }
       clearIO();
       try {
          return configuration.getName();
@@ -72,6 +79,9 @@ public class AcceptorControlImpl extends AbstractControl implements AcceptorCont
 
    @Override
    public Map<String, Object> getParameters() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getParameters(this.acceptor);
+      }
       clearIO();
       try {
          Map<String, Object> clone = new HashMap(configuration.getParams());
@@ -88,6 +98,9 @@ public class AcceptorControlImpl extends AbstractControl implements AcceptorCont
 
    @Override
    public void reload() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.reload(this.acceptor);
+      }
       clearIO();
       try {
          acceptor.reload();
@@ -98,6 +111,9 @@ public class AcceptorControlImpl extends AbstractControl implements AcceptorCont
 
    @Override
    public boolean isStarted() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isStarted(this.acceptor);
+      }
       clearIO();
       try {
          return acceptor.isStarted();
@@ -108,6 +124,9 @@ public class AcceptorControlImpl extends AbstractControl implements AcceptorCont
 
    @Override
    public void start() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.startAcceptor(this.acceptor);
+      }
       clearIO();
       try {
          acceptor.start();
@@ -118,6 +137,9 @@ public class AcceptorControlImpl extends AbstractControl implements AcceptorCont
 
    @Override
    public void stop() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.stopAcceptor(this.acceptor);
+      }
       clearIO();
       try {
          acceptor.stop();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -119,6 +119,7 @@ import org.apache.activemq.artemis.core.transaction.TransactionDetail;
 import org.apache.activemq.artemis.core.transaction.TransactionDetailFactory;
 import org.apache.activemq.artemis.core.transaction.impl.CoreTransactionDetail;
 import org.apache.activemq.artemis.core.transaction.impl.XidImpl;
+import org.apache.activemq.artemis.logs.AuditLogger;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
 import org.apache.activemq.artemis.spi.core.security.jaas.PropertiesLoginModuleConfigurator;
 import org.apache.activemq.artemis.utils.JsonLoader;
@@ -176,6 +177,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public boolean isStarted() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isStarted(this.server);
+      }
       clearIO();
       try {
          return server.isStarted();
@@ -186,6 +190,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String getVersion() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getVersion(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -198,6 +205,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public boolean isBackup() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isBackup(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -210,6 +220,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public boolean isSharedStore() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isSharedStore(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -222,6 +235,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String getBindingsDirectory() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getBindingsDirectory(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -245,6 +261,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String[] getIncomingInterceptorClassNames() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getIncomingInterceptorClassNames(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -257,6 +276,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String[] getOutgoingInterceptorClassNames() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getOutgoingInterceptorClassNames(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -269,6 +291,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public int getJournalBufferSize() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getJournalBufferSize(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -281,6 +306,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public int getJournalBufferTimeout() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getJournalBufferTimeout(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -293,6 +321,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public void setFailoverOnServerShutdown(boolean failoverOnServerShutdown) {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.setFailoverOnServerShutdown(this.server, failoverOnServerShutdown);
+      }
       checkStarted();
 
       clearIO();
@@ -308,6 +339,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public boolean isFailoverOnServerShutdown() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isFailoverOnServerShutdown(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -325,6 +359,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public int getJournalMaxIO() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getJournalMaxIO(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -337,6 +374,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String getJournalDirectory() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getJournalDirectory(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -349,6 +389,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public int getJournalFileSize() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getJournalFileSize(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -361,6 +404,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public int getJournalMinFiles() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getJournalMinFiles(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -373,6 +419,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public int getJournalCompactMinFiles() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getJournalCompactMinFiles(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -385,6 +434,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public int getJournalCompactPercentage() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getJournalCompactPercentage(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -397,6 +449,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public boolean isPersistenceEnabled() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isPersistenceEnabled(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -409,6 +464,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String getJournalType() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getJournalType(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -421,6 +479,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String getPagingDirectory() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getPagingDirectory(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -433,6 +494,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public int getScheduledThreadPoolMaxSize() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getScheduledThreadPoolMaxSize(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -445,6 +509,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public int getThreadPoolMaxSize() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getThreadPoolMaxSize(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -457,6 +524,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public long getSecurityInvalidationInterval() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getSecurityInvalidationInterval(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -469,6 +539,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public boolean isClustered() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isClustered(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -481,6 +554,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public boolean isCreateBindingsDir() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isCreateBindingsDir(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -493,6 +569,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public boolean isCreateJournalDir() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isCreateJournalDir(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -505,6 +584,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public boolean isJournalSyncNonTransactional() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isJournalSyncNonTransactional(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -517,6 +599,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public boolean isJournalSyncTransactional() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isJournalSyncTransactional(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -529,6 +614,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public boolean isSecurityEnabled() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isSecurityEnabled(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -541,6 +629,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public boolean isAsyncConnectionExecutionEnabled() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isAsyncConnectionExecutionEnabled(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -553,6 +644,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public int getDiskScanPeriod() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getDiskScanPeriod(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -565,6 +659,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public int getMaxDiskUsage() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getMaxDiskUsage(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -577,6 +674,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public long getGlobalMaxSize() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getGlobalMaxSize(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -589,6 +689,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public long getAddressMemoryUsage() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getAddressMemoryUsage(this.server);
+      }
       checkStarted();
       clearIO();
       try {
@@ -604,6 +707,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public int getAddressMemoryUsagePercentage() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getAddressMemoryUsagePercentage(this.server);
+      }
       long globalMaxSize = getGlobalMaxSize();
       // no max size set implies 0% used
       if (globalMaxSize <= 0) {
@@ -614,13 +720,15 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
       if (memoryUsed <= 0) {
          return 0;
       }
-
       double result = (100D * memoryUsed) / globalMaxSize;
       return (int) result;
    }
 
    @Override
    public boolean freezeReplication() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.freezeReplication(this.server);
+      }
       Activation activation = server.getActivation();
       if (activation instanceof SharedNothingLiveActivation) {
          SharedNothingLiveActivation liveActivation = (SharedNothingLiveActivation) activation;
@@ -690,6 +798,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String createAddress(String name, String routingTypes) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.createAddress(this.server, name, routingTypes);
+      }
       checkStarted();
 
       clearIO();
@@ -711,6 +822,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String updateAddress(String name, String routingTypes) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.updateAddress(this.server, name, routingTypes);
+      }
       checkStarted();
 
       clearIO();
@@ -742,6 +856,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public void deleteAddress(String name, boolean force) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.deleteAddress(this.server, name, force);
+      }
       checkStarted();
 
       clearIO();
@@ -766,6 +883,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
                            final String name,
                            final String filterStr,
                            final boolean durable) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.deployQueue(this.server, address, name, filterStr, durable);
+      }
       checkStarted();
 
       SimpleString filter = filterStr == null ? null : new SimpleString(filterStr);
@@ -862,6 +982,12 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
                              long autoDeleteDelay,
                              long autoDeleteMessageCount,
                              boolean autoCreateAddress) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.createQueue(this.server, address, routingType, name, filterStr, durable,
+                  maxConsumers, purgeOnNoConsumers, exclusive, groupBuckets, lastValue,
+                  lastValueKey, nonDestructive, consumersBeforeDispatch, delayBeforeDispatch, autoDelete,
+                  autoDeleteDelay, autoDeleteMessageCount, autoCreateAddress);
+      }
       checkStarted();
 
       clearIO();
@@ -923,6 +1049,10 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
                              Integer consumersBeforeDispatch,
                              Long delayBeforeDispatch,
                              String user) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.updateQueue(this.server, name, routingType, filter, maxConsumers, purgeOnNoConsumers,
+                  exclusive, groupRebalance, groupBuckets, nonDestructive, consumersBeforeDispatch, delayBeforeDispatch, user);
+      }
       checkStarted();
 
       clearIO();
@@ -945,6 +1075,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String[] getQueueNames(String routingType) {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getQueueNames(this.server, routingType);
+      }
       checkStarted();
 
       clearIO();
@@ -969,6 +1102,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String[] getClusterConnectionNames() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getClusterConnectionNames(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -987,6 +1123,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String getUptime() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getUptime(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -999,6 +1138,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public long getUptimeMillis() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getUptimeMillis(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -1011,6 +1153,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public boolean isReplicaSync() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isReplicaSync(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -1023,6 +1168,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String[] getAddressNames() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getAddressNames(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -1033,7 +1181,6 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
             AddressControl address = (AddressControl) addresses[i];
             names[i] = address.getAddress();
          }
-
          return names;
       } finally {
          blockOnIO();
@@ -1042,6 +1189,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public void destroyQueue(final String name, final boolean removeConsumers, final boolean autoDeleteAddress) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.destroyQueue(this.server, name, removeConsumers, autoDeleteAddress);
+      }
       checkStarted();
 
       clearIO();
@@ -1065,6 +1215,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String getAddressInfo(String address) throws ActiveMQAddressDoesNotExistException {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getAddressInfo(this.server, address);
+      }
       checkStarted();
 
       clearIO();
@@ -1082,6 +1235,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String listBindingsForAddress(String address) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listBindingsForAddress(this.server, address);
+      }
       checkStarted();
 
       clearIO();
@@ -1096,6 +1252,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String listAddresses(String separator) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listAddresses(this.server, separator);
+      }
       checkStarted();
 
       clearIO();
@@ -1126,6 +1285,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public int getConnectionCount() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getConnectionCount(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -1138,6 +1300,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public long getTotalConnectionCount() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getTotalConnectionCount(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -1150,6 +1315,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public long getTotalMessageCount() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getTotalMessageCount(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -1162,6 +1330,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public long getTotalMessagesAdded() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getTotalMessagesAdded(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -1174,6 +1345,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public long getTotalMessagesAcknowledged() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getTotalMessagesAcknowledged(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -1186,6 +1360,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public long getTotalConsumerCount() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getTotalConsumerCount(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -1198,6 +1375,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public void enableMessageCounters() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.enableMessageCounters(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -1210,6 +1390,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public void disableMessageCounters() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.disableMessageCounters(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -1222,6 +1405,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public void resetAllMessageCounters() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.resetAllMessageCounters(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -1234,6 +1420,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public void resetAllMessageCounterHistories() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.resetAllMessageCounterHistories(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -1246,6 +1435,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public boolean isMessageCounterEnabled() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isMessageCounterEnabled(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -1258,6 +1450,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public synchronized long getMessageCounterSamplePeriod() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getMessageCounterSamplePeriod(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -1270,7 +1465,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public synchronized void setMessageCounterSamplePeriod(final long newPeriod) {
-      checkStarted();
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.setMessageCounterSamplePeriod(this.server, newPeriod);
+      }
 
       checkStarted();
 
@@ -1293,6 +1490,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public int getMessageCounterMaxDayCount() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getMessageCounterMaxDayCount(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -1305,6 +1505,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public void setMessageCounterMaxDayCount(final int count) {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.setMessageCounterMaxDayCount(this.server, count);
+      }
       checkStarted();
 
       clearIO();
@@ -1320,6 +1523,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String[] listPreparedTransactions() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listPreparedTransactions(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -1354,6 +1560,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
    }
 
    public String listPreparedTransactionDetailsAsJSON(TransactionDetailFactory factory) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listPreparedTransactionDetailsAsJSON(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -1398,6 +1607,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
    }
 
    public String listPreparedTransactionDetailsAsHTML(TransactionDetailFactory factory) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listPreparedTransactionDetailsAsHTML(this.server, factory);
+      }
       checkStarted();
 
       clearIO();
@@ -1480,6 +1692,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String[] listHeuristicCommittedTransactions() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listHeuristicCommittedTransactions(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -1498,6 +1713,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String[] listHeuristicRolledBackTransactions() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listHeuristicRolledBackTransactions(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -1516,6 +1734,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public synchronized boolean commitPreparedTransaction(final String transactionAsBase64) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.commitPreparedTransaction(this.server, transactionAsBase64);
+      }
       checkStarted();
 
       clearIO();
@@ -1540,6 +1761,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public synchronized boolean rollbackPreparedTransaction(final String transactionAsBase64) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.rollbackPreparedTransaction(this.server, transactionAsBase64);
+      }
       checkStarted();
 
       clearIO();
@@ -1565,6 +1789,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String[] listRemoteAddresses() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listRemoteAddresses(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -1585,6 +1812,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String[] listRemoteAddresses(final String ipAddress) {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listRemoteAddresses(this.server, ipAddress);
+      }
       checkStarted();
 
       clearIO();
@@ -1606,6 +1836,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public boolean closeConnectionsForAddress(final String ipAddress) {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.closeConnectionsForAddress(this.server, ipAddress);
+      }
       checkStarted();
 
       clearIO();
@@ -1630,6 +1863,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public boolean closeConsumerConnectionsForAddress(final String address) {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.closeConsumerConnectionsForAddress(this.server, address);
+      }
       boolean closed = false;
       checkStarted();
 
@@ -1668,6 +1904,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public boolean closeConnectionsForUser(final String userName) {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.closeConnectionsForUser(this.server, userName);
+      }
       boolean closed = false;
       checkStarted();
 
@@ -1698,6 +1937,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public boolean closeConnectionWithID(final String ID) {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.closeConnectionWithID(this.server, ID);
+      }
       checkStarted();
 
       clearIO();
@@ -1717,6 +1959,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public boolean closeSessionWithID(final String connectionID, final String ID) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.closeSessionWithID(this.server, connectionID, ID);
+      }
       checkStarted();
 
       clearIO();
@@ -1737,6 +1982,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public boolean closeConsumerWithID(final String sessionID, final String ID) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.closeConsumerWithID(this.server, sessionID, ID);
+      }
       checkStarted();
 
       clearIO();
@@ -1762,6 +2010,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String[] listConnectionIDs() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listConnectionIDs(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -1780,6 +2031,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String[] listSessions(final String connectionID) {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listSessions(this.server, connectionID);
+      }
       checkStarted();
 
       clearIO();
@@ -1797,10 +2051,13 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
    }
 
    /* (non-Javadoc)
-   * @see org.apache.activemq.artemis.api.core.management.ActiveMQServerControl#listProducersInfoAsJSON()
-   */
+    * @see org.apache.activemq.artemis.api.core.management.ActiveMQServerControl#listProducersInfoAsJSON()
+    */
    @Override
    public String listProducersInfoAsJSON() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listProducersInfoAsJSON(this.server);
+      }
       JsonArrayBuilder producers = JsonLoader.createArrayBuilder();
 
       for (ServerSession session : server.getSessions()) {
@@ -1812,6 +2069,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String listConnections(String options, int page, int pageSize) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listConnections(this.server, options, page, pageSize);
+      }
       checkStarted();
       clearIO();
       try {
@@ -1827,6 +2087,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String listSessions(String options, int page, int pageSize) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listSessions(this.server, options, page, pageSize);
+      }
       checkStarted();
       clearIO();
       try {
@@ -1841,6 +2104,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String listConsumers(String options, int page, int pageSize) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listConsumers(this.server, options, page, pageSize);
+      }
       checkStarted();
       clearIO();
       try {
@@ -1859,6 +2125,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String listAddresses(String options, int page, int pageSize) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listAddresses(this.server, options, page, pageSize);
+      }
       checkStarted();
       clearIO();
       try {
@@ -1882,6 +2151,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String listQueues(String options, int page, int pageSize) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listQueues(this.server, options, page, pageSize);
+      }
       checkStarted();
 
       clearIO();
@@ -1904,6 +2176,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
    public String listProducers(@Parameter(name = "Options") String options,
                                @Parameter(name = "Page Number") int page,
                                @Parameter(name = "Page Size") int pageSize) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listProducers(this.server, options, page, pageSize);
+      }
       checkStarted();
       clearIO();
       try {
@@ -1922,6 +2197,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String listConnectionsAsJSON() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listConnectionsAsJSON(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -1943,6 +2221,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String listSessionsAsJSON(final String connectionID) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listSessionsAsJSON(this.server, connectionID);
+      }
       checkStarted();
 
       clearIO();
@@ -1961,6 +2242,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String listAllSessionsAsJSON() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listAllSessionsAsJSON(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -1997,6 +2281,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String listConsumersAsJSON(String connectionID) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listConsumersAsJSON(this.server, connectionID);
+      }
       checkStarted();
 
       clearIO();
@@ -2027,6 +2314,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String listAllConsumersAsJSON() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listAllConsumersAsJSON(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -2061,6 +2351,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public Object[] getConnectors() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getConnectors(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -2079,7 +2372,6 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
             ret[i++] = tc;
          }
-
          return ret;
       } finally {
          blockOnIO();
@@ -2088,6 +2380,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String getConnectorsAsJSON() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getConnectorsAsJSON(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -2141,6 +2436,11 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
                                    final String browseRoles,
                                    final String createAddressRoles,
                                    final String deleteAddressRoles) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.addSecuritySettings(this.server, addressMatch, sendRoles, consumeRoles, createDurableQueueRoles,
+                  deleteDurableQueueRoles, createNonDurableQueueRoles, deleteNonDurableQueueRoles, manageRoles,
+                  browseRoles, createAddressRoles, deleteAddressRoles);
+      }
       checkStarted();
 
       clearIO();
@@ -2159,6 +2459,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public void removeSecuritySettings(final String addressMatch) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.removeSecuritySettings(this.server, addressMatch);
+      }
       checkStarted();
 
       clearIO();
@@ -2172,7 +2475,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public Object[] getRoles(final String addressMatch) throws Exception {
-      checkStarted();
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getRoles(this.server, addressMatch);
+      }
 
       checkStarted();
 
@@ -2194,6 +2499,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String getRolesAsJSON(final String addressMatch) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getRolesAsJSON(this.server, addressMatch);
+      }
       checkStarted();
 
       clearIO();
@@ -2212,6 +2520,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String getAddressSettingsAsJSON(final String address) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getAddressSettingsAsJSON(this.server, address);
+      }
       checkStarted();
 
       AddressSettings addressSettings = server.getAddressSettingsRepository().getMatch(address);
@@ -2224,6 +2535,7 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
       if (addressSettings.getExpiryAddress() != null) {
          settings.add("expiryAddress", addressSettings.getExpiryAddress().toString());
       }
+
       return settings.add("expiryDelay", addressSettings.getExpiryDelay())
             .add("maxDeliveryAttempts", addressSettings.getMaxDeliveryAttempts())
             .add("pageCacheMaxSize", addressSettings.getPageCacheMaxSize())
@@ -2304,6 +2616,14 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
                                   final boolean autoDeleteQueues,
                                   final boolean autoCreateAddresses,
                                   final boolean autoDeleteAddresses) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.addAddressSettings(this.server, address, DLA, expiryAddress, expiryDelay, lastValueQueue, deliveryAttempts,
+                  maxSizeBytes, pageSizeBytes, pageMaxCacheSize, redeliveryDelay, redeliveryMultiplier,
+                  maxRedeliveryDelay, redistributionDelay, sendToDLAOnNoRoute, addressFullMessagePolicy,
+                  slowConsumerThreshold, slowConsumerCheckPeriod, slowConsumerPolicy, autoCreateJmsQueues,
+                  autoDeleteJmsQueues, autoCreateJmsTopics, autoDeleteJmsTopics, autoCreateQueues, autoDeleteQueues,
+                  autoCreateAddresses, autoDeleteAddresses);
+      }
       checkStarted();
 
       // JBPAPP-6334 requested this to be pageSizeBytes > maxSizeBytes
@@ -2360,10 +2680,14 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
       server.getAddressSettingsRepository().addMatch(address, addressSettings);
 
       storageManager.storeAddressSetting(new PersistedAddressSetting(new SimpleString(address), addressSettings));
+
    }
 
    @Override
    public void removeAddressSettings(final String addressMatch) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.removeAddressSettings(this.server, addressMatch);
+      }
       checkStarted();
 
       server.getAddressSettingsRepository().removeMatch(addressMatch);
@@ -2390,6 +2714,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String[] getDivertNames() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getDivertNames(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -2453,6 +2780,10 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
                             final String transformerClassName,
                             final Map<String, String> transformerProperties,
                             final String routingType) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.createDivert(this.server, name, routingName, address, forwardingAddress,
+                  exclusive, filterString, transformerClassName, transformerProperties, routingType);
+      }
       checkStarted();
 
       clearIO();
@@ -2467,6 +2798,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public void destroyDivert(final String name) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.destroyDivert(this.server, name);
+      }
       checkStarted();
 
       clearIO();
@@ -2479,6 +2813,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String[] getBridgeNames() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getBridgeNames(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -2597,6 +2934,13 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
                             final boolean ha,
                             final String user,
                             final String password) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.createBridge(this.server, name, queueName, forwardingAddress, filterString,
+                  transformerClassName, transformerProperties, retryInterval, retryIntervalMultiplier,
+                  initialConnectAttempts, reconnectAttempts, useDuplicateDetection, confirmationWindowSize,
+                  producerWindowSize, clientFailureCheckPeriod, staticConnectorsOrDiscoveryGroup,
+                  useDiscoveryGroup, ha, user, "****");
+      }
       checkStarted();
 
       clearIO();
@@ -2635,6 +2979,12 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
                             final boolean ha,
                             final String user,
                             final String password) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.createBridge(this.server, name, queueName, forwardingAddress, filterString,
+                  transformerClassName, retryInterval, retryIntervalMultiplier, initialConnectAttempts,
+                  reconnectAttempts, useDuplicateDetection, confirmationWindowSize, clientFailureCheckPeriod,
+                  staticConnectorsOrDiscoveryGroup, useDiscoveryGroup, ha, user, "****");
+      }
       checkStarted();
 
       clearIO();
@@ -2657,6 +3007,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public void destroyBridge(final String name) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.destroyBridge(this.server, name);
+      }
       checkStarted();
 
       clearIO();
@@ -2669,6 +3022,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public void createConnectorService(final String name, final String factoryClass, final Map<String, Object> parameters) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.createConnectorService(this.server, name, factoryClass, parameters);
+      }
       checkStarted();
 
       clearIO();
@@ -2684,6 +3040,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public void destroyConnectorService(final String name) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.destroyConnectorService(this.server, name);
+      }
       checkStarted();
 
       clearIO();
@@ -2697,6 +3056,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String[] getConnectorServices() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getConnectorServices(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -2710,6 +3072,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public void forceFailover() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.forceFailover(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -2741,6 +3106,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public void scaleDown(String connector) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.scaleDown(this.server, connector);
+      }
       checkStarted();
 
       clearIO();
@@ -2760,12 +3128,14 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
          server.fail(true);
       }
-
    }
 
 
    @Override
    public String listNetworkTopology() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listNetworkTopology(this.server);
+      }
       checkStarted();
 
       clearIO();
@@ -2805,6 +3175,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
    public void removeNotificationListener(final NotificationListener listener,
                                           final NotificationFilter filter,
                                           final Object handback) throws ListenerNotFoundException {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.removeNotificationListener(this.server, listener, filter, handback);
+      }
       clearIO();
       try {
          broadcaster.removeNotificationListener(listener, filter, handback);
@@ -2815,6 +3188,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public void removeNotificationListener(final NotificationListener listener) throws ListenerNotFoundException {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.removeNotificationListener(this.server, listener);
+      }
       clearIO();
       try {
          broadcaster.removeNotificationListener(listener);
@@ -2827,6 +3203,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
    public void addNotificationListener(final NotificationListener listener,
                                        final NotificationFilter filter,
                                        final Object handback) throws IllegalArgumentException {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.addNotificationListener(this.server, listener, filter, handback);
+      }
       clearIO();
       try {
          broadcaster.addNotificationListener(listener, filter, handback);
@@ -2837,6 +3216,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public MBeanNotificationInfo[] getNotificationInfo() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getNotificationInfo(this.server);
+      }
       CoreNotificationType[] values = CoreNotificationType.values();
       String[] names = new String[values.length];
       for (int i = 0; i < values.length; i++) {
@@ -2876,66 +3258,105 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public long getConnectionTTLOverride() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getConnectionTTLOverride(this.server);
+      }
       return configuration.getConnectionTTLOverride();
    }
 
    @Override
    public int getIDCacheSize() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getIDCacheSize(this.server);
+      }
       return configuration.getIDCacheSize();
    }
 
    @Override
    public String getLargeMessagesDirectory() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getLargeMessagesDirectory(this.server);
+      }
       return configuration.getLargeMessagesDirectory();
    }
 
    @Override
    public String getManagementAddress() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getManagementAddress(this.server);
+      }
       return configuration.getManagementAddress().toString();
    }
 
    @Override
    public String getNodeID() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getNodeID(this.server);
+      }
       return server.getNodeID().toString();
    }
 
    @Override
    public String getManagementNotificationAddress() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getManagementNotificationAddress(this.server);
+      }
       return configuration.getManagementNotificationAddress().toString();
    }
 
    @Override
    public long getMessageExpiryScanPeriod() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getMessageExpiryScanPeriod(this.server);
+      }
       return configuration.getMessageExpiryScanPeriod();
    }
 
    @Override
    public long getMessageExpiryThreadPriority() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getMessageExpiryThreadPriority(this.server);
+      }
       return configuration.getMessageExpiryThreadPriority();
    }
 
    @Override
    public long getTransactionTimeout() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getTransactionTimeout(this.server);
+      }
       return configuration.getTransactionTimeout();
    }
 
    @Override
    public long getTransactionTimeoutScanPeriod() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getTransactionTimeoutScanPeriod(this.server);
+      }
       return configuration.getTransactionTimeoutScanPeriod();
    }
 
    @Override
    public boolean isPersistDeliveryCountBeforeDelivery() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isPersistDeliveryCountBeforeDelivery(this.server);
+      }
       return configuration.isPersistDeliveryCountBeforeDelivery();
    }
 
    @Override
    public boolean isPersistIDCache() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isPersistIDCache(this.server);
+      }
       return configuration.isPersistIDCache();
    }
 
    @Override
    public boolean isWildcardRoutingEnabled() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isWildcardRoutingEnabled(this.server);
+      }
       return configuration.isWildcardRoutingEnabled();
    }
 
@@ -2984,6 +3405,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public void addUser(String username, String password, String roles, boolean plaintext) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.addUser(this.server, username, "****", roles, plaintext);
+      }
 
       tcclInvoke(ActiveMQServerControlImpl.class.getClassLoader(), () -> internalAddUser(username, password, roles, plaintext));
    }
@@ -3001,7 +3425,11 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String listUser(String username) throws Exception {
-      return (String)tcclCall(ActiveMQServerControlImpl.class.getClassLoader(), () -> internaListUser(username));
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listUser(this.server, username);
+      }
+
+      return (String) tcclCall(ActiveMQServerControlImpl.class.getClassLoader(), () -> internaListUser(username));
    }
    private String internaListUser(String username) throws Exception {
       PropertiesLoginModuleConfigurator config = getPropertiesLoginModuleConfigurator();
@@ -3022,6 +3450,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public void removeUser(String username) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.removeUser(this.server, username);
+      }
       tcclInvoke(ActiveMQServerControlImpl.class.getClassLoader(), () -> internalRemoveUser(username));
    }
    private void internalRemoveUser(String username) throws Exception {
@@ -3032,6 +3463,9 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public void resetUser(String username, String password, String roles) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.resetUser(this.server, username, "****", roles);
+      }
       tcclInvoke(ActiveMQServerControlImpl.class.getClassLoader(), () -> internalresetUser(username, password, roles));
    }
    private void internalresetUser(String username, String password, String roles) throws Exception {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/AddressControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/AddressControlImpl.java
@@ -43,6 +43,7 @@ import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.impl.AddressInfo;
 import org.apache.activemq.artemis.core.server.management.ManagementService;
 import org.apache.activemq.artemis.core.settings.HierarchicalRepository;
+import org.apache.activemq.artemis.logs.AuditLogger;
 import org.apache.activemq.artemis.utils.JsonLoader;
 
 public class AddressControlImpl extends AbstractControl implements AddressControl {
@@ -94,6 +95,9 @@ public class AddressControlImpl extends AbstractControl implements AddressContro
 
    @Override
    public String[] getRoutingTypes() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getRoutingTypes(this.addressInfo);
+      }
       EnumSet<RoutingType> routingTypes = addressInfo.getRoutingTypes();
       String[] result = new String[routingTypes.size()];
       int i = 0;
@@ -105,6 +109,10 @@ public class AddressControlImpl extends AbstractControl implements AddressContro
 
    @Override
    public String getRoutingTypesAsJSON() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getRoutingTypesAsJSON(this.addressInfo);
+      }
+
       clearIO();
       try {
          JsonArrayBuilder json = JsonLoader.createArrayBuilder();
@@ -121,6 +129,11 @@ public class AddressControlImpl extends AbstractControl implements AddressContro
 
    @Override
    public String[] getQueueNames() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getQueueNames(this.addressInfo);
+      }
+
+      String[] result;
       clearIO();
       try {
          Bindings bindings = server.getPostOffice().lookupBindingsForAddress(addressInfo.getName());
@@ -144,8 +157,12 @@ public class AddressControlImpl extends AbstractControl implements AddressContro
 
    @Override
    public String[] getBindingNames() throws Exception {
-      clearIO();
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getBindingNames(this.addressInfo);
+      }
       try {
+         clearIO();
+
          Bindings bindings = server.getPostOffice().lookupBindingsForAddress(addressInfo.getName());
          if (bindings != null) {
             String[] bindingNames = new String[bindings.getBindings().size()];
@@ -166,6 +183,9 @@ public class AddressControlImpl extends AbstractControl implements AddressContro
 
    @Override
    public Object[] getRoles() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getRoles(this.addressInfo);
+      }
       clearIO();
       try {
          Set<Role> roles = securityRepository.getMatch(addressInfo.getName().toString());
@@ -184,6 +204,9 @@ public class AddressControlImpl extends AbstractControl implements AddressContro
 
    @Override
    public String getRolesAsJSON() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getRolesAsJSON(this.addressInfo);
+      }
       clearIO();
       try {
          JsonArrayBuilder json = JsonLoader.createArrayBuilder();
@@ -200,6 +223,9 @@ public class AddressControlImpl extends AbstractControl implements AddressContro
 
    @Override
    public long getNumberOfBytesPerPage() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getNumberOfBytesPerPage(this.addressInfo);
+      }
       clearIO();
       try {
          final PagingStore pagingStore = getPagingStore();
@@ -218,6 +244,9 @@ public class AddressControlImpl extends AbstractControl implements AddressContro
 
    @Override
    public long getAddressSize() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getAddressSize(this.addressInfo);
+      }
       clearIO();
       try {
          final PagingStore pagingStore = getPagingStore();
@@ -232,6 +261,9 @@ public class AddressControlImpl extends AbstractControl implements AddressContro
 
    @Override
    public long getNumberOfMessages() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getNumberOfMessages(this.addressInfo);
+      }
       clearIO();
       long totalMsgs = 0;
       try {
@@ -253,6 +285,9 @@ public class AddressControlImpl extends AbstractControl implements AddressContro
 
    @Override
    public boolean isPaging() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isPaging(this.addressInfo);
+      }
       clearIO();
       try {
          final PagingStore pagingStore = getPagingStore();
@@ -267,6 +302,9 @@ public class AddressControlImpl extends AbstractControl implements AddressContro
 
    @Override
    public int getNumberOfPages() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getNumberOfPages(this.addressInfo);
+      }
       clearIO();
       try {
          final PagingStore pageStore = getPagingStore();
@@ -283,16 +321,25 @@ public class AddressControlImpl extends AbstractControl implements AddressContro
 
    @Override
    public long getMessageCount() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getMessageCount(this.addressInfo);
+      }
       return getMessageCount(DurabilityType.ALL);
    }
 
    @Override
    public long getRoutedMessageCount() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getRoutedMessageCount(this.addressInfo);
+      }
       return addressInfo.getRoutedMessageCount();
    }
 
    @Override
    public long getUnRoutedMessageCount() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getUnRoutedMessageCount(this.addressInfo);
+      }
       return addressInfo.getUnRoutedMessageCount();
    }
 
@@ -304,6 +351,9 @@ public class AddressControlImpl extends AbstractControl implements AddressContro
                              boolean durable,
                              final String user,
                              final String password) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.sendMessage(this, null, headers, type, body, durable, user, "****");
+      }
       try {
          return sendMessage(addressInfo.getName(), server, headers, type, body, durable, user, password);
       } catch (Exception e) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/BridgeControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/BridgeControlImpl.java
@@ -27,6 +27,7 @@ import org.apache.activemq.artemis.api.core.management.BridgeControl;
 import org.apache.activemq.artemis.core.config.BridgeConfiguration;
 import org.apache.activemq.artemis.core.persistence.StorageManager;
 import org.apache.activemq.artemis.core.server.cluster.Bridge;
+import org.apache.activemq.artemis.logs.AuditLogger;
 
 public class BridgeControlImpl extends AbstractControl implements BridgeControl {
 
@@ -54,6 +55,9 @@ public class BridgeControlImpl extends AbstractControl implements BridgeControl 
 
    @Override
    public String[] getStaticConnectors() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getStaticConnectors(this.bridge);
+      }
       clearIO();
       try {
          List<String> staticConnectors = configuration.getStaticConnectors();
@@ -65,6 +69,9 @@ public class BridgeControlImpl extends AbstractControl implements BridgeControl 
 
    @Override
    public String getForwardingAddress() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getForwardingAddress(this.bridge);
+      }
       clearIO();
       try {
          return configuration.getForwardingAddress();
@@ -75,6 +82,9 @@ public class BridgeControlImpl extends AbstractControl implements BridgeControl 
 
    @Override
    public String getQueueName() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getQueueName(this.bridge);
+      }
       clearIO();
       try {
          return configuration.getQueueName();
@@ -85,6 +95,9 @@ public class BridgeControlImpl extends AbstractControl implements BridgeControl 
 
    @Override
    public String getDiscoveryGroupName() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getDiscoveryGroupName(this.bridge);
+      }
       clearIO();
       try {
          return configuration.getDiscoveryGroupName();
@@ -95,6 +108,9 @@ public class BridgeControlImpl extends AbstractControl implements BridgeControl 
 
    @Override
    public String getFilterString() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getFilterString(this.bridge);
+      }
       clearIO();
       try {
          return configuration.getFilterString();
@@ -105,6 +121,9 @@ public class BridgeControlImpl extends AbstractControl implements BridgeControl 
 
    @Override
    public int getReconnectAttempts() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getReconnectAttempts(this.bridge);
+      }
       clearIO();
       try {
          return configuration.getReconnectAttempts();
@@ -115,6 +134,9 @@ public class BridgeControlImpl extends AbstractControl implements BridgeControl 
 
    @Override
    public String getName() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getName(this.bridge);
+      }
       clearIO();
       try {
          return configuration.getName();
@@ -125,6 +147,9 @@ public class BridgeControlImpl extends AbstractControl implements BridgeControl 
 
    @Override
    public long getRetryInterval() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getRetryInterval(this.bridge);
+      }
       clearIO();
       try {
          return configuration.getRetryInterval();
@@ -135,6 +160,9 @@ public class BridgeControlImpl extends AbstractControl implements BridgeControl 
 
    @Override
    public double getRetryIntervalMultiplier() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getRetryIntervalMultiplier(this.bridge);
+      }
       clearIO();
       try {
          return configuration.getRetryIntervalMultiplier();
@@ -145,6 +173,9 @@ public class BridgeControlImpl extends AbstractControl implements BridgeControl 
 
    @Override
    public String getTransformerClassName() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getTransformerClassName(this.bridge);
+      }
       clearIO();
       try {
          return configuration.getTransformerConfiguration() == null ? null : configuration.getTransformerConfiguration().getClassName();
@@ -155,11 +186,17 @@ public class BridgeControlImpl extends AbstractControl implements BridgeControl 
 
    @Override
    public String getTransformerPropertiesAsJSON() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getTransformerPropertiesAsJSON(this.bridge);
+      }
       return JsonUtil.toJsonObject(getTransformerProperties()).toString();
    }
 
    @Override
    public Map<String, String> getTransformerProperties() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getTransformerProperties(this.bridge);
+      }
       clearIO();
       try {
          return configuration.getTransformerConfiguration() == null ? null : configuration.getTransformerConfiguration().getProperties();
@@ -170,6 +207,9 @@ public class BridgeControlImpl extends AbstractControl implements BridgeControl 
 
    @Override
    public boolean isStarted() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isStartedBridge(this.bridge);
+      }
       clearIO();
       try {
          return bridge.isStarted();
@@ -180,6 +220,9 @@ public class BridgeControlImpl extends AbstractControl implements BridgeControl 
 
    @Override
    public boolean isUseDuplicateDetection() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isUseDuplicateDetection(this.bridge);
+      }
       clearIO();
       try {
          return configuration.isUseDuplicateDetection();
@@ -190,6 +233,9 @@ public class BridgeControlImpl extends AbstractControl implements BridgeControl 
 
    @Override
    public boolean isHA() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isHA(this.bridge);
+      }
       clearIO();
       try {
          return configuration.isHA();
@@ -200,6 +246,9 @@ public class BridgeControlImpl extends AbstractControl implements BridgeControl 
 
    @Override
    public void start() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.startBridge(this.bridge);
+      }
       clearIO();
       try {
          bridge.start();
@@ -210,6 +259,9 @@ public class BridgeControlImpl extends AbstractControl implements BridgeControl 
 
    @Override
    public void stop() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.stopBridge(this.bridge);
+      }
       clearIO();
       try {
          bridge.stop();
@@ -231,6 +283,9 @@ public class BridgeControlImpl extends AbstractControl implements BridgeControl 
 
    @Override
    public long getMessagesPendingAcknowledgement() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getMessagesPendingAcknowledgement(this.bridge);
+      }
       clearIO();
       try {
          return bridge.getMetrics().getMessagesPendingAcknowledgement();
@@ -241,6 +296,9 @@ public class BridgeControlImpl extends AbstractControl implements BridgeControl 
 
    @Override
    public long getMessagesAcknowledged() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getMessagesAcknowledged(this.bridge);
+      }
       clearIO();
       try {
          return bridge.getMetrics().getMessagesAcknowledged();
@@ -251,6 +309,9 @@ public class BridgeControlImpl extends AbstractControl implements BridgeControl 
 
    @Override
    public Map<String, Object> getMetrics() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getMetrics(this.bridge);
+      }
       clearIO();
       try {
          return bridge.getMetrics().convertToMap();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/BroadcastGroupControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/BroadcastGroupControlImpl.java
@@ -25,6 +25,7 @@ import org.apache.activemq.artemis.api.core.UDPBroadcastEndpointFactory;
 import org.apache.activemq.artemis.api.core.management.BroadcastGroupControl;
 import org.apache.activemq.artemis.core.persistence.StorageManager;
 import org.apache.activemq.artemis.core.server.cluster.BroadcastGroup;
+import org.apache.activemq.artemis.logs.AuditLogger;
 
 public class BroadcastGroupControlImpl extends AbstractControl implements BroadcastGroupControl {
 
@@ -52,6 +53,9 @@ public class BroadcastGroupControlImpl extends AbstractControl implements Broadc
 
    @Override
    public String getName() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getName(this.broadcastGroup);
+      }
       clearIO();
       try {
          return configuration.getName();
@@ -62,6 +66,9 @@ public class BroadcastGroupControlImpl extends AbstractControl implements Broadc
 
    @Override
    public long getBroadcastPeriod() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getBroadcastPeriod(this.broadcastGroup);
+      }
       clearIO();
       try {
          return configuration.getBroadcastPeriod();
@@ -72,6 +79,9 @@ public class BroadcastGroupControlImpl extends AbstractControl implements Broadc
 
    @Override
    public Object[] getConnectorPairs() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getConnectorPairs(this.broadcastGroup);
+      }
       clearIO();
       try {
          Object[] ret = new Object[configuration.getConnectorInfos().size()];
@@ -80,7 +90,6 @@ public class BroadcastGroupControlImpl extends AbstractControl implements Broadc
          for (String connector : configuration.getConnectorInfos()) {
             ret[i++] = connector;
          }
-
          return ret;
       } finally {
          blockOnIO();
@@ -89,6 +98,9 @@ public class BroadcastGroupControlImpl extends AbstractControl implements Broadc
 
    @Override
    public String getConnectorPairsAsJSON() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getConnectorPairsAsJSON(this.broadcastGroup);
+      }
       clearIO();
       try {
          return JsonUtil.toJsonArray(configuration.getConnectorInfos()).toString();
@@ -100,6 +112,9 @@ public class BroadcastGroupControlImpl extends AbstractControl implements Broadc
    //todo ghoward we should deal with this properly
    @Override
    public String getGroupAddress() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getGroupAddress(this.broadcastGroup);
+      }
       clearIO();
       try {
          if (configuration.getEndpointFactory() instanceof UDPBroadcastEndpointFactory) {
@@ -113,6 +128,9 @@ public class BroadcastGroupControlImpl extends AbstractControl implements Broadc
 
    @Override
    public int getGroupPort() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getGroupPort(this.broadcastGroup);
+      }
       clearIO();
       try {
          if (configuration.getEndpointFactory() instanceof UDPBroadcastEndpointFactory) {
@@ -126,6 +144,9 @@ public class BroadcastGroupControlImpl extends AbstractControl implements Broadc
 
    @Override
    public int getLocalBindPort() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getLocalBindPort(this.broadcastGroup);
+      }
       clearIO();
       try {
          if (configuration.getEndpointFactory() instanceof UDPBroadcastEndpointFactory) {
@@ -141,6 +162,9 @@ public class BroadcastGroupControlImpl extends AbstractControl implements Broadc
 
    @Override
    public boolean isStarted() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isStarted(this.broadcastGroup);
+      }
       clearIO();
       try {
          return broadcastGroup.isStarted();
@@ -151,6 +175,9 @@ public class BroadcastGroupControlImpl extends AbstractControl implements Broadc
 
    @Override
    public void start() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.startBroadcastGroup(this.broadcastGroup);
+      }
       clearIO();
       try {
          broadcastGroup.start();
@@ -161,6 +188,9 @@ public class BroadcastGroupControlImpl extends AbstractControl implements Broadc
 
    @Override
    public void stop() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.stopBroadcastGroup(this.broadcastGroup);
+      }
       clearIO();
       try {
          broadcastGroup.stop();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ClusterConnectionControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ClusterConnectionControlImpl.java
@@ -28,6 +28,7 @@ import org.apache.activemq.artemis.core.config.ClusterConnectionConfiguration;
 import org.apache.activemq.artemis.core.persistence.StorageManager;
 import org.apache.activemq.artemis.core.server.cluster.ClusterConnection;
 import org.apache.activemq.artemis.core.server.cluster.impl.BridgeMetrics;
+import org.apache.activemq.artemis.logs.AuditLogger;
 
 public class ClusterConnectionControlImpl extends AbstractControl implements ClusterConnectionControl {
 
@@ -55,6 +56,9 @@ public class ClusterConnectionControlImpl extends AbstractControl implements Clu
 
    @Override
    public String getAddress() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getAddress(this.clusterConnection);
+      }
       clearIO();
       try {
          return configuration.getAddress();
@@ -66,6 +70,9 @@ public class ClusterConnectionControlImpl extends AbstractControl implements Clu
 
    @Override
    public String getDiscoveryGroupName() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getDiscoveryGroupName(this.clusterConnection);
+      }
       clearIO();
       try {
          return configuration.getDiscoveryGroupName();
@@ -77,6 +84,9 @@ public class ClusterConnectionControlImpl extends AbstractControl implements Clu
 
    @Override
    public int getMaxHops() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getMaxHops(this.clusterConnection);
+      }
       clearIO();
       try {
          return configuration.getMaxHops();
@@ -88,6 +98,9 @@ public class ClusterConnectionControlImpl extends AbstractControl implements Clu
 
    @Override
    public String getName() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getName(this.clusterConnection);
+      }
       clearIO();
       try {
          return configuration.getName();
@@ -99,6 +112,9 @@ public class ClusterConnectionControlImpl extends AbstractControl implements Clu
 
    @Override
    public long getRetryInterval() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getRetryInterval(this.clusterConnection);
+      }
       clearIO();
       try {
          return configuration.getRetryInterval();
@@ -110,6 +126,9 @@ public class ClusterConnectionControlImpl extends AbstractControl implements Clu
 
    @Override
    public String getNodeID() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getNodeID(this.clusterConnection);
+      }
       clearIO();
       try {
          return clusterConnection.getNodeID();
@@ -120,6 +139,9 @@ public class ClusterConnectionControlImpl extends AbstractControl implements Clu
 
    @Override
    public String[] getStaticConnectors() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getStaticConnectors(this.clusterConnection);
+      }
       clearIO();
       try {
          List<String> staticConnectors = configuration.getStaticConnectors();
@@ -135,6 +157,9 @@ public class ClusterConnectionControlImpl extends AbstractControl implements Clu
 
    @Override
    public String getStaticConnectorsAsJSON() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getStaticConnectorsAsJSON(this.clusterConnection);
+      }
       clearIO();
       try {
          return JsonUtil.toJsonArray(configuration.getStaticConnectors()).toString();
@@ -145,6 +170,9 @@ public class ClusterConnectionControlImpl extends AbstractControl implements Clu
 
    @Override
    public boolean isDuplicateDetection() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isDuplicateDetection(this.clusterConnection);
+      }
       clearIO();
       try {
          return configuration.isDuplicateDetection();
@@ -155,6 +183,9 @@ public class ClusterConnectionControlImpl extends AbstractControl implements Clu
 
    @Override
    public String getMessageLoadBalancingType() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getMessageLoadBalancingType(this.clusterConnection);
+      }
       clearIO();
       try {
          return configuration.getMessageLoadBalancingType().getType();
@@ -165,6 +196,9 @@ public class ClusterConnectionControlImpl extends AbstractControl implements Clu
 
    @Override
    public String getTopology() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getTopology(this.clusterConnection);
+      }
       clearIO();
       try {
          return clusterConnection.getTopology().describe();
@@ -175,6 +209,9 @@ public class ClusterConnectionControlImpl extends AbstractControl implements Clu
 
    @Override
    public Map<String, String> getNodes() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getNodes(this.clusterConnection);
+      }
       clearIO();
       try {
          return clusterConnection.getNodes();
@@ -185,6 +222,9 @@ public class ClusterConnectionControlImpl extends AbstractControl implements Clu
 
    @Override
    public boolean isStarted() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isStarted(this.clusterConnection);
+      }
       clearIO();
       try {
          return clusterConnection.isStarted();
@@ -195,6 +235,9 @@ public class ClusterConnectionControlImpl extends AbstractControl implements Clu
 
    @Override
    public void start() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.startClusterConnection(this.clusterConnection);
+      }
       clearIO();
       try {
          clusterConnection.start();
@@ -206,6 +249,9 @@ public class ClusterConnectionControlImpl extends AbstractControl implements Clu
 
    @Override
    public void stop() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.stopClusterConnection(this.clusterConnection);
+      }
       clearIO();
       try {
          clusterConnection.stop();
@@ -227,6 +273,9 @@ public class ClusterConnectionControlImpl extends AbstractControl implements Clu
 
    @Override
    public long getMessagesPendingAcknowledgement() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getMessagesPendingAcknowledgement(this.clusterConnection);
+      }
       clearIO();
       try {
          return clusterConnection.getMetrics().getMessagesPendingAcknowledgement();
@@ -237,6 +286,9 @@ public class ClusterConnectionControlImpl extends AbstractControl implements Clu
 
    @Override
    public long getMessagesAcknowledged() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getMessagesAcknowledged(this.clusterConnection);
+      }
       clearIO();
       try {
          return clusterConnection.getMetrics().getMessagesAcknowledged();
@@ -247,6 +299,9 @@ public class ClusterConnectionControlImpl extends AbstractControl implements Clu
 
    @Override
    public Map<String, Object> getMetrics()  {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getMetrics(this.clusterConnection);
+      }
       clearIO();
       try {
          return clusterConnection.getMetrics().convertToMap();
@@ -257,6 +312,9 @@ public class ClusterConnectionControlImpl extends AbstractControl implements Clu
 
    @Override
    public Map<String, Object> getBridgeMetrics(String nodeId) {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getBridgeMetrics(this.clusterConnection, nodeId);
+      }
       clearIO();
       try {
          final BridgeMetrics bridgeMetrics = clusterConnection.getBridgeMetrics(nodeId);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/DivertControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/DivertControlImpl.java
@@ -26,6 +26,7 @@ import org.apache.activemq.artemis.api.core.management.DivertControl;
 import org.apache.activemq.artemis.core.config.DivertConfiguration;
 import org.apache.activemq.artemis.core.persistence.StorageManager;
 import org.apache.activemq.artemis.core.server.Divert;
+import org.apache.activemq.artemis.logs.AuditLogger;
 
 public class DivertControlImpl extends AbstractControl implements DivertControl {
 
@@ -53,6 +54,9 @@ public class DivertControlImpl extends AbstractControl implements DivertControl 
 
    @Override
    public String getAddress() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getAddress(this.divert);
+      }
       clearIO();
       try {
          return configuration.getAddress();
@@ -63,6 +67,9 @@ public class DivertControlImpl extends AbstractControl implements DivertControl 
 
    @Override
    public String getFilter() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getFilter(this.divert);
+      }
       clearIO();
       try {
          return configuration.getFilterString();
@@ -73,6 +80,9 @@ public class DivertControlImpl extends AbstractControl implements DivertControl 
 
    @Override
    public String getForwardingAddress() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getForwardingAddress(this.divert);
+      }
       clearIO();
       try {
          return configuration.getForwardingAddress();
@@ -83,6 +93,9 @@ public class DivertControlImpl extends AbstractControl implements DivertControl 
 
    @Override
    public String getRoutingName() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getRoutingName(this.divert);
+      }
       clearIO();
       try {
          return divert.getRoutingName().toString();
@@ -93,6 +106,9 @@ public class DivertControlImpl extends AbstractControl implements DivertControl 
 
    @Override
    public String getTransformerClassName() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getTransformerClassName(this.divert);
+      }
       clearIO();
       try {
          return configuration.getTransformerConfiguration() == null ? null : configuration.getTransformerConfiguration().getClassName();
@@ -103,11 +119,17 @@ public class DivertControlImpl extends AbstractControl implements DivertControl 
 
    @Override
    public String getTransformerPropertiesAsJSON() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getTransformerPropertiesAsJSON(this.divert);
+      }
       return JsonUtil.toJsonObject(getTransformerProperties()).toString();
    }
 
    @Override
    public Map<String, String> getTransformerProperties() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getTransformerProperties(this.divert);
+      }
       clearIO();
       try {
          return configuration.getTransformerConfiguration() == null ? null : configuration.getTransformerConfiguration().getProperties();
@@ -118,6 +140,9 @@ public class DivertControlImpl extends AbstractControl implements DivertControl 
 
    @Override
    public String getRoutingType() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getRoutingType(this.divert);
+      }
       clearIO();
       try {
          return configuration.getRoutingType().toString();
@@ -128,6 +153,9 @@ public class DivertControlImpl extends AbstractControl implements DivertControl 
 
    @Override
    public String getUniqueName() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getUniqueName(this.divert);
+      }
       clearIO();
       try {
          return divert.getUniqueName().toString();
@@ -138,6 +166,9 @@ public class DivertControlImpl extends AbstractControl implements DivertControl 
 
    @Override
    public boolean isExclusive() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isExclusive(this.divert);
+      }
       clearIO();
       try {
          return divert.isExclusive();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/QueueControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/QueueControlImpl.java
@@ -52,6 +52,7 @@ import org.apache.activemq.artemis.core.server.ServerConsumer;
 import org.apache.activemq.artemis.core.settings.HierarchicalRepository;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.selector.filter.Filterable;
+import org.apache.activemq.artemis.logs.AuditLogger;
 import org.apache.activemq.artemis.utils.JsonLoader;
 import org.apache.activemq.artemis.utils.collections.LinkedListIterator;
 
@@ -129,6 +130,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public String getName() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getName(queue);
+      }
       clearIO();
       try {
          return queue.getName().toString();
@@ -139,6 +143,10 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public String getAddress() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getAddress(queue);
+      }
+
       checkStarted();
 
       return address;
@@ -146,6 +154,10 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public String getFilter() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getFilter(queue);
+      }
+
       checkStarted();
 
       clearIO();
@@ -160,6 +172,10 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public boolean isDurable() {
+
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isDurable(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -172,6 +188,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public String getUser() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getUser(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -186,6 +205,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public String getRoutingType() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getRoutingType(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -199,6 +221,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public boolean isTemporary() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isTemporary(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -211,6 +236,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public long getMessageCount() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getMessageCount(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -223,6 +251,10 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public long getPersistentSize() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getPersistentSize(queue);
+      }
+
       checkStarted();
 
       clearIO();
@@ -235,6 +267,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public long getDurableMessageCount() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getDurableMessageCount(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -247,6 +282,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public long getDurablePersistentSize() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getDurablePersistSize(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -259,6 +297,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public int getConsumerCount() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getConsumerCount(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -271,6 +312,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public int getDeliveringCount() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getDeliveringCount(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -283,6 +327,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public long getDeliveringSize() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getDeliveringSize(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -295,6 +342,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public int getDurableDeliveringCount() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getDurableDeliveringCount(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -307,6 +357,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public long getDurableDeliveringSize() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getDurableDeliveringSize(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -319,6 +372,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public long getMessagesAdded() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getMessagesAdded(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -331,6 +387,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public long getMessagesAcknowledged() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getMessagesAcknowledged(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -343,6 +402,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public long getMessagesExpired() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getMessagesExpired(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -355,6 +417,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public long getMessagesKilled() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getMessagesKilled(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -367,6 +432,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public long getID() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getID(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -379,6 +447,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public long getScheduledCount() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getScheduledCount(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -391,6 +462,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public long getScheduledSize() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getScheduledSize(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -403,6 +477,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public long getDurableScheduledCount() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getDurableScheduledCount(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -415,6 +492,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public long getDurableScheduledSize() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getDurableScheduledSize(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -427,6 +507,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public String getDeadLetterAddress() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getDeadLetterAddress(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -444,6 +527,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public String getExpiryAddress() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getExpiryAddress(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -462,6 +548,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public int getMaxConsumers() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getMaxConsumers(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -474,6 +563,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public boolean isPurgeOnNoConsumers() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isPurgeOnNoConsumers(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -486,6 +578,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public boolean isConfigurationManaged() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isConfigurationManaged(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -498,6 +593,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public boolean isExclusive() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isExclusive(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -510,6 +608,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public boolean isLastValue() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isLastValue(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -522,6 +623,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public Map<String, Object>[] listScheduledMessages() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listScheduledMessages(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -535,6 +639,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public String listScheduledMessagesAsJSON() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listScheduledMessagesAsJSON(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -561,6 +668,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public Map<String, Map<String, Object>[]> listDeliveringMessages() throws ActiveMQException {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listDeliveringMessages(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -572,15 +682,18 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
          for (Map.Entry<String, List<MessageReference>> entry : msgs.entrySet()) {
             msgRet.put(entry.getKey(), convertMessagesToMaps(entry.getValue()));
          }
+
          return msgRet;
       } finally {
          blockOnIO();
       }
-
    }
 
    @Override
    public String listDeliveringMessagesAsJSON() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listDeliveringMessagesAsJSON(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -593,6 +706,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public Map<String, Object>[] listMessages(final String filterStr) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listMessages(queue, filterStr);
+      }
       checkStarted();
 
       clearIO();
@@ -623,6 +739,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public String listMessagesAsJSON(final String filter) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listMessagesAsJSON(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -634,6 +753,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
    }
 
    protected Map<String, Object>[] getFirstMessage() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getFirstMessage(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -657,11 +779,18 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public String getFirstMessageAsJSON() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getFirstMessageAsJSON(queue);
+      }
       return toJSON(getFirstMessage());
    }
 
    @Override
    public Long getFirstMessageTimestamp() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getFirstMessageTimestamp(queue);
+      }
+
       Map<String, Object>[] _message = getFirstMessage();
       if (_message == null || _message.length == 0 || _message[0] == null) {
          return null;
@@ -675,6 +804,10 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public Long getFirstMessageAge() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getFirstMessageAge(queue);
+      }
+
       Long firstMessageTimestamp = getFirstMessageTimestamp();
       if (firstMessageTimestamp == null) {
          return null;
@@ -690,12 +823,20 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public long countMessages(final String filterStr) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.countMessages(queue, filterStr);
+      }
+
       Long value = intenalCountMessages(filterStr, null).get(null);
       return value == null ? 0 : value;
    }
 
    @Override
    public String countMessages(final String filterStr, final String groupByProperty) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.countMessages(queue, filterStr, groupByProperty);
+      }
+
       return JsonUtil.toJsonObject(intenalCountMessages(filterStr, groupByProperty)).toString();
    }
 
@@ -730,12 +871,20 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public long countDeliveringMessages(final String filterStr) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.countDeliveringMessages(queue, filterStr);
+      }
+
       Long value = intenalCountDeliveryMessages(filterStr, null).get(null);
       return value == null ? 0 : value;
    }
 
    @Override
    public String countDeliveringMessages(final String filterStr, final String groupByProperty) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.countDeliveringMessages(queue, filterStr, groupByProperty);
+      }
+
       return JsonUtil.toJsonObject(intenalCountDeliveryMessages(filterStr, groupByProperty)).toString();
    }
 
@@ -778,6 +927,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public boolean removeMessage(final long messageID) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.removeMessage(queue, messageID);
+      }
       checkStarted();
 
       clearIO();
@@ -797,6 +949,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public int removeMessages(final int flushLimit, final String filterStr) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.removeMessages(queue, flushLimit, filterStr);
+      }
       checkStarted();
 
       clearIO();
@@ -816,6 +971,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public boolean expireMessage(final long messageID) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.expireMessage(queue, messageID);
+      }
       checkStarted();
 
       clearIO();
@@ -828,6 +986,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public int expireMessages(final String filterStr) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.expireMessages(queue, filterStr);
+      }
       checkStarted();
 
       clearIO();
@@ -843,6 +1004,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public boolean retryMessage(final long messageID) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.retryMessage(queue, messageID);
+      }
 
       checkStarted();
       clearIO();
@@ -878,6 +1042,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public int retryMessages() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.retryMessages(queue);
+      }
       checkStarted();
       clearIO();
 
@@ -897,6 +1064,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
    public boolean moveMessage(final long messageID,
                               final String otherQueueName,
                               final boolean rejectDuplicates) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.moveMessage(queue, messageID, otherQueueName, rejectDuplicates);
+      }
       checkStarted();
 
       clearIO();
@@ -924,6 +1094,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
                            final String filterStr,
                            final String otherQueueName,
                            final boolean rejectDuplicates) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.moveMessages(queue, flushLimit, filterStr, otherQueueName, rejectDuplicates);
+      }
       checkStarted();
 
       clearIO();
@@ -937,7 +1110,6 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
          }
 
          int retValue = queue.moveReferences(flushLimit, filter, binding.getAddress(), rejectDuplicates, binding);
-
          return retValue;
       } finally {
          blockOnIO();
@@ -954,6 +1126,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public int sendMessagesToDeadLetterAddress(final String filterStr) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.sendMessagesToDeadLetterAddress(queue, filterStr);
+      }
       checkStarted();
 
       clearIO();
@@ -973,6 +1148,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
                              boolean durable,
                              final String user,
                              final String password) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.sendMessage(queue, null, headers, type, body, durable, user, "****");
+      }
       try {
          return sendMessage(queue.getAddress(), server, headers, type, body, durable, user, password, queue.getID());
       } catch (Exception e) {
@@ -982,6 +1160,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public boolean sendMessageToDeadLetterAddress(final long messageID) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.sendMessageToDeadLetterAddress(queue, messageID);
+      }
       checkStarted();
 
       clearIO();
@@ -994,6 +1175,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public int changeMessagesPriority(final String filterStr, final int newPriority) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.changeMessagesPriority(queue, filterStr, newPriority);
+      }
       checkStarted();
 
       clearIO();
@@ -1011,6 +1195,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public boolean changeMessagePriority(final long messageID, final int newPriority) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.changeMessagePriority(queue, messageID, newPriority);
+      }
       checkStarted();
 
       clearIO();
@@ -1026,6 +1213,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public String listMessageCounter() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listMessageCounter(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -1040,6 +1230,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public void resetMessageCounter() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.resetMessageCounter(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -1052,6 +1245,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public String listMessageCounterAsHTML() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listMessageCounterAsHTML(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -1064,6 +1260,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public String listMessageCounterHistory() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listMessageCounterHistory(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -1076,6 +1275,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public String listMessageCounterHistoryAsHTML() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listMessageCounterHistoryAsHTML(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -1088,6 +1290,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public void pause() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.pause(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -1101,6 +1306,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public void pause(boolean persist) {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.pause(queue, persist);
+      }
       checkStarted();
 
       clearIO();
@@ -1112,6 +1320,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
    }
    @Override
    public void resume() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.resume(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -1124,6 +1335,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public boolean isPaused() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.isPaused(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -1136,6 +1350,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public CompositeData[] browse(int page, int pageSize) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.browse(queue, page, pageSize);
+      }
       String filter = null;
       checkStarted();
 
@@ -1181,6 +1398,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
    }
    @Override
    public CompositeData[] browse(String filter) throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.browse(queue, filter);
+      }
       checkStarted();
 
       clearIO();
@@ -1216,6 +1436,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public void flushExecutor() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.flushExecutor(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -1228,6 +1451,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public void resetAllGroups() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.resetAllGroups(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -1240,6 +1466,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public void resetGroup(String groupID) {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.resetGroup(queue, groupID);
+      }
       checkStarted();
 
       clearIO();
@@ -1252,6 +1481,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public int getGroupCount() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getGroupCount(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -1264,6 +1496,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public String listGroupsAsJSON() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listGroupsAsJSON(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -1292,6 +1527,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public String listConsumersAsJSON() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.listConsumersAsJSON(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -1330,6 +1568,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public void resetMessagesAdded() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.resetMessagesAdded(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -1343,6 +1584,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public void resetMessagesAcknowledged() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.resetMessagesAcknowledged(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -1356,6 +1600,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public void resetMessagesExpired() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.resetMessagesExpired(queue);
+      }
       checkStarted();
 
       clearIO();
@@ -1369,6 +1616,9 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
    @Override
    public void resetMessagesKilled() throws Exception {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.resetMessagesKilled(queue);
+      }
       checkStarted();
 
       clearIO();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/security/impl/SecurityStoreImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/security/impl/SecurityStoreImpl.java
@@ -35,6 +35,7 @@ import org.apache.activemq.artemis.core.server.management.Notification;
 import org.apache.activemq.artemis.core.server.management.NotificationService;
 import org.apache.activemq.artemis.core.settings.HierarchicalRepository;
 import org.apache.activemq.artemis.core.settings.HierarchicalRepositoryChangeListener;
+import org.apache.activemq.artemis.logs.AuditLogger;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
 import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager;
 import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager2;
@@ -227,11 +228,14 @@ public class SecurityStoreImpl implements SecurityStore, HierarchicalRepositoryC
                notificationService.sendNotification(notification);
             }
 
+            Exception ex;
             if (queue == null) {
-               throw ActiveMQMessageBundle.BUNDLE.userNoPermissions(session.getUsername(), checkType, saddress);
+               ex = ActiveMQMessageBundle.BUNDLE.userNoPermissions(session.getUsername(), checkType, saddress);
             } else {
-               throw ActiveMQMessageBundle.BUNDLE.userNoPermissionsQueue(session.getUsername(), checkType, queue.toString(), saddress);
+               ex = ActiveMQMessageBundle.BUNDLE.userNoPermissionsQueue(session.getUsername(), checkType, queue.toString(), saddress);
             }
+            AuditLogger.securityFailure(ex);
+            throw ex;
          }
          // if we get here we're granted, add to the cache
          ConcurrentHashSet<SimpleString> set = new ConcurrentHashSet<>();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -177,6 +177,7 @@ import org.apache.activemq.artemis.core.settings.impl.ResourceLimitSettings;
 import org.apache.activemq.artemis.core.transaction.ResourceManager;
 import org.apache.activemq.artemis.core.transaction.impl.ResourceManagerImpl;
 import org.apache.activemq.artemis.core.version.Version;
+import org.apache.activemq.artemis.logs.AuditLogger;
 import org.apache.activemq.artemis.spi.core.protocol.ProtocolManagerFactory;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
 import org.apache.activemq.artemis.spi.core.protocol.SessionCallback;
@@ -1448,6 +1449,11 @@ public class ActiveMQServerImpl implements ActiveMQServer {
                                       final boolean autoCreateQueues,
                                       final OperationContext context,
                                       final Map<SimpleString, RoutingType> prefixes) throws Exception {
+
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.createCoreSession(this, name, username, "****", minLargeMessageSize, connection, autoCommitSends,
+                  autoCommitAcks, preAcknowledge, xa, defaultAddress, callback, autoCreateQueues, context, prefixes);
+      }
       String validatedUser = "";
 
       if (securityStore != null) {

--- a/docs/user-manual/en/logging.md
+++ b/docs/user-manual/en/logging.md
@@ -5,7 +5,7 @@ configurable via the `logging.properties` file found in the
 configuration directories. This is configured by Default to log to both
 the console and to a file.
 
-There are 6 loggers available which are as follows:
+There are 8 loggers available which are as follows:
 
 Logger | Description
 ---|---
@@ -15,6 +15,8 @@ org.apache.activemq.artemis.utils|Logs utility calls
 org.apache.activemq.artemis.journal|Logs Journal calls
 org.apache.activemq.artemis.jms|Logs JMS calls
 org.apache.activemq.artemis.integration.bootstrap|Logs bootstrap calls
+org.apache.activemq.audit.base|audit log. Disabled by default
+org.apache.activemq.audit.message|message audit log. Disabled by default
 
 
 ## Logging in a client or with an Embedded server
@@ -85,3 +87,42 @@ formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.PATTERN.properties=pattern
 formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] %s%E%n
 ```
+
+## Configuring Audit Log
+
+The 2 audit loggers can be enabled to record some important operations like
+create/delete queues. By default this logger is disabled. The configuration
+(logging.properties) for audit log is like this by default:
+
+```$xslt
+logger.org.apache.activemq.audit.base.level=ERROR
+logger.org.apache.activemq.audit.base.handlers=AUDIT_FILE
+logger.org.apache.activemq.audit.base.useParentHandlers=false
+
+logger.org.apache.activemq.audit.message.level=ERROR
+logger.org.apache.activemq.audit.message.handlers=AUDIT_FILE
+logger.org.apache.activemq.audit.message.useParentHandlers=false
+...
+```
+
+To enable the audit log change the above level to INFO, like this:
+```$xslt
+logger.org.apache.activemq.audit.base.level=INFO
+logger.org.apache.activemq.audit.base.handlers=AUDIT_FILE
+logger.org.apache.activemq.audit.base.useParentHandlers=false
+
+logger.org.apache.activemq.audit.message.level=INFO
+logger.org.apache.activemq.audit.message.handlers=AUDIT_FILE
+logger.org.apache.activemq.audit.message.useParentHandlers=false
+...
+```
+
+The 2 audit loggers can be disable/enable separately. The second logger
+(org.apache.activemq.audit.message) audits messages in 'hot path'
+(code path that is very sensitive to performance, e.g. sending messages).
+Turn on this audit logger may affect the performance.
+
+Once enabled, all audit records are written into a separate log
+file (by default audit.log).
+
+

--- a/tests/config/logging.properties
+++ b/tests/config/logging.properties
@@ -17,7 +17,7 @@
 
 # Additional logger names to configure (root logger is always configured)
 # Root logger option
-loggers=org.jboss.logging,org.apache.activemq.artemis.core.server,org.apache.activemq.artemis.utils,org.apache.activemq.artemis.journal,org.apache.activemq.artemis.jms,org.apache.activemq.artemis.ra,org.apache.activemq.artemis.tests.unit,org.apache.activemq.artemis.tests.integration,org.apache.activemq.artemis.jms.tests
+loggers=org.jboss.logging,org.apache.activemq.artemis.core.server,org.apache.activemq.artemis.utils,org.apache.activemq.artemis.journal,org.apache.activemq.artemis.jms,org.apache.activemq.artemis.ra,org.apache.activemq.artemis.tests.unit,org.apache.activemq.artemis.tests.integration,org.apache.activemq.artemis.jms.tests,org.apache.activemq.audit
 
 # Root logger level
 logger.level=INFO
@@ -34,6 +34,11 @@ logger.org.apache.activemq.artemis.jms.tests.level=INFO
 # Root logger handlers
 logger.handlers=CONSOLE,TEST
 #logger.handlers=CONSOLE,FILE
+
+# to enable audit change the level to INFO
+logger.org.apache.activemq.audit.level=ERROR
+logger.org.apache.activemq.audit.handlers=AUDIT_FILE
+logger.org.apache.activemq.audit.useParentHandlers=false
 
 # Console handler configuration
 handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
@@ -59,3 +64,17 @@ handler.TEST.formatter=PATTERN
 formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.PATTERN.properties=pattern
 formatter.PATTERN.pattern=[%t] %d{HH:mm:ss,SSS} %-5p [%c] %s%E%n
+
+#Audit logger
+handler.AUDIT_FILE=org.jboss.logmanager.handlers.PeriodicRotatingFileHandler
+handler.AUDIT_FILE.level=INFO
+handler.AUDIT_FILE.properties=suffix,append,autoFlush,fileName
+handler.AUDIT_FILE.suffix=.yyyy-MM-dd
+handler.AUDIT_FILE.append=true
+handler.AUDIT_FILE.autoFlush=true
+handler.AUDIT_FILE.fileName=target/audit.log
+handler.AUDIT_FILE.formatter=AUDIT_PATTERN
+
+formatter.AUDIT_PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+formatter.AUDIT_PATTERN.properties=pattern
+formatter.AUDIT_PATTERN.pattern=%d [AUDIT](%t) %s%E%n

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/AuditLoggerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/AuditLoggerTest.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.management;
+
+import org.apache.activemq.artemis.api.core.Message;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.apache.activemq.artemis.api.core.client.ClientSession;
+import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
+import org.apache.activemq.artemis.api.core.client.ServerLocator;
+import org.apache.activemq.artemis.api.core.management.AddressControl;
+import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.config.impl.SecurityConfiguration;
+import org.apache.activemq.artemis.core.security.Role;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.ActiveMQServers;
+import org.apache.activemq.artemis.spi.core.security.ActiveMQJAASSecurityManager;
+import org.apache.activemq.artemis.spi.core.security.jaas.InVMLoginModule;
+import org.apache.activemq.artemis.tests.util.Wait;
+import org.apache.activemq.artemis.utils.Base64;
+import org.apache.activemq.artemis.utils.RandomUtil;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.util.HashSet;
+import java.util.UUID;
+import java.util.logging.LogManager;
+
+public class AuditLoggerTest extends ManagementTestBase {
+
+   private static final File auditLog = new File("target/audit.log");
+
+   private ActiveMQServer server;
+   private Configuration conf;
+   protected ClientSession session;
+   private ServerLocator locator;
+   private ClientSessionFactory sf;
+
+   @Override
+   @Before
+   public void setUp() throws Exception {
+      super.setUp();
+      emptyLogFile();
+
+      TransportConfiguration connectorConfig = new TransportConfiguration(INVM_CONNECTOR_FACTORY);
+
+      conf = createDefaultNettyConfig().setJMXManagementEnabled(true).addConnectorConfiguration(connectorConfig.getName(), connectorConfig);
+      conf.setSecurityEnabled(true);
+      SecurityConfiguration securityConfiguration = new SecurityConfiguration();
+      securityConfiguration.addUser("guest", "guest");
+      securityConfiguration.addUser("myUser", "myPass");
+      securityConfiguration.addRole("guest", "guest");
+      securityConfiguration.addRole("myUser", "guest");
+      securityConfiguration.setDefaultUser("guest");
+      ActiveMQJAASSecurityManager securityManager = new ActiveMQJAASSecurityManager(InVMLoginModule.class.getName(), securityConfiguration);
+      server = addServer(ActiveMQServers.newActiveMQServer(conf, mbeanServer, securityManager, true));
+      server.start();
+
+      HashSet<Role> role = new HashSet<>();
+      //role guest cannot delete queues
+      role.add(new Role("guest", true, true, true, false, true, false, true, true, true, true));
+      server.getSecurityRepository().addMatch("#", role);
+
+      locator = createInVMNonHALocator().setBlockOnNonDurableSend(true);
+      sf = createSessionFactory(locator);
+      session = sf.createSession("guest", "guest", false, true, false, false, 100);
+      session.start();
+      addClientSession(session);
+   }
+
+   @After
+   @Override
+   public void tearDown() throws Exception {
+      super.tearDown();
+   }
+
+   private void emptyLogFile() throws Exception {
+      if (auditLog.exists()) {
+         try (PrintWriter writer = new PrintWriter(new FileWriter(auditLog))) {
+            writer.print("");
+         }
+      }
+   }
+
+   @Test
+   public void testAuditLog() throws Exception {
+      reloadLoggingConfig("audit.logging.properties");
+      SimpleString address = RandomUtil.randomSimpleString();
+      session.createAddress(address, RoutingType.ANYCAST, false);
+
+      final AddressControl addressControl = ManagementControlHelper.createAddressControl(address, mbeanServer);
+
+      Assert.assertEquals(0, addressControl.getQueueNames().length);
+      session.createQueue(address, RoutingType.ANYCAST, address);
+      Assert.assertEquals(1, addressControl.getQueueNames().length);
+      String uniqueStr = Base64.encodeBytes(UUID.randomUUID().toString().getBytes());
+      addressControl.sendMessage(null, Message.BYTES_TYPE, uniqueStr, false, null, null);
+
+      Wait.waitFor(() -> addressControl.getMessageCount() == 1);
+      Assert.assertEquals(1, addressControl.getMessageCount());
+
+      checkAuditLogRecord(true, "sending a message", uniqueStr);
+
+      //failure log
+      address = RandomUtil.randomSimpleString();
+      session.createAddress(address, RoutingType.ANYCAST, false);
+
+      final AddressControl addressControl2 = ManagementControlHelper.createAddressControl(address, mbeanServer);
+
+      Assert.assertEquals(1, addressControl.getQueueNames().length);
+
+      session.createQueue(address, RoutingType.ANYCAST, address);
+      Wait.waitFor(() -> addressControl2.getQueueNames().length == 1);
+
+      try {
+         session.deleteQueue(address);
+         fail("Deleting queue should get exception");
+      } catch (Exception e) {
+         //ignore
+      }
+
+      checkAuditLogRecord(true, "gets security check failure:", "guest does not have permission='DELETE_NON_DURABLE_QUEUE'");
+      //hot patch not in log
+      checkAuditLogRecord(false, "is sending a core message");
+   }
+
+   private void reloadLoggingConfig(String logFile) {
+      ClassLoader cl = AuditLoggerTest.class.getClassLoader();
+      InputStream inputStream = cl.getResourceAsStream(logFile);
+      LogManager logManager = LogManager.getLogManager();
+      try {
+         logManager.readConfiguration(inputStream);
+      } catch (IOException e) {
+         System.out.println("error loading logging conifg");
+         e.printStackTrace();
+      }
+   }
+
+   @Test
+   public void testAuditHotLog() throws Exception {
+      reloadLoggingConfig("audit.logging.hot.properties");
+      SimpleString address = RandomUtil.randomSimpleString();
+      session.createAddress(address, RoutingType.ANYCAST, false);
+
+      final AddressControl addressControl = ManagementControlHelper.createAddressControl(address, mbeanServer);
+
+      Assert.assertEquals(0, addressControl.getQueueNames().length);
+      session.createQueue(address, RoutingType.ANYCAST, address);
+      Assert.assertEquals(1, addressControl.getQueueNames().length);
+      String uniqueStr = Base64.encodeBytes(UUID.randomUUID().toString().getBytes());
+      addressControl.sendMessage(null, Message.BYTES_TYPE, uniqueStr, false, null, null);
+
+      Wait.waitFor(() -> addressControl.getMessageCount() == 1);
+      Assert.assertEquals(1, addressControl.getMessageCount());
+
+      checkAuditLogRecord(true, "sending a core message");
+   }
+
+   //check the audit log has a line that contains all the values
+   private void checkAuditLogRecord(boolean exist, String... values) throws Exception {
+      assertTrue(auditLog.exists());
+      boolean hasRecord = false;
+      try (BufferedReader reader = new BufferedReader(new FileReader(auditLog))) {
+         String line = reader.readLine();
+         while (line != null) {
+            if (line.contains(values[0])) {
+               boolean hasAll = true;
+               for (int i = 1; i < values.length; i++) {
+                  if (!line.contains(values[i])) {
+                     hasAll = false;
+                     break;
+                  }
+               }
+               if (hasAll) {
+                  hasRecord = true;
+                  System.out.println("audit has it: " + line);
+                  break;
+               }
+            }
+            line = reader.readLine();
+         }
+         if (exist) {
+            assertTrue(hasRecord);
+         } else {
+            assertFalse(hasRecord);
+         }
+      }
+   }
+}

--- a/tests/integration-tests/src/test/resources/audit.logging.hot.properties
+++ b/tests/integration-tests/src/test/resources/audit.logging.hot.properties
@@ -31,12 +31,11 @@ logger.org.eclipse.jetty.level=WARN
 # Root logger handlers
 logger.handlers=FILE,CONSOLE
 
-# to enable audit change the level to INFO
-logger.org.apache.activemq.audit.base.level=ERROR
+logger.org.apache.activemq.audit.base.level=INFO
 logger.org.apache.activemq.audit.base.handlers=AUDIT_FILE
 logger.org.apache.activemq.audit.base.useParentHandlers=false
 
-logger.org.apache.activemq.audit.message.level=ERROR
+logger.org.apache.activemq.audit.message.level=INFO
 logger.org.apache.activemq.audit.message.handlers=AUDIT_FILE
 logger.org.apache.activemq.audit.message.useParentHandlers=false
 
@@ -54,7 +53,7 @@ handler.FILE.properties=suffix,append,autoFlush,fileName
 handler.FILE.suffix=.yyyy-MM-dd
 handler.FILE.append=true
 handler.FILE.autoFlush=true
-handler.FILE.fileName=${artemis.instance}/log/artemis.log
+handler.FILE.fileName=target/artemis.log
 handler.FILE.formatter=PATTERN
 
 # Formatter pattern configuration
@@ -63,13 +62,13 @@ formatter.PATTERN.properties=pattern
 formatter.PATTERN.pattern=%d %-5p [%c] %s%E%n
 
 #Audit logger
+handler.AUDIT_FILE.level=DEBUG
 handler.AUDIT_FILE=org.jboss.logmanager.handlers.PeriodicRotatingFileHandler
-handler.AUDIT_FILE.level=INFO
 handler.AUDIT_FILE.properties=suffix,append,autoFlush,fileName
 handler.AUDIT_FILE.suffix=.yyyy-MM-dd
 handler.AUDIT_FILE.append=true
 handler.AUDIT_FILE.autoFlush=true
-handler.AUDIT_FILE.fileName=${artemis.instance}/log/audit.log
+handler.AUDIT_FILE.fileName=target/audit.log
 handler.AUDIT_FILE.formatter=AUDIT_PATTERN
 
 formatter.AUDIT_PATTERN=org.jboss.logmanager.formatters.PatternFormatter

--- a/tests/integration-tests/src/test/resources/audit.logging.properties
+++ b/tests/integration-tests/src/test/resources/audit.logging.properties
@@ -31,8 +31,7 @@ logger.org.eclipse.jetty.level=WARN
 # Root logger handlers
 logger.handlers=FILE,CONSOLE
 
-# to enable audit change the level to INFO
-logger.org.apache.activemq.audit.base.level=ERROR
+logger.org.apache.activemq.audit.base.level=INFO
 logger.org.apache.activemq.audit.base.handlers=AUDIT_FILE
 logger.org.apache.activemq.audit.base.useParentHandlers=false
 
@@ -54,7 +53,7 @@ handler.FILE.properties=suffix,append,autoFlush,fileName
 handler.FILE.suffix=.yyyy-MM-dd
 handler.FILE.append=true
 handler.FILE.autoFlush=true
-handler.FILE.fileName=${artemis.instance}/log/artemis.log
+handler.FILE.fileName=target/artemis.log
 handler.FILE.formatter=PATTERN
 
 # Formatter pattern configuration
@@ -63,13 +62,13 @@ formatter.PATTERN.properties=pattern
 formatter.PATTERN.pattern=%d %-5p [%c] %s%E%n
 
 #Audit logger
-handler.AUDIT_FILE=org.jboss.logmanager.handlers.PeriodicRotatingFileHandler
 handler.AUDIT_FILE.level=INFO
+handler.AUDIT_FILE=org.jboss.logmanager.handlers.PeriodicRotatingFileHandler
 handler.AUDIT_FILE.properties=suffix,append,autoFlush,fileName
 handler.AUDIT_FILE.suffix=.yyyy-MM-dd
 handler.AUDIT_FILE.append=true
 handler.AUDIT_FILE.autoFlush=true
-handler.AUDIT_FILE.fileName=${artemis.instance}/log/audit.log
+handler.AUDIT_FILE.fileName=target/audit.log
 handler.AUDIT_FILE.formatter=AUDIT_PATTERN
 
 formatter.AUDIT_PATTERN=org.jboss.logmanager.formatters.PatternFormatter


### PR DESCRIPTION
The Audit log allows user to log some important actions,
such as ones performed via management APIs or clients,
like queue management, sending messages, etc.
The log tries to record who (the user if any) doing what
(like deleting a queue) with arguments (if any) and timestamps.

By default the audit log is disabled. Through configuration can
be easily turned on.