### PR TITLE
ARTEMIS-2598 Update netty version to 4.1.43.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,10 +91,10 @@
       <maven.assembly.plugin.version>2.4</maven.assembly.plugin.version>
       <mockito.version>2.25.0</mockito.version>
       <jctools.version>2.1.2</jctools.version>
-      <netty.version>4.1.34.Final</netty.version>
+      <netty.version>4.1.43.Final</netty.version>
 
       <!-- this is basically for tests -->
-      <netty-tcnative-version>2.0.23.Final</netty-tcnative-version>
+      <netty-tcnative-version>2.0.26.Final</netty-tcnative-version>
       <proton.version>0.33.2</proton.version>
       <resteasy.version>3.0.19.Final</resteasy.version>
       <slf4j.version>1.7.21</slf4j.version>

--- a/tests/integration-tests/src/test/resources/restricted-security-client.policy
+++ b/tests/integration-tests/src/test/resources/restricted-security-client.policy
@@ -23,6 +23,8 @@ grant {
         permission java.net.SocketPermission "*:1024-", "connect";
         // Note1: normally, we don't need this permission since the applet allows reading jars loaded by the applet
         // Note2: Which of the following two java.io.FilePermission is necessary depends on the exact Maven command
+        permission java.io.FilePermission "/etc/os-release", "read";
+        permission java.io.FilePermission "/usr/lib/os-release", "read";
         permission java.io.FilePermission "${activemq.basedir}/artemis-core-client/target/classes/-", "read";
         permission java.io.FilePermission "${activemq.basedir}/artemis-core-client/target/artemis-core-client-${project.version}.jar", "read";
         permission java.util.PropertyPermission "activemq.version.property.filename", "read";


### PR DESCRIPTION
Update netty version to 4.1.43.Final and netty-tcnative version to 2.0.26.Final.
Change restricted-security-client.policy because Netty 4.1.43.Final requires
access to two more files: /etc/os-release and /usr/lib/os-release.