### PR TITLE
ARTEMIS-2399 Improve performance when there are a lot of subscribers

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
@@ -251,6 +251,9 @@ public final class ActiveMQDefaultConfiguration {
    // The max number of concurrent reads allowed on paging
    private static int DEFAULT_MAX_CONCURRENT_PAGE_IO = 5;
 
+   // If true the whole page would be read, otherwise just seek and read while getting message
+   private static boolean DEFAULT_READ_WHOLE_PAGE = false;
+
    // the directory to store the journal files in
    private static String DEFAULT_JOURNAL_DIR = "data/journal";
 
@@ -841,6 +844,11 @@ public final class ActiveMQDefaultConfiguration {
     */
    public static int getDefaultMaxConcurrentPageIo() {
       return DEFAULT_MAX_CONCURRENT_PAGE_IO;
+   }
+
+
+   public static boolean isDefaultReadWholePage() {
+      return DEFAULT_READ_WHOLE_PAGE;
    }
 
    /**

--- a/artemis-distribution/src/main/assembly/dep.xml
+++ b/artemis-distribution/src/main/assembly/dep.xml
@@ -82,6 +82,7 @@
             <include>org.jboss.logmanager:jboss-logmanager</include>
             <include>org.jboss.logging:jboss-logging</include>
             <include>org.jboss.slf4j:slf4j-jboss-logmanager</include>
+            <include>org.jctools:jctools-core</include>
             <include>io.netty:netty-all</include>
             <include>io.netty:netty-tcnative-boringssl-static</include>
             <include>org.apache.qpid:proton-j</include>

--- a/artemis-features/src/main/resources/features.xml
+++ b/artemis-features/src/main/resources/features.xml
@@ -64,6 +64,7 @@
 		<bundle dependency="true">mvn:org.apache.commons/commons-configuration2/${commons.config.version}</bundle>
 		<bundle dependency="true">mvn:org.apache.commons/commons-text/1.6</bundle>
 		<bundle dependency="true">mvn:org.apache.commons/commons-lang3/${commons.lang.version}</bundle>
+		<bundle dependency="true">mvn:org.jctools/jctools-core/${jctools.version}</bundle>
 		<!-- Micrometer can't be included until it supports OSGi. It is currently an "optional" Maven dependency. -->
 		<!--bundle dependency="true">mvn:io.micrometer/micrometer-core/${version.micrometer}</bundle-->
 

--- a/artemis-server/pom.xml
+++ b/artemis-server/pom.xml
@@ -90,6 +90,10 @@
          <scope>test</scope>
       </dependency>
       <dependency>
+         <groupId>org.jctools</groupId>
+         <artifactId>jctools-core</artifactId>
+      </dependency>
+      <dependency>
          <groupId>io.netty</groupId>
          <artifactId>netty-buffer</artifactId>
       </dependency>

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
@@ -585,6 +585,17 @@ public interface Configuration {
    Configuration setPageMaxConcurrentIO(int maxIO);
 
    /**
+    * Returns whether the whole page is read while getting message after page cache is evicted. <br>
+    * Default value is {@link org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration#DEFAULT_READ_WHOLE_PAGE}.
+    */
+   boolean isReadWholePage();
+
+   /**
+    * Sets whether the whole page is read while getting message after page cache is evicted.
+    */
+   Configuration setReadWholePage(boolean read);
+
+   /**
     * Returns the file system directory used to store journal log. <br>
     * Default value is {@link org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration#DEFAULT_JOURNAL_DIR}.
     */

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
@@ -176,6 +176,8 @@ public class ConfigurationImpl implements Configuration, Serializable {
 
    private int maxConcurrentPageIO = ActiveMQDefaultConfiguration.getDefaultMaxConcurrentPageIo();
 
+   private boolean readWholePage = ActiveMQDefaultConfiguration.isDefaultReadWholePage();
+
    protected String largeMessagesDirectory = ActiveMQDefaultConfiguration.getDefaultLargeMessagesDir();
 
    protected String bindingsDirectory = ActiveMQDefaultConfiguration.getDefaultBindingsDirectory();
@@ -808,6 +810,17 @@ public class ConfigurationImpl implements Configuration, Serializable {
    @Override
    public ConfigurationImpl setPageMaxConcurrentIO(int maxIO) {
       this.maxConcurrentPageIO = maxIO;
+      return this;
+   }
+
+   @Override
+   public boolean isReadWholePage() {
+      return readWholePage;
+   }
+
+   @Override
+   public ConfigurationImpl setReadWholePage(boolean read) {
+      readWholePage = read;
       return this;
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -568,6 +568,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
       config.setPageMaxConcurrentIO(getInteger(e, "page-max-concurrent-io", config.getPageMaxConcurrentIO(), Validators.MINUS_ONE_OR_GT_ZERO));
 
+      config.setReadWholePage(getBoolean(e, "read-whole-page", config.isReadWholePage()));
+
       config.setPagingDirectory(getString(e, "paging-directory", config.getPagingDirectory(), Validators.NOT_NULL_OR_EMPTY));
 
       config.setCreateJournalDir(getBoolean(e, "create-journal-dir", config.isCreateJournalDir()));

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/PageCache.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/PageCache.java
@@ -36,10 +36,10 @@ public interface PageCache extends SoftValueLongObjectHashMap.ValueCache {
    boolean isLive();
 
    /**
-    * @param messageNumber The order of the message on the page
+    * @param pagePosition page position
     * @return
     */
-   PagedMessage getMessage(int messageNumber);
+   PagedMessage getMessage(PagePosition pagePosition);
 
    void close();
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/PagePosition.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/PagePosition.java
@@ -28,6 +28,8 @@ public interface PagePosition extends Comparable<PagePosition> {
 
    int getMessageNr();
 
+   int getFileOffset();
+
    long getPersistentSize();
 
    void setPersistentSize(long persistentSize);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/LivePageCacheImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/LivePageCacheImpl.java
@@ -18,6 +18,7 @@ package org.apache.activemq.artemis.core.paging.cursor.impl;
 
 import org.apache.activemq.artemis.core.paging.PagedMessage;
 import org.apache.activemq.artemis.core.paging.cursor.LivePageCache;
+import org.apache.activemq.artemis.core.paging.cursor.PagePosition;
 import org.apache.activemq.artemis.core.server.LargeServerMessage;
 import org.apache.activemq.artemis.utils.collections.ConcurrentAppendOnlyChunkedList;
 import org.jboss.logging.Logger;
@@ -61,8 +62,8 @@ public final class LivePageCacheImpl implements LivePageCache {
    }
 
    @Override
-   public PagedMessage getMessage(int messageNumber) {
-      return messages.get(messageNumber);
+   public PagedMessage getMessage(PagePosition pagePosition) {
+      return messages.get(pagePosition.getMessageNr());
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageCacheImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageCacheImpl.java
@@ -18,6 +18,7 @@ package org.apache.activemq.artemis.core.paging.cursor.impl;
 
 import org.apache.activemq.artemis.core.paging.PagedMessage;
 import org.apache.activemq.artemis.core.paging.cursor.PageCache;
+import org.apache.activemq.artemis.core.paging.cursor.PagePosition;
 
 /**
  * The caching associated to a single page.
@@ -43,9 +44,9 @@ class PageCacheImpl implements PageCache {
    // Public --------------------------------------------------------
 
    @Override
-   public PagedMessage getMessage(final int messageNumber) {
-      if (messageNumber < messages.length) {
-         return messages[messageNumber];
+   public PagedMessage getMessage(PagePosition pagePosition) {
+      if (pagePosition.getMessageNr() < messages.length) {
+         return messages[pagePosition.getMessageNr()];
       } else {
          return null;
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PagePositionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PagePositionImpl.java
@@ -31,6 +31,8 @@ public class PagePositionImpl implements PagePosition {
     */
    private int messageNr;
 
+   private int fileOffset = -1;
+
    /**
     * ID used for storage
     */
@@ -45,11 +47,17 @@ public class PagePositionImpl implements PagePosition {
    /**
     * @param pageNr
     * @param messageNr
+    * @param fileOffset
     */
-   public PagePositionImpl(long pageNr, int messageNr) {
+   public PagePositionImpl(long pageNr, int messageNr, int fileOffset) {
       this();
       this.pageNr = pageNr;
       this.messageNr = messageNr;
+      this.fileOffset = fileOffset;
+   }
+
+   public PagePositionImpl(long pageNr, int messageNr) {
+      this(pageNr, messageNr, -1);
    }
 
    public PagePositionImpl() {
@@ -88,6 +96,11 @@ public class PagePositionImpl implements PagePosition {
       return messageNr;
    }
 
+   @Override
+   public int getFileOffset() {
+      return fileOffset;
+   }
+
    /**
     * @return the persistentSize
     */
@@ -120,7 +133,7 @@ public class PagePositionImpl implements PagePosition {
 
    @Override
    public PagePosition nextPage() {
-      return new PagePositionImpl(this.pageNr + 1, 0);
+      return new PagePositionImpl(this.pageNr + 1, 0, 0);
    }
 
    @Override
@@ -150,7 +163,8 @@ public class PagePositionImpl implements PagePosition {
 
    @Override
    public String toString() {
-      return "PagePositionImpl [pageNr=" + pageNr + ", messageNr=" + messageNr + ", recordID=" + recordID + "]";
+      return "PagePositionImpl [pageNr=" + pageNr + ", messageNr=" + messageNr + ", recordID=" + recordID +
+         ", fileOffset=" + fileOffset + "]";
    }
 
    /**

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageReader.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageReader.java
@@ -1,0 +1,141 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.core.paging.cursor.impl;
+
+import org.apache.activemq.artemis.core.paging.PagedMessage;
+import org.apache.activemq.artemis.core.paging.cursor.NonExistentPage;
+import org.apache.activemq.artemis.core.paging.cursor.PageCache;
+import org.apache.activemq.artemis.core.paging.cursor.PagePosition;
+import org.apache.activemq.artemis.core.paging.impl.Page;
+import org.jboss.logging.Logger;
+
+public class PageReader implements PageCache {
+   private static final Logger logger = Logger.getLogger(PageReader.class);
+
+   private final Page page;
+   private final int numberOfMessages;
+   private PagedMessage[] pagedMessages = null;
+
+   public PageReader(Page page, int numberOfMessages) {
+      this.page = page;
+      this.numberOfMessages = numberOfMessages;
+   }
+
+   @Override
+   public long getPageId() {
+      return page.getPageId();
+   }
+
+   @Override
+   public int getNumberOfMessages() {
+      return numberOfMessages;
+   }
+
+   @Override
+   public void setMessages(PagedMessage[] messages) {
+      this.pagedMessages = messages;
+   }
+
+   @Override
+   public synchronized PagedMessage[] getMessages() {
+      if (pagedMessages != null) {
+         return pagedMessages;
+      } else {
+         try {
+            openPage();
+            return page.read().toArray(new PagedMessage[numberOfMessages]);
+         } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+         } finally {
+            close();
+         }
+      }
+   }
+
+   @Override
+   public boolean isLive() {
+      return false;
+   }
+
+   /**
+    * @param pagePosition   page position
+    * @param throwException if {@code true} exception will be thrown when message number is beyond the page
+    * @param keepOpen       if {@code true} page file would keep open after reading message
+    * @return the paged message
+    */
+   public synchronized PagedMessage getMessage(PagePosition pagePosition, boolean throwException, boolean keepOpen) {
+      if (pagePosition.getMessageNr() >= getNumberOfMessages()) {
+         if (throwException) {
+            throw new NonExistentPage("Invalid messageNumber passed = " + pagePosition + " on " + this);
+         }
+         return null;
+      }
+
+      boolean previouslyClosed = true;
+      try {
+         previouslyClosed = openPage();
+         PagedMessage msg;
+         if (pagePosition.getFileOffset() != -1) {
+            msg = page.readMessage(pagePosition.getFileOffset(), pagePosition.getMessageNr(), pagePosition.getMessageNr());
+         } else {
+            if (logger.isTraceEnabled()) {
+               logger.trace("get message from pos " + pagePosition, new Exception("trace get message without file offset"));
+            }
+            msg = page.readMessage(0, 0, pagePosition.getMessageNr());
+         }
+         return msg;
+      } catch (Exception e) {
+         throw new RuntimeException(e.getMessage(), e);
+      } finally {
+         if (!keepOpen && previouslyClosed) {
+            close();
+         }
+      }
+   }
+
+   @Override
+   public synchronized PagedMessage getMessage(PagePosition pagePosition) {
+      return getMessage(pagePosition, false, false);
+   }
+
+   /**
+    * @return true if file was previously closed
+    * @throws Exception
+    */
+   boolean openPage() throws Exception {
+      if (!page.getFile().isOpen()) {
+         page.getFile().open();
+         return true;
+      }
+      return false;
+   }
+
+   @Override
+   public synchronized void close() {
+      try {
+         page.close(false, false);
+      } catch (Exception e) {
+         logger.warn("Closing page " + page.getPageId() + " occurs exception:", e);
+      }
+   }
+
+   @Override
+   public String toString() {
+      return "PageReader::page=" + getPageId() + " numberOfMessages = " + numberOfMessages;
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/Page.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/Page.java
@@ -80,6 +80,12 @@ public final class Page implements Comparable<Page> {
     */
    private Set<PageSubscriptionCounter> pendingCounters;
 
+   private int lastReadMessageNumber;
+   private ByteBuffer readFileBuffer;
+   private final ByteBuffer headerBuffer = ByteBuffer.allocate(HEADER_SIZE);
+   private ChannelBufferWrapper readFileBufferWrapper;
+   private int readProcessedBytes;
+
    public Page(final SimpleString storeName,
                final StorageManager storageManager,
                final SequentialFileFactory factory,
@@ -90,6 +96,7 @@ public final class Page implements Comparable<Page> {
       fileFactory = factory;
       this.storageManager = storageManager;
       this.storeName = storeName;
+      resetReadMessageStatus();
    }
 
    public int getPageId() {
@@ -102,6 +109,129 @@ public final class Page implements Comparable<Page> {
 
    public LivePageCache getLiveCache() {
       return pageCache;
+   }
+
+   private synchronized void resetReadMessageStatus() {
+      lastReadMessageNumber = -3;
+      readProcessedBytes = 0;
+   }
+
+   public synchronized PagedMessage readMessage(int startOffset,
+                                                int startMessageNumber,
+                                                int targetMessageNumber) throws Exception {
+      assert startMessageNumber <= targetMessageNumber;
+
+      if (!file.isOpen()) {
+         throw ActiveMQMessageBundle.BUNDLE.invalidPageIO();
+      }
+      final int fileSize = (int) file.size();
+      try {
+         if (readFileBuffer == null) {
+            readProcessedBytes = startOffset;
+            file.position(readProcessedBytes);
+            readFileBuffer = fileFactory.allocateDirectBuffer(Math.min(fileSize - readProcessedBytes, MIN_CHUNK_SIZE));
+            //the wrapper is reused to avoid unnecessary allocations
+            readFileBufferWrapper = wrapWhole(readFileBuffer);
+            readFileBuffer.limit(0);
+         } else if (lastReadMessageNumber + 1 != targetMessageNumber) {
+            readProcessedBytes = startOffset;
+            file.position(readProcessedBytes);
+            readFileBuffer.limit(0);
+         } else {
+            startMessageNumber = targetMessageNumber;
+         }
+
+         int remainingBytes = fileSize - readProcessedBytes;
+         int currentMessageNumber = startMessageNumber;
+         // First we search forward for the file position of the target number message
+         while (remainingBytes >= MINIMUM_MSG_PERSISTENT_SIZE && currentMessageNumber < targetMessageNumber) {
+            headerBuffer.clear();
+            file.read(headerBuffer);
+            headerBuffer.position(0);
+
+            if (headerBuffer.remaining() >= HEADER_SIZE && headerBuffer.get() == START_BYTE) {
+               final int encodedSize = headerBuffer.getInt();
+               final int nextPosition = readProcessedBytes + HEADER_AND_TRAILER_SIZE + encodedSize;
+               if (nextPosition <= fileSize) {
+                  final int endPosition = nextPosition - 1;
+                  file.position(endPosition);
+                  headerBuffer.rewind();
+                  headerBuffer.limit(1);
+                  file.read(headerBuffer);
+                  headerBuffer.position(0);
+
+                  if (headerBuffer.remaining() >= 1 && headerBuffer.get() == END_BYTE) {
+                     readProcessedBytes = nextPosition;
+                     currentMessageNumber++;
+                  } else {
+                     markFileAsSuspect(file.getFileName(), readProcessedBytes, currentMessageNumber);
+                     break;
+                  }
+               } else {
+                  markFileAsSuspect(file.getFileName(), readProcessedBytes, currentMessageNumber);
+                  break;
+               }
+            } else {
+               markFileAsSuspect(file.getFileName(), readProcessedBytes, currentMessageNumber);
+               break;
+            }
+            remainingBytes = fileSize - readProcessedBytes;
+         }
+
+         // Then we read the target message
+         if (currentMessageNumber == targetMessageNumber && remainingBytes >= MINIMUM_MSG_PERSISTENT_SIZE) {
+            final ByteBuffer oldFileBuffer = readFileBuffer;
+            readFileBuffer = readIntoFileBufferIfNecessary(readFileBuffer, MINIMUM_MSG_PERSISTENT_SIZE, true);
+            //change wrapper if fileBuffer has changed
+            if (readFileBuffer != oldFileBuffer) {
+               readFileBufferWrapper = wrapWhole(readFileBuffer);
+            }
+            final byte startByte = readFileBuffer.get();
+            if (startByte == Page.START_BYTE) {
+               final int encodedSize = readFileBuffer.getInt();
+               final int nextPosition = readProcessedBytes + HEADER_AND_TRAILER_SIZE + encodedSize;
+               if (nextPosition <= fileSize) {
+                  final ByteBuffer currentFileBuffer = readFileBuffer;
+                  readFileBuffer = readIntoFileBufferIfNecessary(readFileBuffer, encodedSize + 1, true);
+                  //change wrapper if fileBuffer has changed
+                  if (readFileBuffer != currentFileBuffer) {
+                     readFileBufferWrapper = wrapWhole(readFileBuffer);
+                  }
+                  final int endPosition = readFileBuffer.position() + encodedSize;
+                  //this check must be performed upfront decoding
+                  if (readFileBuffer.remaining() >= (encodedSize + 1) && readFileBuffer.get(endPosition) == Page.END_BYTE) {
+                     final PagedMessageImpl msg = new PagedMessageImpl(storageManager);
+                     readFileBufferWrapper.setIndex(readFileBuffer.position(), endPosition);
+                     msg.decode(readFileBufferWrapper);
+                     readFileBuffer.position(endPosition + 1);
+                     assert readFileBuffer.get(endPosition) == Page.END_BYTE : "decoding cannot change end byte";
+                     msg.initMessage(storageManager);
+                     if (logger.isTraceEnabled()) {
+                        logger.tracef("Reading message %s on pageId=%d for address=%s", msg, pageId, storeName);
+                     }
+                     readProcessedBytes = nextPosition;
+                     lastReadMessageNumber = targetMessageNumber;
+                     return msg;
+                  } else {
+                     markFileAsSuspect(file.getFileName(), readProcessedBytes, currentMessageNumber);
+                  }
+               } else {
+                  markFileAsSuspect(file.getFileName(), readProcessedBytes, currentMessageNumber);
+               }
+            } else {
+               markFileAsSuspect(file.getFileName(), readProcessedBytes, currentMessageNumber);
+            }
+         }
+      } catch (Exception e) {
+         resetReadMessageStatus();
+         throw e;
+      }
+      resetReadMessageStatus();
+      throw new RuntimeException("target message no." + targetMessageNumber + " not found from start offset " + startOffset + " and start message number " + startMessageNumber);
+   }
+
+   public synchronized List<PagedMessage> read() throws Exception {
+      return read(storageManager);
    }
 
    public synchronized List<PagedMessage> read(StorageManager storage) throws Exception {
@@ -122,10 +252,17 @@ public final class Page implements Comparable<Page> {
       return messages;
    }
 
-   private ByteBuffer allocateAndReadIntoFileBuffer(ByteBuffer fileBuffer, int requiredBytes) throws Exception {
-      final ByteBuffer newFileBuffer = fileFactory.newBuffer(Math.max(requiredBytes, MIN_CHUNK_SIZE));
-      newFileBuffer.put(fileBuffer);
-      fileFactory.releaseBuffer(fileBuffer);
+   private ByteBuffer allocateAndReadIntoFileBuffer(ByteBuffer fileBuffer, int requiredBytes, boolean direct) throws Exception {
+      ByteBuffer newFileBuffer;
+      if (direct) {
+         newFileBuffer = fileFactory.allocateDirectBuffer(Math.max(requiredBytes, MIN_CHUNK_SIZE));
+         newFileBuffer.put(fileBuffer);
+         fileFactory.releaseDirectBuffer(fileBuffer);
+      } else {
+         newFileBuffer = fileFactory.newBuffer(Math.max(requiredBytes, MIN_CHUNK_SIZE));
+         newFileBuffer.put(fileBuffer);
+         fileFactory.releaseBuffer(fileBuffer);
+      }
       fileBuffer = newFileBuffer;
       //move the limit to allow reading as much as possible from the file
       fileBuffer.limit(fileBuffer.capacity());
@@ -138,7 +275,7 @@ public final class Page implements Comparable<Page> {
     * It returns a {@link ByteBuffer} that has {@link ByteBuffer#remaining()} bytes >= {@code requiredBytes}
     * of valid data from {@link #file}.
     */
-   private ByteBuffer readIntoFileBufferIfNecessary(ByteBuffer fileBuffer, int requiredBytes) throws Exception {
+   private ByteBuffer readIntoFileBufferIfNecessary(ByteBuffer fileBuffer, int requiredBytes, boolean direct) throws Exception {
       final int remaining = fileBuffer.remaining();
       //fileBuffer::remaining is the current size of valid data
       final int bytesToBeRead = requiredBytes - remaining;
@@ -162,7 +299,7 @@ public final class Page implements Comparable<Page> {
             file.read(fileBuffer);
             fileBuffer.position(0);
          } else {
-            fileBuffer = allocateAndReadIntoFileBuffer(fileBuffer, requiredBytes);
+            fileBuffer = allocateAndReadIntoFileBuffer(fileBuffer, requiredBytes, direct);
          }
       }
       return fileBuffer;
@@ -189,6 +326,7 @@ public final class Page implements Comparable<Page> {
    //sizeOf(START_BYTE) + sizeOf(MESSAGE LENGTH) + sizeOf(END_BYTE)
    private static final int HEADER_AND_TRAILER_SIZE = DataConstants.SIZE_INT + 2;
    private static final int MINIMUM_MSG_PERSISTENT_SIZE = HEADER_AND_TRAILER_SIZE;
+   private static final int HEADER_SIZE = HEADER_AND_TRAILER_SIZE - 1;
    private static final int MIN_CHUNK_SIZE = Env.osPageSize();
 
    private List<PagedMessage> readFromSequentialFile(StorageManager storage) throws Exception {
@@ -208,7 +346,7 @@ public final class Page implements Comparable<Page> {
             fileBuffer.limit(0);
             do {
                final ByteBuffer oldFileBuffer = fileBuffer;
-               fileBuffer = readIntoFileBufferIfNecessary(fileBuffer, MINIMUM_MSG_PERSISTENT_SIZE);
+               fileBuffer = readIntoFileBufferIfNecessary(fileBuffer, MINIMUM_MSG_PERSISTENT_SIZE, false);
                //change wrapper if fileBuffer has changed
                if (fileBuffer != oldFileBuffer) {
                   fileBufferWrapper = wrapWhole(fileBuffer);
@@ -219,7 +357,7 @@ public final class Page implements Comparable<Page> {
                   final int nextPosition = processedBytes + HEADER_AND_TRAILER_SIZE + encodedSize;
                   if (nextPosition <= fileSize) {
                      final ByteBuffer currentFileBuffer = fileBuffer;
-                     fileBuffer = readIntoFileBufferIfNecessary(fileBuffer, encodedSize + 1);
+                     fileBuffer = readIntoFileBufferIfNecessary(fileBuffer, encodedSize + 1, false);
                      //change wrapper if fileBuffer has changed
                      if (fileBuffer != currentFileBuffer) {
                         fileBufferWrapper = wrapWhole(fileBuffer);
@@ -317,6 +455,11 @@ public final class Page implements Comparable<Page> {
     * While reading the cache we don't need (and shouldn't inform the backup
     */
    public synchronized void close(boolean sendEvent, boolean waitSync) throws Exception {
+      if (readFileBuffer != null) {
+         fileFactory.releaseDirectBuffer(readFileBuffer);
+         readFileBuffer = null;
+      }
+
       if (sendEvent && storageManager != null) {
          storageManager.pageClosed(storeName, pageId);
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingStoreFactoryDatabase.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingStoreFactoryDatabase.java
@@ -82,6 +82,8 @@ public class PagingStoreFactoryDatabase implements PagingStoreFactory {
 
    private JDBCSequentialFile directoryList;
 
+   private final boolean readWholePage;
+
    @Override
    public ScheduledExecutorService getScheduledExecutor() {
       return scheduledExecutor;
@@ -105,6 +107,17 @@ public class PagingStoreFactoryDatabase implements PagingStoreFactory {
                                      final ExecutorFactory executorFactory,
                                      final boolean syncNonTransactional,
                                      final IOCriticalErrorListener critialErrorListener) throws Exception {
+      this(dbConf, storageManager, syncTimeout, scheduledExecutor, executorFactory, syncNonTransactional, critialErrorListener, false);
+   }
+
+   public PagingStoreFactoryDatabase(final DatabaseStorageConfiguration dbConf,
+                                     final StorageManager storageManager,
+                                     final long syncTimeout,
+                                     final ScheduledExecutorService scheduledExecutor,
+                                     final ExecutorFactory executorFactory,
+                                     final boolean syncNonTransactional,
+                                     final IOCriticalErrorListener critialErrorListener,
+                                     final boolean readWholePage) throws Exception {
       this.storageManager = storageManager;
       this.executorFactory = executorFactory;
       this.syncNonTransactional = syncNonTransactional;
@@ -113,6 +126,7 @@ public class PagingStoreFactoryDatabase implements PagingStoreFactory {
       this.dbConf = dbConf;
       this.criticalErrorListener = critialErrorListener;
       this.factoryToTableName = new HashMap<>();
+      this.readWholePage = readWholePage;
       start();
    }
 
@@ -160,7 +174,7 @@ public class PagingStoreFactoryDatabase implements PagingStoreFactory {
                                                StorageManager storageManager,
                                                AddressSettings addressSettings,
                                                ArtemisExecutor executor) {
-      return new PageCursorProviderImpl(store, storageManager, executor, addressSettings.getPageCacheMaxSize());
+      return new PageCursorProviderImpl(store, storageManager, executor, addressSettings.getPageCacheMaxSize(), readWholePage);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingStoreFactoryNIO.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingStoreFactoryNIO.java
@@ -76,6 +76,8 @@ public class PagingStoreFactoryNIO implements PagingStoreFactory {
 
    private final IOCriticalErrorListener critialErrorListener;
 
+   private final boolean readWholePage;
+
    public File getDirectory() {
       return directory;
    }
@@ -111,6 +113,17 @@ public class PagingStoreFactoryNIO implements PagingStoreFactory {
                                 final ExecutorFactory executorFactory,
                                 final boolean syncNonTransactional,
                                 final IOCriticalErrorListener critialErrorListener) {
+      this(storageManager, directory, syncTimeout, scheduledExecutor, executorFactory, syncNonTransactional, critialErrorListener, false);
+   }
+
+   public PagingStoreFactoryNIO(final StorageManager storageManager,
+                                final File directory,
+                                final long syncTimeout,
+                                final ScheduledExecutorService scheduledExecutor,
+                                final ExecutorFactory executorFactory,
+                                final boolean syncNonTransactional,
+                                final IOCriticalErrorListener critialErrorListener,
+                                final boolean readWholePage) {
       this.storageManager = storageManager;
       this.directory = directory;
       this.executorFactory = executorFactory;
@@ -118,6 +131,7 @@ public class PagingStoreFactoryNIO implements PagingStoreFactory {
       this.scheduledExecutor = scheduledExecutor;
       this.syncTimeout = syncTimeout;
       this.critialErrorListener = critialErrorListener;
+      this.readWholePage = readWholePage;
    }
 
    // Public --------------------------------------------------------
@@ -146,7 +160,7 @@ public class PagingStoreFactoryNIO implements PagingStoreFactory {
                                                StorageManager storageManager,
                                                AddressSettings addressSettings,
                                                ArtemisExecutor executor) {
-      return new PageCursorProviderImpl(store, storageManager, executor, addressSettings.getPageCacheMaxSize());
+      return new PageCursorProviderImpl(store, storageManager, executor, addressSettings.getPageCacheMaxSize(), readWholePage);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -2563,9 +2563,9 @@ public class ActiveMQServerImpl implements ActiveMQServer {
    protected PagingStoreFactory getPagingStoreFactory() throws Exception {
       if (configuration.getStoreConfiguration() != null && configuration.getStoreConfiguration().getStoreType() == StoreConfiguration.StoreType.DATABASE) {
          DatabaseStorageConfiguration dbConf = (DatabaseStorageConfiguration) configuration.getStoreConfiguration();
-         return new PagingStoreFactoryDatabase(dbConf, storageManager, configuration.getJournalBufferTimeout_NIO(), scheduledPool, ioExecutorFactory, false, shutdownOnCriticalIO);
+         return new PagingStoreFactoryDatabase(dbConf, storageManager, configuration.getJournalBufferTimeout_NIO(), scheduledPool, ioExecutorFactory, false, shutdownOnCriticalIO, configuration.isReadWholePage());
       }
-      return new PagingStoreFactoryNIO(storageManager, configuration.getPagingLocation(), configuration.getJournalBufferTimeout_NIO(), scheduledPool, ioExecutorFactory, configuration.isJournalSyncNonTransactional(), shutdownOnCriticalIO);
+      return new PagingStoreFactoryNIO(storageManager, configuration.getPagingLocation(), configuration.getJournalBufferTimeout_NIO(), scheduledPool, ioExecutorFactory, configuration.isJournalSyncNonTransactional(), shutdownOnCriticalIO, configuration.isReadWholePage());
    }
 
    /**

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -625,6 +625,14 @@
             </xsd:annotation>
          </xsd:element>
 
+         <xsd:element name="read-whole-page" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Whether the whole page is read while getting message after page cache is evicted.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
          <xsd:element name="journal-directory" type="xsd:string" default="data/journal" maxOccurs="1" minOccurs="0">
             <xsd:annotation>
                <xsd:documentation>

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImplTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImplTest.java
@@ -88,6 +88,7 @@ public class ConfigurationImplTest extends ActiveMQTestBase {
       Assert.assertEquals(ActiveMQDefaultConfiguration.getDefaultMemoryMeasureInterval(), conf.getMemoryMeasureInterval());
       Assert.assertEquals(conf.getJournalLocation(), conf.getNodeManagerLockLocation());
       Assert.assertNull(conf.getJournalDeviceBlockSize());
+      Assert.assertEquals(ActiveMQDefaultConfiguration.isDefaultReadWholePage(), conf.isReadWholePage());
    }
 
    @Test

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
@@ -125,6 +125,7 @@ public class FileConfigurationTest extends ConfigurationImplTest {
       Assert.assertEquals(true, conf.isAmqpUseCoreSubscriptionNaming());
 
       Assert.assertEquals("max concurrent io", 17, conf.getPageMaxConcurrentIO());
+      Assert.assertEquals(true, conf.isReadWholePage());
       Assert.assertEquals("somedir2", conf.getJournalDirectory());
       Assert.assertEquals(false, conf.isCreateJournalDir());
       Assert.assertEquals(JournalType.NIO, conf.getJournalType());

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageReaderTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageReaderTest.java
@@ -1,0 +1,145 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.core.paging.cursor.impl;
+
+import org.apache.activemq.artemis.api.core.ICoreMessage;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.io.SequentialFile;
+import org.apache.activemq.artemis.core.io.SequentialFileFactory;
+import org.apache.activemq.artemis.core.io.nio.NIOSequentialFileFactory;
+import org.apache.activemq.artemis.core.message.impl.CoreMessage;
+import org.apache.activemq.artemis.core.paging.PagedMessage;
+import org.apache.activemq.artemis.core.paging.cursor.NonExistentPage;
+import org.apache.activemq.artemis.core.paging.cursor.PagePosition;
+import org.apache.activemq.artemis.core.paging.impl.Page;
+import org.apache.activemq.artemis.core.paging.impl.PagedMessageImpl;
+import org.apache.activemq.artemis.core.persistence.impl.nullpm.NullStorageManager;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.apache.activemq.artemis.core.paging.cursor.impl.PageSubscriptionImpl.PagePositionAndFileOffset;
+import static org.apache.activemq.artemis.utils.RandomUtil.randomBoolean;
+
+public class PageReaderTest extends ActiveMQTestBase {
+
+   @Test
+   public void testPageReadMessage() throws Exception {
+      recreateDirectory(getTestDir());
+
+      int num = 50;
+      int[] offsets = createPage(num);
+      PageReader pageReader = getPageReader();
+
+      PagedMessage[] pagedMessages = pageReader.getMessages();
+      assertEquals(pagedMessages.length, num);
+
+      PagedMessage pagedMessage = null;
+      for (int i = 0; i < num; i++) {
+         if (randomBoolean()) {
+            PagePosition pagePosition = new PagePositionImpl(10, i);
+            pagedMessage = pageReader.getMessage(pagePosition);
+         } else {
+            int nextFileOffset = pagedMessage == null ? -1 : offsets[i - 1] + pagedMessage.getEncodeSize() + Page.SIZE_RECORD;
+            PagePositionAndFileOffset startPosition = new PagePositionAndFileOffset(nextFileOffset, new PagePositionImpl(10, i - 1));
+            PagePosition pagePosition = startPosition.nextPagePostion();
+            assertEquals(offsets[i], pagePosition.getFileOffset());
+            pagedMessage = pageReader.getMessage(pagePosition);
+         }
+         assertNotNull(pagedMessage);
+         assertEquals(pagedMessage.getMessage().getMessageID(), i);
+         assertEquals(pagedMessages[i].getMessage().getMessageID(), i);
+      }
+
+      pageReader.close();
+   }
+
+   @Test
+   public void testPageReadMessageBeyondPage() throws Exception {
+      recreateDirectory(getTestDir());
+
+      int num = 10;
+      createPage(num);
+      PageReader pageReader = getPageReader();
+
+      assertNull(pageReader.getMessage(new PagePositionImpl(10, num)));
+      try {
+         pageReader.getMessage(new PagePositionImpl(10, num), true, true);
+         assertFalse("Expect exception since message number is beyond page ", true);
+      } catch (NonExistentPage e) {
+      }
+
+      pageReader.close();
+   }
+
+   @Test
+   public void testPageReadMessageKeepOpen() throws Exception {
+      recreateDirectory(getTestDir());
+
+      int num = 10;
+      createPage(num);
+      PageReader pageReader = getPageReader();
+
+      pageReader.getMessage(new PagePositionImpl(10, 1), true, true);
+      assertFalse("Page file should keep open", pageReader.openPage());
+      pageReader.getMessage(new PagePositionImpl(10, 1), true, false);
+      assertFalse("Page file should preserve previous state", pageReader.openPage());
+
+      pageReader.close();
+      pageReader.getMessage(new PagePositionImpl(10, 1), true, false);
+      assertTrue("Page file should preserve previous state", pageReader.openPage());
+
+      pageReader.close();
+   }
+
+   private int[] createPage(int num) throws Exception {
+      SequentialFileFactory factory = new NIOSequentialFileFactory(getTestDirfile(), 1);
+      SequentialFile file = factory.createSequentialFile("00010.page");
+      Page page = new Page(new SimpleString("something"), new NullStorageManager(), factory, file, 10);
+      page.open();
+      SimpleString simpleDestination = new SimpleString("Test");
+      int[] offsets = new int[num];
+      for (int i = 0; i < num; i++) {
+         ICoreMessage msg = new CoreMessage().setMessageID(i).initBuffer(1024);
+
+         for (int j = 0; j < 100; j++) {
+            msg.getBodyBuffer().writeByte((byte) 'b');
+         }
+
+         msg.setAddress(simpleDestination);
+         offsets[i] = (int)page.getFile().position();
+         page.write(new PagedMessageImpl(msg, new long[0]));
+
+         Assert.assertEquals(i + 1, page.getNumberOfMessages());
+      }
+      page.close(false, false);
+      return offsets;
+   }
+
+   private PageReader getPageReader() throws Exception {
+      SequentialFileFactory factory = new NIOSequentialFileFactory(getTestDirfile(), 1);
+      SequentialFile file = factory.createSequentialFile("00010.page");
+      file.open();
+      Page page = new Page(new SimpleString("something"), new NullStorageManager(), factory, file, 10);
+      page.open();
+      page.read(new NullStorageManager());
+      PageReader pageReader = new PageReader(page, page.getNumberOfMessages());
+      return pageReader;
+   }
+
+}

--- a/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
@@ -342,6 +342,7 @@
       <bindings-directory>somedir</bindings-directory>
       <create-bindings-dir>false</create-bindings-dir>
       <page-max-concurrent-io>17</page-max-concurrent-io>
+      <read-whole-page>true</read-whole-page>
       <journal-directory>somedir2</journal-directory>
       <create-journal-dir>false</create-journal-dir>
       <journal-type>NIO</journal-type>

--- a/artemis-server/src/test/resources/ConfigurationTest-xinclude-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-xinclude-config.xml
@@ -256,6 +256,7 @@
       <bindings-directory>somedir</bindings-directory>
       <create-bindings-dir>false</create-bindings-dir>
       <page-max-concurrent-io>17</page-max-concurrent-io>
+      <read-whole-page>true</read-whole-page>
       <journal-directory>somedir2</journal-directory>
       <create-journal-dir>false</create-journal-dir>
       <journal-type>NIO</journal-type>

--- a/artemis-tools/src/test/resources/artemis-configuration.xsd
+++ b/artemis-tools/src/test/resources/artemis-configuration.xsd
@@ -617,6 +617,14 @@
             </xsd:annotation>
          </xsd:element>
 
+         <xsd:element name="read-whole-page" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Whether the whole page is read while getting message after page cache is evicted.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
          <xsd:element name="journal-directory" type="xsd:string" default="data/journal" maxOccurs="1" minOccurs="0">
             <xsd:annotation>
                <xsd:documentation>

--- a/docs/user-manual/en/configuration-index.md
+++ b/docs/user-manual/en/configuration-index.md
@@ -159,6 +159,7 @@ log-delegate-factory-class-name | **deprecated** the name of the factory class t
 name | node name; used in topology notifications if set. | n/a
 [password-codec](masking-passwords.md) | the name of the class (and optional configuration properties) used to decode masked passwords. Only valid when `mask-password` is `true`. | n/a
 [page-max-concurrent-io](paging.md) | The max number of concurrent reads allowed on paging. | 5
+[read-whole-page](paging.md) | If true the whole page would be read, otherwise just seek and read while getting message. | `false`
 [paging-directory](paging.md#configuration)| the directory to store paged messages in. | `data/paging`
 [persist-delivery-count-before-delivery](undelivered-messages.md#delivery-count-persistence) | True means that the delivery count is persisted before delivery. False means that this only happens after a message has been cancelled. | `false`
 [persistence-enabled](persistence.md#zero-persistence)| true means that the server will use the file based journal for persistence. | `true`

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
       <jgroups.version>3.6.13.Final</jgroups.version>
       <maven.assembly.plugin.version>2.4</maven.assembly.plugin.version>
       <mockito.version>2.25.0</mockito.version>
+      <jctools.version>2.1.1</jctools.version>
       <netty.version>4.1.34.Final</netty.version>
       <netty-tcnative-version>2.0.22.Final</netty-tcnative-version>
       <proton.version>0.33.1</proton.version>
@@ -493,6 +494,12 @@
             <!-- License: Apache 2.0 -->
          </dependency>
          <!--needed to compile transport jar-->
+         <dependency>
+            <groupId>org.jctools</groupId>
+            <artifactId>jctools-core</artifactId>
+            <version>${jctools.version}</version>
+            <!-- License: Apache 2.0 -->
+         </dependency>
          <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>

--- a/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/jmx/JmxConnectionTest.java
+++ b/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/jmx/JmxConnectionTest.java
@@ -27,8 +27,8 @@ import java.rmi.server.RemoteObject;
 import java.rmi.server.RemoteRef;
 
 import io.netty.util.internal.PlatformDependent;
-import io.netty.util.internal.shaded.org.jctools.util.UnsafeAccess;
 import org.apache.activemq.artemis.tests.smoke.common.SmokeTestBase;
+import org.jctools.util.UnsafeAccess;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;


### PR DESCRIPTION
Based on discussion from [http://activemq.2283324.n4.nabble.com/Improve-paging-performance-when-there-are-lots-of-subscribers-td4751333.html](url) I decided to take the approach suggested by franz which is different than the one before. Now file offset is put in the PagePostion for reading directly from file and the extra index cache layer is removed.