### PR TITLE
ARTEMIS-2264 Added test that receive all messages instead of remove

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/BackupSyncJournalTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/BackupSyncJournalTest.java
@@ -338,6 +338,16 @@ public class BackupSyncJournalTest extends FailoverTestBase {
       assertNoMoreMessages();
    }
 
+   @Test
+   public void testReceiveAllMessagesWithPurgeOnNoConsumers() throws Exception {
+      final boolean purgeOnNoConsumers = true;
+      createProducerSendSomeMessages();
+      liveServer.getServer().locateQueue(ADDRESS).setPurgeOnNoConsumers(purgeOnNoConsumers);
+      receiveMsgsInRange(0, n_msgs);
+      startBackupCrashLive();
+      assertNoMoreMessages();
+   }
+
    private void startBackupCrashLive() throws Exception {
       assertFalse("backup is started?", backupServer.isStarted());
       liveServer.removeInterceptor(syncDelay);


### PR DESCRIPTION
It improves the test coverage of the same use case ie "PurgeOnNoConsumers prevent removal of messages with replication", but receiving all the messages instead of removing them.