### PR TITLE
ARTEMIS-2359 Upgrade to Guava 24.1

### DIFF
--- a/artemis-hawtio/artemis-console/pom.xml
+++ b/artemis-hawtio/artemis-console/pom.xml
@@ -67,6 +67,12 @@
       <version>${hawtio.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+      <!-- License: Apache 2.0 -->
+    </dependency>
   </dependencies>
 
   <build>
@@ -110,6 +116,7 @@
                 <exclude>bower_components/jquery/src/**/*</exclude>
                 <exclude>bower_components/jquery/test/**/*</exclude>
                 <exclude>bower_components/js-logger/src/**/*</exclude>
+                <excluse>WEB-INF/lib/guava*.jar</excluse>
                 <excluse>WEB-INF/lib/slf4j-api*.jar</excluse>
                 <excluse>lib/camelModel.js</excluse>
                 <exclude>app/activemq/**/*</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
       <commons.beanutils.version>1.9.3</commons.beanutils.version>
       <commons.collections.version>3.2.2</commons.collections.version>
       <fuse.mqtt.client.version>1.14</fuse.mqtt.client.version>
-      <guava.version>19.0</guava.version>
+      <guava.version>24.1-jre</guava.version>
       <jboss.logging.version>3.4.0.Final</jboss.logging.version>
       <jetty.version>9.4.3.v20170317</jetty.version>
       <jgroups.version>3.6.13.Final</jgroups.version>
@@ -103,7 +103,7 @@
       <jb.logmanager.version>2.1.10.Final</jb.logmanager.version>
       <jb.slf4j-jboss-logmanager.version>1.0.4.GA</jb.slf4j-jboss-logmanager.version>
        <version.org.wildfly.common.wildfly-common>1.5.1.Final</version.org.wildfly.common.wildfly-common>
-      <airlift.version>0.7</airlift.version>
+      <airlift.version>0.8</airlift.version>
       <geronimo.annotation.1.1.spec.version>1.0.1</geronimo.annotation.1.1.spec.version>
       <geronimo.ejb.3.0.spec.version>1.0.1</geronimo.ejb.3.0.spec.version>
       <geronimo.jta.1.1.spec.version>1.1.1</geronimo.jta.1.1.spec.version>
@@ -798,6 +798,12 @@
             <artifactId>osgi.cmpn</artifactId>
             <version>6.0.0</version>
             <scope>provided</scope>
+            <!-- License: Apache 2.0 -->
+         </dependency>
+         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
             <!-- License: Apache 2.0 -->
          </dependency>
       </dependencies>


### PR DESCRIPTION
CVE-2018-10237 guava: Unbounded memory allocation in AtomicDoubleArray
and CompoundOrdering classes allow remote attackers to cause a denial
of service.