### PR TITLE
ARTEMIS-2371 Message with huge header shuts broker down

### DIFF
--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/journal/ActiveMQJournalBundle.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/journal/ActiveMQJournalBundle.java
@@ -47,4 +47,7 @@ public interface ActiveMQJournalBundle {
 
    @Message(id = 149004, value = "unable to open file")
    String unableToOpenFile();
+
+   @Message(id = 149005, value = "Message of {0} bytes is bigger than the max record size of {1} bytes. You should try to move large application properties to the message body.", format = Message.Format.MESSAGE_FORMAT)
+   ActiveMQIOErrorException recordLargerThanStoreMax(long recordSize, long maxRecordSize);
 }


### PR DESCRIPTION
Add max record size check before adding a record to prevent that the
broker shuts down, when there is one really large header sent with the
message.