### PR TITLE
ARTEMIS-2620 Avoid Exception on client when large message file corrupted

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/LargeBodyReader.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/LargeBodyReader.java
@@ -62,4 +62,13 @@ public interface LargeBodyReader {
     * This method must not be called directly by ActiveMQ Artemis clients.
     */
    long getSize() throws ActiveMQException;
+
+
+   /**
+    * Check if the large message file matches its size
+    * @return true if matches, false otherwise
+    */
+   default boolean validateLargeMessage(long expectedSize) {
+      return true;
+   }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/LargeBody.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/LargeBody.java
@@ -431,6 +431,15 @@ public class LargeBody {
       public long getSize() throws ActiveMQException {
          return getBodySize();
       }
+
+      @Override
+      public boolean validateLargeMessage(long expectedSize) {
+         try {
+            return cFile.size() == expectedSize;
+         } catch (Exception e) {
+            return false;
+         }
+      }
    }
 
    public boolean hasPendingRecord() {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -2073,4 +2073,8 @@ public interface ActiveMQServerLogger extends BasicLogger {
    @LogMessage(level = Logger.Level.ERROR)
    @Message(id = 224104, value = "Error starting the Acceptor {0} {1}", format = Message.Format.MESSAGE_FORMAT)
    void errorStartingAcceptor(String name, Object configuration);
+
+   @LogMessage(level = Logger.Level.ERROR)
+   @Message(id = 224105, value = "The large message file size does not match expected size {0}, it will be dropped. Message: {1}", format = Message.Format.MESSAGE_FORMAT)
+   void errorLargeMessageFileSize(long sizePendingLargeMessage, LargeServerMessage currentLargeMessage);
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ServerSession.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ServerSession.java
@@ -533,4 +533,6 @@ public interface ServerSession extends SecurityAuth {
    int getDefaultConsumerWindowSize(SimpleString address);
 
    String toManagementString();
+
+   ActiveMQServer getServer();
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerConsumerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerConsumerImpl.java
@@ -1302,6 +1302,12 @@ public class ServerConsumerImpl implements ServerConsumer, ReadyListener {
 
                context.open();
 
+               if (!context.validateLargeMessage(sizePendingLargeMessage)) {
+                  ActiveMQServerLogger.LOGGER.errorLargeMessageFileSize(sizePendingLargeMessage, currentLargeMessage);
+                  finish();
+                  return true;
+               }
+
                sentInitialPacket = true;
 
                int packetSize = callback.sendLargeMessage(ref, currentLargeMessage.toMessage(), ServerConsumerImpl.this, context.getSize(), ref.getDeliveryCount());

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -2328,4 +2328,9 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
    public String toManagementString() {
       return "ServerSession [id=" + getConnectionID() + ":" + getName() + "]";
    }
+
+   @Override
+   public ActiveMQServer getServer() {
+      return server;
+   }
 }


### PR DESCRIPTION
The broker should be more resilient so that it can avoid throwing an
exception on the client side when it encounters an invalid or empty
large message file(corrupted for any reason). It would be better to
deal with it within the broker and not allow the issue to manifest
itself on the consuming client.

Also fixed an ActiveMQServerMessagePlugin issue where beforeSend(),
afterSend(), sendOnException() are not get called with large
messages.