### PR TITLE
NO-JIRA Speeding up tests

### DIFF
--- a/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
@@ -476,6 +476,9 @@ public abstract class ActiveMQTestBase extends Assert {
    protected ConfigurationImpl createBasicConfig(final int serverID) {
       ConfigurationImpl configuration = new ConfigurationImpl().setSecurityEnabled(false).setJournalMinFiles(2).setJournalFileSize(100 * 1024).setJournalType(getDefaultJournalType()).setJournalDirectory(getJournalDir(serverID, false)).setBindingsDirectory(getBindingsDir(serverID, false)).setPagingDirectory(getPageDir(serverID, false)).setLargeMessagesDirectory(getLargeMessagesDir(serverID, false)).setJournalCompactMinFiles(0).setJournalCompactPercentage(0).setClusterPassword(CLUSTER_PASSWORD).setJournalDatasync(false);
 
+      // When it comes to the testsuite, we don't need any batching, I will leave some minimal batching to exercise the codebase
+      configuration.setJournalBufferTimeout_AIO(100).setJournalBufferTimeout_NIO(100);
+
       return configuration;
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSQueueBrowserTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSQueueBrowserTest.java
@@ -260,9 +260,9 @@ public class JMSQueueBrowserTest extends JMSClientTestSupport {
       browser.close();
 
       // Now check that all browser work did not affect the session transaction.
-      assertEquals(5, queueView.getMessageCount());
+      Wait.assertEquals(5, queueView::getMessageCount);
       session.commit();
-      assertEquals(10, queueView.getMessageCount());
+      Wait.assertEquals(10, queueView::getMessageCount);
    }
 
    @Test(timeout = 60000)


### PR DESCRIPTION
When it comes to the testsuite, we don't need timed buffers kicking too much.
This should bring some speed for our testsuite