### PR TITLE
ARTEMIS-2617 Fixing KMPNeedle::searchInto API and specializing it

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
@@ -45,7 +45,6 @@ import org.apache.activemq.artemis.protocol.amqp.util.NettyWritable;
 import org.apache.activemq.artemis.protocol.amqp.util.TLSEncode;
 import org.apache.activemq.artemis.reader.MessageUtil;
 import org.apache.activemq.artemis.utils.ByteUtil;
-import org.apache.activemq.artemis.utils.algo.KMPNeedle;
 import org.apache.activemq.artemis.utils.collections.TypedProperties;
 import org.apache.qpid.proton.amqp.Binary;
 import org.apache.qpid.proton.amqp.Symbol;

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessageSymbolSearch.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessageSymbolSearch.java
@@ -22,7 +22,6 @@ import java.util.IdentityHashMap;
 import java.util.List;
 
 import org.apache.activemq.artemis.protocol.amqp.util.TLSEncode;
-import org.apache.activemq.artemis.utils.algo.KMPNeedle;
 import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.amqp.messaging.AmqpSequence;
 import org.apache.qpid.proton.amqp.messaging.AmqpValue;
@@ -67,7 +66,7 @@ final class AMQPMessageSymbolSearch {
                   constructor.skipValue();
                   final int end = data.position();
                   for (int i = 0, count = needles.length; i < count; i++) {
-                     final int foundIndex = needles[i].searchInto(ReadableBuffer::get, data, end, start);
+                     final int foundIndex = needles[i].searchInto(data, start, end);
                      if (foundIndex != -1) {
                         return true;
                      }


### PR DESCRIPTION
KMPNeedle::searchInto has been specialized and copied
to handle ReadableBuffer in order to save polymorphic
calls on it that would make it slower on hot paths.