### PR TITLE
 NO-JIRA: add .asf.yaml file with github repo metadata

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+github:
+  description: "Mirror of Apache ActiveMQ Artemis"
+  homepage: https://activemq.apache.org/components/artemis
+  labels:
+    - Apache
+    - ActiveMQ
+    - messaging
+    - broker
+
+    - AMQP
+    - AMQPS
+    - AMQP10
+    - OpenWire
+    - MQTT
+    - STOMP
+    - HornetQ
+
+    - Java
+    - JMS


### PR DESCRIPTION
> When making use of a feature in .asf.yaml, please ensure that you have discussed this with the entire project first, and have understood what the configuration changes will do to your workflow and project resources.
>    ~~ https://cwiki.apache.org/confluence/display/INFRA/.asf.yaml+features+for+git+repositories

I believe that the github config part (setting tagline and project labels) is mostly harmless.

The GitHub project page currently has a somewhat random set of tags at the top,
so this should be a big improvement.

https://github.com/apache/activemq-artemis currently contains the following tags

    php, activemq, c, network-client, ruby, python, csharp, cplusplus, java, perl, network-server