### PR TITLE
ARTEMIS-2563 Added option to create queues on all clustered nodes

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -275,6 +275,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
    private static final String RETROACTIVE_MESSAGE_COUNT = "retroactive-message-count";
 
+   private static final String CLUSTERED_QUEUES_NODE_NAME = "clustered-queues";
+
 
    // Attributes ----------------------------------------------------
 
@@ -1185,6 +1187,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
             long retroactiveMessageCount = XMLUtil.parseLong(child);
             Validators.GE_ZERO.validate(RETROACTIVE_MESSAGE_COUNT, retroactiveMessageCount);
             addressSettings.setRetroactiveMessageCount(retroactiveMessageCount);
+         } else if (CLUSTERED_QUEUES_NODE_NAME.equalsIgnoreCase(name)) {
+            addressSettings.setClusteredQueues(XMLUtil.parseBoolean(child));
          }
       }
       return setting;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -272,6 +272,25 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
 
                queueInfos.put(clusterName, info);
 
+               // Global queue creation
+               Binding binding = getBinding(routingName);
+
+               AddressSettings addressSettings = addressSettingsRepository.getMatch(address.toString());
+
+               boolean clusteredQueues = addressSettings.getClusteredQueues();
+
+               if (clusteredQueues && binding == null && distance != 0) {
+                  try {
+                     if (routingName.equals(address)) {
+                        server.createQueue(address, RoutingType.ANYCAST, address, filterString, true, false);
+                     } else {
+                        server.createQueue(address, RoutingType.MULTICAST, routingName, filterString, true, false);
+                     }
+                  } catch (Exception e) {
+                     logger.error("Could not create queue", e);
+                  }
+               }
+
                break;
             }
             case BINDING_REMOVED: {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
@@ -109,6 +109,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    // Default address drop threshold, applied to address settings with BLOCK policy.  -1 means no threshold enabled.
    public static final long DEFAULT_ADDRESS_REJECT_THRESHOLD = -1;
 
+   public static final boolean DEFAULT_CLUSTERED_QUEUES = false;
+
    private AddressFullMessagePolicy addressFullMessagePolicy = null;
 
    private Long maxSizeBytes = null;
@@ -215,6 +217,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
    private Integer defaultConsumerWindowSize = null;
 
+   private Boolean clusteredQueues = null;
+
    //from amq5
    //make it transient
    private transient Integer queuePrefetch = null;
@@ -270,6 +274,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       this.defaultGroupBuckets = other.defaultGroupBuckets;
       this.defaultGroupFirstKey = other.defaultGroupFirstKey;
       this.defaultRingSize = other.defaultRingSize;
+      this.clusteredQueues = other.clusteredQueues;
    }
 
    public AddressSettings() {
@@ -770,6 +775,16 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       return this;
    }
 
+   public boolean getClusteredQueues() {
+      return clusteredQueues != null ? clusteredQueues : AddressSettings.DEFAULT_CLUSTERED_QUEUES;
+   }
+
+   public AddressSettings setClusteredQueues(final boolean clusteredQueues) {
+      this.clusteredQueues = clusteredQueues;
+      return this;
+   }
+
+
    /**
     * merge 2 objects in to 1
     *
@@ -932,6 +947,9 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       }
       if (retroactiveMessageCount == null) {
          retroactiveMessageCount = merged.retroactiveMessageCount;
+      }
+      if (clusteredQueues == null) {
+         clusteredQueues = merged.clusteredQueues;
       }
    }
 
@@ -1105,6 +1123,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       if (buffer.readableBytes() > 0) {
          retroactiveMessageCount = BufferHelper.readNullableLong(buffer);
       }
+
+      clusteredQueues = BufferHelper.readNullableBoolean(buffer);
    }
 
    @Override
@@ -1158,7 +1178,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
          BufferHelper.sizeOfNullableLong(autoDeleteQueuesMessageCount) +
          BufferHelper.sizeOfNullableBoolean(autoDeleteCreatedQueues) +
          BufferHelper.sizeOfNullableLong(defaultRingSize) +
-         BufferHelper.sizeOfNullableLong(retroactiveMessageCount);
+         BufferHelper.sizeOfNullableLong(retroactiveMessageCount) +
+         BufferHelper.sizeOfNullableBoolean(clusteredQueues);
    }
 
    @Override
@@ -1264,6 +1285,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       buffer.writeNullableSimpleString(defaultGroupFirstKey);
 
       BufferHelper.writeNullableLong(buffer, retroactiveMessageCount);
+
+      BufferHelper.writeNullableBoolean(buffer, clusteredQueues);
    }
 
    /* (non-Javadoc)
@@ -1325,6 +1348,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       result = prime * result + ((defaultGroupFirstKey == null) ? 0 : defaultGroupFirstKey.hashCode());
       result = prime * result + ((defaultRingSize == null) ? 0 : defaultRingSize.hashCode());
       result = prime * result + ((retroactiveMessageCount == null) ? 0 : retroactiveMessageCount.hashCode());
+      result = prime * result + ((clusteredQueues == null) ? 0 : clusteredQueues.hashCode());
       return result;
    }
 
@@ -1613,6 +1637,13 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
             return false;
       } else if (!retroactiveMessageCount.equals(other.retroactiveMessageCount))
          return false;
+
+      if (clusteredQueues == null) {
+         if (other.clusteredQueues != null)
+            return false;
+      } else if (!clusteredQueues.equals(other.clusteredQueues))
+         return false;
+
       return true;
    }
 
@@ -1722,6 +1753,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
          defaultRingSize +
          ", retroactiveMessageCount=" +
          retroactiveMessageCount +
+         ", clusteredQueues=" +
+         clusteredQueues +
          "]";
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
@@ -1124,7 +1124,9 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
          retroactiveMessageCount = BufferHelper.readNullableLong(buffer);
       }
 
-      clusteredQueues = BufferHelper.readNullableBoolean(buffer);
+      if (buffer.readableBytes() > 0) {
+         clusteredQueues = BufferHelper.readNullableBoolean(buffer);
+      }
    }
 
    @Override

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -3277,6 +3277,15 @@
                </xsd:annotation>
             </xsd:element>
 
+            <xsd:element name="clustered-queues" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     Queues will get created on the local broker if they are created on a clustered neighbour.
+                     This means all queues exist cluster-wide. It helps with redistribution in certain scenarios
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
             <xsd:element name="send-to-dla-on-no-route" type="xsd:boolean" maxOccurs="1" minOccurs="0">
                <xsd:annotation>
                   <xsd:documentation>
@@ -3516,7 +3525,6 @@
                   </xsd:documentation>
                </xsd:annotation>
             </xsd:element>
-            
          </xsd:all>
 
          <xsd:attribute name="match" type="xsd:string" use="required">

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
@@ -363,6 +363,7 @@ public class FileConfigurationTest extends ConfigurationImplTest {
       assertEquals(RoutingType.MULTICAST, conf.getAddressesSettings().get("a1").getDefaultAddressRoutingType());
       assertEquals(3, conf.getAddressesSettings().get("a1").getDefaultRingSize());
       assertEquals(0, conf.getAddressesSettings().get("a1").getRetroactiveMessageCount());
+      assertEquals(false, conf.getAddressesSettings().get("a1").getClusteredQueues());
 
       assertEquals("a2.1", conf.getAddressesSettings().get("a2").getDeadLetterAddress().toString());
       assertEquals("a2.2", conf.getAddressesSettings().get("a2").getExpiryAddress().toString());
@@ -388,6 +389,7 @@ public class FileConfigurationTest extends ConfigurationImplTest {
       assertEquals(10000, conf.getAddressesSettings().get("a2").getDefaultConsumerWindowSize());
       assertEquals(-1, conf.getAddressesSettings().get("a2").getDefaultRingSize());
       assertEquals(10, conf.getAddressesSettings().get("a2").getRetroactiveMessageCount());
+      assertEquals(true, conf.getAddressesSettings().get("a2").getClusteredQueues());
 
       assertTrue(conf.getResourceLimitSettings().containsKey("myUser"));
       assertEquals(104, conf.getResourceLimitSettings().get("myUser").getMaxConnections());

--- a/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
@@ -463,6 +463,7 @@
             <default-address-routing-type>ANYCAST</default-address-routing-type>
             <default-consumer-window-size>10000</default-consumer-window-size>
             <retroactive-message-count>10</retroactive-message-count>
+            <clustered-queues>true</clustered-queues>
          </address-setting>
       </address-settings>
       <resource-limit-settings>

--- a/artemis-server/src/test/resources/ConfigurationTest-xinclude-config-address-settings.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-xinclude-config-address-settings.xml
@@ -68,5 +68,6 @@
       <default-address-routing-type>ANYCAST</default-address-routing-type>
       <default-consumer-window-size>10000</default-consumer-window-size>
       <retroactive-message-count>10</retroactive-message-count>
+      <clustered-queues>true</clustered-queues>
    </address-setting>
 </address-settings>

--- a/artemis-tools/src/test/resources/artemis-configuration.xsd
+++ b/artemis-tools/src/test/resources/artemis-configuration.xsd
@@ -3133,6 +3133,15 @@
                </xsd:annotation>
             </xsd:element>
 
+            <xsd:element name="clustered-queues" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     Queues will get created on the local broker if they are created on a clustered neighbour.
+                     This means all queues exist cluster-wide. It helps with redistribution in certain scenarios
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
             <xsd:element name="send-to-dla-on-no-route" type="xsd:boolean" maxOccurs="1" minOccurs="0">
                <xsd:annotation>
                   <xsd:documentation>

--- a/docs/user-manual/en/address-model.md
+++ b/docs/user-manual/en/address-model.md
@@ -589,6 +589,7 @@ that would be found in the `broker.xml` file.
       <default-consumers-before-dispatch>0</default-consumers-before-dispatch>
       <default-delay-before-dispatch>-1</default-delay-before-dispatch>
       <redistribution-delay>0</redistribution-delay>
+      <clustered-queues>true</clustered-queues>
       <send-to-dla-on-no-route>true</send-to-dla-on-no-route>
       <slow-consumer-threshold>-1</slow-consumer-threshold>
       <slow-consumer-policy>NOTIFY</slow-consumer-policy>
@@ -719,6 +720,12 @@ before it will begin to dispatch messages. Default is `-1` (wait forever).
 `redistribution-delay` defines how long to wait when the last consumer is
 closed on a queue before redistributing any messages. Read more about
 [clusters](clusters.md#message-redistribution).
+
+`clustered-queues` enables cluster-wide creation of queues.
+This means that in the case of a formed cluster with several active brokers,
+all new queues will get created on each cluster member.
+This helps with redistribution of messages in some scenarios,
+such as where client consumers are fairly static and producers work in an "ad hoc" manner.
 
 `send-to-dla-on-no-route`. If a message is sent to an address, but the server
 does not route it to any queues (e.g. there might be no queues bound to that

--- a/docs/user-manual/en/configuration-index.md
+++ b/docs/user-manual/en/configuration-index.md
@@ -250,6 +250,7 @@ Name | Description | Default
 [default-address-routing-type](address-model.md#routing-type) | Routing type for auto-created addresses if the type can't be otherwise determined | `MULTICAST`
 [default-ring-size](ring-queues.md) | The ring-size applied to queues without an explicit `ring-size` configured | `-1`
 [retroactive-message-count](retroactive-addresses.md) | the number of messages to preserve for future queues created on the matching address | `0`
+[clustered-queues](address-model.md)| Queues are created on all nodes in a cluster | `false`
 
 
 ## bridge type

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/ClusteredQueuesTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/ClusteredQueuesTest.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.cluster.distribution;
+
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.apache.activemq.artemis.core.postoffice.Binding;
+import org.apache.activemq.artemis.core.server.cluster.impl.MessageLoadBalancingType;
+import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
+import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ClusteredQueuesTest extends ClusterTestBase {
+
+   private static final IntegrationTestLogger log = IntegrationTestLogger.LOGGER;
+
+   @Override
+   @Before
+   public void setUp() throws Exception {
+      super.setUp();
+      start();
+   }
+
+   private void start() throws Exception {
+      setupServers();
+   }
+
+   protected boolean isNetty() {
+      return false;
+   }
+
+   @Override
+   protected void setSessionFactoryCreateLocator(int node, boolean ha, TransportConfiguration serverTotc) {
+      super.setSessionFactoryCreateLocator(node, ha, serverTotc);
+      locators[node].setConsumerWindowSize(0);
+   }
+
+   @Test
+   public void testNoClusteredQueueonDefault() throws Exception {
+      setupCluster(MessageLoadBalancingType.ON_DEMAND);
+
+      ClusteredQueuesTest.log.info("Doing test");
+
+      startServers(0, 1);
+
+      setupSessionFactory(0, isNetty());
+      setupSessionFactory(1, isNetty());
+
+      createQueue(0, "queues.testaddress", "queues.testaddress", null, true, RoutingType.ANYCAST);
+      addConsumer(0, 0, "queues.testaddress", null);
+
+      waitForBindings(0, "queues.testaddress", 1, 1, true);
+
+      Binding bindable = servers[1].getPostOffice().getBinding(new SimpleString("queues.testaddress"));
+      Assert.assertTrue(bindable == null);
+      stopServers(0, 1);
+      ClusteredQueuesTest.log.info("Test done");
+   }
+
+   @Test
+   public void testClusteredQueueAnycast() throws Exception {
+      setupCluster(MessageLoadBalancingType.ON_DEMAND);
+      AddressSettings setting = new AddressSettings().setClusteredQueues(true);
+
+      servers[0].getAddressSettingsRepository().addMatch("queues.testaddress", setting);
+      servers[1].getAddressSettingsRepository().addMatch("queues.testaddress", setting);
+
+      ClusteredQueuesTest.log.info("Doing test");
+
+      startServers(0, 1);
+
+      setupSessionFactory(0, isNetty());
+      setupSessionFactory(1, isNetty());
+
+      createQueue(0, "queues.testaddress", "queues.testaddress", null, true, RoutingType.ANYCAST);
+      addConsumer(0, 0, "queues.testaddress", null);
+
+      waitForBindings(1, "queues.testaddress", 1, 0, true);
+
+      Binding bindable = servers[1].getPostOffice().getBinding(new SimpleString("queues.testaddress"));
+      Assert.assertTrue(bindable != null);
+      stopServers(0, 1);
+      ClusteredQueuesTest.log.info("Test done");
+   }
+
+   @Test
+   public void testClusteredQueueMulticast() throws Exception {
+      setupCluster(MessageLoadBalancingType.ON_DEMAND);
+      AddressSettings setting = new AddressSettings().setClusteredQueues(true);
+
+      servers[0].getAddressSettingsRepository().addMatch("queues.testaddress", setting);
+      servers[1].getAddressSettingsRepository().addMatch("queues.testaddress", setting);
+      servers[0].getAddressSettingsRepository().addMatch("queue0", setting);
+      servers[1].getAddressSettingsRepository().addMatch("queue0", setting);
+
+      ClusteredQueuesTest.log.info("Doing test");
+
+      startServers(0, 1);
+
+      setupSessionFactory(0, isNetty());
+      setupSessionFactory(1, isNetty());
+
+      createQueue(0, "queues.testaddress", "queues0", null, true, RoutingType.MULTICAST);
+      addConsumer(0, 0, "queues0", null);
+      waitForBindings(1, "queues.testaddress", 1, 0, true);
+
+      Binding bindable = servers[1].getPostOffice().getBinding(new SimpleString("queues0"));
+      Assert.assertTrue(bindable != null);
+      stopServers(0, 1);
+      ClusteredQueuesTest.log.info("Test done");
+   }
+
+   protected void setupCluster(final MessageLoadBalancingType messageLoadBalancingType) throws Exception {
+      setupClusterConnection("cluster0", "queues", messageLoadBalancingType, 1, isNetty(), 0, 1);
+      setupClusterConnection("cluster1", "queues", messageLoadBalancingType, 1, isNetty(), 1, 0);
+   }
+
+   protected void setupServers() throws Exception {
+      setupServer(0, isFileStorage(), isNetty());
+      setupServer(1, isFileStorage(), isNetty());
+   }
+
+   protected void stopServers() throws Exception {
+      closeAllConsumers();
+      closeAllSessionFactories();
+      closeAllServerLocatorsFactories();
+      stopServers(0, 1);
+      clearServer(0, 1);
+   }
+}


### PR DESCRIPTION
This is to help with redistribution as mentioned in this Jira:
https://issues.apache.org/jira/browse/ARTEMIS-2563

Address option added to enable queue creation on all active nodes in a cluster, which happens on BINDING_ADDED. Since this creates a local binding for remote queues, a redistributor will also get created once a consumer registers