### PR TITLE
NO-JIRA Making Sudo a requirement for NetworkFailureFailoverTest

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/NetworkFailureFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/NetworkFailureFailoverTest.java
@@ -51,6 +51,12 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
+/**
+ * This test will simulate a failure where the network card is gone.
+ * On that case the server should fail (as in stop) and not hung.
+ * If you don't have sudoer access to ifutil, this test will fail.
+ * You should add sudoer on your environment. otherwise you will have to ignore failures here.
+ */
 public class NetworkFailureFailoverTest extends FailoverTestBase {
 
    @Rule
@@ -58,18 +64,16 @@ public class NetworkFailureFailoverTest extends FailoverTestBase {
 
    @BeforeClass
    public static void start() {
-      NetUtil.assumeSudo();
+      NetUtil.failIfNotSudo();
    }
 
-   // 192.0.2.0 is reserved for documentation, so I'm pretty sure this won't exist on any system. (It shouldn't at least)
+   // 192.0.2.0 is reserved for documentation (and testing on this case).
    private static final String LIVE_IP = "192.0.2.0";
 
    private int beforeTime;
 
    @Override
    public void setUp() throws Exception {
-      //      beforeTime = NettyConnection.getLockTimeout();
-      //      NettyConnection.setLockTimeout(1000);
       NetUtil.netUp(LIVE_IP);
       super.setUp();
    }
@@ -77,7 +81,6 @@ public class NetworkFailureFailoverTest extends FailoverTestBase {
    @Override
    public void tearDown() throws Exception {
       super.tearDown();
-      //      NettyConnection.setLockTimeout(beforeTime);
    }
 
    @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/util/network/NetUtil.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/util/network/NetUtil.java
@@ -21,6 +21,8 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.InetAddress;
 import java.util.Iterator;
 import java.util.Map;
@@ -77,14 +79,16 @@ public class NetUtil {
       osUsed = osTmp;
    }
 
-   public static void assumeSudo() {
+   public static void failIfNotSudo() {
       Assume.assumeTrue("non supported OS", osUsed != OS.NON_SUPORTED);
       if (!canSudo()) {
-         System.out.println("Add the following at the end of your /etc/sudoers (use the visudo command)");
-         System.out.println("# ------------------------------------------------------- ");
-         System.out.println(user + " ALL = NOPASSWD: /sbin/ifconfig");
-         System.out.println("# ------------------------------------------------------- ");
-         Assume.assumeFalse(true);
+         StringWriter writer = new StringWriter();
+         PrintWriter out = new PrintWriter(writer);
+         out.println("Add the following at the end of your /etc/sudoers (use the visudo command)");
+         out.println("# ------------------------------------------------------- ");
+         out.println(user + " ALL = NOPASSWD: /sbin/ifconfig");
+         out.println("# ------------------------------------------------------- ");
+         Assert.fail(writer.toString());
       }
    }
 


### PR DESCRIPTION
When setting up a new Jenkins CI, it's required to add sudoer to have this test working
otherwise it will silently pass.