### PR TITLE
NO-JIRA Avoid NPE during backup shutdown

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/impl/ClusterConnectionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/impl/ClusterConnectionImpl.java
@@ -439,7 +439,9 @@ public final class ClusterConnectionImpl implements ClusterConnection, AfterConn
       if (managementService != null) {
          TypedProperties props = new TypedProperties();
          props.putSimpleStringProperty(new SimpleString("name"), name);
-         Notification notification = new Notification(nodeManager.getNodeId().toString(), CoreNotificationType.CLUSTER_CONNECTION_STOPPED, props);
+         //nodeID can be null if there's only a backup
+         SimpleString nodeId = nodeManager.getNodeId();
+         Notification notification = new Notification(nodeId == null ? null : nodeId.toString(), CoreNotificationType.CLUSTER_CONNECTION_STOPPED, props);
          managementService.sendNotification(notification);
       }
       executor.execute(new Runnable() {


### PR DESCRIPTION
When a backup starts without a live, it's nodeID is null.
Added a null check in ClusterConnection's stop() to avoid
NPE if it's shut down.