### PR TITLE
ARTEMIS-2547 fix AMQP Client reconnect fails on broker stop start

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -1249,6 +1249,8 @@ public class ActiveMQServerImpl implements ActiveMQServer {
 
       scaledDownNodeIDs.clear();
 
+      connectedClientIds.clear();
+
       for (ActiveMQComponent externalComponent : externalComponents) {
          try {
             if (externalComponent instanceof ServiceComponent) {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSClientTestSupport.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSClientTestSupport.java
@@ -75,7 +75,7 @@ public abstract class JMSClientTestSupport extends AmqpClientTestSupport {
       return "";
    }
 
-   protected URI getBrokerQpidJMSConnectionURI() {
+   protected String getBrokerQpidJMSConnectionString() {
 
       try {
          int port = AMQP_PORT;
@@ -100,7 +100,23 @@ public abstract class JMSClientTestSupport extends AmqpClientTestSupport {
             uri = uri + "?" + getJmsConnectionURIOptions();
          }
 
-         return new URI(uri);
+         return uri;
+      } catch (Exception e) {
+         throw new RuntimeException();
+      }
+   }
+
+   protected URI getBrokerQpidJMSConnectionURI() {
+      try {
+         return new URI(getBrokerQpidJMSConnectionString());
+      } catch (Exception e) {
+         throw new RuntimeException();
+      }
+   }
+
+   protected URI getBrokerQpidJMSFailoverConnectionURI() {
+      try {
+         return new URI("failover:(" + getBrokerQpidJMSConnectionString() + ")");
       } catch (Exception e) {
          throw new RuntimeException();
       }
@@ -108,6 +124,10 @@ public abstract class JMSClientTestSupport extends AmqpClientTestSupport {
 
    protected Connection createConnection() throws JMSException {
       return createConnection(getBrokerQpidJMSConnectionURI(), null, null, null, true);
+   }
+
+   protected Connection createFailoverConnection() throws JMSException {
+      return createConnection(getBrokerQpidJMSFailoverConnectionURI(), null, null, null, true);
    }
 
    protected Connection createConnection(boolean start) throws JMSException {


### PR DESCRIPTION
Add unit test
Add fix to clear clientids when server is stopped.