### PR TITLE
ARTEMIS-2296 PgResultSet.updateBlob not implemented

### DIFF
--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/file/PostgresSequentialSequentialFileDriver.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/file/PostgresSequentialSequentialFileDriver.java
@@ -107,7 +107,7 @@ public final class PostgresSequentialSequentialFileDriver extends JDBCSequential
    }
 
    @Override
-   public int writeToFile(JDBCSequentialFile file, byte[] data) throws SQLException {
+   public int writeToFile(JDBCSequentialFile file, byte[] data, boolean append) throws SQLException {
       synchronized (connection) {
          LargeObjectManager lobjManager = ((PGConnection) connection).getLargeObjectAPI();
          LargeObject largeObject = null;
@@ -116,7 +116,11 @@ public final class PostgresSequentialSequentialFileDriver extends JDBCSequential
          try {
             connection.setAutoCommit(false);
             largeObject = lobjManager.open(oid, LargeObjectManager.WRITE);
-            largeObject.seek(largeObject.size());
+            if (append) {
+               largeObject.seek(largeObject.size());
+            } else {
+               largeObject.truncate(0);
+            }
             largeObject.write(data);
             largeObject.close();
             connection.commit();


### PR DESCRIPTION
There is no test for this as we don't have a way to embed/test Postgres.
It will need to be verified externally. However, given the exception the
fix looks solid.