### PR TITLE
ARTEMIS-2354 Fix compilation issues on JDK 8

### DIFF
--- a/artemis-dto/pom.xml
+++ b/artemis-dto/pom.xml
@@ -99,9 +99,6 @@
                            <exclude name="**/.git/**" />
                            <exclude name="**/.svn/**" />
                         </schemagen>
-                        <replace file="${project.build.directory}/schema/org.apache.activemq/dto/activemq.xsd"
-                                 token="xmlns:xs=&quot;http://www.w3.org/2001/XMLSchema&quot;"
-                                 value="xmlns=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xs=&quot;http://www.w3.org/2001/XMLSchema&quot;"/>
                         <copy todir="${project.build.directory}/classes">
                            <fileset dir="${project.build.directory}/schema" />
                         </copy>
@@ -127,11 +124,6 @@
                   <groupId>com.sun.xml.bind</groupId>
                   <artifactId>jaxb-jxc</artifactId>
                   <version>${version.jaxb}</version>
-               </dependency>
-               <dependency>
-                  <groupId>org.glassfish.jaxb</groupId>
-                  <artifactId>jaxb-runtime</artifactId>
-                  <version>2.3.2</version>
                </dependency>
             </dependencies>
          </plugin>

--- a/artemis-dto/src/main/java/org/apache/activemq/artemis/dto/package-info.java
+++ b/artemis-dto/src/main/java/org/apache/activemq/artemis/dto/package-info.java
@@ -18,7 +18,6 @@
  * The JAXB POJOs for the XML configuration of ActiveMQ Artemis broker
  */
 @javax.xml.bind.annotation.XmlSchema(
-   xmlns = {@javax.xml.bind.annotation.XmlNs(prefix = "xs", namespaceURI = "http://www.w3.org/2001/XMLSchema")},
    namespace = "http://activemq.org/schema",
    elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.apache.activemq.artemis.dto;

--- a/artemis-features/pom.xml
+++ b/artemis-features/pom.xml
@@ -26,7 +26,7 @@
 	<name>ActiveMQ Artemis Features</name>
 
 	<properties>
-		<karaf.version>4.2.3</karaf.version>
+		<karaf.version>4.1.1</karaf.version>
 	</properties>
 
    <dependencies>

--- a/artemis-selector/pom.xml
+++ b/artemis-selector/pom.xml
@@ -84,48 +84,6 @@
             </plugins>
          </build>
       </profile>
-      <profile>
-         <id>jdk8</id>
-         <activation>
-            <jdk>1.8</jdk>
-            <property>
-               <name>java.vendor</name>
-               <value>!IBM Corporation</value>
-            </property>
-         </activation>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-compiler-plugin</artifactId>
-                  <configuration>
-                     <compilerArgs>
-                        <!-- TODO: do this only for generated-sources -->
-                        <arg>-Xep:MissingOverride:WARN</arg>
-                     </compilerArgs>
-                  </configuration>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-      <profile>
-         <id>jdk11</id>
-         <activation>
-            <jdk>11</jdk>
-            <property>
-               <name>java.vendor</name>
-               <value>!IBM Corporation</value>
-            </property>
-         </activation>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-compiler-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
    </profiles>
 
    <build>
@@ -136,6 +94,16 @@
          </resource>
       </resources>
       <plugins>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+               <compilerArgs>
+                  <!-- TODO: do this only for generated-sources -->
+                  <arg>-Xep:MissingOverride:WARN</arg>
+               </compilerArgs>
+            </configuration>
+         </plugin>
          <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>javacc-maven-plugin</artifactId>

--- a/artemis-website/pom.xml
+++ b/artemis-website/pom.xml
@@ -92,7 +92,7 @@
 
          <plugin>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.1.0</version>
+            <version>2.10.1</version>
             <executions>
                <execution>
                   <id>javadoc-jar</id>
@@ -101,8 +101,6 @@
                      <goal>jar</goal>
                   </goals>
                   <configuration>
-                     <doclint>none</doclint>
-                     <additionalOptions>${forceHtml4}</additionalOptions>
                      <useStandardDocletOptions>true</useStandardDocletOptions>
                      <minmemory>128m</minmemory>
                      <maxmemory>512m</maxmemory>
@@ -131,15 +129,6 @@
    </build>
 
    <profiles>
-      <profile>
-         <id>jdk11</id>
-         <activation>
-            <jdk>11</jdk>
-         </activation>
-         <properties>
-            <forceHtml4>-html4</forceHtml4>
-         </properties>
-      </profile>
       <profile>
          <id>release</id>
          <build>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
       <staging.siteURL>scp://people.apache.org/x1/www/activemq.apache.org</staging.siteURL>
 
       <activemq-artemis-native-version>1.0.0</activemq-artemis-native-version>
-      <karaf.version>4.2.3</karaf.version>
+      <karaf.version>4.0.6</karaf.version>
       <pax.exam.version>4.9.1</pax.exam.version>
       <commons.config.version>2.4</commons.config.version>
       <commons.lang.version>3.0</commons.lang.version>
@@ -867,10 +867,6 @@
          <id>jdk18</id>
          <activation>
             <jdk>1.8</jdk>
-            <property>
-               <name>java.vendor</name>
-               <value>!IBM Corporation</value>
-            </property>
          </activation>
          <build>
             <plugins>
@@ -880,68 +876,6 @@
                   <configuration>
                      <additionalparam>-Xdoclint:none</additionalparam>
                   </configuration>
-               </plugin>
-               <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-compiler-plugin</artifactId>
-                  <!-- version 3.2 is having problems with the APT processor resulting in
-                       java.lang.IllegalStateException: endPosTable already set  -->
-                  <version>3.1</version>
-                  <!-- Enable Google's Error-Prone https://github.com/google/error-prone -->
-                  <configuration>
-                     <showWarnings>true</showWarnings>
-                     <forceJavacCompilerUse>true</forceJavacCompilerUse>
-                     <compilerId>${javac-compiler-id}</compilerId>
-                     <compilerArgs>
-                        <arg>-Xep:MissingOverride:ERROR</arg>
-                        <arg>-Xep:NonAtomicVolatileUpdate:ERROR</arg>
-                        <arg>-Xep:SynchronizeOnNonFinalField:ERROR</arg>
-                        <arg>-Xep:StaticAccessedFromInstance:ERROR</arg>
-                        <arg>-Xep:SynchronizeOnNonFinalField:ERROR</arg>
-                        <arg>-Xep:WaitNotInLoop:ERROR</arg>
-                        <arg>-Xdiags:verbose</arg>
-                     </compilerArgs>
-                  </configuration>
-                  <dependencies>
-                     <dependency>
-                        <groupId>org.codehaus.plexus</groupId>
-                        <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                        <version>2.8</version>
-                     </dependency>
-                     <dependency>
-                        <groupId>com.google.errorprone</groupId>
-                        <artifactId>error_prone_core</artifactId>
-                        <version>2.0.9</version>
-                     </dependency>
-                  </dependencies>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-      <profile>
-         <id>jdk11</id>
-         <activation>
-            <jdk>11</jdk>
-            <property>
-               <name>java.vendor</name>
-               <value>!IBM Corporation</value>
-            </property>
-         </activation>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-javadoc-plugin</artifactId>
-                  <configuration>
-                     <additionalparam>-Xdoclint:none</additionalparam>
-                  </configuration>
-               </plugin>
-               <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-compiler-plugin</artifactId>
-                  <!-- version 3.2 is having problems with the APT processor resulting in
-                       java.lang.IllegalStateException: endPosTable already set  -->
-                  <version>3.1</version>
                </plugin>
             </plugins>
          </build>
@@ -1399,6 +1333,40 @@
                      </goals>
                   </execution>
                </executions>
+            </plugin>
+            <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-compiler-plugin</artifactId>
+               <!-- version 3.2 is having problems with the APT processor resulting in
+                    java.lang.IllegalStateException: endPosTable already set  -->
+               <version>3.1</version>
+               <!-- Enable Google's Error-Prone https://github.com/google/error-prone -->
+               <configuration>
+                 <showWarnings>true</showWarnings>
+                 <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                 <compilerId>${javac-compiler-id}</compilerId>
+                 <compilerArgs>
+                    <arg>-Xep:MissingOverride:ERROR</arg>
+                    <arg>-Xep:NonAtomicVolatileUpdate:ERROR</arg>
+                    <arg>-Xep:SynchronizeOnNonFinalField:ERROR</arg>
+                    <arg>-Xep:StaticAccessedFromInstance:ERROR</arg>
+                    <arg>-Xep:SynchronizeOnNonFinalField:ERROR</arg>
+                    <arg>-Xep:WaitNotInLoop:ERROR</arg>
+                    <arg>-Xdiags:verbose</arg>
+                 </compilerArgs>
+               </configuration>
+               <dependencies>
+                 <dependency>
+                   <groupId>org.codehaus.plexus</groupId>
+                   <artifactId>plexus-compiler-javac-errorprone</artifactId>
+                   <version>2.8</version>
+                 </dependency>
+                 <dependency>
+                   <groupId>com.google.errorprone</groupId>
+                   <artifactId>error_prone_core</artifactId>
+                   <version>2.0.9</version>
+                 </dependency>
+               </dependencies>
             </plugin>
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This reverts partially commit f8d3a8f to include only
the changes that makes possible to run tests with JDK 11:
compile on JDK 11 is outside the scope of the issue.
JDK 11 compilation requires Karaf upgrade, that will
break compatibility with Aether on integration-tests.