### PR TITLE
ARTEMIS-2405 Resource adapter getter should return wrapped objects and not primitive.

### DIFF
--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
@@ -908,11 +908,11 @@ public class ActiveMQResourceAdapter implements ResourceAdapter, Serializable {
       raProperties.setProducerMaxRate(producerMaxRate);
    }
 
-   public void setUseTopologyForLoadBalancing(boolean useTopologyForLoadBalancing) {
+   public void setUseTopologyForLoadBalancing(Boolean useTopologyForLoadBalancing) {
       raProperties.setUseTopologyForLoadBalancing(useTopologyForLoadBalancing);
    }
 
-   public boolean isUseTopologyForLoadBalancing() {
+   public Boolean isUseTopologyForLoadBalancing() {
       return raProperties.isUseTopologyForLoadBalancing();
    }
 
@@ -2093,11 +2093,11 @@ public class ActiveMQResourceAdapter implements ResourceAdapter, Serializable {
       }
    }
 
-   public boolean isIgnoreJTA() {
+   public Boolean isIgnoreJTA() {
       return ignoreJTA;
    }
 
-   public void setIgnoreJTA(boolean ignoreJTA) {
+   public void setIgnoreJTA(Boolean ignoreJTA) {
       this.ignoreJTA = ignoreJTA;
    }
 }


### PR DESCRIPTION
* updating getters/setters to used wrapped objects instead of primitive.

Jira: https://issues.apache.org/jira/browse/ARTEMIS-2405