### PR TITLE
ARTEMIS-2535 Add ignorePartialResultException option to LDAPLoginModule

### DIFF
--- a/docs/user-manual/en/security.md
+++ b/docs/user-manual/en/security.md
@@ -708,6 +708,12 @@ system. It is implemented by
 
 - `referral` - specify how to handle referrals; valid values: `ignore`,
   `follow`, `throw`; default is `ignore`.
+  
+- `ignorePartialResultException` - boolean flag for use when searching Active
+  Directory (AD). AD servers don't handle referrals automatically, which causes 
+  a `PartialResultException` to be thrown when referrals are encountered by a 
+  search, even if `referral` is set to `ignore`. Set to `true` to ignore these 
+  exceptions; default is `false`.
 
 - `expandRoles` - boolean indicating whether to enable the role expansion
   functionality or not; default false. If enabled, then roles within roles will


### PR DESCRIPTION
Active Directory servers are unable to handle referrals automatically. This causes a PartialResultException to be thrown if a referral is encountered beneath the base search DN, even if `Context.REFERRAL` is set to `ignore`. This PR adds an option to ignore these exceptions, allowing login to proceed with the query results received before the exception was encountered.

This is the same solution used by Spring. See https://github.com/spring-projects/spring-ldap/blob/master/core/src/main/java/org/springframework/ldap/core/LdapTemplate.java#L379-L387

Issue: https://issues.apache.org/jira/browse/ARTEMIS-2535