### PR TITLE
ARTEMIS-2451 remove need for knownDestination Cache

### DIFF
--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
@@ -97,8 +97,6 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
 
    private final Set<SimpleString> tempQueues = new ConcurrentHashSet<>();
 
-   private final Set<SimpleString> knownDestinations = new ConcurrentHashSet<>();
-
    private volatile boolean hasNoLocal;
 
    private volatile ExceptionListener exceptionListener;
@@ -543,20 +541,10 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
 
    public void addTemporaryQueue(final SimpleString queueAddress) {
       tempQueues.add(queueAddress);
-      knownDestinations.add(queueAddress);
    }
 
    public void removeTemporaryQueue(final SimpleString queueAddress) {
       tempQueues.remove(queueAddress);
-      knownDestinations.remove(queueAddress);
-   }
-
-   public void addKnownDestination(final SimpleString address) {
-      knownDestinations.add(address);
-   }
-
-   public boolean containsKnownDestination(final SimpleString address) {
-      return knownDestinations.contains(address);
    }
 
    public boolean containsTemporaryQueue(final SimpleString queueAddress) {

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQDestination.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQDestination.java
@@ -352,6 +352,7 @@ public class ActiveMQDestination extends JNDIStorable implements Destination, Se
 
    private final transient ActiveMQSession session;
 
+   private transient boolean created;
    // Constructors --------------------------------------------------
 
    protected ActiveMQDestination(final String address,
@@ -481,6 +482,22 @@ public class ActiveMQDestination extends JNDIStorable implements Destination, Se
 
    public boolean isTemporary() {
       return temporary;
+   }
+
+   public ActiveMQSession getSession() {
+      return session;
+   }
+
+   public ActiveMQConnection getConnection() {
+      return session == null ? null : session.getConnection();
+   }
+
+   public boolean isCreated() {
+      return created;
+   }
+
+   public void setCreated(boolean created) {
+      this.created = created;
    }
 
    public TYPE getType() {

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
@@ -383,7 +383,7 @@ public class ActiveMQSession implements QueueSession, TopicSession {
    void checkDestination(ActiveMQDestination destination) throws JMSException {
       SimpleString address = destination.getSimpleAddress();
       // TODO: What to do with FQQN
-      if (!connection.containsKnownDestination(address)) {
+      if (destination.getConnection() != connection && !destination.isCreated()) {
          try {
             ClientSession.AddressQuery addressQuery = session.addressQuery(address);
 
@@ -425,7 +425,9 @@ public class ActiveMQSession implements QueueSession, TopicSession {
             throw JMSExceptionHelper.convertFromActiveMQException(e);
          }
          // this is done at the end, if no exceptions are thrown
-         connection.addKnownDestination(address);
+         if (destination.getConnection() == connection) {
+            destination.setCreated(true);
+         }
       }
    }
 
@@ -454,7 +456,7 @@ public class ActiveMQSession implements QueueSession, TopicSession {
 
       ActiveMQDestination jbdest = (ActiveMQDestination) destination;
 
-      if (jbdest.isTemporary() && !connection.containsTemporaryQueue(jbdest.getSimpleAddress())) {
+      if (jbdest.isTemporary() && connection != jbdest.getConnection()) {
          throw new JMSException("Can not create consumer for temporary destination " + destination +
                                    " from another JMS connection");
       }
@@ -811,7 +813,9 @@ public class ActiveMQSession implements QueueSession, TopicSession {
                }
             }
 
-            connection.addKnownDestination(dest.getSimpleAddress());
+            if (dest.getConnection() == connection) {
+               dest.setCreated(true);
+            }
 
             consumer = createClientConsumer(dest, null, coreFilterString);
          } else {
@@ -825,7 +829,9 @@ public class ActiveMQSession implements QueueSession, TopicSession {
                }
             }
 
-            connection.addKnownDestination(dest.getSimpleAddress());
+            if (dest.getConnection() == connection) {
+               dest.setCreated(true);
+            }
 
             SimpleString queueName;
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/QueueAutoCreationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/QueueAutoCreationTest.java
@@ -23,10 +23,7 @@ import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.JournalType;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
-import org.apache.activemq.artemis.jms.client.ActiveMQConnection;
-import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
-import org.apache.activemq.artemis.jms.client.ActiveMQQueue;
-import org.apache.activemq.artemis.jms.client.ActiveMQTopic;
+import org.apache.activemq.artemis.jms.client.*;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
 import org.junit.After;
 import org.junit.Assert;
@@ -130,7 +127,7 @@ public class QueueAutoCreationTest extends JMSClientTestSupport {
          producer.send(session.createTextMessage("hello"));
       }
 
-      Assert.assertTrue(((ActiveMQConnection)connection).containsKnownDestination(addressName));
+      Assert.assertTrue(((ActiveMQDestination) topic).isCreated());
    }
 
    private void sendStringOfSize(int msgSize, boolean useCoreReceive) throws JMSException {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/AutoCreateJmsDestinationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/AutoCreateJmsDestinationTest.java
@@ -41,12 +41,8 @@ import org.apache.activemq.artemis.core.client.impl.ServerLocatorImpl;
 import org.apache.activemq.artemis.core.security.Role;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
-import org.apache.activemq.artemis.jms.client.ActiveMQConnection;
-import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
-import org.apache.activemq.artemis.jms.client.ActiveMQQueue;
-import org.apache.activemq.artemis.jms.client.ActiveMQTemporaryTopic;
-import org.apache.activemq.artemis.jms.client.ActiveMQTopic;
-import org.apache.activemq.artemis.tests.util.Wait;
+import org.apache.activemq.artemis.jms.client.*;
+import org.apache.activemq.artemis.junit.Wait;
 import org.apache.activemq.artemis.spi.core.security.ActiveMQJAASSecurityManager;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
 import org.apache.activemq.artemis.tests.util.JMSTestBase;
@@ -300,7 +296,7 @@ public class AutoCreateJmsDestinationTest extends JMSTestBase {
          producer.send(session.createTextMessage("hello"));
       }
 
-      Assert.assertTrue(((ActiveMQConnection)connection).containsKnownDestination(addressName));
+      Assert.assertTrue((((ActiveMQDestination) topic).isCreated()));
    }
 
    @Test (timeout = 30000)
@@ -324,7 +320,7 @@ public class AutoCreateJmsDestinationTest extends JMSTestBase {
             Assert.fail("Expected to throw exception here");
          } catch (JMSException expected) {
          }
-         Assert.assertFalse(((ActiveMQConnection)connection).containsKnownDestination(addressName));
+         Assert.assertFalse(((ActiveMQDestination) queue).isCreated());
       }
 
    }
@@ -349,7 +345,7 @@ public class AutoCreateJmsDestinationTest extends JMSTestBase {
       } catch (JMSException expected) {
       }
 
-      Assert.assertFalse(((ActiveMQConnection)connection).containsKnownDestination(addressName));
+      Assert.assertFalse(((ActiveMQDestination) queue).isCreated());
    }
 
 
@@ -370,7 +366,7 @@ public class AutoCreateJmsDestinationTest extends JMSTestBase {
          MessageProducer producer = session.createProducer(queue);
          Assert.assertNotNull(server.locateQueue(addressName));
 
-         Assert.assertTrue(((ActiveMQConnection) connection).containsKnownDestination(addressName));
+         Assert.assertTrue(((ActiveMQDestination) queue).isCreated());
       }
    }
 


### PR DESCRIPTION
@jbertram this is partially what i was trying to explain as an alternative approach to simply remove the need for the cache https://github.com/apache/activemq-artemis/pull/2794.

I assume you've hit some client side memory leak issue, that you're trying to resolve