### PR TITLE
ARTEMIS-2333 Applying proper fix on Stomp delivery

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnection.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnection.java
@@ -137,8 +137,13 @@ public class NettyConnection implements Connection {
             readyListeners.add(callback);
          }
 
-         return ready && channel.isOpen();
+         return ready;
       }
+   }
+
+   @Override
+   public boolean isOpen() {
+      return channel.isOpen();
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/Connection.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/Connection.java
@@ -43,6 +43,8 @@ public interface Connection {
 
    boolean isWritable(ReadyListener listener);
 
+   boolean isOpen();
+
    /**
     * Causes the current thread to wait until the connection can enqueue the required capacity unless the specified waiting time elapses.
     * The available capacity of the connection could change concurrently hence this method is suitable to perform precise flow-control

--- a/artemis-core-client/src/test/java/org/apache/activemq/artemis/core/protocol/core/impl/ChannelImplTest.java
+++ b/artemis-core-client/src/test/java/org/apache/activemq/artemis/core/protocol/core/impl/ChannelImplTest.java
@@ -344,6 +344,11 @@ public class ChannelImplTest {
             }
 
             @Override
+            public boolean isOpen() {
+               return true;
+            }
+
+            @Override
             public boolean isWritable(ReadyListener listener) {
                return false;
             }

--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompConnection.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompConnection.java
@@ -153,7 +153,7 @@ public final class StompConnection implements RemotingConnection {
 
    @Override
    public boolean isWritable(ReadyListener callback) {
-      return transportConnection.isWritable(callback);
+      return transportConnection.isWritable(callback) && transportConnection.isOpen();
    }
 
    public boolean hasBytes() {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMConnection.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMConnection.java
@@ -117,6 +117,11 @@ public class InVMConnection implements Connection {
    }
 
    @Override
+   public boolean isOpen() {
+      return true;
+   }
+
+   @Override
    public void fireReady(boolean ready) {
    }
 


### PR DESCRIPTION
When connection is dead, the StompSession may deliver a message and if AUTO-ACK it would ack and lose the message