### PR TITLE
ARTEMIS-2593 Thread leak test failure with OpenJ9 JVM

### DIFF
--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/ThreadLeakCheckRule.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/ThreadLeakCheckRule.java
@@ -248,7 +248,7 @@ public class ThreadLeakCheckRule extends TestWatcher {
          return true;
       } else if (javaVendor.contains("IBM") && threadName.equals("MemoryPoolMXBean notification dispatcher")) {
          return true;
-      } else if (javaVendor.contains("IBM") && threadName.contains("MemoryMXBean")) {
+      } else if (threadName.contains("MemoryMXBean")) {
          return true;
       } else if (threadName.contains("globalEventExecutor")) {
          return true;


### PR DESCRIPTION
Add an exception for the thread with name `MemoryMXBean`.