### PR TITLE
ARTEMIS-2458 Fix AMQP Transaction Rollback Ordering

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPSessionCallback.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPSessionCallback.java
@@ -405,8 +405,15 @@ public class AMQPSessionCallback implements SessionCallback {
    public void cancel(Object brokerConsumer, Message message, boolean updateCounts) throws Exception {
       OperationContext oldContext = recoverContext();
       try {
-         ((ServerConsumer) brokerConsumer).individualCancel(message.getMessageID(), updateCounts);
-         ((ServerConsumer) brokerConsumer).getQueue().forceDelivery();
+         try {
+            ((ServerConsumer) brokerConsumer).individualCancel(message.getMessageID(), updateCounts);
+            ((ServerConsumer) brokerConsumer).getQueue().forceDelivery();
+         } catch (IllegalStateException e) {
+            //Ignore this silently, can occur if already cancelled.
+            if (logger.isDebugEnabled()) {
+               logger.debug("silently ignoring cancel", e);
+            }
+         }
       } finally {
          resetContext(oldContext);
       }
@@ -647,6 +654,10 @@ public class AMQPSessionCallback implements SessionCallback {
       } else {
          return false;
       }
+   }
+
+   public ServerSession getServerSession() {
+      return serverSession;
    }
 
    @Override

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/transaction/ProtonTransactionHandler.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/transaction/ProtonTransactionHandler.java
@@ -145,7 +145,7 @@ public class ProtonTransactionHandler implements ProtonDeliveryHandler {
             };
 
             if (discharge.getFail()) {
-               sessionSPI.withinContext(() -> tx.rollback());
+               sessionSPI.withinContext(() -> sessionSPI.getServerSession().doRollback(false, false, tx));
                sessionSPI.afterIO(ioAction);
             } else {
                sessionSPI.withinContext(() -> tx.commit());

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ServerSession.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ServerSession.java
@@ -286,6 +286,10 @@ public interface ServerSession extends SecurityAuth {
                       RoutingContext routingContext) throws Exception;
 
 
+   void doRollback(boolean clientFailed,
+                 boolean lastMessageAsDelived,
+                 Transaction theTx) throws Exception;
+
    RoutingStatus doSend(Transaction tx,
                         Message msg,
                         SimpleString originalAddress,

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/MessageReferenceImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/MessageReferenceImpl.java
@@ -89,7 +89,7 @@ public class MessageReferenceImpl extends LinkedListImpl.Node<MessageReferenceIm
 
    @Override
    public void onDelivery(Consumer<? super MessageReference> onDelivery) {
-      assert this.onDelivery == null;
+      assert onDelivery == null || this.onDelivery == null;
       this.onDelivery = onDelivery;
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
@@ -2466,6 +2466,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
 
       int priority = getPriority(ref);
 
+      ref.onDelivery(null);
       messageReferences.addHead(ref, priority);
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -1928,7 +1928,8 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
       return RoutingStatus.OK;
    }
 
-   private void doRollback(final boolean clientFailed,
+   @Override
+   public void doRollback(final boolean clientFailed,
                            final boolean lastMessageAsDelived,
                            final Transaction theTx) throws Exception {
       boolean wasStarted = started;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JmsTransactedConsumerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JmsTransactedConsumerTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.tests.integration.amqp;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+import javax.jms.Connection;
+import javax.jms.Destination;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+
+import org.junit.Test;
+
+/**
+ * Test consumer behavior for Transacted Session Consumers.
+ */
+public class JmsTransactedConsumerTest extends JMSClientTestSupport {
+   public static final String MESSAGE_NUMBER = "MessageNumber";
+
+   @Override
+   protected String getConfiguredProtocols() {
+      return "AMQP,OPENWIRE,CORE";
+   }
+
+   @Test(timeout = 60000)
+   public void testReceiveSomeThenRollbackOpenWire() throws Exception {
+      try (Connection connection = createOpenWireConnection()) {
+         testReceiveSomeThenRollback(connection);
+      }
+   }
+
+   @Test(timeout = 60000)
+   public void testReceiveSomeThenRollbackCore() throws Exception {
+      try (Connection connection = createCoreConnection()) {
+         testReceiveSomeThenRollback(connection);
+      }
+   }
+
+   @Test(timeout = 60000)
+   public void testReceiveSomeThenRollbackAMQP() throws Exception {
+      try (Connection connection = createConnection()) {
+         testReceiveSomeThenRollback(connection);
+      }
+   }
+
+   public void testReceiveSomeThenRollback(Connection connection) throws Exception {
+      connection.start();
+
+      int totalCount = 5;
+      int consumeBeforeRollback = 2;
+      sendToAmqQueue(totalCount);
+
+
+      Session session = connection.createSession(true, Session.SESSION_TRANSACTED);
+      Queue queue = session.createQueue(name.getMethodName());
+      MessageConsumer consumer = session.createConsumer(queue);
+
+      for (int i = 1; i <= consumeBeforeRollback; i++) {
+         Message message = consumer.receive(3000);
+         assertNotNull(message);
+         assertEquals("Unexpected message number", i, message.getIntProperty(MESSAGE_NUMBER));
+      }
+
+      session.rollback();
+
+      // Consume again.. the previously consumed messages should get delivered
+      // again after the rollback and then the remainder should follow
+      List<Integer> messageNumbers = new ArrayList<>();
+      for (int i = 1; i <= totalCount; i++) {
+         Message message = consumer.receive(3000);
+         assertNotNull("Failed to receive message: " + i, message);
+         int msgNum = message.getIntProperty(MESSAGE_NUMBER);
+         messageNumbers.add(msgNum);
+      }
+
+      session.commit();
+
+      assertEquals("Unexpected size of list", totalCount, messageNumbers.size());
+      for (int i = 0; i < messageNumbers.size(); i++) {
+         assertEquals("Unexpected order of messages: " + messageNumbers, Integer.valueOf(i + 1), messageNumbers.get(i));
+      }
+
+   }
+
+   protected void sendToAmqQueue(int count) throws Exception {
+      Connection activemqConnection = createCoreConnection();
+      Session amqSession = activemqConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+      Queue amqTestQueue = amqSession.createQueue(name.getMethodName());
+      sendMessages(activemqConnection, amqTestQueue, count);
+      activemqConnection.close();
+   }
+
+   public void sendMessages(Connection connection, Destination destination, int count) throws Exception {
+      Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+      MessageProducer p = session.createProducer(destination);
+
+      for (int i = 1; i <= count; i++) {
+         TextMessage message = session.createTextMessage();
+         message.setText("TextMessage: " + i);
+         message.setIntProperty(MESSAGE_NUMBER, i);
+         p.send(message);
+      }
+
+      session.close();
+
+   }
+}


### PR DESCRIPTION
Ensure cancel of in-flight message, occurs before rollback, to ensure ordering guarantee. As like with Core.