### PR TITLE
ARTEMIS-2578 clarify storage capacity messages

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/ByteUtil.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/ByteUtil.java
@@ -42,6 +42,14 @@ public class ByteUtil {
    private static final Pattern KILO = Pattern.compile(prefix + "k" + suffix, Pattern.CASE_INSENSITIVE);
    private static final Pattern MEGA = Pattern.compile(prefix + "m" + suffix, Pattern.CASE_INSENSITIVE);
    private static final Pattern GIGA = Pattern.compile(prefix + "g" + suffix, Pattern.CASE_INSENSITIVE);
+   private static final String[] BYTE_SUFFIXES = new String[] {"E", "P", "T", "G", "M", "K", ""};
+   private static final double[] BYTE_MAGNITUDES = new double[7];
+
+   static {
+      for (int i = 18, j = 0; i >= 0; i -= 3, j++) {
+         BYTE_MAGNITUDES[j] = Math.pow(10, i);
+      }
+   }
 
    public static void debugFrame(Logger logger, String message, ByteBuf byteIn) {
       if (logger.isTraceEnabled()) {
@@ -442,4 +450,12 @@ public class ByteUtil {
       }
    }
 
+   public static String getHumanReadableByteCount(long bytes) {
+      int i = 0;
+      while (i < BYTE_MAGNITUDES.length && BYTE_MAGNITUDES[i] > bytes) {
+         i++;
+      }
+
+      return String.format("%.1f%sB", bytes / BYTE_MAGNITUDES[i], BYTE_SUFFIXES[i]);
+   }
 }

--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/HumanReadableByteCountTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/HumanReadableByteCountTest.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class HumanReadableByteCountTest {
+
+   @Test
+   public void test() {
+      String[] suffixes = new String[] {"K", "M", "G", "T", "P", "E"};
+
+      assertEquals("999.0B", ByteUtil.getHumanReadableByteCount(999));
+      assertEquals("500.0B", ByteUtil.getHumanReadableByteCount(500));
+
+      for (int i = 0, j = 3; i < 6; i++, j += 3) {
+         final long magnitude = (long) Math.pow(10, j);
+         assertEquals("1.0" + suffixes[i] + "B", ByteUtil.getHumanReadableByteCount(magnitude));
+         assertEquals("1.3" + suffixes[i] + "B", ByteUtil.getHumanReadableByteCount(magnitude + (long) (.25 * magnitude)));
+         assertEquals("1.5" + suffixes[i] + "B", ByteUtil.getHumanReadableByteCount(magnitude + (long) (.5 * magnitude)));
+         assertEquals("1.9" + suffixes[i] + "B", ByteUtil.getHumanReadableByteCount(magnitude + (long) (.9 * magnitude)));
+         assertEquals("4.2" + suffixes[i] + "B", ByteUtil.getHumanReadableByteCount(magnitude + (long) (3.2 * magnitude)));
+      }
+   }
+
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/PagingManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/PagingManager.java
@@ -107,6 +107,10 @@ public interface PagingManager extends ActiveMQComponent, HierarchicalRepository
 
    boolean isDiskFull();
 
+   long getDiskUsableSpace();
+
+   long getDiskTotalSpace();
+
    default long getGlobalSize() {
       return 0;
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQMessageBundle.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQMessageBundle.java
@@ -385,8 +385,8 @@ public interface ActiveMQMessageBundle {
    @Message(id = 229118, value = "Management method not applicable for current server configuration")
    IllegalStateException methodNotApplicable();
 
-   @Message(id = 229119, value = "Disk Capacity is Low, cannot produce more messages.")
-   ActiveMQIOErrorException diskBeyondLimit();
+   @Message(id = 229119, value = "Free storage space is at {0} of {1} total. Usage rate is {2} which is beyond the configured <max-disk-usage>. System will start blocking producers.", format = Message.Format.MESSAGE_FORMAT)
+   ActiveMQIOErrorException diskBeyondLimit(String usableSpace, String totalSpace, String usage);
 
    @Message(id = 229120, value = "connection with ID {0} closed by management", format = Message.Format.MESSAGE_FORMAT)
    ActiveMQInternalErrorException connectionWithIDClosedByManagement(String ID);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1341,14 +1341,14 @@ public interface ActiveMQServerLogger extends BasicLogger {
    void impossibleToRouteGrouped();
 
    @LogMessage(level = Logger.Level.WARN)
-   @Message(id = 222210, value = "Storage usage is beyond max-disk-usage. System will start blocking producers.",
+   @Message(id = 222210, value = "Free storage space is at {0} of {1} total. Usage rate is {2} which is beyond the configured <max-disk-usage>. System will start blocking producers.",
       format = Message.Format.MESSAGE_FORMAT)
-   void diskBeyondCapacity();
+   void diskBeyondCapacity(String usableSpace, String totalSpace, String usage);
 
    @LogMessage(level = Logger.Level.INFO)
-   @Message(id = 222211, value = "Storage is back to stable now, under max-disk-usage.",
+   @Message(id = 222211, value = "Free storage space is at {0} of {1} total. Usage rate is {2} which is below the configured <max-disk-usage>.",
       format = Message.Format.MESSAGE_FORMAT)
-   void diskCapacityRestored();
+   void diskCapacityRestored(String usableSpace, String totalSpace, String usage);
 
    @LogMessage(level = Logger.Level.WARN)
    @Message(id = 222212, value = "Disk Full! Blocking message production on address ''{0}''. Clients will report blocked.", format = Message.Format.MESSAGE_FORMAT)

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/GlobalDiskFullTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/GlobalDiskFullTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.activemq.artemis.tests.integration.amqp;
 
+import java.net.URI;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.files.FileStoreMonitor;
@@ -27,11 +31,6 @@ import org.apache.activemq.transport.amqp.client.AmqpSender;
 import org.apache.activemq.transport.amqp.client.AmqpSession;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.net.URI;
-import java.nio.file.FileStore;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 public class GlobalDiskFullTest extends AmqpClientTestSupport {
 
@@ -48,15 +47,15 @@ public class GlobalDiskFullTest extends AmqpClientTestSupport {
       monitor.addCallback(new FileStoreMonitor.Callback() {
 
          @Override
-         public void tick(FileStore store, double usage) {
+         public void tick(long usableSpace, long totalSpace) {
          }
 
          @Override
-         public void over(FileStore store, double usage) {
+         public void over(long usableSpace, long totalSpace) {
             latch.countDown();
          }
          @Override
-         public void under(FileStore store, double usage) {
+         public void under(long usableSpace, long totalSpace) {
          }
       });
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/FakePagingManager.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/FakePagingManager.java
@@ -120,6 +120,16 @@ public final class FakePagingManager implements PagingManager {
       return false;
    }
 
+   @Override
+   public long getDiskUsableSpace() {
+      return 0;
+   }
+
+   @Override
+   public long getDiskTotalSpace() {
+      return 0;
+   }
+
    /*
     * (non-Javadoc)
     * @see org.apache.activemq.artemis.core.paging.PagingManager#isGlobalFull()


### PR DESCRIPTION
This is a surprisingly large change just to fix some log messages, but
the changes were necessary in order to get the relevant data to where it
was being logged. The fact that the data wasn't readily available is
probably why it wasn't logged in the first place.