### PR TITLE
ARTEMIS-2441 Separate Lock Files

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/NodeManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/NodeManager.java
@@ -146,7 +146,7 @@ public abstract class NodeManager implements ActiveMQComponent {
     * the *current* nodeID
     * </ol>
     */
-   protected final synchronized void setUpServerLockFile() throws IOException {
+   protected synchronized void setUpServerLockFile() throws IOException {
       File serverLockFile = newFile(SERVER_LOCK_NAME);
 
       boolean fileCreated = false;


### PR DESCRIPTION
Certain devices or file systems won't support record level locking.
For that reason I am changing FileLockNodeManager to use separate files (one for each position) instead of using tryLock(position);
A good example for this would be cephFS where channel.tryLock or channel.tryLock works but it fails at a record level.