### PR TITLE
NO-JIRA Fix Javadoc @link syntax in ActiveMQServerConsumerPlugin

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/plugin/ActiveMQServerConsumerPlugin.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/plugin/ActiveMQServerConsumerPlugin.java
@@ -37,7 +37,7 @@ public interface ActiveMQServerConsumerPlugin extends ActiveMQServerBasePlugin {
     * @param supportLargeMessage
     * @throws ActiveMQException
     *
-    * @deprecated use {@link #beforeCreateConsumer(long, QueueBinding, SimpleString, boolean, boolean)
+    * @deprecated use {@link #beforeCreateConsumer(long, QueueBinding, SimpleString, boolean, boolean)}
     */
    @Deprecated
    default void beforeCreateConsumer(long consumerID, SimpleString queueName, SimpleString filterString,


### PR DESCRIPTION
Fixes Javadoc warning "Javadoc: Missing closing brace for inline tag"