### PR TITLE
ARTEMIS-2319 Upgrading jboss-logging dependencies

### DIFF
--- a/artemis-cdi-client/pom.xml
+++ b/artemis-cdi-client/pom.xml
@@ -56,6 +56,10 @@
          <artifactId>jboss-logmanager</artifactId>
       </dependency>
       <dependency>
+          <groupId>org.wildfly.common</groupId>
+          <artifactId>wildfly-common</artifactId>
+      </dependency>
+      <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-core-client</artifactId>
          <version>${project.version}</version>

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
@@ -685,6 +685,7 @@ public class Create extends InputAbstract {
       filters.put("${artemis.instance.data}", path(dataFolder));
 
       filters.put("${logmanager}", getLogManager());
+      filters.put("${wildfly-common}", getWildflyCommon());
 
       if (javaOptions == null || javaOptions.length() == 0) {
          javaOptions = "";
@@ -891,6 +892,23 @@ public class Create extends InputAbstract {
       return logManager;
    }
 
+   private String getWildflyCommon() throws IOException {
+      String logManager = "";
+      File dir = new File(path(getHome().toString()) + "/lib");
+
+      File[] matches = dir.listFiles(new FilenameFilter() {
+         @Override
+         public boolean accept(File dir, String name) {
+            return name.startsWith("wildfly-common") && name.endsWith(".jar");
+         }
+      });
+
+      if (matches != null && matches.length > 0) {
+         logManager = matches[0].getName();
+      }
+
+      return logManager;
+   }
    /**
     * It will create the address and queue configurations
     */

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis
@@ -106,9 +106,15 @@ if [ -z "$LOG_MANAGER" ] ; then
   LOG_MANAGER="$ARTEMIS_HOME/lib/${logmanager}"
 fi
 
+WILDFLY_COMMON=`ls $ARTEMIS_HOME/lib/wildfly-common*jar 2>/dev/null`
+if [ -z "$WILDFLY_COMMON" ] ; then
+  # this is the one found when the server was created
+  WILDFLY_COMMON="$ARTEMIS_HOME/lib/${wildfly-common}"
+fi
+
 exec "$JAVACMD" \
     $JAVA_ARGS \
-    -Xbootclasspath/a:"$LOG_MANAGER" \
+    -Xbootclasspath/a:"$LOG_MANAGER:$WILDFLY_COMMON" \
     -Djava.security.auth.login.config="$ARTEMIS_INSTANCE_ETC/login.config" \
     $ARTEMIS_CLUSTER_PROPS \
     -classpath "$CLASSPATH" \

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis-service.xml
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis-service.xml
@@ -69,7 +69,7 @@
    <startargument>run</startargument>
 
    <stopexecutable>%JAVA_HOME%\bin\java.exe</stopexecutable>
-   <stopargument>-Xbootclasspath/a:%ARTEMIS_HOME%\lib\${logmanager}</stopargument>
+   <stopargument>-Xbootclasspath/a:%ARTEMIS_HOME%\lib\${logmanager};%ARTEMIS_HOME%\lib\${wildfly-common}</stopargument>
    <stopargument>-XX:+UseParallelGC</stopargument>
    <stopargument>-Xms512M</stopargument>
    <stopargument>-Xmx1024M</stopargument>

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile.cmd
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile.cmd
@@ -32,7 +32,7 @@ rem Cluster Properties: Used to pass arguments to ActiveMQ Artemis which can be 
 rem set ARTEMIS_CLUSTER_PROPS=-Dactivemq.remoting.default.port=61617 -Dactivemq.remoting.amqp.port=5673 -Dactivemq.remoting.stomp.port=61614 -Dactivemq.remoting.hornetq.port=5446
 
 rem Java Opts
-set JAVA_ARGS=${java-opts} -XX:+PrintClassHistogram -XX:+UseG1GC -Xms512M -Xmx1024M -Xbootclasspath/a:%ARTEMIS_HOME%\lib\${logmanager} -Djava.security.auth.login.config=%ARTEMIS_ETC_DIR%\login.config -Dhawtio.offline="true" -Dhawtio.realm=activemq -Dhawtio.role=${role} -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal -Djolokia.policyLocation=%ARTEMIS_INSTANCE_ETC_URI%\jolokia-access.xml -Dartemis.instance=%ARTEMIS_INSTANCE%
+set JAVA_ARGS=${java-opts} -XX:+PrintClassHistogram -XX:+UseG1GC -Xms512M -Xmx1024M -Xbootclasspath/a:%ARTEMIS_HOME%\lib\${logmanager};%ARTEMIS_HOME%\lib\${wildfly-common} -Djava.security.auth.login.config=%ARTEMIS_ETC_DIR%\login.config -Dhawtio.offline="true" -Dhawtio.realm=activemq -Dhawtio.role=${role} -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal -Djolokia.policyLocation=%ARTEMIS_INSTANCE_ETC_URI%\jolokia-access.xml -Dartemis.instance=%ARTEMIS_INSTANCE%
 
 rem Logs Safepoints JVM pauses: Uncomment to enable them
 rem In addition to the traditional GC logs you could enable some JVM flags to know any meaningful and "hidden" pause that could

--- a/artemis-commons/pom.xml
+++ b/artemis-commons/pom.xml
@@ -51,6 +51,12 @@
          <optional>true</optional>
       </dependency>
       <dependency>
+          <groupId>org.wildfly.common</groupId>
+          <artifactId>wildfly-common</artifactId>
+         <scope>provided</scope>
+         <optional>true</optional>
+      </dependency>
+      <dependency>
          <groupId>org.jboss.logging</groupId>
          <artifactId>jboss-logging</artifactId>
       </dependency>

--- a/artemis-core-client-osgi/pom.xml
+++ b/artemis-core-client-osgi/pom.xml
@@ -48,6 +48,12 @@
          <scope>provided</scope>
       </dependency>
       <dependency>
+          <groupId>org.wildfly.common</groupId>
+          <artifactId>wildfly-common</artifactId>
+         <scope>provided</scope>
+         <optional>true</optional>
+      </dependency>
+      <dependency>
          <groupId>org.jboss.logging</groupId>
          <artifactId>jboss-logging-processor</artifactId>
          <scope>provided</scope>

--- a/artemis-core-client/pom.xml
+++ b/artemis-core-client/pom.xml
@@ -57,6 +57,12 @@
          <optional>true</optional>
       </dependency>
       <dependency>
+          <groupId>org.wildfly.common</groupId>
+          <artifactId>wildfly-common</artifactId>
+         <scope>provided</scope>
+         <optional>true</optional>
+      </dependency>
+      <dependency>
          <groupId>org.jgroups</groupId>
          <artifactId>jgroups</artifactId>
       </dependency>

--- a/artemis-distribution/pom.xml
+++ b/artemis-distribution/pom.xml
@@ -144,13 +144,17 @@
       </dependency>
       <!-- dependencies -->
       <dependency>
-         <groupId>org.jboss.logmanager</groupId>
-         <artifactId>jboss-logmanager</artifactId>
+          <groupId>org.jboss.logmanager</groupId>
+          <artifactId>jboss-logmanager</artifactId>
       </dependency>
-         <dependency>
-            <groupId>org.jboss.slf4j</groupId>
-            <artifactId>slf4j-jboss-logmanager</artifactId>
-         </dependency>
+      <dependency>
+          <groupId>org.jboss.slf4j</groupId>
+          <artifactId>slf4j-jboss-logmanager</artifactId>
+      </dependency>
+      <dependency>
+          <groupId>org.wildfly.common</groupId>
+          <artifactId>wildfly-common</artifactId>
+      </dependency>
        <dependency>
            <groupId>io.airlift</groupId>
            <artifactId>airline</artifactId>

--- a/artemis-distribution/src/main/assembly/dep.xml
+++ b/artemis-distribution/src/main/assembly/dep.xml
@@ -77,6 +77,7 @@
             <include>org.apache.geronimo.specs:geronimo-j2ee-connector_1.5_spec</include>
             <include>org.apache.geronimo.specs:geronimo-ejb_3.0_spec</include>
             <include>org.apache.geronimo.specs:geronimo-jta_1.1_spec</include>
+            <include>org.wildfly.common:wildfly-common</include>
             <include>org.jboss.logmanager:jboss-logmanager</include>
             <include>org.jboss.logging:jboss-logging</include>
             <include>org.jboss.slf4j:slf4j-jboss-logmanager</include>

--- a/artemis-jdbc-store/pom.xml
+++ b/artemis-jdbc-store/pom.xml
@@ -50,6 +50,11 @@
          <scope>test</scope>
       </dependency>
       <dependency>
+          <groupId>org.wildfly.common</groupId>
+          <artifactId>wildfly-common</artifactId>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-commons</artifactId>
          <version>${project.version}</version>

--- a/artemis-jms-client-osgi/pom.xml
+++ b/artemis-jms-client-osgi/pom.xml
@@ -58,6 +58,12 @@
          <scope>provided</scope>
       </dependency>
       <dependency>
+          <groupId>org.wildfly.common</groupId>
+          <artifactId>wildfly-common</artifactId>
+         <scope>provided</scope>
+         <optional>true</optional>
+      </dependency>
+      <dependency>
          <groupId>org.jboss.logging</groupId>
          <artifactId>jboss-logging-processor</artifactId>
          <scope>provided</scope>

--- a/artemis-maven-plugin/pom.xml
+++ b/artemis-maven-plugin/pom.xml
@@ -85,12 +85,12 @@
    </dependencies>
 
    <build>
-   	<pluginManagement>
-   		<plugins>
+      <pluginManagement>
+         <plugins>
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-plugin-plugin</artifactId>
-               <version>3.4</version>
+               <version>3.5.2</version>
                <executions>
                   <execution>
                      <id>default-descriptor</id>

--- a/artemis-protocols/artemis-amqp-protocol/pom.xml
+++ b/artemis-protocols/artemis-amqp-protocol/pom.xml
@@ -70,6 +70,11 @@
          <artifactId>jboss-logmanager</artifactId>
          <scope>test</scope>
       </dependency>
+      <dependency>
+          <groupId>org.wildfly.common</groupId>
+          <artifactId>wildfly-common</artifactId>
+         <scope>test</scope>
+      </dependency>
 
       <!-- this is for the log assertion -->
       <dependency>

--- a/artemis-server-osgi/pom.xml
+++ b/artemis-server-osgi/pom.xml
@@ -83,6 +83,12 @@
          <scope>provided</scope>
       </dependency>
       <dependency>
+          <groupId>org.wildfly.common</groupId>
+          <artifactId>wildfly-common</artifactId>
+         <scope>provided</scope>
+         <optional>true</optional>
+      </dependency>
+      <dependency>
          <groupId>org.jboss.logging</groupId>
          <artifactId>jboss-logging-processor</artifactId>
          <scope>provided</scope>

--- a/artemis-service-extensions/pom.xml
+++ b/artemis-service-extensions/pom.xml
@@ -69,6 +69,11 @@
          <scope>test</scope>
       </dependency>
       <dependency>
+          <groupId>org.wildfly.common</groupId>
+          <artifactId>wildfly-common</artifactId>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
          <groupId>org.apache.geronimo.specs</groupId>
          <artifactId>geronimo-jta_1.1_spec</artifactId>
       </dependency>

--- a/artemis-web/pom.xml
+++ b/artemis-web/pom.xml
@@ -117,5 +117,10 @@
          <artifactId>jboss-logmanager</artifactId>
          <scope>test</scope>
       </dependency>
+      <dependency>
+          <groupId>org.wildfly.common</groupId>
+          <artifactId>wildfly-common</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
       <commons.collections.version>3.2.2</commons.collections.version>
       <fuse.mqtt.client.version>1.14</fuse.mqtt.client.version>
       <guava.version>19.0</guava.version>
-      <jboss.logging.version>3.3.1.Final</jboss.logging.version>
+      <jboss.logging.version>3.4.0.Final</jboss.logging.version>
       <jetty.version>9.4.3.v20170317</jetty.version>
       <jgroups.version>3.6.13.Final</jgroups.version>
       <maven.assembly.plugin.version>2.4</maven.assembly.plugin.version>
@@ -100,8 +100,9 @@
       <json-p.spec.version>1.0-alpha-1</json-p.spec.version>
       <javax.inject.version>1</javax.inject.version>
       <hawtbuff.version>1.11</hawtbuff.version>
-      <jb.logmanager.version>2.0.3.Final</jb.logmanager.version>
+      <jb.logmanager.version>2.1.10.Final</jb.logmanager.version>
       <jb.slf4j-jboss-logmanager.version>1.0.4.GA</jb.slf4j-jboss-logmanager.version>
+       <version.org.wildfly.common.wildfly-common>1.5.1.Final</version.org.wildfly.common.wildfly-common>
       <airlift.version>0.7</airlift.version>
       <geronimo.annotation.1.1.spec.version>1.0.1</geronimo.annotation.1.1.spec.version>
       <geronimo.ejb.3.0.spec.version>1.0.1</geronimo.ejb.3.0.spec.version>
@@ -313,14 +314,14 @@
          <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-processor</artifactId>
-            <version>2.1.0.Final</version>
+            <version>2.2.0.Final</version>
             <optional>true</optional>
             <!-- License: LGPL-->
          </dependency>
          <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-annotations</artifactId>
-            <version>2.1.0.Final</version>
+            <version>2.2.0.Final</version>
             <scope>provided</scope>
             <optional>true</optional>
             <!-- License: Apache 2.0-->
@@ -405,6 +406,12 @@
             <artifactId>slf4j-jboss-logmanager</artifactId>
             <version>${jb.slf4j-jboss-logmanager.version}</version>
             <!-- License: Apache 2.0 -->
+         </dependency>
+         <dependency>
+             <groupId>org.wildfly.common</groupId>
+             <artifactId>wildfly-common</artifactId>
+             <version>${version.org.wildfly.common.wildfly-common}</version>
+             <!-- License: Apache 2.0 -->
          </dependency>
          <dependency>
             <groupId>net.java.dev.javacc</groupId>

--- a/tests/activemq5-unit-tests/pom.xml
+++ b/tests/activemq5-unit-tests/pom.xml
@@ -374,6 +374,10 @@
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>jboss-logmanager</artifactId>
       </dependency>
+      <dependency>
+          <groupId>org.wildfly.common</groupId>
+          <artifactId>wildfly-common</artifactId>
+      </dependency>
 
    </dependencies>
 

--- a/tests/compatibility-tests/pom.xml
+++ b/tests/compatibility-tests/pom.xml
@@ -261,6 +261,10 @@
          <artifactId>jboss-logmanager</artifactId>
       </dependency>
       <dependency>
+          <groupId>org.wildfly.common</groupId>
+          <artifactId>wildfly-common</artifactId>
+      </dependency>
+      <dependency>
          <groupId>org.apache.qpid</groupId>
          <artifactId>qpid-jms-client</artifactId>
          <version>${qpid.jms.version}</version>

--- a/tests/extra-tests/pom.xml
+++ b/tests/extra-tests/pom.xml
@@ -189,6 +189,10 @@
          <artifactId>jboss-logmanager</artifactId>
       </dependency>
       <dependency>
+          <groupId>org.wildfly.common</groupId>
+          <artifactId>wildfly-common</artifactId>
+      </dependency>
+      <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
       </dependency>

--- a/tests/integration-tests/pom.xml
+++ b/tests/integration-tests/pom.xml
@@ -262,6 +262,10 @@
          <artifactId>jboss-logmanager</artifactId>
       </dependency>
       <dependency>
+          <groupId>org.wildfly.common</groupId>
+          <artifactId>wildfly-common</artifactId>
+      </dependency>
+      <dependency>
          <groupId>org.apache.qpid</groupId>
          <artifactId>qpid-jms-client</artifactId>
       </dependency>

--- a/tests/jms-tests/pom.xml
+++ b/tests/jms-tests/pom.xml
@@ -101,6 +101,10 @@
          <groupId>org.jboss.logmanager</groupId>
          <artifactId>jboss-logmanager</artifactId>
       </dependency>
+      <dependency>
+          <groupId>org.wildfly.common</groupId>
+          <artifactId>wildfly-common</artifactId>
+      </dependency>
    </dependencies>
 
    <build>

--- a/tests/joram-tests/pom.xml
+++ b/tests/joram-tests/pom.xml
@@ -99,6 +99,10 @@
          <groupId>org.jboss.logmanager</groupId>
          <artifactId>jboss-logmanager</artifactId>
       </dependency>
+      <dependency>
+          <groupId>org.wildfly.common</groupId>
+          <artifactId>wildfly-common</artifactId>
+      </dependency>
 
    </dependencies>
 

--- a/tests/karaf-client-integration-tests/pom.xml
+++ b/tests/karaf-client-integration-tests/pom.xml
@@ -75,6 +75,11 @@
          <artifactId>jboss-logmanager</artifactId>
          <scope>test</scope>
       </dependency>
+      <dependency>
+          <groupId>org.wildfly.common</groupId>
+          <artifactId>wildfly-common</artifactId>
+         <scope>test</scope>
+      </dependency>
 
       <!-- karaf test -->
 

--- a/tests/performance-tests/pom.xml
+++ b/tests/performance-tests/pom.xml
@@ -110,6 +110,10 @@
          <artifactId>jboss-logmanager</artifactId>
       </dependency>
       <dependency>
+          <groupId>org.wildfly.common</groupId>
+          <artifactId>wildfly-common</artifactId>
+      </dependency>
+      <dependency>
          <groupId>org.jboss.logging</groupId>
          <artifactId>jboss-logging</artifactId>
       </dependency>

--- a/tests/smoke-tests/pom.xml
+++ b/tests/smoke-tests/pom.xml
@@ -104,6 +104,10 @@
          <artifactId>jboss-logmanager</artifactId>
       </dependency>
       <dependency>
+          <groupId>org.wildfly.common</groupId>
+          <artifactId>wildfly-common</artifactId>
+      </dependency>
+      <dependency>
          <groupId>org.fusesource.mqtt-client</groupId>
          <artifactId>mqtt-client</artifactId>
       </dependency>

--- a/tests/unit-tests/pom.xml
+++ b/tests/unit-tests/pom.xml
@@ -140,6 +140,10 @@
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>jboss-logmanager</artifactId>
       </dependency>
+      <dependency>
+          <groupId>org.wildfly.common</groupId>
+          <artifactId>wildfly-common</artifactId>
+      </dependency>
 
       <!-- this is for the log assertion -->
       <dependency>


### PR DESCRIPTION
* Upgrading versions
* Adding wildfly-common dependency as jboss-logmanager now depends on it
for simple common operations such as getting hostname or process id
* Updating bootclasspath with wildfly-common

Jira: https://issues.apache.org/jira/browse/ARTEMIS-2319