### PR TITLE
NO-JIRA Fixing markdown format in intercepting-operations.md

### DIFF
--- a/docs/user-manual/en/intercepting-operations.md
+++ b/docs/user-manual/en/intercepting-operations.md
@@ -37,7 +37,8 @@ public interface StompFrameInterceptor extends BaseInterceptor<StompFrame>
 Likewise for MQTT protocol, an interceptor must implement the interface
 `MQTTInterceptor`:
  
-```java package org.apache.activemq.artemis.core.protocol.mqtt;
+```java
+package org.apache.activemq.artemis.core.protocol.mqtt;
 
 public interface MQTTInterceptor extends BaseInterceptor<MqttMessage>
 {


### PR DESCRIPTION
Both the old and new versions render OK on GitHub, but on
https://activemq.apache.org/artemis/docs/latest/intercepting-operations.html
the old version was not parsed correctly, as can be now seen.