### PR TITLE
NO-JIRA Fix compiler warning in FederationStreamConnectMessage

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/FederationStreamConnectMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/FederationStreamConnectMessage.java
@@ -148,7 +148,7 @@ public abstract class FederationStreamConnectMessage <T extends FederationStream
 
    private FederationPolicy getFederationPolicy(String clazz) {
       try {
-         return (FederationPolicy) Class.forName(clazz).getConstructor(null).newInstance();
+         return (FederationPolicy) Class.forName(clazz).getConstructor((Class<?>) null).newInstance();
       } catch (Exception e) {
          throw new IllegalStateException("Error. Unable to instantiate FederationPolicy: " + e.getMessage(), e);
       }


### PR DESCRIPTION
This fixes the following compiler warning that is reported in Travis builds:

```java
/home/travis/build/apache/activemq-artemis/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/FederationStreamConnectMessage.java:151: warning: non-varargs call of varargs method with inexact argument type for last parameter;

         return (FederationPolicy) Class.forName(clazz).getConstructor(null).newInstance();

  cast to Class<?> for a varargs call
  cast to Class<?>[] for a non-varargs call and to suppress this warning
```