### PR TITLE
ARTEMIS-2613: Add support for DivertBindings for federated addresses

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/config/federation/FederationAddressPolicyConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/config/federation/FederationAddressPolicyConfiguration.java
@@ -34,6 +34,7 @@ public class FederationAddressPolicyConfiguration implements FederationPolicy<Fe
    private Long autoDeleteMessageCount;
    private int maxHops;
    private String transformerRef;
+   private boolean enableDivertBindings;
 
    @Override
    public String getName() {
@@ -109,6 +110,15 @@ public class FederationAddressPolicyConfiguration implements FederationPolicy<Fe
       return this;
    }
 
+   public Boolean isEnableDivertBindings() {
+      return enableDivertBindings;
+   }
+
+   public FederationAddressPolicyConfiguration setEnableDivertBindings(Boolean enableDivertBindings) {
+      this.enableDivertBindings = enableDivertBindings;
+      return this;
+   }
+
    @Override
    public void encode(ActiveMQBuffer buffer) {
       Preconditions.checkArgument(name != null, "name can not be null");
@@ -118,9 +128,9 @@ public class FederationAddressPolicyConfiguration implements FederationPolicy<Fe
       buffer.writeNullableLong(autoDeleteMessageCount);
       buffer.writeInt(maxHops);
       buffer.writeNullableString(transformerRef);
-
       encodeMatchers(buffer, includes);
       encodeMatchers(buffer, excludes);
+      buffer.writeBoolean(enableDivertBindings);
    }
 
    @Override
@@ -131,12 +141,14 @@ public class FederationAddressPolicyConfiguration implements FederationPolicy<Fe
       autoDeleteMessageCount = buffer.readNullableLong();
       maxHops = buffer.readInt();
       transformerRef = buffer.readNullableString();
-
       includes = new HashSet<>();
       excludes = new HashSet<>();
       decodeMatchers(buffer, includes);
       decodeMatchers(buffer, excludes);
 
+      if (buffer.readableBytes() > 0) {
+         enableDivertBindings = buffer.readBoolean();
+      }
    }
 
    private void encodeMatchers(final ActiveMQBuffer buffer, final Set<Matcher> matchers) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -2091,6 +2091,9 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
          } else if (item.getNodeName().equals("transformer-ref")) {
             String transformerRef = item.getNodeValue();
             config.setTransformerRef(transformerRef);
+         } else if (item.getNodeName().equals("enable-divert-bindings")) {
+            boolean enableDivertBindings = Boolean.parseBoolean(item.getNodeValue());
+            config.setEnableDivertBindings(enableDivertBindings);
          }
       }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1659,6 +1659,11 @@ public interface ActiveMQServerLogger extends BasicLogger {
       format = Message.Format.MESSAGE_FORMAT)
    void federationPluginExecutionError(@Cause Throwable e, String pluginMethod);
 
+   @LogMessage(level = Logger.Level.WARN)
+   @Message(id = 222287, value = "Error looking up bindings for address {}.",
+      format = Message.Format.MESSAGE_FORMAT)
+   void federationBindingsLookupError(@Cause Throwable e, SimpleString address);
+
    @LogMessage(level = Logger.Level.ERROR)
    @Message(id = 224000, value = "Failure in initialisation", format = Message.Format.MESSAGE_FORMAT)
    void initializationError(@Cause Throwable e);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/Divert.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/Divert.java
@@ -31,4 +31,6 @@ public interface Divert extends Bindable {
    SimpleString getRoutingName();
 
    Transformer getTransformer();
+
+   SimpleString getForwardAddress();
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/DivertImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/DivertImpl.java
@@ -163,6 +163,11 @@ public class DivertImpl implements Divert {
       return transformer;
    }
 
+   @Override
+   public SimpleString getForwardAddress() {
+      return forwardAddress;
+   }
+
    /* (non-Javadoc)
     * @see java.lang.Object#toString()
     */

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/plugin/ActiveMQServerFederationPlugin.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/plugin/ActiveMQServerFederationPlugin.java
@@ -19,6 +19,8 @@ package org.apache.activemq.artemis.core.server.plugin;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.Message;
+import org.apache.activemq.artemis.core.postoffice.QueueBinding;
+import org.apache.activemq.artemis.core.postoffice.impl.DivertBinding;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.server.ServerConsumer;
 import org.apache.activemq.artemis.core.server.federation.FederatedConsumerKey;
@@ -118,6 +120,10 @@ public interface ActiveMQServerFederationPlugin extends ActiveMQServerBasePlugin
     * @throws ActiveMQException
     */
    default boolean federatedAddressConditionalCreateConsumer(final Queue queue) throws ActiveMQException {
+      return true;
+   }
+
+   default boolean federatedAddressConditionalCreateDivertConsumer(DivertBinding divertBinding, QueueBinding queueBinding) throws ActiveMQException {
       return true;
    }
 

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -1824,6 +1824,7 @@
       <xsd:attribute name="auto-delete-message-count" type="xsd:long" use="optional" />
       <xsd:attribute name="max-hops" type="xsd:int" use="optional" />
       <xsd:attribute name="name" type="xsd:ID" use="required" />
+      <xsd:attribute name="enable-divert-bindings" type="xsd:boolean" use="optional" />
       <xsd:attributeGroup ref="xml:specialAttrs"/>
    </xsd:complexType>
 

--- a/artemis-tools/src/test/resources/artemis-configuration.xsd
+++ b/artemis-tools/src/test/resources/artemis-configuration.xsd
@@ -1696,6 +1696,7 @@
       <xsd:attribute name="auto-delete-message-count" type="xsd:long" use="optional" />
       <xsd:attribute name="max-hops" type="xsd:int" use="optional" />
       <xsd:attribute name="name" type="xsd:ID" use="required" />
+      <xsd:attribute name="enable-divert-bindings" type="xsd:boolean" use="optional" />
       <xsd:attributeGroup ref="xml:specialAttrs"/>
    </xsd:complexType>
 

--- a/docs/user-manual/en/federation-address.md
+++ b/docs/user-manual/en/federation-address.md
@@ -66,6 +66,18 @@ the tree can extend to any depth, and can be extended to without needing to re-c
 
 In this case messages published to the master address can be received by any consumer connected to any broker in the tree.
 
+### Divert Binding Support
+
+Divert binding support can be added as part of the address policy configuration. This will allow the federation to respond
+to divert bindings to create demand. For example, let's say there is one address called "test.federation.source" that is
+included as a match for the federated address and another address called "test.federation.target" that is not included. Normally
+when a queue is created on "test.federation.target" this would not cause a federated consumer to be created because the address
+is not part of the included matches. However, if we create a divert binding such that "test.federation.source" is the source address
+and "test.federation.target" is the forwarded address then demand will now be created. The source address still must be multicast
+but the target address can be multicast or anycast.
+
+An example use case for this might be a divert that redirects JMS topics (multicast addresses) to a JMS queue (anycast addresses) to
+allow for load balancing of the messages on a topic for legacy consumers not supporting JMS 2.0 and shared subscriptions.
 
 ## Configuring Address Federation
 
@@ -134,6 +146,9 @@ and the delay and message count params have been met. This is useful if you want
 - `auto-delete-message-count`. The amount number messages in the upstream queue that the message count must be equal or below before the downstream broker has disconnected before the upstream queue can be eligable for `auto-delete`.
 
 - `transformer-ref`. The ref name for a transformer (see transformer config) that you may wish to configure to transform the message on federation transfer.
+
+- `enable-divert-bindings`. Setting to true will enable divert bindings to be listened for demand. If there is a divert binding with an address that matches the included
+addresses for the stream, any queue bindings that match the forward address of the divert will create demand. Default is false
 
 **note** `address-policy`'s and `queue-policy`'s are able to be defined in the same federation, and be linked to the same upstream.
 

--- a/examples/features/federation/federated-address-divert/pom.xml
+++ b/examples/features/federation/federated-address-divert/pom.xml
@@ -1,0 +1,173 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+
+   <parent>
+      <groupId>org.apache.activemq.examples.federation</groupId>
+      <artifactId>broker-federation</artifactId>
+      <version>2.12.0-SNAPSHOT</version>
+   </parent>
+
+   <artifactId>federated-address-divert</artifactId>
+   <packaging>jar</packaging>
+   <name>ActiveMQ Artemis Federated Address Divert Example</name>
+
+   <properties>
+      <activemq.basedir>${project.basedir}/../../../..</activemq.basedir>
+   </properties>
+
+   <dependencies>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-jms-client</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+   </dependencies>
+
+   <build>
+      <plugins>
+         <plugin>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-maven-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>create0</id>
+                  <goals>
+                     <goal>create</goal>
+                  </goals>
+                  <configuration>
+                     <ignore>${noServer}</ignore>
+                     <instance>${basedir}/target/server0</instance>
+                     <configuration>${basedir}/target/classes/activemq/server0</configuration>
+                     <!-- this makes it easier in certain envs -->
+                     <javaOptions>-Djava.net.preferIPv4Stack=true</javaOptions>
+                  </configuration>
+               </execution>
+               <execution>
+                  <id>create1</id>
+                  <goals>
+                     <goal>create</goal>
+                  </goals>
+                  <configuration>
+                     <ignore>${noServer}</ignore>
+                     <instance>${basedir}/target/server1</instance>
+                     <configuration>${basedir}/target/classes/activemq/server1</configuration>
+                     <!-- this makes it easier in certain envs -->
+                     <javaOptions>-Djava.net.preferIPv4Stack=true</javaOptions>
+                  </configuration>
+               </execution>
+               <execution>
+                  <id>start0</id>
+                  <goals>
+                     <goal>cli</goal>
+                  </goals>
+                  <configuration>
+                     <ignore>${noServer}</ignore>
+                     <spawn>true</spawn>
+                     <location>${basedir}/target/server0</location>
+                     <testURI>tcp://localhost:61616</testURI>
+                     <args>
+                        <param>run</param>
+                     </args>
+                     <name>eu-west-1</name>
+                  </configuration>
+               </execution>
+               <execution>
+                  <id>start1</id>
+                  <goals>
+                     <goal>cli</goal>
+                  </goals>
+                  <configuration>
+                     <ignore>${noServer}</ignore>
+                     <spawn>true</spawn>
+                     <location>${basedir}/target/server1</location>
+                     <testURI>tcp://localhost:61617</testURI>
+                     <args>
+                        <param>run</param>
+                     </args>
+                     <name>eu-east-1</name>
+                  </configuration>
+               </execution>
+               <execution>
+                  <id>runClient</id>
+                  <goals>
+                     <goal>runClient</goal>
+                  </goals>
+                  <configuration>
+                     <clientClass>org.apache.activemq.artemis.jms.example.FederatedAddressDivertExample</clientClass>
+                  </configuration>
+               </execution>
+               <execution>
+                  <id>stop0</id>
+                  <goals>
+                     <goal>cli</goal>
+                  </goals>
+                  <configuration>
+                     <ignore>${noServer}</ignore>
+                     <location>${basedir}/target/server0</location>
+                     <args>
+                        <param>stop</param>
+                     </args>
+                  </configuration>
+               </execution>
+               <execution>
+                  <id>stop1</id>
+                  <goals>
+                     <goal>cli</goal>
+                  </goals>
+                  <configuration>
+                     <ignore>${noServer}</ignore>
+                     <location>${basedir}/target/server1</location>
+                     <args>
+                        <param>stop</param>
+                     </args>
+                  </configuration>
+               </execution>
+            </executions>
+            <dependencies>
+               <dependency>
+                  <groupId>org.apache.activemq.examples.federation</groupId>
+                  <artifactId>federated-address-divert</artifactId>
+                  <version>${project.version}</version>
+               </dependency>
+            </dependencies>
+         </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-clean-plugin</artifactId>
+         </plugin>
+      </plugins>
+   </build>
+   <profiles>
+      <profile>
+         <id>release</id>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>com.vladsch.flexmark</groupId>
+                  <artifactId>markdown-page-generator-plugin</artifactId>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+   </profiles>
+</project>

--- a/examples/features/federation/federated-address-divert/readme.md
+++ b/examples/features/federation/federated-address-divert/readme.md
@@ -1,0 +1,18 @@
+# Federated Address Divert Example
+
+To run the example, simply type **mvn verify** from this directory, or **mvn -PnoServer verify** if you want to start and create the broker manually.
+
+This example demonstrates a core multicast address deployed on two different brokers. The two brokers are configured to form a federated address mesh.
+
+In the example we name the brokers eu-west and eu-east.
+
+The following is then carried out:
+
+1. create a divert binding with a source address of exampleTopic and target address of divertExampleTopic on eu-west
+
+1. create a consumer on the topic divertExampleTopic on eu-west and create a producer on the topic exampleTopic on eu-east.
+
+2. send some messages via the producer on eu-east, and we verify the eu-west consumer receives the messages because of the divert binding demand
+
+
+For more information on ActiveMQ Artemis Federation please see the federation section of the user manual.

--- a/examples/features/federation/federated-address-divert/src/main/java/org/apache/activemq/artemis/jms/example/FederatedAddressDivertExample.java
+++ b/examples/features/federation/federated-address-divert/src/main/java/org/apache/activemq/artemis/jms/example/FederatedAddressDivertExample.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.jms.example;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import javax.jms.Topic;
+import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+
+/**
+ * A simple example that demonstrates multicast address replication between remote servers,
+ * using Address Federation feature and diverts.
+ */
+public class FederatedAddressDivertExample {
+
+   public static void main(final String[] args) throws Exception {
+      Connection connectionEUWest = null;
+
+      Connection connectionEUEast = null;
+
+
+      try {
+         // Step 1. Instantiate the Topic (multicast) for the producers
+         Topic topic = ActiveMQJMSClient.createTopic("exampleTopic");
+
+         //Create a topic for the consumers
+         Topic topic2 = ActiveMQJMSClient.createTopic("divertExampleTopic");
+
+         // Step 2. Instantiate connection towards server EU West
+         ConnectionFactory cfEUWest = new ActiveMQConnectionFactory("tcp://localhost:61616");
+
+         // Step 3. Instantiate connection towards server EU East
+         ConnectionFactory cfEUEast = new ActiveMQConnectionFactory("tcp://localhost:61617");
+
+
+         // Step 5. We create a JMS Connection connectionEUWest which is a connection to server EU West
+         connectionEUWest = cfEUWest.createConnection();
+
+         // Step 6. We create a JMS Connection connectionEUEast which is a connection to server EU East
+         connectionEUEast = cfEUEast.createConnection();
+
+         // Step 8. We create a JMS Session on server EU West
+         Session sessionEUWest = connectionEUWest.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+         // Step 9. We create a JMS Session on server EU East
+         Session sessionEUEast = connectionEUEast.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+         // Step 11. We start the connections to ensure delivery occurs on them
+         connectionEUWest.start();
+
+         connectionEUEast.start();
+
+         // Step 12. We create a JMS MessageProducer object on each server
+         MessageProducer producerEUEast = sessionEUEast.createProducer(topic);
+
+         // Step 13. We create JMS MessageConsumer objects on each server - Messages will be diverted to this topic
+         MessageConsumer consumerEUWest = sessionEUWest.createSharedDurableConsumer(topic2, "exampleSubscription");
+
+
+         // Step 14. Let a little time for everything to start and form.
+
+         Thread.sleep(5000);
+
+         // Step 13. We send some messages to server EU West
+         final int numMessages = 10;
+
+         // Step 15. Repeat same test one last time, this time sending on EU East
+
+         for (int i = 0; i < numMessages; i++) {
+            TextMessage message = sessionEUEast.createTextMessage("This is text sent from EU East, message " + i);
+
+            producerEUEast.send(message);
+
+            System.out.println("EU East   :: Sent message: " + message.getText());
+         }
+
+         // Step 14. We now consume those messages on *all* servers .
+         // We note that every consumer, receives a message even so on seperate servers
+
+         for (int i = 0; i < numMessages; i++) {
+            TextMessage messageEUWest = (TextMessage) consumerEUWest.receive(5000);
+
+            System.out.println("EU West   :: Got message: " + messageEUWest.getText());
+         }
+      } finally {
+         // Step 16. Be sure to close our resources!
+         if (connectionEUWest != null) {
+            connectionEUWest.stop();
+            connectionEUWest.close();
+         }
+
+         if (connectionEUEast != null) {
+            connectionEUEast.stop();
+            connectionEUEast.close();
+         }
+      }
+   }
+}

--- a/examples/features/federation/federated-address-divert/src/main/resources/activemq/server0/broker.xml
+++ b/examples/features/federation/federated-address-divert/src/main/resources/activemq/server0/broker.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<configuration xmlns="urn:activemq" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+   <core xmlns="urn:activemq:core">
+
+      <name>eu-west-1-master</name>
+
+      <bindings-directory>./data/bindings</bindings-directory>
+
+      <journal-directory>./data/journal</journal-directory>
+
+      <large-messages-directory>./data/largemessages</large-messages-directory>
+
+      <paging-directory>./data/paging</paging-directory>
+      <!-- Connectors -->
+
+      <connectors>
+         <connector name="netty-connector">tcp://localhost:61616</connector>
+         <connector name="eu-west-1-connector">tcp://localhost:61616</connector>
+         <connector name="eu-east-1-connector">tcp://localhost:61617</connector>
+      </connectors>
+
+      <!-- Acceptors -->
+      <acceptors>
+         <acceptor name="netty-acceptor">tcp://localhost:61616</acceptor>
+      </acceptors>
+
+      <!-- Federation -->
+
+      <federations>
+         <federation name="eu-west-1-federation">
+            <upstream name="eu-east-1-upstream">
+               <circuit-breaker-timeout>1000</circuit-breaker-timeout>
+               <static-connectors>
+                  <connector-ref>eu-east-1-connector</connector-ref>
+               </static-connectors>
+               <policy ref="policySetA"/>
+            </upstream>
+
+            <policy-set name="policySetA">
+               <policy ref="address-federation" />
+            </policy-set>
+
+            <!-- Enable the use of divert bindings -->
+            <address-policy name="address-federation" enable-divert-bindings="true">
+               <include address-match="exampleTopic" />
+            </address-policy>
+         </federation>
+      </federations>
+
+      <!-- Divert configuration -->
+      <diverts>
+         <divert name="federation-divert">
+            <routing-name>federation-divert</routing-name>
+            <address>exampleTopic</address>
+            <forwarding-address>divertExampleTopic</forwarding-address>
+            <exclusive>true</exclusive>
+         </divert>
+      </diverts>
+
+      <!-- Other config -->
+
+      <security-settings>
+         <!--security for example queue-->
+         <security-setting match="exampleTopic">
+            <permission roles="guest" type="createDurableQueue"/>
+            <permission roles="guest" type="deleteDurableQueue"/>
+            <permission roles="guest" type="createNonDurableQueue"/>
+            <permission roles="guest" type="deleteNonDurableQueue"/>
+            <permission roles="guest" type="consume"/>
+            <permission roles="guest" type="send"/>
+         </security-setting>
+         <security-setting match="divertExampleTopic">
+            <permission roles="guest" type="createDurableQueue"/>
+            <permission roles="guest" type="deleteDurableQueue"/>
+            <permission roles="guest" type="createNonDurableQueue"/>
+            <permission roles="guest" type="deleteNonDurableQueue"/>
+            <permission roles="guest" type="consume"/>
+            <permission roles="guest" type="send"/>
+         </security-setting>
+      </security-settings>
+
+      <addresses>
+         <address name="exampleTopic">
+            <multicast />
+         </address>
+         <address name="divertExampleTopic">
+            <multicast>
+               <queue name="exampleSubscription"/>
+            </multicast>
+         </address>
+      </addresses>
+   </core>
+</configuration>

--- a/examples/features/federation/federated-address-divert/src/main/resources/activemq/server1/broker.xml
+++ b/examples/features/federation/federated-address-divert/src/main/resources/activemq/server1/broker.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<configuration xmlns="urn:activemq" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+   <core xmlns="urn:activemq:core">
+
+      <name>eu-east-1-master</name>
+
+      <bindings-directory>target/server1/data/messaging/bindings</bindings-directory>
+
+      <journal-directory>target/server1/data/messaging/journal</journal-directory>
+
+      <large-messages-directory>target/server1/data/messaging/largemessages</large-messages-directory>
+
+      <paging-directory>target/server1/data/messaging/paging</paging-directory>
+
+      <!-- Connectors -->
+      <connectors>
+         <connector name="netty-connector">tcp://localhost:61617</connector>
+         <connector name="eu-west-1-connector">tcp://localhost:61616</connector>
+         <connector name="eu-east-1-connector">tcp://localhost:61617</connector>
+      </connectors>
+
+      <!-- Acceptors -->
+      <acceptors>
+         <acceptor name="netty-acceptor">tcp://localhost:61617</acceptor>
+      </acceptors>
+
+      <!-- Other config -->
+
+      <security-settings>
+         <!--security for example queue-->
+         <security-setting match="exampleTopic">
+            <permission roles="guest" type="createDurableQueue"/>
+            <permission roles="guest" type="deleteDurableQueue"/>
+            <permission roles="guest" type="createNonDurableQueue"/>
+            <permission roles="guest" type="deleteNonDurableQueue"/>
+            <permission roles="guest" type="consume"/>
+            <permission roles="guest" type="send"/>
+         </security-setting>
+      </security-settings>
+
+      <addresses>
+         <address name="exampleTopic">
+            <multicast />
+         </address>
+      </addresses>
+   </core>
+</configuration>

--- a/examples/features/federation/pom.xml
+++ b/examples/features/federation/pom.xml
@@ -53,6 +53,7 @@ under the License.
             <module>federated-address</module>
             <module>federated-address-downstream</module>
             <module>federated-address-downstream-upstream</module>
+            <module>federated-address-divert</module>
          </modules>
       </profile>
       <profile>
@@ -64,6 +65,7 @@ under the License.
             <module>federated-address</module>
             <module>federated-address-downstream</module>
             <module>federated-address-downstream-upstream</module>
+            <module>federated-address-divert</module>
          </modules>
       </profile>
    </profiles>


### PR DESCRIPTION
This will allow federated addresses to create remote consumers based on
the existing of divert bindings and matching queue bindings.  See the Jira at [AMQ-2613](https://issues.apache.org/jira/browse/ARTEMIS-2613) for more information. 