### PR TITLE
NO-JIRA Fix QueueImplTest#testRoundRobinWithQueueing

### DIFF
--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/impl/QueueImplTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/impl/QueueImplTest.java
@@ -584,14 +584,6 @@ public class QueueImplTest extends ActiveMQTestBase {
 
       // Test first with queueing
 
-      for (int i = 0; i < numMessages; i++) {
-         MessageReference ref = generateReference(queue, i);
-
-         refs.add(ref);
-
-         queue.addTail(ref);
-      }
-
       FakeConsumer cons1 = new FakeConsumer();
 
       FakeConsumer cons2 = new FakeConsumer();
@@ -599,6 +591,14 @@ public class QueueImplTest extends ActiveMQTestBase {
       queue.addConsumer(cons1);
 
       queue.addConsumer(cons2);
+
+      for (int i = 0; i < numMessages; i++) {
+         MessageReference ref = generateReference(queue, i);
+
+         refs.add(ref);
+
+         queue.addTail(ref);
+      }
 
       queue.resume();
 


### PR DESCRIPTION
This test fails occasionally because the queue's delivering thread
may interference with the consumer's iterator during consumers adding.
The result is that the first of the 2 consumers may get iterated
twice and therefore the messages received by the 2 consumers are
not even.

Tha change puts the message add after the consumer add so that
the delivering thread only kicks off after consumers are all added
and messages should be evenly distributed to both consumers.