### PR TITLE
ARTEMIS-2601 Update jetty version to 9.4.26.v20200117

### DIFF
--- a/artemis-distribution/pom.xml
+++ b/artemis-distribution/pom.xml
@@ -232,6 +232,10 @@
            <groupId>org.apache.johnzon</groupId>
            <artifactId>johnzon-core</artifactId>
        </dependency>
+      <dependency>
+         <groupId>org.apache.geronimo.specs</groupId>
+         <artifactId>geronimo-jaspic_1.0_spec</artifactId>
+      </dependency>
    </dependencies>
 
    <build>

--- a/artemis-distribution/src/main/assembly/dep.xml
+++ b/artemis-distribution/src/main/assembly/dep.xml
@@ -107,6 +107,7 @@
             <include>com.sun.xml.bind:jaxb-impl</include>
             <include>com.sun.xml.bind:jaxb-core</include>
             <include>javax.activation:activation</include>
+            <include>org.apache.geronimo.specs:geronimo-jaspic_1.0_spec</include>
          </includes>
          <!--excludes>
             <exclude>org.apache.activemq:artemis-website</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -822,6 +822,11 @@
             <version>${guava.version}</version>
             <!-- License: Apache 2.0 -->
          </dependency>
+         <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jaspic_1.0_spec</artifactId>
+            <version>1.0</version>
+         </dependency>
       </dependencies>
 
    </dependencyManagement>


### PR DESCRIPTION
Add required dependency org.apache.geronimo.specs:geronimo-jaspic_1.0_spec.