### PR TITLE
ARTEMIS-2310 support system prop sub in xincludes

### DIFF
--- a/artemis-core-client/src/test/java/org/apache/activemq/artemis/util/XMLUtilTest.java
+++ b/artemis-core-client/src/test/java/org/apache/activemq/artemis/util/XMLUtilTest.java
@@ -214,7 +214,7 @@ public class XMLUtilTest extends SilentTestCase {
       String after = "<configuration>\n" + "   <test name=\"test1\">content1</test>\n" + "   <test name=\"test2\">content2</test>\n" + "   <test name=\"test3\">content3</test>\n" + "   <test name=\"test4\">content4</test>\n" + "   <test name=\"test5\">content5</test>\n" + "   <test name=\"test6\">content6</test>\n" + "</configuration>";
       System.setProperty("sysprop1", "test1");
       System.setProperty("sysprop2", "content4");
-      String replaced = XMLUtil.replaceSystemProps(before);
+      String replaced = XMLUtil.replaceSystemPropsInString(before);
       Assert.assertEquals(after, replaced);
    }
 

--- a/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/impl/JMSServerManagerImpl.java
+++ b/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/impl/JMSServerManagerImpl.java
@@ -17,9 +17,6 @@
 package org.apache.activemq.artemis.jms.server.impl;
 
 import javax.naming.NamingException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
 import java.net.InetAddress;
 import java.net.URL;
 import java.net.UnknownHostException;
@@ -1632,13 +1629,7 @@ public class JMSServerManagerImpl implements JMSServerManager, ActivateCallback 
       public void reload(URL url) throws Exception {
          ActiveMQServerLogger.LOGGER.reloadingConfiguration("jms");
 
-         InputStream input = url.openStream();
-         String xml;
-         try (Reader reader = new InputStreamReader(input)) {
-            xml = XMLUtil.readerToString(reader);
-         }
-         xml = XMLUtil.replaceSystemProps(xml);
-         Element e = XMLUtil.stringToElement(xml);
+         Element e = XMLUtil.urlToElement(url);
 
          if (config instanceof FileJMSConfiguration) {
             NodeList children = e.getElementsByTagName("jms");

--- a/artemis-rest/src/main/java/org/apache/activemq/artemis/rest/MessageServiceManager.java
+++ b/artemis-rest/src/main/java/org/apache/activemq/artemis/rest/MessageServiceManager.java
@@ -124,7 +124,7 @@ public class MessageServiceManager {
             JAXBContext jaxb = JAXBContext.newInstance(MessageServiceConfiguration.class);
             try (Reader reader = new InputStreamReader(url.openStream())) {
                String xml = XMLUtil.readerToString(reader);
-               xml = XMLUtil.replaceSystemProps(xml);
+               xml = XMLUtil.replaceSystemPropsInString(xml);
                configuration = (MessageServiceConfiguration) jaxb.createUnmarshaller().unmarshal(new StringReader(xml));
             }
          }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/FileDeploymentManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/FileDeploymentManager.java
@@ -17,8 +17,6 @@
 package org.apache.activemq.artemis.core.config;
 
 import javax.management.MBeanServer;
-import java.io.InputStreamReader;
-import java.io.Reader;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -68,23 +66,18 @@ public class FileDeploymentManager {
          // The URL is outside of the classloader. Trying a pure url now
          url = new URL(configurationUrl);
       }
-      // create a reader
-      try (Reader reader = new InputStreamReader(url.openStream())) {
-         String xml = XMLUtil.readerToString(reader);
-         //replace any system props
-         xml = XMLUtil.replaceSystemProps(xml);
-         Element e = XMLUtil.stringToElement(xml);
 
-         //iterate around all the deployables
-         for (Deployable deployable : deployables.values()) {
-            String root = deployable.getRootElement();
-            NodeList children = e.getElementsByTagName(root);
-            //if the root element exists then parse it
-            if (root != null && children.getLength() > 0) {
-               Node item = children.item(0);
-               XMLUtil.validate(item, deployable.getSchema());
-               deployable.parse((Element) item, url);
-            }
+      Element e = XMLUtil.urlToElement(url);
+
+      //iterate around all the deployables
+      for (Deployable deployable : deployables.values()) {
+         String root = deployable.getRootElement();
+         NodeList children = e.getElementsByTagName(root);
+         //if the root element exists then parse it
+         if (root != null && children.getLength() > 0) {
+            Node item = children.item(0);
+            XMLUtil.validate(item, deployable.getSchema());
+            deployable.parse((Element) item, url);
          }
       }
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/LegacyJMSConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/LegacyJMSConfiguration.java
@@ -18,8 +18,6 @@ package org.apache.activemq.artemis.core.config.impl;
 
 import javax.management.MBeanServer;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
 import java.net.URL;
 import java.util.Map;
 
@@ -102,10 +100,7 @@ public class LegacyJMSConfiguration implements Deployable {
 
 
    public void parseConfiguration(final InputStream input) throws Exception {
-      Reader reader = new InputStreamReader(input);
-      String xml = XMLUtil.readerToString(reader);
-      xml = XMLUtil.replaceSystemProps(xml);
-      Element e = XMLUtil.stringToElement(xml);
+      Element e = XMLUtil.streamToElement(input);
       // only parse elements from <jms>
       NodeList children = e.getElementsByTagName(CONFIGURATION_SCHEMA_ROOT_ELEMENT);
       if (children.getLength() > 0) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -16,9 +16,12 @@
  */
 package org.apache.activemq.artemis.core.deployers.impl;
 
+import javax.xml.XMLConstants;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
@@ -92,12 +95,6 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-
-import javax.xml.XMLConstants;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.validation.Schema;
-import javax.xml.validation.SchemaFactory;
-import javax.xml.validation.Validator;
 
 /**
  * Parses an XML document according to the {@literal artemis-configuration.xsd} schema.
@@ -286,10 +283,7 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
    }
 
    public Configuration parseMainConfig(final InputStream input) throws Exception {
-      Reader reader = new InputStreamReader(input);
-      String xml = XMLUtil.readerToString(reader);
-      xml = XMLUtil.replaceSystemProps(xml);
-      Element e = XMLUtil.stringToElement(xml);
+      Element e = XMLUtil.streamToElement(input);
       SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
       Schema schema = schemaFactory.newSchema(XMLUtil.findResource("schema/artemis-server.xsd"));
       Validator validator = schema.newValidator();

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
@@ -64,6 +64,13 @@ import org.junit.Test;
 
 public class FileConfigurationTest extends ConfigurationImplTest {
 
+   static {
+      System.setProperty("a2Prop", "a2");
+      System.setProperty("falseProp", "false");
+      System.setProperty("trueProp", "true");
+      System.setProperty("ninetyTwoProp", "92");
+   }
+
    protected String getConfigurationName() {
       return "ConfigurationTest-full-config.xml";
    }

--- a/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
@@ -84,7 +84,7 @@
             tcp://0.0.0.0:61616?
             tcpNoDelay=456;
             connectionTtl=44;
-            connectionsAllowed=92
+            connectionsAllowed=${ninetyTwoProp}
          </acceptor>
          <acceptor>vm://0?e1=z1;e2=567;connectionsAllowed=87</acceptor>
       </acceptors>
@@ -364,7 +364,7 @@
          <security-setting match="a1">
             <permission type="createNonDurableQueue" roles="a1.1"/>
          </security-setting>
-         <security-setting match="a2">
+         <security-setting match="${a2Prop}">
             <permission type="deleteNonDurableQueue" roles="a2.1"/>
          </security-setting>
       </security-settings>
@@ -438,11 +438,11 @@
          <address name="addr1">
             <anycast>
                <queue name="q1">
-                  <durable>false</durable>
+                  <durable>${falseProp}</durable>
                   <filter string="color='blue'"/>
                </queue>
-               <queue name="q2" max-consumers="-1" purge-on-no-consumers="false">
-                  <durable>true</durable>
+               <queue name="q2" max-consumers="-1" purge-on-no-consumers="${falseProp}">
+                  <durable>${trueProp}</durable>
                   <filter string="color='green'"/>
                </queue>
             </anycast>
@@ -452,8 +452,8 @@
                <queue name="q3" max-consumers="10" >
                   <filter string="color='red'"/>
                </queue>
-               <queue name="q4" purge-on-no-consumers="true">
-                  <durable>true</durable>
+               <queue name="q4" purge-on-no-consumers="${trueProp}">
+                  <durable>${trueProp}</durable>
                </queue>
             </multicast>
          </address>

--- a/artemis-server/src/test/resources/ConfigurationTest-xinclude-config-acceptors.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-xinclude-config-acceptors.xml
@@ -14,11 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<security-settings xmlns="urn:activemq:core">
-   <security-setting match="a1">
-      <permission type="createNonDurableQueue" roles="a1.1"/>
-   </security-setting>
-   <security-setting match="${a2Prop}">
-      <permission type="deleteNonDurableQueue" roles="a2.1"/>
-   </security-setting>
-</security-settings>
+<acceptors xmlns="urn:activemq:core">
+   <acceptor>tcp://0.0.0.0:61616?tcpNoDelay=456;connectionTtl=44;connectionsAllowed=${ninetyTwoProp}</acceptor>
+   <acceptor>vm://0?e1=z1;e2=567;connectionsAllowed=87</acceptor>
+</acceptors>

--- a/artemis-server/src/test/resources/ConfigurationTest-xinclude-config-addresses.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-xinclude-config-addresses.xml
@@ -18,11 +18,11 @@
    <address name="addr1">
       <anycast>
          <queue name="q1">
-            <durable>false</durable>
+            <durable>${falseProp}</durable>
             <filter string="color='blue'"/>
          </queue>
-         <queue name="q2" max-consumers="-1" purge-on-no-consumers="false">
-            <durable>true</durable>
+         <queue name="q2" max-consumers="-1" purge-on-no-consumers="${falseProp}">
+            <durable>${trueProp}</durable>
             <filter string="color='green'"/>
          </queue>
       </anycast>
@@ -32,8 +32,8 @@
          <queue name="q3" max-consumers="10" >
             <filter string="color='red'"/>
          </queue>
-         <queue name="q4" purge-on-no-consumers="true">
-            <durable>true</durable>
+         <queue name="q4" purge-on-no-consumers="${trueProp}">
+            <durable>${trueProp}</durable>
          </queue>
       </multicast>
    </address>

--- a/artemis-server/src/test/resources/ConfigurationTest-xinclude-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-xinclude-config.xml
@@ -76,10 +76,9 @@
          <connector name="connector1">tcp://localhost1:5678?localAddress=mylocal;localPort=99</connector>
          <connector name="connector2">vm://5</connector>
       </connectors>
-      <acceptors>
-         <acceptor>tcp://0.0.0.0:61616?tcpNoDelay=456;connectionTtl=44;connectionsAllowed=92</acceptor>
-         <acceptor>vm://0?e1=z1;e2=567;connectionsAllowed=87</acceptor>
-      </acceptors>
+
+      <xi:include href="./src/test/resources/ConfigurationTest-xinclude-config-acceptors.xml"/>
+
       <broadcast-groups>
          <broadcast-group name="bg1">
             <local-bind-port>10999</local-bind-port>

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/config/impl/ConfigurationValidationTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/config/impl/ConfigurationValidationTest.java
@@ -26,6 +26,13 @@ import org.w3c.dom.Element;
 
 public class ConfigurationValidationTest extends ActiveMQTestBase {
 
+   static {
+      System.setProperty("a2Prop", "a2");
+      System.setProperty("falseProp", "false");
+      System.setProperty("trueProp", "true");
+      System.setProperty("ninetyTwoProp", "92");
+   }
+
    // Constants -----------------------------------------------------
 
    // Attributes ----------------------------------------------------


### PR DESCRIPTION
Historically the broker has read the XML configuration file as a String,
substituted system properties, and then parsed that String into an XML
document. However, this method won't substitute system properties in the
files which are imported via xinclude. In order to substitue system
properties in xincluded files the substitution needs to be performed
after the file is parsed into an XML document. This commit implements
that change and refactors the XMLUtil class a bit to eliminate redundant
code, obsolete comments, etc.