### PR TITLE
ARTEMIS-2414 Sync before closing file in case data loss

### DIFF
--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/mapped/MappedSequentialFile.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/mapped/MappedSequentialFile.java
@@ -361,6 +361,8 @@ final class MappedSequentialFile implements SequentialFile {
    @Override
    public void close(boolean waitOnSync) {
       if (this.mappedFile != null) {
+         if (factory.isDatasync())
+            this.mappedFile.force();
          this.mappedFile.close();
          this.mappedFile = null;
       }

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/nio/NIOSequentialFile.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/nio/NIOSequentialFile.java
@@ -135,6 +135,8 @@ public class NIOSequentialFile extends AbstractSequentialFile {
 
       try {
          if (channel != null) {
+            if (factory.isDatasync())
+               channel.force(false);
             channel.close();
          }
       } catch (ClosedChannelException e) {


### PR DESCRIPTION
When we open a new page, the page sync timer might sync the current page, i.e. the new page and after it responses are sent back to client. And the old page is closed(not synced), we may lose messages if server crashes before dirty page cache written back into disk.

When we switch journal file to the new file, TimedBuffer::flushBatch will be called in the old file. Then the file would be synced except in the case user sets "journalDatasync" to false. For safety we'd better sync journal file before closing it.