### PR TITLE
ARTEMIS-2308 Support exporting metrics to Prometheus

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
@@ -245,6 +245,9 @@ public class Create extends InputAbstract {
    @Option(name = "--mapped", description = "Sets the journal as mapped.")
    private boolean mapped;
 
+   @Option(name = "--prometheus", description = "Enables Prometheus support.")
+   private boolean prometheus;
+
    // this is used by the setupJournalType method
    private JournalType journalType;
 
@@ -576,6 +579,12 @@ public class Create extends InputAbstract {
       }
 
       filters.put("${journal.settings}", journalType.name());
+
+      if (prometheus) {
+         filters.put("${prometheus}", " prometheusServletEnabled=\"true\"");
+      } else {
+         filters.put("${prometheus}", "");
+      }
 
       if (sslKey != null) {
          filters.put("${web.protocol}", "https");

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/bootstrap-web-settings.txt
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/bootstrap-web-settings.txt
@@ -1,5 +1,5 @@
    <!-- The web server is only bound to localhost by default -->
-   <web bind="${web.protocol}://${http.host}:${http.port}" path="web"${extra.web.attributes}>
+   <web bind="${web.protocol}://${http.host}:${http.port}" path="web"${extra.web.attributes}${prometheus}>
        <app url="activemq-branding" war="activemq-branding.war"/>
        <app url="artemis-plugin" war="artemis-plugin.war"/>
        <app url="console" war="console.war"/>

--- a/artemis-distribution/src/main/assembly/dep.xml
+++ b/artemis-distribution/src/main/assembly/dep.xml
@@ -70,6 +70,10 @@
             <include>org.apache.activemq:artemis-web</include>
             <include>org.apache.activemq.rest:artemis-rest</include>
             <include>org.apache.qpid:qpid-jms-client</include>
+            <include>io.prometheus:simpleclient_servlet</include>
+            <include>io.prometheus:simpleclient_hotspot</include>
+            <include>io.prometheus:simpleclient_common</include>
+            <include>io.prometheus:simpleclient</include>
 
             <!-- dependencies -->
             <include>org.apache.geronimo.specs:geronimo-jms_2.0_spec</include>

--- a/artemis-dto/src/main/java/org/apache/activemq/artemis/dto/WebServerDTO.java
+++ b/artemis-dto/src/main/java/org/apache/activemq/artemis/dto/WebServerDTO.java
@@ -47,6 +47,12 @@ public class WebServerDTO extends ComponentDTO {
    @XmlAttribute
    public String trustStorePath;
 
+   @XmlAttribute
+   public Boolean prometheusServletEnabled = false;
+
+   @XmlAttribute
+   public String prometheusServletContext = "metrics";
+
    @XmlElementRef
    public List<AppDTO> apps;
 

--- a/artemis-features/src/main/resources/features.xml
+++ b/artemis-features/src/main/resources/features.xml
@@ -65,6 +65,7 @@
 		<bundle dependency="true">mvn:org.apache.commons/commons-configuration2/${commons.config.version}</bundle>
 		<bundle dependency="true">mvn:org.apache.commons/commons-text/1.6</bundle>
 		<bundle dependency="true">mvn:org.apache.commons/commons-lang3/${commons.lang.version}</bundle>
+		<bundle dependency="true">mvn:io.prometheus/simpleclient/${version.prometheus}</bundle>
 
 		<bundle>mvn:org.apache.activemq/activemq-artemis-native/${activemq-artemis-native-version}</bundle>
 		<bundle>mvn:org.apache.activemq/artemis-server-osgi/${pom.version}</bundle>

--- a/artemis-server/pom.xml
+++ b/artemis-server/pom.xml
@@ -132,6 +132,10 @@
          <artifactId>commons-configuration2</artifactId>
       </dependency>
       <dependency>
+         <groupId>io.prometheus</groupId>
+         <artifactId>simpleclient</artifactId>
+      </dependency>
+      <dependency>
          <groupId>commons-io</groupId>
          <artifactId>commons-io</artifactId>
          <version>2.6</version>

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
@@ -436,6 +436,10 @@ public interface Configuration {
 
    Configuration addDivertConfiguration(DivertConfiguration config);
 
+   PrometheusJmxExporterConfiguration getPrometheusJmxExporterConfiguration();
+
+   Configuration setPrometheusJmxExporterConfiguration(PrometheusJmxExporterConfiguration config);
+
    /**
     * Returns the cluster connections configured for this server.
     * <p>

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/PrometheusJmxExporterConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/PrometheusJmxExporterConfiguration.java
@@ -1,0 +1,240 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.core.config;
+
+import javax.management.ObjectName;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import io.prometheus.client.Collector;
+
+public class PrometheusJmxExporterConfiguration implements Serializable {
+
+   private static final long serialVersionUID = 9174674625543070014L;
+   private boolean lowercaseOutputName = true;
+   private boolean lowercaseOutputLabelNames = true;
+   private List<ObjectName> whitelistObjectNames = new ArrayList<>();
+   private List<ObjectName> blacklistObjectNames = new ArrayList<>();
+   public final List<Rule> DEFAULT_RULES = Arrays.asList(
+      new PrometheusJmxExporterConfiguration.Rule()
+         .setPattern("^org.apache.activemq.artemis<broker=\"([^\"]*)\"><>([^:]*):\\s(.*)")
+         .setName("artemis_$2")
+         .setAttrNameSnakeCase(true)
+         .setType(Collector.Type.COUNTER),
+      new PrometheusJmxExporterConfiguration.Rule()
+         .setPattern("^org.apache.activemq.artemis<broker=\"([^\"]*)\",\\s*component=addresses,\\s*address=\"([^\"]*)\"><>([^:]*):\\s(.*)")
+         .setName("artemis_$3")
+         .setAttrNameSnakeCase(true)
+         .setType(Collector.Type.COUNTER)
+         .addLabelName("address")
+         .addLabelValue("$2"),
+      new PrometheusJmxExporterConfiguration.Rule()
+         .setPattern("^org.apache.activemq.artemis<broker=\"([^\"]*)\",\\s*component=addresses,\\s*address=\"([^\"]*)\",\\s*subcomponent=(queue|topic)s,\\s*routing-type=\"([^\"]*)\",\\s*(queue|topic)=\"([^\"]*)\"><>([^: ]*):\\s(.*)")
+         .setName("artemis_$7")
+         .setAttrNameSnakeCase(true)
+         .setType(Collector.Type.COUNTER)
+         .addLabelName("address")
+         .addLabelValue("$2")
+         .addLabelName("$5")
+         .addLabelValue("$6")
+   );
+   private List<Rule> rules = DEFAULT_RULES;
+
+   public boolean isLowercaseOutputName() {
+      return lowercaseOutputName;
+   }
+
+   public PrometheusJmxExporterConfiguration setLowercaseOutputName(boolean lowercaseOutputName) {
+      this.lowercaseOutputName = lowercaseOutputName;
+      return this;
+   }
+
+   public boolean isLowercaseOutputLabelNames() {
+      return lowercaseOutputLabelNames;
+   }
+
+   public PrometheusJmxExporterConfiguration setLowercaseOutputLabelNames(boolean lowercaseOutputLabelNames) {
+      this.lowercaseOutputLabelNames = lowercaseOutputLabelNames;
+      return this;
+   }
+
+   public List<ObjectName> getWhitelistObjectNames() {
+      return whitelistObjectNames;
+   }
+
+   public PrometheusJmxExporterConfiguration setWhitelistObjectNames(List<ObjectName> whitelistObjectNames) {
+      this.whitelistObjectNames = whitelistObjectNames;
+      return this;
+   }
+
+   public PrometheusJmxExporterConfiguration addWhitelistObjectName(ObjectName whitelistObjectName) {
+      this.whitelistObjectNames.add(whitelistObjectName);
+      return this;
+   }
+
+   public List<ObjectName> getBlacklistObjectNames() {
+      return blacklistObjectNames;
+   }
+
+   public PrometheusJmxExporterConfiguration setBlacklistObjectNames(List<ObjectName> blacklistObjectNames) {
+      this.blacklistObjectNames = blacklistObjectNames;
+      return this;
+   }
+
+   public PrometheusJmxExporterConfiguration addBlacklistObjectName(ObjectName blacklistObjectName) {
+      this.blacklistObjectNames.add(blacklistObjectName);
+      return this;
+   }
+
+   public List<Rule> getRules() {
+      return rules;
+   }
+
+   public PrometheusJmxExporterConfiguration setRules(List<Rule> rules) {
+      this.rules = rules;
+      return this;
+   }
+
+   public PrometheusJmxExporterConfiguration addRule(Rule rule) {
+      this.rules.add(rule);
+      return this;
+   }
+
+   @Override
+   public String toString() {
+      return getClass().getSimpleName() + "[lowercaseOutputName=" + lowercaseOutputName + ", lowercaseOutputLabelNames=" + lowercaseOutputLabelNames + ", whitelistObjectNames=" + whitelistObjectNames + ", blacklistObjectNames=" + blacklistObjectNames + ", DEFAULT_RULES=" + DEFAULT_RULES + ", rules=" + rules + '}';
+   }
+
+   public static class Rule implements Serializable {
+
+      private static final long serialVersionUID = 5591373460394255494L;
+      private Pattern pattern;
+      private String name;
+      private String value;
+      private Double valueFactor = 1.0;
+      private String help;
+      private boolean attrNameSnakeCase;
+      private Collector.Type type = Collector.Type.UNTYPED;
+      private ArrayList<String> labelNames = new ArrayList<>();
+      private ArrayList<String> labelValues = new ArrayList<>();
+
+      public Pattern getPattern() {
+         return pattern;
+      }
+
+      public Rule setPattern(Pattern pattern) {
+         this.pattern = pattern;
+         return this;
+      }
+
+      public Rule setPattern(String pattern) {
+         this.pattern = Pattern.compile("^.*(?:" + pattern + ").*$");
+         return this;
+      }
+
+      public String getName() {
+         return name;
+      }
+
+      public Rule setName(String name) {
+         this.name = name;
+         return this;
+      }
+
+      public String getValue() {
+         return value;
+      }
+
+      public Rule setValue(String value) {
+         this.value = value;
+         return this;
+      }
+
+      public Double getValueFactor() {
+         return valueFactor;
+      }
+
+      public Rule setValueFactor(Double valueFactor) {
+         this.valueFactor = valueFactor;
+         return this;
+      }
+
+      public String getHelp() {
+         return help;
+      }
+
+      public Rule setHelp(String help) {
+         this.help = help;
+         return this;
+      }
+
+      public boolean isAttrNameSnakeCase() {
+         return attrNameSnakeCase;
+      }
+
+      public Rule setAttrNameSnakeCase(boolean attrNameSnakeCase) {
+         this.attrNameSnakeCase = attrNameSnakeCase;
+         return this;
+      }
+
+      public Collector.Type getType() {
+         return type;
+      }
+
+      public Rule setType(Collector.Type type) {
+         this.type = type;
+         return this;
+      }
+
+      public ArrayList<String> getLabelNames() {
+         return labelNames;
+      }
+
+      public Rule setLabelNames(ArrayList<String> labelNames) {
+         this.labelNames = labelNames;
+         return this;
+      }
+
+      public Rule addLabelName(String labelName) {
+         this.labelNames.add(labelName);
+         return this;
+      }
+
+      public ArrayList<String> getLabelValues() {
+         return labelValues;
+      }
+
+      public Rule setLabelValues(ArrayList<String> labelValues) {
+         this.labelValues = labelValues;
+         return this;
+      }
+
+      public Rule addLabelValue(String labelValue) {
+         this.labelValues.add(labelValue);
+         return this;
+      }
+
+      @Override
+      public String toString() {
+         return "Rule{" + "pattern=" + pattern + ", name='" + name + '\'' + ", value='" + value + '\'' + ", valueFactor=" + valueFactor + ", help='" + help + '\'' + ", attrNameSnakeCase=" + attrNameSnakeCase + ", type=" + type + ", labelNames=" + labelNames + ", labelValues=" + labelValues + '}';
+      }
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
@@ -41,6 +41,7 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
+import org.apache.activemq.artemis.core.config.PrometheusJmxExporterConfiguration;
 import org.apache.activemq.artemis.core.config.storage.DatabaseStorageConfiguration;
 import org.apache.activemq.artemis.core.config.FederationConfiguration;
 import org.apache.activemq.artemis.core.server.plugin.ActiveMQServerAddressPlugin;
@@ -154,6 +155,8 @@ public class ConfigurationImpl implements Configuration, Serializable {
    protected List<BridgeConfiguration> bridgeConfigurations = new ArrayList<>();
 
    protected List<DivertConfiguration> divertConfigurations = new ArrayList<>();
+
+   protected PrometheusJmxExporterConfiguration prometheusJmxExporterConfiguration = new PrometheusJmxExporterConfiguration();
 
    protected List<ClusterConnectionConfiguration> clusterConfigurations = new ArrayList<>();
 
@@ -700,6 +703,17 @@ public class ConfigurationImpl implements Configuration, Serializable {
    @Override
    public ConfigurationImpl addDivertConfiguration(final DivertConfiguration config) {
       divertConfigurations.add(config);
+      return this;
+   }
+
+   @Override
+   public PrometheusJmxExporterConfiguration getPrometheusJmxExporterConfiguration() {
+      return prometheusJmxExporterConfiguration;
+   }
+
+   @Override
+   public ConfigurationImpl setPrometheusJmxExporterConfiguration(PrometheusJmxExporterConfiguration config) {
+      this.prometheusJmxExporterConfiguration = config;
       return this;
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/Validators.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/Validators.java
@@ -18,6 +18,7 @@ package org.apache.activemq.artemis.core.config.impl;
 
 import java.util.EnumSet;
 
+import io.prometheus.client.Collector;
 import org.apache.activemq.artemis.core.server.ActiveMQMessageBundle;
 import org.apache.activemq.artemis.core.server.ComponentConfigurationRoutingType;
 import org.apache.activemq.artemis.core.server.JournalType;
@@ -219,6 +220,18 @@ public final class Validators {
          int val = (Integer) value;
          if (val < -1) {
             throw ActiveMQMessageBundle.BUNDLE.invalidMaxConsumers(name, val);
+         }
+      }
+   };
+
+   public static final Validator PROMETHEUS_METRIC_TYPE = new Validator() {
+      @Override
+      public void validate(final String name, final Object value) {
+         String val = (String) value;
+         if (val == null || !val.equals(Collector.Type.GAUGE.toString()) &&
+            !val.equals(Collector.Type.COUNTER.toString()) &&
+            !val.equals(Collector.Type.UNTYPED.toString())) {
+            throw ActiveMQMessageBundle.BUNDLE.invalidPrometheusMetricType(val);
          }
       }
    };

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQMessageBundle.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQMessageBundle.java
@@ -470,4 +470,7 @@ public interface ActiveMQMessageBundle {
 
    @Message(id = 229224, value = "User {0} does not exist", format = Message.Format.MESSAGE_FORMAT)
    IllegalArgumentException userDoesNotExist(String user);
+
+   @Message(id = 229225, value = "Invalid Prometheus metric type {0}", format = Message.Format.MESSAGE_FORMAT)
+   IllegalArgumentException invalidPrometheusMetricType(String val);
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1998,4 +1998,8 @@ public interface ActiveMQServerLogger extends BasicLogger {
    @LogMessage(level = Logger.Level.ERROR)
    @Message(id = 224097, value = "Failed to start server", format = Message.Format.MESSAGE_FORMAT)
    void failedToStartServer(@Cause Throwable t);
+
+   @LogMessage(level = Logger.Level.ERROR)
+   @Message(id = 224098, value = "JMX scrape failed", format = Message.Format.MESSAGE_FORMAT)
+   void jmxScrapeFailed(@Cause Throwable t);
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/prometheus/JmxCollector.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/prometheus/JmxCollector.java
@@ -1,0 +1,297 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.core.server.prometheus;
+
+import javax.management.MBeanServer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+
+import io.prometheus.client.Collector;
+import org.apache.activemq.artemis.core.config.PrometheusJmxExporterConfiguration;
+import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
+import org.apache.activemq.artemis.core.server.management.ArtemisMBeanServerBuilder;
+import org.jboss.logging.Logger;
+
+import static java.lang.String.format;
+
+public class JmxCollector extends Collector {
+
+   private static final Logger logger = Logger.getLogger(JmxCollector.class.getName());
+
+   private final JmxMBeanPropertyCache jmxMBeanPropertyCache = new JmxMBeanPropertyCache();
+   private MBeanServer mBeanServer;
+   private PrometheusJmxExporterConfiguration config;
+
+   public JmxCollector(MBeanServer mBeanServer, PrometheusJmxExporterConfiguration prometheusJmxExporterConfiguration) {
+      config = prometheusJmxExporterConfiguration;
+      this.mBeanServer = mBeanServer;
+   }
+
+   @Override
+   public List<MetricFamilySamples> collect() {
+      if (logger.isTraceEnabled()) {
+         logger.trace("Collecting Prometheus metrics using: " + config);
+      }
+      // set this key to bypass the server guard which implements RBAC for MBeans
+      ArtemisMBeanServerBuilder.GUARD_BYPASS.set(ArtemisMBeanServerBuilder.KEY);
+
+      Receiver receiver = new Receiver();
+      JmxScraper scraper = new JmxScraper(mBeanServer, receiver, jmxMBeanPropertyCache, config.getWhitelistObjectNames(), config.getBlacklistObjectNames());
+      long start = System.nanoTime();
+      double error = 0;
+
+      try {
+         scraper.doScrape();
+      } catch (Exception e) {
+         error = 1;
+         ActiveMQServerLogger.LOGGER.jmxScrapeFailed(e);
+      } finally {
+         ArtemisMBeanServerBuilder.GUARD_BYPASS.remove();
+      }
+      List<MetricFamilySamples> mfsList = new ArrayList<>();
+      mfsList.addAll(receiver.metricFamilySamplesMap.values());
+      List<MetricFamilySamples.Sample> samples = new ArrayList<>();
+      samples.add(new MetricFamilySamples.Sample("jmx_scrape_duration_seconds", new ArrayList<>(), new ArrayList<>(), (System.nanoTime() - start) / 1.0E9));
+      mfsList.add(new MetricFamilySamples("jmx_scrape_duration_seconds", Type.GAUGE, "Time this JMX scrape took, in seconds.", samples));
+
+      samples = new ArrayList<>();
+      samples.add(new MetricFamilySamples.Sample("jmx_scrape_error", new ArrayList<>(), new ArrayList<>(), error));
+      mfsList.add(new MetricFamilySamples("jmx_scrape_error", Type.GAUGE, "Non-zero if this scrape failed.", samples));
+      return mfsList;
+   }
+
+   static String toSnakeAndLowerCase(String attrName) {
+      if (attrName == null || attrName.isEmpty()) {
+         return attrName;
+      }
+      char firstChar = attrName.subSequence(0, 1).charAt(0);
+      boolean prevCharIsUpperCaseOrUnderscore = Character.isUpperCase(firstChar) || firstChar == '_';
+      StringBuilder resultBuilder = new StringBuilder(attrName.length()).append(Character.toLowerCase(firstChar));
+      for (char attrChar : attrName.substring(1).toCharArray()) {
+         boolean charIsUpperCase = Character.isUpperCase(attrChar);
+         if (!prevCharIsUpperCaseOrUnderscore && charIsUpperCase) {
+            resultBuilder.append("_");
+         }
+         resultBuilder.append(Character.toLowerCase(attrChar));
+         prevCharIsUpperCaseOrUnderscore = charIsUpperCase || attrChar == '_';
+      }
+      return resultBuilder.toString();
+   }
+
+   /**
+    * Change invalid chars to underscore, and merge underscores.
+    *
+    * @param name Input string
+    * @return
+    */
+   static String safeName(String name) {
+      if (name == null) {
+         return null;
+      }
+      boolean prevCharIsUnderscore = false;
+      StringBuilder safeNameBuilder = new StringBuilder(name.length());
+      if (!name.isEmpty() && Character.isDigit(name.charAt(0))) {
+         // prevent a numeric prefix.
+         safeNameBuilder.append("_");
+      }
+      for (char nameChar : name.toCharArray()) {
+         boolean isUnsafeChar = !(Character.isLetterOrDigit(nameChar) || nameChar == ':' || nameChar == '_');
+         if ((isUnsafeChar || nameChar == '_')) {
+            if (prevCharIsUnderscore) {
+               continue;
+            } else {
+               safeNameBuilder.append("_");
+               prevCharIsUnderscore = true;
+            }
+         } else {
+            safeNameBuilder.append(nameChar);
+            prevCharIsUnderscore = false;
+         }
+      }
+
+      return safeNameBuilder.toString();
+   }
+
+   class Receiver implements JmxScraper.MBeanReceiver {
+
+      Map<String, MetricFamilySamples> metricFamilySamplesMap = new HashMap<>();
+
+      private static final char SEP = '_';
+
+      // [] and () are special in regexes, so swtich to <>.
+      private String angleBrackets(String s) {
+         return "<" + s.substring(1, s.length() - 1) + ">";
+      }
+
+      void addSample(MetricFamilySamples.Sample sample, Type type, String help) {
+         MetricFamilySamples mfs = metricFamilySamplesMap.get(sample.name);
+         if (mfs == null) {
+            // JmxScraper.MBeanReceiver is only called from one thread,
+            // so there's no race here.
+            mfs = new MetricFamilySamples(sample.name, type, help, new ArrayList<>());
+            metricFamilySamplesMap.put(sample.name, mfs);
+         }
+         mfs.samples.add(sample);
+      }
+
+      private void defaultExport(String domain,
+                                 LinkedHashMap<String, String> beanProperties,
+                                 LinkedList<String> attrKeys,
+                                 String attrName,
+                                 String help,
+                                 Object value,
+                                 Type type) {
+         StringBuilder name = new StringBuilder();
+         name.append(domain);
+         if (beanProperties.size() > 0) {
+            name.append(SEP);
+            name.append(beanProperties.values().iterator().next());
+         }
+         for (String k : attrKeys) {
+            name.append(SEP);
+            name.append(k);
+         }
+         name.append(SEP);
+         name.append(attrName);
+         String fullname = safeName(name.toString());
+
+         if (config.isLowercaseOutputName()) {
+            fullname = fullname.toLowerCase();
+         }
+
+         List<String> labelNames = new ArrayList<>();
+         List<String> labelValues = new ArrayList<>();
+         if (beanProperties.size() > 1) {
+            Iterator<Map.Entry<String, String>> iter = beanProperties.entrySet().iterator();
+            // Skip the first one, it's been used in the name.
+            iter.next();
+            while (iter.hasNext()) {
+               Map.Entry<String, String> entry = iter.next();
+               String labelName = safeName(entry.getKey());
+               if (config.isLowercaseOutputLabelNames()) {
+                  labelName = labelName.toLowerCase();
+               }
+               labelNames.add(labelName);
+               labelValues.add(entry.getValue());
+            }
+         }
+
+         addSample(new MetricFamilySamples.Sample(fullname, labelNames, labelValues, ((Number) value).doubleValue()), type, help);
+      }
+
+      @Override
+      public void recordBean(String domain,
+                             LinkedHashMap<String, String> beanProperties,
+                             LinkedList<String> attrKeys,
+                             String attrName,
+                             String attrType,
+                             String attrDescription,
+                             Object beanValue) {
+
+         String beanName = domain + angleBrackets(beanProperties.toString()) + angleBrackets(attrKeys.toString());
+         // attrDescription tends not to be useful, so give the fully qualified name too.
+         String help = attrDescription + " (" + beanName + attrName + ")";
+         String attrNameSnakeCase = toSnakeAndLowerCase(attrName);
+
+         for (PrometheusJmxExporterConfiguration.Rule rule : config.getRules()) {
+            Matcher matcher = null;
+            String matchName = beanName + (rule.isAttrNameSnakeCase() ? attrNameSnakeCase : attrName);
+            if (rule.getPattern() != null) {
+               matcher = rule.getPattern().matcher(matchName + ": " + beanValue);
+               if (!matcher.matches()) {
+                  continue;
+               }
+            }
+
+            Number value;
+            if (rule.getValue() != null && !rule.getValue().isEmpty()) {
+               String val = matcher.replaceAll(rule.getValue());
+
+               try {
+                  beanValue = Double.valueOf(val);
+               } catch (NumberFormatException e) {
+                  ActiveMQServerLogger.LOGGER.trace("Unable to parse configured value '" + val + "' to number for bean: " + beanName + attrName + ": " + beanValue);
+                  return;
+               }
+            }
+            if (beanValue instanceof Number) {
+               value = ((Number) beanValue).doubleValue() * rule.getValueFactor();
+            } else if (beanValue instanceof Boolean) {
+               value = (Boolean) beanValue ? 1 : 0;
+            } else {
+               ActiveMQServerLogger.LOGGER.trace("Ignoring unsupported bean: " + beanName + attrName + ": " + beanValue);
+               return;
+            }
+
+            // If there's no name provided, use default export format.
+            if (rule.getName() == null) {
+               defaultExport(domain, beanProperties, attrKeys, rule.isAttrNameSnakeCase() ? attrNameSnakeCase : attrName, help, value, rule.getType());
+               return;
+            }
+
+            // Matcher is set below here due to validation in the constructor.
+            String name = safeName(matcher.replaceAll(rule.getName()));
+            if (name.isEmpty()) {
+               return;
+            }
+            if (config.isLowercaseOutputName()) {
+               name = name.toLowerCase();
+            }
+
+            // Set the help.
+            if (rule.getHelp() != null) {
+               help = matcher.replaceAll(rule.getHelp());
+            }
+
+            // Set the labels.
+            ArrayList<String> labelNames = new ArrayList<>();
+            ArrayList<String> labelValues = new ArrayList<>();
+            if (rule.getLabelNames() != null) {
+               for (int i = 0; i < rule.getLabelNames().size(); i++) {
+                  final String unsafeLabelName = rule.getLabelNames().get(i);
+                  final String labelValReplacement = rule.getLabelValues().get(i);
+                  try {
+                     String labelName = safeName(matcher.replaceAll(unsafeLabelName));
+                     String labelValue = matcher.replaceAll(labelValReplacement);
+                     if (config.isLowercaseOutputLabelNames()) {
+                        labelName = labelName.toLowerCase();
+                     }
+                     if (!labelName.isEmpty() && !labelValue.isEmpty()) {
+                        labelNames.add(labelName);
+                        labelValues.add(labelValue);
+                     }
+                  } catch (Exception e) {
+                     throw new RuntimeException(format("Matcher '%s' unable to use: '%s' value: '%s'", matcher, unsafeLabelName, labelValReplacement), e);
+                  }
+               }
+            }
+
+            // Add to samples.
+            ActiveMQServerLogger.LOGGER.trace("add metric sample: " + name + " " + labelNames + " " + labelValues + " " + value.doubleValue());
+            addSample(new MetricFamilySamples.Sample(name, labelNames, labelValues, value.doubleValue()), rule.getType(), help);
+            return;
+         }
+      }
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/prometheus/JmxMBeanPropertyCache.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/prometheus/JmxMBeanPropertyCache.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.core.server.prometheus;
+
+import javax.management.ObjectName;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * This object stores a mapping of mBean objectNames to mBean key property lists. The main purpose of it is to reduce
+ * the frequency with which we invoke PROPERTY_PATTERN when discovering mBeans.
+ */
+class JmxMBeanPropertyCache {
+
+   private static final Pattern PROPERTY_PATTERN = Pattern.compile("([^,=:\\*\\?]+)" + // Name - non-empty, anything but comma, equals, colon, star, or question mark
+                                                                      "=" +  // Equals
+                                                                      "(" + // Either
+                                                                      "\"" + // Quoted
+                                                                      "(?:" + // A possibly empty sequence of
+                                                                      "[^\\\\\"]*" + // Greedily match anything but backslash or quote
+                                                                      "(?:\\\\.)?" + // Greedily see if we can match an escaped sequence
+                                                                      ")*" + "\"" + "|" + // Or
+                                                                      "[^,=:\"]*" + // Unquoted - can be empty, anything but comma, equals, colon, or quote
+                                                                      ")");
+
+   // Implement a version of ObjectName.getKeyPropertyList that returns the
+   // properties in the ordered they were added (the ObjectName stores them
+   // in the order they were added).
+   private final Map<ObjectName, LinkedHashMap<String, String>> keyPropertiesPerBean;
+
+   JmxMBeanPropertyCache() {
+      this.keyPropertiesPerBean = new ConcurrentHashMap<ObjectName, LinkedHashMap<String, String>>();
+   }
+
+   Map<ObjectName, LinkedHashMap<String, String>> getKeyPropertiesPerBean() {
+      return keyPropertiesPerBean;
+   }
+
+   public LinkedHashMap<String, String> getKeyPropertyList(ObjectName mbeanName) {
+      LinkedHashMap<String, String> keyProperties = keyPropertiesPerBean.get(mbeanName);
+      if (keyProperties == null) {
+         keyProperties = new LinkedHashMap<String, String>();
+         String properties = mbeanName.getKeyPropertyListString();
+         Matcher match = PROPERTY_PATTERN.matcher(properties);
+         while (match.lookingAt()) {
+            keyProperties.put(match.group(1), match.group(2));
+            properties = properties.substring(match.end());
+            if (properties.startsWith(",")) {
+               properties = properties.substring(1);
+            }
+            match.reset(properties);
+         }
+         keyPropertiesPerBean.put(mbeanName, keyProperties);
+      }
+      return keyProperties;
+   }
+
+   public void onlyKeepMBeans(Set<ObjectName> latestBeans) {
+      for (ObjectName prevName : keyPropertiesPerBean.keySet()) {
+         if (!latestBeans.contains(prevName)) {
+            keyPropertiesPerBean.remove(prevName);
+         }
+      }
+   }
+
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/prometheus/JmxScraper.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/prometheus/JmxScraper.java
@@ -1,0 +1,246 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.core.server.prometheus;
+
+import javax.management.Attribute;
+import javax.management.AttributeList;
+import javax.management.JMException;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanInfo;
+import javax.management.MBeanServer;
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
+import javax.management.openmbean.CompositeData;
+import javax.management.openmbean.CompositeType;
+import javax.management.openmbean.TabularData;
+import javax.management.openmbean.TabularType;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.jboss.logging.Logger;
+
+class JmxScraper {
+
+   private static final Logger logger = Logger.getLogger(JmxScraper.class.getName());
+
+   public interface MBeanReceiver {
+
+      void recordBean(String domain,
+                      LinkedHashMap<String, String> beanProperties,
+                      LinkedList<String> attrKeys,
+                      String attrName,
+                      String attrType,
+                      String attrDescription,
+                      Object value);
+   }
+
+   private final MBeanReceiver receiver;
+   private MBeanServer mBeanServer;
+   private final List<ObjectName> whitelistObjectNames, blacklistObjectNames;
+   private final JmxMBeanPropertyCache jmxMBeanPropertyCache;
+
+   JmxScraper(MBeanServer mBeanServer,
+              MBeanReceiver receiver,
+              JmxMBeanPropertyCache jmxMBeanPropertyCache,
+              List<ObjectName> whitelistObjectNames,
+              List<ObjectName> blacklistObjectNames) {
+      this.receiver = receiver;
+      this.whitelistObjectNames = whitelistObjectNames;
+      this.blacklistObjectNames = blacklistObjectNames;
+      this.jmxMBeanPropertyCache = jmxMBeanPropertyCache;
+      this.mBeanServer = mBeanServer;
+   }
+
+   /**
+    * Get a list of mbeans and scrape their values.
+    *
+    * Values are passed to the receiver in a single thread.
+    */
+   public void doScrape() throws Exception {
+      // Query MBean names, see #89 for reasons queryMBeans() is used instead of queryNames()
+      Set<ObjectName> mBeanNames = new HashSet<>();
+      if (whitelistObjectNames == null || whitelistObjectNames.size() == 0) {
+         for (ObjectInstance instance : mBeanServer.queryMBeans(null, null)) {
+            mBeanNames.add(instance.getObjectName());
+         }
+      } else {
+         for (ObjectName name : whitelistObjectNames) {
+            for (ObjectInstance instance : mBeanServer.queryMBeans(name, null)) {
+               mBeanNames.add(instance.getObjectName());
+            }
+         }
+      }
+
+      for (ObjectName name : blacklistObjectNames) {
+         for (ObjectInstance instance : mBeanServer.queryMBeans(name, null)) {
+            mBeanNames.remove(instance.getObjectName());
+         }
+      }
+
+      // Now that we have *only* the whitelisted mBeans, remove any old ones from the cache:
+      jmxMBeanPropertyCache.onlyKeepMBeans(mBeanNames);
+
+      for (ObjectName objectName : mBeanNames) {
+         long start = System.nanoTime();
+         scrapeBean(mBeanServer, objectName);
+         logger.trace("TIME: " + (System.nanoTime() - start) + " ns for " + objectName.toString());
+      }
+   }
+
+   private void scrapeBean(MBeanServerConnection beanConn, ObjectName mbeanName) {
+      MBeanInfo info;
+      try {
+         info = beanConn.getMBeanInfo(mbeanName);
+      } catch (IOException e) {
+         logScrape(mbeanName.toString(), "getMBeanInfo Fail: " + e);
+         return;
+      } catch (JMException e) {
+         logScrape(mbeanName.toString(), "getMBeanInfo Fail: " + e);
+         return;
+      }
+      MBeanAttributeInfo[] attrInfos = info.getAttributes();
+
+      Map<String, MBeanAttributeInfo> name2AttrInfo = new LinkedHashMap<>();
+      for (int idx = 0; idx < attrInfos.length; ++idx) {
+         MBeanAttributeInfo attr = attrInfos[idx];
+         if (!attr.isReadable()) {
+            logScrape(mbeanName, attr, "not readable");
+            continue;
+         }
+         name2AttrInfo.put(attr.getName(), attr);
+      }
+      final AttributeList attributes;
+      try {
+         attributes = beanConn.getAttributes(mbeanName, name2AttrInfo.keySet().toArray(new String[0]));
+      } catch (Exception e) {
+         logScrape(mbeanName, name2AttrInfo.keySet(), "Fail: " + e);
+         return;
+      }
+      for (Attribute attribute : attributes.asList()) {
+         MBeanAttributeInfo attr = name2AttrInfo.get(attribute.getName());
+         logScrape(mbeanName, attr, "process");
+         processBeanValue(mbeanName.getDomain(), jmxMBeanPropertyCache.getKeyPropertyList(mbeanName), new LinkedList<String>(), attr.getName(), attr.getType(), attr.getDescription(), attribute.getValue());
+      }
+   }
+
+   /**
+    * Recursive function for exporting the values of an mBean.
+    * JMX is a very open technology, without any prescribed way of declaring mBeans
+    * so this function tries to do a best-effort pass of getting the values/names
+    * out in a way it can be processed elsewhere easily.
+    */
+   private void processBeanValue(String domain,
+                                 LinkedHashMap<String, String> beanProperties,
+                                 LinkedList<String> attrKeys,
+                                 String attrName,
+                                 String attrType,
+                                 String attrDescription,
+                                 Object value) {
+      if (value == null) {
+         logScrape(domain + beanProperties + attrName, "null");
+      } else if (value instanceof Number || value instanceof String || value instanceof Boolean) {
+         logScrape(domain + beanProperties + attrName, value.toString());
+         this.receiver.recordBean(domain, beanProperties, attrKeys, attrName, attrType, attrDescription, value);
+      } else if (value instanceof CompositeData) {
+         logScrape(domain + beanProperties + attrName, "compositedata");
+         CompositeData composite = (CompositeData) value;
+         CompositeType type = composite.getCompositeType();
+         attrKeys = new LinkedList<String>(attrKeys);
+         attrKeys.add(attrName);
+         for (String key : type.keySet()) {
+            String typ = type.getType(key).getTypeName();
+            Object valu = composite.get(key);
+            processBeanValue(domain, beanProperties, attrKeys, key, typ, type.getDescription(), valu);
+         }
+      } else if (value instanceof TabularData) {
+         // I don't pretend to have a good understanding of TabularData.
+         // The real world usage doesn't appear to match how they were
+         // meant to be used according to the docs. I've only seen them
+         // used as 'key' 'value' pairs even when 'value' is itself a
+         // CompositeData of multiple values.
+         logScrape(domain + beanProperties + attrName, "tabulardata");
+         TabularData tds = (TabularData) value;
+         TabularType tt = tds.getTabularType();
+
+         List<String> rowKeys = tt.getIndexNames();
+
+         CompositeType type = tt.getRowType();
+         Set<String> valueKeys = new TreeSet<>(type.keySet());
+         valueKeys.removeAll(rowKeys);
+
+         LinkedList<String> extendedAttrKeys = new LinkedList<>(attrKeys);
+         extendedAttrKeys.add(attrName);
+         for (Object valu : tds.values()) {
+            if (valu instanceof CompositeData) {
+               CompositeData composite = (CompositeData) valu;
+               LinkedHashMap<String, String> l2s = new LinkedHashMap<>(beanProperties);
+               for (String idx : rowKeys) {
+                  Object obj = composite.get(idx);
+                  if (obj != null) {
+                     // Nested tabulardata will repeat the 'key' label, so
+                     // append a suffix to distinguish each.
+                     while (l2s.containsKey(idx)) {
+                        idx = idx + "_";
+                     }
+                     l2s.put(idx, obj.toString());
+                  }
+               }
+               for (String valueIdx : valueKeys) {
+                  LinkedList<String> attrNames = extendedAttrKeys;
+                  String typ = type.getType(valueIdx).getTypeName();
+                  String name = valueIdx;
+                  if (valueIdx.toLowerCase().equals("value")) {
+                     // Skip appending 'value' to the name
+                     attrNames = attrKeys;
+                     name = attrName;
+                  }
+                  processBeanValue(domain, l2s, attrNames, name, typ, type.getDescription(), composite.get(valueIdx));
+               }
+            } else {
+               logScrape(domain, "not a correct tabulardata format");
+            }
+         }
+      } else if (value.getClass().isArray()) {
+         logScrape(domain, "arrays are unsupported");
+      } else {
+         logScrape(domain + beanProperties, attrType + " is not exported");
+      }
+   }
+
+   /**
+    * For debugging.
+    */
+   private static void logScrape(ObjectName mbeanName, Set<String> names, String msg) {
+      logScrape(mbeanName + "_" + names, msg);
+   }
+
+   private static void logScrape(ObjectName mbeanName, MBeanAttributeInfo attr, String msg) {
+      logScrape(mbeanName + "'_'" + attr.getName(), msg);
+   }
+
+   private static void logScrape(String name, String msg) {
+      logger.log(Logger.Level.TRACE, "scrape: '" + name + "': " + msg);
+   }
+}

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -862,6 +862,80 @@
             </xsd:simpleType>
          </xsd:element>
 
+         <xsd:element name="prometheus-jmx-exporter" maxOccurs="1" minOccurs="0">
+            <xsd:complexType>
+               <xsd:annotation>
+                  <xsd:documentation>
+                     The configuration for the Prometheus JMX exporter
+                  </xsd:documentation>
+               </xsd:annotation>
+               <xsd:all>
+                  <xsd:element name="lowercase-output-name" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
+                     <xsd:annotation>
+                        <xsd:documentation>
+                           Lowercase the output metric name. Applies to default format and name.
+                        </xsd:documentation>
+                     </xsd:annotation>
+                  </xsd:element>
+                  <xsd:element name="lowercase-output-label-names" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
+                     <xsd:annotation>
+                        <xsd:documentation>
+                           Lowercase the output metric label names. Applies to default format and labels.
+                        </xsd:documentation>
+                     </xsd:annotation>
+                  </xsd:element>
+                  <xsd:element name="whitelist" maxOccurs="1" minOccurs="0">
+                     <xsd:complexType>
+                        <xsd:annotation>
+                           <xsd:documentation>
+                              A list of JMX ObjectNames to query.
+                           </xsd:documentation>
+                        </xsd:annotation>
+                        <xsd:sequence>
+                           <xsd:element name="object-name" maxOccurs="unbounded" minOccurs="0">
+                              <xsd:annotation>
+                                 <xsd:documentation>
+                                    a JMX ObjectName
+                                 </xsd:documentation>
+                              </xsd:annotation>
+                           </xsd:element>
+                        </xsd:sequence>
+                        <xsd:attributeGroup ref="xml:specialAttrs"/>
+                     </xsd:complexType>
+                  </xsd:element>
+                  <xsd:element name="blacklist" maxOccurs="1" minOccurs="0">
+                     <xsd:complexType>
+                        <xsd:annotation>
+                           <xsd:documentation>
+                              A list of ObjectNames to not query. Takes precedence over whitelisted ObjectNames.
+                              Defaults to none.
+                           </xsd:documentation>
+                        </xsd:annotation>
+                        <xsd:sequence>
+                           <xsd:element name="object-name" maxOccurs="unbounded" minOccurs="0">
+                              <xsd:annotation>
+                                 <xsd:documentation>
+                                    a JMX ObjectName
+                                 </xsd:documentation>
+                              </xsd:annotation>
+                           </xsd:element>
+                        </xsd:sequence>
+                        <xsd:attributeGroup ref="xml:specialAttrs"/>
+                     </xsd:complexType>
+                  </xsd:element>
+                  <xsd:element name="rules" maxOccurs="1" minOccurs="0">
+                     <xsd:complexType>
+                        <xsd:sequence>
+                           <xsd:element name="rule" type="ruleType" maxOccurs="unbounded" minOccurs="0"/>
+                        </xsd:sequence>
+                        <xsd:attributeGroup ref="xml:specialAttrs"/>
+                     </xsd:complexType>
+                  </xsd:element>
+               </xsd:all>
+               <xsd:attributeGroup ref="xml:specialAttrs"/>
+            </xsd:complexType>
+         </xsd:element>
+
          <xsd:element name="security-settings" maxOccurs="1" minOccurs="0">
             <xsd:annotation>
                <xsd:documentation>
@@ -2870,6 +2944,88 @@
             </xsd:documentation>
          </xsd:annotation>
       </xsd:attribute>
+      <xsd:attributeGroup ref="xml:specialAttrs"/>
+   </xsd:complexType>
+
+   <xsd:complexType name="ruleType">
+      <xsd:all>
+         <xsd:element name="name" type="xsd:string" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The metric name to set. Capture groups from the pattern can be used. If not specified, the default
+                  format will be used. If it evaluates to empty, processing of this attribute stops with no output.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="pattern" type="xsd:string" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Regex pattern to match against each bean attribute. The pattern is not anchored. Capture groups
+                  can be used in other options. Defaults to matching everything.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="value" type="xsd:string" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Value for the metric. Static values and capture groups from the pattern can be used. If not
+                  specified the scraped mBean value will be used.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="value-factor" type="xsd:double" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Value for the metric. Static values and capture groups from the pattern can be used. If not
+                  specified the scraped mBean value will be used.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="help" type="xsd:string" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Help text for the metric. Capture groups from pattern can be used. name must be set to use
+                  this. Defaults to the mBean attribute description and the full name of the attribute.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="attr-name-snake-case" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Converts the attribute name to snake case. This is seen in the names matched by the pattern
+                  and the default format. For example, "anAttrName" to "an_attr_name".
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:element name="type" default="UNTYPED" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  The type of the metric, can be GAUGE, COUNTER or UNTYPED. name must be set to use this.
+               </xsd:documentation>
+            </xsd:annotation>
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:enumeration value="UNTYPED"/>
+                  <xsd:enumeration value="COUNTER"/>
+                  <xsd:enumeration value="GAUGE"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+         <xsd:element name="labels" maxOccurs="1" minOccurs="0">
+            <xsd:complexType>
+               <xsd:sequence>
+                  <xsd:element name="label" type="labelType" maxOccurs="unbounded" minOccurs="0"/>
+               </xsd:sequence>
+               <xsd:attributeGroup ref="xml:specialAttrs"/>
+            </xsd:complexType>
+         </xsd:element>
+      </xsd:all>
+      <xsd:attributeGroup ref="xml:specialAttrs"/>
+   </xsd:complexType>
+
+   <xsd:complexType name="labelType">
+      <xsd:attribute name="name" type="xsd:string" use="required" />
+      <xsd:attribute name="value" type="xsd:string" use="required" />
       <xsd:attributeGroup ref="xml:specialAttrs"/>
    </xsd:complexType>
 

--- a/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
@@ -279,6 +279,45 @@
          </federation>
       </federations>
 
+      <prometheus-jmx-exporter>
+         <lowercase-output-name>true</lowercase-output-name>
+         <lowercase-output-label-names>true</lowercase-output-label-names>
+         <whitelist>
+            <object-name>org.apache.whitelist:*</object-name>
+         </whitelist>
+         <blacklist>
+            <object-name>org.apache.blacklist1:*</object-name>
+            <object-name>org.apache.blacklist2:*</object-name>
+         </blacklist>
+         <rules>
+            <rule>
+               <name>ruleName1</name>
+               <attr-name-snake-case>true</attr-name-snake-case>
+               <type>COUNTER</type>
+               <pattern>pattern1</pattern>
+               <help>ruleHelp1</help>
+               <value>ruleValue1</value>
+               <value-factor>2.0</value-factor>
+               <labels>
+                  <label name="labelName1" value="labelValue1"/>
+               </labels>
+            </rule>
+            <rule>
+               <name>ruleName2</name>
+               <attr-name-snake-case>false</attr-name-snake-case>
+               <type>GAUGE</type>
+               <pattern>pattern2</pattern>
+               <help>ruleHelp2</help>
+               <value>ruleValue2</value>
+               <value-factor>3.0</value-factor>
+               <labels>
+                  <label name="labelName2" value="labelValue2"/>
+                  <label name="labelName3" value="labelValue3"/>
+               </labels>
+            </rule>
+         </rules>
+      </prometheus-jmx-exporter>
+
       <ha-policy>
          <!--only one of the following-->
          <!--on server shutdown scale down to another live server-->

--- a/artemis-server/src/test/resources/ConfigurationTest-xinclude-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-xinclude-config.xml
@@ -193,6 +193,44 @@
             <discovery-group-ref discovery-group-name="dg1"/>
          </bridge>
       </bridges>
+      <prometheus-jmx-exporter>
+         <lowercase-output-name>true</lowercase-output-name>
+         <lowercase-output-label-names>true</lowercase-output-label-names>
+         <whitelist>
+            <object-name>org.apache.whitelist:*</object-name>
+         </whitelist>
+         <blacklist>
+            <object-name>org.apache.blacklist1:*</object-name>
+            <object-name>org.apache.blacklist2:*</object-name>
+         </blacklist>
+         <rules>
+            <rule>
+               <name>ruleName1</name>
+               <attr-name-snake-case>true</attr-name-snake-case>
+               <type>COUNTER</type>
+               <pattern>pattern1</pattern>
+               <help>ruleHelp1</help>
+               <value>ruleValue1</value>
+               <value-factor>2.0</value-factor>
+               <labels>
+                  <label name="labelName1" value="labelValue1"/>
+               </labels>
+            </rule>
+            <rule>
+               <name>ruleName2</name>
+               <attr-name-snake-case>false</attr-name-snake-case>
+               <type>GAUGE</type>
+               <pattern>pattern2</pattern>
+               <help>ruleHelp2</help>
+               <value>ruleValue2</value>
+               <value-factor>3.0</value-factor>
+               <labels>
+                  <label name="labelName2" value="labelValue2"/>
+                  <label name="labelName3" value="labelValue3"/>
+               </labels>
+            </rule>
+         </rules>
+      </prometheus-jmx-exporter>
       <ha-policy>
          <!--only one of the following-->
          <!--on server shutdown scale down to another live server-->

--- a/artemis-web/pom.xml
+++ b/artemis-web/pom.xml
@@ -102,6 +102,14 @@
          <artifactId>netty-handler</artifactId>
       </dependency>
       <dependency>
+         <groupId>io.prometheus</groupId>
+         <artifactId>simpleclient_servlet</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>io.prometheus</groupId>
+         <artifactId>simpleclient_hotspot</artifactId>
+      </dependency>
+      <dependency>
          <groupId>org.eclipse.jetty.aggregate</groupId>
          <artifactId>jetty-all</artifactId>
          <type>jar</type>

--- a/artemis-web/src/main/java/org/apache/activemq/artemis/ActiveMQWebLogger.java
+++ b/artemis-web/src/main/java/org/apache/activemq/artemis/ActiveMQWebLogger.java
@@ -58,4 +58,8 @@ public interface ActiveMQWebLogger extends BasicLogger {
    @LogMessage(level = Logger.Level.INFO)
    @Message(id = 241004, value = "Artemis Console available at {0}", format = Message.Format.MESSAGE_FORMAT)
    void consoleAvailable(String bind);
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 241005, value = "Prometheus metrics available at {0}", format = Message.Format.MESSAGE_FORMAT)
+   void metricsAvailable(String bind);
 }

--- a/docs/user-manual/en/SUMMARY.md
+++ b/docs/user-manual/en/SUMMARY.md
@@ -45,6 +45,7 @@
 * [Extra Acknowledge Modes](pre-acknowledge.md)
 * [Management](management.md)
 * [Management Console](management-console.md)
+* [Prometheus](prometheus.md)
 * [Security](security.md)
 * [Masking Passwords](masking-passwords.md)
 * [Broker Plugins](broker-plugins.md)

--- a/docs/user-manual/en/configuration-index.md
+++ b/docs/user-manual/en/configuration-index.md
@@ -162,6 +162,7 @@ name | node name; used in topology notifications if set. | n/a
 [persist-delivery-count-before-delivery](undelivered-messages.md#delivery-count-persistence) | True means that the delivery count is persisted before delivery. False means that this only happens after a message has been cancelled. | `false`
 [persistence-enabled](persistence.md#zero-persistence)| true means that the server will use the file based journal for persistence. | `true`
 [persist-id-cache](duplicate-detection.md#configuring-the-duplicate-id-cache) | true means that ID's are persisted to the journal. | `true`
+[prometheus-jmx-exporter](prometheus.md) | configuration for the Prometheus JMX exporter | n/a
 queues | **deprecated** [use addresses](#address-type) | n/a
 [remoting-incoming-interceptors](intercepting-operations.md)| a list of &lt;class-name/&gt; elements with the names of classes to use for intercepting incoming remoting packets | n/a
 [remoting-outgoing-interceptors](intercepting-operations.md)| a list of &lt;class-name/&gt; elements with the names of classes to use for intercepting outgoing remoting packets | n/a
@@ -359,6 +360,36 @@ user | the name of the user to associate with the creation of the queue | n/a
 [last-value](last-value-queues.md) | use last-value semantics | `false`
 consumers-before-dispatch | number of consumers required before dispatching messages | 0
 delay-before-dispatch | milliseconds to wait for `consumers-before-dispatch` to be met before dispatching messages anyway | -1 (wait forever)
+
+## prometheus-jmx-exporter type
+
+Name | Description | Default
+---|---|---
+lowercaseOutputName | Lowercase the output metric name. Applies to default format and `name`. | `false`
+lowercaseOutputLabelNames | Lowercase the output metric label names. Applies to default format and `labels`. | `false`
+whitelistObjectNames | A list of [ObjectNames](http://docs.oracle.com/javase/6/docs/api/javax/management/ObjectName.html) to query. | all MBeans
+blacklistObjectNames | A list of [ObjectNames](http://docs.oracle.com/javase/6/docs/api/javax/management/ObjectName.html) to not query. Takes precedence over `whitelistObjectNames`. | none
+rules | A list of rules to apply in order, processing stops at the first matching rule. Attributes that aren't matched aren't collected. | collects everything in the default format.
+
+## rule type
+
+Name | Description | Default
+---|---|---
+pattern | Regex pattern to match against each bean attribute. The pattern is not anchored. Capture groups can be used in other options. | matches everything
+attrNameSnakeCase | Converts the attribute name to snake case. This is seen in the names matched by the pattern and the default format. For example, anAttrName to an\_attr\_name. | `false`
+name | The metric name to set. Capture groups from the `pattern` can be used. If not specified, the default format will be used. If it evaluates to empty, processing of this attribute stops with no output. | empty
+value | Value for the metric. Static values and capture groups from the `pattern` can be used. | scraped MBean value
+valueFactor | Optional number that `value` (or the scraped mBean value if `value` is not specified) is multiplied by, mainly used to convert mBean values from milliseconds to seconds. | `1.0`
+labels | A list of `label` elements | n/a
+help | Help text for the metric. Capture groups from `pattern` can be used. `name` must be set to use this. | the MBean attribute description and the full name of the attribute
+type | The type of the metric, can be `GAUGE`, `COUNTER` or `UNTYPED`. `name` must be set to use this. | `UNTYPED`
+
+## label type
+
+Name | Description | Default
+---|---|---
+name | Capture groups from `pattern` can be used in each. `name` must be set to use this. Empty names are ignored. If not specified and the default format is not being used, no labels are set. | empty
+value | Capture groups from `pattern` can be used in each. `name` must be set to use this. Empty values are ignored. If not specified and the default format is not being used, no labels are set. | empty
 
 
 ## security-setting type

--- a/docs/user-manual/en/prometheus.md
+++ b/docs/user-manual/en/prometheus.md
@@ -1,0 +1,148 @@
+# Prometheus Support
+
+Apache ActiveMQ Artemis supports exporting metrics for consumption by
+[Prometheus](https://prometheus.io/). Prometheus
+
+## Configuration
+
+Prometheus support is provided by 2 main components:
+
+- A servlet - This servlet is configured in `bootstrap.xml` as part of the
+  embedded Jetty HTTP server. By default it is enabled and is available at
+  "metrics" (e.g. http://localhost:8161/metrics). See relevant configuration
+  options in the [Web Server](web-server.md) chapter.
+
+- JMX exporter -  This is based on the
+  [Prometheus JMX Exporter](https://github.com/prometheus/jmx_exporter) and has
+  very similar configuration, but instead of running as a Java Agent it runs
+  within the broker and is configured via `broker.xml`. By default, **no
+  configuration of the JMX exporter is required to export metrics for the
+  broker, addresses, and queues**. See more about the default configuration
+  below.
+
+> **Note:**
+>
+> Since the exporter works on *JMX* metrics the `<jmx-management-enabled>`
+> element must be set to `true`. To be clear, this is the default value.
+
+### JMX Exporter Configuration
+
+Here's an example configuration of the Prometheus JMS exporter from
+`broker.xml`:
+
+```xml
+<prometheus-jmx-exporter>
+   <lowercase-output-name>true</lowercase-output-name>
+   <lowercase-output-label-names>true</lowercase-output-label-names>
+   <whitelist>
+      <object-name>org.apache.activemq.artemis:*</object-name>
+   </whitelist>
+   <blacklist>
+      <object-name>java.nio:*</object-name>
+   </blacklist>
+   <rules>
+      <rule>
+         <pattern>pattern1</pattern>
+         <name>myMetric</name>
+         <attr-name-snake-case>true</attr-name-snake-case>
+         <type>COUNTER</type>
+         <help>ruleHelp</help>
+         <value>ruleValue</value>
+         <value-factor>2.0</value-factor>
+         <labels>
+            <label name="labelName" value="labelValue"/>
+         </labels>
+      </rule>
+   </rules>
+</prometheus-jmx-exporter>
+```
+
+#### `prometheus-jmx-exporter`
+
+- `lowercaseOutputName` - Lowercase the output metric name. Applies to default
+  format and `name`. Defaults to `true`.
+- `lowercaseOutputLabelNames` - Lowercase the output metric label names.
+  Applies to default format and `labels`. Defaults to `true`.
+- `whitelistObjectNames` - A list of [ObjectNames](http://docs.oracle.com/javase/6/docs/api/javax/management/ObjectName.html)
+  to query. Defaults to all mBeans.
+- `blacklistObjectNames` - A list of [ObjectNames](http://docs.oracle.com/javase/6/docs/api/javax/management/ObjectName.html)
+  to not query. Takes precedence over `whitelistObjectNames`. Defaults to none.
+- `rules` - A list of `rule` elements to apply in order. Processing stops at
+  the first matching rule. Attributes that aren't matched aren't collected. If
+  not specified, defaults to collecting everything in the default format.
+
+#### `rule`
+
+- `pattern` - Regex pattern to match against each bean attribute. The pattern
+  is not anchored. Capture groups can be used in other options. Defaults to
+  matching everything.
+- `attrNameSnakeCase` - Converts the attribute name to snake case. This is seen
+  in the names matched by the pattern and the default format. For example,
+  `anAttrName` to `an_attr_name`. Defaults to `false`.
+- `name` - The metric name to set. Capture groups from the `pattern` can be
+  used. If not specified, the default format will be used. If it evaluates to
+  empty, processing of this attribute stops with no output.
+- `value` - Value for the metric. Static values and capture groups from the
+  `pattern` can be used. If not specified the scraped mBean value will be used.
+- `valueFactor` - Optional number that `value` (or the scraped mBean value if
+  `value` is not specified) is multiplied by, mainly used to convert mBean
+  values from milliseconds to seconds.
+- `labels` - A list of `label` elements.
+- `help` - Help text for the metric. Capture groups from `pattern` can be used.
+  `name` must be set to use this. Defaults to the mBean attribute description
+  and the full name of the attribute.
+- `type` - The type of the metric, can be `GAUGE`, `COUNTER` or `UNTYPED`.
+  `name` must be set to use this. Defaults to `UNTYPED`.
+
+
+#### `label`
+
+Capture groups from `pattern` can be used in each. `name` must be set to use
+this. Empty names and values are ignored. If not specified and the default
+format is not being used, no labels are set.
+
+- `name`
+- `value`
+
+#### Default Configuration
+
+By default no configuration is necessary to export metrics for the broker,
+addresses, and queues. The following rules are embedded in the code and used
+when no other rules are specified. If any rules are specified explicitly via
+`broker.xml` then *all* of the following rules are removed. These rules were
+adapted from [these](https://github.com/prometheus/jmx_exporter/blob/master/example_configs/artemis-2.yml)
+available from the Prometheus JMX Exporter GitHub project. The various
+`pattern` elements have been changed slightly to be properly escaped for
+HTML rather than YAML.
+
+```xml
+<prometheus-jmx-exporter>
+   <rules>
+      <rule>
+         <pattern>^org.apache.activemq.artemis&lt;broker=&quot;([^&quot;]*)&quot;>&lt;>([^:]*):\s(.*)</pattern>
+         <name>artemis_$2</name>
+         <attr-name-snake-case>true</attr-name-snake-case>
+         <type>COUNTER</type>
+      </rule>
+      <rule>
+         <pattern>^org.apache.activemq.artemis&lt;broker=&quot;([^&quot;]*)&quot;,\s*component=addresses,\s*address=&quot;([^&quot;]*)&quot;>&lt;>([^:]*):\s(.*)</pattern>
+         <name>artemis_$3</name>
+         <attr-name-snake-case>true</attr-name-snake-case>
+         <type>COUNTER</type>
+         <labels>
+            <label name="address" value="$2"/>
+         </labels>
+      </rule>
+      <rule>
+         <pattern>^org.apache.activemq.artemis&lt;broker=&quot;([^&quot;]*)&quot;,\s*component=addresses,\s*address=&quot;([^&quot;]*)&quot;,\s*subcomponent=queues,\s*routing-type=&quot;([^&quot;]*)&quot;,\s*(queue|topic)=&quot;([^&quot;]*)&quot;>&lt;>([^: ]*):\s(.*)</pattern>
+         <name>artemis_$6</name>
+         <attr-name-snake-case>true</attr-name-snake-case>
+         <type>COUNTER</type>
+         <labels>
+            <label name="address" value="$2"/>
+            <label name="queue" value="$5"/>
+         </labels>
+      </rule>
+   </rules>
+</prometheus-jmx-exporter>
+```

--- a/docs/user-manual/en/using-server.md
+++ b/docs/user-manual/en/using-server.md
@@ -101,17 +101,27 @@ For a full list of updated properties always use:
                 [--encoding <encoding>] [--etc <etc>] [--failover-on-shutdown] [--force]
                 [--global-max-size <globalMaxSize>] [--home <home>] [--host <host>]
                 [--http-host <httpHost>] [--http-port <httpPort>]
-                [--java-options <javaOptions>] [--mapped] [--max-hops <maxHops>]
-                [--message-load-balancing <messageLoadBalancing>] [--name <name>]
-                [--nio] [--no-amqp-acceptor] [--no-autocreate] [--no-autotune]
-                [--no-fsync] [--no-hornetq-acceptor] [--no-mqtt-acceptor]
-                [--no-stomp-acceptor] [--no-web] [--paging] [--password <password>]
-                [--ping <ping>] [--port-offset <portOffset>] [--queues <queues>]
-                [--replicated] [--require-login] [--role <role>] [--shared-store]
-                [--silent] [--slave] [--ssl-key <sslKey>]
-                [--ssl-key-password <sslKeyPassword>] [--ssl-trust <sslTrust>]
-                [--ssl-trust-password <sslTrustPassword>] [--use-client-auth]
-                [--user <user>] [--verbose] [--] <directory>
+                [--java-options <javaOptions>] [--jdbc]
+                [--jdbc-bindings-table-name <jdbcBindings>]
+                [--jdbc-connection-url <jdbcURL>]
+                [--jdbc-driver-class-name <jdbcClassName>]
+                [--jdbc-large-message-table-name <jdbcLargeMessages>]
+                [--jdbc-lock-expiration <jdbcLockExpiration>]
+                [--jdbc-lock-renew-period <jdbcLockRenewPeriod>]
+                [--jdbc-message-table-name <jdbcMessages>]
+                [--jdbc-network-timeout <jdbcNetworkTimeout>]
+                [--jdbc-node-manager-table-name <jdbcNodeManager>]
+                [--jdbc-page-store-table-name <jdbcPageStore>] [--mapped]
+                [--max-hops <maxHops>] [--message-load-balancing <messageLoadBalancing>]
+                [--name <name>] [--nio] [--no-amqp-acceptor] [--no-autocreate]
+                [--no-autotune] [--no-fsync] [--no-hornetq-acceptor]
+                [--no-mqtt-acceptor] [--no-stomp-acceptor] [--no-web] [--paging]
+                [--password <password>] [--ping <ping>] [--port-offset <portOffset>]
+                [--prometheus] [--queues <queues>] [--relax-jolokia] [--replicated]
+                [--require-login] [--role <role>] [--shared-store] [--silent] [--slave]
+                [--ssl-key <sslKey>] [--ssl-key-password <sslKeyPassword>]
+                [--ssl-trust <sslTrust>] [--ssl-trust-password <sslTrustPassword>]
+                [--use-client-auth] [--user <user>] [--verbose] [--] <directory>
 
  OPTIONS
          --addresses <addresses>
@@ -155,8 +165,9 @@ For a full list of updated properties always use:
              The encoding that text files should use
 
          --etc <etc>
-             Directory where ActiveMQ configuration is located. Paths can be absolute or
-             relative to artemis.instance directory ('etc' by default)
+             Directory where ActiveMQ configuration is located. Paths can be
+             absolute or relative to artemis.instance directory ('etc' by
+             default)
 
          --failover-on-shutdown
              Valid for shared store: will shutdown trigger a failover? (Default:
@@ -183,6 +194,39 @@ For a full list of updated properties always use:
 
          --java-options <javaOptions>
              Extra java options to be passed to the profile
+
+         --jdbc
+             It will activate jdbc
+
+         --jdbc-bindings-table-name <jdbcBindings>
+             Name of the jdbc bindigns table
+
+         --jdbc-connection-url <jdbcURL>
+             The connection used for the database
+
+         --jdbc-driver-class-name <jdbcClassName>
+             JDBC driver classname
+
+         --jdbc-large-message-table-name <jdbcLargeMessages>
+             Name of the large messages table
+
+         --jdbc-lock-expiration <jdbcLockExpiration>
+             Lock expiration
+
+         --jdbc-lock-renew-period <jdbcLockRenewPeriod>
+             Lock Renew Period
+
+         --jdbc-message-table-name <jdbcMessages>
+             Name of the jdbc messages table
+
+         --jdbc-network-timeout <jdbcNetworkTimeout>
+             Network timeout
+
+         --jdbc-node-manager-table-name <jdbcNodeManager>
+             Name of the jdbc node manager table
+
+         --jdbc-page-store-table-name <jdbcPageStore>
+             Name of the page store messages table
 
          --mapped
              Sets the journal as mapped.
@@ -240,8 +284,15 @@ For a full list of updated properties always use:
          --port-offset <portOffset>
              Off sets the ports of every acceptor
 
+         --prometheus
+             Enables Prometheus support.
+
          --queues <queues>
-             Comma separated list of queues.
+             Comma separated list of queues with the option to specify a routing
+             type. (ex: --queues myqueue,mytopic:multicast)
+
+         --relax-jolokia
+             disable strict checking on jolokia-access.xml
 
          --replicated
              Enable broker replication

--- a/docs/user-manual/en/web-server.md
+++ b/docs/user-manual/en/web-server.md
@@ -41,6 +41,12 @@ The `web` element has the following attributes:
   using `https`. Can be masked using `ENC()` syntax or by defining
   `passwordCodec`. See more in the [password masking](masking-passwords.md)
   chapter.
+- `prometheusServletEnabled` A boolean value to indicate whether or not
+  Prometheus metrics should be exposed via an embedded servlet. Default is
+  `false`. See more in the [Prometheus](prometheus.md) chapter.
+- `prometheusServletContext` The context value to use when exporting
+  Prometheus metrics. Default is `metrics`. See more in the
+  [Prometheus](prometheus.md) chapter.
 
 Each web application should be defined in an `app` element. The `app` element
 has the following attributes:

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@
       <version.org.jacoco>0.7.9</version.org.jacoco>
       <version.org.jacoco.plugin>0.7.9</version.org.jacoco.plugin>
       <version.maven.jar.plugin>2.4</version.maven.jar.plugin>
+      <version.prometheus>0.6.0</version.prometheus>
 
       <!-- used on tests -->
       <groovy.version>2.4.3</groovy.version>
@@ -694,6 +695,26 @@
             <groupId>xalan</groupId>
             <artifactId>xalan</artifactId>
             <version>2.7.2</version>
+         </dependency>
+
+         <!-- Needed for Prometheus -->
+         <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_servlet</artifactId>
+            <version>${version.prometheus}</version>
+            <!-- license Apache 2 -->
+         </dependency>
+         <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_hotspot</artifactId>
+            <version>${version.prometheus}</version>
+            <!-- license Apache 2 -->
+         </dependency>
+         <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <version>${version.prometheus}</version>
+            <!-- license Apache 2 -->
          </dependency>
 
          <dependency>

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/prometheus/PrometheusTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/prometheus/PrometheusTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <br>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <br>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.tests.integration.prometheus;
+
+import java.util.Enumeration;
+import java.util.UUID;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.client.ClientConsumer;
+import org.apache.activemq.artemis.api.core.client.ClientMessage;
+import org.apache.activemq.artemis.api.core.client.ClientProducer;
+import org.apache.activemq.artemis.api.core.client.ClientSession;
+import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
+import org.apache.activemq.artemis.api.core.client.ServerLocator;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PrometheusTest extends ActiveMQTestBase {
+
+   protected ActiveMQServer server;
+
+   protected ClientSession session;
+
+   protected ClientSessionFactory sf;
+
+   protected ServerLocator locator;
+
+   @Override
+   @Before
+   public void setUp() throws Exception {
+      super.setUp();
+
+      server = createServer(false, createDefaultInVMConfig());
+      server.getConfiguration().setJMXManagementEnabled(true);
+      server.start();
+
+      locator = createInVMNonHALocator();
+      sf = createSessionFactory(locator);
+      session = addClientSession(sf.createSession(false, true, true));
+   }
+
+   @Test
+   public void testExpectedMetricsArePresent() throws Exception {
+      final String data = "Simple Text " + UUID.randomUUID().toString();
+      final String queueName = "simpleQueue";
+      final String addressName = "simpleAddress";
+
+      session.createQueue(addressName, RoutingType.ANYCAST, queueName);
+      ClientProducer producer = session.createProducer(addressName);
+      ClientMessage message = session.createMessage(false);
+      message.getBodyBuffer().writeString(data);
+      producer.send(message);
+      producer.close();
+      ClientConsumer consumer = session.createConsumer(queueName);
+      session.start();
+      message = consumer.receive(1000);
+      assertNotNull(message);
+      message.acknowledge();
+      session.commit();
+      assertEquals(data, message.getBodyBuffer().readString());
+
+      // Make sure metrics for the queue are available
+      String[] sampleNames = {"artemis_messages_added", "artemis_messages_acknowledged"};
+      Double[] sampleValues = {1.0, 1.0};
+      boolean[] sampleFound = new boolean[2];
+      int i = 0;
+      Enumeration<Collector.MetricFamilySamples> allSamples = CollectorRegistry.defaultRegistry.metricFamilySamples();
+      while (allSamples.hasMoreElements()) {
+         Collector.MetricFamilySamples samples = allSamples.nextElement();
+         for (int j = 0; j < sampleNames.length; j++) {
+            if (samples.name.equals(sampleNames[j])) {
+               IntegrationTestLogger.LOGGER.info(samples);
+               for (Collector.MetricFamilySamples.Sample sample : samples.samples) {
+                  if (sample.labelValues.contains(queueName)) {
+                     assertEquals(sampleValues[j], sample.value, 0);
+                     sampleFound[j] = true;
+                  }
+               }
+            }
+         }
+         i++;
+      }
+
+      for (int j = 0; j < sampleFound.length; j++) {
+         assertTrue(sampleNames[j] + " not found!", sampleFound[j]);
+      }
+   }
+}


### PR DESCRIPTION
This commit adds an integrated implementation of the Prometheus JMX
Exporter (https://github.com/prometheus/jmx_exporter).

An integrated approach was preferrable to running the JMX exporter as a
Java Agent (which is the standard usage pattern) for several reasons.

The JMX Exporter Java Agent starts its own HTTP server, but we already
have an HTTP server available via embedded Jetty. This creates an
additional port to manage (which can be a significant hurdle in some
environments) as well as additional security attack vector. Securing
this web server via SSL requires setting the various Java SSL system
properties which may have undesirable consequences for other components
in the JVM. Also, the various keystore passwords cannot be masked when
set via system properties. Masking passwords is a requirement in many
environments. All these problems go away if the embedded Jetty HTTP
server is used.

The JMX Exporter Java Agent has its own YAML-based configuration file.
For usability's sake it is preferrable to avoid the proliferation of
configuration across different files and formats. All the same
configuration elements available via the individual YAML file are
available via broker.xml.

In general, configuring the Java Agent is a bit clumsy as it requires
command-line changes (e.g. modifying artemis.profile). An integrated
approach avoids these changes.

The RBAC security enforced on the MBean server makes using the Java
Agent difficult without modifications to the way the MBean server is
built/configured. Using an integrated approach reduces those changes
to a few lines.