### PR TITLE
ARTEMIS-2350 Fix ClassNotFoundException while invoking listConsumers

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/JsonUtil.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/JsonUtil.java
@@ -16,7 +16,6 @@
  */
 package org.apache.activemq.artemis.api.core;
 
-import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonArrayBuilder;
 import javax.json.JsonNumber;
@@ -275,11 +274,11 @@ public final class JsonUtil {
    }
 
    public static JsonArray readJsonArray(String jsonString) {
-      return Json.createReader(new StringReader(jsonString)).readArray();
+      return JsonLoader.createReader(new StringReader(jsonString)).readArray();
    }
 
    public static JsonObject readJsonObject(String jsonString) {
-      return Json.createReader(new StringReader(jsonString)).readObject();
+      return JsonLoader.createReader(new StringReader(jsonString)).readObject();
    }
 
    public static Map<String, String> readJsonProperties(String jsonString) {

--- a/tests/smoke-tests/pom.xml
+++ b/tests/smoke-tests/pom.xml
@@ -229,6 +229,24 @@
                      </args>
                   </configuration>
                </execution>
+               <execution>
+                  <phase>test-compile</phase>
+                  <id>create-createJMX2</id>
+                  <goals>
+                     <goal>create</goal>
+                  </goals>
+                  <configuration>
+                     <allowAnonymous>true</allowAnonymous>
+                     <user>admin</user>
+                     <password>admin</password>
+                     <instance>${basedir}/target/jmx2</instance>
+                     <args>
+                        <!-- this is needed to run the server remotely -->
+                        <arg>--java-options</arg>
+                        <arg>-Djava.rmi.server.hostname=localhost -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=11099 -Dcom.sun.management.jmxremote.rmi.port=11098 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false</arg>
+                     </args>
+                  </configuration>
+               </execution>
 
             </executions>
             <dependencies>

--- a/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/jmx2/JmxServerControlTest.java
+++ b/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/jmx2/JmxServerControlTest.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.tests.smoke.jmx2;
+
+import javax.jms.Session;
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import javax.management.MBeanServerConnection;
+import javax.management.MBeanServerInvocationHandler;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
+import org.apache.activemq.artemis.api.core.JsonUtil;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl;
+import org.apache.activemq.artemis.api.core.management.ObjectNameBuilder;
+import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.apache.activemq.artemis.jms.client.ActiveMQQueue;
+import org.apache.activemq.artemis.tests.smoke.common.SmokeTestBase;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class JmxServerControlTest extends SmokeTestBase {
+   // This test will use a smoke created by the pom on this project (smoke-tsts)
+
+   private static final String JMX_SERVER_HOSTNAME = "localhost";
+   private static final int JMX_SERVER_PORT = 11099;
+
+   public static final String SERVER_NAME_0 = "jmx2";
+
+   @Before
+   public void before() throws Exception {
+      cleanupData(SERVER_NAME_0);
+      disableCheckThread();
+      startServer(SERVER_NAME_0, 0, 30000);
+   }
+
+   @Test
+   public void testListConsumers() throws Exception {
+      // Without this, the RMI server would bind to the default interface IP (the user's local IP mostly)
+      System.setProperty("java.rmi.server.hostname", JMX_SERVER_HOSTNAME);
+
+      // I don't specify both ports here manually on purpose. See actual RMI registry connection port extraction below.
+      String urlString = "service:jmx:rmi:///jndi/rmi://" + JMX_SERVER_HOSTNAME + ":" + JMX_SERVER_PORT + "/jmxrmi";
+
+      JMXServiceURL url = new JMXServiceURL(urlString);
+      JMXConnector jmxConnector = null;
+
+      try {
+         jmxConnector = JMXConnectorFactory.connect(url);
+         System.out.println("Successfully connected to: " + urlString);
+      } catch (Exception e) {
+         jmxConnector = null;
+         e.printStackTrace();
+         Assert.fail(e.getMessage());
+      }
+
+      try {
+         MBeanServerConnection mBeanServerConnection = jmxConnector.getMBeanServerConnection();
+         String brokerName = "0.0.0.0";  // configured e.g. in broker.xml <broker-name> element
+         ObjectNameBuilder objectNameBuilder = ObjectNameBuilder.create(ActiveMQDefaultConfiguration.getDefaultJmxDomain(), brokerName, true);
+         ActiveMQServerControl activeMQServerControl = MBeanServerInvocationHandler.newProxyInstance(mBeanServerConnection, objectNameBuilder.getActiveMQServerObjectName(), ActiveMQServerControl.class, false);
+
+         String addressName = "test_list_consumers_address";
+         String queueName = "test_list_consumers_queue";
+         activeMQServerControl.createAddress(addressName, RoutingType.ANYCAST.name());
+         activeMQServerControl.createQueue(addressName, queueName, RoutingType.ANYCAST.name());
+         String uri = "tcp://localhost:61616";
+         try (ActiveMQConnectionFactory cf = ActiveMQJMSClient.createConnectionFactory(uri, null)) {
+            cf.createConnection().createSession(true, Session.SESSION_TRANSACTED).createConsumer(new ActiveMQQueue(queueName));
+
+            String options = JsonUtil.toJsonObject(ImmutableMap.of("field","queue", "operation", "EQUALS", "value", queueName)).toString();
+            String consumersAsJsonString = activeMQServerControl.listConsumers(options, 1, 10);
+
+            JsonObject consumersAsJsonObject = JsonUtil.readJsonObject(consumersAsJsonString);
+            JsonArray array = (JsonArray) consumersAsJsonObject.get("data");
+
+            Assert.assertEquals("number of consumers returned from query", 1, array.size());
+            JsonObject jsonConsumer = array.getJsonObject(0);
+            Assert.assertEquals("queue name in consumer", queueName, jsonConsumer.getString("queue"));
+            Assert.assertEquals("address name in consumer", addressName, jsonConsumer.getString("address"));
+         }
+      } finally {
+         jmxConnector.close();
+      }
+   }
+}


### PR DESCRIPTION
The exception is as follows:

2019-05-22 20:27:25,842 FINE [sun.rmi.server.call] RMI TCP Connection(3)-10.49.7.20: [10.49.7.20] exception: : javax.management.RuntimeMBeanException: javax.json.JsonException: org.apache.johnzon.core.JsonProviderImpl not found
at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.rethrow(DefaultMBeanServerInterceptor.java:839) [rt.jar:1.8.0_121]
at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.rethrowMaybeMBeanException(DefaultMBeanServerInterceptor.java:852) [rt.jar:1.8.0_121]
at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.invoke(DefaultMBeanServerInterceptor.java:821) [rt.jar:1.8.0_121]
at com.sun.jmx.mbeanserver.JmxMBeanServer.invoke(JmxMBeanServer.java:801) [rt.jar:1.8.0_121]
at javax.management.remote.rmi.RMIConnectionImpl.doOperation(RMIConnectionImpl.java:1468) [rt.jar:1.8.0_121]
at javax.management.remote.rmi.RMIConnectionImpl.access$300(RMIConnectionImpl.java:76) [rt.jar:1.8.0_121]
at javax.management.remote.rmi.RMIConnectionImpl$PrivilegedOperation.run(RMIConnectionImpl.java:1309) [rt.jar:1.8.0_121]
at javax.management.remote.rmi.RMIConnectionImpl.doPrivilegedOperation(RMIConnectionImpl.java:1401) [rt.jar:1.8.0_121]
at javax.management.remote.rmi.RMIConnectionImpl.invoke(RMIConnectionImpl.java:829) [rt.jar:1.8.0_121]
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) [rt.jar:1.8.0_121]
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) [rt.jar:1.8.0_121]
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) [rt.jar:1.8.0_121]
at java.lang.reflect.Method.invoke(Method.java:498) [rt.jar:1.8.0_121]
at sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:346) [rt.jar:1.8.0_121]
at sun.rmi.transport.Transport$1.run(Transport.java:200) [rt.jar:1.8.0_121]
at sun.rmi.transport.Transport$1.run(Transport.java:197) [rt.jar:1.8.0_121]
at java.security.AccessController.doPrivileged(Native Method) [rt.jar:1.8.0_121]
at sun.rmi.transport.Transport.serviceCall(Transport.java:196) [rt.jar:1.8.0_121]
at sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:568) [rt.jar:1.8.0_121]
at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:826) [rt.jar:1.8.0_121]
at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(TCPTransport.java:683) [rt.jar:1.8.0_121]
at java.security.AccessController.doPrivileged(Native Method) [rt.jar:1.8.0_121]
at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:682) [rt.jar:1.8.0_121]
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [rt.jar:1.8.0_121]
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [rt.jar:1.8.0_121]
at java.lang.Thread.run(Thread.java:745) [rt.jar:1.8.0_121]
Caused by: javax.json.JsonException: org.apache.johnzon.core.JsonProviderImpl not found

at javax.json.spi.JsonProvider.doLoadProvider(JsonProvider.java:132)
at javax.json.spi.JsonProvider.provider(JsonProvider.java:64)
at javax.json.Json.createReader(Json.java:68)
at org.apache.activemq.artemis.api.core.JsonUtil.readJsonObject(JsonUtil.java:282)
at org.apache.activemq.artemis.core.management.impl.view.ActiveMQAbstractView.setOptions(ActiveMQAbstractView.java:122)
at org.apache.activemq.artemis.core.management.impl.ActiveMQServerControlImpl.listConsumers(ActiveMQServerControlImpl.java:2222)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) [rt.jar:1.8.0_121]
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) [rt.jar:1.8.0_121]
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) [rt.jar:1.8.0_121]
at java.lang.reflect.Method.invoke(Method.java:498) [rt.jar:1.8.0_121]
at sun.reflect.misc.Trampoline.invoke(MethodUtil.java:71) [rt.jar:1.8.0_121]
at sun.reflect.GeneratedMethodAccessor12.invoke(Unknown Source) [:1.8.0_121]
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) [rt.jar:1.8.0_121]
at java.lang.reflect.Method.invoke(Method.java:498) [rt.jar:1.8.0_121]
at sun.reflect.misc.MethodUtil.invoke(MethodUtil.java:275) [rt.jar:1.8.0_121]
at com.sun.jmx.mbeanserver.StandardMBeanIntrospector.invokeM2(StandardMBeanIntrospector.java:112) [rt.jar:1.8.0_121]
at com.sun.jmx.mbeanserver.StandardMBeanIntrospector.invokeM2(StandardMBeanIntrospector.java:46) [rt.jar:1.8.0_121]
at com.sun.jmx.mbeanserver.MBeanIntrospector.invokeM(MBeanIntrospector.java:237) [rt.jar:1.8.0_121]
at com.sun.jmx.mbeanserver.PerInterface.invoke(PerInterface.java:138) [rt.jar:1.8.0_121]
at com.sun.jmx.mbeanserver.MBeanSupport.invoke(MBeanSupport.java:252) [rt.jar:1.8.0_121]
at javax.management.StandardMBean.invoke(StandardMBean.java:405) [rt.jar:1.8.0_121]
at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.invoke(DefaultMBeanServerInterceptor.java:819) [rt.jar:1.8.0_121]
... 23 more
Caused by: java.lang.ClassNotFoundException: org.apache.johnzon.core.JsonProviderImpl
at java.net.URLClassLoader.findClass(URLClassLoader.java:381) [rt.jar:1.8.0_121]
at java.lang.ClassLoader.loadClass(ClassLoader.java:424) [rt.jar:1.8.0_121]
at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331) [rt.jar:1.8.0_121]
at java.lang.ClassLoader.loadClass(ClassLoader.java:357) [rt.jar:1.8.0_121]
at javax.json.spi.JsonProvider.doLoadProvider(JsonProvider.java:129)
... 44 more

 

JsonUtil::readJsonObject uses Json::createReader which loads JsonProvider in the SystemClassLoader. Use JsonLoader::createReader instead where JsonProvider is loaded in the UrlClassLoader.

 