### PR TITLE
ARTEMIS-2437 Allow extended types in annotations in AMQP to Core

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/converter/AMQPMessageSupport.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/converter/AMQPMessageSupport.java
@@ -155,6 +155,7 @@ public final class AMQPMessageSupport {
    public static final String DELIVERY_ANNOTATION_PREFIX = "DA_";
    public static final String MESSAGE_ANNOTATION_PREFIX = "MA_";
    public static final String FOOTER_PREFIX = "FT_";
+   public static final String ENCODED_PREFIX = "ENCODED_";
 
    public static final String JMS_AMQP_HEADER = JMS_AMQP_PREFIX + HEADER;
    public static final String JMS_AMQP_HEADER_DURABLE = JMS_AMQP_PREFIX + HEADER + DURABLE;
@@ -168,6 +169,9 @@ public final class AMQPMessageSupport {
    public static final String JMS_AMQP_DELIVERY_ANNOTATION_PREFIX = JMS_AMQP_PREFIX + DELIVERY_ANNOTATION_PREFIX;
    public static final String JMS_AMQP_MESSAGE_ANNOTATION_PREFIX = JMS_AMQP_PREFIX + MESSAGE_ANNOTATION_PREFIX;
    public static final String JMS_AMQP_FOOTER_PREFIX = JMS_AMQP_PREFIX + FOOTER_PREFIX;
+   public static final String JMS_AMQP_ENCODED_DELIVERY_ANNOTATION_PREFIX = JMS_AMQP_PREFIX + ENCODED_PREFIX + DELIVERY_ANNOTATION_PREFIX;
+   public static final String JMS_AMQP_ENCODED_MESSAGE_ANNOTATION_PREFIX = JMS_AMQP_PREFIX + ENCODED_PREFIX + MESSAGE_ANNOTATION_PREFIX;
+   public static final String JMS_AMQP_ENCODED_FOOTER_PREFIX = JMS_AMQP_PREFIX + ENCODED_PREFIX + FOOTER_PREFIX;
    public static final String JMS_AMQP_ORIGINAL_ENCODING = JMS_AMQP_PREFIX + ORIGINAL_ENCODING;
 
    // Message body type definitions

--- a/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/converter/TestConversions.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/converter/TestConversions.java
@@ -16,13 +16,22 @@
  */
 package org.apache.activemq.artemis.protocol.amqp.converter;
 
+import static org.apache.activemq.artemis.protocol.amqp.converter.AMQPMessageSupport.AMQP_NULL;
+import static org.apache.activemq.artemis.protocol.amqp.converter.AMQPMessageSupport.JMS_AMQP_ENCODED_DELIVERY_ANNOTATION_PREFIX;
+import static org.apache.activemq.artemis.protocol.amqp.converter.AMQPMessageSupport.JMS_AMQP_ENCODED_FOOTER_PREFIX;
+import static org.apache.activemq.artemis.protocol.amqp.converter.AMQPMessageSupport.JMS_AMQP_ENCODED_MESSAGE_ANNOTATION_PREFIX;
+import static org.apache.activemq.artemis.protocol.amqp.converter.AMQPMessageSupport.JMS_AMQP_ORIGINAL_ENCODING;
+
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.activemq.artemis.api.core.ICoreMessage;
 import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.buffers.impl.ResetLimitWrappedActiveMQBuffer;
+import org.apache.activemq.artemis.core.message.impl.CoreMessage;
 import org.apache.activemq.artemis.protocol.amqp.broker.AMQPMessage;
 import org.apache.activemq.artemis.protocol.amqp.converter.jms.ServerJMSBytesMessage;
 import org.apache.activemq.artemis.protocol.amqp.converter.jms.ServerJMSMapMessage;
@@ -31,17 +40,24 @@ import org.apache.activemq.artemis.protocol.amqp.converter.jms.ServerJMSStreamMe
 import org.apache.activemq.artemis.protocol.amqp.converter.jms.ServerJMSTextMessage;
 import org.apache.activemq.artemis.protocol.amqp.util.NettyReadable;
 import org.apache.activemq.artemis.protocol.amqp.util.NettyWritable;
+import org.apache.activemq.artemis.protocol.amqp.util.TLSEncode;
 import org.apache.activemq.artemis.utils.collections.TypedProperties;
 import org.apache.qpid.proton.amqp.Binary;
+import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.amqp.messaging.AmqpSequence;
 import org.apache.qpid.proton.amqp.messaging.AmqpValue;
 import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
 import org.apache.qpid.proton.amqp.messaging.Data;
+import org.apache.qpid.proton.amqp.messaging.Footer;
+import org.apache.qpid.proton.amqp.messaging.MessageAnnotations;
+import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.WritableBuffer;
 import org.apache.qpid.proton.message.Message;
 import org.apache.qpid.proton.message.impl.MessageImpl;
 import org.junit.Assert;
 import org.junit.Test;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 
 
@@ -226,6 +242,157 @@ public class TestConversions extends Assert {
       assertEquals(text, textMessage.getText());
    }
 
+   @SuppressWarnings("unchecked")
+   @Test
+   public void testConvertMessageWithMapInMessageAnnotations() throws Exception {
+      Map<String, Object> mapprop = createPropertiesMap();
+      ApplicationProperties properties = new ApplicationProperties(mapprop);
+      MessageImpl message = (MessageImpl) Message.Factory.create();
+      message.setApplicationProperties(properties);
+
+      final String annotationName = "x-opt-test-annotation";
+      final Symbol annotationNameSymbol = Symbol.valueOf(annotationName);
+
+      Map<String, String> embeddedMap = new LinkedHashMap<>();
+      embeddedMap.put("key1", "value1");
+      embeddedMap.put("key2", "value2");
+      embeddedMap.put("key3", "value3");
+      Map<Symbol, Object> annotationsMap = new LinkedHashMap<>();
+      annotationsMap.put(annotationNameSymbol, embeddedMap);
+      MessageAnnotations messageAnnotations = new MessageAnnotations(annotationsMap);
+      byte[] encodedEmbeddedMap = encodeObject(embeddedMap);
+
+      Map<String, Object> mapValues = new HashMap<>();
+      mapValues.put("somestr", "value");
+      mapValues.put("someint", Integer.valueOf(1));
+
+      message.setMessageAnnotations(messageAnnotations);
+      message.setBody(new AmqpValue(mapValues));
+
+      AMQPMessage encodedMessage = encodeAndCreateAMQPMessage(message);
+
+      ICoreMessage serverMessage = encodedMessage.toCore();
+      serverMessage.getReadOnlyBodyBuffer();
+
+      ServerJMSMapMessage mapMessage = (ServerJMSMapMessage) ServerJMSMessage.wrapCoreMessage(serverMessage);
+      mapMessage.decode();
+
+      verifyProperties(mapMessage);
+
+      assertEquals(1, mapMessage.getInt("someint"));
+      assertEquals("value", mapMessage.getString("somestr"));
+      assertTrue(mapMessage.propertyExists(JMS_AMQP_ENCODED_MESSAGE_ANNOTATION_PREFIX + annotationName));
+      assertArrayEquals(encodedEmbeddedMap, (byte[]) mapMessage.getObjectProperty(JMS_AMQP_ENCODED_MESSAGE_ANNOTATION_PREFIX + annotationName));
+
+      AMQPMessage newAMQP = CoreAmqpConverter.fromCore(mapMessage.getInnerMessage());
+      assertNotNull(newAMQP.getBody());
+      assertNotNull(newAMQP.getMessageAnnotations());
+      assertNotNull(newAMQP.getMessageAnnotations().getValue());
+      assertTrue(newAMQP.getMessageAnnotations().getValue().containsKey(annotationNameSymbol));
+      Object result = newAMQP.getMessageAnnotations().getValue().get(annotationNameSymbol);
+      assertTrue(result instanceof Map);
+      assertEquals(embeddedMap, (Map<String, String>) result);
+   }
+
+   @SuppressWarnings("unchecked")
+   @Test
+   public void testConvertMessageWithMapInFooter() throws Exception {
+      Map<String, Object> mapprop = createPropertiesMap();
+      ApplicationProperties properties = new ApplicationProperties(mapprop);
+      MessageImpl message = (MessageImpl) Message.Factory.create();
+      message.setApplicationProperties(properties);
+
+      final String footerName = "test-footer";
+      final Symbol footerNameSymbol = Symbol.valueOf(footerName);
+
+      Map<String, String> embeddedMap = new LinkedHashMap<>();
+      embeddedMap.put("key1", "value1");
+      embeddedMap.put("key2", "value2");
+      embeddedMap.put("key3", "value3");
+      Map<Symbol, Object> footerMap = new LinkedHashMap<>();
+      footerMap.put(footerNameSymbol, embeddedMap);
+      Footer messageFooter = new Footer(footerMap);
+      byte[] encodedEmbeddedMap = encodeObject(embeddedMap);
+
+      Map<String, Object> mapValues = new HashMap<>();
+      mapValues.put("somestr", "value");
+      mapValues.put("someint", Integer.valueOf(1));
+
+      message.setFooter(messageFooter);
+      message.setBody(new AmqpValue(mapValues));
+
+      AMQPMessage encodedMessage = encodeAndCreateAMQPMessage(message);
+
+      ICoreMessage serverMessage = encodedMessage.toCore();
+      serverMessage.getReadOnlyBodyBuffer();
+
+      ServerJMSMapMessage mapMessage = (ServerJMSMapMessage) ServerJMSMessage.wrapCoreMessage(serverMessage);
+      mapMessage.decode();
+
+      verifyProperties(mapMessage);
+
+      assertEquals(1, mapMessage.getInt("someint"));
+      assertEquals("value", mapMessage.getString("somestr"));
+      assertTrue(mapMessage.propertyExists(JMS_AMQP_ENCODED_FOOTER_PREFIX + footerName));
+      assertArrayEquals(encodedEmbeddedMap, (byte[]) mapMessage.getObjectProperty(JMS_AMQP_ENCODED_FOOTER_PREFIX + footerName));
+
+      AMQPMessage newAMQP = CoreAmqpConverter.fromCore(mapMessage.getInnerMessage());
+      assertNotNull(newAMQP.getBody());
+      assertNotNull(newAMQP.getFooter());
+      assertNotNull(newAMQP.getFooter().getValue());
+      assertTrue(newAMQP.getFooter().getValue().containsKey(footerNameSymbol));
+      Object result = newAMQP.getFooter().getValue().get(footerNameSymbol);
+      assertTrue(result instanceof Map);
+      assertEquals(embeddedMap, (Map<String, String>) result);
+   }
+
+   @SuppressWarnings("unchecked")
+   @Test
+   public void testConvertFromCoreWithEncodedDeliveryAnnotationProperty() throws Exception {
+
+      final String annotationName = "x-opt-test-annotation";
+      final Symbol annotationNameSymbol = Symbol.valueOf(annotationName);
+
+      Map<String, String> embeddedMap = new LinkedHashMap<>();
+      embeddedMap.put("key1", "value1");
+      embeddedMap.put("key2", "value2");
+      embeddedMap.put("key3", "value3");
+
+      byte[] encodedEmbeddedMap = encodeObject(embeddedMap);
+
+      ServerJMSMessage serverMessage = createMessage();
+
+      serverMessage.setShortProperty(JMS_AMQP_ORIGINAL_ENCODING, AMQP_NULL);
+      serverMessage.setObjectProperty(JMS_AMQP_ENCODED_DELIVERY_ANNOTATION_PREFIX + annotationName, encodedEmbeddedMap);
+      serverMessage.encode();
+
+      AMQPMessage newAMQP = CoreAmqpConverter.fromCore(serverMessage.getInnerMessage());
+      assertNull(newAMQP.getBody());
+      assertNotNull(newAMQP.getDeliveryAnnotations());
+      assertNotNull(newAMQP.getDeliveryAnnotations().getValue());
+      assertTrue(newAMQP.getDeliveryAnnotations().getValue().containsKey(annotationNameSymbol));
+      Object result = newAMQP.getDeliveryAnnotations().getValue().get(annotationNameSymbol);
+      assertTrue(result instanceof Map);
+      assertEquals(embeddedMap, (Map<String, String>) result);
+   }
+
+   private byte[] encodeObject(Object toEncode) {
+      ByteBuf scratch = Unpooled.buffer();
+      EncoderImpl encoder = TLSEncode.getEncoder();
+      encoder.setByteBuffer(new NettyWritable(scratch));
+
+      try {
+         encoder.writeObject(toEncode);
+      } finally {
+         encoder.setByteBuffer((WritableBuffer) null);
+      }
+
+      byte[] result = new byte[scratch.writerIndex()];
+      scratch.readBytes(result);
+
+      return result;
+   }
+
    private AMQPMessage encodeAndCreateAMQPMessage(MessageImpl message) {
       NettyWritable encoded = new NettyWritable(Unpooled.buffer(1024));
       message.encode(encoded);
@@ -233,5 +400,16 @@ public class TestConversions extends Assert {
       NettyReadable readable = new NettyReadable(encoded.getByteBuf());
 
       return new AMQPMessage(AMQPMessage.DEFAULT_MESSAGE_FORMAT, readable, null, null);
+   }
+
+   private ServerJMSMessage createMessage() {
+      return new ServerJMSMessage(newMessage(org.apache.activemq.artemis.api.core.Message.DEFAULT_TYPE));
+   }
+
+   private CoreMessage newMessage(byte messageType) {
+      CoreMessage message = new CoreMessage(0, 512);
+      message.setType(messageType);
+      ((ResetLimitWrappedActiveMQBuffer) message.getBodyBuffer()).setMessage(null);
+      return message;
    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
       <mockito.version>2.25.0</mockito.version>
       <netty.version>4.1.34.Final</netty.version>
       <netty-tcnative-version>2.0.22.Final</netty-tcnative-version>
-      <proton.version>0.33.1</proton.version>
+      <proton.version>0.33.2</proton.version>
       <resteasy.version>3.0.19.Final</resteasy.version>
       <slf4j.version>1.7.21</slf4j.version>
       <qpid.jms.version>0.43.0</qpid.jms.version>

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpExpiredMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpExpiredMessageTest.java
@@ -171,7 +171,7 @@ public class AmqpExpiredMessageTest extends AmqpClientTestSupport {
       sender.send(message);
       sender.close();
 
-      assertEquals(1, queueView.getMessageCount());
+      Wait.assertEquals(1, queueView::getMessageCount);
 
       // Now try and get the message
       AmqpReceiver receiver = session.createReceiver(getQueueName());
@@ -204,7 +204,7 @@ public class AmqpExpiredMessageTest extends AmqpClientTestSupport {
       sender.send(message);
       sender.close();
 
-      assertEquals(1, queueView.getMessageCount());
+      Wait.assertEquals(1, queueView::getMessageCount);
 
       Thread.sleep(1000);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpLargeMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpLargeMessageTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -51,6 +52,7 @@ import org.apache.activemq.transport.amqp.client.AmqpSender;
 import org.apache.activemq.transport.amqp.client.AmqpSession;
 import org.apache.qpid.jms.JmsConnectionFactory;
 import org.apache.qpid.proton.amqp.Binary;
+import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.amqp.messaging.AmqpSequence;
 import org.apache.qpid.proton.amqp.messaging.AmqpValue;
 import org.apache.qpid.proton.amqp.messaging.Data;
@@ -110,6 +112,52 @@ public class AmqpLargeMessageTest extends AmqpClientTestSupport {
 
          ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory();
          receiveJMS(nMsgs, factory);
+      } finally {
+         connection.close();
+      }
+   }
+
+   @Test(timeout = 60000)
+   public void testSendAMQPMessageWithComplexAnnotationsReceiveCore() throws Exception {
+      server.getAddressSettingsRepository().addMatch("#", new AddressSettings().setDefaultAddressRoutingType(RoutingType.ANYCAST));
+
+      AmqpClient client = createAmqpClient();
+      AmqpConnection connection = addConnection(client.connect());
+      try {
+         connection.connect();
+
+         String annotation = "x-opt-embedded-map";
+         Map<String, String> embeddedMap = new LinkedHashMap<>();
+         embeddedMap.put("test-key-1", "value-1");
+         embeddedMap.put("test-key-2", "value-2");
+         embeddedMap.put("test-key-3", "value-3");
+
+         AmqpSession session = connection.createSession();
+         AmqpSender sender = session.createSender(testQueueName);
+         AmqpMessage message = createAmqpMessage((byte) 'A', PAYLOAD);
+
+         message.setApplicationProperty("IntProperty", (Integer) 42);
+         message.setDurable(true);
+         message.setMessageAnnotation(annotation, embeddedMap);
+         sender.send(message);
+
+         session.close();
+
+         Wait.assertEquals(1, () -> getMessageCount(server.getPostOffice(), testQueueName));
+
+         try (ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory();
+              Connection connection2 = factory.createConnection()) {
+
+            Session session2 = connection2.createSession(false, Session.AUTO_ACKNOWLEDGE);
+            connection2.start();
+            MessageConsumer consumer = session2.createConsumer(session2.createQueue(testQueueName));
+
+            Message received = consumer.receive(5000);
+            Assert.assertNotNull(received);
+            Assert.assertEquals(42, received.getIntProperty("IntProperty"));
+
+            connection2.close();
+         }
       } finally {
          connection.close();
       }
@@ -201,6 +249,62 @@ public class AmqpLargeMessageTest extends AmqpClientTestSupport {
          session.close();
 
       } finally {
+         connection.close();
+      }
+   }
+
+   @Test(timeout = 60000)
+   public void testSendAMQPMessageWithComplexAnnotationsReceiveAMQP() throws Exception {
+      server.getAddressSettingsRepository().addMatch("#", new AddressSettings().setDefaultAddressRoutingType(RoutingType.ANYCAST));
+
+      String testQueueName = "ConnectionFrameSize";
+      int nMsgs = 200;
+
+      AmqpClient client = createAmqpClient();
+
+      Symbol annotation = Symbol.valueOf("x-opt-embedded-map");
+      Map<String, String> embeddedMap = new LinkedHashMap<>();
+      embeddedMap.put("test-key-1", "value-1");
+      embeddedMap.put("test-key-2", "value-2");
+      embeddedMap.put("test-key-3", "value-3");
+
+      {
+         AmqpConnection connection = addConnection(client.connect());
+         AmqpSession session = connection.createSession();
+         AmqpSender sender = session.createSender(testQueueName);
+         AmqpMessage message = createAmqpMessage((byte) 'A', PAYLOAD);
+
+         message.setApplicationProperty("IntProperty", (Integer) 42);
+         message.setDurable(true);
+         message.setMessageAnnotation(annotation.toString(), embeddedMap);
+         sender.send(message);
+         session.close();
+         connection.close();
+      }
+
+      Wait.assertEquals(1, () -> getMessageCount(server.getPostOffice(), testQueueName));
+
+      {
+         AmqpConnection connection = addConnection(client.connect());
+         AmqpSession session = connection.createSession();
+         AmqpReceiver receiver = session.createReceiver(testQueueName);
+         receiver.flow(nMsgs);
+
+         AmqpMessage message = receiver.receive(5, TimeUnit.SECONDS);
+         assertNotNull("Failed to read message with embedded map in annotations", message);
+         MessageImpl wrapped = (MessageImpl) message.getWrappedMessage();
+         if (wrapped.getBody() instanceof Data) {
+            Data data = (Data) wrapped.getBody();
+            System.out.println("received : message: " + data.getValue().getLength());
+            assertEquals(PAYLOAD, data.getValue().getLength());
+         }
+
+         assertNotNull(message.getWrappedMessage().getMessageAnnotations());
+         assertNotNull(message.getWrappedMessage().getMessageAnnotations().getValue());
+         assertEquals(embeddedMap, message.getWrappedMessage().getMessageAnnotations().getValue().get(annotation));
+
+         message.accept();
+         session.close();
          connection.close();
       }
    }


### PR DESCRIPTION
When converting from AMQP to core and back again support annotations that
aren't able to be placed into Core message properties by storing the bytes
from encoding the types to AMQP encodings and then decoding them again
when converting back into AMQP messages.