### PR TITLE
ARTEMIS-2410 max-saved-replicated-journals-size=0 throws ArrayIndexOutOfBoundsException

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/files/FileMoveManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/files/FileMoveManager.java
@@ -92,12 +92,10 @@ public class FileMoveManager {
          return;
       }
 
-      // Since we will create one folder, we are already taking that one into consideration
-      internalCheckOldFolders(1);
-
       int whereToMove = getMaxID() + 1;
 
       if (maxFolders == 0) {
+         internalCheckOldFolders(0);
          ActiveMQServerLogger.LOGGER.backupDeletingData(folder.getPath());
          for (String fileMove : files) {
             File fileFrom = new File(folder, fileMove);
@@ -105,6 +103,8 @@ public class FileMoveManager {
             deleteTree(fileFrom);
          }
       } else {
+         // Since we will create one folder, we are already taking that one into consideration
+         internalCheckOldFolders(1);
          File folderTo = getFolder(whereToMove);
          folderTo.mkdirs();
 

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/files/FileMoveManagerTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/files/FileMoveManagerTest.java
@@ -272,17 +272,21 @@ public class FileMoveManagerTest {
             File folderF = new File(dataLocation, "folder" + f);
             folderF.mkdirs();
 
+            File replicaFolder = new File(dataLocation, FileMoveManager.PREFIX + f);
+            replicaFolder.mkdir();
+
             // FILES_PER_FOLDER + f, I'm just creating more files as f grows.
             // this is just to make each folder unique somehow
             for (int i = 0; i < FILES_PER_FOLDER + f; i++) {
                createFile(folderF, i);
+               createFile(replicaFolder, i);
             }
          }
 
          manager.doMove();
 
-         // We will always have maximum of 3 folders
          Assert.assertEquals(0, manager.getNumberOfFolders());
+         Assert.assertEquals(0, manager.getFiles().length);
       }
 
       Assert.assertEquals(0, manager.getMaxID());


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARTEMIS-2410