### PR TITLE
ARTEMIS-2367 Adding rule to avoid files leaking on the main folder

### DIFF
--- a/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
@@ -171,6 +171,14 @@ public abstract class ActiveMQTestBase extends Assert {
    @ClassRule
    public static ThreadLeakCheckRule leakCheckRule = new ThreadLeakCheckRule();
 
+   /** We should not under any circunstance create data outside of ./target
+    *  if you have a test failing because because of this rule for any reason,
+    *  even if you use afterClass events, move the test to ./target and always cleanup after
+    *  your data even under ./target.
+    *  Do not try to disable this rule! Fix your test! */
+   @Rule
+   public NoFilesBehind noFilesBehind = new NoFilesBehind("data");
+
    /** This will cleanup any system property changed inside tests */
    @Rule
    public CleanupSystemPropertiesRule propertiesRule = new CleanupSystemPropertiesRule();

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/NoFilesBehind.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/NoFilesBehind.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.tests.util;
+
+import java.io.File;
+
+import org.apache.activemq.artemis.utils.FileUtil;
+import org.jboss.logging.Logger;
+import org.junit.Assert;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+/**
+ * This is useful to make sure you won't have leaking threads between tests
+ */
+public class NoFilesBehind extends TestWatcher {
+
+   private static Logger log = Logger.getLogger(NoFilesBehind.class);
+
+   private final String[] filesToCheck;
+
+   public NoFilesBehind(String... filesToCheck) {
+      this.filesToCheck = filesToCheck;
+   }
+
+   private File checkFiles() {
+      for (String f : filesToCheck) {
+         File fileCheck = new File(f);
+         if (fileCheck.exists()) {
+            return fileCheck;
+         }
+      }
+
+      return null;
+   }
+
+   /**
+    * Override to set up your specific external resource.
+    *
+    * @throws if setup fails (which will disable {@code after}
+    */
+   @Override
+   protected void starting(Description description) {
+      // do nothing
+
+      File leaked = checkFiles();
+
+      if (leaked != null) {
+         Assert.fail("A previous test left a folder around:: " + leaked.getAbsolutePath());
+      }
+
+   }
+
+
+   @Override
+   protected void failed(Throwable e, Description description) {
+   }
+
+   @Override
+   protected void succeeded(Description description) {
+   }
+
+   /**
+    * Override to tear down your specific external resource.
+    */
+   @Override
+   protected void finished(Description description) {
+
+      File leaked = checkFiles();
+
+      if (leaked != null) {
+         try {
+            Assert.fail(leaked.getAbsolutePath() + " is being left behind");
+         } finally {
+            try {
+               FileUtil.deleteDirectory(leaked);
+            } catch (Throwable almostIgnored) {
+               // nothing we can do about it.. but we will log a stack trace for debugging
+               almostIgnored.printStackTrace();
+            }
+         }
+      }
+   }
+
+}

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/divert/DivertTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/divert/DivertTest.java
@@ -1318,7 +1318,7 @@ public class DivertTest extends ActiveMQTestBase {
       };
       serviceRegistry.addDivertTransformer(DIVERT, transformer);
 
-      ActiveMQServer server = addServer(new ActiveMQServerImpl(null, null, null, null, serviceRegistry));
+      ActiveMQServer server = addServer(new ActiveMQServerImpl(createBasicConfig(), null, null, null, serviceRegistry));
       server.start();
       server.waitForActivation(100, TimeUnit.MILLISECONDS);
       server.createQueue(ADDRESS, RoutingType.MULTICAST, SimpleString.toSimpleString("myQueue"), null, false, false);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/JMSServerStartStopTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/JMSServerStartStopTest.java
@@ -61,6 +61,7 @@ public class JMSServerStartStopTest extends ActiveMQTestBase {
       deploymentManager.addDeployable(fc);
       deploymentManager.readConfiguration();
 
+
       ActiveMQJAASSecurityManager sm = new ActiveMQJAASSecurityManager(InVMLoginModule.class.getName(), new SecurityConfiguration());
 
       server = addServer(new ActiveMQServerImpl(fc, sm));

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/JournalFileSizeTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/JournalFileSizeTest.java
@@ -21,12 +21,13 @@ import java.io.File;
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
 import org.apache.activemq.artemis.core.io.aio.AIOSequentialFileFactory;
 import org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.actors.OrderedExecutorFactory;
 import org.apache.activemq.artemis.utils.critical.EmptyCriticalAnalyzer;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class JournalFileSizeTest {
+public class JournalFileSizeTest extends ActiveMQTestBase {
 
    private static int align;
 
@@ -39,9 +40,16 @@ public class JournalFileSizeTest {
       }
    }
 
+   @Override
+   protected ConfigurationImpl createBasicConfig(final int serverID) {
+      ConfigurationImpl configuration = new ConfigurationImpl().setJournalDirectory(getJournalDir(serverID, false)).setBindingsDirectory(getBindingsDir(serverID, false)).setPagingDirectory(getPageDir(serverID, false)).setLargeMessagesDirectory(getLargeMessagesDir(serverID, false));
+
+      return configuration;
+   }
+
    @Test
-   public void testIncorrectFileSizeLower() {
-      ConfigurationImpl config = new ConfigurationImpl();
+   public void testIncorrectFileSizeLower() throws Exception {
+      ConfigurationImpl config = createBasicConfig();
       int origFileSize = config.getJournalFileSize();
       config.setJournalFileSize(origFileSize + (align / 2 - 1));
       JournalStorageManager manager = new JournalStorageManager(config, EmptyCriticalAnalyzer.getInstance(), new OrderedExecutorFactory(null), new OrderedExecutorFactory(null));
@@ -50,8 +58,8 @@ public class JournalFileSizeTest {
    }
 
    @Test
-   public void testIncorrectFileSizeHigher() {
-      ConfigurationImpl config = new ConfigurationImpl();
+   public void testIncorrectFileSizeHigher() throws Exception {
+      ConfigurationImpl config = createBasicConfig();
       int origFileSize = config.getJournalFileSize();
       config.setJournalFileSize(origFileSize + (align / 2 + 1));
       JournalStorageManager manager = new JournalStorageManager(config, EmptyCriticalAnalyzer.getInstance(), new OrderedExecutorFactory(null), new OrderedExecutorFactory(null));
@@ -60,8 +68,8 @@ public class JournalFileSizeTest {
    }
 
    @Test
-   public void testIncorrectFileSizeHalf() {
-      ConfigurationImpl config = new ConfigurationImpl();
+   public void testIncorrectFileSizeHalf() throws Exception {
+      ConfigurationImpl config = createBasicConfig();
       int origFileSize = config.getJournalFileSize();
       config.setJournalFileSize(origFileSize + (align / 2));
       JournalStorageManager manager = new JournalStorageManager(config,EmptyCriticalAnalyzer.getInstance(), new OrderedExecutorFactory(null), new OrderedExecutorFactory(null));

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/SuppliedThreadPoolTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/SuppliedThreadPoolTest.java
@@ -46,7 +46,7 @@ public class SuppliedThreadPoolTest extends ActiveMQTestBase {
       serviceRegistry.setExecutorService(Executors.newFixedThreadPool(1, ActiveMQThreadFactory.defaultThreadFactory()));
       serviceRegistry.setIOExecutorService(Executors.newFixedThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory()));
       serviceRegistry.setScheduledExecutorService(Executors.newScheduledThreadPool(1, ActiveMQThreadFactory.defaultThreadFactory()));
-      server = new ActiveMQServerImpl(null, null, null, null, serviceRegistry);
+      server = new ActiveMQServerImpl(createBasicConfig(), null, null, null, serviceRegistry);
       server.start();
       server.waitForActivation(100, TimeUnit.MILLISECONDS);
    }

--- a/tests/integration-tests/src/test/resources/broker-logging-plugin-wrong.xml
+++ b/tests/integration-tests/src/test/resources/broker-logging-plugin-wrong.xml
@@ -26,6 +26,7 @@
          <connector name="netty-connector">tcp://localhost:61616</connector>
       </connectors>
 
+      <persistence-enabled>false</persistence-enabled>
       <journal-directory>./target/tmp/activemq-unit-test/broker-plugin-test/</journal-directory>
 
       <acceptors>

--- a/tests/integration-tests/src/test/resources/broker-logging-plugin.xml
+++ b/tests/integration-tests/src/test/resources/broker-logging-plugin.xml
@@ -26,6 +26,7 @@
          <connector name="netty-connector">tcp://localhost:61616</connector>
       </connectors>
 
+      <persistence-enabled>false</persistence-enabled>
       <journal-directory>./target/tmp/activemq-unit-test/broker-plugin-test/</journal-directory>
 
       <acceptors>

--- a/tests/integration-tests/src/test/resources/broker-plugins-config.xml
+++ b/tests/integration-tests/src/test/resources/broker-plugins-config.xml
@@ -22,6 +22,7 @@
    </jms>
    <core xmlns="urn:activemq:core">
 
+      <persistence-enabled>false</persistence-enabled>
       <connectors>
          <connector name="netty-connector">tcp://localhost:61616</connector>
       </connectors>

--- a/tests/integration-tests/src/test/resources/reload-queue-filter-updated.xml
+++ b/tests/integration-tests/src/test/resources/reload-queue-filter-updated.xml
@@ -24,6 +24,7 @@ under the License.
 
    <core xmlns="urn:activemq:core">
       <security-enabled>false</security-enabled>
+      <persistence-enabled>false</persistence-enabled>
 
       <acceptors>
          <acceptor name="artemis">tcp://0.0.0.0:61616</acceptor>

--- a/tests/integration-tests/src/test/resources/reload-queue-filter.xml
+++ b/tests/integration-tests/src/test/resources/reload-queue-filter.xml
@@ -24,6 +24,7 @@ under the License.
 
    <core xmlns="urn:activemq:core">
       <security-enabled>false</security-enabled>
+      <persistence-enabled>false</persistence-enabled>
 
       <acceptors>
          <acceptor name="artemis">tcp://0.0.0.0:61616</acceptor>

--- a/tests/integration-tests/src/test/resources/reload-queue-routingtype-updated.xml
+++ b/tests/integration-tests/src/test/resources/reload-queue-routingtype-updated.xml
@@ -24,6 +24,7 @@ under the License.
 
    <core xmlns="urn:activemq:core">
       <security-enabled>false</security-enabled>
+      <persistence-enabled>false</persistence-enabled>
 
       <acceptors>
          <!-- Default ActiveMQ Artemis Acceptor.  Multi-protocol adapter.  Currently supports ActiveMQ Artemis Core, OpenWire, STOMP, AMQP, MQTT, and HornetQ Core. -->

--- a/tests/integration-tests/src/test/resources/reload-queue-routingtype.xml
+++ b/tests/integration-tests/src/test/resources/reload-queue-routingtype.xml
@@ -24,6 +24,7 @@ under the License.
 
    <core xmlns="urn:activemq:core">
       <security-enabled>false</security-enabled>
+      <persistence-enabled>false</persistence-enabled>
 
       <acceptors>
          <!-- Default ActiveMQ Artemis Acceptor.  Multi-protocol adapter.  Currently supports ActiveMQ Artemis Core, OpenWire, STOMP, AMQP, MQTT, and HornetQ Core. -->

--- a/tests/integration-tests/src/test/resources/server-start-stop-config1.xml
+++ b/tests/integration-tests/src/test/resources/server-start-stop-config1.xml
@@ -26,7 +26,10 @@
          <connector name="netty-connector">tcp://localhost:61616</connector>
       </connectors>
 
-      <journal-directory>./target/tmp/activemq-unit-test/start-stop-data</journal-directory>
+      <journal-directory>./target/tmp/activemq-unit-test/start-stop-data/journal</journal-directory>
+      <paging-directory>./target/tmp/activemq-unit-test/start-stop-data/paging</paging-directory>
+      <bindings-directory>./target/tmp/activemq-unit-test/start-stop-data/paging</bindings-directory>
+      <large-messages-directory>./target/tmp/activemq-unit-test/start-stop-data/paging</large-messages-directory>
 
       <acceptors>
          <acceptor name="netty-acceptor">tcp://localhost:61616</acceptor>


### PR DESCRIPTION
We had to fix a few cases where data folder was being created outside of the ./target output.
This is just to avoid re-ocurrence of that.