### PR TITLE
ARTEMIS-2385 Log header for rejecting message with too large header

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalStorageManager.java
@@ -556,6 +556,12 @@ public class JournalStorageManager extends AbstractJournalStorageManager {
             final int messageEncodeSize = largeMessage.getEncodeSize();
 
             if (messageEncodeSize > maxRecordSize) {
+               ActiveMQServerLogger.LOGGER.messageWithHeaderTooLarge(largeMessage.getMessageID(), logger.getName());
+
+               if (logger.isDebugEnabled()) {
+                  logger.debug("Message header too large for " + largeMessage);
+               }
+
                throw ActiveMQJournalBundle.BUNDLE.recordLargerThanStoreMax(messageEncodeSize, maxRecordSize);
             }
          }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -2002,4 +2002,9 @@ public interface ActiveMQServerLogger extends BasicLogger {
    @LogMessage(level = Logger.Level.INFO)
    @Message(id = 224098, value = "Received a vote saying the backup is live with connector: {0}", format = Message.Format.MESSAGE_FORMAT)
    void qourumBackupIsLive(String liveConnector);
+
+   @LogMessage(level = Logger.Level.WARN)
+   @Message(id = 224099, value = "Message with ID {0} has a header too large. More information available on debug level for class {1}",
+      format = Message.Format.MESSAGE_FORMAT)
+   void messageWithHeaderTooLarge(Long messageID, String loggerClass);
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpLargeMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpLargeMessageTest.java
@@ -285,7 +285,7 @@ public class AmqpLargeMessageTest extends AmqpClientTestSupport {
 
          connection.connect();
 
-         final int strLength = 1024 * 1024;
+         final int strLength = 512 * 1024;
          AmqpSession session = connection.createSession();
          AmqpSender sender = session.createSender(testQueueName);
 


### PR DESCRIPTION
Use warning level to add in the log the ID and debug level to add in the
log the message header of rejecting message with too large header.