### PR TITLE
NO-JIRA: fix .asf.yaml invalid GitHub labels

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,18 +18,19 @@ github:
   description: "Mirror of Apache ActiveMQ Artemis"
   homepage: https://activemq.apache.org/components/artemis
   labels:
-    - Apache
-    - ActiveMQ
+    - apache
+    - activemq
+    - activemq-artemis
     - messaging
     - broker
 
-    - AMQP
-    - AMQPS
-    - AMQP10
-    - OpenWire
-    - MQTT
-    - STOMP
-    - HornetQ
+    - amqp
+    - amqps
+    - amqp10
+    - openwire
+    - mqtt
+    - stomp
+    - hornetq
 
-    - Java
-    - JMS
+    - java
+    - jms


### PR DESCRIPTION
```
An error occurred while running github feature in .asf.yaml!:
.asf.yaml: Invalid GitHub label 'Apache' - must be lowercase alphanumerical and <= 35 characters!
```