### PR TITLE
ARTEMIS-2342 Use a URL instead of a URI for the logging.configuration…

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.management.ManagementFactory;
-import java.net.URI;
 import java.net.URL;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -2772,7 +2771,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
 
       if (System.getProperty("logging.configuration") != null) {
          try {
-            reloadManager.addCallback(new URI(System.getProperty("logging.configuration")).toURL(), new LoggingConfigurationFileReloader());
+            reloadManager.addCallback(new URL(System.getProperty("logging.configuration")), new LoggingConfigurationFileReloader());
          } catch (Exception e) {
             // a syntax error with the logging system property shouldn't prevent the server from starting
             ActiveMQServerLogger.LOGGER.problemAddingConfigReloadCallback(System.getProperty("logging.configuration"), e);


### PR DESCRIPTION
… property. The property the log manager itself expects is a URL which could result in an invalid URI missing the // prefix after file:.

https://issues.apache.org/jira/browse/ARTEMIS-2342