### PR TITLE
ARTEMIS-2603 Deadlock between pageStore.getCurrentID and page.cleanup

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingStoreImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingStoreImpl.java
@@ -1169,7 +1169,7 @@ public class PagingStoreImpl implements PagingStore {
 
    @Override
    public Collection<Integer> getCurrentIds() throws Exception {
-      lock.writeLock().lock();
+      lock.readLock().lock();
       try {
          List<Integer> ids = new ArrayList<>();
          SequentialFileFactory factory = fileFactory;
@@ -1180,7 +1180,7 @@ public class PagingStoreImpl implements PagingStore {
          }
          return ids;
       } finally {
-         lock.writeLock().unlock();
+         lock.readLock().unlock();
       }
    }
 


### PR DESCRIPTION
This happened when JournalStorageManager.startReplication and PageStore.cleanup were called between multiple threads.