### PR TITLE
ARTEMIS-1925 combine STRICT and OFF with redistribution

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
@@ -172,7 +172,7 @@ public class Create extends InputAbstract {
    @Option(name = "--max-hops", description = "Number of hops on the cluster configuration")
    private int maxHops = 0;
 
-   @Option(name = "--message-load-balancing", description = "Load balancing policy on cluster. [ON_DEMAND (default) | STRICT | OFF]")
+   @Option(name = "--message-load-balancing", description = "Load balancing policy on cluster. [ON_DEMAND (default) | STRICT | OFF | STRICT_WITH_REDISTRIBUTION | OFF_WITH_REDISTRIBUTION]")
    private MessageLoadBalancingType messageLoadBalancing = MessageLoadBalancingType.ON_DEMAND;
 
    @Option(name = "--replicated", description = "Enable broker replication")

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/Validators.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/Validators.java
@@ -219,7 +219,9 @@ public final class Validators {
          String val = (String) value;
          if (val == null || !val.equals(MessageLoadBalancingType.OFF.toString()) &&
             !val.equals(MessageLoadBalancingType.STRICT.toString()) &&
-            !val.equals(MessageLoadBalancingType.ON_DEMAND.toString())) {
+            !val.equals(MessageLoadBalancingType.ON_DEMAND.toString()) &&
+            !val.equals(MessageLoadBalancingType.OFF_WITH_REDISTRIBUTION.toString()) &&
+            !val.equals(MessageLoadBalancingType.STRICT_WITH_REDISTRIBUTION.toString())) {
             throw ActiveMQMessageBundle.BUNDLE.invalidMessageLoadBalancingType(val);
          }
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/BindingsImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/BindingsImpl.java
@@ -193,7 +193,7 @@ public final class BindingsImpl implements Bindings {
 
    @Override
    public boolean allowRedistribute() {
-      return messageLoadBalancingType.equals(MessageLoadBalancingType.ON_DEMAND);
+      return messageLoadBalancingType.equals(MessageLoadBalancingType.ON_DEMAND) || messageLoadBalancingType.equals(MessageLoadBalancingType.STRICT_WITH_REDISTRIBUTION) || messageLoadBalancingType.equals(MessageLoadBalancingType.OFF_WITH_REDISTRIBUTION);
    }
 
    @Override
@@ -434,7 +434,7 @@ public final class BindingsImpl implements Bindings {
          if (filter == null || filter.match(message)) {
             // bindings.length == 1 ==> only a local queue so we don't check for matching consumers (it's an
             // unnecessary overhead)
-            if (length == 1 || (binding.isConnected() && (messageLoadBalancingType.equals(MessageLoadBalancingType.STRICT) || binding.isHighAcceptPriority(message)))) {
+            if (length == 1 || (binding.isConnected() && ((messageLoadBalancingType.equals(MessageLoadBalancingType.STRICT) || messageLoadBalancingType.equals(MessageLoadBalancingType.STRICT_WITH_REDISTRIBUTION)) || binding.isHighAcceptPriority(message)))) {
                theBinding = binding;
 
                pos = incrementPos(pos, length);
@@ -479,7 +479,7 @@ public final class BindingsImpl implements Bindings {
          routingNamePositions.put(routingName, pos);
       }
 
-      if (messageLoadBalancingType.equals(MessageLoadBalancingType.OFF) && theBinding instanceof RemoteQueueBinding) {
+      if ((messageLoadBalancingType.equals(MessageLoadBalancingType.OFF) || messageLoadBalancingType.equals(MessageLoadBalancingType.OFF_WITH_REDISTRIBUTION)) && (theBinding instanceof RemoteQueueBinding && !messageLoadBalancingType.equals(MessageLoadBalancingType.OFF_WITH_REDISTRIBUTION))) {
          if (exclusivelyRemote(bindings)) {
             theBinding = null;
          } else {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/impl/MessageLoadBalancingType.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/impl/MessageLoadBalancingType.java
@@ -20,7 +20,7 @@ import org.apache.activemq.artemis.utils.uri.BeanSupport;
 import org.apache.commons.beanutils.Converter;
 
 public enum MessageLoadBalancingType {
-   OFF("OFF"), STRICT("STRICT"), ON_DEMAND("ON_DEMAND");
+   OFF("OFF"), STRICT("STRICT"), ON_DEMAND("ON_DEMAND"), OFF_WITH_REDISTRIBUTION("OFF_WITH_REDISTRIBUTION"), STRICT_WITH_REDISTRIBUTION("STRICT_WITH_REDISTRIBUTION");
 
    static {
       // for URI support on ClusterConnection
@@ -52,6 +52,10 @@ public enum MessageLoadBalancingType {
          return MessageLoadBalancingType.STRICT;
       } else if (string.equals(ON_DEMAND.getType())) {
          return MessageLoadBalancingType.ON_DEMAND;
+      } else if (string.equals(OFF_WITH_REDISTRIBUTION.getType())) {
+         return MessageLoadBalancingType.OFF_WITH_REDISTRIBUTION;
+      } else if (string.equals(STRICT_WITH_REDISTRIBUTION.getType())) {
+         return MessageLoadBalancingType.STRICT_WITH_REDISTRIBUTION;
       } else {
          return null;
       }

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -1945,6 +1945,8 @@
                   <xsd:enumeration value="OFF"/>
                   <xsd:enumeration value="STRICT"/>
                   <xsd:enumeration value="ON_DEMAND"/>
+                  <xsd:enumeration value="OFF_WITH_REDISTRIBUTION"/>
+                  <xsd:enumeration value="STRICT_WITH_REDISTRIBUTION"/>
                </xsd:restriction>
             </xsd:simpleType>
          </xsd:element>

--- a/docs/user-manual/en/clusters.md
+++ b/docs/user-manual/en/clusters.md
@@ -608,12 +608,22 @@ specified. The following shows all the available configuration options
 
 - `message-load-balancing`. This parameter determines if/how
   messages will be distributed between other nodes of the cluster.
-  It can be one of three values - `OFF`, `STRICT`, or `ON_DEMAND` 
-  (default). This parameter replaces the deprecated
-  `forward-when-no-consumers` parameter.
+  It can be one of five values - `OFF`, `OFF_WITH_REDISTRIBUTION`,
+  `STRICT`, `STRICT_WITH_REDISTRIBUTION` or `ON_DEMAND` (default).
+  This parameter replaces the deprecated  `forward-when-no-consumers`
+  parameter.
+
+  Keep in mind that this message forwarding/balancing is what we call
+  "initial distribution." It is different than *redistribution* which
+  is [discussed below](#message-redistribution). This distinction is
+  important because redistribution is configured differently and has
+  unique semantics (e.g. it *does not* support filters (selectors)).
   
   If this is set to `OFF` then messages will never be forwarded to
-  another node in the cluster
+  another node in the cluster nor with they be redistributed.
+
+  If this is set to `OFF_WITH_REDISTRIBUTION` then the behavior is the
+  same as with `OFF` except that messages can be redistributed.
 
   If this is set to `STRICT` then each incoming message will be round
   robin'd even though the same queues on the other nodes of the
@@ -621,21 +631,20 @@ specified. The following shows all the available configuration options
   that have non matching message filters (selectors). Note that
   Apache ActiveMQ Artemis will *not* forward messages to other nodes
   if there are no *queues* of the same name on the other nodes, even
-  if this parameter is set to `STRICT`. Using `STRICT` is like setting
-  the legacy `forward-when-no-consumers` parameter to `true`.
+  if this parameter is set to `STRICT`. Messages will never be
+  redistributed. Using `STRICT` is like setting the legacy
+  `forward-when-no-consumers` parameter to `true`.
+
+  If this is set to `STRICT_WITH_REDISTRIBUTION` then the behavior is
+  the same as with `STRICT` except that messages can be redistributed.
 
   If this is set to `ON_DEMAND` then Apache ActiveMQ Artemis will only
   forward messages to other nodes of the cluster if the address to which
   they are being forwarded has queues which have consumers, and if those
   consumers have message filters (selectors) at least one of those
-  selectors must match the message. Using `ON_DEMAND` is like setting
-  the legacy `forward-when-no-consumers` parameter to `false`.
-  
-  Keep in mind that this message forwarding/balancing is what we call
-  "initial distribution." It is different than *redistribution* which
-  is [discussed below](#message-redistribution). This distinction is 
-  important because redistribution is configured differently and has 
-  unique semantics (e.g. it *does not* support filters (selectors)).
+  selectors must match the message. Messages can be redistributed.
+  Using `ON_DEMAND` is like setting the legacy
+  `forward-when-no-consumers` parameter to `false`.
 
   Default is `ON_DEMAND`.
 
@@ -824,7 +833,8 @@ This is where message redistribution comes in. With message
 redistribution Apache ActiveMQ Artemis can be configured to automatically
 *redistribute* messages from queues which have no consumers back to
 other nodes in the cluster which do have matching consumers. To enable
-this functionality `message-load-balancing` must be `ON_DEMAND`.
+this functionality `message-load-balancing` must be either `ON_DEMAND`,
+`OFF_WITH_REDISTRIBUTION` or `STRICT_WITH_REDISTRIBUTION`.
 
 Message redistribution can be configured to kick in immediately after
 the last consumer on a queue is closed, or to wait a configurable delay

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/AnycastRoutingWithClusterTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/AnycastRoutingWithClusterTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.tests.integration.cluster.distribution;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
@@ -25,8 +27,26 @@ import org.apache.activemq.artemis.core.server.cluster.impl.MessageLoadBalancing
 import org.apache.activemq.artemis.core.server.group.impl.GroupingHandlerConfiguration;
 import org.apache.activemq.artemis.tests.util.Wait;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+@RunWith(value = Parameterized.class)
 public class AnycastRoutingWithClusterTest extends ClusterTestBase {
+   private final MessageLoadBalancingType messageLoadBalancingType;
+
+   @Parameterized.Parameters(name = "messageLoadBalancingType={0}")
+   public static Collection<MessageLoadBalancingType[]> getParams() {
+      return Arrays.asList(new MessageLoadBalancingType[][] {{MessageLoadBalancingType.STRICT}, {MessageLoadBalancingType.STRICT_WITH_REDISTRIBUTION}});
+   }
+
+
+   /**
+    * @param messageLoadBalancingType
+    */
+   public AnycastRoutingWithClusterTest(MessageLoadBalancingType messageLoadBalancingType) {
+      super();
+      this.messageLoadBalancingType = messageLoadBalancingType;
+   }
 
    /**
     * Test anycast address with single distributed queue in a 3 node cluster environment.  Messages should be
@@ -43,9 +63,9 @@ public class AnycastRoutingWithClusterTest extends ClusterTestBase {
          setupServer(i, isFileStorage(), isNetty());
       }
 
-      setupClusterConnection("cluster0", clusterAddress, MessageLoadBalancingType.STRICT, 1, isNetty(), 0, 1, 2);
-      setupClusterConnection("cluster1", clusterAddress, MessageLoadBalancingType.STRICT, 1, isNetty(), 1, 0, 2);
-      setupClusterConnection("cluster2", clusterAddress, MessageLoadBalancingType.STRICT, 1, isNetty(), 2, 0, 1);
+      setupClusterConnection("cluster0", clusterAddress, messageLoadBalancingType, 1, isNetty(), 0, 1, 2);
+      setupClusterConnection("cluster1", clusterAddress, messageLoadBalancingType, 1, isNetty(), 1, 0, 2);
+      setupClusterConnection("cluster2", clusterAddress, messageLoadBalancingType, 1, isNetty(), 2, 0, 1);
 
       setUpGroupHandler(GroupingHandlerConfiguration.TYPE.LOCAL, 0);
       setUpGroupHandler(GroupingHandlerConfiguration.TYPE.REMOTE, 1);
@@ -104,9 +124,9 @@ public class AnycastRoutingWithClusterTest extends ClusterTestBase {
          setupServer(i, isFileStorage(), isNetty());
       }
 
-      setupClusterConnection("cluster0", clusterAddress, MessageLoadBalancingType.STRICT, 1, isNetty(), 0, 1, 2);
-      setupClusterConnection("cluster1", clusterAddress, MessageLoadBalancingType.STRICT, 1, isNetty(), 1, 0, 2);
-      setupClusterConnection("cluster2", clusterAddress, MessageLoadBalancingType.STRICT, 1, isNetty(), 2, 0, 1);
+      setupClusterConnection("cluster0", clusterAddress, messageLoadBalancingType, 1, isNetty(), 0, 1, 2);
+      setupClusterConnection("cluster1", clusterAddress, messageLoadBalancingType, 1, isNetty(), 1, 0, 2);
+      setupClusterConnection("cluster2", clusterAddress, messageLoadBalancingType, 1, isNetty(), 2, 0, 1);
 
       setUpGroupHandler(GroupingHandlerConfiguration.TYPE.LOCAL, 0);
       setUpGroupHandler(GroupingHandlerConfiguration.TYPE.REMOTE, 1);
@@ -164,9 +184,9 @@ public class AnycastRoutingWithClusterTest extends ClusterTestBase {
          setupServer(i, isFileStorage(), isNetty());
       }
 
-      setupClusterConnection("cluster0", clusterAddress, MessageLoadBalancingType.STRICT, 1, isNetty(), 0, 1, 2);
-      setupClusterConnection("cluster1", clusterAddress, MessageLoadBalancingType.STRICT, 1, isNetty(), 1, 0, 2);
-      setupClusterConnection("cluster2", clusterAddress, MessageLoadBalancingType.STRICT, 1, isNetty(), 2, 0, 1);
+      setupClusterConnection("cluster0", clusterAddress, messageLoadBalancingType, 1, isNetty(), 0, 1, 2);
+      setupClusterConnection("cluster1", clusterAddress, messageLoadBalancingType, 1, isNetty(), 1, 0, 2);
+      setupClusterConnection("cluster2", clusterAddress, messageLoadBalancingType, 1, isNetty(), 2, 0, 1);
 
       setUpGroupHandler(GroupingHandlerConfiguration.TYPE.LOCAL, 0);
       setUpGroupHandler(GroupingHandlerConfiguration.TYPE.REMOTE, 1);
@@ -226,9 +246,9 @@ public class AnycastRoutingWithClusterTest extends ClusterTestBase {
          setupServer(i, isFileStorage(), isNetty());
       }
 
-      setupClusterConnection("cluster0", clusterAddress, MessageLoadBalancingType.STRICT, 1, isNetty(), 0, 1, 2);
-      setupClusterConnection("cluster1", clusterAddress, MessageLoadBalancingType.STRICT, 1, isNetty(), 1, 0, 2);
-      setupClusterConnection("cluster2", clusterAddress, MessageLoadBalancingType.STRICT, 1, isNetty(), 2, 0, 1);
+      setupClusterConnection("cluster0", clusterAddress, messageLoadBalancingType, 1, isNetty(), 0, 1, 2);
+      setupClusterConnection("cluster1", clusterAddress, messageLoadBalancingType, 1, isNetty(), 1, 0, 2);
+      setupClusterConnection("cluster2", clusterAddress, messageLoadBalancingType, 1, isNetty(), 2, 0, 1);
 
       setUpGroupHandler(GroupingHandlerConfiguration.TYPE.LOCAL, 0);
       setUpGroupHandler(GroupingHandlerConfiguration.TYPE.REMOTE, 1);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/ExpireWhileLoadBalanceTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/ExpireWhileLoadBalanceTest.java
@@ -17,6 +17,9 @@
 
 package org.apache.activemq.artemis.tests.integration.cluster.distribution;
 
+import java.util.Arrays;
+import java.util.Collection;
+
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
@@ -32,8 +35,25 @@ import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+@RunWith(value = Parameterized.class)
 public class ExpireWhileLoadBalanceTest extends ClusterTestBase {
+   private final MessageLoadBalancingType messageLoadBalancingType;
+
+   @Parameterized.Parameters(name = "messageLoadBalancingType={0}")
+   public static Collection<MessageLoadBalancingType[]> getParams() {
+      return Arrays.asList(new MessageLoadBalancingType[][] {{MessageLoadBalancingType.STRICT}, {MessageLoadBalancingType.STRICT_WITH_REDISTRIBUTION}});
+   }
+
+   /**
+    * @param messageLoadBalancingType
+    */
+   public ExpireWhileLoadBalanceTest(MessageLoadBalancingType messageLoadBalancingType) {
+      super();
+      this.messageLoadBalancingType = messageLoadBalancingType;
+   }
 
    @Before
    @Override
@@ -48,11 +68,11 @@ public class ExpireWhileLoadBalanceTest extends ClusterTestBase {
          servers[i].getConfiguration().setMessageExpiryScanPeriod(100);
       }
 
-      setupClusterConnection("cluster0", "queues", MessageLoadBalancingType.STRICT, 1, true, 0, 1, 2);
+      setupClusterConnection("cluster0", "queues", messageLoadBalancingType, 1, true, 0, 1, 2);
 
-      setupClusterConnection("cluster1", "queues", MessageLoadBalancingType.STRICT, 1, true, 1, 0, 2);
+      setupClusterConnection("cluster1", "queues", messageLoadBalancingType, 1, true, 1, 0, 2);
 
-      setupClusterConnection("cluster2", "queues", MessageLoadBalancingType.STRICT, 1, true, 2, 0, 1);
+      setupClusterConnection("cluster2", "queues", messageLoadBalancingType, 1, true, 2, 0, 1);
 
       startServers(0, 1, 2);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/LargeMessageRedistributionTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/LargeMessageRedistributionTest.java
@@ -25,6 +25,13 @@ public class LargeMessageRedistributionTest extends MessageRedistributionTest {
 
    private static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
 
+   /**
+    * @param messageLoadBalancingType
+    */
+   public LargeMessageRedistributionTest(MessageLoadBalancingType messageLoadBalancingType) {
+      super(messageLoadBalancingType);
+   }
+
    @Override
    public boolean isLargeMessage() {
       return true;
@@ -32,11 +39,13 @@ public class LargeMessageRedistributionTest extends MessageRedistributionTest {
 
    @Test
    public void testRedistributionLargeMessageDirCleanup() throws Exception {
+      org.junit.Assume.assumeTrue(messageLoadBalancingType == MessageLoadBalancingType.ON_DEMAND);
+
       final long delay = 1000;
       final int numMessages = 5;
 
       setRedistributionDelay(delay);
-      setupCluster(MessageLoadBalancingType.ON_DEMAND);
+      setupCluster(messageLoadBalancingType);
 
       startServers(0, 1);
 


### PR DESCRIPTION
This commit adds two new message-load-balancing types:
STRICT_WITH_REDISTRIBUTION and OFF_WITH_REDISTRIBUTION. These allow
redistribution with the semantics of the existing STRICT and OFF
message-load-balancing types respectively. Previously you could only get
redistribution if you were using ON_DEMAND. The semantics for STRICT and
OFF were not changed so as not to impact existing users.