### PR TITLE
ARTEMIS-2409 Convert HornetQ field names in consumer/queue selector s…

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/SelectorTranslator.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/SelectorTranslator.java
@@ -54,6 +54,21 @@ public class SelectorTranslator {
 
    }
 
+   public static String convertHQToActiveMQFilterString(final String hqFilterString) {
+      if (hqFilterString == null) {
+         return null;
+      }
+
+      String filterString = SelectorTranslator.parse(hqFilterString, "HQDurable", "AMQDurable");
+      filterString = SelectorTranslator.parse(filterString, "HQPriority", "AMQPriority");
+      filterString = SelectorTranslator.parse(filterString, "HQTimestamp", "AMQTimestamp");
+      filterString = SelectorTranslator.parse(filterString, "HQUserID", "AMQUserID");
+      filterString = SelectorTranslator.parse(filterString, "HQExpiration", "AMQExpiration");
+
+      return filterString;
+
+   }
+
    private static String parse(final String input, final String match, final String replace) {
       final char quote = '\'';
 

--- a/artemis-protocols/artemis-hornetq-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/hornetq/HornetQProtocolManagerFactory.java
+++ b/artemis-protocols/artemis-hornetq-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/hornetq/HornetQProtocolManagerFactory.java
@@ -47,6 +47,7 @@ public class HornetQProtocolManagerFactory extends CoreProtocolManagerFactory {
       List<Interceptor> hqOutgoing = filterInterceptors(outgoingInterceptors);
 
       hqIncoming.add(new HQPropertiesConversionInterceptor(true));
+      hqIncoming.add(new HQFilterConversionInterceptor());
       hqOutgoing.add(new HQPropertiesConversionInterceptor(false));
 
       stripPasswordParameters(parameters);

--- a/artemis-protocols/artemis-hqclient-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/hornetq/HQFilterConversionInterceptor.java
+++ b/artemis-protocols/artemis-hqclient-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/hornetq/HQFilterConversionInterceptor.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.core.protocol.hornetq;
+
+import org.apache.activemq.artemis.api.core.Interceptor;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.protocol.core.Packet;
+import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
+import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.CreateQueueMessage;
+import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.CreateSharedQueueMessage;
+import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionCreateConsumerMessage;
+import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
+import org.apache.activemq.artemis.utils.SelectorTranslator;
+
+public class HQFilterConversionInterceptor implements Interceptor {
+   @Override
+   public boolean intercept(Packet packet, RemotingConnection connection) {
+      if (packet.getType() == PacketImpl.SESS_CREATECONSUMER) {
+         handleMessage((SessionCreateConsumerMessage) packet);
+      } else if (packet.getType() == PacketImpl.CREATE_QUEUE || packet.getType() == PacketImpl.CREATE_QUEUE_V2) {
+         handleMessage((CreateQueueMessage) packet);
+      } else if (packet.getType() == PacketImpl.CREATE_SHARED_QUEUE || packet.getType() == PacketImpl.CREATE_SHARED_QUEUE_V2) {
+         handleMessage((CreateSharedQueueMessage) packet);
+      }
+      return true;
+   }
+
+   private void handleMessage(SessionCreateConsumerMessage message) {
+      message.setFilterString(replaceFilterString(message.getFilterString()));
+   }
+
+   private void handleMessage(CreateQueueMessage message) {
+      message.setFilterString(replaceFilterString(message.getFilterString()));
+   }
+
+   private void handleMessage(CreateSharedQueueMessage message) {
+      message.setFilterString(replaceFilterString(message.getFilterString()));
+   }
+
+   private SimpleString replaceFilterString(SimpleString filterString) {
+      if (filterString == null) {
+         return null;
+      }
+      return SimpleString.toSimpleString(
+            SelectorTranslator.convertHQToActiveMQFilterString(filterString.toString()));
+   }
+}

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/jms/client/SelectorTranslatorTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/jms/client/SelectorTranslatorTest.java
@@ -204,6 +204,37 @@ public class SelectorTranslatorTest extends ActiveMQTestBase {
       checkNoSubstitute("JMSType");
    }
 
+   @Test
+   public void testConvertHQFilterString() {
+      String selector = "HQUserID = 'ID:AMQ-12435678'";
+
+      Assert.assertEquals("AMQUserID = 'ID:AMQ-12435678'", SelectorTranslator.convertHQToActiveMQFilterString(selector));
+
+      selector = "HQUserID = 'HQUserID'";
+
+      Assert.assertEquals("AMQUserID = 'HQUserID'", SelectorTranslator.convertHQToActiveMQFilterString(selector));
+
+      selector = "HQUserID = 'ID:AMQ-12435678'";
+
+      Assert.assertEquals("AMQUserID = 'ID:AMQ-12435678'", SelectorTranslator.convertHQToActiveMQFilterString(selector));
+
+      selector = "HQDurable='NON_DURABLE'";
+
+      Assert.assertEquals("AMQDurable='NON_DURABLE'", SelectorTranslator.convertHQToActiveMQFilterString(selector));
+
+      selector = "HQPriority=5";
+
+      Assert.assertEquals("AMQPriority=5", SelectorTranslator.convertHQToActiveMQFilterString(selector));
+
+      selector = "HQTimestamp=12345678";
+
+      Assert.assertEquals("AMQTimestamp=12345678", SelectorTranslator.convertHQToActiveMQFilterString(selector));
+
+      selector = "HQExpiration=12345678";
+
+      Assert.assertEquals("AMQExpiration=12345678", SelectorTranslator.convertHQToActiveMQFilterString(selector));
+   }
+
    // Private -------------------------------------------------------------------------------------
 
    private void checkNoSubstitute(final String fieldName) {


### PR DESCRIPTION
…trings

https://issues.apache.org/jira/browse/ARTEMIS-2409

When HornetQ client connects to Artemis broker and creates a consumer with a selector defined, the field names in the selector string are not translated into correct internal field names on the broker side.