### PR TITLE
Treat empty providerUrl string same way as null value.

### DIFF
--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jndi/ActiveMQInitialContextFactory.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jndi/ActiveMQInitialContextFactory.java
@@ -56,7 +56,7 @@ public class ActiveMQInitialContextFactory implements InitialContextFactory {
       Map<String, Object> data = new ConcurrentHashMap<>();
 
       String providerUrl = (String) environment.get(javax.naming.Context.PROVIDER_URL);
-      if (providerUrl != null) {
+      if (providerUrl != null && !providerUrl.isEmpty()) {
          try {
             JMSFactoryType providedFactoryType = getFactoryType(providerUrl);
             if (providedFactoryType == null) {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/SimpleJNDIClientTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/SimpleJNDIClientTest.java
@@ -104,6 +104,18 @@ public class SimpleJNDIClientTest extends ActiveMQTestBase {
    }
 
    @Test
+   public void testEmptyConnectionFactoryString() throws NamingException, JMSException {
+      Hashtable<String, String> props = new Hashtable<>();
+      props.put(Context.INITIAL_CONTEXT_FACTORY, "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory");
+      props.put("connectionFactory.ConnectionFactory", "vm://0");
+
+      //IIB v10 assumes this property is mandatory and sets it to an empty string when not specified
+      props.put("java.naming.provider.url", "");
+      new InitialContext(props);//Must not throw an exception
+
+   }
+
+   @Test
    public void testVMCF1() throws NamingException, JMSException {
       Hashtable<String, String> props = new Hashtable<>();
       props.put(Context.INITIAL_CONTEXT_FACTORY, "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory");


### PR DESCRIPTION
The toolking I'm using somehow always sets `java.naming.provider.url` to an empty string by default. I couldn't find a way to set it to `null`. I wanted to use the client-side JNDI but instead I was getting this exception:
```
java.lang.NullPointerException
	at java.util.concurrent.ConcurrentHashMap.get(ConcurrentHashMap.java:947)
	at org.apache.activemq.artemis.utils.uri.URIFactory.newObject(URIFactory.java:63)
	at org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory.createConnectionFactory(ActiveMQInitialContextFactory.java:185)
	at org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory.getInitialContext(ActiveMQInitialContextFactory.java:65)
	at javax.naming.spi.NamingManager.getInitialContext(NamingManager.java:695)
	at javax.naming.InitialContext.getDefaultInitCtx(InitialContext.java:324)
	at javax.naming.InitialContext.init(InitialContext.java:255)
	at javax.naming.InitialContext.<init>(InitialContext.java:227)
	at javax.naming.directory.InitialDirContext.<init>(InitialDirContext.java:112)
	at com.ibm.broker.jmsclienthelper.JMSClientHelper.setInitialContext(JMSClientHelper.java:851)
	at com.ibm.broker.jmsclienthelper.JMSClientRequestResponseHelper.setupJMSRequest(JMSClientRequestResponseHelper.java:939)
	at com.ibm.broker.jmsclientnodes.JMSClientOutputNode.evaluate(JMSClientOutputNode.java:483)
	at com.ibm.broker.plugin.MbNode.evaluate(MbNode.java:1453)

javax.naming.NamingException: Invalid broker URL
	at org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory.getInitialContext(ActiveMQInitialContextFactory.java:73)
	at javax.naming.spi.NamingManager.getInitialContext(NamingManager.java:695)
	at javax.naming.InitialContext.getDefaultInitCtx(InitialContext.java:324)
	at javax.naming.InitialContext.init(InitialContext.java:255)
	at javax.naming.InitialContext.<init>(InitialContext.java:227)
	at javax.naming.directory.InitialDirContext.<init>(InitialDirContext.java:112)
	at com.ibm.broker.jmsclienthelper.JMSClientHelper.setInitialContext(JMSClientHelper.java:851)
	at com.ibm.broker.jmsclienthelper.JMSClientRequestResponseHelper.setupJMSRequest(JMSClientRequestResponseHelper.java:939)
	at com.ibm.broker.jmsclientnodes.JMSClientOutputNode.evaluate(JMSClientOutputNode.java:483)
	at com.ibm.broker.plugin.MbNode.evaluate(MbNode.java:1453)
```