### PR TITLE
ARTEMIS-2645 refactor CLI FQQN support

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/Browse.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/Browse.java
@@ -49,10 +49,15 @@ public class Browse extends DestAbstract {
             } else {
                session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
             }
-            Destination dest = lookupDestination(session);
+            Destination dest = getDestination(session);
             threadsArray[i] = new ConsumerThread(session, dest, i);
 
-            threadsArray[i].setVerbose(verbose).setSleep(sleep).setMessageCount(messageCount).setFilter(filter).setBrowse(true);
+            threadsArray[i]
+               .setVerbose(verbose)
+               .setSleep(sleep)
+               .setMessageCount(messageCount)
+               .setFilter(filter)
+               .setBrowse(true);
          }
 
          for (ConsumerThread thread : threadsArray) {
@@ -69,11 +74,6 @@ public class Browse extends DestAbstract {
          }
 
          return received;
-      } finally {
-         if (factory instanceof AutoCloseable) {
-            ((AutoCloseable) factory).close();
-         }
       }
    }
-
 }

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/ProducerThread.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/ProducerThread.java
@@ -30,7 +30,6 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.activemq.artemis.jms.client.ActiveMQMessage;
 import org.apache.activemq.artemis.utils.ReusableLatch;
 
 public class ProducerThread extends Thread {
@@ -49,7 +48,6 @@ public class ProducerThread extends Thread {
    long msgTTL = 0L;
    String msgGroupID = null;
    int transactionBatchSize;
-   byte[] queueId = null;
 
    int transactions = 0;
    final AtomicInteger sentCount = new AtomicInteger(0);
@@ -123,10 +121,6 @@ public class ProducerThread extends Thread {
 
    private void sendMessage(MessageProducer producer, String threadName) throws Exception {
       Message message = createMessage(sentCount.get(), threadName);
-
-      if (queueId != null) {
-         ((ActiveMQMessage) message).getCoreMessage().putBytesProperty(org.apache.activemq.artemis.api.core.Message.HDR_ROUTE_TO_IDS, queueId);
-      }
 
       producer.send(message);
       if (verbose) {
@@ -376,9 +370,5 @@ public class ProducerThread extends Thread {
    public ProducerThread setObjectSize(int objectSize) {
       this.objectSize = objectSize;
       return this;
-   }
-
-   public void setQueueId(byte[] queueId) {
-      this.queueId = queueId;
    }
 }

--- a/artemis-cli/src/test/java/org/apache/activemq/cli/test/CliProducerTest.java
+++ b/artemis-cli/src/test/java/org/apache/activemq/cli/test/CliProducerTest.java
@@ -18,6 +18,7 @@ package org.apache.activemq.cli.test;
 
 import org.apache.activemq.artemis.cli.Artemis;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.apache.activemq.artemis.utils.CompositeAddress;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -73,10 +74,8 @@ public class CliProducerTest extends CliTestBase {
 
    private void checkSentMessages(Session session, String address, String messageBody) throws Exception {
       final boolean isCustomMessageBody = messageBody != null;
-      boolean fqqn = false;
-      if (address.contains("::")) fqqn = true;
 
-      List<Message> received = consumeMessages(session, address, TEST_MESSAGE_COUNT, fqqn);
+      List<Message> received = consumeMessages(session, address, TEST_MESSAGE_COUNT, CompositeAddress.isFullyQualified(address));
       for (int i = 0; i < TEST_MESSAGE_COUNT; i++) {
          if (!isCustomMessageBody) messageBody = "test message: " + String.valueOf(i);
          assertEquals(messageBody, ((TextMessage) received.get(i)).getText());


### PR DESCRIPTION
FQQN support for the CLI was implemented via ARTEMIS-1840 before general
FQQN support was added for producers via ARTEMIS-1867. The CLI's FQQN
functionality is slightly different from what is now generally available
and it can be confusing for users. By refactoring the CLI to use the
general FQQN support the code can be much simpler and consistent with
the expected behavior. Refactoring includes:

 - Deprecating the use of "fqqn://". The CLI commands use JMS so using
   "fqqn://" (instead of "queue://" or "topic://") makes the destination
   type ambiguous which can yield unexpected message routing behavior.
   Now "queue://" and "topic://" can be used with the normal FQQN syntax
   (e.g. address::queue).
 - Eliminating the use of the _AMQ_ROUTE_TO header when sending messags
   to an FQQN. The _AMQ_ROUTE_TO header is an internal header used when
   routing messages over a cluster bridge. Using it in the CLI for FQQN
   support was a clever hack, but using the general FQQN support
   eliminates complexity and makes behavior consistent between
   standalone JMS clients using FQQN and the CLI.
 - De-duplicating MessageSerializer initialization boilerplate.
 - Removing limitation where using an FQQN with an anycast address
   required the same name for the address and queue.