### PR TITLE
ARTEMIS-2383 Upgrade to Guava 24.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
       <commons.beanutils.version>1.9.3</commons.beanutils.version>
       <commons.collections.version>3.2.2</commons.collections.version>
       <fuse.mqtt.client.version>1.14</fuse.mqtt.client.version>
-      <guava.version>24.1-jre</guava.version>
+      <guava.version>24.1.1-jre</guava.version>
       <jboss.logging.version>3.4.0.Final</jboss.logging.version>
       <jetty.version>9.4.3.v20170317</jetty.version>
       <jgroups.version>3.6.13.Final</jgroups.version>


### PR DESCRIPTION
Guava 24.1.1 is the correct version to fix https://github.com/apache/activemq-artemis/pull/2687.