### PR TITLE
NO-JIRA Fix NoProcessFilesBehind build on IBM JDK 8

### DIFF
--- a/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/NoProcessFilesBehind.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/NoProcessFilesBehind.java
@@ -105,7 +105,7 @@ public class NoProcessFilesBehind extends TestWatcher {
       java.lang.management.RuntimeMXBean runtime = java.lang.management.ManagementFactory.getRuntimeMXBean();
       java.lang.reflect.Field jvmField = runtime.getClass().getDeclaredField("jvm");
       jvmField.setAccessible(true);
-      sun.management.VMManagement jvm = (sun.management.VMManagement) jvmField.get(runtime);
+      Object jvm = jvmField.get(runtime);
       java.lang.reflect.Method getProcessIdMethod = jvm.getClass().getDeclaredMethod("getProcessId");
       getProcessIdMethod.setAccessible(true);
       return (Integer) getProcessIdMethod.invoke(jvm);


### PR DESCRIPTION
Remove sun.management.VMManagement to build NoProcessFilesBehind with
IBM JDK 8.