### PR TITLE
ARTEMIS-2349 CLI FQQN name parsing is incorrect

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/Consumer.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/Consumer.java
@@ -29,6 +29,7 @@ import java.io.OutputStream;
 import io.airlift.airline.Command;
 import io.airlift.airline.Option;
 import org.apache.activemq.artemis.cli.commands.ActionContext;
+import org.apache.activemq.artemis.cli.commands.util.DestinationUtil;
 import org.apache.activemq.artemis.cli.factory.serialize.MessageSerializer;
 
 @Command(name = "consumer", description = "It will consume messages from an instance")
@@ -95,7 +96,7 @@ public class Consumer extends DestAbstract {
             }
 
             // Do validation on FQQN
-            Destination dest = isFQQN() ? session.createQueue(getFQQNFromDestination(destination)) : lookupDestination(session);
+            Destination dest = isFQQN() ? session.createQueue(DestinationUtil.getFQQNFromDestination(destination)) : lookupDestination(session);
             threadsArray[i] = new ConsumerThread(session, dest, i);
 
             threadsArray[i].setVerbose(verbose).setSleep(sleep).setDurable(durable).setBatchSize(txBatchSize).setBreakOnNull(breakOnNull)

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/DestAbstract.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/DestAbstract.java
@@ -40,10 +40,6 @@ public class DestAbstract extends ConnectionAbstract {
 
    public static final String DEFAULT_MESSAGE_SERIALIZER = "org.apache.activemq.artemis.cli.factory.serialize.XMLMessageSerializer";
 
-   private static final String FQQN_PREFIX = "fqqn://";
-
-   private static final String FQQN_SEPERATOR = "::";
-
    @Option(name = "--destination", description = "Destination to be used. It can be prefixed with queue:// or topic:// or fqqn:// (Default: queue://TEST)")
    String destination = "queue://TEST";
 
@@ -131,17 +127,5 @@ public class DestAbstract extends ConnectionAbstract {
             }
          }
       }
-   }
-
-   protected String getQueueFromFQQN(String fqqn) {
-      return fqqn.substring(fqqn.indexOf(FQQN_SEPERATOR) + FQQN_SEPERATOR.length());
-   }
-
-   protected String getAddressFromFQQN(String fqqn) {
-      return fqqn.substring(fqqn.indexOf(FQQN_PREFIX) + FQQN_PREFIX.length(), fqqn.indexOf(FQQN_SEPERATOR));
-   }
-
-   protected String getFQQNFromDestination(String destination) {
-      return destination.substring(destination.indexOf(FQQN_PREFIX) + FQQN_PREFIX.length());
    }
 }

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/Producer.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/Producer.java
@@ -32,6 +32,7 @@ import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.management.ManagementHelper;
 import org.apache.activemq.artemis.cli.commands.ActionContext;
+import org.apache.activemq.artemis.cli.commands.util.DestinationUtil;
 import org.apache.activemq.artemis.cli.factory.serialize.MessageSerializer;
 import org.apache.activemq.artemis.jms.client.ActiveMQMessage;
 
@@ -75,7 +76,7 @@ public class Producer extends DestAbstract {
          byte[] queueId = null;
          boolean isFQQN = isFQQN();
          if (isFQQN) {
-            queueId = getQueueIdFromName(getQueueFromFQQN(destination));
+            queueId = getQueueIdFromName(DestinationUtil.getQueueFromFQQN(destination));
          }
 
          // If we are reading from file, we process messages sequentially to guarantee ordering.  i.e. no thread creation.
@@ -152,9 +153,9 @@ public class Producer extends DestAbstract {
       if (!isFQQN) {
          dest = lookupDestination(session);
       } else {
-         String address = getAddressFromFQQN(destination);
-         if (isFQQNAnycast(getQueueFromFQQN(destination))) {
-            String queue = getQueueFromFQQN(destination);
+         String address = DestinationUtil.getAddressFromFQQN(destination);
+         if (isFQQNAnycast(DestinationUtil.getQueueFromFQQN(destination))) {
+            String queue = DestinationUtil.getQueueFromFQQN(destination);
             if (!queue.equals(address)) {
                throw new ActiveMQException("FQQN support is limited to Anycast queues where the queue name equals the address.");
             }

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/util/DestinationUtil.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/util/DestinationUtil.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.cli.commands.util;
+
+public final class DestinationUtil {
+
+   private static final String FQQN_PREFIX = "fqqn://";
+   private static final String FQQN_SEPERATOR = "::";
+
+   public static String getAddressFromFQQN(String fqqn) {
+      return fqqn.substring(fqqn.indexOf(FQQN_SEPERATOR) + FQQN_SEPERATOR.length());
+   }
+
+   public static String getQueueFromFQQN(String fqqn) {
+      return fqqn.substring(fqqn.indexOf(FQQN_PREFIX) + FQQN_PREFIX.length(), fqqn.indexOf(FQQN_SEPERATOR));
+   }
+
+   public static String getFQQNFromDestination(String destination) {
+      return destination.substring(destination.indexOf(FQQN_PREFIX) + FQQN_PREFIX.length());
+   }
+}

--- a/artemis-cli/src/test/java/org/apache/activemq/cli/test/DestinationUtilTest.java
+++ b/artemis-cli/src/test/java/org/apache/activemq/cli/test/DestinationUtilTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.cli.test;
+
+import org.apache.activemq.artemis.cli.commands.util.DestinationUtil;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DestinationUtilTest {
+
+   private static final String TEST_FQQN_URL = "fqqn://myQueue0::myAddress0";
+   private static final String TEST_FQQN = "myQueue0::myAddress0";
+   private static final String TEST_QUEUE_NAME = "myQueue0";
+   private static final String TEST_ADDR_NAME = "myAddress0";
+
+   @Test
+   public void testFQQNUtil() throws Exception {
+      String qName = DestinationUtil.getQueueFromFQQN(TEST_FQQN_URL);
+      String addrName = DestinationUtil.getAddressFromFQQN(TEST_FQQN_URL);
+      String fqqn = DestinationUtil.getFQQNFromDestination(TEST_FQQN_URL);
+      assertEquals(TEST_QUEUE_NAME, qName);
+      assertEquals(TEST_ADDR_NAME, addrName);
+      assertEquals(TEST_FQQN, fqqn);
+   }
+}


### PR DESCRIPTION
Fixed the wrong returned values in those methods.
Also move those methods into a util class to make
testing easy.