### PR TITLE
ARTEMIS-2321 Paging GC improvements

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/PageCache.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/PageCache.java
@@ -17,9 +17,9 @@
 package org.apache.activemq.artemis.core.paging.cursor;
 
 import org.apache.activemq.artemis.core.paging.PagedMessage;
-import org.apache.activemq.artemis.utils.SoftValueHashMap;
+import org.apache.activemq.artemis.utils.SoftValueLongObjectHashMap;
 
-public interface PageCache extends SoftValueHashMap.ValueCache {
+public interface PageCache extends SoftValueLongObjectHashMap.ValueCache {
 
    long getPageId();
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/LivePageCacheImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/LivePageCacheImpl.java
@@ -18,7 +18,6 @@ package org.apache.activemq.artemis.core.paging.cursor.impl;
 
 import org.apache.activemq.artemis.core.paging.PagedMessage;
 import org.apache.activemq.artemis.core.paging.cursor.LivePageCache;
-import org.apache.activemq.artemis.core.paging.impl.Page;
 import org.apache.activemq.artemis.core.server.LargeServerMessage;
 import org.apache.activemq.artemis.utils.collections.ConcurrentAppendOnlyChunkedList;
 import org.jboss.logging.Logger;
@@ -34,18 +33,18 @@ public final class LivePageCacheImpl implements LivePageCache {
 
    private final ConcurrentAppendOnlyChunkedList<PagedMessage> messages;
 
-   private final Page page;
+   private final long pageId;
 
    private volatile boolean isLive = true;
 
-   public LivePageCacheImpl(final Page page) {
-      this.page = page;
+   public LivePageCacheImpl(final long pageId) {
+      this.pageId = pageId;
       this.messages = new ConcurrentAppendOnlyChunkedList<>(CHUNK_SIZE);
    }
 
    @Override
    public long getPageId() {
-      return page.getPageId();
+      return pageId;
    }
 
    @Override
@@ -92,6 +91,6 @@ public final class LivePageCacheImpl implements LivePageCache {
 
    @Override
    public String toString() {
-      return "LivePacheCacheImpl::page=" + page.getPageId() + " number of messages=" + getNumberOfMessages() + " isLive = " + isLive;
+      return "LivePacheCacheImpl::page=" + pageId + " number of messages=" + getNumberOfMessages() + " isLive = " + isLive;
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageCacheImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageCacheImpl.java
@@ -18,7 +18,6 @@ package org.apache.activemq.artemis.core.paging.cursor.impl;
 
 import org.apache.activemq.artemis.core.paging.PagedMessage;
 import org.apache.activemq.artemis.core.paging.cursor.PageCache;
-import org.apache.activemq.artemis.core.paging.impl.Page;
 
 /**
  * The caching associated to a single page.
@@ -31,14 +30,14 @@ class PageCacheImpl implements PageCache {
 
    private PagedMessage[] messages;
 
-   private final Page page;
+   private final long pageId;
 
    // Static --------------------------------------------------------
 
    // Constructors --------------------------------------------------
 
-   PageCacheImpl(final Page page) {
-      this.page = page;
+   PageCacheImpl(final long pageId) {
+      this.pageId = pageId;
    }
 
    // Public --------------------------------------------------------
@@ -54,7 +53,7 @@ class PageCacheImpl implements PageCache {
 
    @Override
    public long getPageId() {
-      return page.getPageId();
+      return pageId;
    }
 
    @Override
@@ -78,7 +77,7 @@ class PageCacheImpl implements PageCache {
 
    @Override
    public String toString() {
-      return "PageCacheImpl::page=" + page.getPageId() + " numberOfMessages = " + messages.length;
+      return "PageCacheImpl::page=" + pageId + " numberOfMessages = " + messages.length;
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageCursorProviderImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageCursorProviderImpl.java
@@ -567,8 +567,8 @@ public class PageCursorProviderImpl implements PageCursorProvider {
    // Protected -----------------------------------------------------
 
    /* Protected as we may let test cases to instrument the test */
-   protected PageCacheImpl createPageCache(final long pageId) throws Exception {
-      return new PageCacheImpl(pagingStore.createPage((int) pageId));
+   protected PageCacheImpl createPageCache(final long pageId) {
+      return new PageCacheImpl(pageId);
    }
 
    // Private -------------------------------------------------------

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageCursorProviderImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageCursorProviderImpl.java
@@ -19,8 +19,6 @@ package org.apache.activemq.artemis.core.paging.cursor.impl;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -39,8 +37,9 @@ import org.apache.activemq.artemis.core.persistence.StorageManager;
 import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
 import org.apache.activemq.artemis.core.transaction.Transaction;
 import org.apache.activemq.artemis.core.transaction.impl.TransactionImpl;
-import org.apache.activemq.artemis.utils.SoftValueHashMap;
+import org.apache.activemq.artemis.utils.SoftValueLongObjectHashMap;
 import org.apache.activemq.artemis.utils.actors.ArtemisExecutor;
+import org.apache.activemq.artemis.utils.collections.ConcurrentLongHashMap;
 import org.jboss.logging.Logger;
 
 /**
@@ -70,9 +69,9 @@ public class PageCursorProviderImpl implements PageCursorProvider {
    // This is the same executor used at the PageStoreImpl. One Executor per pageStore
    private final ArtemisExecutor executor;
 
-   private final SoftValueHashMap<Long, PageCache> softCache;
+   private final SoftValueLongObjectHashMap<PageCache> softCache;
 
-   private final ConcurrentMap<Long, PageSubscription> activeCursors = new ConcurrentHashMap<>();
+   private final ConcurrentLongHashMap<PageSubscription> activeCursors = new ConcurrentLongHashMap<>();
 
    // Static --------------------------------------------------------
 
@@ -85,7 +84,7 @@ public class PageCursorProviderImpl implements PageCursorProvider {
       this.pagingStore = pagingStore;
       this.storageManager = storageManager;
       this.executor = executor;
-      this.softCache = new SoftValueHashMap<>(maxCacheSize);
+      this.softCache = new SoftValueLongObjectHashMap<>(maxCacheSize);
    }
 
    // Public --------------------------------------------------------

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingStoreImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingStoreImpl.java
@@ -445,7 +445,7 @@ public class PagingStoreImpl implements PagingStore {
 
                   List<PagedMessage> messages = currentPage.read(storageManager);
 
-                  LivePageCache pageCache = new LivePageCacheImpl(currentPage);
+                  LivePageCache pageCache = new LivePageCacheImpl(currentPageId);
 
                   for (PagedMessage msg : messages) {
                      pageCache.addLiveMessage(msg);
@@ -1091,7 +1091,7 @@ public class PagingStoreImpl implements PagingStore {
 
          currentPage = createPage(tmpCurrentPageId);
 
-         LivePageCache pageCache = new LivePageCacheImpl(currentPage);
+         LivePageCache pageCache = new LivePageCacheImpl(tmpCurrentPageId);
 
          currentPage.setLiveCache(pageCache);
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/SoftValueMapTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/SoftValueMapTest.java
@@ -17,7 +17,7 @@
 package org.apache.activemq.artemis.tests.unit.util;
 
 import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
-import org.apache.activemq.artemis.utils.SoftValueHashMap;
+import org.apache.activemq.artemis.utils.SoftValueLongObjectHashMap;
 import org.junit.Test;
 
 public class SoftValueMapTest extends ActiveMQTestBase {
@@ -40,7 +40,7 @@ public class SoftValueMapTest extends ActiveMQTestBase {
       // each buffer will be 1/10th of the maxMemory
       int bufferSize = (int) (maxMemory / 100);
 
-      SoftValueHashMap<Long, Value> softCache = new SoftValueHashMap<>(100);
+      SoftValueLongObjectHashMap<Value> softCache = new SoftValueLongObjectHashMap<>(100);
 
       final int MAX_ELEMENTS = 1000;
 
@@ -59,7 +59,7 @@ public class SoftValueMapTest extends ActiveMQTestBase {
    public void testEvictionsLeastUsed() {
       forceGC();
 
-      SoftValueHashMap<Long, Value> softCache = new SoftValueHashMap<>(200);
+      SoftValueLongObjectHashMap<Value> softCache = new SoftValueLongObjectHashMap<>(200);
 
       for (long i = 0; i < 100; i++) {
          Value v = new Value(new byte[1]);
@@ -99,7 +99,7 @@ public class SoftValueMapTest extends ActiveMQTestBase {
       Value two = new Value(new byte[100]);
       Value three = new Value(new byte[100]);
 
-      SoftValueHashMap<Integer, Value> softCache = new SoftValueHashMap<>(2);
+      SoftValueLongObjectHashMap<Value> softCache = new SoftValueLongObjectHashMap<>(2);
       softCache.put(3, three);
       softCache.put(2, two);
       softCache.put(1, one);
@@ -110,7 +110,7 @@ public class SoftValueMapTest extends ActiveMQTestBase {
 
    }
 
-   class Value implements SoftValueHashMap.ValueCache {
+   class Value implements SoftValueLongObjectHashMap.ValueCache {
 
       byte[] payload;
 
@@ -121,7 +121,7 @@ public class SoftValueMapTest extends ActiveMQTestBase {
       }
 
       /* (non-Javadoc)
-       * @see org.apache.activemq.artemis.utils.SoftValueHashMap.ValueCache#isLive()
+       * @see org.apache.activemq.artemis.utils.SoftValueLongObjectHashMap.ValueCache#isLive()
        */
       @Override
       public boolean isLive() {


### PR DESCRIPTION
It contains several improvements:

- PageCursorProviderImpl can use primitive maps
- PageCache doesn't need a Page reference
- Removed unnecessary volatile/Atomic operations and fields
- PageCursorInfo caches number of msgs to save Page::read