### PR TITLE
ARTEMIS-2534 Deleting addresses auto created on configuration reload

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -3014,9 +3014,11 @@ public class ActiveMQServerImpl implements ActiveMQServer {
               .collect(Collectors.toSet());
 
       for (SimpleString addressName : listAddressNames()) {
+         AddressInfo addressInfo = getAddressInfo(addressName);
          AddressSettings addressSettings = getAddressSettingsRepository().getMatch(addressName.toString());
 
-         if (!addressesInConfig.contains(addressName.toString()) && addressSettings.getConfigDeleteAddresses() == DeletionPolicy.FORCE) {
+         if (!addressesInConfig.contains(addressName.toString()) && addressInfo != null && !addressInfo.isAutoCreated() &&
+            addressSettings.getConfigDeleteAddresses() == DeletionPolicy.FORCE) {
             for (Queue queue : listQueues(addressName)) {
                ActiveMQServerLogger.LOGGER.undeployQueue(queue.getName());
                try {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/RedeployTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/RedeployTest.java
@@ -84,6 +84,8 @@ public class RedeployTest extends ActiveMQTestBase {
          Assert.assertNotNull("Address wasn't autocreated accordingly", consumer.receive(5000));
       }
 
+      Assert.assertNotNull(getQueue(embeddedActiveMQ, "autoQueue"));
+
       // this simulates a remote queue or other type being added that wouldnt get deleted, its not valid to have this happen but it can happen when addresses and queues are auto created in a clustered env
       embeddedActiveMQ.getActiveMQServer().getPostOffice().addBinding(new RemoteQueueBindingImpl(5L,
               new SimpleString("autoQueue"),
@@ -116,6 +118,8 @@ public class RedeployTest extends ActiveMQTestBase {
          latch.await(10, TimeUnit.SECONDS);
 
          Assert.assertTrue(tryConsume());
+
+         Assert.assertNotNull(getQueue(embeddedActiveMQ, "autoQueue"));
 
          factory = new ActiveMQConnectionFactory();
          try (Connection connection = factory.createConnection()) {


### PR DESCRIPTION
Skip the deletion of address's and queue's auto created on configuration
reload.