### PR TITLE
NO-JIRA Fix FailoverTest#testForceBlockingReturn

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/DelayInterceptor.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/DelayInterceptor.java
@@ -22,15 +22,25 @@ import org.apache.activemq.artemis.core.protocol.core.Packet;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 public class DelayInterceptor implements Interceptor {
+
+   private final CountDownLatch latch = new CountDownLatch(1);
 
    @Override
    public boolean intercept(final Packet packet, final RemotingConnection connection) throws ActiveMQException {
       if (packet.getType() == PacketImpl.SESS_SEND) {
+         latch.countDown();
          // Lose the send
          return false;
       } else {
          return true;
       }
+   }
+
+   public boolean await() throws InterruptedException {
+      return latch.await(10, TimeUnit.SECONDS);
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailoverTest.java
@@ -1917,7 +1917,8 @@ public class FailoverTest extends FailoverTestBase {
       createClientSessionFactory();
 
       // Add an interceptor to delay the send method so we can get time to cause failover before it returns
-      liveServer.getServer().getRemotingService().addIncomingInterceptor(new DelayInterceptor());
+      DelayInterceptor interceptor = new DelayInterceptor();
+      liveServer.getServer().getRemotingService().addIncomingInterceptor(interceptor);
 
       final ClientSession session = createSession(sf, true, true, 0);
 
@@ -1946,6 +1947,11 @@ public class FailoverTest extends FailoverTestBase {
       Sender sender = new Sender();
 
       sender.start();
+
+      //if server crash too early,
+      //sender will directly send to backup. so
+      //need some waiting here.
+      assertTrue(interceptor.await());
 
       crash(session);
 


### PR DESCRIPTION
The test may fail if the live crashes too soon and the
message is directly sent to backup and the expected
blocking send will never happen.
To fix that a wait is added to ensure the message
is sent to the live (and intercepted) before
crashing the live.