### PR TITLE
Update duplicate-detection.md

### DIFF
--- a/docs/user-manual/en/duplicate-detection.md
+++ b/docs/user-manual/en/duplicate-detection.md
@@ -110,7 +110,7 @@ size of `n` elements, then the `n + 1`th id stored will overwrite the
 
 The maximum size of the cache is configured by the parameter
 `id-cache-size` in `broker.xml`, the default value is
-`2000` elements.
+`20000` elements.
 
 The caches can also be configured to persist to disk or not. This is
 configured by the parameter `persist-id-cache`, also in


### PR DESCRIPTION
The default id cache size is 20000.

https://github.com/apache/activemq-artemis/blob/master/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java#L234
