### PR TITLE
ARTEMIS-2604 Optimizations on journal loading

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/CompositeAddress.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/CompositeAddress.java
@@ -35,7 +35,15 @@ public class CompositeAddress {
    }
 
    public static SimpleString extractQueueName(SimpleString name) {
-      return name == null ? null : new SimpleString(extractQueueName(name.toString()));
+      if (name == null) {
+         return null;
+      }
+      final String nameString = name.toString();
+      final String queueName = extractQueueName(nameString);
+      if (queueName.equals(nameString)) {
+         return name;
+      }
+      return new SimpleString(queueName);
    }
 
    public static String extractQueueName(String queue) {
@@ -50,7 +58,15 @@ public class CompositeAddress {
    }
 
    public static SimpleString extractAddressName(SimpleString address) {
-      return address == null ? null : new SimpleString(extractAddressName(address.toString()));
+      if (address == null) {
+         return null;
+      }
+      final String addrString = address.toString();
+      final String addressName = extractAddressName(addrString);
+      if (addressName.equals(addrString)) {
+         return address;
+      }
+      return new SimpleString(addressName);
    }
 
    public static String extractAddressName(String address) {

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/Message.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/Message.java
@@ -186,6 +186,10 @@ public interface Message {
       // only on core
    }
 
+   default boolean searchScheduledDeliveryTime() {
+      return getScheduledDeliveryTime() != null;
+   }
+
    default RoutingType getRoutingType() {
       return null;
    }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/Message.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/Message.java
@@ -186,7 +186,11 @@ public interface Message {
       // only on core
    }
 
-   default boolean searchScheduledDeliveryTime() {
+   /**
+    * Search for the existence of the property: an implementor can save
+    * the message to be decoded, if possible.
+    */
+   default boolean hasScheduledDeliveryTime() {
       return getScheduledDeliveryTime() != null;
    }
 

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessage.java
@@ -26,6 +26,7 @@ import java.util.zip.Inflater;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
@@ -134,7 +135,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
    }
 
    public CoreMessage initBuffer(final int initialMessageBufferSize) {
-      buffer = ActiveMQBuffers.dynamicBuffer(initialMessageBufferSize).byteBuf();
+      buffer = Unpooled.buffer(initialMessageBufferSize);
 
       // There's a bug in netty which means a dynamic buffer won't resize until you write a byte
       buffer.writeByte((byte) 0);

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessage.java
@@ -1086,7 +1086,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
    }
 
    @Override
-   public boolean searchScheduledDeliveryTime() {
+   public boolean hasScheduledDeliveryTime() {
       return searchProperty(Message.HDR_SCHEDULED_DELIVERY_TIME);
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AbstractJournalStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AbstractJournalStorageManager.java
@@ -41,11 +41,13 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import javax.transaction.xa.Xid;
 
+import io.netty.buffer.Unpooled;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.Pair;
 import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.buffers.impl.ChannelBufferWrapper;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.filter.Filter;
 import org.apache.activemq.artemis.core.io.IOCallback;
@@ -869,7 +871,9 @@ public abstract class AbstractJournalStorageManager extends CriticalComponentImp
 
                byte[] data = record.data;
 
-               ActiveMQBuffer buff = ActiveMQBuffers.wrappedBuffer(data);
+               // We can make this byte[] buffer releasable, because subsequent methods using it are not supposed
+               // to release it. It saves creating useless UnreleasableByteBuf wrappers
+               ChannelBufferWrapper buff = new ChannelBufferWrapper(Unpooled.wrappedBuffer(data), true);
 
                byte recordType = record.getUserRecordType();
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -1181,9 +1181,12 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
 
       MessageReference reference = MessageReference.Factory.createReference(message, queue);
 
-      Long scheduledDeliveryTime = message.getScheduledDeliveryTime();
-      if (scheduledDeliveryTime != null) {
-         reference.setScheduledDeliveryTime(scheduledDeliveryTime);
+      Long scheduledDeliveryTime;
+      if (message.searchScheduledDeliveryTime()) {
+         scheduledDeliveryTime = message.getScheduledDeliveryTime();
+         if (scheduledDeliveryTime != null) {
+            reference.setScheduledDeliveryTime(scheduledDeliveryTime);
+         }
       }
 
       message.incrementDurableRefCount();
@@ -1433,7 +1436,10 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
 
       Transaction tx = context.getTransaction();
 
-      Long deliveryTime = message.getScheduledDeliveryTime();
+      Long deliveryTime = null;
+      if (message.searchScheduledDeliveryTime()) {
+         deliveryTime = message.getScheduledDeliveryTime();
+      }
 
       for (Map.Entry<SimpleString, RouteContextList> entry : context.getContexListing().entrySet()) {
          PagingStore store = pagingManager.getPageStore(entry.getKey());

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -1182,7 +1182,7 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
       MessageReference reference = MessageReference.Factory.createReference(message, queue);
 
       Long scheduledDeliveryTime;
-      if (message.searchScheduledDeliveryTime()) {
+      if (message.hasScheduledDeliveryTime()) {
          scheduledDeliveryTime = message.getScheduledDeliveryTime();
          if (scheduledDeliveryTime != null) {
             reference.setScheduledDeliveryTime(scheduledDeliveryTime);
@@ -1437,7 +1437,7 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
       Transaction tx = context.getTransaction();
 
       Long deliveryTime = null;
-      if (message.searchScheduledDeliveryTime()) {
+      if (message.hasScheduledDeliveryTime()) {
          deliveryTime = message.getScheduledDeliveryTime();
       }
 


### PR DESCRIPTION
I've opened this for discussion, so PLEASE DON'T MERGE IT YET.

I've yet to implement the same optimization for other properties (ie `getDuplicateProperty` and `getLastValueProperty`) and for the `AMQPMessage`, while providing adeguate test coverage.

I will need some help from @gemmellr and @tabish121 , because I see that implementing an `AMQPMessage::searchProperty(SimpleString key)` that won't force encoding (if not already happened) of the whole message isn't trivial due to my ignorance of the protocol and probably the wrong approach to the problem.