### PR TITLE
Network check custom ping priority

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ docs/hacking-guide/en/_book
 
 # overlay outpit
 **/overlays/**/*
+artemis-server/.sts4-cache/classpath-data.json

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ docs/hacking-guide/en/_book
 # overlay outpit
 **/overlays/**/*
 artemis-server/.sts4-cache/classpath-data.json
+.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,3 @@ docs/hacking-guide/en/_book
 
 # overlay outpit
 **/overlays/**/*
-artemis-server/.sts4-cache/classpath-data.json

--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,3 @@ docs/hacking-guide/en/_book
 # overlay outpit
 **/overlays/**/*
 artemis-server/.sts4-cache/classpath-data.json
-.vscode/settings.json

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/core/server/NetworkHealthCheck.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/core/server/NetworkHealthCheck.java
@@ -331,7 +331,7 @@ public class NetworkHealthCheck extends ActiveMQScheduledComponent {
       }
 
       try {
-         if (address.isReachable(networkInterface, 0, networkTimeout)) {
+         if (!hasCustomPingCommand() && address.isReachable(networkInterface, 0, networkTimeout)) {
             if (logger.isTraceEnabled()) {
                logger.tracef(address + " OK");
             }
@@ -414,5 +414,9 @@ public class NetworkHealthCheck extends ActiveMQScheduledComponent {
 
    public boolean isEmpty() {
       return addresses.isEmpty() && urls.isEmpty();
+   }
+
+   public boolean hasCustomPingCommand() {
+      return getIpv4Command().equals(IPV4_DEFAULT_COMMAND) && getIpv6Command().equals(IPV6_DEFAULT_COMMAND);
    }
 }

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/core/server/NetworkHealthCheck.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/core/server/NetworkHealthCheck.java
@@ -417,6 +417,6 @@ public class NetworkHealthCheck extends ActiveMQScheduledComponent {
    }
 
    public boolean hasCustomPingCommand() {
-      return getIpv4Command().equals(IPV4_DEFAULT_COMMAND) && getIpv6Command().equals(IPV6_DEFAULT_COMMAND);
+      return !getIpv4Command().equals(IPV4_DEFAULT_COMMAND) || !getIpv6Command().equals(IPV6_DEFAULT_COMMAND);
    }
 }


### PR DESCRIPTION
this change allows a custom ping command to run during network failure and after network is recovered.
Our custom ping app does a lot of checking and is used to delay the start of artemis after a network failure is resolved.