### PR TITLE
ARTEMIS-2321 Non-blocking Page::read on page cache

### DIFF
--- a/artemis-server/pom.xml
+++ b/artemis-server/pom.xml
@@ -189,6 +189,11 @@
          <artifactId>derby</artifactId>
          <scope>test</scope>
       </dependency>
+      <dependency>
+         <groupId>org.mockito</groupId>
+         <artifactId>mockito-core</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
 
    <profiles>

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/StorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/StorageManager.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.Pair;
@@ -145,6 +146,12 @@ public interface StorageManager extends IDGenerator, ActiveMQComponent {
     * @throws Exception
     */
    void beforePageRead() throws Exception;
+
+   /**
+    * Like {@link #beforePageRead()} but return {@code true} if acquired within {@code timeout},
+    * {@code false} otherwise.
+    */
+   boolean beforePageRead(long timeout, TimeUnit unit) throws InterruptedException;
 
    /**
     * We need a safeguard in place to avoid too much concurrent IO happening on Paging, otherwise

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AbstractJournalStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AbstractJournalStorageManager.java
@@ -1633,6 +1633,15 @@ public abstract class AbstractJournalStorageManager extends CriticalComponentImp
    }
 
    @Override
+   public boolean beforePageRead(long timeout, TimeUnit unit) throws InterruptedException {
+      final Semaphore pageMaxConcurrentIO = this.pageMaxConcurrentIO;
+      if (pageMaxConcurrentIO == null) {
+         return true;
+      }
+      return pageMaxConcurrentIO.tryAcquire(timeout, unit);
+   }
+
+   @Override
    public void afterPageRead() throws Exception {
       if (pageMaxConcurrentIO != null) {
          pageMaxConcurrentIO.release();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/nullpm/NullStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/nullpm/NullStorageManager.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.activemq.artemis.api.core.Message;
@@ -575,6 +576,11 @@ public class NullStorageManager implements StorageManager {
 
    @Override
    public void beforePageRead() throws Exception {
+   }
+
+   @Override
+   public boolean beforePageRead(long timeout, TimeUnit unit) throws InterruptedException {
+      return true;
    }
 
    @Override

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageCursorProviderImplTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageCursorProviderImplTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.paging.cursor.impl;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.activemq.artemis.core.paging.PagingStore;
+import org.apache.activemq.artemis.core.paging.cursor.PageCache;
+import org.apache.activemq.artemis.core.paging.impl.Page;
+import org.apache.activemq.artemis.core.persistence.StorageManager;
+import org.apache.activemq.artemis.utils.actors.ArtemisExecutor;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static java.util.Collections.emptyList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PageCursorProviderImplTest {
+
+   @Test(timeout = 30_000)
+   public void shouldAllowConcurrentPageReads() throws Exception {
+      final PagingStore pagingStore = mock(PagingStore.class);
+      final StorageManager storageManager = mock(StorageManager.class);
+      when(storageManager.beforePageRead(anyLong(), any(TimeUnit.class))).thenReturn(true);
+      final int pages = 2;
+      final ArtemisExecutor artemisExecutor = mock(ArtemisExecutor.class);
+      final PageCursorProviderImpl pageCursorProvider = new PageCursorProviderImpl(pagingStore, storageManager, artemisExecutor, 2);
+      when(pagingStore.getCurrentWritingPage()).thenReturn(pages);
+      when(pagingStore.checkPageFileExists(anyInt())).thenReturn(true);
+      final Page firstPage = mock(Page.class);
+      when(firstPage.getPageId()).thenReturn(1);
+      when(pagingStore.createPage(1)).thenReturn(firstPage);
+      final Page secondPage = mock(Page.class);
+      when(secondPage.getPageId()).thenReturn(2);
+      when(pagingStore.createPage(2)).thenReturn(secondPage);
+      final CountDownLatch finishFirstPageRead = new CountDownLatch(1);
+      final Thread concurrentRead = new Thread(() -> {
+         try {
+            final PageCache cache = pageCursorProvider.getPageCache(2);
+            Assert.assertNotNull(cache);
+         } finally {
+            finishFirstPageRead.countDown();
+         }
+      });
+      try {
+         when(firstPage.read(storageManager)).then(invocationOnMock -> {
+            concurrentRead.start();
+            finishFirstPageRead.await();
+            return emptyList();
+         });
+         Assert.assertNotNull(pageCursorProvider.getPageCache(1));
+      } finally {
+         pageCursorProvider.stop();
+         concurrentRead.interrupt();
+         concurrentRead.join();
+      }
+   }
+
+}

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/transaction/impl/TransactionImplTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/transaction/impl/TransactionImplTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
@@ -287,6 +288,11 @@ public class TransactionImplTest extends ActiveMQTestBase {
       @Override
       public void beforePageRead() throws Exception {
 
+      }
+
+      @Override
+      public boolean beforePageRead(long timeout, TimeUnit unit) throws InterruptedException {
+         return true;
       }
 
       @Override

--- a/artemis-server/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/artemis-server/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/pom.xml
+++ b/pom.xml
@@ -1631,6 +1631,8 @@
                   <exclude>activemq-artemis-native/src/main/c/org_apache_activemq_artemis_jlibaio_LibaioContext.h</exclude>
                   <exclude>**/dependency-reduced-pom.xml</exclude>
 
+                  <!-- Mockito -->
+                  <exclude>**/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker</exclude>
                </excludes>
             </configuration>
             <executions>

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SendAckFailTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SendAckFailTest.java
@@ -366,6 +366,11 @@ public class SendAckFailTest extends SpawnedTestBase {
       }
 
       @Override
+      public boolean beforePageRead(long timeout, TimeUnit unit) throws InterruptedException {
+         return manager.beforePageRead(timeout, unit);
+      }
+
+      @Override
       public void afterPageRead() throws Exception {
          manager.afterPageRead();
       }


### PR DESCRIPTION
It includes just the scalability improvements of https://github.com/apache/activemq-artemis/pull/2645.
It is addressing the case where N different pages need to be read concurrently from `PageCursorProviderImpl`: in the original version the `Page::read` would be serialized and will wait each others to happen to make the cache available again, while this change allow to read concurrently different pages without blocking the whole cache.
 