### PR TITLE
ARTEMIS-2399 Fix performance degradation when there are a lot of subscribers

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageIndexCacheImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageIndexCacheImpl.java
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.core.paging.cursor.impl;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.apache.activemq.artemis.core.paging.PagedMessage;
+import org.apache.activemq.artemis.core.paging.cursor.PageCache;
+import org.apache.activemq.artemis.core.paging.impl.Page;
+import org.jboss.logging.Logger;
+
+public class PageIndexCacheImpl implements PageCache {
+   private static final Logger logger = Logger.getLogger(PageIndexCacheImpl.class);
+
+   private final long pageId;
+   private Page page;
+
+   // message number to file position map
+   private TreeMap<Integer, Integer> messageIndex;
+   private int numberOfMessages;
+
+   public PageIndexCacheImpl(long pageId) {
+      this.pageId = pageId;
+   }
+
+   public void setPage(Page page) {
+      this.page = page;
+   }
+
+   public void setNumberOfMessages(final int numberOfMessages) {
+      this.numberOfMessages = numberOfMessages;
+   }
+
+   public void setMessageIndex(final TreeMap<Integer, Integer> messageIndex) {
+      this.messageIndex = messageIndex;
+   }
+
+   @Override
+   public long getPageId() {
+      return pageId;
+   }
+
+   @Override
+   public int getNumberOfMessages() {
+      return numberOfMessages;
+   }
+
+   @Override
+   public void setMessages(PagedMessage[] messages) {
+      throw new UnsupportedOperationException("set messages should not be called for index page cache");
+   }
+
+   @Override
+   public PagedMessage[] getMessages() {
+      throw new UnsupportedOperationException("get messages should not be called for index page cache");
+   }
+
+   @Override
+   public boolean isLive() {
+      return false;
+   }
+
+   @Override
+   public PagedMessage getMessage(int messageNumber) {
+      try {
+         Map.Entry<Integer, Integer> floorEntry = messageIndex.floorEntry(messageNumber);
+         int startOffset = 0;
+         int startMessageNumber = 0;
+         if (floorEntry != null) {
+            startMessageNumber = floorEntry.getKey();
+            startOffset = floorEntry.getValue();
+         }
+         return page.readMessage(startOffset, startMessageNumber, messageNumber);
+      } catch (Exception e) {
+         throw new RuntimeException(e.getMessage(), e);
+      }
+   }
+
+   @Override
+   public void close() {
+      if (page != null) {
+         try {
+            page.close();
+         } catch (Exception e) {
+            logger.warn("Closing page " + pageId + " occurs exception:", e);
+         } finally {
+            messageIndex.clear();
+            messageIndex = null;
+         }
+      }
+   }
+}

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageIndexCacheImplTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageIndexCacheImplTest.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.core.paging.cursor.impl;
+
+import java.util.TreeMap;
+
+import org.apache.activemq.artemis.api.core.ICoreMessage;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.io.SequentialFile;
+import org.apache.activemq.artemis.core.io.SequentialFileFactory;
+import org.apache.activemq.artemis.core.io.nio.NIOSequentialFileFactory;
+import org.apache.activemq.artemis.core.message.impl.CoreMessage;
+import org.apache.activemq.artemis.core.paging.impl.Page;
+import org.apache.activemq.artemis.core.paging.impl.PagedMessageImpl;
+import org.apache.activemq.artemis.core.persistence.impl.nullpm.NullStorageManager;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PageIndexCacheImplTest extends ActiveMQTestBase {
+   @Test
+   public void testPageReadMessage() throws Exception {
+      recreateDirectory(getTestDir());
+
+      SequentialFileFactory factory = new NIOSequentialFileFactory(getTestDirfile(), 1);
+      SequentialFile file = factory.createSequentialFile("00010.page");
+      Page page = new Page(new SimpleString("something"), new NullStorageManager(), factory, file, 10);
+      page.open();
+      SimpleString simpleDestination = new SimpleString("Test");
+      for (int i = 0; i < 100; i++) {
+         ICoreMessage msg = new CoreMessage().setMessageID(i).initBuffer(1024);
+
+         for (int j = 0; j < 1000; j++) {
+            msg.getBodyBuffer().writeByte((byte) 'b');
+         }
+
+         msg.setAddress(simpleDestination);
+
+         page.write(new PagedMessageImpl(msg, new long[0]));
+
+         Assert.assertEquals(i + 1, page.getNumberOfMessages());
+      }
+      page.sync();
+      page.close();
+
+      file = factory.createSequentialFile("00010.page");
+      file.open();
+      page = new Page(new SimpleString("something"), new NullStorageManager(), factory, file, 10);
+      TreeMap<Integer, Integer> indexMap = new TreeMap<>();
+      page.read(new NullStorageManager(), indexMap);
+
+      assertTrue(indexMap.size() > 0);
+      assertEquals(indexMap.firstKey().intValue(), 4);
+      assertTrue(indexMap.firstEntry().getValue().intValue() > 4096);
+
+      PageIndexCacheImpl pageIndexCache = new PageIndexCacheImpl(10);
+      pageIndexCache.setNumberOfMessages(page.getNumberOfMessages());
+      pageIndexCache.setMessageIndex(indexMap);
+      pageIndexCache.setPage(page);
+      for (int i = 0; i < 10; i++) {
+         for (int j = 0; j < 5; j++) {
+            int num = i * 5 + j;
+            assertEquals(pageIndexCache.getMessage(num).getMessage().getMessageID(), num);
+         }
+         for (int j = 0; j < 5; j++) {
+            int num = 50 + i * 5 + j;
+            assertEquals(pageIndexCache.getMessage(num).getMessage().getMessageID(), num);
+         }
+      }
+      try {
+         pageIndexCache.getMessage(100);
+         assertTrue("message num out of index", false);
+      } catch (Exception e) {
+      }
+      pageIndexCache.close();
+   }
+}


### PR DESCRIPTION
We noticed that there was a significant drop in performance when entering page mode in the case of multiple subscribers.

### **Environment**:
broker 2.9.0
cpu: 4 cores, memory: 8G, disk: ssd 500G
broker.xml:
         `<thread-pool-max-size>60</thread-pool-max-size>
         <address-setting match="#">
                 <max-size-bytes>51Mb</max-size-bytes>
                 <page-size-bytes>50Mb</page-size-bytes>
                 <page-max-cache-size>1</page-max-cache-size>
                 <address-full-policy>PAGE</address-full-policy>
         </address-setting> 
         <message-expiry-scan-period>-1</message-expiry-scan-period>`
         
### **Test steps**:
We created a topic and 100 queues bound to it. We ran our GrinderRunner test in our inner test infra cluster with 500 threads producing messages(200-500 bytes size) and 560 threads, each one picked a random queue to subscribe. The test showed performance is bad: 13000 msg/s sent and 5000 msg/s received.
producer tps and latency:
![orig_producer](https://user-images.githubusercontent.com/7719761/60018577-55444180-96be-11e9-816d-d0d6881ddcc7.png)
consumer tps and latency:
![orig_consumer](https://user-images.githubusercontent.com/7719761/60018663-81f85900-96be-11e9-892c-f2e27874c24f.png)

### **Analysis**:
There were two root causes:
1. Usually 1000 messages are delivered at once, sometimes less if consumers are busy. Then depage() is called to fill the queue with number of messages delivered in last step. To read these messages we need to read the whole page. It's acceptable if the page is in the softValueCache. But in the case of multiple subscribers with different cursor position, they read there own page file, put it in the cache and evict other pages. At the later time, when they need to read it again, they found it not in cache and have to read the whole page from disk which spends much time and puts pressure on disk.
2. For multiple subscribers to the same address, just one executor is responsible for delivering which means at the same moment only one queue is delivering. Thus the queue maybe stalled for a long time. We get queueMemorySize messages into memory, and when we deliver these after a long time, we probably need to query message and read page file again.

### **Solution**:
1. We add a new cache called PageIndexCache which stores the message number and file position. This cache is built when we first read the page and put it into softValueCache. If the page is evicted from softValueCache later, we'll use PageIndexCache to read message. In this way, we don't need to read the whole page for just a few messages.
2. In most cases, one depage round is followed by at most MAX_SCHEDULED_RUNNERS deliver round. Thus we just need to read MAX_DELIVERIES_IN_LOOP * MAX_SCHEDULED_RUNNERS messages. This reduces the possibility of requering the reference case the Garbage Collection removes it and keeps enough messages to deliver each time.

With this pr we get the result: 11000 msg/s sent and 16500 msg/s received.
producer tps and latency:
![pr1_producer](https://user-images.githubusercontent.com/7719761/60022057-a99eef80-96c5-11e9-9b9c-d6c7ae06e8fa.png)
consumer tps and latency:
![pr1_consumer](https://user-images.githubusercontent.com/7719761/60022227-f84c8980-96c5-11e9-90bf-76f1a48bf85f.png)


