### PR TITLE
ARTEMIS-2451 eliminate knownDestinations cache

### DIFF
--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
@@ -97,8 +97,6 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
 
    private final Set<SimpleString> tempQueues = new ConcurrentHashSet<>();
 
-   private final Set<SimpleString> knownDestinations = new ConcurrentHashSet<>();
-
    private volatile boolean hasNoLocal;
 
    private volatile ExceptionListener exceptionListener;
@@ -543,20 +541,10 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
 
    public void addTemporaryQueue(final SimpleString queueAddress) {
       tempQueues.add(queueAddress);
-      knownDestinations.add(queueAddress);
    }
 
    public void removeTemporaryQueue(final SimpleString queueAddress) {
       tempQueues.remove(queueAddress);
-      knownDestinations.remove(queueAddress);
-   }
-
-   public void addKnownDestination(final SimpleString address) {
-      knownDestinations.add(address);
-   }
-
-   public boolean containsKnownDestination(final SimpleString address) {
-      return knownDestinations.contains(address);
    }
 
    public boolean containsTemporaryQueue(final SimpleString queueAddress) {

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQDestination.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQDestination.java
@@ -352,6 +352,7 @@ public class ActiveMQDestination extends JNDIStorable implements Destination, Se
 
    private final transient ActiveMQSession session;
 
+   private transient boolean created;
    // Constructors --------------------------------------------------
 
    protected ActiveMQDestination(final String address,
@@ -449,6 +450,7 @@ public class ActiveMQDestination extends JNDIStorable implements Destination, Se
             } else {
                sessionToUse.deleteTemporaryTopic(this);
             }
+            setCreated(false);
          } finally {
             if (openedHere) {
                sessionToUse.close();
@@ -481,6 +483,14 @@ public class ActiveMQDestination extends JNDIStorable implements Destination, Se
 
    public boolean isTemporary() {
       return temporary;
+   }
+
+   public boolean isCreated() {
+      return created;
+   }
+
+   public void setCreated(boolean created) {
+      this.created = created;
    }
 
    public TYPE getType() {

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
@@ -383,7 +383,7 @@ public class ActiveMQSession implements QueueSession, TopicSession {
    void checkDestination(ActiveMQDestination destination) throws JMSException {
       SimpleString address = destination.getSimpleAddress();
       // TODO: What to do with FQQN
-      if (!connection.containsKnownDestination(address)) {
+      if (!destination.isCreated()) {
          try {
             ClientSession.AddressQuery addressQuery = session.addressQuery(address);
 
@@ -425,7 +425,7 @@ public class ActiveMQSession implements QueueSession, TopicSession {
             throw JMSExceptionHelper.convertFromActiveMQException(e);
          }
          // this is done at the end, if no exceptions are thrown
-         connection.addKnownDestination(address);
+         destination.setCreated(true);
       }
    }
 
@@ -811,7 +811,7 @@ public class ActiveMQSession implements QueueSession, TopicSession {
                }
             }
 
-            connection.addKnownDestination(dest.getSimpleAddress());
+            dest.setCreated(true);
 
             consumer = createClientConsumer(dest, null, coreFilterString);
          } else {
@@ -825,7 +825,7 @@ public class ActiveMQSession implements QueueSession, TopicSession {
                }
             }
 
-            connection.addKnownDestination(dest.getSimpleAddress());
+            dest.setCreated(true);
 
             SimpleString queueName;
 
@@ -998,6 +998,8 @@ public class ActiveMQSession implements QueueSession, TopicSession {
          session.createTemporaryQueue(simpleAddress, RoutingType.ANYCAST, simpleAddress);
 
          connection.addTemporaryQueue(simpleAddress);
+
+         queue.setCreated(true);
 
          return queue;
       } catch (ActiveMQException e) {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/QueueAutoCreationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/QueueAutoCreationTest.java
@@ -25,6 +25,7 @@ import org.apache.activemq.artemis.core.server.JournalType;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnection;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.apache.activemq.artemis.jms.client.ActiveMQDestination;
 import org.apache.activemq.artemis.jms.client.ActiveMQQueue;
 import org.apache.activemq.artemis.jms.client.ActiveMQTopic;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
@@ -130,7 +131,7 @@ public class QueueAutoCreationTest extends JMSClientTestSupport {
          producer.send(session.createTextMessage("hello"));
       }
 
-      Assert.assertTrue(((ActiveMQConnection)connection).containsKnownDestination(addressName));
+      Assert.assertTrue(((ActiveMQDestination) topic).isCreated());
    }
 
    private void sendStringOfSize(int msgSize, boolean useCoreReceive) throws JMSException {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/AutoCreateJmsDestinationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/AutoCreateJmsDestinationTest.java
@@ -41,15 +41,15 @@ import org.apache.activemq.artemis.core.client.impl.ServerLocatorImpl;
 import org.apache.activemq.artemis.core.security.Role;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
-import org.apache.activemq.artemis.jms.client.ActiveMQConnection;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.apache.activemq.artemis.jms.client.ActiveMQDestination;
 import org.apache.activemq.artemis.jms.client.ActiveMQQueue;
 import org.apache.activemq.artemis.jms.client.ActiveMQTemporaryTopic;
 import org.apache.activemq.artemis.jms.client.ActiveMQTopic;
-import org.apache.activemq.artemis.tests.util.Wait;
 import org.apache.activemq.artemis.spi.core.security.ActiveMQJAASSecurityManager;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
 import org.apache.activemq.artemis.tests.util.JMSTestBase;
+import org.apache.activemq.artemis.tests.util.Wait;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
 import org.junit.After;
 import org.junit.Assert;
@@ -300,7 +300,7 @@ public class AutoCreateJmsDestinationTest extends JMSTestBase {
          producer.send(session.createTextMessage("hello"));
       }
 
-      Assert.assertTrue(((ActiveMQConnection)connection).containsKnownDestination(addressName));
+      Assert.assertTrue((((ActiveMQDestination) topic).isCreated()));
    }
 
    @Test (timeout = 30000)
@@ -324,7 +324,7 @@ public class AutoCreateJmsDestinationTest extends JMSTestBase {
             Assert.fail("Expected to throw exception here");
          } catch (JMSException expected) {
          }
-         Assert.assertFalse(((ActiveMQConnection)connection).containsKnownDestination(addressName));
+         Assert.assertFalse(((ActiveMQDestination) queue).isCreated());
       }
 
    }
@@ -349,7 +349,7 @@ public class AutoCreateJmsDestinationTest extends JMSTestBase {
       } catch (JMSException expected) {
       }
 
-      Assert.assertFalse(((ActiveMQConnection)connection).containsKnownDestination(addressName));
+      Assert.assertFalse(((ActiveMQDestination) queue).isCreated());
    }
 
 
@@ -370,7 +370,7 @@ public class AutoCreateJmsDestinationTest extends JMSTestBase {
          MessageProducer producer = session.createProducer(queue);
          Assert.assertNotNull(server.locateQueue(addressName));
 
-         Assert.assertTrue(((ActiveMQConnection) connection).containsKnownDestination(addressName));
+         Assert.assertTrue(((ActiveMQDestination) queue).isCreated());
       }
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/TemporaryDestinationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/TemporaryDestinationTest.java
@@ -33,6 +33,7 @@ import org.apache.activemq.artemis.core.server.ServerSession;
 import org.apache.activemq.artemis.core.server.impl.ServerSessionImpl;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnection;
+import org.apache.activemq.artemis.jms.client.ActiveMQDestination;
 import org.apache.activemq.artemis.spi.core.security.ActiveMQJAASSecurityManager;
 import org.apache.activemq.artemis.tests.util.JMSTestBase;
 import org.junit.Before;
@@ -79,9 +80,11 @@ public class TemporaryDestinationTest extends JMSTestBase {
 
          consumer.close();
 
+         assertTrue(((ActiveMQDestination) tempQueue).isCreated());
+
          tempQueue.delete();
 
-         assertFalse(conn.containsKnownDestination(SimpleString.toSimpleString(tempQueue.getQueueName())));
+         assertFalse(((ActiveMQDestination) tempQueue).isCreated());
 
          assertFalse(conn.containsTemporaryQueue(SimpleString.toSimpleString(tempQueue.getQueueName())));
       } finally {


### PR DESCRIPTION
This is based on the work from #2796.  The connection tracking in that PR was removed as it's not necessary since we still track temporary queues.