### PR TITLE
ARTEMIS-2650 The delivering count is wrong after reconnecting an openwire client

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireMessageConverter.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireMessageConverter.java
@@ -632,9 +632,14 @@ public final class OpenWireMessageConverter {
          ByteSequence midSeq = new ByteSequence(midBytes);
          mid = (MessageId) marshaller.unmarshal(midSeq);
       } else {
-         //JMSMessageID should be started with "ID:"
-         String midd = "ID:" + UUIDGenerator.getInstance().generateStringUUID() + ":-1:-1:-1:-1";
-         mid = new MessageId(midd);
+         final SimpleString connectionId = (SimpleString) coreMessage.getObjectProperty(MessageUtil.CONNECTION_ID_PROPERTY_NAME);
+         if (connectionId != null) {
+            mid = new MessageId("ID:" + connectionId.toString() + ":-1:-1:-1", coreMessage.getMessageID());
+         } else {
+            //JMSMessageID should be started with "ID:"
+            String midd = "ID:" + UUIDGenerator.getInstance().generateStringUUID() + ":-1:-1:-1:-1";
+            mid = new MessageId(midd);
+         }
       }
 
       amqMsg.setMessageId(mid);

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQConsumer.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQConsumer.java
@@ -304,7 +304,11 @@ public class AMQConsumer {
 
       List<MessageReference> ackList = serverConsumer.getDeliveringReferencesBasedOnProtocol(removeReferences, first, last);
 
-      acquireCredit(ack.getMessageCount());
+      if (ack.isIndividualAck() || ack.isStandardAck() || ack.isPoisonAck()) {
+         acquireCredit(ackList.size());
+      } else {
+         acquireCredit(ack.getMessageCount());
+      }
 
       if (removeReferences) {
 


### PR DESCRIPTION
Fix the conversion of the message id from the CORE messages.
Fix the credits acquired for acknowledges related to undelivered messages.