### PR TITLE
ARTEMIS-2627 simpleSecureServer failing on IBM JDK 8

### DIFF
--- a/artemis-dto/pom.xml
+++ b/artemis-dto/pom.xml
@@ -60,6 +60,11 @@
          <artifactId>activation</artifactId>
          <version>${version.activation}</version>
       </dependency>
+      <dependency>
+         <groupId>junit</groupId>
+         <artifactId>junit</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
 
    <build>

--- a/artemis-dto/src/main/java/org/apache/activemq/artemis/dto/WebServerDTO.java
+++ b/artemis-dto/src/main/java/org/apache/activemq/artemis/dto/WebServerDTO.java
@@ -59,6 +59,18 @@ public class WebServerDTO extends ComponentDTO {
    @XmlAttribute
    private String trustStorePassword;
 
+   @XmlAttribute
+   private String includedTLSProtocols;
+
+   @XmlAttribute
+   private String excludedTLSProtocols;
+
+   @XmlAttribute
+   private String includedCipherSuites;
+
+   @XmlAttribute
+   private String excludedCipherSuites;
+
    public WebServerDTO() {
       componentClassName = "org.apache.activemq.artemis.component.WebServerComponent";
    }
@@ -81,5 +93,53 @@ public class WebServerDTO extends ComponentDTO {
 
    public void setTrustStorePassword(String trustStorePassword) {
       this.trustStorePassword = trustStorePassword;
+   }
+
+   private String[] unmarshalArray(String text) {
+      if (text == null) {
+         return null;
+      }
+
+      return text.split(",");
+   }
+
+   private String marshalArray(String[] array) {
+      if (array == null) {
+         return null;
+      }
+
+      return String.join(",", array);
+   }
+
+   public String[] getIncludedTLSProtocols() {
+      return unmarshalArray(includedTLSProtocols);
+   }
+
+   public void setIncludedTLSProtocols(String... protocols) {
+      includedTLSProtocols = marshalArray(protocols);
+   }
+
+   public String[] getExcludedTLSProtocols() {
+      return unmarshalArray(excludedTLSProtocols);
+   }
+
+   public void setExcludedTLSProtocols(String... protocols) {
+      excludedTLSProtocols = marshalArray(protocols);
+   }
+
+   public String[] getIncludedCipherSuites() {
+      return unmarshalArray(includedCipherSuites);
+   }
+
+   public void setIncludedCipherSuites(String... cipherSuites) {
+      includedCipherSuites = marshalArray(cipherSuites);
+   }
+
+   public String[] getExcludedCipherSuites() {
+      return unmarshalArray(excludedCipherSuites);
+   }
+
+   public void setExcludedCipherSuites(String... cipherSuites) {
+      excludedCipherSuites = marshalArray(cipherSuites);
    }
 }

--- a/artemis-dto/src/test/java/org/apache/activemq/artemis/dto/test/WebServerDTOTest.java
+++ b/artemis-dto/src/test/java/org/apache/activemq/artemis/dto/test/WebServerDTOTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.dto.test;
+
+import org.apache.activemq.artemis.dto.WebServerDTO;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class WebServerDTOTest extends Assert {
+
+   @Test
+   public void testDefault() {
+      WebServerDTO webServer = new WebServerDTO();
+
+      Assert.assertNull(webServer.getIncludedTLSProtocols());
+      Assert.assertNull(webServer.getExcludedTLSProtocols());
+      Assert.assertNull(webServer.getIncludedCipherSuites());
+      Assert.assertNull(webServer.getExcludedCipherSuites());
+   }
+
+   @Test
+   public void testValues() {
+      WebServerDTO webServer = new WebServerDTO();
+
+      webServer.setIncludedTLSProtocols("TLSv1.2");
+      Assert.assertArrayEquals(new String[] {"TLSv1.2"}, webServer.getIncludedTLSProtocols());
+
+      webServer.setExcludedTLSProtocols("TLSv1,TLSv1.1");
+      Assert.assertArrayEquals(new String[] {"TLSv1", "TLSv1.1"}, webServer.getExcludedTLSProtocols());
+
+      webServer.setIncludedCipherSuites( "^SSL_.*$");
+      Assert.assertArrayEquals(new String[] {"^SSL_.*$"}, webServer.getIncludedCipherSuites());
+
+      webServer.setExcludedCipherSuites( "^.*_(MD5|SHA|SHA1)$,^TLS_RSA_.*$,^.*_NULL_.*$,^.*_anon_.*$");
+      Assert.assertArrayEquals(new String[] {"^.*_(MD5|SHA|SHA1)$", "^TLS_RSA_.*$", "^.*_NULL_.*$", "^.*_anon_.*$"}, webServer.getExcludedCipherSuites());
+   }
+
+   @Test
+   public void testEmptyValues() {
+      WebServerDTO webServer = new WebServerDTO();
+
+      webServer.setIncludedTLSProtocols("");
+      Assert.assertArrayEquals(new String[] {""}, webServer.getIncludedTLSProtocols());
+
+      webServer.setExcludedTLSProtocols("");
+      Assert.assertArrayEquals(new String[] {""}, webServer.getExcludedTLSProtocols());
+
+      webServer.setIncludedCipherSuites("");
+      Assert.assertArrayEquals(new String[] {""}, webServer.getIncludedCipherSuites());
+
+      webServer.setExcludedCipherSuites("");
+      Assert.assertArrayEquals(new String[] {""}, webServer.getExcludedCipherSuites());
+   }
+
+   @Test
+   public void testNullValues() {
+      WebServerDTO webServer = new WebServerDTO();
+
+      webServer.setIncludedTLSProtocols(null);
+      Assert.assertNull(webServer.getIncludedTLSProtocols());
+
+      webServer.setExcludedTLSProtocols(null);
+      Assert.assertNull(webServer.getExcludedTLSProtocols());
+
+      webServer.setIncludedCipherSuites(null);
+      Assert.assertNull(webServer.getIncludedCipherSuites());
+
+      webServer.setExcludedCipherSuites(null);
+      Assert.assertNull(webServer.getExcludedCipherSuites());
+   }
+}

--- a/artemis-web/src/main/java/org/apache/activemq/artemis/component/WebServerComponent.java
+++ b/artemis-web/src/main/java/org/apache/activemq/artemis/component/WebServerComponent.java
@@ -72,6 +72,20 @@ public class WebServerComponent implements ExternalComponent {
          SslContextFactory.Server sslFactory = new SslContextFactory.Server();
          sslFactory.setKeyStorePath(webServerConfig.keyStorePath == null ? artemisInstance + "/etc/keystore.jks" : webServerConfig.keyStorePath);
          sslFactory.setKeyStorePassword(webServerConfig.getKeyStorePassword() == null ? "password" : webServerConfig.getKeyStorePassword());
+         String[] ips = sslFactory.getIncludeProtocols();
+
+         if (webServerConfig.getIncludedTLSProtocols() != null) {
+            sslFactory.setIncludeProtocols(webServerConfig.getIncludedTLSProtocols());
+         }
+         if (webServerConfig.getExcludedTLSProtocols() != null) {
+            sslFactory.setExcludeProtocols(webServerConfig.getExcludedTLSProtocols());
+         }
+         if (webServerConfig.getIncludedCipherSuites() != null) {
+            sslFactory.setIncludeCipherSuites(webServerConfig.getIncludedCipherSuites());
+         }
+         if (webServerConfig.getExcludedCipherSuites() != null) {
+            sslFactory.setExcludeCipherSuites(webServerConfig.getExcludedCipherSuites());
+         }
          if (webServerConfig.clientAuth != null) {
             sslFactory.setNeedClientAuth(webServerConfig.clientAuth);
             if (webServerConfig.clientAuth) {

--- a/docs/user-manual/en/web-server.md
+++ b/docs/user-manual/en/web-server.md
@@ -41,6 +41,14 @@ The `web` element has the following attributes:
   using `https`. Can be masked using `ENC()` syntax or by defining
   `passwordCodec`. See more in the [password masking](masking-passwords.md)
   chapter.
+- `includedTLSProtocols` A comma seperated list of included TLS protocols,
+  ie `"TLSv1,TLSv1.1,TLSv1.2"`. Only applicable when using `https`.
+- `excludedTLSProtocols` A comma seperated list of excluded TLS protocols,
+  ie `"TLSv1,TLSv1.1,TLSv1.2"`. Only applicable when using `https`.
+- `includedCipherSuites` A comma seperated list of included cipher suites.
+  Only applicable when using `https`.
+- `excludedCipherSuites` A comma seperated list of excluded cipher suites.
+  Only applicable when using `https`.
 
 Each web application should be defined in an `app` element. The `app` element
 has the following attributes:


### PR DESCRIPTION
Remove excluded cipher suites matching the prefix `SSL` because the names of the
IBM JDK 8 cipher suites have the prefix `SSL` while the
`DEFAULT_EXCLUDED_CIPHER_SUITES` of org.eclipse.jetty.util.ssl.SslContextFactory
includes "^SSL_.*$". So all IBM JDK cipher suites are excluded by
SslContextFactory using the `DEFAULT_EXCLUDED_CIPHER_SUITES`.