### PR TITLE
ARTEMIS-2509 Add some basic support for legacy openwire

### DIFF
--- a/artemis-distribution/pom.xml
+++ b/artemis-distribution/pom.xml
@@ -164,6 +164,10 @@
            <artifactId>activemq-client</artifactId>
        </dependency>
        <dependency>
+           <groupId>org.apache.activemq</groupId>
+           <artifactId>activemq-openwire-legacy</artifactId>
+       </dependency>
+       <dependency>
           <groupId>org.eclipse.jetty.aggregate</groupId>
           <artifactId>jetty-all</artifactId>
           <type>jar</type>

--- a/artemis-distribution/src/main/assembly/dep.xml
+++ b/artemis-distribution/src/main/assembly/dep.xml
@@ -87,6 +87,7 @@
             <include>io.netty:netty-tcnative-boringssl-static</include>
             <include>org.apache.qpid:proton-j</include>
             <include>org.apache.activemq:activemq-client</include>
+            <include>org.apache.activemq:activemq-openwire-legacy</include>
             <include>org.slf4j:slf4j-api</include>
             <include>io.airlift:airline</include>
             <include>com.google.guava:guava</include>

--- a/pom.xml
+++ b/pom.xml
@@ -569,6 +569,12 @@
             <!-- License: Apache 2.0 -->
          </dependency>
          <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>activemq-openwire-legacy</artifactId>
+            <version>${activemq5-version}</version>
+            <!-- License: Apache 2.0 -->
+         </dependency>
+         <dependency>
            <groupId>org.slf4j</groupId>
            <artifactId>slf4j-api</artifactId>
            <version>${slf4j.version}</version>


### PR DESCRIPTION
This is needed to aid some lift and shift migration from activemq5 where non-java clients have support for older openwire protocols.

