### PR TITLE
Updated Apache BeanUtils to address CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
       <commons.lang.version>3.0</commons.lang.version>
       <activemq5-version>5.14.5</activemq5-version>
       <apache.derby.version>10.11.1.1</apache.derby.version>
-      <commons.beanutils.version>1.9.3</commons.beanutils.version>
+      <commons.beanutils.version>1.9.4</commons.beanutils.version>
       <commons.collections.version>3.2.2</commons.collections.version>
       <fuse.mqtt.client.version>1.14</fuse.mqtt.client.version>
       <guava.version>24.1.1-jre</guava.version>


### PR DESCRIPTION
1.9.4 is a minor update do address CVE-2014-0114:
http://commons.apache.org/proper/commons-beanutils/javadocs/v1.9.4/RELEASE-NOTES.txt