### PR TITLE
ARTEMIS-2309 TempQueueCleanerUpper instances are leaking

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -291,6 +291,10 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
       this.closeables.add(closeable);
    }
 
+   public Map<SimpleString, TempQueueCleanerUpper> getTempQueueCleanUppers() {
+      return tempQueueCleannerUppers;
+   }
+
    @Override
    public Executor getSessionExecutor() {
       return sessionExecutor;


### PR DESCRIPTION
The changes from ARTEMIS-2189 mean that
o.a.a.a.c.s.i.ServerSessionImpl#deleteQueue
is no longer called from the same ServerSessionImpl instance that
created it which means that TempQueueCleanerUpper instances will leak.
To resolve the leak the tracking Map should be static (i.e. shared among
all the ServerSessionImpl instances) so it doesn't matter which session
creates or deletes the temporary queue.