### PR TITLE
ARTEMIS-2442 throw ActiveMQResourceLimitException if session/queue limit is reached

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/ActiveMQExceptionType.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/ActiveMQExceptionType.java
@@ -261,6 +261,12 @@ public enum ActiveMQExceptionType {
       public ActiveMQException createException(String msg) {
          return new ActiveMQReplicationTimeooutException(msg);
       }
+   },
+   RESOURCE_LIMIT_REACHED(221) {
+      @Override
+      public ActiveMQException createException(String msg) {
+         return new ActiveMQResourceLimitException(msg);
+      }
    };
    private static final Map<Integer, ActiveMQExceptionType> TYPE_MAP;
 

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/ActiveMQResourceLimitException.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/ActiveMQResourceLimitException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.api.core;
+
+public final class ActiveMQResourceLimitException extends ActiveMQException {
+
+   private static final long serialVersionUID = 4630616634531784944L;
+
+   public ActiveMQResourceLimitException() {
+      super(ActiveMQExceptionType.RESOURCE_LIMIT_REACHED);
+   }
+
+   public ActiveMQResourceLimitException(String msg) {
+      super(ActiveMQExceptionType.RESOURCE_LIMIT_REACHED, msg);
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQMessageBundle.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQMessageBundle.java
@@ -39,6 +39,7 @@ import org.apache.activemq.artemis.api.core.ActiveMQNonExistentQueueException;
 import org.apache.activemq.artemis.api.core.ActiveMQQueueExistsException;
 import org.apache.activemq.artemis.api.core.ActiveMQQueueMaxConsumerLimitReached;
 import org.apache.activemq.artemis.api.core.ActiveMQReplicationTimeooutException;
+import org.apache.activemq.artemis.api.core.ActiveMQResourceLimitException;
 import org.apache.activemq.artemis.api.core.ActiveMQSecurityException;
 import org.apache.activemq.artemis.api.core.ActiveMQSessionCreationException;
 import org.apache.activemq.artemis.api.core.ActiveMQUnexpectedRoutingTypeForAddress;
@@ -359,10 +360,10 @@ public interface ActiveMQMessageBundle {
    ActiveMQIllegalStateException unsupportedHAPolicyConfiguration(Object o);
 
    @Message(id = 229110, value = "Too many sessions for user ''{0}''. Sessions allowed: {1}.", format = Message.Format.MESSAGE_FORMAT)
-   ActiveMQSessionCreationException sessionLimitReached(String username, int limit);
+   ActiveMQResourceLimitException sessionLimitReached(String username, int limit);
 
    @Message(id = 229111, value = "Too many queues created by user ''{0}''. Queues allowed: {1}.", format = Message.Format.MESSAGE_FORMAT)
-   ActiveMQSessionCreationException queueLimitReached(String username, int limit);
+   ActiveMQResourceLimitException queueLimitReached(String username, int limit);
 
    @Message(id = 229112, value = "Cannot set MBeanServer during startup or while started")
    IllegalStateException cannotSetMBeanserver();


### PR DESCRIPTION
Now ActiveMQSessionCreationException is thrown when session/queue limit is reached. ActiveMQSessionCreationException  is used to indicate server is starting. It would cause session recreation retries all the time. Session creation should fail fast when limit is reached so client can try to connect other brokers in cluster.