### PR TITLE
ARTEMIS-2444 Artemis hawtio plugin overriding sublevel tabs

### DIFF
--- a/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/artemisPlugin.js
+++ b/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/artemisPlugin.js
@@ -218,35 +218,7 @@ var ARTEMIS = (function(ARTEMIS) {
          }
       });
 
-      subLevelTabs = [];
-
-      subLevelTabs.push({
-         content: '<i class="icon-list"></i> Attributes',
-         title: "View the attribute values on your selection",
-         isValid: function () {
-           return true;
-         },
-           href: function () { if (workspace.isTopTabActive("artemis")) return "#/jmx/attributes"; else return  "#/jmx/attributes";}
-      });
-
-      subLevelTabs.push({
-         content: '<i class="icon-leaf"></i> Operations',
-         title: "Execute operations on your selection",
-         isValid: function () {
-           return true;
-         },
-         href: function () { if (workspace.isTopTabActive("artemis")) return "#/jmx/operations"; else return  "#/jmx/operations";}
-      });
-
-      subLevelTabs.push({
-         content: '<i class="icon-bar-chart"></i> Chart',
-         title: "View a chart of the metrics on your selection",
-         isValid: function () {
-           return true;
-         },
-         href: function () { if (workspace.isTopTabActive("artemis")) return "#/jmx/charts"; else return  "#/jmx/charts";}
-      });
-
+      subLevelTabs = workspace.subLevelTabs;
 
       subLevelTabs.push({
          content: '<i class="icon-plus"></i> Create',


### PR DESCRIPTION
This fix addresses an issue in the HawtIO Artemis plugin where it was overriding the workspace sublevel tabs, thereby causing the HawtIO Camel plugin to only display a limited number of tabs in the UI.