### PR TITLE
ARTEMIS-2344 return security errors for unauthorized anonymous sasl

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPSessionContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPSessionContext.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.activemq.artemis.api.core.ActiveMQSecurityException;
 import org.apache.activemq.artemis.core.server.ServerProducer;
 import org.apache.activemq.artemis.core.server.impl.ServerProducerImpl;
 import org.apache.activemq.artemis.protocol.amqp.broker.AMQPSessionCallback;
@@ -69,6 +70,8 @@ public class AMQPSessionContext extends ProtonInitializable {
          if (sessionSPI != null) {
             try {
                sessionSPI.init(this, connection.getSASLResult());
+            } catch (ActiveMQSecurityException e) {
+               throw e;
             } catch (Exception e) {
                throw new ActiveMQAMQPInternalErrorException(e.getMessage(), e);
             }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/handler/ProtonHandler.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/handler/ProtonHandler.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.EventLoop;
+import org.apache.activemq.artemis.api.core.ActiveMQSecurityException;
 import org.apache.activemq.artemis.protocol.amqp.proton.AMQPConnectionContext;
 import org.apache.activemq.artemis.protocol.amqp.proton.ProtonInitializable;
 import org.apache.activemq.artemis.protocol.amqp.sasl.ClientSASL;
@@ -482,6 +483,13 @@ public class ProtonHandler extends ProtonInitializable implements SaslListener {
                }
                try {
                   Events.dispatch(ev, h);
+               } catch (ActiveMQSecurityException e) {
+                  log.warn(e.getMessage(), e);
+                  ErrorCondition error = new ErrorCondition();
+                  error.setCondition(AmqpError.UNAUTHORIZED_ACCESS);
+                  error.setDescription(e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage());
+                  connection.setCondition(error);
+                  connection.close();
                } catch (Exception e) {
                   log.warn(e.getMessage(), e);
                   ErrorCondition error = new ErrorCondition();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSConnectionWithSecurityTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSConnectionWithSecurityTest.java
@@ -27,7 +27,10 @@ import javax.jms.Session;
 import javax.jms.TextMessage;
 
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
+import org.apache.qpid.jms.JmsConnectionFactory;
 import org.junit.Test;
+
+import java.net.URI;
 
 public class JMSConnectionWithSecurityTest extends JMSClientTestSupport {
 
@@ -50,6 +53,25 @@ public class JMSConnectionWithSecurityTest extends JMSClientTestSupport {
          fail("Expected JMSException");
       } catch (JMSSecurityException ex) {
          IntegrationTestLogger.LOGGER.debug("Failed to authenticate connection with no user / password.");
+      } finally {
+         if (connection != null) {
+            connection.close();
+         }
+      }
+   }
+
+   @Test(timeout = 10000)
+   public void testNoUserOrPasswordWithoutSaslRestrictions() throws Exception {
+      Connection connection = null;
+      JmsConnectionFactory factory = new JmsConnectionFactory(new URI("amqp://localhost:" + AMQP_PORT));
+      try {
+         connection = factory.createConnection();
+         connection.start();
+         fail("Expected Exception");
+      } catch (JMSSecurityException ex) {
+         IntegrationTestLogger.LOGGER.debug("Failed to authenticate connection with no user / password.");
+      } catch (Exception ex) {
+         fail("Expected JMSSecurityException");
       } finally {
          if (connection != null) {
             connection.close();


### PR DESCRIPTION
When user attempts unauthorized anonymous sasl the broker can return an
error of 'failed' instead of the security error that is expected in
these cases.