### PR TITLE
ARTEMIS-2596 (kill -9) AMQ causes tmp web dir space usage to increase

### DIFF
--- a/artemis-web/src/test/java/org/apache/activemq/cli/test/WebServerComponentTest.java
+++ b/artemis-web/src/test/java/org/apache/activemq/cli/test/WebServerComponentTest.java
@@ -18,13 +18,22 @@ package org.apache.activemq.cli.test;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
+import java.io.BufferedInputStream;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
@@ -43,14 +52,18 @@ import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.CharsetUtil;
 import org.apache.activemq.artemis.cli.factory.xml.XmlBrokerFactoryHandler;
 import org.apache.activemq.artemis.component.WebServerComponent;
 import org.apache.activemq.artemis.core.remoting.impl.ssl.SSLSupport;
 import org.apache.activemq.artemis.core.server.ActiveMQComponent;
+import org.apache.activemq.artemis.dto.AppDTO;
 import org.apache.activemq.artemis.dto.BrokerDTO;
 import org.apache.activemq.artemis.dto.WebServerDTO;
+import org.eclipse.jetty.webapp.WebAppContext;
+import org.eclipse.jetty.webapp.WebInfConfiguration;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -66,6 +79,7 @@ public class WebServerComponentTest extends Assert {
 
    @Before
    public void setupNetty() throws URISyntaxException {
+      System.setProperty("jetty.base", "./target");
       // Configure the client.
       group = new NioEventLoopGroup();
       bootstrap = new Bootstrap();
@@ -77,6 +91,7 @@ public class WebServerComponentTest extends Assert {
       for (ActiveMQComponent c : testedComponents) {
          c.stop();
       }
+      testedComponents.clear();
    }
 
    @Test
@@ -110,7 +125,7 @@ public class WebServerComponentTest extends Assert {
       // Send the HTTP request.
       ch.writeAndFlush(request);
       assertTrue(latch.await(5, TimeUnit.SECONDS));
-      assertEquals(clientHandler.body, "12345");
+      assertEquals("12345", clientHandler.body.toString());
       assertNull(clientHandler.serverHeader);
       // Wait for the server to close the connection.
       ch.close();
@@ -149,7 +164,7 @@ public class WebServerComponentTest extends Assert {
       // Send the HTTP request.
       ch.writeAndFlush(request);
       assertTrue(latch.await(5, TimeUnit.SECONDS));
-      assertEquals(clientHandler.body, "12345");
+      assertEquals("12345", clientHandler.body.toString());
       // Wait for the server to close the connection.
       ch.close();
       Assert.assertTrue(webServerComponent.isStarted());
@@ -192,6 +207,7 @@ public class WebServerComponentTest extends Assert {
 
       CountDownLatch latch = new CountDownLatch(1);
       final ClientHandler clientHandler = new ClientHandler(latch);
+
       bootstrap.group(group).channel(NioSocketChannel.class).handler(new ChannelInitializer() {
          @Override
          protected void initChannel(Channel ch) throws Exception {
@@ -210,7 +226,7 @@ public class WebServerComponentTest extends Assert {
       // Send the HTTP request.
       ch.writeAndFlush(request);
       assertTrue(latch.await(5, TimeUnit.SECONDS));
-      assertEquals(clientHandler.body, "12345");
+      assertEquals("12345", clientHandler.body.toString());
       assertNull(clientHandler.serverHeader);
       // Wait for the server to close the connection.
       ch.close();
@@ -270,7 +286,7 @@ public class WebServerComponentTest extends Assert {
       // Send the HTTP request.
       ch.writeAndFlush(request);
       assertTrue(latch.await(5, TimeUnit.SECONDS));
-      assertEquals(clientHandler.body, "12345");
+      assertEquals("12345", clientHandler.body.toString());
       // Wait for the server to close the connection.
       ch.close();
       Assert.assertTrue(webServerComponent.isStarted());
@@ -316,10 +332,167 @@ public class WebServerComponentTest extends Assert {
       assertEquals(trustPassword, broker.web.getTrustStorePassword());
    }
 
+   @Test
+   public void testServerCleanupBeforeStart() throws Exception {
+      final String warName = "simple-app.war";
+      createTestWar(warName);
+      WebServerDTO webServerDTO = new WebServerDTO();
+      webServerDTO.bind = "http://localhost:0";
+      webServerDTO.path = "";
+      webServerDTO.apps = new ArrayList<>();
+      AppDTO app = new AppDTO();
+      app.url = "simple-app/";
+      app.war = warName;
+      webServerDTO.apps.add(app);
+      WebServerComponent webServerComponent = new WebServerComponent();
+      Assert.assertFalse(webServerComponent.isStarted());
+      testedComponents.add(webServerComponent);
+      webServerComponent.configure(webServerDTO, "./target", "./target");
+      //create some garbage
+      List<WebAppContext> contexts = webServerComponent.getWebContexts();
+
+      File targetDir = new File("./target");
+      File workDir = new File(targetDir, "web-work");
+      workDir.mkdir();
+
+      WebInfConfiguration cfg = new WebInfConfiguration();
+      assertEquals(1, contexts.size());
+      WebAppContext ctxt = contexts.get(0);
+      List<File> garbage = new ArrayList<>();
+
+      ctxt.setAttribute("javax.servlet.context.tempdir", new File(workDir, "jetty-context0"));
+
+      cfg.resolveTempDirectory(ctxt);
+      File tmpdir = ctxt.getTempDirectory();
+      File testDir = tmpdir.getParentFile();
+      createGarbagesInDir(testDir, garbage);
+
+      assertTrue(garbage.size() > 0);
+
+      for (File file : garbage) {
+         assertTrue(file.exists());
+      }
+
+      webServerComponent.start();
+
+      //make sure those garbage are gone
+      for (File file : garbage) {
+         assertFalse("file exist: " + file.getAbsolutePath(), file.exists());
+      }
+
+      //check the war is working
+      final int port = webServerComponent.getPort();
+
+      // Make the connection attempt.
+      CountDownLatch latch = new CountDownLatch(1);
+      final ClientHandler clientHandler = new ClientHandler(latch);
+      bootstrap.group(group).channel(NioSocketChannel.class).handler(new ChannelInitializer() {
+         @Override
+         protected void initChannel(Channel ch) throws Exception {
+            ch.pipeline().addLast(new HttpClientCodec(8192, 8192, 8192, false));
+            ch.pipeline().addLast(clientHandler);
+         }
+      });
+
+      Channel ch = bootstrap.connect("localhost", port).sync().channel();
+
+      String warUrl = "http://localhost:" + port + "/" + app.url;
+
+      URI uri = new URI(warUrl);
+
+      // Prepare the HTTP request.
+      HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri.getRawPath());
+      request.headers().set(HttpHeaderNames.HOST, "localhost");
+
+      // Send the HTTP request.
+      ch.writeAndFlush(request);
+      assertTrue(latch.await(5, TimeUnit.SECONDS));
+
+      assertTrue("content: " + clientHandler.body.toString(), clientHandler.body.toString().contains("Hello Artemis Test"));
+      assertNull(clientHandler.serverHeader);
+      // Wait for the server to close the connection.
+      ch.close();
+      Assert.assertTrue(webServerComponent.isStarted());
+      webServerComponent.stop(true);
+      Assert.assertFalse(webServerComponent.isStarted());
+   }
+
+   private void createTestWar(String warName) throws Exception {
+      File warFile = new File("target", warName);
+      File srcFile = new File("src/test/webapp");
+      createJarFile(srcFile, warFile);
+   }
+
+   private void createJarFile(File srcFile, File jarFile) throws IOException {
+      Manifest manifest = new Manifest();
+      manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+      try (JarOutputStream target = new JarOutputStream(new FileOutputStream(jarFile), manifest)) {
+         addFile(srcFile, target, "src/test/webapp");
+      }
+   }
+
+   private void addFile(File source, JarOutputStream target, String nameBase) throws IOException {
+      if (source.isDirectory()) {
+         String name = source.getPath().replace("\\", "/");
+         if (!name.isEmpty()) {
+            name = name.substring(nameBase.length());
+            if (!name.endsWith("/")) {
+               name += "/";
+            }
+            JarEntry entry = new JarEntry(name);
+            entry.setTime(source.lastModified());
+            target.putNextEntry(entry);
+            target.closeEntry();
+         }
+         for (File nestedFile: source.listFiles()) {
+            addFile(nestedFile, target, nameBase);
+         }
+         return;
+      }
+
+      String name = source.getPath().replace("\\", "/");
+      name = name.substring(nameBase.length());
+      JarEntry entry = new JarEntry(name);
+      entry.setTime(source.lastModified());
+      target.putNextEntry(entry);
+      try (BufferedInputStream input  = new BufferedInputStream(new FileInputStream(source))) {
+         byte[] buffer = new byte[1024];
+         while (true) {
+            int count = input.read(buffer);
+            if (count == -1)
+               break;
+            target.write(buffer, 0, count);
+         }
+         target.closeEntry();
+      }
+   }
+
+   private void createGarbagesInDir(File tempDirectory, List<File> garbage) throws IOException {
+      if (!tempDirectory.exists()) {
+         tempDirectory.mkdirs();
+      }
+      createRandomJettyFiles(tempDirectory, 10, garbage);
+   }
+
+   private void createRandomJettyFiles(File dir, int num, List<File> collector) throws IOException {
+      for (int i = 0; i < num; i++) {
+         String randomName = "jetty-" + UUID.randomUUID().toString();
+         File file = new File(dir, randomName);
+         if (i % 2 == 0) {
+            //create a dir
+            file.mkdir();
+         } else {
+            //normal file
+            file.createNewFile();
+         }
+         collector.add(file);
+      }
+   }
+
    class ClientHandler extends SimpleChannelInboundHandler<HttpObject> {
 
       private CountDownLatch latch;
-      private String body;
+      private StringBuilder body = new StringBuilder();
       private String serverHeader;
 
       ClientHandler(CountDownLatch latch) {
@@ -333,8 +506,10 @@ public class WebServerComponentTest extends Assert {
             serverHeader = response.headers().get("Server");
          } else if (msg instanceof HttpContent) {
             HttpContent content = (HttpContent) msg;
-            body = content.content().toString(CharsetUtil.UTF_8);
-            latch.countDown();
+            body.append(content.content().toString(CharsetUtil.UTF_8));
+            if (msg instanceof LastHttpContent) {
+               latch.countDown();
+            }
          }
       }
 

--- a/artemis-web/src/test/webapp/WEB-INF/web.xml
+++ b/artemis-web/src/test/webapp/WEB-INF/web.xml
@@ -1,0 +1,26 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  Architecture
+-->
+<web-app xmlns="http://java.sun.com/xml/ns/j2ee"
+	      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	      xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee
+	      http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
+	      version="2.4">
+
+    <display-name>Simple War Application</display-name>
+
+</web-app>

--- a/artemis-web/src/test/webapp/index.html
+++ b/artemis-web/src/test/webapp/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  Architecture
+-->
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>simple web</title>
+  </head>
+  <body>
+    <h1>Hello Artemis Test</h1>
+  </body>
+</html>


### PR DESCRIPTION
If you kill the server without invoking a normal shutdown, tmp
web files are not cleaned out.  This leaves old webapp folders
lingering until a normal shutdown.

In a failover test environment that repeatedly kills the server,
this causes disk space usage issues.

The fix is to add a cleanup method before the web server starts.
It searches the tmp web dir if there is any leftover files/dirs
and delete them if any.