### PR TITLE
ARTEMIS-2558 Add the commented out args to dump the java heap on OOME

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
@@ -720,7 +720,9 @@ public class Create extends InputAbstract {
       filters.put("${artemis.instance.etc.uri}", etcFolder.toURI().toString());
       filters.put("${artemis.instance.etc.uri.windows}", etcFolder.toURI().toString().replaceAll("%", "%%"));
       filters.put("${artemis.instance.etc}", path(etcFolder));
-      new File(directory, "log").mkdirs();
+      File logFolder = createDirectory("log", directory);
+      File oomeDumpFile = new File(logFolder, "oom_dump.hprof");
+      filters.put("${artemis.instance.oome.dump}", path(oomeDumpFile));
       new File(directory, "tmp").mkdirs();
       new File(directory, "lib").mkdirs();
       File dataFolder = createDirectory(data, directory);

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis
@@ -112,6 +112,11 @@ if [ -z "$WILDFLY_COMMON" ] ; then
   WILDFLY_COMMON="$ARTEMIS_HOME/lib/${wildfly-common}"
 fi
 
+if [ -f "$ARTEMIS_OOME_DUMP" ] ; then
+  # backup the last OOME heap dump
+  mv $ARTEMIS_OOME_DUMP $ARTEMIS_OOME_DUMP.bkp
+fi
+
 exec "$JAVACMD" \
     $JAVA_ARGS \
     -Xbootclasspath/a:"$LOG_MANAGER:$WILDFLY_COMMON" \

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis.cmd
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis.cmd
@@ -52,6 +52,12 @@ rem "Set Defaults."
 set ARTEMIS_LOGGING_CONF=%ARTEMIS_INSTANCE_ETC_URI%/logging.properties
 set ARTEMIS_LOG_MANAGER=org.jboss.logmanager.LogManager
 
+if not exist "%ARTEMIS_OOME_DUMP%" goto NO_ARTEMIS_OOME_DUMP
+rem "Backup the last OOME heap dump"
+move /Y "%ARTEMIS_OOME_DUMP%" "%ARTEMIS_OOME_DUMP%.bkp"
+
+:NO_ARTEMIS_OOME_DUMP
+
 rem "Create full JVM Args"
 set JVM_ARGS=%JAVA_ARGS%
 if not "%ARTEMIS_CLUSTER_PROPS%"=="" set JVM_ARGS=%JVM_ARGS% %ARTEMIS_CLUSTER_PROPS%

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile
@@ -19,6 +19,7 @@ ARTEMIS_HOME='${artemis.home}'
 ARTEMIS_INSTANCE='${artemis.instance}'
 ARTEMIS_DATA_DIR='${artemis.instance.data}'
 ARTEMIS_ETC_DIR='${artemis.instance.etc}'
+ARTEMIS_OOME_DUMP='${artemis.instance.oome.dump}'
 
 # The logging config will need an URI
 # this will be encoded in case you use spaces or special characters
@@ -40,6 +41,10 @@ JAVA_ARGS="${java-opts} -XX:+PrintClassHistogram -XX:+UseG1GC -Xms512M -Xmx2G -D
 # and dependent by JVM background work (eg method deoptimizations, lock unbiasing, JNI, counted loops and obviously GC activity).
 # Replace "all_pauses.log" with the file name you want to log to.
 # JAVA_ARGS="$JAVA_ARGS -XX:+PrintSafepointStatistics -XX:PrintSafepointStatisticsCount=1 -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCApplicationConcurrentTime -XX:+LogVMOutput -XX:LogFile=all_pauses.log"
+
+#
+# Enables the dumping of the java heap when a java.lang.OutOfMemoryError exception is thrown.
+# JAVA_ARGS="$JAVA_ARGS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${ARTEMIS_OOME_DUMP}"
 
 # Debug args: Uncomment to enable debug
 #DEBUG_ARGS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile.cmd
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile.cmd
@@ -20,6 +20,7 @@ set ARTEMIS_HOME="${artemis.home}"
 set ARTEMIS_INSTANCE="${artemis.instance}"
 set ARTEMIS_DATA_DIR="${artemis.instance.data}"
 set ARTEMIS_ETC_DIR="${artemis.instance.etc}"
+set ARTEMIS_OOME_DUMP="${artemis.instance.oome.dump}"
 
 
 rem The logging config will need an URI
@@ -40,6 +41,9 @@ rem affect the latencies of the services delivered by the broker, including thos
 rem and dependent by JVM background work (eg method deoptimizations, lock unbiasing, JNI, counted loops and obviously GC activity).
 rem Replace "all_pauses.log" with the file name you want to log to.
 rem set JAVA_ARGS=%JAVA_ARGS% -XX:+PrintSafepointStatistics -XX:PrintSafepointStatisticsCount=1 -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCApplicationConcurrentTime -XX:+LogVMOutput -XX:LogFile=all_pauses.log
+
+rem Enables the dumping of the java heap when a java.lang.OutOfMemoryError exception is thrown.
+rem set JAVA_ARGS=%JAVA_ARGS% -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=%ARTEMIS_OOME_DUMP%
 
 rem Debug args: Uncomment to enable debug
 rem set DEBUG_ARGS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005


### PR DESCRIPTION
Add the commented out args to dump the first java heap on OOME for
process and backup the previous java heap on OOME at startup.