### PR TITLE
ARTEMIS-1925 combine STRICT and OFF with redistribution

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
@@ -175,7 +175,7 @@ public class Create extends InputAbstract {
    @Option(name = "--max-hops", description = "Number of hops on the cluster configuration")
    private int maxHops = 0;
 
-   @Option(name = "--message-load-balancing", description = "Load balancing policy on cluster. [ON_DEMAND (default) | STRICT | OFF]")
+   @Option(name = "--message-load-balancing", description = "Load balancing policy on cluster. [ON_DEMAND (default) | STRICT | OFF | STRICT_WITH_REDISTRIBUTION | REDISTRIBUTION_ONLY]")
    private MessageLoadBalancingType messageLoadBalancing = MessageLoadBalancingType.ON_DEMAND;
 
    @Option(name = "--replicated", description = "Enable broker replication")

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/Validators.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/Validators.java
@@ -219,7 +219,9 @@ public final class Validators {
          String val = (String) value;
          if (val == null || !val.equals(MessageLoadBalancingType.OFF.toString()) &&
             !val.equals(MessageLoadBalancingType.STRICT.toString()) &&
-            !val.equals(MessageLoadBalancingType.ON_DEMAND.toString())) {
+            !val.equals(MessageLoadBalancingType.ON_DEMAND.toString()) &&
+            !val.equals(MessageLoadBalancingType.REDISTRIBUTION_ONLY.toString()) &&
+            !val.equals(MessageLoadBalancingType.STRICT_WITH_REDISTRIBUTION.toString())) {
             throw ActiveMQMessageBundle.BUNDLE.invalidMessageLoadBalancingType(val);
          }
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/Binding.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/Binding.java
@@ -46,6 +46,8 @@ public interface Binding extends UnproposalListener {
 
    boolean isHighAcceptPriority(Message message);
 
+   boolean isHighAcceptPriority(Message message, boolean redistributing);
+
    boolean isExclusive();
 
    Long getID();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/BindingsImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/BindingsImpl.java
@@ -200,7 +200,7 @@ public final class BindingsImpl implements Bindings {
 
    @Override
    public boolean allowRedistribute() {
-      return messageLoadBalancingType.equals(MessageLoadBalancingType.ON_DEMAND);
+      return messageLoadBalancingType.equals(MessageLoadBalancingType.ON_DEMAND) || messageLoadBalancingType.equals(MessageLoadBalancingType.STRICT_WITH_REDISTRIBUTION) || messageLoadBalancingType.equals(MessageLoadBalancingType.REDISTRIBUTION_ONLY);
    }
 
    @Override
@@ -257,7 +257,7 @@ public final class BindingsImpl implements Bindings {
 
          Filter filter = binding.getFilter();
 
-         boolean highPrior = binding.isHighAcceptPriority(message);
+         boolean highPrior = binding.isHighAcceptPriority(message, true);
 
          if (highPrior && binding.getBindable() != originatingQueue && (filter == null || filter.match(message))) {
             theBinding = binding;
@@ -441,7 +441,7 @@ public final class BindingsImpl implements Bindings {
          if (filter == null || filter.match(message)) {
             // bindings.length == 1 ==> only a local queue so we don't check for matching consumers (it's an
             // unnecessary overhead)
-            if (length == 1 || (binding.isConnected() && (messageLoadBalancingType.equals(MessageLoadBalancingType.STRICT) || binding.isHighAcceptPriority(message)))) {
+            if (length == 1 || (binding.isConnected() && ((messageLoadBalancingType.equals(MessageLoadBalancingType.STRICT) || messageLoadBalancingType.equals(MessageLoadBalancingType.STRICT_WITH_REDISTRIBUTION)) || binding.isHighAcceptPriority(message)))) {
                theBinding = binding;
 
                pos = incrementPos(pos, length);
@@ -486,7 +486,7 @@ public final class BindingsImpl implements Bindings {
          routingNamePositions.put(routingName, pos);
       }
 
-      if (messageLoadBalancingType.equals(MessageLoadBalancingType.OFF) && theBinding instanceof RemoteQueueBinding) {
+      if ((messageLoadBalancingType.equals(MessageLoadBalancingType.OFF) || messageLoadBalancingType.equals(MessageLoadBalancingType.REDISTRIBUTION_ONLY)) && theBinding instanceof RemoteQueueBinding) {
          if (exclusivelyRemote(bindings)) {
             theBinding = null;
          } else {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/DivertBinding.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/DivertBinding.java
@@ -95,6 +95,11 @@ public class DivertBinding implements Binding {
 
    @Override
    public boolean isHighAcceptPriority(final Message message) {
+      return isHighAcceptPriority(message, false);
+   }
+
+   @Override
+   public boolean isHighAcceptPriority(final Message message, boolean redistributing) {
       return true;
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/LocalQueueBinding.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/LocalQueueBinding.java
@@ -109,6 +109,11 @@ public class LocalQueueBinding implements QueueBinding {
 
    @Override
    public boolean isHighAcceptPriority(final Message message) {
+      return isHighAcceptPriority(message, false);
+   }
+
+   @Override
+   public boolean isHighAcceptPriority(final Message message, boolean redistributing) {
       // It's a high accept priority if the queue has at least one matching consumer
 
       return queue.hasMatchingConsumer(message);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/impl/MessageLoadBalancingType.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/impl/MessageLoadBalancingType.java
@@ -20,7 +20,7 @@ import org.apache.activemq.artemis.utils.uri.BeanSupport;
 import org.apache.commons.beanutils.Converter;
 
 public enum MessageLoadBalancingType {
-   OFF("OFF"), STRICT("STRICT"), ON_DEMAND("ON_DEMAND");
+   OFF("OFF"), REDISTRIBUTION_ONLY("REDISTRIBUTION_ONLY"), STRICT("STRICT"), STRICT_WITH_REDISTRIBUTION("STRICT_WITH_REDISTRIBUTION"), ON_DEMAND("ON_DEMAND");
 
    static {
       // for URI support on ClusterConnection
@@ -52,6 +52,10 @@ public enum MessageLoadBalancingType {
          return MessageLoadBalancingType.STRICT;
       } else if (string.equals(ON_DEMAND.getType())) {
          return MessageLoadBalancingType.ON_DEMAND;
+      } else if (string.equals(REDISTRIBUTION_ONLY.getType())) {
+         return MessageLoadBalancingType.REDISTRIBUTION_ONLY;
+      } else if (string.equals(STRICT_WITH_REDISTRIBUTION.getType())) {
+         return MessageLoadBalancingType.STRICT_WITH_REDISTRIBUTION;
       } else {
          return null;
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/impl/RemoteQueueBindingImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/impl/RemoteQueueBindingImpl.java
@@ -154,7 +154,12 @@ public class RemoteQueueBindingImpl implements RemoteQueueBinding {
 
    @Override
    public synchronized boolean isHighAcceptPriority(final Message message) {
-      if (consumerCount == 0 || messageLoadBalancingType.equals(MessageLoadBalancingType.OFF)) {
+      return isHighAcceptPriority(message, false);
+   }
+
+   @Override
+   public synchronized boolean isHighAcceptPriority(final Message message, boolean redistributing) {
+      if (consumerCount == 0 || (messageLoadBalancingType.equals(MessageLoadBalancingType.OFF) || (messageLoadBalancingType.equals(MessageLoadBalancingType.REDISTRIBUTION_ONLY) && !redistributing))) {
          return false;
       }
 

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -2268,6 +2268,8 @@
                   <xsd:enumeration value="OFF"/>
                   <xsd:enumeration value="STRICT"/>
                   <xsd:enumeration value="ON_DEMAND"/>
+                  <xsd:enumeration value="REDISTRIBUTION_ONLY"/>
+                  <xsd:enumeration value="STRICT_WITH_REDISTRIBUTION"/>
                </xsd:restriction>
             </xsd:simpleType>
          </xsd:element>

--- a/docs/user-manual/en/clusters.md
+++ b/docs/user-manual/en/clusters.md
@@ -608,12 +608,22 @@ specified. The following shows all the available configuration options
 
 - `message-load-balancing`. This parameter determines if/how
   messages will be distributed between other nodes of the cluster.
-  It can be one of three values - `OFF`, `STRICT`, or `ON_DEMAND` 
-  (default). This parameter replaces the deprecated
-  `forward-when-no-consumers` parameter.
+  It can be one of five values - `OFF`, `REDISTRIBUTION_ONLY`,
+  `STRICT`, `STRICT_WITH_REDISTRIBUTION` or `ON_DEMAND` (default).
+  This parameter replaces the deprecated  `forward-when-no-consumers`
+  parameter.
+
+  Keep in mind that this message forwarding/balancing is what we call
+  "initial distribution." It is different than *redistribution* which
+  is [discussed below](#message-redistribution). This distinction is
+  important because redistribution is configured differently and has
+  unique semantics (e.g. it *does not* support filters (selectors)).
   
   If this is set to `OFF` then messages will never be forwarded to
-  another node in the cluster
+  another node in the cluster nor with they be redistributed.
+
+  If this is set to `REDISTRIBUTION_ONLY` then the behavior is the
+  same as with `OFF` except that messages can be redistributed.
 
   If this is set to `STRICT` then each incoming message will be round
   robin'd even though the same queues on the other nodes of the
@@ -621,21 +631,20 @@ specified. The following shows all the available configuration options
   that have non matching message filters (selectors). Note that
   Apache ActiveMQ Artemis will *not* forward messages to other nodes
   if there are no *queues* of the same name on the other nodes, even
-  if this parameter is set to `STRICT`. Using `STRICT` is like setting
-  the legacy `forward-when-no-consumers` parameter to `true`.
+  if this parameter is set to `STRICT`. Messages will never be
+  redistributed. Using `STRICT` is like setting the legacy
+  `forward-when-no-consumers` parameter to `true`.
+
+  If this is set to `STRICT_WITH_REDISTRIBUTION` then the behavior is
+  the same as with `STRICT` except that messages can be redistributed.
 
   If this is set to `ON_DEMAND` then Apache ActiveMQ Artemis will only
   forward messages to other nodes of the cluster if the address to which
   they are being forwarded has queues which have consumers, and if those
   consumers have message filters (selectors) at least one of those
-  selectors must match the message. Using `ON_DEMAND` is like setting
-  the legacy `forward-when-no-consumers` parameter to `false`.
-  
-  Keep in mind that this message forwarding/balancing is what we call
-  "initial distribution." It is different than *redistribution* which
-  is [discussed below](#message-redistribution). This distinction is 
-  important because redistribution is configured differently and has 
-  unique semantics (e.g. it *does not* support filters (selectors)).
+  selectors must match the message. Messages can be redistributed.
+  Using `ON_DEMAND` is like setting the legacy
+  `forward-when-no-consumers` parameter to `false`.
 
   Default is `ON_DEMAND`.
 
@@ -824,7 +833,8 @@ This is where message redistribution comes in. With message
 redistribution Apache ActiveMQ Artemis can be configured to automatically
 *redistribute* messages from queues which have no consumers back to
 other nodes in the cluster which do have matching consumers. To enable
-this functionality `message-load-balancing` must be `ON_DEMAND`.
+this functionality `message-load-balancing` must be either `ON_DEMAND`,
+`REDISTRIBUTION_ONLY` or `STRICT_WITH_REDISTRIBUTION`.
 
 Message redistribution can be configured to kick in immediately after
 the last consumer on a queue is closed, or to wait a configurable delay

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/AnycastRoutingWithClusterTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/AnycastRoutingWithClusterTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.tests.integration.cluster.distribution;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
@@ -25,8 +27,26 @@ import org.apache.activemq.artemis.core.server.cluster.impl.MessageLoadBalancing
 import org.apache.activemq.artemis.core.server.group.impl.GroupingHandlerConfiguration;
 import org.apache.activemq.artemis.tests.util.Wait;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+@RunWith(value = Parameterized.class)
 public class AnycastRoutingWithClusterTest extends ClusterTestBase {
+   private final MessageLoadBalancingType messageLoadBalancingType;
+
+   @Parameterized.Parameters(name = "messageLoadBalancingType={0}")
+   public static Collection<MessageLoadBalancingType[]> getParams() {
+      return Arrays.asList(new MessageLoadBalancingType[][] {{MessageLoadBalancingType.STRICT}, {MessageLoadBalancingType.STRICT_WITH_REDISTRIBUTION}});
+   }
+
+
+   /**
+    * @param messageLoadBalancingType
+    */
+   public AnycastRoutingWithClusterTest(MessageLoadBalancingType messageLoadBalancingType) {
+      super();
+      this.messageLoadBalancingType = messageLoadBalancingType;
+   }
 
    /**
     * Test anycast address with single distributed queue in a 3 node cluster environment.  Messages should be
@@ -43,9 +63,9 @@ public class AnycastRoutingWithClusterTest extends ClusterTestBase {
          setupServer(i, isFileStorage(), isNetty());
       }
 
-      setupClusterConnection("cluster0", clusterAddress, MessageLoadBalancingType.STRICT, 1, isNetty(), 0, 1, 2);
-      setupClusterConnection("cluster1", clusterAddress, MessageLoadBalancingType.STRICT, 1, isNetty(), 1, 0, 2);
-      setupClusterConnection("cluster2", clusterAddress, MessageLoadBalancingType.STRICT, 1, isNetty(), 2, 0, 1);
+      setupClusterConnection("cluster0", clusterAddress, messageLoadBalancingType, 1, isNetty(), 0, 1, 2);
+      setupClusterConnection("cluster1", clusterAddress, messageLoadBalancingType, 1, isNetty(), 1, 0, 2);
+      setupClusterConnection("cluster2", clusterAddress, messageLoadBalancingType, 1, isNetty(), 2, 0, 1);
 
       setUpGroupHandler(GroupingHandlerConfiguration.TYPE.LOCAL, 0);
       setUpGroupHandler(GroupingHandlerConfiguration.TYPE.REMOTE, 1);
@@ -104,9 +124,9 @@ public class AnycastRoutingWithClusterTest extends ClusterTestBase {
          setupServer(i, isFileStorage(), isNetty());
       }
 
-      setupClusterConnection("cluster0", clusterAddress, MessageLoadBalancingType.STRICT, 1, isNetty(), 0, 1, 2);
-      setupClusterConnection("cluster1", clusterAddress, MessageLoadBalancingType.STRICT, 1, isNetty(), 1, 0, 2);
-      setupClusterConnection("cluster2", clusterAddress, MessageLoadBalancingType.STRICT, 1, isNetty(), 2, 0, 1);
+      setupClusterConnection("cluster0", clusterAddress, messageLoadBalancingType, 1, isNetty(), 0, 1, 2);
+      setupClusterConnection("cluster1", clusterAddress, messageLoadBalancingType, 1, isNetty(), 1, 0, 2);
+      setupClusterConnection("cluster2", clusterAddress, messageLoadBalancingType, 1, isNetty(), 2, 0, 1);
 
       setUpGroupHandler(GroupingHandlerConfiguration.TYPE.LOCAL, 0);
       setUpGroupHandler(GroupingHandlerConfiguration.TYPE.REMOTE, 1);
@@ -164,9 +184,9 @@ public class AnycastRoutingWithClusterTest extends ClusterTestBase {
          setupServer(i, isFileStorage(), isNetty());
       }
 
-      setupClusterConnection("cluster0", clusterAddress, MessageLoadBalancingType.STRICT, 1, isNetty(), 0, 1, 2);
-      setupClusterConnection("cluster1", clusterAddress, MessageLoadBalancingType.STRICT, 1, isNetty(), 1, 0, 2);
-      setupClusterConnection("cluster2", clusterAddress, MessageLoadBalancingType.STRICT, 1, isNetty(), 2, 0, 1);
+      setupClusterConnection("cluster0", clusterAddress, messageLoadBalancingType, 1, isNetty(), 0, 1, 2);
+      setupClusterConnection("cluster1", clusterAddress, messageLoadBalancingType, 1, isNetty(), 1, 0, 2);
+      setupClusterConnection("cluster2", clusterAddress, messageLoadBalancingType, 1, isNetty(), 2, 0, 1);
 
       setUpGroupHandler(GroupingHandlerConfiguration.TYPE.LOCAL, 0);
       setUpGroupHandler(GroupingHandlerConfiguration.TYPE.REMOTE, 1);
@@ -226,9 +246,9 @@ public class AnycastRoutingWithClusterTest extends ClusterTestBase {
          setupServer(i, isFileStorage(), isNetty());
       }
 
-      setupClusterConnection("cluster0", clusterAddress, MessageLoadBalancingType.STRICT, 1, isNetty(), 0, 1, 2);
-      setupClusterConnection("cluster1", clusterAddress, MessageLoadBalancingType.STRICT, 1, isNetty(), 1, 0, 2);
-      setupClusterConnection("cluster2", clusterAddress, MessageLoadBalancingType.STRICT, 1, isNetty(), 2, 0, 1);
+      setupClusterConnection("cluster0", clusterAddress, messageLoadBalancingType, 1, isNetty(), 0, 1, 2);
+      setupClusterConnection("cluster1", clusterAddress, messageLoadBalancingType, 1, isNetty(), 1, 0, 2);
+      setupClusterConnection("cluster2", clusterAddress, messageLoadBalancingType, 1, isNetty(), 2, 0, 1);
 
       setUpGroupHandler(GroupingHandlerConfiguration.TYPE.LOCAL, 0);
       setUpGroupHandler(GroupingHandlerConfiguration.TYPE.REMOTE, 1);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/ExpireWhileLoadBalanceTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/ExpireWhileLoadBalanceTest.java
@@ -17,14 +17,17 @@
 
 package org.apache.activemq.artemis.tests.integration.cluster.distribution;
 
+import java.util.Arrays;
+import java.util.Collection;
+
 import org.apache.activemq.artemis.api.core.QueueConfiguration;
+import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
-import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.core.server.cluster.ClusterConnection;
 import org.apache.activemq.artemis.core.server.cluster.MessageFlowRecord;
 import org.apache.activemq.artemis.core.server.cluster.impl.ClusterConnectionImpl;
@@ -33,8 +36,25 @@ import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+@RunWith(value = Parameterized.class)
 public class ExpireWhileLoadBalanceTest extends ClusterTestBase {
+   private final MessageLoadBalancingType messageLoadBalancingType;
+
+   @Parameterized.Parameters(name = "messageLoadBalancingType={0}")
+   public static Collection<MessageLoadBalancingType[]> getParams() {
+      return Arrays.asList(new MessageLoadBalancingType[][] {{MessageLoadBalancingType.STRICT}, {MessageLoadBalancingType.STRICT_WITH_REDISTRIBUTION}});
+   }
+
+   /**
+    * @param messageLoadBalancingType
+    */
+   public ExpireWhileLoadBalanceTest(MessageLoadBalancingType messageLoadBalancingType) {
+      super();
+      this.messageLoadBalancingType = messageLoadBalancingType;
+   }
 
    @Before
    @Override
@@ -49,11 +69,11 @@ public class ExpireWhileLoadBalanceTest extends ClusterTestBase {
          servers[i].getConfiguration().setMessageExpiryScanPeriod(100);
       }
 
-      setupClusterConnection("cluster0", "queues", MessageLoadBalancingType.STRICT, 1, true, 0, 1, 2);
+      setupClusterConnection("cluster0", "queues", messageLoadBalancingType, 1, true, 0, 1, 2);
 
-      setupClusterConnection("cluster1", "queues", MessageLoadBalancingType.STRICT, 1, true, 1, 0, 2);
+      setupClusterConnection("cluster1", "queues", messageLoadBalancingType, 1, true, 1, 0, 2);
 
-      setupClusterConnection("cluster2", "queues", MessageLoadBalancingType.STRICT, 1, true, 2, 0, 1);
+      setupClusterConnection("cluster2", "queues", messageLoadBalancingType, 1, true, 2, 0, 1);
 
       startServers(0, 1, 2);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/LargeMessageRedistributionTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/LargeMessageRedistributionTest.java
@@ -22,6 +22,13 @@ import org.junit.Test;
 
 public class LargeMessageRedistributionTest extends MessageRedistributionTest {
 
+   /**
+    * @param messageLoadBalancingType
+    */
+   public LargeMessageRedistributionTest(MessageLoadBalancingType messageLoadBalancingType) {
+      super(messageLoadBalancingType);
+   }
+
    @Override
    public boolean isLargeMessage() {
       return true;
@@ -29,11 +36,13 @@ public class LargeMessageRedistributionTest extends MessageRedistributionTest {
 
    @Test
    public void testRedistributionLargeMessageDirCleanup() throws Exception {
+      org.junit.Assume.assumeTrue(messageLoadBalancingType == MessageLoadBalancingType.ON_DEMAND);
+
       final long delay = 1000;
       final int numMessages = 5;
 
       setRedistributionDelay(delay);
-      setupCluster(MessageLoadBalancingType.ON_DEMAND);
+      setupCluster(messageLoadBalancingType);
 
       startServers(0, 1);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/MessageRedistributionTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/MessageRedistributionTest.java
@@ -20,6 +20,8 @@ import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.activemq.artemis.api.core.Message;
@@ -45,8 +47,25 @@ import org.jboss.logging.Logger;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+@RunWith(value = Parameterized.class)
 public class MessageRedistributionTest extends ClusterTestBase {
+   protected final MessageLoadBalancingType messageLoadBalancingType;
+
+   @Parameterized.Parameters(name = "messageLoadBalancingType={0}")
+   public static Collection<MessageLoadBalancingType[]> getParams() {
+      return Arrays.asList(new MessageLoadBalancingType[][] {{MessageLoadBalancingType.ON_DEMAND}, {MessageLoadBalancingType.REDISTRIBUTION_ONLY}, {MessageLoadBalancingType.STRICT_WITH_REDISTRIBUTION}});
+   }
+
+   /**
+    * @param messageLoadBalancingType
+    */
+   public MessageRedistributionTest(MessageLoadBalancingType messageLoadBalancingType) {
+      super();
+      this.messageLoadBalancingType = messageLoadBalancingType;
+   }
 
    private static final Logger log = Logger.getLogger(MessageRedistributionTest.class);
 
@@ -82,7 +101,8 @@ public class MessageRedistributionTest extends ClusterTestBase {
    //https://issues.jboss.org/browse/HORNETQ-1061
    @Test
    public void testRedistributionWithMessageGroups() throws Exception {
-      setupCluster(MessageLoadBalancingType.ON_DEMAND);
+      org.junit.Assume.assumeTrue(messageLoadBalancingType == MessageLoadBalancingType.ON_DEMAND);
+      setupCluster(messageLoadBalancingType);
 
       log.debug("Doing test");
 
@@ -171,7 +191,7 @@ public class MessageRedistributionTest extends ClusterTestBase {
    //https://issues.jboss.org/browse/HORNETQ-1057
    @Test
    public void testRedistributionStopsWhenConsumerAdded() throws Exception {
-      setupCluster(MessageLoadBalancingType.ON_DEMAND);
+      setupCluster(messageLoadBalancingType);
 
       log.debug("Doing test");
 
@@ -208,7 +228,7 @@ public class MessageRedistributionTest extends ClusterTestBase {
 
    @Test
    public void testRedistributionWhenConsumerIsClosed() throws Exception {
-      setupCluster(MessageLoadBalancingType.ON_DEMAND);
+      setupCluster(messageLoadBalancingType);
 
       log.debug("Doing test");
 
@@ -249,7 +269,8 @@ public class MessageRedistributionTest extends ClusterTestBase {
 
    @Test
    public void testRedistributionWhenConsumerIsClosedDifferentQueues() throws Exception {
-      setupCluster(MessageLoadBalancingType.ON_DEMAND);
+      org.junit.Assume.assumeTrue(messageLoadBalancingType == MessageLoadBalancingType.ON_DEMAND);
+      setupCluster(messageLoadBalancingType);
 
       startServers(0, 1, 2);
 
@@ -331,7 +352,7 @@ public class MessageRedistributionTest extends ClusterTestBase {
 
    @Test
    public void testRedistributionWhenConsumerIsClosedNotConsumersOnAllNodes() throws Exception {
-      setupCluster(MessageLoadBalancingType.ON_DEMAND);
+      setupCluster(messageLoadBalancingType);
 
       startServers(0, 1, 2);
 
@@ -418,7 +439,8 @@ public class MessageRedistributionTest extends ClusterTestBase {
 
    @Test
    public void testNoRedistributionWhenConsumerIsClosedNoConsumersOnOtherNodes() throws Exception {
-      setupCluster(MessageLoadBalancingType.ON_DEMAND);
+      org.junit.Assume.assumeFalse(messageLoadBalancingType == MessageLoadBalancingType.STRICT_WITH_REDISTRIBUTION);
+      setupCluster(messageLoadBalancingType);
 
       startServers(0, 1, 2);
 
@@ -467,7 +489,7 @@ public class MessageRedistributionTest extends ClusterTestBase {
 
    @Test
    public void testRedistributeWithScheduling() throws Exception {
-      setupCluster(MessageLoadBalancingType.ON_DEMAND);
+      setupCluster(messageLoadBalancingType);
 
       AddressSettings setting = new AddressSettings().setRedeliveryDelay(10000);
       servers[0].getAddressSettingsRepository().addMatch("queues.testaddress", setting);
@@ -572,7 +594,7 @@ public class MessageRedistributionTest extends ClusterTestBase {
 
    @Test
    public void testRedistributionWhenConsumerIsClosedQueuesWithFilters() throws Exception {
-      setupCluster(MessageLoadBalancingType.ON_DEMAND);
+      setupCluster(messageLoadBalancingType);
 
       startServers(0, 1, 2);
 
@@ -612,7 +634,7 @@ public class MessageRedistributionTest extends ClusterTestBase {
 
    @Test
    public void testRedistributionWhenConsumerIsClosedConsumersWithFilters() throws Exception {
-      setupCluster(MessageLoadBalancingType.ON_DEMAND);
+      setupCluster(messageLoadBalancingType);
 
       startServers(0, 1, 2);
 
@@ -652,6 +674,7 @@ public class MessageRedistributionTest extends ClusterTestBase {
 
    @Test
    public void testRedistributionWithPrefixesWhenRemoteConsumerIsAdded() throws Exception {
+      org.junit.Assume.assumeTrue(messageLoadBalancingType == MessageLoadBalancingType.ON_DEMAND);
 
       for (int i = 0; i <= 2; i++) {
          ActiveMQServer server = getServer(i);
@@ -660,7 +683,7 @@ public class MessageRedistributionTest extends ClusterTestBase {
          }
       }
 
-      setupCluster(MessageLoadBalancingType.ON_DEMAND);
+      setupCluster(messageLoadBalancingType);
 
       startServers(0, 1, 2);
 
@@ -698,7 +721,8 @@ public class MessageRedistributionTest extends ClusterTestBase {
 
    @Test
    public void testRedistributionWhenRemoteConsumerIsAdded() throws Exception {
-      setupCluster(MessageLoadBalancingType.ON_DEMAND);
+      org.junit.Assume.assumeFalse(messageLoadBalancingType == MessageLoadBalancingType.STRICT_WITH_REDISTRIBUTION);
+      setupCluster(messageLoadBalancingType);
 
       startServers(0, 1, 2);
 
@@ -731,9 +755,93 @@ public class MessageRedistributionTest extends ClusterTestBase {
    }
 
    @Test
+   public void testRedistributionOnlyWhenLocalConsumerIsRemoved() throws Exception {
+      org.junit.Assume.assumeTrue(messageLoadBalancingType == MessageLoadBalancingType.REDISTRIBUTION_ONLY);
+      setupCluster(messageLoadBalancingType);
+
+      startServers(0, 1, 2);
+
+      setupSessionFactory(0, isNetty());
+      setupSessionFactory(1, isNetty());
+      setupSessionFactory(2, isNetty());
+
+      createQueue(0, "queues.testaddress", "queue0", null, false);
+      createQueue(1, "queues.testaddress", "queue0", null, false);
+      createQueue(2, "queues.testaddress", "queue0", null, false);
+
+      addConsumer(0, 0, "queue0", null);
+      addConsumer(1, 1, "queue0", null);
+
+      waitForBindings(0, "queues.testaddress", 1, 1, true);
+      waitForBindings(1, "queues.testaddress", 1, 1, true);
+      waitForBindings(2, "queues.testaddress", 1, 0, true);
+
+      waitForBindings(0, "queues.testaddress", 2, 1, false);
+      waitForBindings(1, "queues.testaddress", 2, 1, false);
+      waitForBindings(2, "queues.testaddress", 2, 2, false);
+
+      send(0, "queues.testaddress", 20, false, null);
+
+      Wait.assertTrue(() -> servers[0].locateQueue(SimpleString.toSimpleString("queue0")).getMessageCount() == 20, 2000, 100);
+      Wait.assertTrue(() -> servers[1].locateQueue(SimpleString.toSimpleString("queue0")).getMessageCount() == 0, 2000, 100);
+      Wait.assertTrue(() -> servers[2].locateQueue(SimpleString.toSimpleString("queue0")).getMessageCount() == 0, 2000, 100);
+
+      removeConsumer(0);
+
+      Wait.assertTrue(() -> servers[0].locateQueue(SimpleString.toSimpleString("queue0")).getMessageCount() == 0, 2000, 100);
+      Wait.assertTrue(() -> servers[1].locateQueue(SimpleString.toSimpleString("queue0")).getMessageCount() == 20, 2000, 100);
+      Wait.assertTrue(() -> servers[2].locateQueue(SimpleString.toSimpleString("queue0")).getMessageCount() == 0, 2000, 100);
+
+      verifyReceiveAll(20, 1);
+      verifyNotReceive(1);
+   }
+
+   @Test
+   public void testRedistributionOnlyWithRemoteConsumer() throws Exception {
+      org.junit.Assume.assumeTrue(messageLoadBalancingType == MessageLoadBalancingType.REDISTRIBUTION_ONLY);
+      setupCluster(messageLoadBalancingType);
+      setRedistributionDelay(2000);
+      startServers(0, 1, 2);
+
+      setupSessionFactory(0, isNetty());
+      setupSessionFactory(1, isNetty());
+      setupSessionFactory(2, isNetty());
+
+      createQueue(0, "queues.testaddress", "queue0", null, false);
+      createQueue(1, "queues.testaddress", "queue0", null, false);
+      createQueue(2, "queues.testaddress", "queue0", null, false);
+
+      addConsumer(1, 1, "queue0", null);
+
+      waitForBindings(0, "queues.testaddress", 1, 0, true);
+      waitForBindings(1, "queues.testaddress", 1, 1, true);
+      waitForBindings(2, "queues.testaddress", 1, 0, true);
+
+      waitForBindings(0, "queues.testaddress", 2, 1, false);
+      waitForBindings(1, "queues.testaddress", 2, 0, false);
+      waitForBindings(2, "queues.testaddress", 2, 1, false);
+
+      send(0, "queues.testaddress", 20, false, null);
+
+      // make sure the messages are on the node to which they were sent (i.e. not load-balanced and not yet redistributed)
+      Wait.assertTrue(() -> servers[0].locateQueue(SimpleString.toSimpleString("queue0")).getMessageCount() == 20, 1000, 100);
+      Wait.assertTrue(() -> servers[1].locateQueue(SimpleString.toSimpleString("queue0")).getMessageCount() == 0, 1000, 100);
+      Wait.assertTrue(() -> servers[2].locateQueue(SimpleString.toSimpleString("queue0")).getMessageCount() == 0, 1000, 100);
+
+      // make sure the messages are redistributed to the node with the consumer
+      Wait.assertTrue(() -> servers[0].locateQueue(SimpleString.toSimpleString("queue0")).getMessageCount() == 0, 3000, 100);
+      Wait.assertTrue(() -> servers[1].locateQueue(SimpleString.toSimpleString("queue0")).getMessageCount() == 20, 3000, 100);
+      Wait.assertTrue(() -> servers[2].locateQueue(SimpleString.toSimpleString("queue0")).getMessageCount() == 0, 3000, 100);
+
+      verifyReceiveAll(20, 1);
+      verifyNotReceive(1);
+   }
+
+   @Test
    public void testBackAndForth() throws Exception {
+      org.junit.Assume.assumeFalse(messageLoadBalancingType == MessageLoadBalancingType.STRICT_WITH_REDISTRIBUTION);
       for (int i = 0; i < 10; i++) {
-         setupCluster(MessageLoadBalancingType.ON_DEMAND);
+         setupCluster(messageLoadBalancingType);
 
          startServers(0, 1, 2);
 
@@ -832,13 +940,14 @@ public class MessageRedistributionTest extends ClusterTestBase {
    }
 
    public void internalTestBackAndForth2(final boolean useDuplicateDetection) throws Exception {
+      org.junit.Assume.assumeFalse(messageLoadBalancingType == MessageLoadBalancingType.STRICT_WITH_REDISTRIBUTION);
       AtomicInteger duplDetection = null;
 
       if (useDuplicateDetection) {
          duplDetection = new AtomicInteger(0);
       }
       for (int i = 0; i < 10; i++) {
-         setupCluster(MessageLoadBalancingType.ON_DEMAND);
+         setupCluster(messageLoadBalancingType);
 
          startServers(0, 1);
 
@@ -902,7 +1011,8 @@ public class MessageRedistributionTest extends ClusterTestBase {
 
    @Test
    public void testRedistributionToQueuesWhereNotAllMessagesMatch() throws Exception {
-      setupCluster(MessageLoadBalancingType.ON_DEMAND);
+      org.junit.Assume.assumeFalse(messageLoadBalancingType == MessageLoadBalancingType.STRICT_WITH_REDISTRIBUTION);
+      setupCluster(messageLoadBalancingType);
 
       startServers(0, 1, 2);
 
@@ -940,10 +1050,11 @@ public class MessageRedistributionTest extends ClusterTestBase {
 
    @Test
    public void testDelayedRedistribution() throws Exception {
+      org.junit.Assume.assumeTrue(messageLoadBalancingType == MessageLoadBalancingType.ON_DEMAND);
       final long delay = 1000;
       setRedistributionDelay(delay);
 
-      setupCluster(MessageLoadBalancingType.ON_DEMAND);
+      setupCluster(messageLoadBalancingType);
 
       startServers(0, 1, 2);
 
@@ -979,10 +1090,11 @@ public class MessageRedistributionTest extends ClusterTestBase {
 
    @Test
    public void testDelayedRedistributionCancelled() throws Exception {
+      org.junit.Assume.assumeFalse(messageLoadBalancingType == MessageLoadBalancingType.STRICT_WITH_REDISTRIBUTION);
       final long delay = 1000;
       setRedistributionDelay(delay);
 
-      setupCluster(MessageLoadBalancingType.ON_DEMAND);
+      setupCluster(messageLoadBalancingType);
 
       startServers(0, 1, 2);
 
@@ -1021,7 +1133,8 @@ public class MessageRedistributionTest extends ClusterTestBase {
 
    @Test
    public void testRedistributionNumberOfMessagesGreaterThanBatchSize() throws Exception {
-      setupCluster(MessageLoadBalancingType.ON_DEMAND);
+      org.junit.Assume.assumeFalse(messageLoadBalancingType == MessageLoadBalancingType.STRICT_WITH_REDISTRIBUTION);
+      setupCluster(messageLoadBalancingType);
 
       startServers(0, 1, 2);
 
@@ -1068,7 +1181,7 @@ public class MessageRedistributionTest extends ClusterTestBase {
     */
    @Test
    public void testRedistributionWhenNewNodeIsAddedWithConsumer() throws Exception {
-      setupCluster(MessageLoadBalancingType.ON_DEMAND);
+      setupCluster(messageLoadBalancingType);
 
       startServers(0);
 
@@ -1099,7 +1212,8 @@ public class MessageRedistributionTest extends ClusterTestBase {
 
    @Test
    public void testRedistributionWithPagingOnTarget() throws Exception {
-      setupCluster(MessageLoadBalancingType.ON_DEMAND);
+      org.junit.Assume.assumeTrue(messageLoadBalancingType == MessageLoadBalancingType.ON_DEMAND);
+      setupCluster(messageLoadBalancingType);
 
       AddressSettings as = new AddressSettings().setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE).setPageSizeBytes(10000).setMaxSizeBytes(20000);
 

--- a/tests/performance-jmh/src/main/java/org/apache/activemq/artemis/tests/performance/jmh/WildcardAddressManagerPerfTest.java
+++ b/tests/performance-jmh/src/main/java/org/apache/activemq/artemis/tests/performance/jmh/WildcardAddressManagerPerfTest.java
@@ -115,6 +115,11 @@ public class WildcardAddressManagerPerfTest {
       }
 
       @Override
+      public boolean isHighAcceptPriority(Message message, boolean redistributing) {
+         return false;
+      }
+
+      @Override
       public boolean isExclusive() {
          return false;
       }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/BindingsImplTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/BindingsImplTest.java
@@ -398,6 +398,11 @@ public class BindingsImplTest extends ActiveMQTestBase {
       }
 
       @Override
+      public boolean isHighAcceptPriority(final Message message, boolean redistributing) {
+         return false;
+      }
+
+      @Override
       public void route(final Message message, final RoutingContext context) throws Exception {
 
       }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/WildcardAddressManagerPerfTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/WildcardAddressManagerPerfTest.java
@@ -174,6 +174,11 @@ public class WildcardAddressManagerPerfTest {
       }
 
       @Override
+      public boolean isHighAcceptPriority(Message message, boolean redistributing) {
+         return false;
+      }
+
+      @Override
       public boolean isExclusive() {
          return false;
       }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/WildcardAddressManagerUnitTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/WildcardAddressManagerUnitTest.java
@@ -352,6 +352,11 @@ public class WildcardAddressManagerUnitTest extends ActiveMQTestBase {
       }
 
       @Override
+      public boolean isHighAcceptPriority(Message message, boolean redistributing) {
+         return false;
+      }
+
+      @Override
       public boolean isExclusive() {
          return false;
       }


### PR DESCRIPTION
This commit adds two new message-load-balancing types:
STRICT_WITH_REDISTRIBUTION and REDISTRIBUTION_ONLY. These allow
redistribution with the semantics of the existing STRICT and OFF
message-load-balancing types respectively. Previously you could only get
redistribution if you were using ON_DEMAND. The semantics for STRICT and
OFF were not changed so as not to impact existing users.