### PR TITLE
Artemis-2563 Add option to create queue on all active clustered nodes

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -208,6 +208,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
    private static final String DEFAULT_DELAY_BEFORE_DISPATCH = "default-delay-before-dispatch";
 
    private static final String REDISTRIBUTION_DELAY_NODE_NAME = "redistribution-delay";
+   
+   private static final String CLUSTERED_QUEUES_NODE_NAME = "clustered-queues";
 
    private static final String SEND_TO_DLA_ON_NO_ROUTE = "send-to-dla-on-no-route";
 
@@ -1100,6 +1102,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
             addressSettings.setMaxDeliveryAttempts(XMLUtil.parseInt(child));
          } else if (REDISTRIBUTION_DELAY_NODE_NAME.equalsIgnoreCase(name)) {
             addressSettings.setRedistributionDelay(XMLUtil.parseLong(child));
+         } else if (CLUSTERED_QUEUES_NODE_NAME.equalsIgnoreCase(name)) {
+           addressSettings.setClusteredQueues(XMLUtil.parseBoolean(child));
          } else if (SEND_TO_DLA_ON_NO_ROUTE.equalsIgnoreCase(name)) {
             addressSettings.setSendToDLAOnNoRoute(XMLUtil.parseBoolean(child));
          } else if (SLOW_CONSUMER_THRESHOLD_NODE_NAME.equalsIgnoreCase(name)) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -101,7 +101,8 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 /**
- * Parses an XML document according to the {@literal artemis-configuration.xsd} schema.
+ * Parses an XML document according to the {@literal artemis-configuration.xsd}
+ * schema.
  */
 public final class FileConfigurationParser extends XMLConfigurationUtil {
 
@@ -208,7 +209,7 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
    private static final String DEFAULT_DELAY_BEFORE_DISPATCH = "default-delay-before-dispatch";
 
    private static final String REDISTRIBUTION_DELAY_NODE_NAME = "redistribution-delay";
-   
+
    private static final String CLUSTERED_QUEUES_NODE_NAME = "clustered-queues";
 
    private static final String SEND_TO_DLA_ON_NO_ROUTE = "send-to-dla-on-no-route";
@@ -277,7 +278,6 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
    private static final String RETROACTIVE_MESSAGE_COUNT = "retroactive-message-count";
 
-
    // Attributes ----------------------------------------------------
 
    private boolean validateAIO = false;
@@ -316,7 +316,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
       config.setName(getString(e, "name", config.getName(), Validators.NO_CHECK));
 
-      config.setSystemPropertyPrefix(getString(e, "system-property-prefix", config.getSystemPropertyPrefix(), Validators.NOT_NULL_OR_EMPTY));
+      config.setSystemPropertyPrefix(getString(e, "system-property-prefix",
+            config.getSystemPropertyPrefix(), Validators.NOT_NULL_OR_EMPTY));
 
       NodeList haPolicyNodes = e.getElementsByTagName("ha-policy");
 
@@ -324,7 +325,7 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
          parseHAPolicyConfiguration((Element) haPolicyNodes.item(0), config);
       }
 
-      //if we aren already set then set to default
+      // if we aren already set then set to default
       if (config.getHAPolicyConfiguration() == null) {
          config.setHAPolicyConfiguration(new LiveOnlyPolicyConfiguration());
       }
@@ -337,78 +338,109 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
       config.setResolveProtocols(getBoolean(e, "resolve-protocols", config.isResolveProtocols()));
 
-      config.setPersistenceEnabled(getBoolean(e, "persistence-enabled", config.isPersistenceEnabled()));
+      config.setPersistenceEnabled(
+            getBoolean(e, "persistence-enabled", config.isPersistenceEnabled()));
 
-      config.setPersistDeliveryCountBeforeDelivery(getBoolean(e, "persist-delivery-count-before-delivery", config.isPersistDeliveryCountBeforeDelivery()));
+      config.setPersistDeliveryCountBeforeDelivery(
+            getBoolean(e, "persist-delivery-count-before-delivery",
+                  config.isPersistDeliveryCountBeforeDelivery()));
 
-      config.setScheduledThreadPoolMaxSize(getInteger(e, "scheduled-thread-pool-max-size", config.getScheduledThreadPoolMaxSize(), Validators.GT_ZERO));
+      config.setScheduledThreadPoolMaxSize(getInteger(e, "scheduled-thread-pool-max-size",
+            config.getScheduledThreadPoolMaxSize(), Validators.GT_ZERO));
 
-      config.setThreadPoolMaxSize(getInteger(e, "thread-pool-max-size", config.getThreadPoolMaxSize(), Validators.MINUS_ONE_OR_GT_ZERO));
+      config.setThreadPoolMaxSize(getInteger(e, "thread-pool-max-size",
+            config.getThreadPoolMaxSize(), Validators.MINUS_ONE_OR_GT_ZERO));
 
       config.setSecurityEnabled(getBoolean(e, "security-enabled", config.isSecurityEnabled()));
 
-      config.setGracefulShutdownEnabled(getBoolean(e, "graceful-shutdown-enabled", config.isGracefulShutdownEnabled()));
+      config.setGracefulShutdownEnabled(
+            getBoolean(e, "graceful-shutdown-enabled", config.isGracefulShutdownEnabled()));
 
-      config.setGracefulShutdownTimeout(getLong(e, "graceful-shutdown-timeout", config.getGracefulShutdownTimeout(), Validators.MINUS_ONE_OR_GE_ZERO));
+      config.setGracefulShutdownTimeout(getLong(e, "graceful-shutdown-timeout",
+            config.getGracefulShutdownTimeout(), Validators.MINUS_ONE_OR_GE_ZERO));
 
-      config.setJMXManagementEnabled(getBoolean(e, "jmx-management-enabled", config.isJMXManagementEnabled()));
+      config.setJMXManagementEnabled(
+            getBoolean(e, "jmx-management-enabled", config.isJMXManagementEnabled()));
 
-      config.setJMXDomain(getString(e, "jmx-domain", config.getJMXDomain(), Validators.NOT_NULL_OR_EMPTY));
+      config.setJMXDomain(
+            getString(e, "jmx-domain", config.getJMXDomain(), Validators.NOT_NULL_OR_EMPTY));
 
       config.setJMXUseBrokerName(getBoolean(e, "jmx-use-broker-name", config.isJMXUseBrokerName()));
 
-      config.setSecurityInvalidationInterval(getLong(e, "security-invalidation-interval", config.getSecurityInvalidationInterval(), Validators.GT_ZERO));
+      config.setSecurityInvalidationInterval(getLong(e, "security-invalidation-interval",
+            config.getSecurityInvalidationInterval(), Validators.GT_ZERO));
 
-      config.setConnectionTTLOverride(getLong(e, "connection-ttl-override", config.getConnectionTTLOverride(), Validators.MINUS_ONE_OR_GT_ZERO));
+      config.setConnectionTTLOverride(getLong(e, "connection-ttl-override",
+            config.getConnectionTTLOverride(), Validators.MINUS_ONE_OR_GT_ZERO));
 
-      config.setEnabledAsyncConnectionExecution(getBoolean(e, "async-connection-execution-enabled", config.isAsyncConnectionExecutionEnabled()));
+      config.setEnabledAsyncConnectionExecution(getBoolean(e, "async-connection-execution-enabled",
+            config.isAsyncConnectionExecutionEnabled()));
 
-      config.setTransactionTimeout(getLong(e, "transaction-timeout", config.getTransactionTimeout(), Validators.GT_ZERO));
+      config.setTransactionTimeout(
+            getLong(e, "transaction-timeout", config.getTransactionTimeout(), Validators.GT_ZERO));
 
-      config.setTransactionTimeoutScanPeriod(getLong(e, "transaction-timeout-scan-period", config.getTransactionTimeoutScanPeriod(), Validators.GT_ZERO));
+      config.setTransactionTimeoutScanPeriod(getLong(e, "transaction-timeout-scan-period",
+            config.getTransactionTimeoutScanPeriod(), Validators.GT_ZERO));
 
-      config.setMessageExpiryScanPeriod(getLong(e, "message-expiry-scan-period", config.getMessageExpiryScanPeriod(), Validators.MINUS_ONE_OR_GT_ZERO));
+      config.setMessageExpiryScanPeriod(getLong(e, "message-expiry-scan-period",
+            config.getMessageExpiryScanPeriod(), Validators.MINUS_ONE_OR_GT_ZERO));
 
-      config.setMessageExpiryThreadPriority(getInteger(e, "message-expiry-thread-priority", config.getMessageExpiryThreadPriority(), Validators.THREAD_PRIORITY_RANGE));
+      config.setMessageExpiryThreadPriority(getInteger(e, "message-expiry-thread-priority",
+            config.getMessageExpiryThreadPriority(), Validators.THREAD_PRIORITY_RANGE));
 
-      config.setAddressQueueScanPeriod(getLong(e, "address-queue-scan-period", config.getAddressQueueScanPeriod(), Validators.MINUS_ONE_OR_GT_ZERO));
+      config.setAddressQueueScanPeriod(getLong(e, "address-queue-scan-period",
+            config.getAddressQueueScanPeriod(), Validators.MINUS_ONE_OR_GT_ZERO));
 
-      config.setIDCacheSize(getInteger(e, "id-cache-size", config.getIDCacheSize(), Validators.GT_ZERO));
+      config.setIDCacheSize(
+            getInteger(e, "id-cache-size", config.getIDCacheSize(), Validators.GT_ZERO));
 
       config.setPersistIDCache(getBoolean(e, "persist-id-cache", config.isPersistIDCache()));
 
-      config.setManagementAddress(new SimpleString(getString(e, "management-address", config.getManagementAddress().toString(), Validators.NOT_NULL_OR_EMPTY)));
+      config.setManagementAddress(new SimpleString(getString(e, "management-address",
+            config.getManagementAddress().toString(), Validators.NOT_NULL_OR_EMPTY)));
 
-      config.setManagementNotificationAddress(new SimpleString(getString(e, "management-notification-address", config.getManagementNotificationAddress().toString(), Validators.NOT_NULL_OR_EMPTY)));
+      config.setManagementNotificationAddress(new SimpleString(getString(e,
+            "management-notification-address", config.getManagementNotificationAddress().toString(),
+            Validators.NOT_NULL_OR_EMPTY)));
 
       config.setMaskPassword(getBoolean(e, "mask-password", null));
 
-      config.setPasswordCodec(getString(e, "password-codec", DefaultSensitiveStringCodec.class.getName(), Validators.NOT_NULL_OR_EMPTY));
+      config.setPasswordCodec(getString(e, "password-codec",
+            DefaultSensitiveStringCodec.class.getName(), Validators.NOT_NULL_OR_EMPTY));
 
-      config.setPopulateValidatedUser(getBoolean(e, "populate-validated-user", config.isPopulateValidatedUser()));
+      config.setPopulateValidatedUser(
+            getBoolean(e, "populate-validated-user", config.isPopulateValidatedUser()));
 
-      config.setRejectEmptyValidatedUser(getBoolean(e, "reject-empty-validated-user", config.isRejectEmptyValidatedUser()));
+      config.setRejectEmptyValidatedUser(
+            getBoolean(e, "reject-empty-validated-user", config.isRejectEmptyValidatedUser()));
 
-      config.setConnectionTtlCheckInterval(getLong(e, "connection-ttl-check-interval", config.getConnectionTtlCheckInterval(), Validators.GT_ZERO));
+      config.setConnectionTtlCheckInterval(getLong(e, "connection-ttl-check-interval",
+            config.getConnectionTtlCheckInterval(), Validators.GT_ZERO));
 
-      config.setConfigurationFileRefreshPeriod(getLong(e, "configuration-file-refresh-period", config.getConfigurationFileRefreshPeriod(), Validators.GT_ZERO));
+      config.setConfigurationFileRefreshPeriod(getLong(e, "configuration-file-refresh-period",
+            config.getConfigurationFileRefreshPeriod(), Validators.GT_ZERO));
 
-      long globalMaxSize = getTextBytesAsLongBytes(e, GLOBAL_MAX_SIZE, -1, Validators.MINUS_ONE_OR_GT_ZERO);
+      long globalMaxSize = getTextBytesAsLongBytes(e, GLOBAL_MAX_SIZE, -1,
+            Validators.MINUS_ONE_OR_GT_ZERO);
 
       if (globalMaxSize > 0) {
-         // We only set it if it's not set on the XML, otherwise getGlobalMaxSize will calculate it.
+         // We only set it if it's not set on the XML, otherwise getGlobalMaxSize will
+         // calculate it.
          // We do it this way because it will be valid also on the case of embedded
          config.setGlobalMaxSize(globalMaxSize);
       }
 
-      config.setMaxDiskUsage(getInteger(e, MAX_DISK_USAGE, config.getMaxDiskUsage(), Validators.PERCENTAGE_OR_MINUS_ONE));
+      config.setMaxDiskUsage(getInteger(e, MAX_DISK_USAGE, config.getMaxDiskUsage(),
+            Validators.PERCENTAGE_OR_MINUS_ONE));
 
-      config.setDiskScanPeriod(getInteger(e, DISK_SCAN_PERIOD, config.getDiskScanPeriod(), Validators.MINUS_ONE_OR_GT_ZERO));
+      config.setDiskScanPeriod(getInteger(e, DISK_SCAN_PERIOD, config.getDiskScanPeriod(),
+            Validators.MINUS_ONE_OR_GT_ZERO));
 
-      config.setInternalNamingPrefix(getString(e, INTERNAL_NAMING_PREFIX, config.getInternalNamingPrefix(), Validators.NO_CHECK));
+      config.setInternalNamingPrefix(getString(e, INTERNAL_NAMING_PREFIX,
+            config.getInternalNamingPrefix(), Validators.NO_CHECK));
 
-      config.setAmqpUseCoreSubscriptionNaming(getBoolean(e, AMQP_USE_CORE_SUBSCRIPTION_NAMING, config.isAmqpUseCoreSubscriptionNaming()));
-
+      config.setAmqpUseCoreSubscriptionNaming(getBoolean(e, AMQP_USE_CORE_SUBSCRIPTION_NAMING,
+            config.isAmqpUseCoreSubscriptionNaming()));
 
       // parsing cluster password
       String passwordText = getString(e, "cluster-password", null, Validators.NO_CHECK);
@@ -416,11 +448,13 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       final Boolean maskText = config.isMaskPassword();
 
       if (passwordText != null) {
-         String resolvedPassword = PasswordMaskingUtil.resolveMask(maskText, passwordText, config.getPasswordCodec());
+         String resolvedPassword = PasswordMaskingUtil.resolveMask(maskText, passwordText,
+               config.getPasswordCodec());
          config.setClusterPassword(resolvedPassword);
       }
 
-      config.setClusterUser(getString(e, "cluster-user", config.getClusterUser(), Validators.NO_CHECK));
+      config.setClusterUser(
+            getString(e, "cluster-user", config.getClusterUser(), Validators.NO_CHECK));
 
       NodeList interceptorNodes = e.getElementsByTagName("remoting-interceptors");
 
@@ -477,7 +511,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       for (int i = 0; i < connectorNodes.getLength(); i++) {
          Element connectorNode = (Element) connectorNodes.item(i);
 
-         TransportConfiguration connectorConfig = parseConnectorTransportConfiguration(connectorNode, config);
+         TransportConfiguration connectorConfig = parseConnectorTransportConfiguration(
+               connectorNode, config);
 
          if (connectorConfig.getName() == null) {
             ActiveMQServerLogger.LOGGER.connectorWithNoName();
@@ -499,7 +534,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       for (int i = 0; i < acceptorNodes.getLength(); i++) {
          Element acceptorNode = (Element) acceptorNodes.item(i);
 
-         TransportConfiguration acceptorConfig = parseAcceptorTransportConfiguration(acceptorNode, config);
+         TransportConfiguration acceptorConfig = parseAcceptorTransportConfiguration(acceptorNode,
+               config);
 
          config.getAcceptorConfigurations().add(acceptorConfig);
       }
@@ -569,31 +605,40 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       }
       // Persistence config
 
-      config.setLargeMessagesDirectory(getString(e, "large-messages-directory", config.getLargeMessagesDirectory(), Validators.NOT_NULL_OR_EMPTY));
+      config.setLargeMessagesDirectory(getString(e, "large-messages-directory",
+            config.getLargeMessagesDirectory(), Validators.NOT_NULL_OR_EMPTY));
 
-      config.setBindingsDirectory(getString(e, "bindings-directory", config.getBindingsDirectory(), Validators.NOT_NULL_OR_EMPTY));
+      config.setBindingsDirectory(getString(e, "bindings-directory", config.getBindingsDirectory(),
+            Validators.NOT_NULL_OR_EMPTY));
 
-      config.setCreateBindingsDir(getBoolean(e, "create-bindings-dir", config.isCreateBindingsDir()));
+      config.setCreateBindingsDir(
+            getBoolean(e, "create-bindings-dir", config.isCreateBindingsDir()));
 
-      config.setJournalDirectory(getString(e, "journal-directory", config.getJournalDirectory(), Validators.NOT_NULL_OR_EMPTY));
+      config.setJournalDirectory(getString(e, "journal-directory", config.getJournalDirectory(),
+            Validators.NOT_NULL_OR_EMPTY));
 
-      config.setNodeManagerLockDirectory(getString(e, "node-manager-lock-directory", null, Validators.NO_CHECK));
+      config.setNodeManagerLockDirectory(
+            getString(e, "node-manager-lock-directory", null, Validators.NO_CHECK));
 
-      config.setPageMaxConcurrentIO(getInteger(e, "page-max-concurrent-io", config.getPageMaxConcurrentIO(), Validators.MINUS_ONE_OR_GT_ZERO));
+      config.setPageMaxConcurrentIO(getInteger(e, "page-max-concurrent-io",
+            config.getPageMaxConcurrentIO(), Validators.MINUS_ONE_OR_GT_ZERO));
 
       config.setReadWholePage(getBoolean(e, "read-whole-page", config.isReadWholePage()));
 
-      config.setPagingDirectory(getString(e, "paging-directory", config.getPagingDirectory(), Validators.NOT_NULL_OR_EMPTY));
+      config.setPagingDirectory(getString(e, "paging-directory", config.getPagingDirectory(),
+            Validators.NOT_NULL_OR_EMPTY));
 
       config.setCreateJournalDir(getBoolean(e, "create-journal-dir", config.isCreateJournalDir()));
 
-      String s = getString(e, "journal-type", config.getJournalType().toString(), Validators.JOURNAL_TYPE);
+      String s = getString(e, "journal-type", config.getJournalType().toString(),
+            Validators.JOURNAL_TYPE);
 
       config.setJournalType(JournalType.getType(s));
 
       if (config.getJournalType() == JournalType.ASYNCIO) {
          // https://jira.jboss.org/jira/browse/HORNETQ-295
-         // We do the check here to see if AIO is supported so we can use the correct defaults and/or use
+         // We do the check here to see if AIO is supported so we can use the correct
+         // defaults and/or use
          // correct settings in xml
          // If we fall back later on these settings can be ignored
          boolean supportsAIO = AIOSequentialFileFactory.isSupported();
@@ -608,19 +653,35 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
       config.setJournalDatasync(getBoolean(e, "journal-datasync", config.isJournalDatasync()));
 
-      config.setJournalSyncTransactional(getBoolean(e, "journal-sync-transactional", config.isJournalSyncTransactional()));
+      config.setJournalSyncTransactional(
+            getBoolean(e, "journal-sync-transactional", config.isJournalSyncTransactional()));
 
-      config.setJournalSyncNonTransactional(getBoolean(e, "journal-sync-non-transactional", config.isJournalSyncNonTransactional()));
+      config.setJournalSyncNonTransactional(getBoolean(e, "journal-sync-non-transactional",
+            config.isJournalSyncNonTransactional()));
 
-      config.setJournalFileSize(getTextBytesAsIntBytes(e, "journal-file-size", config.getJournalFileSize(), Validators.POSITIVE_INT));
+      config.setJournalFileSize(getTextBytesAsIntBytes(e, "journal-file-size",
+            config.getJournalFileSize(), Validators.POSITIVE_INT));
 
-      int journalBufferTimeout = getInteger(e, "journal-buffer-timeout", config.getJournalType() == JournalType.ASYNCIO ? ArtemisConstants.DEFAULT_JOURNAL_BUFFER_TIMEOUT_AIO : ArtemisConstants.DEFAULT_JOURNAL_BUFFER_TIMEOUT_NIO, Validators.GE_ZERO);
+      int journalBufferTimeout = getInteger(e, "journal-buffer-timeout",
+            config.getJournalType() == JournalType.ASYNCIO
+                  ? ArtemisConstants.DEFAULT_JOURNAL_BUFFER_TIMEOUT_AIO
+                  : ArtemisConstants.DEFAULT_JOURNAL_BUFFER_TIMEOUT_NIO,
+            Validators.GE_ZERO);
 
-      int journalBufferSize = getTextBytesAsIntBytes(e, "journal-buffer-size", config.getJournalType() == JournalType.ASYNCIO ? ArtemisConstants.DEFAULT_JOURNAL_BUFFER_SIZE_AIO : ArtemisConstants.DEFAULT_JOURNAL_BUFFER_SIZE_NIO, Validators.POSITIVE_INT);
+      int journalBufferSize = getTextBytesAsIntBytes(e, "journal-buffer-size",
+            config.getJournalType() == JournalType.ASYNCIO
+                  ? ArtemisConstants.DEFAULT_JOURNAL_BUFFER_SIZE_AIO
+                  : ArtemisConstants.DEFAULT_JOURNAL_BUFFER_SIZE_NIO,
+            Validators.POSITIVE_INT);
 
-      int journalMaxIO = getInteger(e, "journal-max-io", config.getJournalType() == JournalType.ASYNCIO ? ActiveMQDefaultConfiguration.getDefaultJournalMaxIoAio() : ActiveMQDefaultConfiguration.getDefaultJournalMaxIoNio(), Validators.GT_ZERO);
+      int journalMaxIO = getInteger(e, "journal-max-io",
+            config.getJournalType() == JournalType.ASYNCIO
+                  ? ActiveMQDefaultConfiguration.getDefaultJournalMaxIoAio()
+                  : ActiveMQDefaultConfiguration.getDefaultJournalMaxIoNio(),
+            Validators.GT_ZERO);
 
-      config.setJournalDeviceBlockSize(getInteger(e, "journal-device-block-size", null, Validators.MINUS_ONE_OR_GE_ZERO));
+      config.setJournalDeviceBlockSize(
+            getInteger(e, "journal-device-block-size", null, Validators.MINUS_ONE_OR_GE_ZERO));
 
       if (config.getJournalType() == JournalType.ASYNCIO) {
          config.setJournalBufferTimeout_AIO(journalBufferTimeout);
@@ -632,57 +693,82 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
          config.setJournalMaxIO_NIO(journalMaxIO);
       }
 
-      config.setJournalFileOpenTimeout(getInteger(e, "journal-file-open-timeout", ActiveMQDefaultConfiguration.getDefaultJournalFileOpenTimeout(), Validators.GT_ZERO));
+      config.setJournalFileOpenTimeout(getInteger(e, "journal-file-open-timeout",
+            ActiveMQDefaultConfiguration.getDefaultJournalFileOpenTimeout(), Validators.GT_ZERO));
 
-      config.setJournalMinFiles(getInteger(e, "journal-min-files", config.getJournalMinFiles(), Validators.GT_ZERO));
+      config.setJournalMinFiles(
+            getInteger(e, "journal-min-files", config.getJournalMinFiles(), Validators.GT_ZERO));
 
-      config.setJournalPoolFiles(getInteger(e, "journal-pool-files", config.getJournalPoolFiles(), Validators.MINUS_ONE_OR_GT_ZERO));
+      config.setJournalPoolFiles(getInteger(e, "journal-pool-files", config.getJournalPoolFiles(),
+            Validators.MINUS_ONE_OR_GT_ZERO));
 
-      config.setJournalCompactMinFiles(getInteger(e, "journal-compact-min-files", config.getJournalCompactMinFiles(), Validators.GE_ZERO));
+      config.setJournalCompactMinFiles(getInteger(e, "journal-compact-min-files",
+            config.getJournalCompactMinFiles(), Validators.GE_ZERO));
 
-      config.setJournalCompactPercentage(getInteger(e, "journal-compact-percentage", config.getJournalCompactPercentage(), Validators.PERCENTAGE));
+      config.setJournalCompactPercentage(getInteger(e, "journal-compact-percentage",
+            config.getJournalCompactPercentage(), Validators.PERCENTAGE));
 
-      config.setLogJournalWriteRate(getBoolean(e, "log-journal-write-rate", ActiveMQDefaultConfiguration.isDefaultJournalLogWriteRate()));
+      config.setLogJournalWriteRate(getBoolean(e, "log-journal-write-rate",
+            ActiveMQDefaultConfiguration.isDefaultJournalLogWriteRate()));
 
       if (e.hasAttribute("wild-card-routing-enabled")) {
-         config.setWildcardRoutingEnabled(getBoolean(e, "wild-card-routing-enabled", config.isWildcardRoutingEnabled()));
+         config.setWildcardRoutingEnabled(
+               getBoolean(e, "wild-card-routing-enabled", config.isWildcardRoutingEnabled()));
       }
 
-      config.setMessageCounterEnabled(getBoolean(e, "message-counter-enabled", config.isMessageCounterEnabled()));
+      config.setMessageCounterEnabled(
+            getBoolean(e, "message-counter-enabled", config.isMessageCounterEnabled()));
 
-      config.setMessageCounterSamplePeriod(getLong(e, "message-counter-sample-period", config.getMessageCounterSamplePeriod(), Validators.GT_ZERO));
+      config.setMessageCounterSamplePeriod(getLong(e, "message-counter-sample-period",
+            config.getMessageCounterSamplePeriod(), Validators.GT_ZERO));
 
-      config.setMessageCounterMaxDayHistory(getInteger(e, "message-counter-max-day-history", config.getMessageCounterMaxDayHistory(), Validators.GT_ZERO));
+      config.setMessageCounterMaxDayHistory(getInteger(e, "message-counter-max-day-history",
+            config.getMessageCounterMaxDayHistory(), Validators.GT_ZERO));
 
-      config.setServerDumpInterval(getLong(e, "server-dump-interval", config.getServerDumpInterval(), Validators.MINUS_ONE_OR_GT_ZERO)); // in milliseconds
+      config.setServerDumpInterval(getLong(e, "server-dump-interval",
+            config.getServerDumpInterval(), Validators.MINUS_ONE_OR_GT_ZERO)); // in milliseconds
 
-      config.setMemoryWarningThreshold(getInteger(e, "memory-warning-threshold", config.getMemoryWarningThreshold(), Validators.PERCENTAGE));
+      config.setMemoryWarningThreshold(getInteger(e, "memory-warning-threshold",
+            config.getMemoryWarningThreshold(), Validators.PERCENTAGE));
 
-      config.setMemoryMeasureInterval(getLong(e, "memory-measure-interval", config.getMemoryMeasureInterval(), Validators.MINUS_ONE_OR_GT_ZERO));
+      config.setMemoryMeasureInterval(getLong(e, "memory-measure-interval",
+            config.getMemoryMeasureInterval(), Validators.MINUS_ONE_OR_GT_ZERO));
 
-      config.setNetworkCheckList(getString(e, "network-check-list", config.getNetworkCheckList(), Validators.NO_CHECK));
+      config.setNetworkCheckList(
+            getString(e, "network-check-list", config.getNetworkCheckList(), Validators.NO_CHECK));
 
-      config.setNetworkCheckURLList(getString(e, "network-check-URL-list", config.getNetworkCheckURLList(), Validators.NO_CHECK));
+      config.setNetworkCheckURLList(getString(e, "network-check-URL-list",
+            config.getNetworkCheckURLList(), Validators.NO_CHECK));
 
-      config.setNetworkCheckPeriod(getLong(e, "network-check-period", config.getNetworkCheckPeriod(), Validators.GT_ZERO));
+      config.setNetworkCheckPeriod(
+            getLong(e, "network-check-period", config.getNetworkCheckPeriod(), Validators.GT_ZERO));
 
-      config.setNetworkCheckTimeout(getInteger(e, "network-check-timeout", config.getNetworkCheckTimeout(), Validators.GT_ZERO));
+      config.setNetworkCheckTimeout(getInteger(e, "network-check-timeout",
+            config.getNetworkCheckTimeout(), Validators.GT_ZERO));
 
-      config.setNetworCheckNIC(getString(e, "network-check-NIC", config.getNetworkCheckNIC(), Validators.NO_CHECK));
+      config.setNetworCheckNIC(
+            getString(e, "network-check-NIC", config.getNetworkCheckNIC(), Validators.NO_CHECK));
 
-      config.setNetworkCheckPing6Command(getString(e, "network-check-ping6-command", config.getNetworkCheckPing6Command(), Validators.NO_CHECK));
+      config.setNetworkCheckPing6Command(getString(e, "network-check-ping6-command",
+            config.getNetworkCheckPing6Command(), Validators.NO_CHECK));
 
-      config.setNetworkCheckPingCommand(getString(e, "network-check-ping-command", config.getNetworkCheckPingCommand(), Validators.NO_CHECK));
+      config.setNetworkCheckPingCommand(getString(e, "network-check-ping-command",
+            config.getNetworkCheckPingCommand(), Validators.NO_CHECK));
 
       config.setCriticalAnalyzer(getBoolean(e, "critical-analyzer", config.isCriticalAnalyzer()));
 
-      config.setCriticalAnalyzerTimeout(getLong(e, "critical-analyzer-timeout", config.getCriticalAnalyzerTimeout(), Validators.GE_ZERO));
+      config.setCriticalAnalyzerTimeout(getLong(e, "critical-analyzer-timeout",
+            config.getCriticalAnalyzerTimeout(), Validators.GE_ZERO));
 
-      config.setCriticalAnalyzerCheckPeriod(getLong(e, "critical-analyzer-check-period", config.getCriticalAnalyzerCheckPeriod(), Validators.GE_ZERO));
+      config.setCriticalAnalyzerCheckPeriod(getLong(e, "critical-analyzer-check-period",
+            config.getCriticalAnalyzerCheckPeriod(), Validators.GE_ZERO));
 
-      config.setCriticalAnalyzerPolicy(CriticalAnalyzerPolicy.valueOf(getString(e, "critical-analyzer-policy", config.getCriticalAnalyzerPolicy().name(), Validators.NOT_NULL_OR_EMPTY)));
+      config.setCriticalAnalyzerPolicy(
+            CriticalAnalyzerPolicy.valueOf(getString(e, "critical-analyzer-policy",
+                  config.getCriticalAnalyzerPolicy().name(), Validators.NOT_NULL_OR_EMPTY)));
 
-      config.setPageSyncTimeout(getInteger(e, "page-sync-timeout", config.getJournalBufferTimeout_NIO(), Validators.GE_ZERO));
+      config.setPageSyncTimeout(getInteger(e, "page-sync-timeout",
+            config.getJournalBufferTimeout_NIO(), Validators.GE_ZERO));
 
       parseAddressSettings(e, config);
 
@@ -738,12 +824,14 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
          }
          list = node.getElementsByTagName(SECURITY_ELEMENT_NAME);
          for (int i = 0; i < list.getLength(); i++) {
-            Pair<String, Set<Role>> securityItem = parseSecurityRoles(list.item(i), config.getSecurityRoleNameMappings());
+            Pair<String, Set<Role>> securityItem = parseSecurityRoles(list.item(i),
+                  config.getSecurityRoleNameMappings());
             config.putSecurityRoles(securityItem.getA(), securityItem.getB());
          }
          list = node.getElementsByTagName(SECURITY_PLUGIN_ELEMENT_NAME);
          for (int i = 0; i < list.getLength(); i++) {
-            Pair<SecuritySettingPlugin, Map<String, String>> securityItem = parseSecuritySettingPlugins(list.item(i), config.isMaskPassword(), config.getPasswordCodec());
+            Pair<SecuritySettingPlugin, Map<String, String>> securityItem = parseSecuritySettingPlugins(
+                  list.item(i), config.isMaskPassword(), config.getPasswordCodec());
             config.addSecuritySettingPlugin(securityItem.getA().init(securityItem.getB()));
          }
       }
@@ -766,12 +854,14 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
       Map<String, String> properties = getMapOfChildPropertyElements(item);
 
-      ActiveMQServerPlugin serverPlugin = AccessController.doPrivileged(new PrivilegedAction<ActiveMQServerPlugin>() {
-         @Override
-         public ActiveMQServerPlugin run() {
-            return (ActiveMQServerPlugin) ClassloadingUtil.newInstanceFromClassLoader(FileConfigurationParser.class, clazz);
-         }
-      });
+      ActiveMQServerPlugin serverPlugin = AccessController
+            .doPrivileged(new PrivilegedAction<ActiveMQServerPlugin>() {
+               @Override
+               public ActiveMQServerPlugin run() {
+                  return (ActiveMQServerPlugin) ClassloadingUtil
+                        .newInstanceFromClassLoader(FileConfigurationParser.class, clazz);
+               }
+            });
 
       serverPlugin.init(properties);
 
@@ -797,12 +887,14 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
       Map<String, String> properties = getMapOfChildPropertyElements(item);
 
-      ActiveMQMetricsPlugin metricsPlugin = AccessController.doPrivileged(new PrivilegedAction<ActiveMQMetricsPlugin>() {
-         @Override
-         public ActiveMQMetricsPlugin run() {
-            return (ActiveMQMetricsPlugin) ClassloadingUtil.newInstanceFromClassLoader(FileConfigurationParser.class, clazz);
-         }
-      });
+      ActiveMQMetricsPlugin metricsPlugin = AccessController
+            .doPrivileged(new PrivilegedAction<ActiveMQMetricsPlugin>() {
+               @Override
+               public ActiveMQMetricsPlugin run() {
+                  return (ActiveMQMetricsPlugin) ClassloadingUtil
+                        .newInstanceFromClassLoader(FileConfigurationParser.class, clazz);
+               }
+            });
 
       ActiveMQServerLogger.LOGGER.initializingMetricsPlugin(clazz, properties.toString());
       config.setMetricsPlugin(metricsPlugin.init(properties));
@@ -818,11 +910,13 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       NodeList elements = e.getElementsByTagName("queues");
       if (elements.getLength() != 0) {
          Element node = (Element) elements.item(0);
-         config.setQueueConfigurations(parseQueueConfigurations(node, ActiveMQDefaultConfiguration.DEFAULT_ROUTING_TYPE));
+         config.setQueueConfigurations(
+               parseQueueConfigurations(node, ActiveMQDefaultConfiguration.DEFAULT_ROUTING_TYPE));
       }
    }
 
-   private List<CoreQueueConfiguration> parseQueueConfigurations(final Element node, RoutingType routingType) {
+   private List<CoreQueueConfiguration> parseQueueConfigurations(final Element node,
+         RoutingType routingType) {
       List<CoreQueueConfiguration> queueConfigurations = new ArrayList<>();
       NodeList list = node.getElementsByTagName("queue");
       for (int i = 0; i < list.getLength(); i++) {
@@ -886,7 +980,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
     * @param node
     * @return
     */
-   protected Pair<String, Set<Role>> parseSecurityRoles(final Node node, final Map<String, Set<String>> roleMappings) {
+   protected Pair<String, Set<Role>> parseSecurityRoles(final Node node,
+         final Map<String, Set<String>> roleMappings) {
       final String match = node.getAttributes().getNamedItem("match").getNodeValue();
 
       Set<Role> securityRoles = new HashSet<>();
@@ -950,16 +1045,23 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       }
 
       for (String role : allRoles) {
-         securityRoles.add(new Role(role, send.contains(role), consume.contains(role), createDurableQueue.contains(role), deleteDurableQueue.contains(role), createNonDurableQueue.contains(role), deleteNonDurableQueue.contains(role), manageRoles.contains(role), browseRoles.contains(role), createAddressRoles.contains(role), deleteAddressRoles.contains(role)));
+         securityRoles.add(new Role(role, send.contains(role), consume.contains(role),
+               createDurableQueue.contains(role), deleteDurableQueue.contains(role),
+               createNonDurableQueue.contains(role), deleteNonDurableQueue.contains(role),
+               manageRoles.contains(role), browseRoles.contains(role),
+               createAddressRoles.contains(role), deleteAddressRoles.contains(role)));
       }
 
       return securityMatch;
    }
 
    /**
-    * Translate and expand a set of role names to a set of mapped role names, also includes the original role names
-    * @param roles the original set of role names
-    * @param roleMappings a one-to-many mapping of original role names to mapped role names
+    * Translate and expand a set of role names to a set of mapped role names, also
+    * includes the original role names
+    *
+    * @param roles        the original set of role names
+    * @param roleMappings a one-to-many mapping of original role names to mapped
+    *                     role names
     * @return the final set of mapped role names
     */
    private String[] getMappedRoleNames(String[] roles, Map<String, Set<String>> roleMappings) {
@@ -973,7 +1075,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       return mappedRoles.toArray(new String[mappedRoles.size()]);
    }
 
-   private Pair<SecuritySettingPlugin, Map<String, String>> parseSecuritySettingPlugins(Node item, Boolean maskPassword, String passwordCodec) throws Exception {
+   private Pair<SecuritySettingPlugin, Map<String, String>> parseSecuritySettingPlugins(Node item,
+         Boolean maskPassword, String passwordCodec) throws Exception {
       final String clazz = item.getAttributes().getNamedItem("class-name").getNodeValue();
       final Map<String, String> settings = new HashMap<>();
       NodeList children = item.getChildNodes();
@@ -984,31 +1087,34 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
             final String settingName = getAttributeValue(child, NAME_ATTR_NAME);
             String settingValue = getAttributeValue(child, VALUE_ATTR_NAME);
             if (settingValue != null && PasswordMaskingUtil.isEncMasked(settingValue)) {
-               settingValue = PasswordMaskingUtil.resolveMask(maskPassword, settingValue, passwordCodec);
+               settingValue = PasswordMaskingUtil.resolveMask(maskPassword, settingValue,
+                     passwordCodec);
             }
             settings.put(settingName, settingValue);
          }
       }
 
-      SecuritySettingPlugin securitySettingPlugin = AccessController.doPrivileged(new PrivilegedAction<SecuritySettingPlugin>() {
-         @Override
-         public SecuritySettingPlugin run() {
-            return (SecuritySettingPlugin) ClassloadingUtil.newInstanceFromClassLoader(FileConfigurationParser.class, clazz);
-         }
-      });
+      SecuritySettingPlugin securitySettingPlugin = AccessController
+            .doPrivileged(new PrivilegedAction<SecuritySettingPlugin>() {
+               @Override
+               public SecuritySettingPlugin run() {
+                  return (SecuritySettingPlugin) ClassloadingUtil
+                        .newInstanceFromClassLoader(FileConfigurationParser.class, clazz);
+               }
+            });
 
       return new Pair<>(securitySettingPlugin, settings);
    }
 
    /**
-    * Computes the map of internal ActiveMQ role names to sets of external (e.g. LDAP) role names.  For example, given a role
-    * "myrole" with a DN of "cn=myrole,dc=local,dc=com":
-    *      from="cn=myrole,dc=local,dc=com", to="amq,admin,guest"
-    *      from="cn=myOtherRole,dc=local,dc=com", to="amq"
-    * The resulting map will consist of:
-    *      amq => {"cn=myrole,dc=local,dc=com","cn=myOtherRole",dc=local,dc=com"}
-    *      admin => {"cn=myrole,dc=local,dc=com"}
-    *      guest => {"cn=myrole,dc=local,dc=com"}
+    * Computes the map of internal ActiveMQ role names to sets of external (e.g.
+    * LDAP) role names. For example, given a role "myrole" with a DN of
+    * "cn=myrole,dc=local,dc=com": from="cn=myrole,dc=local,dc=com",
+    * to="amq,admin,guest" from="cn=myOtherRole,dc=local,dc=com", to="amq" The
+    * resulting map will consist of: amq =>
+    * {"cn=myrole,dc=local,dc=com","cn=myOtherRole",dc=local,dc=com"} admin =>
+    * {"cn=myrole,dc=local,dc=com"} guest => {"cn=myrole,dc=local,dc=com"}
+    *
     * @param item the role-mapping node
     * @return the map of local ActiveMQ role names to the set of mapped role names
     */
@@ -1062,15 +1168,20 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
             addressSettings.setRedeliveryMultiplier(XMLUtil.parseDouble(child));
          } else if (REDELIVERY_COLLISION_AVOIDANCE_FACTOR_NODE_NAME.equalsIgnoreCase(name)) {
             double redeliveryCollisionAvoidanceFactor = XMLUtil.parseDouble(child);
-            Validators.GE_ZERO.validate(REDELIVERY_COLLISION_AVOIDANCE_FACTOR_NODE_NAME, redeliveryCollisionAvoidanceFactor);
-            Validators.LE_ONE.validate(REDELIVERY_COLLISION_AVOIDANCE_FACTOR_NODE_NAME, redeliveryCollisionAvoidanceFactor);
-            addressSettings.setRedeliveryCollisionAvoidanceFactor(redeliveryCollisionAvoidanceFactor);
+            Validators.GE_ZERO.validate(REDELIVERY_COLLISION_AVOIDANCE_FACTOR_NODE_NAME,
+                  redeliveryCollisionAvoidanceFactor);
+            Validators.LE_ONE.validate(REDELIVERY_COLLISION_AVOIDANCE_FACTOR_NODE_NAME,
+                  redeliveryCollisionAvoidanceFactor);
+            addressSettings
+                  .setRedeliveryCollisionAvoidanceFactor(redeliveryCollisionAvoidanceFactor);
          } else if (MAX_REDELIVERY_DELAY_NODE_NAME.equalsIgnoreCase(name)) {
             addressSettings.setMaxRedeliveryDelay(XMLUtil.parseLong(child));
          } else if (MAX_SIZE_BYTES_NODE_NAME.equalsIgnoreCase(name)) {
-            addressSettings.setMaxSizeBytes(ByteUtil.convertTextBytes(getTrimmedTextContent(child)));
+            addressSettings
+                  .setMaxSizeBytes(ByteUtil.convertTextBytes(getTrimmedTextContent(child)));
          } else if (MAX_SIZE_BYTES_REJECT_THRESHOLD_NODE_NAME.equalsIgnoreCase(name)) {
-            addressSettings.setMaxSizeBytesRejectThreshold(ByteUtil.convertTextBytes(getTrimmedTextContent(child)));
+            addressSettings.setMaxSizeBytesRejectThreshold(
+                  ByteUtil.convertTextBytes(getTrimmedTextContent(child)));
          } else if (PAGE_SIZE_BYTES_NODE_NAME.equalsIgnoreCase(name)) {
             long pageSizeLong = ByteUtil.convertTextBytes(getTrimmedTextContent(child));
             Validators.POSITIVE_INT.validate(PAGE_SIZE_BYTES_NODE_NAME, pageSizeLong);
@@ -1081,13 +1192,16 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
             addressSettings.setMessageCounterHistoryDayLimit(XMLUtil.parseInt(child));
          } else if (ADDRESS_FULL_MESSAGE_POLICY_NODE_NAME.equalsIgnoreCase(name)) {
             String value = getTrimmedTextContent(child);
-            Validators.ADDRESS_FULL_MESSAGE_POLICY_TYPE.validate(ADDRESS_FULL_MESSAGE_POLICY_NODE_NAME, value);
+            Validators.ADDRESS_FULL_MESSAGE_POLICY_TYPE
+                  .validate(ADDRESS_FULL_MESSAGE_POLICY_NODE_NAME, value);
             AddressFullMessagePolicy policy = Enum.valueOf(AddressFullMessagePolicy.class, value);
             addressSettings.setAddressFullMessagePolicy(policy);
-         } else if (LVQ_NODE_NAME.equalsIgnoreCase(name) || DEFAULT_LVQ_NODE_NAME.equalsIgnoreCase(name)) {
+         } else if (LVQ_NODE_NAME.equalsIgnoreCase(name)
+               || DEFAULT_LVQ_NODE_NAME.equalsIgnoreCase(name)) {
             addressSettings.setDefaultLastValueQueue(XMLUtil.parseBoolean(child));
          } else if (DEFAULT_LVQ_KEY_NODE_NAME.equalsIgnoreCase(name)) {
-            addressSettings.setDefaultLastValueKey(SimpleString.toSimpleString(getTrimmedTextContent(child)));
+            addressSettings.setDefaultLastValueKey(
+                  SimpleString.toSimpleString(getTrimmedTextContent(child)));
          } else if (DEFAULT_NON_DESTRUCTIVE_NODE_NAME.equalsIgnoreCase(name)) {
             addressSettings.setDefaultNonDestructive(XMLUtil.parseBoolean(child));
          } else if (DEFAULT_EXCLUSIVE_NODE_NAME.equalsIgnoreCase(name)) {
@@ -1097,23 +1211,26 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
          } else if (DEFAULT_GROUP_BUCKETS.equalsIgnoreCase(name)) {
             addressSettings.setDefaultGroupBuckets(XMLUtil.parseInt(child));
          } else if (DEFAULT_GROUP_FIRST_KEY.equalsIgnoreCase(name)) {
-            addressSettings.setDefaultGroupFirstKey(SimpleString.toSimpleString(getTrimmedTextContent(child)));
+            addressSettings.setDefaultGroupFirstKey(
+                  SimpleString.toSimpleString(getTrimmedTextContent(child)));
          } else if (MAX_DELIVERY_ATTEMPTS.equalsIgnoreCase(name)) {
             addressSettings.setMaxDeliveryAttempts(XMLUtil.parseInt(child));
          } else if (REDISTRIBUTION_DELAY_NODE_NAME.equalsIgnoreCase(name)) {
             addressSettings.setRedistributionDelay(XMLUtil.parseLong(child));
          } else if (CLUSTERED_QUEUES_NODE_NAME.equalsIgnoreCase(name)) {
-           addressSettings.setClusteredQueues(XMLUtil.parseBoolean(child));
+            addressSettings.setClusteredQueues(XMLUtil.parseBoolean(child));
          } else if (SEND_TO_DLA_ON_NO_ROUTE.equalsIgnoreCase(name)) {
             addressSettings.setSendToDLAOnNoRoute(XMLUtil.parseBoolean(child));
          } else if (SLOW_CONSUMER_THRESHOLD_NODE_NAME.equalsIgnoreCase(name)) {
             long slowConsumerThreshold = XMLUtil.parseLong(child);
-            Validators.MINUS_ONE_OR_GT_ZERO.validate(SLOW_CONSUMER_THRESHOLD_NODE_NAME, slowConsumerThreshold);
+            Validators.MINUS_ONE_OR_GT_ZERO.validate(SLOW_CONSUMER_THRESHOLD_NODE_NAME,
+                  slowConsumerThreshold);
 
             addressSettings.setSlowConsumerThreshold(slowConsumerThreshold);
          } else if (SLOW_CONSUMER_CHECK_PERIOD_NODE_NAME.equalsIgnoreCase(name)) {
             long slowConsumerCheckPeriod = XMLUtil.parseLong(child);
-            Validators.GT_ZERO.validate(SLOW_CONSUMER_CHECK_PERIOD_NODE_NAME, slowConsumerCheckPeriod);
+            Validators.GT_ZERO.validate(SLOW_CONSUMER_CHECK_PERIOD_NODE_NAME,
+                  slowConsumerCheckPeriod);
 
             addressSettings.setSlowConsumerCheckPeriod(slowConsumerCheckPeriod);
          } else if (SLOW_CONSUMER_POLICY_NODE_NAME.equalsIgnoreCase(name)) {
@@ -1141,7 +1258,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
             addressSettings.setAutoDeleteQueuesDelay(autoDeleteQueuesDelay);
          } else if (AUTO_DELETE_QUEUES_MESSAGE_COUNT.equalsIgnoreCase(name)) {
             long autoDeleteQueuesMessageCount = XMLUtil.parseLong(child);
-            Validators.MINUS_ONE_OR_GE_ZERO.validate(AUTO_DELETE_QUEUES_MESSAGE_COUNT, autoDeleteQueuesMessageCount);
+            Validators.MINUS_ONE_OR_GE_ZERO.validate(AUTO_DELETE_QUEUES_MESSAGE_COUNT,
+                  autoDeleteQueuesMessageCount);
             addressSettings.setAutoDeleteQueuesMessageCount(autoDeleteQueuesMessageCount);
          } else if (CONFIG_DELETE_QUEUES.equalsIgnoreCase(name)) {
             String value = getTrimmedTextContent(child);
@@ -1282,24 +1400,13 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
          }
       }
 
-      return new CoreQueueConfiguration()
-              .setAddress(address)
-              .setName(name)
-              .setFilterString(filterString)
-              .setDurable(durable)
-              .setMaxConsumers(maxConsumers)
-              .setPurgeOnNoConsumers(purgeOnNoConsumers)
-              .setUser(user)
-              .setExclusive(exclusive)
-              .setGroupRebalance(groupRebalance)
-              .setGroupBuckets(groupBuckets)
-              .setGroupFirstKey(groupFirstKey)
-              .setLastValue(lastValue)
-              .setLastValueKey(lastValueKey)
-              .setNonDestructive(nonDestructive)
-              .setConsumersBeforeDispatch(consumersBeforeDispatch)
-              .setDelayBeforeDispatch(delayBeforeDispatch)
-              .setRingSize(ringSize);
+      return new CoreQueueConfiguration().setAddress(address).setName(name)
+            .setFilterString(filterString).setDurable(durable).setMaxConsumers(maxConsumers)
+            .setPurgeOnNoConsumers(purgeOnNoConsumers).setUser(user).setExclusive(exclusive)
+            .setGroupRebalance(groupRebalance).setGroupBuckets(groupBuckets)
+            .setGroupFirstKey(groupFirstKey).setLastValue(lastValue).setLastValueKey(lastValueKey)
+            .setNonDestructive(nonDestructive).setConsumersBeforeDispatch(consumersBeforeDispatch)
+            .setDelayBeforeDispatch(delayBeforeDispatch).setRingSize(ringSize);
    }
 
    protected CoreAddressConfiguration parseAddressConfiguration(final Node node) {
@@ -1314,10 +1421,12 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
          Node child = children.item(j);
          if (child.getNodeName().equals("multicast")) {
             addressConfiguration.addRoutingType(RoutingType.MULTICAST);
-            queueConfigurations.addAll(parseQueueConfigurations((Element) child, RoutingType.MULTICAST));
+            queueConfigurations
+                  .addAll(parseQueueConfigurations((Element) child, RoutingType.MULTICAST));
          } else if (child.getNodeName().equals("anycast")) {
             addressConfiguration.addRoutingType(RoutingType.ANYCAST);
-            queueConfigurations.addAll(parseQueueConfigurations((Element) child, RoutingType.ANYCAST));
+            queueConfigurations
+                  .addAll(parseQueueConfigurations((Element) child, RoutingType.ANYCAST));
          }
       }
 
@@ -1330,7 +1439,7 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
    }
 
    private TransportConfiguration parseAcceptorTransportConfiguration(final Element e,
-                                                                      final Configuration mainConfig) throws Exception {
+         final Configuration mainConfig) throws Exception {
       Node nameNode = e.getAttributes().getNamedItem("name");
 
       String name = nameNode != null ? nameNode.getNodeValue() : null;
@@ -1342,10 +1451,12 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       Map<String, Object> params = configurations.get(0).getParams();
 
       if (mainConfig.isMaskPassword() != null) {
-         params.put(ActiveMQDefaultConfiguration.getPropMaskPassword(), mainConfig.isMaskPassword());
+         params.put(ActiveMQDefaultConfiguration.getPropMaskPassword(),
+               mainConfig.isMaskPassword());
 
          if (mainConfig.isMaskPassword() && mainConfig.getPasswordCodec() != null) {
-            params.put(ActiveMQDefaultConfiguration.getPropPasswordCodec(), mainConfig.getPasswordCodec());
+            params.put(ActiveMQDefaultConfiguration.getPropPasswordCodec(),
+                  mainConfig.getPasswordCodec());
          }
       }
 
@@ -1353,7 +1464,7 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
    }
 
    private TransportConfiguration parseConnectorTransportConfiguration(final Element e,
-                                                                       final Configuration mainConfig) throws Exception {
+         final Configuration mainConfig) throws Exception {
       Node nameNode = e.getAttributes().getNamedItem("name");
 
       String name = nameNode != null ? nameNode.getNodeValue() : null;
@@ -1365,10 +1476,12 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       Map<String, Object> params = configurations.get(0).getParams();
 
       if (mainConfig.isMaskPassword() != null) {
-         params.put(ActiveMQDefaultConfiguration.getPropMaskPassword(), mainConfig.isMaskPassword());
+         params.put(ActiveMQDefaultConfiguration.getPropMaskPassword(),
+               mainConfig.isMaskPassword());
 
          if (mainConfig.isMaskPassword() && mainConfig.getPasswordCodec() != null) {
-            params.put(ActiveMQDefaultConfiguration.getPropPasswordCodec(), mainConfig.getPasswordCodec());
+            params.put(ActiveMQDefaultConfiguration.getPropPasswordCodec(),
+                  mainConfig.getPasswordCodec());
          }
       }
 
@@ -1390,7 +1503,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       STORE_TYPE_LIST.add("file-store");
    }
 
-   private void parseStoreConfiguration(final Element e, final Configuration mainConfig) throws Exception {
+   private void parseStoreConfiguration(final Element e, final Configuration mainConfig)
+         throws Exception {
       for (String storeType : STORE_TYPE_LIST) {
          NodeList storeNodeList = e.getElementsByTagName(storeType);
          if (storeNodeList.getLength() > 0) {
@@ -1439,7 +1553,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
                NodeList colocatedNodeList = e.getElementsByTagName("colocated");
                if (colocatedNodeList.getLength() > 0) {
                   Element colocatedNode = (Element) colocatedNodeList.item(0);
-                  mainConfig.setHAPolicyConfiguration(createColocatedHaPolicy(colocatedNode, false));
+                  mainConfig
+                        .setHAPolicyConfiguration(createColocatedHaPolicy(colocatedNode, false));
                }
             } else if (haNode.getTagName().equals("live-only")) {
                NodeList noneNodeList = e.getElementsByTagName("live-only");
@@ -1461,25 +1576,36 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
    private ReplicatedPolicyConfiguration createReplicatedHaPolicy(Element policyNode) {
       ReplicatedPolicyConfiguration configuration = new ReplicatedPolicyConfiguration();
 
-      configuration.setQuorumVoteWait(getInteger(policyNode, "quorum-vote-wait", ActiveMQDefaultConfiguration.getDefaultQuorumVoteWait(), Validators.GT_ZERO));
+      configuration.setQuorumVoteWait(getInteger(policyNode, "quorum-vote-wait",
+            ActiveMQDefaultConfiguration.getDefaultQuorumVoteWait(), Validators.GT_ZERO));
 
-      configuration.setCheckForLiveServer(getBoolean(policyNode, "check-for-live-server", configuration.isCheckForLiveServer()));
+      configuration.setCheckForLiveServer(
+            getBoolean(policyNode, "check-for-live-server", configuration.isCheckForLiveServer()));
 
-      configuration.setGroupName(getString(policyNode, "group-name", configuration.getGroupName(), Validators.NO_CHECK));
+      configuration.setGroupName(
+            getString(policyNode, "group-name", configuration.getGroupName(), Validators.NO_CHECK));
 
-      configuration.setClusterName(getString(policyNode, "cluster-name", configuration.getClusterName(), Validators.NO_CHECK));
+      configuration.setClusterName(getString(policyNode, "cluster-name",
+            configuration.getClusterName(), Validators.NO_CHECK));
 
-      configuration.setInitialReplicationSyncTimeout(getLong(policyNode, "initial-replication-sync-timeout", configuration.getInitialReplicationSyncTimeout(), Validators.GT_ZERO));
+      configuration.setInitialReplicationSyncTimeout(
+            getLong(policyNode, "initial-replication-sync-timeout",
+                  configuration.getInitialReplicationSyncTimeout(), Validators.GT_ZERO));
 
-      configuration.setVoteOnReplicationFailure(getBoolean(policyNode, "vote-on-replication-failure", configuration.getVoteOnReplicationFailure()));
+      configuration.setVoteOnReplicationFailure(getBoolean(policyNode,
+            "vote-on-replication-failure", configuration.getVoteOnReplicationFailure()));
 
-      configuration.setVoteRetries(getInteger(policyNode, "vote-retries", configuration.getVoteRetries(), Validators.MINUS_ONE_OR_GE_ZERO));
+      configuration.setVoteRetries(getInteger(policyNode, "vote-retries",
+            configuration.getVoteRetries(), Validators.MINUS_ONE_OR_GE_ZERO));
 
-      configuration.setVoteRetryWait(getLong(policyNode, "vote-retry-wait", configuration.getVoteRetryWait(), Validators.GT_ZERO));
+      configuration.setVoteRetryWait(getLong(policyNode, "vote-retry-wait",
+            configuration.getVoteRetryWait(), Validators.GT_ZERO));
 
-      configuration.setRetryReplicationWait(getLong(policyNode, "retry-replication-wait", configuration.getVoteRetryWait(), Validators.GT_ZERO));
+      configuration.setRetryReplicationWait(getLong(policyNode, "retry-replication-wait",
+            configuration.getVoteRetryWait(), Validators.GT_ZERO));
 
-      configuration.setQuorumSize(getInteger(policyNode, "quorum-size", configuration.getQuorumSize(), Validators.MINUS_ONE_OR_GT_ZERO));
+      configuration.setQuorumSize(getInteger(policyNode, "quorum-size",
+            configuration.getQuorumSize(), Validators.MINUS_ONE_OR_GT_ZERO));
 
       return configuration;
    }
@@ -1488,40 +1614,57 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
       ReplicaPolicyConfiguration configuration = new ReplicaPolicyConfiguration();
 
-      configuration.setQuorumVoteWait(getInteger(policyNode, "quorum-vote-wait", ActiveMQDefaultConfiguration.getDefaultQuorumVoteWait(), Validators.GT_ZERO));
+      configuration.setQuorumVoteWait(getInteger(policyNode, "quorum-vote-wait",
+            ActiveMQDefaultConfiguration.getDefaultQuorumVoteWait(), Validators.GT_ZERO));
 
-      configuration.setRestartBackup(getBoolean(policyNode, "restart-backup", configuration.isRestartBackup()));
+      configuration.setRestartBackup(
+            getBoolean(policyNode, "restart-backup", configuration.isRestartBackup()));
 
-      configuration.setGroupName(getString(policyNode, "group-name", configuration.getGroupName(), Validators.NO_CHECK));
+      configuration.setGroupName(
+            getString(policyNode, "group-name", configuration.getGroupName(), Validators.NO_CHECK));
 
-      configuration.setAllowFailBack(getBoolean(policyNode, "allow-failback", configuration.isAllowFailBack()));
+      configuration.setAllowFailBack(
+            getBoolean(policyNode, "allow-failback", configuration.isAllowFailBack()));
 
-      configuration.setInitialReplicationSyncTimeout(getLong(policyNode, "initial-replication-sync-timeout", configuration.getInitialReplicationSyncTimeout(), Validators.GT_ZERO));
+      configuration.setInitialReplicationSyncTimeout(
+            getLong(policyNode, "initial-replication-sync-timeout",
+                  configuration.getInitialReplicationSyncTimeout(), Validators.GT_ZERO));
 
-      configuration.setClusterName(getString(policyNode, "cluster-name", configuration.getClusterName(), Validators.NO_CHECK));
+      configuration.setClusterName(getString(policyNode, "cluster-name",
+            configuration.getClusterName(), Validators.NO_CHECK));
 
-      configuration.setMaxSavedReplicatedJournalsSize(getInteger(policyNode, "max-saved-replicated-journals-size", configuration.getMaxSavedReplicatedJournalsSize(), Validators.MINUS_ONE_OR_GE_ZERO));
+      configuration.setMaxSavedReplicatedJournalsSize(getInteger(policyNode,
+            "max-saved-replicated-journals-size", configuration.getMaxSavedReplicatedJournalsSize(),
+            Validators.MINUS_ONE_OR_GE_ZERO));
 
       configuration.setScaleDownConfiguration(parseScaleDownConfig(policyNode));
 
-      configuration.setVoteOnReplicationFailure(getBoolean(policyNode, "vote-on-replication-failure", configuration.getVoteOnReplicationFailure()));
+      configuration.setVoteOnReplicationFailure(getBoolean(policyNode,
+            "vote-on-replication-failure", configuration.getVoteOnReplicationFailure()));
 
-      configuration.setVoteRetries(getInteger(policyNode, "vote-retries", configuration.getVoteRetries(), Validators.MINUS_ONE_OR_GE_ZERO));
+      configuration.setVoteRetries(getInteger(policyNode, "vote-retries",
+            configuration.getVoteRetries(), Validators.MINUS_ONE_OR_GE_ZERO));
 
-      configuration.setVoteRetryWait(getLong(policyNode, "vote-retry-wait", configuration.getVoteRetryWait(), Validators.GT_ZERO));
+      configuration.setVoteRetryWait(getLong(policyNode, "vote-retry-wait",
+            configuration.getVoteRetryWait(), Validators.GT_ZERO));
 
-      configuration.setRetryReplicationWait(getLong(policyNode, "retry-replication-wait", configuration.getVoteRetryWait(), Validators.GT_ZERO));
+      configuration.setRetryReplicationWait(getLong(policyNode, "retry-replication-wait",
+            configuration.getVoteRetryWait(), Validators.GT_ZERO));
 
-      configuration.setQuorumSize(getInteger(policyNode, "quorum-size", configuration.getQuorumSize(), Validators.MINUS_ONE_OR_GT_ZERO));
+      configuration.setQuorumSize(getInteger(policyNode, "quorum-size",
+            configuration.getQuorumSize(), Validators.MINUS_ONE_OR_GT_ZERO));
 
       return configuration;
    }
 
-   private SharedStoreMasterPolicyConfiguration createSharedStoreMasterHaPolicy(Element policyNode) {
+   private SharedStoreMasterPolicyConfiguration createSharedStoreMasterHaPolicy(
+         Element policyNode) {
       SharedStoreMasterPolicyConfiguration configuration = new SharedStoreMasterPolicyConfiguration();
 
-      configuration.setFailoverOnServerShutdown(getBoolean(policyNode, "failover-on-shutdown", configuration.isFailoverOnServerShutdown()));
-      configuration.setWaitForActivation(getBoolean(policyNode, "wait-for-activation", configuration.isWaitForActivation()));
+      configuration.setFailoverOnServerShutdown(getBoolean(policyNode, "failover-on-shutdown",
+            configuration.isFailoverOnServerShutdown()));
+      configuration.setWaitForActivation(
+            getBoolean(policyNode, "wait-for-activation", configuration.isWaitForActivation()));
 
       return configuration;
    }
@@ -1529,37 +1672,46 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
    private SharedStoreSlavePolicyConfiguration createSharedStoreSlaveHaPolicy(Element policyNode) {
       SharedStoreSlavePolicyConfiguration configuration = new SharedStoreSlavePolicyConfiguration();
 
-      configuration.setAllowFailBack(getBoolean(policyNode, "allow-failback", configuration.isAllowFailBack()));
+      configuration.setAllowFailBack(
+            getBoolean(policyNode, "allow-failback", configuration.isAllowFailBack()));
 
-      configuration.setFailoverOnServerShutdown(getBoolean(policyNode, "failover-on-shutdown", configuration.isFailoverOnServerShutdown()));
+      configuration.setFailoverOnServerShutdown(getBoolean(policyNode, "failover-on-shutdown",
+            configuration.isFailoverOnServerShutdown()));
 
-      configuration.setRestartBackup(getBoolean(policyNode, "restart-backup", configuration.isRestartBackup()));
+      configuration.setRestartBackup(
+            getBoolean(policyNode, "restart-backup", configuration.isRestartBackup()));
 
       configuration.setScaleDownConfiguration(parseScaleDownConfig(policyNode));
 
       return configuration;
    }
 
-   private ColocatedPolicyConfiguration createColocatedHaPolicy(Element policyNode, boolean replicated) {
+   private ColocatedPolicyConfiguration createColocatedHaPolicy(Element policyNode,
+         boolean replicated) {
       ColocatedPolicyConfiguration configuration = new ColocatedPolicyConfiguration();
 
-      boolean requestBackup = getBoolean(policyNode, "request-backup", configuration.isRequestBackup());
+      boolean requestBackup = getBoolean(policyNode, "request-backup",
+            configuration.isRequestBackup());
 
       configuration.setRequestBackup(requestBackup);
 
-      int backupRequestRetries = getInteger(policyNode, "backup-request-retries", configuration.getBackupRequestRetries(), Validators.MINUS_ONE_OR_GE_ZERO);
+      int backupRequestRetries = getInteger(policyNode, "backup-request-retries",
+            configuration.getBackupRequestRetries(), Validators.MINUS_ONE_OR_GE_ZERO);
 
       configuration.setBackupRequestRetries(backupRequestRetries);
 
-      long backupRequestRetryInterval = getLong(policyNode, "backup-request-retry-interval", configuration.getBackupRequestRetryInterval(), Validators.GT_ZERO);
+      long backupRequestRetryInterval = getLong(policyNode, "backup-request-retry-interval",
+            configuration.getBackupRequestRetryInterval(), Validators.GT_ZERO);
 
       configuration.setBackupRequestRetryInterval(backupRequestRetryInterval);
 
-      int maxBackups = getInteger(policyNode, "max-backups", configuration.getMaxBackups(), Validators.GE_ZERO);
+      int maxBackups = getInteger(policyNode, "max-backups", configuration.getMaxBackups(),
+            Validators.GE_ZERO);
 
       configuration.setMaxBackups(maxBackups);
 
-      int backupPortOffset = getInteger(policyNode, "backup-port-offset", configuration.getBackupPortOffset(), Validators.GT_ZERO);
+      int backupPortOffset = getInteger(policyNode, "backup-port-offset",
+            configuration.getBackupPortOffset(), Validators.GT_ZERO);
 
       configuration.setBackupPortOffset(backupPortOffset);
 
@@ -1579,12 +1731,14 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       NodeList masterNodeList = policyNode.getElementsByTagName("master");
       if (masterNodeList.getLength() > 0) {
          Element masterNode = (Element) masterNodeList.item(0);
-         configuration.setLiveConfig(replicated ? createReplicatedHaPolicy(masterNode) : createSharedStoreMasterHaPolicy(masterNode));
+         configuration.setLiveConfig(replicated ? createReplicatedHaPolicy(masterNode)
+               : createSharedStoreMasterHaPolicy(masterNode));
       }
       NodeList slaveNodeList = policyNode.getElementsByTagName("slave");
       if (slaveNodeList.getLength() > 0) {
          Element slaveNode = (Element) slaveNodeList.item(0);
-         configuration.setBackupConfig(replicated ? createReplicaHaPolicy(slaveNode) : createSharedStoreSlaveHaPolicy(slaveNode));
+         configuration.setBackupConfig(replicated ? createReplicaHaPolicy(slaveNode)
+               : createSharedStoreSlaveHaPolicy(slaveNode));
       }
 
       return configuration;
@@ -1598,15 +1752,18 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
          Element scaleDownElement = (Element) scaleDownNode.item(0);
 
-         scaleDownConfiguration.setEnabled(getBoolean(scaleDownElement, "enabled", scaleDownConfiguration.isEnabled()));
+         scaleDownConfiguration.setEnabled(
+               getBoolean(scaleDownElement, "enabled", scaleDownConfiguration.isEnabled()));
 
          NodeList discoveryGroupRef = scaleDownElement.getElementsByTagName("discovery-group-ref");
 
          if (discoveryGroupRef.item(0) != null) {
-            scaleDownConfiguration.setDiscoveryGroup(discoveryGroupRef.item(0).getAttributes().getNamedItem("discovery-group-name").getNodeValue());
+            scaleDownConfiguration.setDiscoveryGroup(discoveryGroupRef.item(0).getAttributes()
+                  .getNamedItem("discovery-group-name").getNodeValue());
          }
 
-         String scaleDownGroupName = getString(scaleDownElement, "group-name", scaleDownConfiguration.getGroupName(), Validators.NO_CHECK);
+         String scaleDownGroupName = getString(scaleDownElement, "group-name",
+               scaleDownConfiguration.getGroupName(), Validators.NO_CHECK);
 
          scaleDownConfiguration.setGroupName(scaleDownGroupName);
 
@@ -1628,27 +1785,42 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       return null;
    }
 
-   private DatabaseStorageConfiguration createDatabaseStoreConfig(Element storeNode, Configuration mainConfig) throws Exception {
+   private DatabaseStorageConfiguration createDatabaseStoreConfig(Element storeNode,
+         Configuration mainConfig) throws Exception {
       DatabaseStorageConfiguration conf = new DatabaseStorageConfiguration();
-      conf.setBindingsTableName(getString(storeNode, "bindings-table-name", conf.getBindingsTableName(), Validators.NO_CHECK));
-      conf.setMessageTableName(getString(storeNode, "message-table-name", conf.getMessageTableName(), Validators.NO_CHECK));
-      conf.setLargeMessageTableName(getString(storeNode, "large-message-table-name", conf.getJdbcConnectionUrl(), Validators.NO_CHECK));
-      conf.setPageStoreTableName(getString(storeNode, "page-store-table-name", conf.getPageStoreTableName(), Validators.NO_CHECK));
-      conf.setNodeManagerStoreTableName(getString(storeNode, "node-manager-store-table-name", conf.getNodeManagerStoreTableName(), Validators.NO_CHECK));
-      conf.setJdbcConnectionUrl(getString(storeNode, "jdbc-connection-url", conf.getJdbcConnectionUrl(), Validators.NO_CHECK));
-      conf.setJdbcDriverClassName(getString(storeNode, "jdbc-driver-class-name", conf.getJdbcDriverClassName(), Validators.NO_CHECK));
-      conf.setJdbcNetworkTimeout(getInteger(storeNode, "jdbc-network-timeout", conf.getJdbcNetworkTimeout(), Validators.NO_CHECK));
-      conf.setJdbcLockRenewPeriodMillis(getLong(storeNode, "jdbc-lock-renew-period", conf.getJdbcLockRenewPeriodMillis(), Validators.NO_CHECK));
-      conf.setJdbcLockExpirationMillis(getLong(storeNode, "jdbc-lock-expiration", conf.getJdbcLockExpirationMillis(), Validators.NO_CHECK));
-      conf.setJdbcJournalSyncPeriodMillis(getLong(storeNode, "jdbc-journal-sync-period", conf.getJdbcJournalSyncPeriodMillis(), Validators.NO_CHECK));
+      conf.setBindingsTableName(getString(storeNode, "bindings-table-name",
+            conf.getBindingsTableName(), Validators.NO_CHECK));
+      conf.setMessageTableName(getString(storeNode, "message-table-name",
+            conf.getMessageTableName(), Validators.NO_CHECK));
+      conf.setLargeMessageTableName(getString(storeNode, "large-message-table-name",
+            conf.getJdbcConnectionUrl(), Validators.NO_CHECK));
+      conf.setPageStoreTableName(getString(storeNode, "page-store-table-name",
+            conf.getPageStoreTableName(), Validators.NO_CHECK));
+      conf.setNodeManagerStoreTableName(getString(storeNode, "node-manager-store-table-name",
+            conf.getNodeManagerStoreTableName(), Validators.NO_CHECK));
+      conf.setJdbcConnectionUrl(getString(storeNode, "jdbc-connection-url",
+            conf.getJdbcConnectionUrl(), Validators.NO_CHECK));
+      conf.setJdbcDriverClassName(getString(storeNode, "jdbc-driver-class-name",
+            conf.getJdbcDriverClassName(), Validators.NO_CHECK));
+      conf.setJdbcNetworkTimeout(getInteger(storeNode, "jdbc-network-timeout",
+            conf.getJdbcNetworkTimeout(), Validators.NO_CHECK));
+      conf.setJdbcLockRenewPeriodMillis(getLong(storeNode, "jdbc-lock-renew-period",
+            conf.getJdbcLockRenewPeriodMillis(), Validators.NO_CHECK));
+      conf.setJdbcLockExpirationMillis(getLong(storeNode, "jdbc-lock-expiration",
+            conf.getJdbcLockExpirationMillis(), Validators.NO_CHECK));
+      conf.setJdbcJournalSyncPeriodMillis(getLong(storeNode, "jdbc-journal-sync-period",
+            conf.getJdbcJournalSyncPeriodMillis(), Validators.NO_CHECK));
       String jdbcUser = getString(storeNode, "jdbc-user", conf.getJdbcUser(), Validators.NO_CHECK);
       if (jdbcUser != null) {
-         jdbcUser = PasswordMaskingUtil.resolveMask(mainConfig.isMaskPassword(), jdbcUser, mainConfig.getPasswordCodec());
+         jdbcUser = PasswordMaskingUtil.resolveMask(mainConfig.isMaskPassword(), jdbcUser,
+               mainConfig.getPasswordCodec());
       }
       conf.setJdbcUser(jdbcUser);
-      String password = getString(storeNode, "jdbc-password", conf.getJdbcPassword(), Validators.NO_CHECK);
+      String password = getString(storeNode, "jdbc-password", conf.getJdbcPassword(),
+            Validators.NO_CHECK);
       if (password != null) {
-         password = PasswordMaskingUtil.resolveMask(mainConfig.isMaskPassword(), password, mainConfig.getPasswordCodec());
+         password = PasswordMaskingUtil.resolveMask(mainConfig.isMaskPassword(), password,
+               mainConfig.getPasswordCodec());
       }
       conf.setJdbcPassword(password);
       return conf;
@@ -1669,13 +1841,15 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
          Node child = children.item(j);
 
          if (child.getNodeName().equals("connector-ref")) {
-            String connectorName = getString(e, "connector-ref", null, Validators.NOT_NULL_OR_EMPTY);
+            String connectorName = getString(e, "connector-ref", null,
+                  Validators.NOT_NULL_OR_EMPTY);
 
             connectorNames.add(connectorName);
          }
       }
 
-      long broadcastPeriod = getLong(e, "broadcast-period", ActiveMQDefaultConfiguration.getDefaultBroadcastPeriod(), Validators.GT_ZERO);
+      long broadcastPeriod = getLong(e, "broadcast-period",
+            ActiveMQDefaultConfiguration.getDefaultBroadcastPeriod(), Validators.GT_ZERO);
 
       String localAddress = getString(e, "local-bind-address", null, Validators.NO_CHECK);
 
@@ -1694,12 +1868,17 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       BroadcastEndpointFactory endpointFactory;
 
       if (jgroupsFile != null) {
-         endpointFactory = new JGroupsFileBroadcastEndpointFactory().setFile(jgroupsFile).setChannelName(jgroupsChannel);
+         endpointFactory = new JGroupsFileBroadcastEndpointFactory().setFile(jgroupsFile)
+               .setChannelName(jgroupsChannel);
       } else {
-         endpointFactory = new UDPBroadcastEndpointFactory().setGroupAddress(groupAddress).setGroupPort(groupPort).setLocalBindAddress(localAddress).setLocalBindPort(localBindPort);
+         endpointFactory = new UDPBroadcastEndpointFactory().setGroupAddress(groupAddress)
+               .setGroupPort(groupPort).setLocalBindAddress(localAddress)
+               .setLocalBindPort(localBindPort);
       }
 
-      BroadcastGroupConfiguration config = new BroadcastGroupConfiguration().setName(name).setBroadcastPeriod(broadcastPeriod).setConnectorInfos(connectorNames).setEndpointFactory(endpointFactory);
+      BroadcastGroupConfiguration config = new BroadcastGroupConfiguration().setName(name)
+            .setBroadcastPeriod(broadcastPeriod).setConnectorInfos(connectorNames)
+            .setEndpointFactory(endpointFactory);
 
       mainConfig.getBroadcastGroupConfigurations().add(config);
    }
@@ -1707,9 +1886,11 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
    private void parseDiscoveryGroupConfiguration(final Element e, final Configuration mainConfig) {
       String name = e.getAttribute("name");
 
-      long discoveryInitialWaitTimeout = getLong(e, "initial-wait-timeout", ActiveMQClient.DEFAULT_DISCOVERY_INITIAL_WAIT_TIMEOUT, Validators.GT_ZERO);
+      long discoveryInitialWaitTimeout = getLong(e, "initial-wait-timeout",
+            ActiveMQClient.DEFAULT_DISCOVERY_INITIAL_WAIT_TIMEOUT, Validators.GT_ZERO);
 
-      long refreshTimeout = getLong(e, "refresh-timeout", ActiveMQDefaultConfiguration.getDefaultBroadcastRefreshTimeout(), Validators.GT_ZERO);
+      long refreshTimeout = getLong(e, "refresh-timeout",
+            ActiveMQDefaultConfiguration.getDefaultBroadcastRefreshTimeout(), Validators.GT_ZERO);
 
       String localBindAddress = getString(e, "local-bind-address", null, Validators.NO_CHECK);
 
@@ -1726,12 +1907,18 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       // TODO: validate if either jgroups or UDP is being filled
       BroadcastEndpointFactory endpointFactory;
       if (jgroupsFile != null) {
-         endpointFactory = new JGroupsFileBroadcastEndpointFactory().setFile(jgroupsFile).setChannelName(jgroupsChannel);
+         endpointFactory = new JGroupsFileBroadcastEndpointFactory().setFile(jgroupsFile)
+               .setChannelName(jgroupsChannel);
       } else {
-         endpointFactory = new UDPBroadcastEndpointFactory().setGroupAddress(groupAddress).setGroupPort(groupPort).setLocalBindAddress(localBindAddress).setLocalBindPort(localBindPort);
+         endpointFactory = new UDPBroadcastEndpointFactory().setGroupAddress(groupAddress)
+               .setGroupPort(groupPort).setLocalBindAddress(localBindAddress)
+               .setLocalBindPort(localBindPort);
       }
 
-      DiscoveryGroupConfiguration config = new DiscoveryGroupConfiguration().setName(name).setRefreshTimeout(refreshTimeout).setDiscoveryInitialWaitTimeout(discoveryInitialWaitTimeout).setBroadcastEndpointFactory(endpointFactory);
+      DiscoveryGroupConfiguration config = new DiscoveryGroupConfiguration().setName(name)
+            .setRefreshTimeout(refreshTimeout)
+            .setDiscoveryInitialWaitTimeout(discoveryInitialWaitTimeout)
+            .setBroadcastEndpointFactory(endpointFactory);
 
       if (mainConfig.getDiscoveryGroupConfigurations().containsKey(name)) {
          ActiveMQServerLogger.LOGGER.discoveryGroupAlreadyDeployed(name);
@@ -1743,7 +1930,7 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
    }
 
    private void parseClusterConnectionConfigurationURI(final Element e,
-                                                       final Configuration mainConfig) throws Exception {
+         final Configuration mainConfig) throws Exception {
       String name = e.getAttribute("name");
 
       String uri = e.getAttribute("address");
@@ -1753,7 +1940,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       System.out.println("Adding cluster connection :: " + config);
    }
 
-   private void parseClusterConnectionConfiguration(final Element e, final Configuration mainConfig) throws Exception {
+   private void parseClusterConnectionConfiguration(final Element e, final Configuration mainConfig)
+         throws Exception {
       String name = e.getAttribute("name");
 
       String address = getString(e, "address", "", Validators.NO_CHECK);
@@ -1765,12 +1953,14 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
          return;
       }
 
-      boolean duplicateDetection = getBoolean(e, "use-duplicate-detection", ActiveMQDefaultConfiguration.isDefaultClusterDuplicateDetection());
+      boolean duplicateDetection = getBoolean(e, "use-duplicate-detection",
+            ActiveMQDefaultConfiguration.isDefaultClusterDuplicateDetection());
 
       MessageLoadBalancingType messageLoadBalancingType;
 
       if (parameterExists(e, "forward-when-no-consumers")) {
-         boolean forwardWhenNoConsumers = getBoolean(e, "forward-when-no-consumers", ActiveMQDefaultConfiguration.isDefaultClusterForwardWhenNoConsumers());
+         boolean forwardWhenNoConsumers = getBoolean(e, "forward-when-no-consumers",
+               ActiveMQDefaultConfiguration.isDefaultClusterForwardWhenNoConsumers());
          if (forwardWhenNoConsumers) {
             messageLoadBalancingType = MessageLoadBalancingType.STRICT;
          } else {
@@ -1778,38 +1968,63 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
          }
       } else {
 
-         messageLoadBalancingType = Enum.valueOf(MessageLoadBalancingType.class, getString(e, "message-load-balancing", ActiveMQDefaultConfiguration.getDefaultClusterMessageLoadBalancingType(), Validators.MESSAGE_LOAD_BALANCING_TYPE));
+         messageLoadBalancingType = Enum.valueOf(MessageLoadBalancingType.class,
+               getString(e, "message-load-balancing",
+                     ActiveMQDefaultConfiguration.getDefaultClusterMessageLoadBalancingType(),
+                     Validators.MESSAGE_LOAD_BALANCING_TYPE));
       }
 
-      int maxHops = getInteger(e, "max-hops", ActiveMQDefaultConfiguration.getDefaultClusterMaxHops(), Validators.GE_ZERO);
+      int maxHops = getInteger(e, "max-hops",
+            ActiveMQDefaultConfiguration.getDefaultClusterMaxHops(), Validators.GE_ZERO);
 
-      long clientFailureCheckPeriod = getLong(e, "check-period", ActiveMQDefaultConfiguration.getDefaultClusterFailureCheckPeriod(), Validators.GT_ZERO);
+      long clientFailureCheckPeriod = getLong(e, "check-period",
+            ActiveMQDefaultConfiguration.getDefaultClusterFailureCheckPeriod(), Validators.GT_ZERO);
 
-      long connectionTTL = getLong(e, "connection-ttl", ActiveMQDefaultConfiguration.getDefaultClusterConnectionTtl(), Validators.GT_ZERO);
+      long connectionTTL = getLong(e, "connection-ttl",
+            ActiveMQDefaultConfiguration.getDefaultClusterConnectionTtl(), Validators.GT_ZERO);
 
-      long retryInterval = getLong(e, "retry-interval", ActiveMQDefaultConfiguration.getDefaultClusterRetryInterval(), Validators.GT_ZERO);
+      long retryInterval = getLong(e, "retry-interval",
+            ActiveMQDefaultConfiguration.getDefaultClusterRetryInterval(), Validators.GT_ZERO);
 
-      long callTimeout = getLong(e, "call-timeout", ActiveMQClient.DEFAULT_CALL_TIMEOUT, Validators.GT_ZERO);
+      long callTimeout = getLong(e, "call-timeout", ActiveMQClient.DEFAULT_CALL_TIMEOUT,
+            Validators.GT_ZERO);
 
-      long callFailoverTimeout = getLong(e, "call-failover-timeout", ActiveMQClient.DEFAULT_CALL_FAILOVER_TIMEOUT, Validators.MINUS_ONE_OR_GT_ZERO);
+      long callFailoverTimeout = getLong(e, "call-failover-timeout",
+            ActiveMQClient.DEFAULT_CALL_FAILOVER_TIMEOUT, Validators.MINUS_ONE_OR_GT_ZERO);
 
-      double retryIntervalMultiplier = getDouble(e, "retry-interval-multiplier", ActiveMQDefaultConfiguration.getDefaultClusterRetryIntervalMultiplier(), Validators.GT_ZERO);
+      double retryIntervalMultiplier = getDouble(e, "retry-interval-multiplier",
+            ActiveMQDefaultConfiguration.getDefaultClusterRetryIntervalMultiplier(),
+            Validators.GT_ZERO);
 
-      int minLargeMessageSize = getTextBytesAsIntBytes(e, "min-large-message-size", ActiveMQClient.DEFAULT_MIN_LARGE_MESSAGE_SIZE, Validators.POSITIVE_INT);
+      int minLargeMessageSize = getTextBytesAsIntBytes(e, "min-large-message-size",
+            ActiveMQClient.DEFAULT_MIN_LARGE_MESSAGE_SIZE, Validators.POSITIVE_INT);
 
-      long maxRetryInterval = getLong(e, "max-retry-interval", ActiveMQDefaultConfiguration.getDefaultClusterMaxRetryInterval(), Validators.GT_ZERO);
+      long maxRetryInterval = getLong(e, "max-retry-interval",
+            ActiveMQDefaultConfiguration.getDefaultClusterMaxRetryInterval(), Validators.GT_ZERO);
 
-      int initialConnectAttempts = getInteger(e, "initial-connect-attempts", ActiveMQDefaultConfiguration.getDefaultClusterInitialConnectAttempts(), Validators.MINUS_ONE_OR_GE_ZERO);
+      int initialConnectAttempts = getInteger(e, "initial-connect-attempts",
+            ActiveMQDefaultConfiguration.getDefaultClusterInitialConnectAttempts(),
+            Validators.MINUS_ONE_OR_GE_ZERO);
 
-      int reconnectAttempts = getInteger(e, "reconnect-attempts", ActiveMQDefaultConfiguration.getDefaultClusterReconnectAttempts(), Validators.MINUS_ONE_OR_GE_ZERO);
+      int reconnectAttempts = getInteger(e, "reconnect-attempts",
+            ActiveMQDefaultConfiguration.getDefaultClusterReconnectAttempts(),
+            Validators.MINUS_ONE_OR_GE_ZERO);
 
-      int confirmationWindowSize = getTextBytesAsIntBytes(e, "confirmation-window-size", ActiveMQDefaultConfiguration.getDefaultClusterConfirmationWindowSize(), Validators.POSITIVE_INT);
+      int confirmationWindowSize = getTextBytesAsIntBytes(e, "confirmation-window-size",
+            ActiveMQDefaultConfiguration.getDefaultClusterConfirmationWindowSize(),
+            Validators.POSITIVE_INT);
 
-      int producerWindowSize = getTextBytesAsIntBytes(e, "producer-window-size", ActiveMQDefaultConfiguration.getDefaultBridgeProducerWindowSize(), Validators.MINUS_ONE_OR_POSITIVE_INT);
+      int producerWindowSize = getTextBytesAsIntBytes(e, "producer-window-size",
+            ActiveMQDefaultConfiguration.getDefaultBridgeProducerWindowSize(),
+            Validators.MINUS_ONE_OR_POSITIVE_INT);
 
-      long clusterNotificationInterval = getLong(e, "notification-interval", ActiveMQDefaultConfiguration.getDefaultClusterNotificationInterval(), Validators.GT_ZERO);
+      long clusterNotificationInterval = getLong(e, "notification-interval",
+            ActiveMQDefaultConfiguration.getDefaultClusterNotificationInterval(),
+            Validators.GT_ZERO);
 
-      int clusterNotificationAttempts = getInteger(e, "notification-attempts", ActiveMQDefaultConfiguration.getDefaultClusterNotificationAttempts(), Validators.GT_ZERO);
+      int clusterNotificationAttempts = getInteger(e, "notification-attempts",
+            ActiveMQDefaultConfiguration.getDefaultClusterNotificationAttempts(),
+            Validators.GT_ZERO);
 
       String scaleDownConnector = e.getAttribute("scale-down-connector");
 
@@ -1825,17 +2040,32 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
          Node child = children.item(j);
 
          if (child.getNodeName().equals("discovery-group-ref")) {
-            discoveryGroupName = child.getAttributes().getNamedItem("discovery-group-name").getNodeValue();
+            discoveryGroupName = child.getAttributes().getNamedItem("discovery-group-name")
+                  .getNodeValue();
          } else if (child.getNodeName().equals("static-connectors")) {
             Node attr = child.getAttributes().getNamedItem("allow-direct-connections-only");
             if (attr != null) {
-               allowDirectConnectionsOnly = "true".equalsIgnoreCase(attr.getNodeValue()) || allowDirectConnectionsOnly;
+               allowDirectConnectionsOnly = "true".equalsIgnoreCase(attr.getNodeValue())
+                     || allowDirectConnectionsOnly;
             }
             getStaticConnectors(staticConnectorNames, child);
          }
       }
 
-      ClusterConnectionConfiguration config = new ClusterConnectionConfiguration().setName(name).setAddress(address).setConnectorName(connectorName).setMinLargeMessageSize(minLargeMessageSize).setClientFailureCheckPeriod(clientFailureCheckPeriod).setConnectionTTL(connectionTTL).setRetryInterval(retryInterval).setRetryIntervalMultiplier(retryIntervalMultiplier).setMaxRetryInterval(maxRetryInterval).setInitialConnectAttempts(initialConnectAttempts).setReconnectAttempts(reconnectAttempts).setCallTimeout(callTimeout).setCallFailoverTimeout(callFailoverTimeout).setDuplicateDetection(duplicateDetection).setMessageLoadBalancingType(messageLoadBalancingType).setMaxHops(maxHops).setConfirmationWindowSize(confirmationWindowSize).setProducerWindowSize(producerWindowSize).setAllowDirectConnectionsOnly(allowDirectConnectionsOnly).setClusterNotificationInterval(clusterNotificationInterval).setClusterNotificationAttempts(clusterNotificationAttempts);
+      ClusterConnectionConfiguration config = new ClusterConnectionConfiguration().setName(name)
+            .setAddress(address).setConnectorName(connectorName)
+            .setMinLargeMessageSize(minLargeMessageSize)
+            .setClientFailureCheckPeriod(clientFailureCheckPeriod).setConnectionTTL(connectionTTL)
+            .setRetryInterval(retryInterval).setRetryIntervalMultiplier(retryIntervalMultiplier)
+            .setMaxRetryInterval(maxRetryInterval).setInitialConnectAttempts(initialConnectAttempts)
+            .setReconnectAttempts(reconnectAttempts).setCallTimeout(callTimeout)
+            .setCallFailoverTimeout(callFailoverTimeout).setDuplicateDetection(duplicateDetection)
+            .setMessageLoadBalancingType(messageLoadBalancingType).setMaxHops(maxHops)
+            .setConfirmationWindowSize(confirmationWindowSize)
+            .setProducerWindowSize(producerWindowSize)
+            .setAllowDirectConnectionsOnly(allowDirectConnectionsOnly)
+            .setClusterNotificationInterval(clusterNotificationInterval)
+            .setClusterNotificationAttempts(clusterNotificationAttempts);
 
       if (discoveryGroupName == null) {
          config.setStaticConnectors(staticConnectorNames);
@@ -1846,14 +2076,26 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       mainConfig.getClusterConfigurations().add(config);
    }
 
-   private void parseGroupingHandlerConfiguration(final Element node, final Configuration mainConfiguration) {
+   private void parseGroupingHandlerConfiguration(final Element node,
+         final Configuration mainConfiguration) {
       String name = node.getAttribute("name");
       String type = getString(node, "type", null, Validators.NOT_NULL_OR_EMPTY);
       String address = getString(node, "address", "", Validators.NO_CHECK);
-      Integer timeout = getInteger(node, "timeout", ActiveMQDefaultConfiguration.getDefaultGroupingHandlerTimeout(), Validators.GT_ZERO);
-      Long groupTimeout = getLong(node, "group-timeout", ActiveMQDefaultConfiguration.getDefaultGroupingHandlerGroupTimeout(), Validators.MINUS_ONE_OR_GT_ZERO);
-      Long reaperPeriod = getLong(node, "reaper-period", ActiveMQDefaultConfiguration.getDefaultGroupingHandlerReaperPeriod(), Validators.GT_ZERO);
-      mainConfiguration.setGroupingHandlerConfiguration(new GroupingHandlerConfiguration().setName(new SimpleString(name)).setType(type.equals(GroupingHandlerConfiguration.TYPE.LOCAL.getType()) ? GroupingHandlerConfiguration.TYPE.LOCAL : GroupingHandlerConfiguration.TYPE.REMOTE).setAddress(new SimpleString(address)).setTimeout(timeout).setGroupTimeout(groupTimeout).setReaperPeriod(reaperPeriod));
+      Integer timeout = getInteger(node, "timeout",
+            ActiveMQDefaultConfiguration.getDefaultGroupingHandlerTimeout(), Validators.GT_ZERO);
+      Long groupTimeout = getLong(node, "group-timeout",
+            ActiveMQDefaultConfiguration.getDefaultGroupingHandlerGroupTimeout(),
+            Validators.MINUS_ONE_OR_GT_ZERO);
+      Long reaperPeriod = getLong(node, "reaper-period",
+            ActiveMQDefaultConfiguration.getDefaultGroupingHandlerReaperPeriod(),
+            Validators.GT_ZERO);
+      mainConfiguration.setGroupingHandlerConfiguration(new GroupingHandlerConfiguration()
+            .setName(new SimpleString(name))
+            .setType(type.equals(GroupingHandlerConfiguration.TYPE.LOCAL.getType())
+                  ? GroupingHandlerConfiguration.TYPE.LOCAL
+                  : GroupingHandlerConfiguration.TYPE.REMOTE)
+            .setAddress(new SimpleString(address)).setTimeout(timeout).setGroupTimeout(groupTimeout)
+            .setReaperPeriod(reaperPeriod));
    }
 
    private TransformerConfiguration getTransformerConfiguration(final Node node) {
@@ -1865,47 +2107,70 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
    }
 
    private TransformerConfiguration getTransformerConfiguration(final String transformerClassName) {
-      return new TransformerConfiguration(transformerClassName).setProperties(Collections.EMPTY_MAP);
+      return new TransformerConfiguration(transformerClassName)
+            .setProperties(Collections.EMPTY_MAP);
    }
 
-   private void parseBridgeConfiguration(final Element brNode, final Configuration mainConfig) throws Exception {
+   private void parseBridgeConfiguration(final Element brNode, final Configuration mainConfig)
+         throws Exception {
       String name = brNode.getAttribute("name");
 
       String queueName = getString(brNode, "queue-name", null, Validators.NOT_NULL_OR_EMPTY);
 
       String forwardingAddress = getString(brNode, "forwarding-address", null, Validators.NO_CHECK);
 
-      String transformerClassName = getString(brNode, "transformer-class-name", null, Validators.NO_CHECK);
+      String transformerClassName = getString(brNode, "transformer-class-name", null,
+            Validators.NO_CHECK);
 
       // Default bridge conf
-      int confirmationWindowSize = getTextBytesAsIntBytes(brNode, "confirmation-window-size", ActiveMQDefaultConfiguration.getDefaultBridgeConfirmationWindowSize(), Validators.POSITIVE_INT);
+      int confirmationWindowSize = getTextBytesAsIntBytes(brNode, "confirmation-window-size",
+            ActiveMQDefaultConfiguration.getDefaultBridgeConfirmationWindowSize(),
+            Validators.POSITIVE_INT);
 
-      int producerWindowSize = getTextBytesAsIntBytes(brNode, "producer-window-size", ActiveMQDefaultConfiguration.getDefaultBridgeConfirmationWindowSize(), Validators.POSITIVE_INT);
+      int producerWindowSize = getTextBytesAsIntBytes(brNode, "producer-window-size",
+            ActiveMQDefaultConfiguration.getDefaultBridgeConfirmationWindowSize(),
+            Validators.POSITIVE_INT);
 
-      long retryInterval = getLong(brNode, "retry-interval", ActiveMQClient.DEFAULT_RETRY_INTERVAL, Validators.GT_ZERO);
+      long retryInterval = getLong(brNode, "retry-interval", ActiveMQClient.DEFAULT_RETRY_INTERVAL,
+            Validators.GT_ZERO);
 
-      long clientFailureCheckPeriod = getLong(brNode, "check-period", ActiveMQClient.DEFAULT_CLIENT_FAILURE_CHECK_PERIOD, Validators.GT_ZERO);
+      long clientFailureCheckPeriod = getLong(brNode, "check-period",
+            ActiveMQClient.DEFAULT_CLIENT_FAILURE_CHECK_PERIOD, Validators.GT_ZERO);
 
-      long connectionTTL = getLong(brNode, "connection-ttl", ActiveMQClient.DEFAULT_CONNECTION_TTL, Validators.GT_ZERO);
+      long connectionTTL = getLong(brNode, "connection-ttl", ActiveMQClient.DEFAULT_CONNECTION_TTL,
+            Validators.GT_ZERO);
 
-      int minLargeMessageSize = getTextBytesAsIntBytes(brNode, "min-large-message-size", ActiveMQClient.DEFAULT_MIN_LARGE_MESSAGE_SIZE, Validators.POSITIVE_INT);
+      int minLargeMessageSize = getTextBytesAsIntBytes(brNode, "min-large-message-size",
+            ActiveMQClient.DEFAULT_MIN_LARGE_MESSAGE_SIZE, Validators.POSITIVE_INT);
 
-      long maxRetryInterval = getLong(brNode, "max-retry-interval", ActiveMQClient.DEFAULT_MAX_RETRY_INTERVAL, Validators.GT_ZERO);
+      long maxRetryInterval = getLong(brNode, "max-retry-interval",
+            ActiveMQClient.DEFAULT_MAX_RETRY_INTERVAL, Validators.GT_ZERO);
 
-      double retryIntervalMultiplier = getDouble(brNode, "retry-interval-multiplier", ActiveMQClient.DEFAULT_RETRY_INTERVAL_MULTIPLIER, Validators.GT_ZERO);
+      double retryIntervalMultiplier = getDouble(brNode, "retry-interval-multiplier",
+            ActiveMQClient.DEFAULT_RETRY_INTERVAL_MULTIPLIER, Validators.GT_ZERO);
 
-      int initialConnectAttempts = getInteger(brNode, "initial-connect-attempts", ActiveMQDefaultConfiguration.getDefaultBridgeInitialConnectAttempts(), Validators.MINUS_ONE_OR_GE_ZERO);
+      int initialConnectAttempts = getInteger(brNode, "initial-connect-attempts",
+            ActiveMQDefaultConfiguration.getDefaultBridgeInitialConnectAttempts(),
+            Validators.MINUS_ONE_OR_GE_ZERO);
 
-      int reconnectAttempts = getInteger(brNode, "reconnect-attempts", ActiveMQDefaultConfiguration.getDefaultBridgeReconnectAttempts(), Validators.MINUS_ONE_OR_GE_ZERO);
+      int reconnectAttempts = getInteger(brNode, "reconnect-attempts",
+            ActiveMQDefaultConfiguration.getDefaultBridgeReconnectAttempts(),
+            Validators.MINUS_ONE_OR_GE_ZERO);
 
-      int reconnectAttemptsSameNode = getInteger(brNode, "reconnect-attempts-same-node", ActiveMQDefaultConfiguration.getDefaultBridgeConnectSameNode(), Validators.MINUS_ONE_OR_GE_ZERO);
+      int reconnectAttemptsSameNode = getInteger(brNode, "reconnect-attempts-same-node",
+            ActiveMQDefaultConfiguration.getDefaultBridgeConnectSameNode(),
+            Validators.MINUS_ONE_OR_GE_ZERO);
 
-      boolean useDuplicateDetection = getBoolean(brNode, "use-duplicate-detection", ActiveMQDefaultConfiguration.isDefaultBridgeDuplicateDetection());
+      boolean useDuplicateDetection = getBoolean(brNode, "use-duplicate-detection",
+            ActiveMQDefaultConfiguration.isDefaultBridgeDuplicateDetection());
 
-      String user = getString(brNode, "user", ActiveMQDefaultConfiguration.getDefaultClusterUser(), Validators.NO_CHECK);
+      String user = getString(brNode, "user", ActiveMQDefaultConfiguration.getDefaultClusterUser(),
+            Validators.NO_CHECK);
 
-      ComponentConfigurationRoutingType routingType = ComponentConfigurationRoutingType.valueOf(getString(brNode, "routing-type", ActiveMQDefaultConfiguration.getDefaultBridgeRoutingType(), Validators.COMPONENT_ROUTING_TYPE));
-
+      ComponentConfigurationRoutingType routingType = ComponentConfigurationRoutingType
+            .valueOf(getString(brNode, "routing-type",
+                  ActiveMQDefaultConfiguration.getDefaultBridgeRoutingType(),
+                  Validators.COMPONENT_ROUTING_TYPE));
 
       NodeList clusterPassNodes = brNode.getElementsByTagName("password");
       String password = null;
@@ -1916,7 +2181,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       }
 
       if (password != null) {
-         password = PasswordMaskingUtil.resolveMask(mainConfig.isMaskPassword(), password, mainConfig.getPasswordCodec());
+         password = PasswordMaskingUtil.resolveMask(mainConfig.isMaskPassword(), password,
+               mainConfig.getPasswordCodec());
       } else {
          password = ActiveMQDefaultConfiguration.getDefaultClusterPassword();
       }
@@ -1939,7 +2205,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
          if (child.getNodeName().equals("filter")) {
             filterString = child.getAttributes().getNamedItem("string").getNodeValue();
          } else if (child.getNodeName().equals("discovery-group-ref")) {
-            discoveryGroupName = child.getAttributes().getNamedItem("discovery-group-name").getNodeValue();
+            discoveryGroupName = child.getAttributes().getNamedItem("discovery-group-name")
+                  .getNodeValue();
          } else if (child.getNodeName().equals("static-connectors")) {
             getStaticConnectors(staticConnectorNames, child);
          } else if (child.getNodeName().equals("transformer")) {
@@ -1951,28 +2218,20 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
          transformerConfiguration = getTransformerConfiguration(transformerClassName);
       }
 
-      BridgeConfiguration config = new BridgeConfiguration()
-         .setName(name)
-         .setQueueName(queueName)
-         .setForwardingAddress(forwardingAddress)
-         .setFilterString(filterString)
-         .setTransformerConfiguration(transformerConfiguration)
-         .setMinLargeMessageSize(minLargeMessageSize)
-         .setClientFailureCheckPeriod(clientFailureCheckPeriod)
-         .setConnectionTTL(connectionTTL)
-         .setRetryInterval(retryInterval)
-         .setMaxRetryInterval(maxRetryInterval)
-         .setRetryIntervalMultiplier(retryIntervalMultiplier)
-         .setInitialConnectAttempts(initialConnectAttempts)
-         .setReconnectAttempts(reconnectAttempts)
-         .setReconnectAttemptsOnSameNode(reconnectAttemptsSameNode)
-         .setUseDuplicateDetection(useDuplicateDetection)
-         .setConfirmationWindowSize(confirmationWindowSize)
-         .setProducerWindowSize(producerWindowSize)
-         .setHA(ha)
-         .setUser(user)
-         .setPassword(password)
-         .setRoutingType(routingType);
+      BridgeConfiguration config = new BridgeConfiguration().setName(name).setQueueName(queueName)
+            .setForwardingAddress(forwardingAddress).setFilterString(filterString)
+            .setTransformerConfiguration(transformerConfiguration)
+            .setMinLargeMessageSize(minLargeMessageSize)
+            .setClientFailureCheckPeriod(clientFailureCheckPeriod).setConnectionTTL(connectionTTL)
+            .setRetryInterval(retryInterval).setMaxRetryInterval(maxRetryInterval)
+            .setRetryIntervalMultiplier(retryIntervalMultiplier)
+            .setInitialConnectAttempts(initialConnectAttempts)
+            .setReconnectAttempts(reconnectAttempts)
+            .setReconnectAttemptsOnSameNode(reconnectAttemptsSameNode)
+            .setUseDuplicateDetection(useDuplicateDetection)
+            .setConfirmationWindowSize(confirmationWindowSize)
+            .setProducerWindowSize(producerWindowSize).setHA(ha).setUser(user).setPassword(password)
+            .setRoutingType(routingType);
 
       if (!staticConnectorNames.isEmpty()) {
          config.setStaticConnectors(staticConnectorNames);
@@ -1983,7 +2242,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       mainConfig.getBridgeConfigurations().add(config);
    }
 
-   private void parseFederationConfiguration(final Element fedNode, final Configuration mainConfig) throws Exception {
+   private void parseFederationConfiguration(final Element fedNode, final Configuration mainConfig)
+         throws Exception {
       FederationConfiguration config = new FederationConfiguration();
 
       String name = fedNode.getAttribute("name");
@@ -1995,7 +2255,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       String passwordTextFederation = fedNode.getAttribute("password");
 
       if (passwordTextFederation != null && !passwordTextFederation.isEmpty()) {
-         String resolvedPassword = PasswordMaskingUtil.resolveMask(mainConfig.isMaskPassword(), passwordTextFederation, mainConfig.getPasswordCodec());
+         String resolvedPassword = PasswordMaskingUtil.resolveMask(mainConfig.isMaskPassword(),
+               passwordTextFederation, mainConfig.getPasswordCodec());
          credentials.setPassword(resolvedPassword);
       }
 
@@ -2012,15 +2273,15 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
          } else if (child.getNodeName().equals("downstream")) {
             config.addDownstreamConfiguration(getDownstream((Element) child, mainConfig));
          } else if (child.getNodeName().equals("policy-set")) {
-            config.addFederationPolicy(getPolicySet((Element)child, mainConfig));
+            config.addFederationPolicy(getPolicySet((Element) child, mainConfig));
          } else if (child.getNodeName().equals("queue-policy")) {
-            config.addFederationPolicy(getQueuePolicy((Element)child, mainConfig));
+            config.addFederationPolicy(getQueuePolicy((Element) child, mainConfig));
          } else if (child.getNodeName().equals("address-policy")) {
-            config.addFederationPolicy(getAddressPolicy((Element)child, mainConfig));
+            config.addFederationPolicy(getAddressPolicy((Element) child, mainConfig));
          } else if (child.getNodeName().equals("transformer")) {
             TransformerConfiguration transformerConfiguration = getTransformerConfiguration(child);
             config.addTransformerConfiguration(new FederationTransformerConfiguration(
-               ((Element)child).getAttribute("name"), transformerConfiguration));
+                  ((Element) child).getAttribute("name"), transformerConfiguration));
          }
       }
 
@@ -2028,7 +2289,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
    }
 
-   private FederationQueuePolicyConfiguration getQueuePolicy(Element policyNod, final Configuration mainConfig) throws Exception {
+   private FederationQueuePolicyConfiguration getQueuePolicy(Element policyNod,
+         final Configuration mainConfig) throws Exception {
       FederationQueuePolicyConfiguration config = new FederationQueuePolicyConfiguration();
       config.setName(policyNod.getAttribute("name"));
 
@@ -2058,7 +2320,6 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
          }
       }
 
-
       return config;
    }
 
@@ -2069,8 +2330,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       return matcher;
    }
 
-
-   private FederationAddressPolicyConfiguration getAddressPolicy(Element policyNod, final Configuration mainConfig) throws Exception {
+   private FederationAddressPolicyConfiguration getAddressPolicy(Element policyNod,
+         final Configuration mainConfig) throws Exception {
       FederationAddressPolicyConfiguration config = new FederationAddressPolicyConfiguration();
       config.setName(policyNod.getAttribute("name"));
 
@@ -2090,7 +2351,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
             config.setAutoDeleteDelay(autoDeleteDelay);
          } else if (item.getNodeName().equals("auto-delete-message-count")) {
             long autoDeleteMessageCount = Long.parseLong(item.getNodeValue());
-            Validators.MINUS_ONE_OR_GE_ZERO.validate("auto-delete-message-count", autoDeleteMessageCount);
+            Validators.MINUS_ONE_OR_GE_ZERO.validate("auto-delete-message-count",
+                  autoDeleteMessageCount);
             config.setAutoDeleteMessageCount(autoDeleteMessageCount);
          } else if (item.getNodeName().equals("transformer-ref")) {
             String transformerRef = item.getNodeValue();
@@ -2110,7 +2372,6 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
          }
       }
 
-
       return config;
    }
 
@@ -2120,7 +2381,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       return matcher;
    }
 
-   private FederationPolicySet getPolicySet(Element policySetNode, final Configuration mainConfig) throws Exception {
+   private FederationPolicySet getPolicySet(Element policySetNode, final Configuration mainConfig)
+         throws Exception {
       FederationPolicySet config = new FederationPolicySet();
       config.setName(policySetNode.getAttribute("name"));
 
@@ -2128,12 +2390,11 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
       List<String> policyRefs = new ArrayList<>();
 
-
       for (int j = 0; j < children.getLength(); j++) {
          Node child = children.item(j);
 
          if (child.getNodeName().equals("policy")) {
-            policyRefs.add(((Element)child).getAttribute("ref"));
+            policyRefs.add(((Element) child).getAttribute("ref"));
          }
       }
       config.addPolicyRefs(policyRefs);
@@ -2141,8 +2402,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       return config;
    }
 
-   private <T extends FederationStreamConfiguration> T getFederationStream(final T config, final Element upstreamNode,
-       final Configuration mainConfig) throws Exception {
+   private <T extends FederationStreamConfiguration> T getFederationStream(final T config,
+         final Element upstreamNode, final Configuration mainConfig) throws Exception {
 
       String name = upstreamNode.getAttribute("name");
       config.setName(name);
@@ -2151,7 +2412,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       String passwordTextFederation = upstreamNode.getAttribute("password");
 
       if (passwordTextFederation != null && !passwordTextFederation.isEmpty()) {
-         String resolvedPassword = PasswordMaskingUtil.resolveMask(mainConfig.isMaskPassword(), passwordTextFederation, mainConfig.getPasswordCodec());
+         String resolvedPassword = PasswordMaskingUtil.resolveMask(mainConfig.isMaskPassword(),
+               passwordTextFederation, mainConfig.getPasswordCodec());
          config.getConnectionConfiguration().setPassword(resolvedPassword);
       }
 
@@ -2168,17 +2430,33 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
       boolean ha = getBoolean(upstreamNode, "ha", false);
 
-      long circuitBreakerTimeout = getLong(upstreamNode, "circuit-breaker-timeout", config.getConnectionConfiguration().getCircuitBreakerTimeout(), Validators.MINUS_ONE_OR_GE_ZERO);
+      long circuitBreakerTimeout = getLong(upstreamNode, "circuit-breaker-timeout",
+            config.getConnectionConfiguration().getCircuitBreakerTimeout(),
+            Validators.MINUS_ONE_OR_GE_ZERO);
 
-      long clientFailureCheckPeriod = getLong(upstreamNode, "check-period", ActiveMQDefaultConfiguration.getDefaultFederationFailureCheckPeriod(), Validators.GT_ZERO);
-      long connectionTTL = getLong(upstreamNode, "connection-ttl", ActiveMQDefaultConfiguration.getDefaultFederationConnectionTtl(), Validators.GT_ZERO);
-      long retryInterval = getLong(upstreamNode, "retry-interval", ActiveMQDefaultConfiguration.getDefaultFederationRetryInterval(), Validators.GT_ZERO);
-      long callTimeout = getLong(upstreamNode, "call-timeout", ActiveMQClient.DEFAULT_CALL_TIMEOUT, Validators.GT_ZERO);
-      long callFailoverTimeout = getLong(upstreamNode, "call-failover-timeout", ActiveMQClient.DEFAULT_CALL_FAILOVER_TIMEOUT, Validators.MINUS_ONE_OR_GT_ZERO);
-      double retryIntervalMultiplier = getDouble(upstreamNode, "retry-interval-multiplier", ActiveMQDefaultConfiguration.getDefaultFederationRetryIntervalMultiplier(), Validators.GT_ZERO);
-      long maxRetryInterval = getLong(upstreamNode, "max-retry-interval", ActiveMQDefaultConfiguration.getDefaultFederationMaxRetryInterval(), Validators.GT_ZERO);
-      int initialConnectAttempts = getInteger(upstreamNode, "initial-connect-attempts", ActiveMQDefaultConfiguration.getDefaultFederationInitialConnectAttempts(), Validators.MINUS_ONE_OR_GE_ZERO);
-      int reconnectAttempts = getInteger(upstreamNode, "reconnect-attempts", ActiveMQDefaultConfiguration.getDefaultFederationReconnectAttempts(), Validators.MINUS_ONE_OR_GE_ZERO);
+      long clientFailureCheckPeriod = getLong(upstreamNode, "check-period",
+            ActiveMQDefaultConfiguration.getDefaultFederationFailureCheckPeriod(),
+            Validators.GT_ZERO);
+      long connectionTTL = getLong(upstreamNode, "connection-ttl",
+            ActiveMQDefaultConfiguration.getDefaultFederationConnectionTtl(), Validators.GT_ZERO);
+      long retryInterval = getLong(upstreamNode, "retry-interval",
+            ActiveMQDefaultConfiguration.getDefaultFederationRetryInterval(), Validators.GT_ZERO);
+      long callTimeout = getLong(upstreamNode, "call-timeout", ActiveMQClient.DEFAULT_CALL_TIMEOUT,
+            Validators.GT_ZERO);
+      long callFailoverTimeout = getLong(upstreamNode, "call-failover-timeout",
+            ActiveMQClient.DEFAULT_CALL_FAILOVER_TIMEOUT, Validators.MINUS_ONE_OR_GT_ZERO);
+      double retryIntervalMultiplier = getDouble(upstreamNode, "retry-interval-multiplier",
+            ActiveMQDefaultConfiguration.getDefaultFederationRetryIntervalMultiplier(),
+            Validators.GT_ZERO);
+      long maxRetryInterval = getLong(upstreamNode, "max-retry-interval",
+            ActiveMQDefaultConfiguration.getDefaultFederationMaxRetryInterval(),
+            Validators.GT_ZERO);
+      int initialConnectAttempts = getInteger(upstreamNode, "initial-connect-attempts",
+            ActiveMQDefaultConfiguration.getDefaultFederationInitialConnectAttempts(),
+            Validators.MINUS_ONE_OR_GE_ZERO);
+      int reconnectAttempts = getInteger(upstreamNode, "reconnect-attempts",
+            ActiveMQDefaultConfiguration.getDefaultFederationReconnectAttempts(),
+            Validators.MINUS_ONE_OR_GE_ZERO);
 
       List<String> staticConnectorNames = new ArrayList<>();
 
@@ -2188,32 +2466,26 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
       List<String> policyRefs = new ArrayList<>();
 
-
       for (int j = 0; j < children.getLength(); j++) {
          Node child = children.item(j);
 
          if (child.getNodeName().equals("discovery-group-ref")) {
-            discoveryGroupName = child.getAttributes().getNamedItem("discovery-group-name").getNodeValue();
+            discoveryGroupName = child.getAttributes().getNamedItem("discovery-group-name")
+                  .getNodeValue();
          } else if (child.getNodeName().equals("static-connectors")) {
             getStaticConnectors(staticConnectorNames, child);
          } else if (child.getNodeName().equals("policy")) {
-            policyRefs.add(((Element)child).getAttribute("ref"));
+            policyRefs.add(((Element) child).getAttribute("ref"));
          }
       }
       config.addPolicyRefs(policyRefs);
 
-      config.getConnectionConfiguration()
-          .setCircuitBreakerTimeout(circuitBreakerTimeout)
-          .setHA(ha)
-          .setClientFailureCheckPeriod(clientFailureCheckPeriod)
-          .setConnectionTTL(connectionTTL)
-          .setRetryInterval(retryInterval)
-          .setRetryIntervalMultiplier(retryIntervalMultiplier)
-          .setMaxRetryInterval(maxRetryInterval)
-          .setInitialConnectAttempts(initialConnectAttempts)
-          .setReconnectAttempts(reconnectAttempts)
-          .setCallTimeout(callTimeout)
-          .setCallFailoverTimeout(callFailoverTimeout);
+      config.getConnectionConfiguration().setCircuitBreakerTimeout(circuitBreakerTimeout).setHA(ha)
+            .setClientFailureCheckPeriod(clientFailureCheckPeriod).setConnectionTTL(connectionTTL)
+            .setRetryInterval(retryInterval).setRetryIntervalMultiplier(retryIntervalMultiplier)
+            .setMaxRetryInterval(maxRetryInterval).setInitialConnectAttempts(initialConnectAttempts)
+            .setReconnectAttempts(reconnectAttempts).setCallTimeout(callTimeout)
+            .setCallFailoverTimeout(callFailoverTimeout);
 
       if (!staticConnectorNames.isEmpty()) {
          config.getConnectionConfiguration().setStaticConnectors(staticConnectorNames);
@@ -2223,15 +2495,18 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       return config;
    }
 
-   private FederationUpstreamConfiguration getUpstream(final Element upstreamNode, final Configuration mainConfig) throws Exception {
+   private FederationUpstreamConfiguration getUpstream(final Element upstreamNode,
+         final Configuration mainConfig) throws Exception {
       return getFederationStream(new FederationUpstreamConfiguration(), upstreamNode, mainConfig);
    }
 
-   private FederationDownstreamConfiguration getDownstream(final Element downstreamNode, final Configuration mainConfig) throws Exception {
-      final FederationDownstreamConfiguration downstreamConfiguration =
-          getFederationStream(new FederationDownstreamConfiguration(), downstreamNode, mainConfig);
+   private FederationDownstreamConfiguration getDownstream(final Element downstreamNode,
+         final Configuration mainConfig) throws Exception {
+      final FederationDownstreamConfiguration downstreamConfiguration = getFederationStream(
+            new FederationDownstreamConfiguration(), downstreamNode, mainConfig);
 
-      final String upstreamRef = getString(downstreamNode,"upstream-connector-ref", null, Validators.NOT_NULL_OR_EMPTY);
+      final String upstreamRef = getString(downstreamNode, "upstream-connector-ref", null,
+            Validators.NOT_NULL_OR_EMPTY);
       downstreamConfiguration.setUpstreamConfigurationRef(upstreamRef);
 
       return downstreamConfiguration;
@@ -2256,13 +2531,18 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
       String address = getString(e, "address", null, Validators.NOT_NULL_OR_EMPTY);
 
-      String forwardingAddress = getString(e, "forwarding-address", null, Validators.NOT_NULL_OR_EMPTY);
+      String forwardingAddress = getString(e, "forwarding-address", null,
+            Validators.NOT_NULL_OR_EMPTY);
 
-      boolean exclusive = getBoolean(e, "exclusive", ActiveMQDefaultConfiguration.isDefaultDivertExclusive());
+      boolean exclusive = getBoolean(e, "exclusive",
+            ActiveMQDefaultConfiguration.isDefaultDivertExclusive());
 
-      String transformerClassName = getString(e, "transformer-class-name", null, Validators.NO_CHECK);
+      String transformerClassName = getString(e, "transformer-class-name", null,
+            Validators.NO_CHECK);
 
-      ComponentConfigurationRoutingType routingType = ComponentConfigurationRoutingType.valueOf(getString(e, "routing-type", ActiveMQDefaultConfiguration.getDefaultDivertRoutingType(), Validators.COMPONENT_ROUTING_TYPE));
+      ComponentConfigurationRoutingType routingType = ComponentConfigurationRoutingType.valueOf(
+            getString(e, "routing-type", ActiveMQDefaultConfiguration.getDefaultDivertRoutingType(),
+                  Validators.COMPONENT_ROUTING_TYPE));
 
       TransformerConfiguration transformerConfiguration = null;
 
@@ -2284,7 +2564,10 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
          transformerConfiguration = getTransformerConfiguration(transformerClassName);
       }
 
-      DivertConfiguration config = new DivertConfiguration().setName(name).setRoutingName(routingName).setAddress(address).setForwardingAddress(forwardingAddress).setExclusive(exclusive).setFilterString(filterString).setTransformerConfiguration(transformerConfiguration).setRoutingType(routingType);
+      DivertConfiguration config = new DivertConfiguration().setName(name)
+            .setRoutingName(routingName).setAddress(address).setForwardingAddress(forwardingAddress)
+            .setExclusive(exclusive).setFilterString(filterString)
+            .setTransformerConfiguration(transformerConfiguration).setRoutingType(routingType);
 
       mainConfig.getDivertConfigurations().add(config);
    }
@@ -2296,9 +2579,14 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
    protected void parseWildcardConfiguration(final Element e, final Configuration mainConfig) {
       WildcardConfiguration conf = mainConfig.getWildcardConfiguration();
 
-      conf.setDelimiter(getString(e, "delimiter", Character.toString(conf.getDelimiter()), Validators.NO_CHECK).charAt(0));
-      conf.setAnyWords(getString(e, "any-words", Character.toString(conf.getAnyWords()), Validators.NO_CHECK).charAt(0));
-      conf.setSingleWord(getString(e, "single-word", Character.toString(conf.getSingleWord()), Validators.NO_CHECK).charAt(0));
+      conf.setDelimiter(
+            getString(e, "delimiter", Character.toString(conf.getDelimiter()), Validators.NO_CHECK)
+                  .charAt(0));
+      conf.setAnyWords(
+            getString(e, "any-words", Character.toString(conf.getAnyWords()), Validators.NO_CHECK)
+                  .charAt(0));
+      conf.setSingleWord(getString(e, "single-word", Character.toString(conf.getSingleWord()),
+            Validators.NO_CHECK).charAt(0));
       conf.setRoutingEnabled(getBoolean(e, "enabled", conf.isRoutingEnabled()));
       conf.setRoutingEnabled(getBoolean(e, "routing-enabled", conf.isRoutingEnabled()));
    }
@@ -2328,6 +2616,7 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
          params.put(key, nValue.getTextContent());
       }
 
-      return new ConnectorServiceConfiguration().setFactoryClassName(clazz).setParams(params).setName(name);
+      return new ConnectorServiceConfiguration().setFactoryClassName(clazz).setParams(params)
+            .setName(name);
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -278,12 +278,12 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
 
                boolean clusteredQueues = addressSettings.getClusteredQueues();
 
-               if (clusteredQueues && binding == null) {
+               if (clusteredQueues && binding == null && distance != 0) {
                   try {
                      if (routingName.equals(address)) {
                         server.createQueue(address, RoutingType.ANYCAST, address, filterString, true, false);
                      } else {
-                        server.createQueue(address, RoutingType.MULTICAST, address, filterString, true, false);
+                        server.createQueue(address, RoutingType.MULTICAST, routingName, filterString, true, false);
                      }
                   } catch (Exception e) {
                      logger.error("Could not create queue", e);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -272,6 +272,19 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
 
                queueInfos.put(clusterName, info);
 
+               //Global queue creation fix
+               Binding binding = getBinding(routingName);
+
+               if (true && binding == null) {
+                  if(routingName.equals(address)) {
+                     try {
+                        server.createQueue(address, RoutingType.ANYCAST, address, filterString, true, false);
+                     } catch (Exception e) {
+                        logger.error("Could not create queue", e);
+                     }
+                  }
+               }
+
                break;
             }
             case BINDING_REMOVED: {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -94,8 +94,9 @@ import org.apache.activemq.artemis.utils.collections.TypedProperties;
 import org.jboss.logging.Logger;
 
 /**
- * This is the class that will make the routing to Queues and decide which consumer will get the messages
- * It's the queue component on distributing the messages * *
+ * This is the class that will make the routing to Queues and decide which
+ * consumer will get the messages It's the queue component on distributing the
+ * messages * *
  */
 public class PostOfficeImpl implements PostOffice, NotificationListener, BindingsFactory {
 
@@ -141,17 +142,11 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
 
    private final ActiveMQServer server;
 
-   public PostOfficeImpl(final ActiveMQServer server,
-                         final StorageManager storageManager,
-                         final PagingManager pagingManager,
-                         final QueueFactory bindableFactory,
-                         final ManagementService managementService,
-                         final long expiryReaperPeriod,
-                         final long addressQueueReaperPeriod,
-                         final WildcardConfiguration wildcardConfiguration,
-                         final int idCacheSize,
-                         final boolean persistIDCache,
-                         final HierarchicalRepository<AddressSettings> addressSettingsRepository) {
+   public PostOfficeImpl(final ActiveMQServer server, final StorageManager storageManager,
+         final PagingManager pagingManager, final QueueFactory bindableFactory,
+         final ManagementService managementService, final long expiryReaperPeriod, final long addressQueueReaperPeriod,
+         final WildcardConfiguration wildcardConfiguration, final int idCacheSize, final boolean persistIDCache,
+         final HierarchicalRepository<AddressSettings> addressSettingsRepository) {
       this.storageManager = storageManager;
 
       queueFactory = bindableFactory;
@@ -165,9 +160,11 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
       this.addressQueueReaperPeriod = addressQueueReaperPeriod;
 
       if (wildcardConfiguration.isRoutingEnabled()) {
-         addressManager = new WildcardAddressManager(this, wildcardConfiguration, storageManager, server.getMetricsManager());
+         addressManager = new WildcardAddressManager(this, wildcardConfiguration, storageManager,
+               server.getMetricsManager());
       } else {
-         addressManager = new SimpleAddressManager(this, wildcardConfiguration, storageManager, server.getMetricsManager());
+         addressManager = new SimpleAddressManager(this, wildcardConfiguration, storageManager,
+               server.getMetricsManager());
       }
 
       this.idCacheSize = idCacheSize;
@@ -192,7 +189,8 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
       queueFactory.setPostOffice(this);
 
       // The flag started needs to be set before starting the Reaper Thread
-      // This is to avoid thread leakages where the Reaper would run beyond the life cycle of the
+      // This is to avoid thread leakages where the Reaper would run beyond the life
+      // cycle of the
       // PostOffice
       started = true;
    }
@@ -262,7 +260,8 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
                SimpleString filterString = props.getSimpleStringProperty(ManagementHelper.HDR_FILTERSTRING);
 
                if (!props.containsProperty(ManagementHelper.HDR_DISTANCE)) {
-                  logger.debug("PostOffice notification / BINDING_ADDED: HDR_DISANCE not specified, giving up propagation on notifications");
+                  logger.debug(
+                        "PostOffice notification / BINDING_ADDED: HDR_DISANCE not specified, giving up propagation on notifications");
                   return;
                }
 
@@ -272,20 +271,22 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
 
                queueInfos.put(clusterName, info);
 
-               //Global queue creation fix
+               // Global queue creation fix
                Binding binding = getBinding(routingName);
-               
+
                AddressSettings addressSettings = addressSettingsRepository.getMatch(address.toString());
 
                boolean clusteredQueues = addressSettings.getClusteredQueues();
 
                if (clusteredQueues && binding == null) {
-                  if(routingName.equals(address)) {
-                     try {
+                  try {
+                     if (routingName.equals(address)) {
                         server.createQueue(address, RoutingType.ANYCAST, address, filterString, true, false);
-                     } catch (Exception e) {
-                        logger.error("Could not create queue", e);
+                     } else {
+                        server.createQueue(address, RoutingType.MULTICAST, address, filterString, true, false);
                      }
+                  } catch (Exception e) {
+                     logger.error("Could not create queue", e);
                   }
                }
 
@@ -295,7 +296,8 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
                TypedProperties props = notification.getProperties();
 
                if (!props.containsProperty(ManagementHelper.HDR_CLUSTER_NAME)) {
-                  logger.debug("PostOffice notification / BINDING_REMOVED: HDR_CLUSTER_NAME not specified, giving up propagation on notifications");
+                  logger.debug(
+                        "PostOffice notification / BINDING_REMOVED: HDR_CLUSTER_NAME not specified, giving up propagation on notifications");
                   return;
                }
 
@@ -304,7 +306,8 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
                QueueInfo info = queueInfos.remove(clusterName);
 
                if (info == null) {
-                  logger.debug("PostOffice notification / BINDING_REMOVED: Cannot find queue info for queue \" + clusterName");
+                  logger.debug(
+                        "PostOffice notification / BINDING_REMOVED: Cannot find queue info for queue \" + clusterName");
                   return;
                }
 
@@ -325,7 +328,9 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
                QueueInfo info = queueInfos.get(clusterName);
 
                if (info == null) {
-                  logger.debug("PostOffice notification / CONSUMER_CREATED: Could not find queue created on clusterName = " + clusterName);
+                  logger.debug(
+                        "PostOffice notification / CONSUMER_CREATED: Could not find queue created on clusterName = "
+                              + clusterName);
                   return;
                }
 
@@ -364,7 +369,8 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
                      // We have a local queue
                      Queue queue = (Queue) binding.getBindable();
 
-                     AddressSettings addressSettings = addressSettingsRepository.getMatch(binding.getAddress().toString());
+                     AddressSettings addressSettings = addressSettingsRepository
+                           .getMatch(binding.getAddress().toString());
 
                      long redistributionDelay = addressSettings.getRedistributionDelay();
 
@@ -428,7 +434,8 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
 
                      Queue queue = (Queue) binding.getBindable();
 
-                     AddressSettings addressSettings = addressSettingsRepository.getMatch(binding.getAddress().toString());
+                     AddressSettings addressSettings = addressSettingsRepository
+                           .getMatch(binding.getAddress().toString());
 
                      long redistributionDelay = addressSettings.getRedistributionDelay();
 
@@ -480,7 +487,8 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
                if (server.hasBrokerAddressPlugins()) {
                   server.callBrokerAddressPlugins(plugin -> plugin.afterAddAddress(addressInfo, reload));
                }
-               long retroactiveMessageCount = addressSettingsRepository.getMatch(addressInfo.getName().toString()).getRetroactiveMessageCount();
+               long retroactiveMessageCount = addressSettingsRepository.getMatch(addressInfo.getName().toString())
+                     .getRetroactiveMessageCount();
                if (retroactiveMessageCount > 0) {
                   createRetroactiveResources(addressInfo.getName(), retroactiveMessageCount, reload);
                }
@@ -501,12 +509,16 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
          String delimiter = server.getConfiguration().getWildcardConfiguration().getDelimiterString();
          String address = ResourceNames.decomposeRetroactiveResourceAddressName(prefix, delimiter, name.toString());
          AddressSettings settings = addressSettingsRepository.getMatch(address);
-         Queue internalAnycastQueue = server.locateQueue(ResourceNames.getRetroactiveResourceQueueName(prefix, delimiter, SimpleString.toSimpleString(address), RoutingType.ANYCAST));
-         if (internalAnycastQueue != null && internalAnycastQueue.getRingSize() != settings.getRetroactiveMessageCount()) {
+         Queue internalAnycastQueue = server.locateQueue(ResourceNames.getRetroactiveResourceQueueName(prefix,
+               delimiter, SimpleString.toSimpleString(address), RoutingType.ANYCAST));
+         if (internalAnycastQueue != null
+               && internalAnycastQueue.getRingSize() != settings.getRetroactiveMessageCount()) {
             internalAnycastQueue.setRingSize(settings.getRetroactiveMessageCount());
          }
-         Queue internalMulticastQueue = server.locateQueue(ResourceNames.getRetroactiveResourceQueueName(prefix, delimiter, SimpleString.toSimpleString(address), RoutingType.MULTICAST));
-         if (internalMulticastQueue != null && internalMulticastQueue.getRingSize() != settings.getRetroactiveMessageCount()) {
+         Queue internalMulticastQueue = server.locateQueue(ResourceNames.getRetroactiveResourceQueueName(prefix,
+               delimiter, SimpleString.toSimpleString(address), RoutingType.MULTICAST));
+         if (internalMulticastQueue != null
+               && internalMulticastQueue.getRingSize() != settings.getRetroactiveMessageCount()) {
             internalMulticastQueue.setRingSize(settings.getRetroactiveMessageCount());
          }
       };
@@ -514,81 +526,38 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
       server.getAddressInfo(name).setRepositoryChangeListener(repositoryChangeListener);
    }
 
-   private void createRetroactiveResources(final SimpleString retroactiveAddressName, final long retroactiveMessageCount, final boolean reload) throws Exception {
+   private void createRetroactiveResources(final SimpleString retroactiveAddressName,
+         final long retroactiveMessageCount, final boolean reload) throws Exception {
       String prefix = server.getInternalNamingPrefix();
       String delimiter = server.getConfiguration().getWildcardConfiguration().getDelimiterString();
-      final SimpleString internalAddressName = ResourceNames.getRetroactiveResourceAddressName(prefix, delimiter, retroactiveAddressName);
-      final SimpleString internalAnycastQueueName = ResourceNames.getRetroactiveResourceQueueName(prefix, delimiter, retroactiveAddressName, RoutingType.ANYCAST);
-      final SimpleString internalMulticastQueueName = ResourceNames.getRetroactiveResourceQueueName(prefix, delimiter, retroactiveAddressName, RoutingType.MULTICAST);
-      final SimpleString internalDivertName = ResourceNames.getRetroactiveResourceDivertName(prefix, delimiter, retroactiveAddressName);
+      final SimpleString internalAddressName = ResourceNames.getRetroactiveResourceAddressName(prefix, delimiter,
+            retroactiveAddressName);
+      final SimpleString internalAnycastQueueName = ResourceNames.getRetroactiveResourceQueueName(prefix, delimiter,
+            retroactiveAddressName, RoutingType.ANYCAST);
+      final SimpleString internalMulticastQueueName = ResourceNames.getRetroactiveResourceQueueName(prefix, delimiter,
+            retroactiveAddressName, RoutingType.MULTICAST);
+      final SimpleString internalDivertName = ResourceNames.getRetroactiveResourceDivertName(prefix, delimiter,
+            retroactiveAddressName);
 
       if (!reload) {
-         AddressInfo addressInfo = new AddressInfo(internalAddressName)
-            .addRoutingType(RoutingType.MULTICAST)
-            .addRoutingType(RoutingType.ANYCAST)
-            .setInternal(false);
+         AddressInfo addressInfo = new AddressInfo(internalAddressName).addRoutingType(RoutingType.MULTICAST)
+               .addRoutingType(RoutingType.ANYCAST).setInternal(false);
          addAddressInfo(addressInfo);
          AddressSettings addressSettings = addressSettingsRepository.getMatch(internalAddressName.toString());
-         server.createQueue(internalAddressName,
-                            RoutingType.MULTICAST,
-                            internalMulticastQueueName,
-                            null,
-                            null,
-                            true,
-                            false,
-                            false,
-                            false,
-                            false,
-                            0,
-                            false,
-                            false,
-                            false,
-                            addressSettings.getDefaultGroupBuckets(),
-                            null,
-                            addressSettings.isDefaultLastValueQueue(),
-                            addressSettings.getDefaultLastValueKey(),
-                            false,
-                            0,
-                            0L,
-                            false,
-                            0L,
-                            0L,
-                            false,
-                            retroactiveMessageCount);
+         server.createQueue(internalAddressName, RoutingType.MULTICAST, internalMulticastQueueName, null, null, true,
+               false, false, false, false, 0, false, false, false, addressSettings.getDefaultGroupBuckets(), null,
+               addressSettings.isDefaultLastValueQueue(), addressSettings.getDefaultLastValueKey(), false, 0, 0L, false,
+               0L, 0L, false, retroactiveMessageCount);
 
-         server.createQueue(internalAddressName,
-                            RoutingType.ANYCAST,
-                            internalAnycastQueueName,
-                            null,
-                            null,
-                            true,
-                            false,
-                            false,
-                            false,
-                            false,
-                            0,
-                            false,
-                            false,
-                            false,
-                            addressSettings.getDefaultGroupBuckets(),
-                            null,
-                            addressSettings.isDefaultLastValueQueue(),
-                            addressSettings.getDefaultLastValueKey(),
-                            false,
-                            0,
-                            0L,
-                            false,
-                            0L,
-                            0L,
-                            false,
-                            retroactiveMessageCount);
+         server.createQueue(internalAddressName, RoutingType.ANYCAST, internalAnycastQueueName, null, null, true, false,
+               false, false, false, 0, false, false, false, addressSettings.getDefaultGroupBuckets(), null,
+               addressSettings.isDefaultLastValueQueue(), addressSettings.getDefaultLastValueKey(), false, 0, 0L, false,
+               0L, 0L, false, retroactiveMessageCount);
       }
-      server.deployDivert(new DivertConfiguration()
-                             .setName(internalDivertName.toString())
-                             .setAddress(retroactiveAddressName.toString())
-                             .setExclusive(false)
-                             .setForwardingAddress(internalAddressName.toString())
-                             .setRoutingType(ComponentConfigurationRoutingType.PASS));
+      server.deployDivert(new DivertConfiguration().setName(internalDivertName.toString())
+            .setAddress(retroactiveAddressName.toString()).setExclusive(false)
+            .setForwardingAddress(internalAddressName.toString())
+            .setRoutingType(ComponentConfigurationRoutingType.PASS));
    }
 
    private void removeRetroactiveResources(SimpleString address) throws Exception {
@@ -600,12 +569,14 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
          server.destroyDivert(internalDivertName);
       }
 
-      SimpleString internalAnycastQueueName = ResourceNames.getRetroactiveResourceQueueName(prefix, delimiter, address, RoutingType.ANYCAST);
+      SimpleString internalAnycastQueueName = ResourceNames.getRetroactiveResourceQueueName(prefix, delimiter, address,
+            RoutingType.ANYCAST);
       if (server.locateQueue(internalAnycastQueueName) != null) {
          server.destroyQueue(internalAnycastQueueName);
       }
 
-      SimpleString internalMulticastQueueName = ResourceNames.getRetroactiveResourceQueueName(prefix, delimiter, address, RoutingType.MULTICAST);
+      SimpleString internalMulticastQueueName = ResourceNames.getRetroactiveResourceQueueName(prefix, delimiter,
+            address, RoutingType.MULTICAST);
       if (server.locateQueue(internalMulticastQueueName) != null) {
          server.destroyQueue(internalMulticastQueueName);
       }
@@ -617,39 +588,20 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
    }
 
    @Override
-   public QueueBinding updateQueue(SimpleString name,
-                                   RoutingType routingType,
-                                   Filter filter,
-                                   Integer maxConsumers,
-                                   Boolean purgeOnNoConsumers,
-                                   Boolean exclusive,
-                                   Boolean groupRebalance,
-                                   Integer groupBuckets,
-                                   SimpleString groupFirstKey,
-                                   Boolean nonDestructive,
-                                   Integer consumersBeforeDispatch,
-                                   Long delayBeforeDispatch,
-                                   SimpleString user,
-                                   Boolean configurationManaged) throws Exception {
-      return updateQueue(name, routingType, filter, maxConsumers, purgeOnNoConsumers, exclusive, groupRebalance, groupBuckets, groupFirstKey, nonDestructive, consumersBeforeDispatch, delayBeforeDispatch, user, configurationManaged, null);
+   public QueueBinding updateQueue(SimpleString name, RoutingType routingType, Filter filter, Integer maxConsumers,
+         Boolean purgeOnNoConsumers, Boolean exclusive, Boolean groupRebalance, Integer groupBuckets,
+         SimpleString groupFirstKey, Boolean nonDestructive, Integer consumersBeforeDispatch, Long delayBeforeDispatch,
+         SimpleString user, Boolean configurationManaged) throws Exception {
+      return updateQueue(name, routingType, filter, maxConsumers, purgeOnNoConsumers, exclusive, groupRebalance,
+            groupBuckets, groupFirstKey, nonDestructive, consumersBeforeDispatch, delayBeforeDispatch, user,
+            configurationManaged, null);
    }
 
    @Override
-   public QueueBinding updateQueue(SimpleString name,
-                                   RoutingType routingType,
-                                   Filter filter,
-                                   Integer maxConsumers,
-                                   Boolean purgeOnNoConsumers,
-                                   Boolean exclusive,
-                                   Boolean groupRebalance,
-                                   Integer groupBuckets,
-                                   SimpleString groupFirstKey,
-                                   Boolean nonDestructive,
-                                   Integer consumersBeforeDispatch,
-                                   Long delayBeforeDispatch,
-                                   SimpleString user,
-                                   Boolean configurationManaged,
-                                   Long ringSize) throws Exception {
+   public QueueBinding updateQueue(SimpleString name, RoutingType routingType, Filter filter, Integer maxConsumers,
+         Boolean purgeOnNoConsumers, Boolean exclusive, Boolean groupRebalance, Integer groupBuckets,
+         SimpleString groupFirstKey, Boolean nonDestructive, Integer consumersBeforeDispatch, Long delayBeforeDispatch,
+         SimpleString user, Boolean configurationManaged, Long ringSize) throws Exception {
       synchronized (this) {
          final QueueBinding queueBinding = (QueueBinding) addressManager.getBinding(name);
          if (queueBinding == null) {
@@ -664,11 +616,12 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
 
             boolean changed = false;
 
-            //validate update
+            // validate update
             if (maxConsumers != null && maxConsumers.intValue() != Queue.MAX_CONSUMERS_UNLIMITED) {
                final int consumerCount = queue.getConsumerCount();
                if (consumerCount > maxConsumers) {
-                  throw ActiveMQMessageBundle.BUNDLE.invalidMaxConsumersUpdate(name.toString(), maxConsumers, consumerCount);
+                  throw ActiveMQMessageBundle.BUNDLE.invalidMaxConsumersUpdate(name.toString(), maxConsumers,
+                        consumerCount);
                }
             }
             if (routingType != null) {
@@ -676,11 +629,12 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
                final AddressInfo addressInfo = addressManager.getAddressInfo(address);
                final EnumSet<RoutingType> addressRoutingTypes = addressInfo.getRoutingTypes();
                if (!addressRoutingTypes.contains(routingType)) {
-                  throw ActiveMQMessageBundle.BUNDLE.invalidRoutingTypeUpdate(name.toString(), routingType, address.toString(), addressRoutingTypes);
+                  throw ActiveMQMessageBundle.BUNDLE.invalidRoutingTypeUpdate(name.toString(), routingType,
+                        address.toString(), addressRoutingTypes);
                }
             }
 
-            //atomic update
+            // atomic update
             if (maxConsumers != null && queue.getMaxConsumers() != maxConsumers.intValue()) {
                changed = true;
                queue.setMaxConsumer(maxConsumers);
@@ -713,7 +667,8 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
                changed = true;
                queue.setNonDestructive(nonDestructive);
             }
-            if (consumersBeforeDispatch != null && !consumersBeforeDispatch.equals(queue.getConsumersBeforeDispatch())) {
+            if (consumersBeforeDispatch != null
+                  && !consumersBeforeDispatch.equals(queue.getConsumersBeforeDispatch())) {
                changed = true;
                queue.setConsumersBeforeDispatch(consumersBeforeDispatch.intValue());
             }
@@ -765,8 +720,7 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
    }
 
    @Override
-   public AddressInfo updateAddressInfo(SimpleString addressName,
-                                        EnumSet<RoutingType> routingTypes) throws Exception {
+   public AddressInfo updateAddressInfo(SimpleString addressName, EnumSet<RoutingType> routingTypes) throws Exception {
       synchronized (this) {
          if (server.hasBrokerAddressPlugins()) {
             server.callBrokerAddressPlugins(plugin -> plugin.beforeUpdateAddress(addressName, routingTypes));
@@ -780,7 +734,6 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
          return address;
       }
    }
-
 
    @Override
    public AddressInfo removeAddressInfo(SimpleString address) throws Exception {
@@ -798,7 +751,7 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
          if (force) {
             for (Binding binding : bindingsForAddress.getBindings()) {
                if (binding instanceof QueueBinding) {
-                  ((QueueBinding)binding).getQueue().deleteQueue(true);
+                  ((QueueBinding) binding).getQueue().deleteQueue(true);
                }
             }
 
@@ -838,10 +791,13 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
       return queues;
    }
 
-   // TODO - needs to be synchronized to prevent happening concurrently with activate()
+   // TODO - needs to be synchronized to prevent happening concurrently with
+   // activate()
    // (and possible removeBinding and other methods)
-   // Otherwise can have situation where createQueue comes in before failover, then failover occurs
-   // and post office is activated but queue remains unactivated after failover so delivery never occurs
+   // Otherwise can have situation where createQueue comes in before failover, then
+   // failover occurs
+   // and post office is activated but queue remains unactivated after failover so
+   // delivery never occurs
    // even though failover is complete
    @Override
    public synchronized void addBinding(final Binding binding) throws Exception {
@@ -874,7 +830,8 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
       String uid = UUIDGenerator.getInstance().generateStringUUID();
 
       if (logger.isDebugEnabled()) {
-         logger.debug("ClusterCommunication::Sending notification for addBinding " + binding + " from server " + server);
+         logger.debug(
+               "ClusterCommunication::Sending notification for addBinding " + binding + " from server " + server);
       }
 
       managementService.sendNotification(new Notification(uid, CoreNotificationType.BINDING_ADDED, props));
@@ -886,9 +843,8 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
    }
 
    @Override
-   public synchronized Binding removeBinding(final SimpleString uniqueName,
-                                             Transaction tx,
-                                             boolean deleteData) throws Exception {
+   public synchronized Binding removeBinding(final SimpleString uniqueName, Transaction tx, boolean deleteData)
+         throws Exception {
 
       if (server.hasBrokerBindingPlugins()) {
          server.callBrokerBindingPlugins(plugin -> plugin.beforeRemoveBinding(uniqueName, tx, deleteData));
@@ -1021,35 +977,26 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
    }
 
    @Override
-   public RoutingStatus route(Message message,
-                              Transaction tx,
-                              boolean direct,
-                              boolean rejectDuplicates) throws Exception {
+   public RoutingStatus route(Message message, Transaction tx, boolean direct, boolean rejectDuplicates)
+         throws Exception {
       return route(message, new RoutingContextImpl(tx), direct, rejectDuplicates, null);
    }
 
    @Override
-   public RoutingStatus route(final Message message,
-                              final Transaction tx,
-                              final boolean direct,
-                              final boolean rejectDuplicates,
-                              final Binding binding) throws Exception {
+   public RoutingStatus route(final Message message, final Transaction tx, final boolean direct,
+         final boolean rejectDuplicates, final Binding binding) throws Exception {
       return route(message, new RoutingContextImpl(tx), direct, rejectDuplicates, binding);
    }
 
    @Override
-   public RoutingStatus route(final Message message,
-                              final RoutingContext context,
-                              final boolean direct) throws Exception {
+   public RoutingStatus route(final Message message, final RoutingContext context, final boolean direct)
+         throws Exception {
       return route(message, context, direct, true, null);
    }
 
    @Override
-   public RoutingStatus route(final Message message,
-                              final RoutingContext context,
-                              final boolean direct,
-                              boolean rejectDuplicates,
-                              final Binding bindingMove) throws Exception {
+   public RoutingStatus route(final Message message, final RoutingContext context, final boolean direct,
+         boolean rejectDuplicates, final Binding bindingMove) throws Exception {
 
       RoutingStatus result;
       // Sanity check
@@ -1092,7 +1039,8 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
          if (addressInfo != null) {
             addressInfo.incrementUnRoutedMessageCount();
          }
-         // this is a debug and not warn because this could be a regular scenario on publish-subscribe queues (or topic subscriptions on JMS)
+         // this is a debug and not warn because this could be a regular scenario on
+         // publish-subscribe queues (or topic subscriptions on JMS)
          if (logger.isDebugEnabled()) {
             logger.debug("Couldn't find any bindings for address=" + address + " on message=" + message);
          }
@@ -1140,7 +1088,8 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
                result = RoutingStatus.NO_BINDINGS;
 
                if (logger.isDebugEnabled()) {
-                  logger.debug("Message " + message + " is not going anywhere as it didn't have a binding on address:" + address);
+                  logger.debug("Message " + message + " is not going anywhere as it didn't have a binding on address:"
+                        + address);
                }
 
                if (message.isLargeMessage()) {
@@ -1184,7 +1133,8 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
 
       // A -1 <expiry-delay> means don't do anything
       if (expirationOverride >= 0) {
-         // only override the exiration on messages where the expiration hasn't been set by the user
+         // only override the exiration on messages where the expiration hasn't been set
+         // by the user
          if (message.getExpiration() == 0) {
             message.setExpiration(System.currentTimeMillis() + expirationOverride);
          }
@@ -1221,16 +1171,17 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
    }
 
    /**
-    * The redistribution can't process the route right away as we may be dealing with a large message which will need to be processed on a different thread
+    * The redistribution can't process the route right away as we may be dealing
+    * with a large message which will need to be processed on a different thread
     */
    @Override
-   public Pair<RoutingContext, Message> redistribute(final Message message,
-                                                     final Queue originatingQueue,
-                                                     final Transaction tx) throws Exception {
+   public Pair<RoutingContext, Message> redistribute(final Message message, final Queue originatingQueue,
+         final Transaction tx) throws Exception {
       Bindings bindings = addressManager.getBindingsForRoutingAddress(originatingQueue.getAddress());
 
       if (bindings != null && bindings.allowRedistribute()) {
-         // We have to copy the message and store it separately, otherwise we may lose remote bindings in case of restart before the message
+         // We have to copy the message and store it separately, otherwise we may lose
+         // remote bindings in case of restart before the message
          // arrived the target node
          // as described on https://issues.jboss.org/browse/JBPAPP-6130
          Message copyRedistribute = message.copy(storageManager.generateID());
@@ -1241,8 +1192,8 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
                @Override
                public void afterRollback(Transaction tx) {
                   try {
-                     //this will cause large message file to be
-                     //cleaned up
+                     // this will cause large message file to be
+                     // cleaned up
                      copyRedistribute.decrementRefCount();
                   } catch (Exception e) {
                      logger.warn("Failed to clean up message: " + copyRedistribute);
@@ -1295,7 +1246,8 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
    }
 
    @Override
-   public void updateMessageLoadBalancingTypeForAddress(SimpleString  address, MessageLoadBalancingType messageLoadBalancingType) throws Exception {
+   public void updateMessageLoadBalancingTypeForAddress(SimpleString address,
+         MessageLoadBalancingType messageLoadBalancingType) throws Exception {
       addressManager.updateMessageLoadBalancingTypeForAddress(address, messageLoadBalancingType);
    }
 
@@ -1305,17 +1257,18 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
    }
 
    @Override
-   public SimpleString getMatchingQueue(SimpleString address,
-                                        SimpleString queueName,
-                                        RoutingType routingType) throws Exception {
+   public SimpleString getMatchingQueue(SimpleString address, SimpleString queueName, RoutingType routingType)
+         throws Exception {
       return addressManager.getMatchingQueue(address, queueName, routingType);
    }
 
    @Override
    public void sendQueueInfoToQueue(final SimpleString queueName, final SimpleString address) throws Exception {
-      // We send direct to the queue so we can send it to the same queue that is bound to the notifications address -
+      // We send direct to the queue so we can send it to the same queue that is bound
+      // to the notifications address -
       // this is crucial for ensuring
-      // that queue infos and notifications are received in a contiguous consistent stream
+      // that queue infos and notifications are received in a contiguous consistent
+      // stream
       Binding binding = addressManager.getBinding(queueName);
 
       if (binding == null) {
@@ -1323,12 +1276,14 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
       }
 
       if (logger.isDebugEnabled()) {
-         logger.debug("PostOffice.sendQueueInfoToQueue on server=" + this.server + ", queueName=" + queueName + " and address=" + address);
+         logger.debug("PostOffice.sendQueueInfoToQueue on server=" + this.server + ", queueName=" + queueName
+               + " and address=" + address);
       }
 
       Queue queue = (Queue) binding.getBindable();
 
-      // Need to lock to make sure all queue info and notifications are in the correct order with no gaps
+      // Need to lock to make sure all queue info and notifications are in the correct
+      // order with no gaps
       synchronized (notificationLock) {
          // First send a reset message
 
@@ -1391,7 +1346,9 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
 
    }
 
-   /* (non-Javadoc)
+   /*
+    * (non-Javadoc)
+    *
     * @see java.lang.Object#toString()
     */
    @Override
@@ -1427,7 +1384,8 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
 
       @Override
       public void afterCommit(Transaction tx) {
-         // We need to try delivering async after paging, or nothing may start a delivery after paging since nothing is
+         // We need to try delivering async after paging, or nothing may start a delivery
+         // after paging since nothing is
          // going towards the queues
          // The queue will try to depage case it's empty
          for (Queue queue : queues) {
@@ -1443,9 +1401,8 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
    }
 
    @Override
-   public void processRoute(final Message message,
-                            final RoutingContext context,
-                            final boolean direct) throws Exception {
+   public void processRoute(final Message message, final RoutingContext context, final boolean direct)
+         throws Exception {
       final List<MessageReference> refs = new ArrayList<>();
 
       Transaction tx = context.getTransaction();
@@ -1460,7 +1417,8 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
                confirmLargeMessageSend(tx, message);
             }
 
-            // We need to kick delivery so the Queues may check for the cursors case they are empty
+            // We need to kick delivery so the Queues may check for the cursors case they
+            // are empty
             schedulePageDelivery(tx, entry);
             continue;
          }
@@ -1562,7 +1520,8 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
             if (tx == null) {
                storageManager.confirmPendingLargeMessage(largeServerMessage.getPendingRecordID());
             } else {
-               storageManager.confirmPendingLargeMessageTX(tx, largeServerMessage.getMessageID(), largeServerMessage.getPendingRecordID());
+               storageManager.confirmPendingLargeMessageTX(tx, largeServerMessage.getMessageID(),
+                     largeServerMessage.getPendingRecordID());
             }
             largeServerMessage.setPendingRecordID(-1);
          }
@@ -1570,7 +1529,8 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
    }
 
    /**
-    * This will kick a delivery async on the queue, so the queue may have a chance to depage messages
+    * This will kick a delivery async on the queue, so the queue may have a chance
+    * to depage messages
     *
     * @param tx
     * @param entry
@@ -1613,18 +1573,18 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
       }
    }
 
-   private boolean checkDuplicateID(final Message message,
-                                    final RoutingContext context,
-                                    boolean rejectDuplicates,
-                                    AtomicBoolean startedTX) throws Exception {
+   private boolean checkDuplicateID(final Message message, final RoutingContext context, boolean rejectDuplicates,
+         AtomicBoolean startedTX) throws Exception {
       // Check the DuplicateCache for the Bridge first
 
       Object bridgeDup = message.removeExtraBytesProperty(Message.HDR_BRIDGE_DUPLICATE_ID);
       if (bridgeDup != null) {
-         // if the message is being sent from the bridge, we just ignore the duplicate id, and use the internal one
+         // if the message is being sent from the bridge, we just ignore the duplicate
+         // id, and use the internal one
          byte[] bridgeDupBytes = (byte[]) bridgeDup;
 
-         DuplicateIDCache cacheBridge = getDuplicateIDCache(BRIDGE_CACHE_STR.concat(context.getAddress(message).toString()));
+         DuplicateIDCache cacheBridge = getDuplicateIDCache(
+               BRIDGE_CACHE_STR.concat(context.getAddress(message).toString()));
 
          if (context.getTransaction() == null) {
             context.setTransaction(new TransactionImpl(storageManager));
@@ -1654,7 +1614,8 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
             if (rejectDuplicates && isDuplicate) {
                ActiveMQServerLogger.LOGGER.duplicateMessageDetected(message);
 
-               String warnMessage = "Duplicate message detected - message will not be routed. Message information:" + message.toString();
+               String warnMessage = "Duplicate message detected - message will not be routed. Message information:"
+                     + message.toString();
 
                if (context.getTransaction() != null) {
                   context.getTransaction().markAsRollbackOnly(new ActiveMQDuplicateIdException(warnMessage));
@@ -1668,7 +1629,8 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
 
          if (cache != null && !isDuplicate) {
             if (context.getTransaction() == null) {
-               // We need to store the duplicate id atomically with the message storage, so we need to create a tx for this
+               // We need to store the duplicate id atomically with the message storage, so we
+               // need to create a tx for this
                context.setTransaction(new TransactionImpl(storageManager));
 
                startedTX.set(true);
@@ -1682,14 +1644,16 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
    }
 
    /**
-    * The expiry scanner can't be started until the whole server has been started other wise you may get races
+    * The expiry scanner can't be started until the whole server has been started
+    * other wise you may get races
     */
    @Override
    public synchronized void startExpiryScanner() {
       if (expiryReaperPeriod > 0) {
          if (expiryReaperRunnable != null)
             expiryReaperRunnable.stop();
-         expiryReaperRunnable = new ExpiryReaper(server.getScheduledPool(), server.getExecutorFactory().getExecutor(), expiryReaperPeriod, TimeUnit.MILLISECONDS, false);
+         expiryReaperRunnable = new ExpiryReaper(server.getScheduledPool(), server.getExecutorFactory().getExecutor(),
+               expiryReaperPeriod, TimeUnit.MILLISECONDS, false);
 
          expiryReaperRunnable.start();
       }
@@ -1700,7 +1664,8 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
       if (addressQueueReaperPeriod > 0) {
          if (addressQueueReaperRunnable != null)
             addressQueueReaperRunnable.stop();
-         addressQueueReaperRunnable = new AddressQueueReaper(server.getScheduledPool(), server.getExecutorFactory().getExecutor(), addressQueueReaperPeriod, TimeUnit.MILLISECONDS, false);
+         addressQueueReaperRunnable = new AddressQueueReaper(server.getScheduledPool(),
+               server.getExecutorFactory().getExecutor(), addressQueueReaperPeriod, TimeUnit.MILLISECONDS, false);
 
          addressQueueReaperRunnable.start();
       }
@@ -1723,11 +1688,8 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
 
    private final class ExpiryReaper extends ActiveMQScheduledComponent {
 
-      ExpiryReaper(ScheduledExecutorService scheduledExecutorService,
-                   Executor executor,
-                   long checkPeriod,
-                   TimeUnit timeUnit,
-                   boolean onDemand) {
+      ExpiryReaper(ScheduledExecutorService scheduledExecutorService, Executor executor, long checkPeriod,
+            TimeUnit timeUnit, boolean onDemand) {
          super(scheduledExecutorService, executor, checkPeriod, timeUnit, onDemand);
       }
 
@@ -1747,18 +1709,17 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
 
    private final class AddressQueueReaper extends ActiveMQScheduledComponent {
 
-      AddressQueueReaper(ScheduledExecutorService scheduledExecutorService,
-                         Executor executor,
-                         long checkPeriod,
-                         TimeUnit timeUnit,
-                         boolean onDemand) {
+      AddressQueueReaper(ScheduledExecutorService scheduledExecutorService, Executor executor, long checkPeriod,
+            TimeUnit timeUnit, boolean onDemand) {
          super(scheduledExecutorService, executor, checkPeriod, timeUnit, onDemand);
       }
 
       @Override
       public void run() {
          for (Queue queue : getLocalQueues()) {
-            if (!queue.isInternalQueue() && QueueManagerImpl.isAutoDelete(queue) && QueueManagerImpl.consumerCountCheck(queue) && QueueManagerImpl.delayCheck(queue) && QueueManagerImpl.messageCountCheck(queue)) {
+            if (!queue.isInternalQueue() && QueueManagerImpl.isAutoDelete(queue)
+                  && QueueManagerImpl.consumerCountCheck(queue) && QueueManagerImpl.delayCheck(queue)
+                  && QueueManagerImpl.messageCountCheck(queue)) {
                QueueManagerImpl.performAutoDeleteQueue(server, queue);
             }
          }
@@ -1770,7 +1731,10 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
             AddressSettings settings = addressSettingsRepository.getMatch(address.toString());
 
             try {
-               if (settings.isAutoDeleteAddresses() && addressInfo != null && addressInfo.isAutoCreated() && !isAddressBound(address) && addressInfo.getBindingRemovedTimestamp() != -1 && (System.currentTimeMillis() - addressInfo.getBindingRemovedTimestamp() >= settings.getAutoDeleteAddressesDelay())) {
+               if (settings.isAutoDeleteAddresses() && addressInfo != null && addressInfo.isAutoCreated()
+                     && !isAddressBound(address) && addressInfo.getBindingRemovedTimestamp() != -1
+                     && (System.currentTimeMillis() - addressInfo.getBindingRemovedTimestamp() >= settings
+                           .getAutoDeleteAddressesDelay())) {
 
                   if (ActiveMQServerLogger.LOGGER.isDebugEnabled()) {
                      ActiveMQServerLogger.LOGGER.debug("deleting auto-created address \"" + address + ".\"");

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -274,8 +274,12 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
 
                //Global queue creation fix
                Binding binding = getBinding(routingName);
+               
+               AddressSettings addressSettings = addressSettingsRepository.getMatch(address.toString());
 
-               if (true && binding == null) {
+               boolean clusteredQueues = addressSettings.getClusteredQueues();
+
+               if (clusteredQueues && binding == null) {
                   if(routingName.equals(address)) {
                      try {
                         server.createQueue(address, RoutingType.ANYCAST, address, filterString, true, false);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
@@ -91,6 +91,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    public static final DeletionPolicy DEFAULT_CONFIG_DELETE_ADDRESSES = DeletionPolicy.OFF;
 
    public static final long DEFAULT_REDISTRIBUTION_DELAY = -1;
+   
+   public static final boolean DEFAULT_CLUSTERED_QUEUES = false;
 
    public static final long DEFAULT_EXPIRY_DELAY = -1;
 
@@ -152,6 +154,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    private SimpleString defaultGroupFirstKey = null;
 
    private Long redistributionDelay = null;
+   
+   private Boolean clusteredQueues = null;
 
    private Boolean sendToDLAOnNoRoute = null;
 
@@ -239,6 +243,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       this.defaultNonDestructive = other.defaultNonDestructive;
       this.defaultExclusiveQueue = other.defaultExclusiveQueue;
       this.redistributionDelay = other.redistributionDelay;
+      this.clusteredQueues = other.clusteredQueues;
       this.sendToDLAOnNoRoute = other.sendToDLAOnNoRoute;
       this.slowConsumerThreshold = other.slowConsumerThreshold;
       this.slowConsumerCheckPeriod = other.slowConsumerCheckPeriod;
@@ -637,6 +642,15 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       this.redistributionDelay = redistributionDelay;
       return this;
    }
+   
+   public boolean getClusteredQueues() {
+     return clusteredQueues != null ? clusteredQueues : AddressSettings.DEFAULT_CLUSTERED_QUEUES;
+   }
+   
+   public AddressSettings setClusteredQueues(final boolean value) {
+     clusteredQueues = value;
+     return this;
+  }
 
    public long getSlowConsumerThreshold() {
       return slowConsumerThreshold != null ? slowConsumerThreshold : AddressSettings.DEFAULT_SLOW_CONSUMER_THRESHOLD;
@@ -819,6 +833,9 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       if (redistributionDelay == null) {
          redistributionDelay = merged.redistributionDelay;
       }
+      if (clusteredQueues == null) {
+        clusteredQueues = merged.clusteredQueues;
+      }
       if (sendToDLAOnNoRoute == null) {
          sendToDLAOnNoRoute = merged.sendToDLAOnNoRoute;
       }
@@ -984,6 +1001,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       defaultLastValueQueue = BufferHelper.readNullableBoolean(buffer);
 
       redistributionDelay = BufferHelper.readNullableLong(buffer);
+      
+      clusteredQueues = BufferHelper.readNullableBoolean(buffer);
 
       sendToDLAOnNoRoute = BufferHelper.readNullableBoolean(buffer);
 
@@ -1126,6 +1145,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
          BufferHelper.sizeOfNullableLong(expiryDelay) +
          BufferHelper.sizeOfNullableBoolean(defaultLastValueQueue) +
          BufferHelper.sizeOfNullableLong(redistributionDelay) +
+         BufferHelper.sizeOfNullableBoolean(clusteredQueues) +
          BufferHelper.sizeOfNullableBoolean(sendToDLAOnNoRoute) +
          BufferHelper.sizeOfNullableLong(slowConsumerCheckPeriod) +
          BufferHelper.sizeOfNullableLong(slowConsumerThreshold) +
@@ -1192,6 +1212,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       BufferHelper.writeNullableBoolean(buffer, defaultLastValueQueue);
 
       BufferHelper.writeNullableLong(buffer, redistributionDelay);
+      
+      BufferHelper.writeNullableBoolean(buffer, clusteredQueues);
 
       BufferHelper.writeNullableBoolean(buffer, sendToDLAOnNoRoute);
 
@@ -1292,6 +1314,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       result = prime * result + ((redeliveryCollisionAvoidanceFactor == null) ? 0 : redeliveryCollisionAvoidanceFactor.hashCode());
       result = prime * result + ((maxRedeliveryDelay == null) ? 0 : maxRedeliveryDelay.hashCode());
       result = prime * result + ((redistributionDelay == null) ? 0 : redistributionDelay.hashCode());
+      result = prime * result + ((clusteredQueues == null) ? 0 : clusteredQueues.hashCode());
       result = prime * result + ((sendToDLAOnNoRoute == null) ? 0 : sendToDLAOnNoRoute.hashCode());
       result = prime * result + ((slowConsumerThreshold == null) ? 0 : slowConsumerThreshold.hashCode());
       result = prime * result + ((slowConsumerCheckPeriod == null) ? 0 : slowConsumerCheckPeriod.hashCode());
@@ -1435,6 +1458,11 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
             return false;
       } else if (!redistributionDelay.equals(other.redistributionDelay))
          return false;
+      if (clusteredQueues == null) {
+        if (other.clusteredQueues != null)
+           return false;
+     } else if (!clusteredQueues.equals(other.clusteredQueues))
+        return false;
       if (sendToDLAOnNoRoute == null) {
          if (other.sendToDLAOnNoRoute != null)
             return false;
@@ -1660,6 +1688,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
          maxRedeliveryDelay +
          ", redistributionDelay=" +
          redistributionDelay +
+         ", clusteredQueues=" +
+         clusteredQueues +
          ", sendToDLAOnNoRoute=" +
          sendToDLAOnNoRoute +
          ", slowConsumerThreshold=" +

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
@@ -91,7 +91,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    public static final DeletionPolicy DEFAULT_CONFIG_DELETE_ADDRESSES = DeletionPolicy.OFF;
 
    public static final long DEFAULT_REDISTRIBUTION_DELAY = -1;
-   
+
    public static final boolean DEFAULT_CLUSTERED_QUEUES = false;
 
    public static final long DEFAULT_EXPIRY_DELAY = -1;
@@ -108,7 +108,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
    public static final int DEFAULT_QUEUE_PREFETCH = 1000;
 
-   // Default address drop threshold, applied to address settings with BLOCK policy.  -1 means no threshold enabled.
+   // Default address drop threshold, applied to address settings with BLOCK
+   // policy. -1 means no threshold enabled.
    public static final long DEFAULT_ADDRESS_REJECT_THRESHOLD = -1;
 
    private AddressFullMessagePolicy addressFullMessagePolicy = null;
@@ -154,7 +155,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    private SimpleString defaultGroupFirstKey = null;
 
    private Long redistributionDelay = null;
-   
+
    private Boolean clusteredQueues = null;
 
    private Boolean sendToDLAOnNoRoute = null;
@@ -219,8 +220,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
    private Integer defaultConsumerWindowSize = null;
 
-   //from amq5
-   //make it transient
+   // from amq5
+   // make it transient
    private transient Integer queuePrefetch = null;
 
    public AddressSettings(AddressSettings other) {
@@ -282,7 +283,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
    @Deprecated
    public boolean isAutoCreateJmsQueues() {
-      return autoCreateJmsQueues != null ? autoCreateJmsQueues : AddressSettings.DEFAULT_AUTO_CREATE_JMS_QUEUES;
+      return autoCreateJmsQueues != null ? autoCreateJmsQueues
+            : AddressSettings.DEFAULT_AUTO_CREATE_JMS_QUEUES;
    }
 
    @Deprecated
@@ -293,7 +295,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
    @Deprecated
    public boolean isAutoDeleteJmsQueues() {
-      return autoDeleteJmsQueues != null ? autoDeleteJmsQueues : AddressSettings.DEFAULT_AUTO_DELETE_JMS_QUEUES;
+      return autoDeleteJmsQueues != null ? autoDeleteJmsQueues
+            : AddressSettings.DEFAULT_AUTO_DELETE_JMS_QUEUES;
    }
 
    @Deprecated
@@ -304,7 +307,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
    @Deprecated
    public boolean isAutoCreateJmsTopics() {
-      return autoCreateJmsTopics != null ? autoCreateJmsTopics : AddressSettings.DEFAULT_AUTO_CREATE_TOPICS;
+      return autoCreateJmsTopics != null ? autoCreateJmsTopics
+            : AddressSettings.DEFAULT_AUTO_CREATE_TOPICS;
    }
 
    @Deprecated
@@ -315,7 +319,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
    @Deprecated
    public boolean isAutoDeleteJmsTopics() {
-      return autoDeleteJmsTopics != null ? autoDeleteJmsTopics : AddressSettings.DEFAULT_AUTO_DELETE_TOPICS;
+      return autoDeleteJmsTopics != null ? autoDeleteJmsTopics
+            : AddressSettings.DEFAULT_AUTO_DELETE_TOPICS;
    }
 
    @Deprecated
@@ -325,7 +330,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public boolean isAutoCreateQueues() {
-      return autoCreateQueues != null ? autoCreateQueues : AddressSettings.DEFAULT_AUTO_CREATE_QUEUES;
+      return autoCreateQueues != null ? autoCreateQueues
+            : AddressSettings.DEFAULT_AUTO_CREATE_QUEUES;
    }
 
    public AddressSettings setAutoCreateQueues(Boolean autoCreateQueues) {
@@ -334,7 +340,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public boolean isAutoDeleteQueues() {
-      return autoDeleteQueues != null ? autoDeleteQueues : AddressSettings.DEFAULT_AUTO_DELETE_QUEUES;
+      return autoDeleteQueues != null ? autoDeleteQueues
+            : AddressSettings.DEFAULT_AUTO_DELETE_QUEUES;
    }
 
    public AddressSettings setAutoDeleteQueues(Boolean autoDeleteQueues) {
@@ -348,12 +355,13 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public boolean isAutoDeleteCreatedQueues() {
-      return autoDeleteCreatedQueues != null ? autoDeleteCreatedQueues : AddressSettings.DEFAULT_AUTO_DELETE_CREATED_QUEUES;
+      return autoDeleteCreatedQueues != null ? autoDeleteCreatedQueues
+            : AddressSettings.DEFAULT_AUTO_DELETE_CREATED_QUEUES;
    }
 
-
    public long getAutoDeleteQueuesDelay() {
-      return autoDeleteQueuesDelay != null ? autoDeleteQueuesDelay : AddressSettings.DEFAULT_AUTO_DELETE_QUEUES_DELAY;
+      return autoDeleteQueuesDelay != null ? autoDeleteQueuesDelay
+            : AddressSettings.DEFAULT_AUTO_DELETE_QUEUES_DELAY;
    }
 
    public AddressSettings setAutoDeleteQueuesDelay(final long autoDeleteQueuesDelay) {
@@ -362,7 +370,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public long getAutoDeleteQueuesMessageCount() {
-      return autoDeleteQueuesMessageCount != null ? autoDeleteQueuesMessageCount : AddressSettings.DEFAULT_AUTO_DELETE_QUEUES_MESSAGE_COUNT;
+      return autoDeleteQueuesMessageCount != null ? autoDeleteQueuesMessageCount
+            : AddressSettings.DEFAULT_AUTO_DELETE_QUEUES_MESSAGE_COUNT;
    }
 
    public AddressSettings setAutoDeleteQueuesMessageCount(final long autoDeleteQueuesMessageCount) {
@@ -370,9 +379,9 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       return this;
    }
 
-
    public DeletionPolicy getConfigDeleteQueues() {
-      return configDeleteQueues != null ? configDeleteQueues : AddressSettings.DEFAULT_CONFIG_DELETE_QUEUES;
+      return configDeleteQueues != null ? configDeleteQueues
+            : AddressSettings.DEFAULT_CONFIG_DELETE_QUEUES;
    }
 
    public AddressSettings setConfigDeleteQueues(DeletionPolicy configDeleteQueues) {
@@ -381,7 +390,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public boolean isAutoCreateAddresses() {
-      return autoCreateAddresses != null ? autoCreateAddresses : AddressSettings.DEFAULT_AUTO_CREATE_ADDRESSES;
+      return autoCreateAddresses != null ? autoCreateAddresses
+            : AddressSettings.DEFAULT_AUTO_CREATE_ADDRESSES;
    }
 
    public AddressSettings setAutoCreateAddresses(Boolean autoCreateAddresses) {
@@ -390,7 +400,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public boolean isAutoDeleteAddresses() {
-      return autoDeleteAddresses != null ? autoDeleteAddresses : AddressSettings.DEFAULT_AUTO_DELETE_ADDRESSES;
+      return autoDeleteAddresses != null ? autoDeleteAddresses
+            : AddressSettings.DEFAULT_AUTO_DELETE_ADDRESSES;
    }
 
    public AddressSettings setAutoDeleteAddresses(Boolean autoDeleteAddresses) {
@@ -399,7 +410,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public long getAutoDeleteAddressesDelay() {
-      return autoDeleteAddressesDelay != null ? autoDeleteAddressesDelay : AddressSettings.DEFAULT_AUTO_DELETE_ADDRESSES_DELAY;
+      return autoDeleteAddressesDelay != null ? autoDeleteAddressesDelay
+            : AddressSettings.DEFAULT_AUTO_DELETE_ADDRESSES_DELAY;
    }
 
    public AddressSettings setAutoDeleteAddressesDelay(final long autoDeleteAddressesDelay) {
@@ -408,7 +420,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public DeletionPolicy getConfigDeleteAddresses() {
-      return configDeleteAddresses != null ? configDeleteAddresses : AddressSettings.DEFAULT_CONFIG_DELETE_ADDRESSES;
+      return configDeleteAddresses != null ? configDeleteAddresses
+            : AddressSettings.DEFAULT_CONFIG_DELETE_ADDRESSES;
    }
 
    public AddressSettings setConfigDeleteAddresses(DeletionPolicy configDeleteAddresses) {
@@ -417,7 +430,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public int getDefaultMaxConsumers() {
-      return defaultMaxConsumers != null ? defaultMaxConsumers : ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers();
+      return defaultMaxConsumers != null ? defaultMaxConsumers
+            : ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers();
    }
 
    public AddressSettings setDefaultMaxConsumers(Integer defaultMaxConsumers) {
@@ -426,16 +440,19 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public int getDefaultConsumersBeforeDispatch() {
-      return defaultConsumersBeforeDispatch != null ? defaultConsumersBeforeDispatch : ActiveMQDefaultConfiguration.getDefaultConsumersBeforeDispatch();
+      return defaultConsumersBeforeDispatch != null ? defaultConsumersBeforeDispatch
+            : ActiveMQDefaultConfiguration.getDefaultConsumersBeforeDispatch();
    }
 
-   public AddressSettings setDefaultConsumersBeforeDispatch(Integer defaultConsumersBeforeDispatch) {
+   public AddressSettings setDefaultConsumersBeforeDispatch(
+         Integer defaultConsumersBeforeDispatch) {
       this.defaultConsumersBeforeDispatch = defaultConsumersBeforeDispatch;
       return this;
    }
 
    public long getDefaultDelayBeforeDispatch() {
-      return defaultDelayBeforeDispatch != null ? defaultDelayBeforeDispatch : ActiveMQDefaultConfiguration.getDefaultDelayBeforeDispatch();
+      return defaultDelayBeforeDispatch != null ? defaultDelayBeforeDispatch
+            : ActiveMQDefaultConfiguration.getDefaultDelayBeforeDispatch();
    }
 
    public AddressSettings setDefaultDelayBeforeDispatch(Long defaultDelayBeforeDispatch) {
@@ -444,7 +461,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public boolean isDefaultPurgeOnNoConsumers() {
-      return defaultPurgeOnNoConsumers != null ? defaultPurgeOnNoConsumers : ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers();
+      return defaultPurgeOnNoConsumers != null ? defaultPurgeOnNoConsumers
+            : ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers();
    }
 
    public AddressSettings setDefaultPurgeOnNoConsumers(Boolean defaultPurgeOnNoConsumers) {
@@ -453,7 +471,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public RoutingType getDefaultQueueRoutingType() {
-      return defaultQueueRoutingType != null ? defaultQueueRoutingType : ActiveMQDefaultConfiguration.getDefaultRoutingType();
+      return defaultQueueRoutingType != null ? defaultQueueRoutingType
+            : ActiveMQDefaultConfiguration.getDefaultRoutingType();
    }
 
    public AddressSettings setDefaultQueueRoutingType(RoutingType defaultQueueRoutingType) {
@@ -462,7 +481,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public RoutingType getDefaultAddressRoutingType() {
-      return defaultAddressRoutingType != null ? defaultAddressRoutingType : ActiveMQDefaultConfiguration.getDefaultRoutingType();
+      return defaultAddressRoutingType != null ? defaultAddressRoutingType
+            : ActiveMQDefaultConfiguration.getDefaultRoutingType();
    }
 
    public AddressSettings setDefaultAddressRoutingType(RoutingType defaultAddressRoutingType) {
@@ -471,7 +491,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public boolean isDefaultLastValueQueue() {
-      return defaultLastValueQueue != null ? defaultLastValueQueue : AddressSettings.DEFAULT_LAST_VALUE_QUEUE;
+      return defaultLastValueQueue != null ? defaultLastValueQueue
+            : AddressSettings.DEFAULT_LAST_VALUE_QUEUE;
    }
 
    public AddressSettings setDefaultLastValueQueue(final boolean defaultLastValueQueue) {
@@ -480,7 +501,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public SimpleString getDefaultLastValueKey() {
-      return defaultLastValueKey != null ? defaultLastValueKey : ActiveMQDefaultConfiguration.getDefaultLastValueKey();
+      return defaultLastValueKey != null ? defaultLastValueKey
+            : ActiveMQDefaultConfiguration.getDefaultLastValueKey();
    }
 
    public AddressSettings setDefaultLastValueKey(final SimpleString defaultLastValueKey) {
@@ -489,7 +511,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public boolean isDefaultNonDestructive() {
-      return defaultNonDestructive != null ? defaultNonDestructive : ActiveMQDefaultConfiguration.getDefaultNonDestructive();
+      return defaultNonDestructive != null ? defaultNonDestructive
+            : ActiveMQDefaultConfiguration.getDefaultNonDestructive();
    }
 
    public AddressSettings setDefaultNonDestructive(final boolean defaultNonDestructive) {
@@ -498,7 +521,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public boolean isDefaultExclusiveQueue() {
-      return defaultExclusiveQueue != null ? defaultExclusiveQueue : ActiveMQDefaultConfiguration.getDefaultExclusive();
+      return defaultExclusiveQueue != null ? defaultExclusiveQueue
+            : ActiveMQDefaultConfiguration.getDefaultExclusive();
    }
 
    public AddressSettings setDefaultExclusiveQueue(Boolean defaultExclusiveQueue) {
@@ -507,10 +531,12 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public AddressFullMessagePolicy getAddressFullMessagePolicy() {
-      return addressFullMessagePolicy != null ? addressFullMessagePolicy : AddressSettings.DEFAULT_ADDRESS_FULL_MESSAGE_POLICY;
+      return addressFullMessagePolicy != null ? addressFullMessagePolicy
+            : AddressSettings.DEFAULT_ADDRESS_FULL_MESSAGE_POLICY;
    }
 
-   public AddressSettings setAddressFullMessagePolicy(final AddressFullMessagePolicy addressFullMessagePolicy) {
+   public AddressSettings setAddressFullMessagePolicy(
+         final AddressFullMessagePolicy addressFullMessagePolicy) {
       this.addressFullMessagePolicy = addressFullMessagePolicy;
       return this;
    }
@@ -543,7 +569,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public int getMaxDeliveryAttempts() {
-      return maxDeliveryAttempts != null ? maxDeliveryAttempts : AddressSettings.DEFAULT_MAX_DELIVERY_ATTEMPTS;
+      return maxDeliveryAttempts != null ? maxDeliveryAttempts
+            : AddressSettings.DEFAULT_MAX_DELIVERY_ATTEMPTS;
    }
 
    public AddressSettings setMaxDeliveryAttempts(final int maxDeliveryAttempts) {
@@ -552,10 +579,12 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public int getMessageCounterHistoryDayLimit() {
-      return messageCounterHistoryDayLimit != null ? messageCounterHistoryDayLimit : AddressSettings.DEFAULT_MESSAGE_COUNTER_HISTORY_DAY_LIMIT;
+      return messageCounterHistoryDayLimit != null ? messageCounterHistoryDayLimit
+            : AddressSettings.DEFAULT_MESSAGE_COUNTER_HISTORY_DAY_LIMIT;
    }
 
-   public AddressSettings setMessageCounterHistoryDayLimit(final int messageCounterHistoryDayLimit) {
+   public AddressSettings setMessageCounterHistoryDayLimit(
+         final int messageCounterHistoryDayLimit) {
       this.messageCounterHistoryDayLimit = messageCounterHistoryDayLimit;
       return this;
    }
@@ -570,7 +599,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public double getRedeliveryMultiplier() {
-      return redeliveryMultiplier != null ? redeliveryMultiplier : AddressSettings.DEFAULT_REDELIVER_MULTIPLIER;
+      return redeliveryMultiplier != null ? redeliveryMultiplier
+            : AddressSettings.DEFAULT_REDELIVER_MULTIPLIER;
    }
 
    public AddressSettings setRedeliveryMultiplier(final double redeliveryMultiplier) {
@@ -579,10 +609,12 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public double getRedeliveryCollisionAvoidanceFactor() {
-      return redeliveryCollisionAvoidanceFactor != null ? redeliveryCollisionAvoidanceFactor : AddressSettings.DEFAULT_REDELIVER_COLLISION_AVOIDANCE_FACTOR;
+      return redeliveryCollisionAvoidanceFactor != null ? redeliveryCollisionAvoidanceFactor
+            : AddressSettings.DEFAULT_REDELIVER_COLLISION_AVOIDANCE_FACTOR;
    }
 
-   public AddressSettings setRedeliveryCollisionAvoidanceFactor(final double redeliveryCollisionAvoidanceFactor) {
+   public AddressSettings setRedeliveryCollisionAvoidanceFactor(
+         final double redeliveryCollisionAvoidanceFactor) {
       this.redeliveryCollisionAvoidanceFactor = redeliveryCollisionAvoidanceFactor;
       return this;
    }
@@ -626,7 +658,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public boolean isSendToDLAOnNoRoute() {
-      return sendToDLAOnNoRoute != null ? sendToDLAOnNoRoute : AddressSettings.DEFAULT_SEND_TO_DLA_ON_NO_ROUTE;
+      return sendToDLAOnNoRoute != null ? sendToDLAOnNoRoute
+            : AddressSettings.DEFAULT_SEND_TO_DLA_ON_NO_ROUTE;
    }
 
    public AddressSettings setSendToDLAOnNoRoute(final boolean value) {
@@ -635,25 +668,27 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public long getRedistributionDelay() {
-      return redistributionDelay != null ? redistributionDelay : AddressSettings.DEFAULT_REDISTRIBUTION_DELAY;
+      return redistributionDelay != null ? redistributionDelay
+            : AddressSettings.DEFAULT_REDISTRIBUTION_DELAY;
    }
 
    public AddressSettings setRedistributionDelay(final long redistributionDelay) {
       this.redistributionDelay = redistributionDelay;
       return this;
    }
-   
+
    public boolean getClusteredQueues() {
-     return clusteredQueues != null ? clusteredQueues : AddressSettings.DEFAULT_CLUSTERED_QUEUES;
+      return clusteredQueues != null ? clusteredQueues : AddressSettings.DEFAULT_CLUSTERED_QUEUES;
    }
-   
+
    public AddressSettings setClusteredQueues(final boolean value) {
-     clusteredQueues = value;
-     return this;
-  }
+      clusteredQueues = value;
+      return this;
+   }
 
    public long getSlowConsumerThreshold() {
-      return slowConsumerThreshold != null ? slowConsumerThreshold : AddressSettings.DEFAULT_SLOW_CONSUMER_THRESHOLD;
+      return slowConsumerThreshold != null ? slowConsumerThreshold
+            : AddressSettings.DEFAULT_SLOW_CONSUMER_THRESHOLD;
    }
 
    public AddressSettings setSlowConsumerThreshold(final long slowConsumerThreshold) {
@@ -662,7 +697,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public long getSlowConsumerCheckPeriod() {
-      return slowConsumerCheckPeriod != null ? slowConsumerCheckPeriod : AddressSettings.DEFAULT_SLOW_CONSUMER_CHECK_PERIOD;
+      return slowConsumerCheckPeriod != null ? slowConsumerCheckPeriod
+            : AddressSettings.DEFAULT_SLOW_CONSUMER_CHECK_PERIOD;
    }
 
    public AddressSettings setSlowConsumerCheckPeriod(final long slowConsumerCheckPeriod) {
@@ -671,7 +707,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public SlowConsumerPolicy getSlowConsumerPolicy() {
-      return slowConsumerPolicy != null ? slowConsumerPolicy : AddressSettings.DEFAULT_SLOW_CONSUMER_POLICY;
+      return slowConsumerPolicy != null ? slowConsumerPolicy
+            : AddressSettings.DEFAULT_SLOW_CONSUMER_POLICY;
    }
 
    public AddressSettings setSlowConsumerPolicy(final SlowConsumerPolicy slowConsumerPolicy) {
@@ -680,7 +717,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public int getManagementBrowsePageSize() {
-      return managementBrowsePageSize != null ? managementBrowsePageSize : AddressSettings.MANAGEMENT_BROWSE_PAGE_SIZE;
+      return managementBrowsePageSize != null ? managementBrowsePageSize
+            : AddressSettings.MANAGEMENT_BROWSE_PAGE_SIZE;
    }
 
    public AddressSettings setManagementBrowsePageSize(int managementBrowsePageSize) {
@@ -698,7 +736,9 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public long getMaxSizeBytesRejectThreshold() {
-      return (maxSizeBytesRejectThreshold == null) ? AddressSettings.DEFAULT_ADDRESS_REJECT_THRESHOLD : maxSizeBytesRejectThreshold;
+      return (maxSizeBytesRejectThreshold == null)
+            ? AddressSettings.DEFAULT_ADDRESS_REJECT_THRESHOLD
+            : maxSizeBytesRejectThreshold;
    }
 
    public AddressSettings setMaxSizeBytesRejectThreshold(long maxSizeBytesRejectThreshold) {
@@ -710,7 +750,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
     * @return the defaultConsumerWindowSize
     */
    public int getDefaultConsumerWindowSize() {
-      return defaultConsumerWindowSize != null ? defaultConsumerWindowSize : ActiveMQClient.DEFAULT_CONSUMER_WINDOW_SIZE;
+      return defaultConsumerWindowSize != null ? defaultConsumerWindowSize
+            : ActiveMQClient.DEFAULT_CONSUMER_WINDOW_SIZE;
    }
 
    /**
@@ -725,7 +766,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
     * @return the defaultGroupBuckets
     */
    public boolean isDefaultGroupRebalance() {
-      return defaultGroupRebalance != null ? defaultGroupRebalance : ActiveMQDefaultConfiguration.getDefaultGroupRebalance();
+      return defaultGroupRebalance != null ? defaultGroupRebalance
+            : ActiveMQDefaultConfiguration.getDefaultGroupRebalance();
    }
 
    /**
@@ -740,14 +782,16 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
     * @return the defaultGroupBuckets
     */
    public int getDefaultGroupBuckets() {
-      return defaultGroupBuckets != null ? defaultGroupBuckets : ActiveMQDefaultConfiguration.getDefaultGroupBuckets();
+      return defaultGroupBuckets != null ? defaultGroupBuckets
+            : ActiveMQDefaultConfiguration.getDefaultGroupBuckets();
    }
 
    /**
     * @return the defaultGroupFirstKey
     */
    public SimpleString getDefaultGroupFirstKey() {
-      return defaultGroupFirstKey != null ? defaultGroupFirstKey : ActiveMQDefaultConfiguration.getDefaultGroupFirstKey();
+      return defaultGroupFirstKey != null ? defaultGroupFirstKey
+            : ActiveMQDefaultConfiguration.getDefaultGroupFirstKey();
    }
 
    /**
@@ -767,7 +811,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public long getDefaultRingSize() {
-      return defaultRingSize != null ? defaultRingSize : ActiveMQDefaultConfiguration.DEFAULT_RING_SIZE;
+      return defaultRingSize != null ? defaultRingSize
+            : ActiveMQDefaultConfiguration.DEFAULT_RING_SIZE;
    }
 
    public AddressSettings setDefaultRingSize(final long defaultRingSize) {
@@ -776,7 +821,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public long getRetroactiveMessageCount() {
-      return retroactiveMessageCount != null ? retroactiveMessageCount : ActiveMQDefaultConfiguration.DEFAULT_RETROACTIVE_MESSAGE_COUNT;
+      return retroactiveMessageCount != null ? retroactiveMessageCount
+            : ActiveMQDefaultConfiguration.DEFAULT_RETROACTIVE_MESSAGE_COUNT;
    }
 
    public AddressSettings setRetroactiveMessageCount(final long defaultRetroactiveMessageCount) {
@@ -834,7 +880,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
          redistributionDelay = merged.redistributionDelay;
       }
       if (clusteredQueues == null) {
-        clusteredQueues = merged.clusteredQueues;
+         clusteredQueues = merged.clusteredQueues;
       }
       if (sendToDLAOnNoRoute == null) {
          sendToDLAOnNoRoute = merged.sendToDLAOnNoRoute;
@@ -1001,8 +1047,6 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       defaultLastValueQueue = BufferHelper.readNullableBoolean(buffer);
 
       redistributionDelay = BufferHelper.readNullableLong(buffer);
-      
-      clusteredQueues = BufferHelper.readNullableBoolean(buffer);
 
       sendToDLAOnNoRoute = BufferHelper.readNullableBoolean(buffer);
 
@@ -1124,70 +1168,81 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       if (buffer.readableBytes() > 0) {
          retroactiveMessageCount = BufferHelper.readNullableLong(buffer);
       }
+
+      clusteredQueues = BufferHelper.readNullableBoolean(buffer);
    }
 
    @Override
    public int getEncodeSize() {
 
-      return BufferHelper.sizeOfNullableSimpleString(addressFullMessagePolicy != null ? addressFullMessagePolicy.toString() : null) +
-         BufferHelper.sizeOfNullableLong(maxSizeBytes) +
-         BufferHelper.sizeOfNullableLong(pageSizeBytes == null ? null : Long.valueOf(pageSizeBytes)) +
-         BufferHelper.sizeOfNullableInteger(pageMaxCache) +
-         BufferHelper.sizeOfNullableBoolean(dropMessagesWhenFull) +
-         BufferHelper.sizeOfNullableInteger(maxDeliveryAttempts) +
-         BufferHelper.sizeOfNullableInteger(messageCounterHistoryDayLimit) +
-         BufferHelper.sizeOfNullableLong(redeliveryDelay) +
-         BufferHelper.sizeOfNullableDouble(redeliveryMultiplier) +
-         BufferHelper.sizeOfNullableDouble(redeliveryCollisionAvoidanceFactor) +
-         BufferHelper.sizeOfNullableLong(maxRedeliveryDelay) +
-         SimpleString.sizeofNullableString(deadLetterAddress) +
-         SimpleString.sizeofNullableString(expiryAddress) +
-         BufferHelper.sizeOfNullableLong(expiryDelay) +
-         BufferHelper.sizeOfNullableBoolean(defaultLastValueQueue) +
-         BufferHelper.sizeOfNullableLong(redistributionDelay) +
-         BufferHelper.sizeOfNullableBoolean(clusteredQueues) +
-         BufferHelper.sizeOfNullableBoolean(sendToDLAOnNoRoute) +
-         BufferHelper.sizeOfNullableLong(slowConsumerCheckPeriod) +
-         BufferHelper.sizeOfNullableLong(slowConsumerThreshold) +
-         BufferHelper.sizeOfNullableSimpleString(slowConsumerPolicy != null ? slowConsumerPolicy.toString() : null) +
-         BufferHelper.sizeOfNullableBoolean(autoCreateJmsQueues) +
-         BufferHelper.sizeOfNullableBoolean(autoDeleteJmsQueues) +
-         BufferHelper.sizeOfNullableBoolean(autoCreateJmsTopics) +
-         BufferHelper.sizeOfNullableBoolean(autoDeleteJmsTopics) +
-         BufferHelper.sizeOfNullableBoolean(autoCreateQueues) +
-         BufferHelper.sizeOfNullableBoolean(autoDeleteQueues) + BufferHelper.sizeOfNullableSimpleString(configDeleteQueues != null ? configDeleteQueues.toString() : null) +
-         BufferHelper.sizeOfNullableBoolean(autoCreateAddresses) +
-         BufferHelper.sizeOfNullableBoolean(autoDeleteAddresses) + BufferHelper.sizeOfNullableSimpleString(configDeleteAddresses != null ? configDeleteAddresses.toString() : null) +
-         BufferHelper.sizeOfNullableInteger(managementBrowsePageSize) +
-         BufferHelper.sizeOfNullableLong(maxSizeBytesRejectThreshold) +
-         BufferHelper.sizeOfNullableInteger(defaultMaxConsumers) +
-         BufferHelper.sizeOfNullableBoolean(defaultPurgeOnNoConsumers) +
-         DataConstants.SIZE_BYTE +
-         DataConstants.SIZE_BYTE +
-         BufferHelper.sizeOfNullableBoolean(defaultExclusiveQueue) +
-         BufferHelper.sizeOfNullableInteger(defaultConsumersBeforeDispatch) +
-         BufferHelper.sizeOfNullableLong(defaultDelayBeforeDispatch) +
-         BufferHelper.sizeOfNullableInteger(defaultConsumerWindowSize) +
-         SimpleString.sizeofNullableString(defaultLastValueKey) +
-         BufferHelper.sizeOfNullableBoolean(defaultNonDestructive) +
-         BufferHelper.sizeOfNullableLong(autoDeleteQueuesDelay) +
-         BufferHelper.sizeOfNullableLong(autoDeleteAddressesDelay) +
-         BufferHelper.sizeOfNullableBoolean(defaultGroupRebalance) +
-         BufferHelper.sizeOfNullableInteger(defaultGroupBuckets) +
-         SimpleString.sizeofNullableString(defaultGroupFirstKey) +
-         BufferHelper.sizeOfNullableLong(autoDeleteQueuesMessageCount) +
-         BufferHelper.sizeOfNullableBoolean(autoDeleteCreatedQueues) +
-         BufferHelper.sizeOfNullableLong(defaultRingSize) +
-         BufferHelper.sizeOfNullableLong(retroactiveMessageCount);
+      return BufferHelper.sizeOfNullableSimpleString(
+            addressFullMessagePolicy != null ? addressFullMessagePolicy.toString() : null)
+            + BufferHelper.sizeOfNullableLong(maxSizeBytes)
+            + BufferHelper
+                  .sizeOfNullableLong(pageSizeBytes == null ? null : Long.valueOf(pageSizeBytes))
+            + BufferHelper.sizeOfNullableInteger(pageMaxCache)
+            + BufferHelper.sizeOfNullableBoolean(dropMessagesWhenFull)
+            + BufferHelper.sizeOfNullableInteger(maxDeliveryAttempts)
+            + BufferHelper.sizeOfNullableInteger(messageCounterHistoryDayLimit)
+            + BufferHelper.sizeOfNullableLong(redeliveryDelay)
+            + BufferHelper.sizeOfNullableDouble(redeliveryMultiplier)
+            + BufferHelper.sizeOfNullableDouble(redeliveryCollisionAvoidanceFactor)
+            + BufferHelper.sizeOfNullableLong(maxRedeliveryDelay)
+            + SimpleString.sizeofNullableString(deadLetterAddress)
+            + SimpleString.sizeofNullableString(expiryAddress)
+            + BufferHelper.sizeOfNullableLong(expiryDelay)
+            + BufferHelper.sizeOfNullableBoolean(defaultLastValueQueue)
+            + BufferHelper.sizeOfNullableLong(redistributionDelay)
+            + BufferHelper.sizeOfNullableBoolean(sendToDLAOnNoRoute)
+            + BufferHelper.sizeOfNullableLong(slowConsumerCheckPeriod)
+            + BufferHelper.sizeOfNullableLong(slowConsumerThreshold)
+            + BufferHelper.sizeOfNullableSimpleString(
+                  slowConsumerPolicy != null ? slowConsumerPolicy.toString() : null)
+            + BufferHelper.sizeOfNullableBoolean(autoCreateJmsQueues)
+            + BufferHelper.sizeOfNullableBoolean(autoDeleteJmsQueues)
+            + BufferHelper.sizeOfNullableBoolean(autoCreateJmsTopics)
+            + BufferHelper.sizeOfNullableBoolean(autoDeleteJmsTopics)
+            + BufferHelper.sizeOfNullableBoolean(autoCreateQueues)
+            + BufferHelper.sizeOfNullableBoolean(autoDeleteQueues)
+            + BufferHelper.sizeOfNullableSimpleString(
+                  configDeleteQueues != null ? configDeleteQueues.toString() : null)
+            + BufferHelper.sizeOfNullableBoolean(autoCreateAddresses)
+            + BufferHelper.sizeOfNullableBoolean(autoDeleteAddresses)
+            + BufferHelper.sizeOfNullableSimpleString(
+                  configDeleteAddresses != null ? configDeleteAddresses.toString() : null)
+            + BufferHelper.sizeOfNullableInteger(managementBrowsePageSize)
+            + BufferHelper.sizeOfNullableLong(maxSizeBytesRejectThreshold)
+            + BufferHelper.sizeOfNullableInteger(defaultMaxConsumers)
+            + BufferHelper.sizeOfNullableBoolean(defaultPurgeOnNoConsumers)
+            + DataConstants.SIZE_BYTE + DataConstants.SIZE_BYTE
+            + BufferHelper.sizeOfNullableBoolean(defaultExclusiveQueue)
+            + BufferHelper.sizeOfNullableInteger(defaultConsumersBeforeDispatch)
+            + BufferHelper.sizeOfNullableLong(defaultDelayBeforeDispatch)
+            + BufferHelper.sizeOfNullableInteger(defaultConsumerWindowSize)
+            + SimpleString.sizeofNullableString(defaultLastValueKey)
+            + BufferHelper.sizeOfNullableBoolean(defaultNonDestructive)
+            + BufferHelper.sizeOfNullableLong(autoDeleteQueuesDelay)
+            + BufferHelper.sizeOfNullableLong(autoDeleteAddressesDelay)
+            + BufferHelper.sizeOfNullableBoolean(defaultGroupRebalance)
+            + BufferHelper.sizeOfNullableInteger(defaultGroupBuckets)
+            + SimpleString.sizeofNullableString(defaultGroupFirstKey)
+            + BufferHelper.sizeOfNullableLong(autoDeleteQueuesMessageCount)
+            + BufferHelper.sizeOfNullableBoolean(autoDeleteCreatedQueues)
+            + BufferHelper.sizeOfNullableLong(defaultRingSize)
+            + BufferHelper.sizeOfNullableLong(retroactiveMessageCount)
+            + BufferHelper.sizeOfNullableBoolean(clusteredQueues);
    }
 
    @Override
    public void encode(ActiveMQBuffer buffer) {
-      buffer.writeNullableSimpleString(addressFullMessagePolicy != null ? new SimpleString(addressFullMessagePolicy.toString()) : null);
+      buffer.writeNullableSimpleString(
+            addressFullMessagePolicy != null ? new SimpleString(addressFullMessagePolicy.toString())
+                  : null);
 
       BufferHelper.writeNullableLong(buffer, maxSizeBytes);
 
-      BufferHelper.writeNullableLong(buffer, pageSizeBytes == null ? null : Long.valueOf(pageSizeBytes));
+      BufferHelper.writeNullableLong(buffer,
+            pageSizeBytes == null ? null : Long.valueOf(pageSizeBytes));
 
       BufferHelper.writeNullableInteger(buffer, pageMaxCache);
 
@@ -1212,7 +1267,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       BufferHelper.writeNullableBoolean(buffer, defaultLastValueQueue);
 
       BufferHelper.writeNullableLong(buffer, redistributionDelay);
-      
+
       BufferHelper.writeNullableBoolean(buffer, clusteredQueues);
 
       BufferHelper.writeNullableBoolean(buffer, sendToDLAOnNoRoute);
@@ -1221,7 +1276,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
       BufferHelper.writeNullableLong(buffer, slowConsumerCheckPeriod);
 
-      buffer.writeNullableSimpleString(slowConsumerPolicy != null ? new SimpleString(slowConsumerPolicy.toString()) : null);
+      buffer.writeNullableSimpleString(
+            slowConsumerPolicy != null ? new SimpleString(slowConsumerPolicy.toString()) : null);
 
       BufferHelper.writeNullableBoolean(buffer, autoCreateJmsQueues);
 
@@ -1235,13 +1291,16 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
       BufferHelper.writeNullableBoolean(buffer, autoDeleteQueues);
 
-      buffer.writeNullableSimpleString(configDeleteQueues != null ? new SimpleString(configDeleteQueues.toString()) : null);
+      buffer.writeNullableSimpleString(
+            configDeleteQueues != null ? new SimpleString(configDeleteQueues.toString()) : null);
 
       BufferHelper.writeNullableBoolean(buffer, autoCreateAddresses);
 
       BufferHelper.writeNullableBoolean(buffer, autoDeleteAddresses);
 
-      buffer.writeNullableSimpleString(configDeleteAddresses != null ? new SimpleString(configDeleteAddresses.toString()) : null);
+      buffer.writeNullableSimpleString(
+            configDeleteAddresses != null ? new SimpleString(configDeleteAddresses.toString())
+                  : null);
 
       BufferHelper.writeNullableInteger(buffer, managementBrowsePageSize);
 
@@ -1253,7 +1312,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
       buffer.writeByte(defaultQueueRoutingType == null ? -1 : defaultQueueRoutingType.getType());
 
-      buffer.writeByte(defaultAddressRoutingType == null ? -1 : defaultAddressRoutingType.getType());
+      buffer.writeByte(
+            defaultAddressRoutingType == null ? -1 : defaultAddressRoutingType.getType());
 
       BufferHelper.writeNullableBoolean(buffer, defaultExclusiveQueue);
 
@@ -1288,70 +1348,111 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       BufferHelper.writeNullableLong(buffer, retroactiveMessageCount);
    }
 
-   /* (non-Javadoc)
-       * @see java.lang.Object#hashCode()
-       */
+   /*
+    * (non-Javadoc)
+    *
+    * @see java.lang.Object#hashCode()
+    */
    @Override
    public int hashCode() {
       final int prime = 31;
       int result = 1;
-      result = prime * result + ((addressFullMessagePolicy == null) ? 0 : addressFullMessagePolicy.hashCode());
+      result = prime * result
+            + ((addressFullMessagePolicy == null) ? 0 : addressFullMessagePolicy.hashCode());
       result = prime * result + ((deadLetterAddress == null) ? 0 : deadLetterAddress.hashCode());
-      result = prime * result + ((dropMessagesWhenFull == null) ? 0 : dropMessagesWhenFull.hashCode());
+      result = prime * result
+            + ((dropMessagesWhenFull == null) ? 0 : dropMessagesWhenFull.hashCode());
       result = prime * result + ((expiryAddress == null) ? 0 : expiryAddress.hashCode());
       result = prime * result + ((expiryDelay == null) ? 0 : expiryDelay.hashCode());
-      result = prime * result + ((defaultLastValueQueue == null) ? 0 : defaultLastValueQueue.hashCode());
-      result = prime * result + ((defaultLastValueKey == null) ? 0 : defaultLastValueKey.hashCode());
-      result = prime * result + ((defaultNonDestructive == null) ? 0 : defaultNonDestructive.hashCode());
-      result = prime * result + ((defaultExclusiveQueue == null) ? 0 : defaultExclusiveQueue.hashCode());
-      result = prime * result + ((maxDeliveryAttempts == null) ? 0 : maxDeliveryAttempts.hashCode());
+      result = prime * result
+            + ((defaultLastValueQueue == null) ? 0 : defaultLastValueQueue.hashCode());
+      result = prime * result
+            + ((defaultLastValueKey == null) ? 0 : defaultLastValueKey.hashCode());
+      result = prime * result
+            + ((defaultNonDestructive == null) ? 0 : defaultNonDestructive.hashCode());
+      result = prime * result
+            + ((defaultExclusiveQueue == null) ? 0 : defaultExclusiveQueue.hashCode());
+      result = prime * result
+            + ((maxDeliveryAttempts == null) ? 0 : maxDeliveryAttempts.hashCode());
       result = prime * result + ((maxSizeBytes == null) ? 0 : maxSizeBytes.hashCode());
-      result = prime * result + ((messageCounterHistoryDayLimit == null) ? 0 : messageCounterHistoryDayLimit.hashCode());
+      result = prime * result + ((messageCounterHistoryDayLimit == null) ? 0
+            : messageCounterHistoryDayLimit.hashCode());
       result = prime * result + ((pageSizeBytes == null) ? 0 : pageSizeBytes.hashCode());
       result = prime * result + ((pageMaxCache == null) ? 0 : pageMaxCache.hashCode());
       result = prime * result + ((redeliveryDelay == null) ? 0 : redeliveryDelay.hashCode());
-      result = prime * result + ((redeliveryMultiplier == null) ? 0 : redeliveryMultiplier.hashCode());
-      result = prime * result + ((redeliveryCollisionAvoidanceFactor == null) ? 0 : redeliveryCollisionAvoidanceFactor.hashCode());
+      result = prime * result
+            + ((redeliveryMultiplier == null) ? 0 : redeliveryMultiplier.hashCode());
+      result = prime * result + ((redeliveryCollisionAvoidanceFactor == null) ? 0
+            : redeliveryCollisionAvoidanceFactor.hashCode());
       result = prime * result + ((maxRedeliveryDelay == null) ? 0 : maxRedeliveryDelay.hashCode());
-      result = prime * result + ((redistributionDelay == null) ? 0 : redistributionDelay.hashCode());
+      result = prime * result
+            + ((redistributionDelay == null) ? 0 : redistributionDelay.hashCode());
       result = prime * result + ((clusteredQueues == null) ? 0 : clusteredQueues.hashCode());
       result = prime * result + ((sendToDLAOnNoRoute == null) ? 0 : sendToDLAOnNoRoute.hashCode());
-      result = prime * result + ((slowConsumerThreshold == null) ? 0 : slowConsumerThreshold.hashCode());
-      result = prime * result + ((slowConsumerCheckPeriod == null) ? 0 : slowConsumerCheckPeriod.hashCode());
+      result = prime * result
+            + ((slowConsumerThreshold == null) ? 0 : slowConsumerThreshold.hashCode());
+      result = prime * result
+            + ((slowConsumerCheckPeriod == null) ? 0 : slowConsumerCheckPeriod.hashCode());
       result = prime * result + ((slowConsumerPolicy == null) ? 0 : slowConsumerPolicy.hashCode());
-      result = prime * result + ((autoCreateJmsQueues == null) ? 0 : autoCreateJmsQueues.hashCode());
-      result = prime * result + ((autoDeleteJmsQueues == null) ? 0 : autoDeleteJmsQueues.hashCode());
-      result = prime * result + ((autoCreateJmsTopics == null) ? 0 : autoCreateJmsTopics.hashCode());
-      result = prime * result + ((autoDeleteJmsTopics == null) ? 0 : autoDeleteJmsTopics.hashCode());
+      result = prime * result
+            + ((autoCreateJmsQueues == null) ? 0 : autoCreateJmsQueues.hashCode());
+      result = prime * result
+            + ((autoDeleteJmsQueues == null) ? 0 : autoDeleteJmsQueues.hashCode());
+      result = prime * result
+            + ((autoCreateJmsTopics == null) ? 0 : autoCreateJmsTopics.hashCode());
+      result = prime * result
+            + ((autoDeleteJmsTopics == null) ? 0 : autoDeleteJmsTopics.hashCode());
       result = prime * result + ((autoCreateQueues == null) ? 0 : autoCreateQueues.hashCode());
       result = prime * result + ((autoDeleteQueues == null) ? 0 : autoDeleteQueues.hashCode());
-      result = prime * result + ((autoDeleteCreatedQueues == null) ? 0 : autoDeleteCreatedQueues.hashCode());
-      result = prime * result + ((autoDeleteQueuesDelay == null) ? 0 : autoDeleteQueuesDelay.hashCode());
-      result = prime * result + ((autoDeleteQueuesMessageCount == null) ? 0 : autoDeleteQueuesMessageCount.hashCode());
+      result = prime * result
+            + ((autoDeleteCreatedQueues == null) ? 0 : autoDeleteCreatedQueues.hashCode());
+      result = prime * result
+            + ((autoDeleteQueuesDelay == null) ? 0 : autoDeleteQueuesDelay.hashCode());
+      result = prime * result + ((autoDeleteQueuesMessageCount == null) ? 0
+            : autoDeleteQueuesMessageCount.hashCode());
       result = prime * result + ((configDeleteQueues == null) ? 0 : configDeleteQueues.hashCode());
-      result = prime * result + ((autoCreateAddresses == null) ? 0 : autoCreateAddresses.hashCode());
-      result = prime * result + ((autoDeleteAddresses == null) ? 0 : autoDeleteAddresses.hashCode());
-      result = prime * result + ((autoDeleteAddressesDelay == null) ? 0 : autoDeleteAddressesDelay.hashCode());
-      result = prime * result + ((configDeleteAddresses == null) ? 0 : configDeleteAddresses.hashCode());
-      result = prime * result + ((managementBrowsePageSize == null) ? 0 : managementBrowsePageSize.hashCode());
+      result = prime * result
+            + ((autoCreateAddresses == null) ? 0 : autoCreateAddresses.hashCode());
+      result = prime * result
+            + ((autoDeleteAddresses == null) ? 0 : autoDeleteAddresses.hashCode());
+      result = prime * result
+            + ((autoDeleteAddressesDelay == null) ? 0 : autoDeleteAddressesDelay.hashCode());
+      result = prime * result
+            + ((configDeleteAddresses == null) ? 0 : configDeleteAddresses.hashCode());
+      result = prime * result
+            + ((managementBrowsePageSize == null) ? 0 : managementBrowsePageSize.hashCode());
       result = prime * result + ((queuePrefetch == null) ? 0 : queuePrefetch.hashCode());
-      result = prime * result + ((maxSizeBytesRejectThreshold == null) ? 0 : maxSizeBytesRejectThreshold.hashCode());
-      result = prime * result + ((defaultMaxConsumers == null) ? 0 : defaultMaxConsumers.hashCode());
-      result = prime * result + ((defaultPurgeOnNoConsumers == null) ? 0 : defaultPurgeOnNoConsumers.hashCode());
-      result = prime * result + ((defaultQueueRoutingType == null) ? 0 : defaultQueueRoutingType.hashCode());
-      result = prime * result + ((defaultAddressRoutingType == null) ? 0 : defaultAddressRoutingType.hashCode());
-      result = prime * result + ((defaultConsumersBeforeDispatch == null) ? 0 : defaultConsumersBeforeDispatch.hashCode());
-      result = prime * result + ((defaultDelayBeforeDispatch == null) ? 0 : defaultDelayBeforeDispatch.hashCode());
-      result = prime * result + ((defaultConsumerWindowSize == null) ? 0 : defaultConsumerWindowSize.hashCode());
-      result = prime * result + ((defaultGroupRebalance == null) ? 0 : defaultGroupRebalance.hashCode());
-      result = prime * result + ((defaultGroupBuckets == null) ? 0 : defaultGroupBuckets.hashCode());
-      result = prime * result + ((defaultGroupFirstKey == null) ? 0 : defaultGroupFirstKey.hashCode());
+      result = prime * result
+            + ((maxSizeBytesRejectThreshold == null) ? 0 : maxSizeBytesRejectThreshold.hashCode());
+      result = prime * result
+            + ((defaultMaxConsumers == null) ? 0 : defaultMaxConsumers.hashCode());
+      result = prime * result
+            + ((defaultPurgeOnNoConsumers == null) ? 0 : defaultPurgeOnNoConsumers.hashCode());
+      result = prime * result
+            + ((defaultQueueRoutingType == null) ? 0 : defaultQueueRoutingType.hashCode());
+      result = prime * result
+            + ((defaultAddressRoutingType == null) ? 0 : defaultAddressRoutingType.hashCode());
+      result = prime * result + ((defaultConsumersBeforeDispatch == null) ? 0
+            : defaultConsumersBeforeDispatch.hashCode());
+      result = prime * result
+            + ((defaultDelayBeforeDispatch == null) ? 0 : defaultDelayBeforeDispatch.hashCode());
+      result = prime * result
+            + ((defaultConsumerWindowSize == null) ? 0 : defaultConsumerWindowSize.hashCode());
+      result = prime * result
+            + ((defaultGroupRebalance == null) ? 0 : defaultGroupRebalance.hashCode());
+      result = prime * result
+            + ((defaultGroupBuckets == null) ? 0 : defaultGroupBuckets.hashCode());
+      result = prime * result
+            + ((defaultGroupFirstKey == null) ? 0 : defaultGroupFirstKey.hashCode());
       result = prime * result + ((defaultRingSize == null) ? 0 : defaultRingSize.hashCode());
-      result = prime * result + ((retroactiveMessageCount == null) ? 0 : retroactiveMessageCount.hashCode());
+      result = prime * result
+            + ((retroactiveMessageCount == null) ? 0 : retroactiveMessageCount.hashCode());
       return result;
    }
 
-   /* (non-Javadoc)
+   /*
+    * (non-Javadoc)
+    *
     * @see java.lang.Object#equals(java.lang.Object)
     */
    @Override
@@ -1446,7 +1547,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       if (redeliveryCollisionAvoidanceFactor == null) {
          if (other.redeliveryCollisionAvoidanceFactor != null)
             return false;
-      } else if (!redeliveryCollisionAvoidanceFactor.equals(other.redeliveryCollisionAvoidanceFactor))
+      } else if (!redeliveryCollisionAvoidanceFactor
+            .equals(other.redeliveryCollisionAvoidanceFactor))
          return false;
       if (maxRedeliveryDelay == null) {
          if (other.maxRedeliveryDelay != null)
@@ -1459,10 +1561,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       } else if (!redistributionDelay.equals(other.redistributionDelay))
          return false;
       if (clusteredQueues == null) {
-        if (other.clusteredQueues != null)
-           return false;
-     } else if (!clusteredQueues.equals(other.clusteredQueues))
-        return false;
+         if (other.clusteredQueues != null)
+            return false;
+      } else if (!clusteredQueues.equals(other.clusteredQueues))
+         return false;
       if (sendToDLAOnNoRoute == null) {
          if (other.sendToDLAOnNoRoute != null)
             return false;
@@ -1644,114 +1746,49 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       return true;
    }
 
-   /* (non-Javadoc)
+   /*
+    * (non-Javadoc)
+    *
     * @see java.lang.Object#toString()
     */
    @Override
    public String toString() {
-      return "AddressSettings [addressFullMessagePolicy=" + addressFullMessagePolicy +
-         ", deadLetterAddress=" +
-         deadLetterAddress +
-         ", dropMessagesWhenFull=" +
-         dropMessagesWhenFull +
-         ", expiryAddress=" +
-         expiryAddress +
-         ", expiryDelay=" +
-         expiryDelay +
-         ", defaultLastValueQueue=" +
-         defaultLastValueQueue +
-         ", defaultLastValueKey=" +
-         defaultLastValueKey +
-         ", defaultNonDestructive=" +
-         defaultNonDestructive +
-         ", defaultExclusiveQueue=" +
-         defaultExclusiveQueue +
-         ", maxDeliveryAttempts=" +
-         maxDeliveryAttempts +
-         ", maxSizeBytes=" +
-         maxSizeBytes +
-         ", maxSizeBytesRejectThreshold=" +
-         maxSizeBytesRejectThreshold +
-         ", messageCounterHistoryDayLimit=" +
-         messageCounterHistoryDayLimit +
-         ", pageSizeBytes=" +
-         pageSizeBytes +
-         ", pageMaxCache=" +
-         pageMaxCache +
-         ", redeliveryDelay=" +
-         redeliveryDelay +
-         ", redeliveryMultiplier=" +
-         redeliveryMultiplier +
-         ", redeliveryCollisionAvoidanceFactor=" +
-         redeliveryCollisionAvoidanceFactor +
-         ", maxRedeliveryDelay=" +
-         maxRedeliveryDelay +
-         ", redistributionDelay=" +
-         redistributionDelay +
-         ", clusteredQueues=" +
-         clusteredQueues +
-         ", sendToDLAOnNoRoute=" +
-         sendToDLAOnNoRoute +
-         ", slowConsumerThreshold=" +
-         slowConsumerThreshold +
-         ", slowConsumerCheckPeriod=" +
-         slowConsumerCheckPeriod +
-         ", slowConsumerPolicy=" +
-         slowConsumerPolicy +
-         ", autoCreateJmsQueues=" +
-         autoCreateJmsQueues +
-         ", autoDeleteJmsQueues=" +
-         autoDeleteJmsQueues +
-         ", autoCreateJmsTopics=" +
-         autoCreateJmsTopics +
-         ", autoDeleteJmsTopics=" +
-         autoDeleteJmsTopics +
-         ", autoCreateQueues=" +
-         autoCreateQueues +
-         ", autoDeleteQueues=" +
-         autoDeleteQueues +
-         ", autoDeleteCreatedQueues=" +
-         autoDeleteCreatedQueues +
-         ", autoDeleteQueuesDelay=" +
-         autoDeleteQueuesDelay +
-         ", autoDeleteQueuesMessageCount=" +
-         autoDeleteQueuesMessageCount +
-         ", configDeleteQueues=" +
-         configDeleteQueues +
-         ", autoCreateAddresses=" +
-         autoCreateAddresses +
-         ", autoDeleteAddresses=" +
-         autoDeleteAddresses +
-         ", autoDeleteAddressesDelay=" +
-         autoDeleteAddressesDelay +
-         ", configDeleteAddresses=" +
-         configDeleteAddresses +
-         ", managementBrowsePageSize=" +
-         managementBrowsePageSize +
-         ", defaultMaxConsumers=" +
-         defaultMaxConsumers +
-         ", defaultPurgeOnNoConsumers=" +
-         defaultPurgeOnNoConsumers +
-         ", defaultQueueRoutingType=" +
-         defaultQueueRoutingType +
-         ", defaultAddressRoutingType=" +
-         defaultAddressRoutingType +
-         ", defaultConsumersBeforeDispatch=" +
-         defaultConsumersBeforeDispatch +
-         ", defaultDelayBeforeDispatch=" +
-         defaultDelayBeforeDispatch +
-         ", defaultClientWindowSize=" +
-         defaultConsumerWindowSize +
-         ", defaultGroupRebalance=" +
-         defaultGroupRebalance +
-         ", defaultGroupBuckets=" +
-         defaultGroupBuckets +
-         ", defaultGroupFirstKey=" +
-         defaultGroupFirstKey +
-         ", defaultRingSize=" +
-         defaultRingSize +
-         ", retroactiveMessageCount=" +
-         retroactiveMessageCount +
-         "]";
+      return "AddressSettings [addressFullMessagePolicy=" + addressFullMessagePolicy
+            + ", deadLetterAddress=" + deadLetterAddress + ", dropMessagesWhenFull="
+            + dropMessagesWhenFull + ", expiryAddress=" + expiryAddress + ", expiryDelay="
+            + expiryDelay + ", defaultLastValueQueue=" + defaultLastValueQueue
+            + ", defaultLastValueKey=" + defaultLastValueKey + ", defaultNonDestructive="
+            + defaultNonDestructive + ", defaultExclusiveQueue=" + defaultExclusiveQueue
+            + ", maxDeliveryAttempts=" + maxDeliveryAttempts + ", maxSizeBytes=" + maxSizeBytes
+            + ", maxSizeBytesRejectThreshold=" + maxSizeBytesRejectThreshold
+            + ", messageCounterHistoryDayLimit=" + messageCounterHistoryDayLimit
+            + ", pageSizeBytes=" + pageSizeBytes + ", pageMaxCache=" + pageMaxCache
+            + ", redeliveryDelay=" + redeliveryDelay + ", redeliveryMultiplier="
+            + redeliveryMultiplier + ", redeliveryCollisionAvoidanceFactor="
+            + redeliveryCollisionAvoidanceFactor + ", maxRedeliveryDelay=" + maxRedeliveryDelay
+            + ", redistributionDelay=" + redistributionDelay + ", clusteredQueues="
+            + clusteredQueues + ", sendToDLAOnNoRoute=" + sendToDLAOnNoRoute
+            + ", slowConsumerThreshold=" + slowConsumerThreshold + ", slowConsumerCheckPeriod="
+            + slowConsumerCheckPeriod + ", slowConsumerPolicy=" + slowConsumerPolicy
+            + ", autoCreateJmsQueues=" + autoCreateJmsQueues + ", autoDeleteJmsQueues="
+            + autoDeleteJmsQueues + ", autoCreateJmsTopics=" + autoCreateJmsTopics
+            + ", autoDeleteJmsTopics=" + autoDeleteJmsTopics + ", autoCreateQueues="
+            + autoCreateQueues + ", autoDeleteQueues=" + autoDeleteQueues
+            + ", autoDeleteCreatedQueues=" + autoDeleteCreatedQueues + ", autoDeleteQueuesDelay="
+            + autoDeleteQueuesDelay + ", autoDeleteQueuesMessageCount="
+            + autoDeleteQueuesMessageCount + ", configDeleteQueues=" + configDeleteQueues
+            + ", autoCreateAddresses=" + autoCreateAddresses + ", autoDeleteAddresses="
+            + autoDeleteAddresses + ", autoDeleteAddressesDelay=" + autoDeleteAddressesDelay
+            + ", configDeleteAddresses=" + configDeleteAddresses + ", managementBrowsePageSize="
+            + managementBrowsePageSize + ", defaultMaxConsumers=" + defaultMaxConsumers
+            + ", defaultPurgeOnNoConsumers=" + defaultPurgeOnNoConsumers
+            + ", defaultQueueRoutingType=" + defaultQueueRoutingType
+            + ", defaultAddressRoutingType=" + defaultAddressRoutingType
+            + ", defaultConsumersBeforeDispatch=" + defaultConsumersBeforeDispatch
+            + ", defaultDelayBeforeDispatch=" + defaultDelayBeforeDispatch
+            + ", defaultClientWindowSize=" + defaultConsumerWindowSize + ", defaultGroupRebalance="
+            + defaultGroupRebalance + ", defaultGroupBuckets=" + defaultGroupBuckets
+            + ", defaultGroupFirstKey=" + defaultGroupFirstKey + ", defaultRingSize="
+            + defaultRingSize + ", retroactiveMessageCount=" + retroactiveMessageCount + "]";
    }
 }

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -3276,12 +3276,12 @@
                   </xsd:documentation>
                </xsd:annotation>
             </xsd:element>
-            
+
             <xsd:element name="clustered-queues" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
                <xsd:annotation>
                   <xsd:documentation>
-                     Anycast queues will get created on the local broker if they are created on a clustered neighbour.
-                     This means all Anycast queues exist cluster-wide. It helps with redistribution in certain scenarios
+                     Queues will get created on the local broker if they are created on a clustered neighbour.
+                     This means all queues exist cluster-wide. It helps with redistribution in certain scenarios
                   </xsd:documentation>
                </xsd:annotation>
             </xsd:element>
@@ -3525,7 +3525,6 @@
                   </xsd:documentation>
                </xsd:annotation>
             </xsd:element>
-            
          </xsd:all>
 
          <xsd:attribute name="match" type="xsd:string" use="required">

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -3276,6 +3276,15 @@
                   </xsd:documentation>
                </xsd:annotation>
             </xsd:element>
+            
+            <xsd:element name="clustered-queues" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     Anycast queues will get created on the local broker if they are created on a clustered neighbour.
+                     This means all Anycast queues exist cluster-wide. It helps with redistribution in certain scenarios
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
 
             <xsd:element name="send-to-dla-on-no-route" type="xsd:boolean" maxOccurs="1" minOccurs="0">
                <xsd:annotation>

--- a/docs/user-manual/en/address-model.md
+++ b/docs/user-manual/en/address-model.md
@@ -721,9 +721,9 @@ before it will begin to dispatch messages. Default is `-1` (wait forever).
 closed on a queue before redistributing any messages. Read more about
 [clusters](clusters.md#message-redistribution).
 
-`clustered-queues` enables cluster-wide creation of `ANYCAST` queues. 
+`clustered-queues` enables cluster-wide creation of queues. 
 This means that in the case of a formed cluster with several active brokers, 
-all new `ANYCAST` queues will get created on each cluster member. 
+all new queues will get created on each cluster member. 
 This helps with redistribution of messages in some scenarios, 
 such as where client consumers are fairly static and producers work in an "ad hoc" manner.
 

--- a/docs/user-manual/en/address-model.md
+++ b/docs/user-manual/en/address-model.md
@@ -589,6 +589,7 @@ that would be found in the `broker.xml` file.
       <default-consumers-before-dispatch>0</default-consumers-before-dispatch>
       <default-delay-before-dispatch>-1</default-delay-before-dispatch>
       <redistribution-delay>0</redistribution-delay>
+      <clustered-queues>true</clustered-queues>
       <send-to-dla-on-no-route>true</send-to-dla-on-no-route>
       <slow-consumer-threshold>-1</slow-consumer-threshold>
       <slow-consumer-policy>NOTIFY</slow-consumer-policy>
@@ -719,6 +720,12 @@ before it will begin to dispatch messages. Default is `-1` (wait forever).
 `redistribution-delay` defines how long to wait when the last consumer is
 closed on a queue before redistributing any messages. Read more about
 [clusters](clusters.md#message-redistribution).
+
+`clustered-queues` enables cluster-wide creation of `ANYCAST` queues. 
+This means that in the case of a formed cluster with several active brokers, 
+all new `ANYCAST` queues will get created on each cluster member. 
+This helps with redistribution of messages in some scenarios, 
+such as where client consumers are fairly static and producers work in an "ad hoc" manner.
 
 `send-to-dla-on-no-route`. If a message is sent to an address, but the server
 does not route it to any queues (e.g. there might be no queues bound to that


### PR DESCRIPTION
This is to help with redistribution as mentioned in this Jira:
https://issues.apache.org/jira/browse/ARTEMIS-2563

Address option added to enable queue creation on all active nodes in a cluster, which happens on BINDING_ADDED. Since this creates a local binding for remote queues, a redistributor will also get created once a consumer registers