### PR TITLE
ARTEMIS-2649 refactor ORIG message props

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/Message.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/Message.java
@@ -463,28 +463,38 @@ public interface Message {
    }
 
    default void referenceOriginalMessage(final Message original, String originalQueue) {
-      Object queueOnMessage = original.getBrokerProperty(Message.HDR_ORIGINAL_QUEUE);
+      Object originalQueueOnMessage = original.getBrokerProperty(Message.HDR_ORIGINAL_QUEUE);
 
-      if (queueOnMessage != null) {
-         setBrokerProperty(Message.HDR_ORIGINAL_QUEUE, queueOnMessage);
-      } else if (originalQueue != null) {
-         setBrokerProperty(Message.HDR_ORIGINAL_QUEUE, originalQueue);
+      if (originalQueueOnMessage != null) {
+         setBreadcrumb(Message.HDR_ORIGINAL_QUEUE, originalQueueOnMessage);
       }
+
+      setBrokerProperty(Message.HDR_ORIGINAL_QUEUE, originalQueue);
 
       Object originalID = original.getBrokerProperty(Message.HDR_ORIG_MESSAGE_ID);
 
       if (originalID != null) {
-         setBrokerProperty(Message.HDR_ORIGINAL_ADDRESS, original.getBrokerProperty(Message.HDR_ORIGINAL_ADDRESS));
+         setBreadcrumb(Message.HDR_ORIGINAL_ADDRESS, original.getBrokerProperty(Message.HDR_ORIGINAL_ADDRESS));
 
-         setBrokerProperty(Message.HDR_ORIG_MESSAGE_ID, originalID);
-      } else {
-         setBrokerProperty(Message.HDR_ORIGINAL_ADDRESS, original.getAddress());
-
-         setBrokerProperty(Message.HDR_ORIG_MESSAGE_ID, original.getMessageID());
+         setBreadcrumb(Message.HDR_ORIG_MESSAGE_ID, originalID);
       }
+
+      setBrokerProperty(Message.HDR_ORIGINAL_ADDRESS, original.getAddress());
+
+      setBrokerProperty(Message.HDR_ORIG_MESSAGE_ID, original.getMessageID());
 
       // reset expiry
       setExpiration(0);
+   }
+
+   default void setBreadcrumb(SimpleString headerName, Object headerValue) {
+      final String separator = "_";
+      Integer index = 0;
+      while (getBrokerProperty(headerName.concat(separator).concat(index.toString())) != null) {
+         index++;
+      }
+
+      setBrokerProperty(headerName.concat(separator).concat(index.toString()), headerValue);
    }
 
    /**

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1674,6 +1674,11 @@ public interface ActiveMQServerLogger extends BasicLogger {
       format = Message.Format.MESSAGE_FORMAT)
    void pageLookupError(int pageNr, int messageNr, int offset, int startNr);
 
+   @LogMessage(level = Logger.Level.WARN)
+   @Message(id = 222289, value = "Did not route to any matching bindings on dead-letter-address {0} and auto-create-dead-letter-resources is true; dropping message: {1}",
+      format = Message.Format.MESSAGE_FORMAT)
+   void noMatchingBindingsOnDLAWithAutoCreateDLAResources(SimpleString address, String message);
+
    @LogMessage(level = Logger.Level.ERROR)
    @Message(id = 224000, value = "Failure in initialisation", format = Message.Format.MESSAGE_FORMAT)
    void initializationError(@Cause Throwable e);

--- a/docs/user-manual/en/SUMMARY.md
+++ b/docs/user-manual/en/SUMMARY.md
@@ -75,6 +75,7 @@
 * [Spring Integration](spring-integration.md)
 * [CDI Integration](cdi-integration.md)
 * [Intercepting Operations](intercepting-operations.md)
+* [Breadcrumb Message Properties](breadcrumbs.md)
 * [Data Tools](data-tools.md)
 * [Maven Plugin](maven-plugin.md)
 * [Unit Testing](unit-testing.md)

--- a/docs/user-manual/en/breadcrumbs.md
+++ b/docs/user-manual/en/breadcrumbs.md
@@ -1,0 +1,67 @@
+# Breadcrumb Message Properties
+
+There are several operations within the broker that result in copying a
+message. These include:
+
+- Diverting a message from one address to another.
+- Moving an expired message from a queue to the configured `expiry-address`
+- Moving a message which has exceeded its `max-delivery-attempts` from a queue
+  to the configured `dead-letter-address`
+- Using the management API to administratively move messages from one queue to
+  another
+
+When this happens the body and properties of the original message are copied to
+a new message. However, the copying process removes some potentially important
+pieces of data so those are preserved in the following special message
+properties:
+
+- `_AMQ_ORIG_ADDRESS`
+
+  a String property containing the *original address* of the message
+
+- `_AMQ_ORIG_QUEUE`
+
+  a String property containing the *original queue* of the message
+
+- `_AMQ_ORIG_MESSAGE_ID`
+
+  a String property containing the *original message ID* of the message
+
+It's possible for the aforementioned operations to be combined. For example, a
+message may be diverted from one address to another where it lands in a queue
+and a consumer tries & fails to consume it such that the message is then sent
+to a dead-letter address. Or a message may be administratively moved from one
+queue to another where it then expires.
+
+This process results in several copies and several different `ORIG` properties.
+To preserve the entire history any existing values for `_AMQ_ORIG_ADDRESS`,
+`_AMQ_ORIG_QUEUE`, and `_AMQ_ORIG_MESSAGE_ID` are copied to new properties
+using their original name suffixed with `_` plus an ascending numerical value
+starting at 0.
+
+Expanding on the first use-case described above, consider a client who sends a
+message to address `A` (to which the broker assigns `123` as the message ID).
+The broker has a `divert` named `divertAtoB` which takes the message sent to
+address `A` and forwards it to address `B` where it lands in the anycast queue
+`X`. When this happens the message will have a new message ID of `456` and the
+following `ORIG` properties:
+
+- `_AMQ_ORIG_ADDRESS`: `A`
+- `_AMQ_ORIG_QUEUE`: `divertAtoB` (i.e. the name of the `divert`)
+- `_AMQ_ORIG_MESSAGE_ID`: `123`
+
+Now consider a consumer which receives the message from queue `X`, but (for
+whatever reason) keeps calling `rollback()` on its session forcing redeliveries
+until the message is sent to the dead-letter address `DLA`. When this happens
+the message will have a new message ID of `456` and the following `ORIG`
+properties:
+
+- `_AMQ_ORIG_ADDRESS`: `B`
+- `_AMQ_ORIG_QUEUE`: `X`
+- `_AMQ_ORIG_MESSAGE_ID`: `456`
+- `_AMQ_ORIG_ADDRESS_0`: `A`
+- `_AMQ_ORIG_QUEUE_0`: `divertAtoB`
+- `_AMQ_ORIG_MESSAGE_ID_0`: `123`
+
+Using these "bread crumb" properties a message can be tracked through each
+different step.

--- a/docs/user-manual/en/diverts.md
+++ b/docs/user-manual/en/diverts.md
@@ -57,12 +57,7 @@ geographically distributed servers, creating your global messaging mesh.
 Diverts are defined as xml in the `broker.xml` file at the `core` attribute level.
 There can be zero or more diverts in the file.
 
-Diverted message gets a new message ID, and its address is set to a forward
-address. To access original values, use message properties: original destination
-is stored in a String property `_AMQ_ORIG_ADDRESS` (`Message.HDR_ORIGINAL_ADDRESS`
-constant from the Core API), and the original message ID in a Long property
-`_AMQ_ORIG_MESSAGE_ID` (`Message.HDR_ORIG_MESSAGE_ID` constant from the
-Core API).
+Diverted messages get [breadcrumb properties](breadcrumbs.md).
 
 Please see the examples for a full working example showing you how to
 configure and use diverts.

--- a/docs/user-manual/en/message-expiry.md
+++ b/docs/user-manual/en/message-expiry.md
@@ -28,18 +28,8 @@ JMS MessageProducer allows to set a TimeToLive for the messages it sent:
 producer.setTimeToLive(5000);
 ```
 
-Expired messages which are consumed from an expiry address have the following
-properties:
-
-- `_AMQ_ORIG_ADDRESS`
-
-  a String property containing the *original address* of the expired
-  message
-
-- `_AMQ_ORIG_QUEUE`
-
-  a String property containing the *original queue* of the expired
-  message
+Expired messages get [breadcrumb properties](breadcrumbs.md) plus this additional
+property:
 
 - `_AMQ_ACTUAL_EXPIRY`
 
@@ -123,16 +113,15 @@ an `address-setting` to configure the `expiry-address` much less
 the actual `address` and `queue` to hold the expired messages.
 
 The solution to this problem is to set the `auto-create-expiry-resources`
-`address-setting` to `true` (it's `false` by default) so that the
-broker will create the `address` and `queue` to deal with the
-expired messages automatically. The `address` created will be the
-one defined by the `expiry-address`. A `MULTICAST` `queue` will be
-created on that `address`. It will be named by the `address` to which
-the message was originally sent, and it will have a filter defined using
-the aforementioned `_AMQ_ORIG_ADDRESS` property so that it will only
-receive messages sent to the relevant `address`. The `queue` name can be
-configured with a prefix and suffix. See the relevant settings in the
-table below:
+`address-setting` to `true` (it's `false` by default) so that the broker will
+create the `address` and `queue` to deal with the expired messages
+automatically. The `address` created will be the one defined by the
+`expiry-address`. A `MULTICAST` `queue` will be created on that `address`.
+It will be named by the `address` to which the message was previously sent, and
+it will have a filter defined using the breadcrumb property `_AMQ_ORIG_ADDRESS`
+so that it will only receive messages sent to the relevant `address`. The
+`queue` name can be configured with a prefix and suffix. See the relevant
+settings in the table below:
 
 `address-setting`|default
 ---|---

--- a/docs/user-manual/en/undelivered-messages.md
+++ b/docs/user-manual/en/undelivered-messages.md
@@ -165,18 +165,7 @@ set of addresses (see [Understanding the Wildcard Syntax](wildcard-syntax.md)).
 
 ### Dead Letter Properties
 
-Dead letter messages which are consumed from a dead letter address have
-the following properties:
-
-- `_AMQ_ORIG_ADDRESS`
-
-  a String property containing the *original address* of the dead
-  letter message
-
-- `_AMQ_ORIG_QUEUE`
-
-  a String property containing the *original queue* of the dead letter
-  message
+Dead letter messages get [breadcrumb properties](breadcrumbs.md).
 
 ### Automatically Creating Dead Letter Resources
 
@@ -194,16 +183,15 @@ an `address-setting` to configure the `dead-letter-address` much less
 the actual `address` and `queue` to hold the undelivered messages.
 
 The solution to this problem is to set the `auto-create-dead-letter-resources`
-`address-setting` to `true` (it's `false` by default) so that the
-broker will create the `address` and `queue` to deal with the
-undelivered messages automatically. The `address` created will be the
-one defined by the `dead-letter-address`. A `MULTICAST` `queue` will be
-created on that `address`. It will be named by the `address` to which
-the message was originally sent, and it will have a filter defined using
-the aforementioned `_AMQ_ORIG_ADDRESS` property so that it will only
-receive messages sent to the relevant `address`. The `queue` name can be
-configured with a prefix and suffix. See the relevant settings in the
-table below:
+`address-setting` to `true` (it's `false` by default) so that the broker will
+create the `address` and `queue` to deal with the undelivered messages
+automatically. The `address` created will be the one defined by the
+`dead-letter-address`. A `MULTICAST` `queue` will be created on that `address`.
+It will be named by the `address` to which the message was previously sent, and
+it will have a filter defined using the breadcrumb property `_AMQ_ORIG_ADDRESS`
+so that it will only receive messages sent to the relevant `address`. The
+`queue` name can be configured with a prefix and suffix. See the relevant
+settings in the table below:
 
 `address-setting`|default
 ---|---

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/divert/DivertTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/divert/DivertTest.java
@@ -1465,4 +1465,42 @@ public class DivertTest extends ActiveMQTestBase {
       server.destroyDivert(SimpleString.toSimpleString(DIVERT));
       assertNull(serviceRegistry.getDivertTransformer(DIVERT, null));
    }
+
+   @Test
+   public void testBreadCrumbs() throws Exception {
+      final String testAddress = "testAddress";
+      final SimpleString queue = SimpleString.toSimpleString("queue");
+      final int COUNT = 25;
+
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(createDefaultInVMConfig(), false));
+      server.start();
+
+      server.createQueue(SimpleString.toSimpleString(testAddress + (COUNT)), RoutingType.ANYCAST, queue, null, true, false);
+      for (int i = 0; i < COUNT; i++) {
+         server.deployDivert(new DivertConfiguration()
+                                .setName("divert" + i)
+                                .setAddress(testAddress + i)
+                                .setForwardingAddress(testAddress + (i + 1)));
+      }
+
+      ServerLocator locator = createInVMNonHALocator();
+      ClientSessionFactory sf = createSessionFactory(locator);
+      ClientSession session = sf.createSession(false, true, true);
+      session.start();
+
+      ClientProducer producer = session.createProducer(new SimpleString(testAddress + "0"));
+      ClientConsumer consumer1 = session.createConsumer(queue);
+      ClientMessage message = session.createMessage(false);
+      producer.send(message);
+
+      message = consumer1.receive(DivertTest.TIMEOUT);
+      Assert.assertNotNull(message);
+      message.acknowledge();
+      System.out.println(message);
+      Assert.assertEquals("testAddress" + COUNT, message.getAddress());
+      Assert.assertEquals("testAddress" + (COUNT - 1), message.getStringProperty(Message.HDR_ORIGINAL_ADDRESS));
+      for (int i = 0; i < COUNT - 1; i++) {
+         Assert.assertEquals("testAddress" + i, message.getStringProperty(Message.HDR_ORIGINAL_ADDRESS.concat("_").concat(Integer.toString(i))));
+      }
+   }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlTest.java
@@ -1685,6 +1685,50 @@ public class QueueControlTest extends ManagementTestBase {
       session.deleteQueue(queue);
    }
 
+   @Test
+   public void testBreadCrumbs() throws Exception {
+      final String testAddress = "testAddress";
+      final SimpleString queue = SimpleString.toSimpleString("queue");
+      final int COUNT = 25;
+
+      for (int i = 0; i < COUNT; i++) {
+         server.createQueue(SimpleString.toSimpleString(testAddress + i), RoutingType.ANYCAST, queue.concat(Integer.toString(i)), null, true, false);
+      }
+
+      ServerLocator locator = createInVMNonHALocator();
+      ClientSessionFactory sf = createSessionFactory(locator);
+      ClientSession session = sf.createSession(false, true, true);
+      session.start();
+
+      ClientProducer producer = session.createProducer(new SimpleString(testAddress + "0"));
+      ClientMessage message = session.createMessage(durable);
+      producer.send(message);
+      producer.close();
+
+      for (int i = 0; i < COUNT - 1; i++) {
+         QueueControl queueControl = createManagementControl(SimpleString.toSimpleString(testAddress + i), queue.concat(Integer.toString(i)), RoutingType.ANYCAST);
+         QueueControl otherQueueControl = createManagementControl(SimpleString.toSimpleString(testAddress + (i + 1)), queue.concat(Integer.toString(i + 1)), RoutingType.ANYCAST);
+         assertMessageMetrics(queueControl, 1, durable);
+         assertMessageMetrics(otherQueueControl, 0, durable);
+
+         int moved = queueControl.moveMessages(null, queue.concat(Integer.toString(i + 1)).toString());
+         Assert.assertEquals(1, moved);
+         assertMessageMetrics(queueControl, 0, durable);
+         assertMessageMetrics(otherQueueControl, 1, durable);
+      }
+
+      ClientConsumer consumer1 = session.createConsumer(queue.concat(Integer.toString(COUNT - 1)));
+      message = consumer1.receive(1000);
+      Assert.assertNotNull(message);
+      message.acknowledge();
+      System.out.println(message);
+      Assert.assertEquals(testAddress + (COUNT - 1), message.getAddress());
+      Assert.assertEquals(testAddress + (COUNT - 2), message.getStringProperty(Message.HDR_ORIGINAL_ADDRESS));
+      for (int i = 0; i < COUNT - 2; i++) {
+         Assert.assertEquals(testAddress + i, message.getStringProperty(Message.HDR_ORIGINAL_ADDRESS.concat("_").concat(Integer.toString(i))));
+      }
+   }
+
    /**
     * <ol>
     * <li>send 2 message to queue</li>

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/AutoCreateDeadLetterResourcesTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/AutoCreateDeadLetterResourcesTest.java
@@ -19,6 +19,7 @@ package org.apache.activemq.artemis.tests.integration.server;
 
 import javax.jms.JMSContext;
 
+import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.QueueConfiguration;
 import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.api.core.SimpleString;
@@ -28,6 +29,7 @@ import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
+import org.apache.activemq.artemis.core.config.DivertConfiguration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
@@ -196,8 +198,75 @@ public class AutoCreateDeadLetterResourcesTest extends ActiveMQTestBase {
       assertNotNull(context.createConsumer(context.createQueue(fqqn)).receive(2000));
    }
 
-   private void triggerDlaDelivery() throws Exception {
+   @Test
+   public void testDivertedMessage() throws Exception {
+      SimpleString dlqName = AddressSettings.DEFAULT_DEAD_LETTER_QUEUE_PREFIX.concat(addressA).concat(AddressSettings.DEFAULT_DEAD_LETTER_QUEUE_SUFFIX);
+      String divertAddress = "divertAddress";
+
+      server.deployDivert(new DivertConfiguration().setName("testDivert").setAddress(divertAddress).setForwardingAddress(addressA.toString()));
+
       server.createQueue(new QueueConfiguration(queueA).setAddress(addressA).setRoutingType(RoutingType.ANYCAST));
+
+      ServerLocator locator = createInVMNonHALocator();
+      ClientSessionFactory sessionFactory = createSessionFactory(locator);
+      ClientSession session = addClientSession(sessionFactory.createSession(true, true));
+      ClientProducer producer = addClientProducer(session.createProducer(divertAddress));
+      producer.send(session.createMessage(true));
+      producer.close();
+
+      Wait.assertEquals(1L, () -> server.locateQueue(queueA).getMessageCount(), 2000, 100);
+
+      triggerDlaDelivery();
+
+      Wait.assertTrue(() -> server.locateQueue(dlqName).getMessageCount() == 1, 2000, 100);
+
+      ClientConsumer consumer = session.createConsumer(dlqName);
+      session.start();
+      ClientMessage message = consumer.receive(1000);
+      assertNotNull(message);
+      message.acknowledge();
+      assertTrue(message.containsProperty(Message.HDR_ORIGINAL_ADDRESS.concat("_0")));
+      assertEquals(divertAddress, message.getStringProperty(Message.HDR_ORIGINAL_ADDRESS.concat("_0")));
+   }
+
+   @Test
+   public void testMovedMessage() throws Exception {
+      SimpleString dlqName = AddressSettings.DEFAULT_DEAD_LETTER_QUEUE_PREFIX.concat(addressA).concat(AddressSettings.DEFAULT_DEAD_LETTER_QUEUE_SUFFIX);
+      final SimpleString moveFromAddress = new SimpleString("moveFromAddress");
+      final SimpleString moveFromQueue = new SimpleString("moveFromQueue");
+      server.createQueue(new QueueConfiguration(moveFromQueue).setAddress(moveFromAddress).setRoutingType(RoutingType.ANYCAST));
+      server.createQueue(new QueueConfiguration(queueA).setAddress(addressA).setRoutingType(RoutingType.ANYCAST));
+
+      ServerLocator locator = createInVMNonHALocator();
+      ClientSessionFactory sessionFactory = createSessionFactory(locator);
+      ClientSession session = addClientSession(sessionFactory.createSession(true, true));
+      ClientProducer producer = addClientProducer(session.createProducer(moveFromAddress));
+      producer.send(session.createMessage(true));
+      producer.close();
+
+      server.locateQueue(moveFromQueue).moveReferences(null, addressA, null);
+
+      Wait.assertEquals(1L, () -> server.locateQueue(queueA).getMessageCount(), 2000, 100);
+
+      triggerDlaDelivery();
+
+      Wait.assertTrue(() -> server.locateQueue(dlqName).getMessageCount() == 1, 2000, 100);
+
+      ClientConsumer consumer = session.createConsumer(dlqName);
+      session.start();
+      ClientMessage message = consumer.receive(1000);
+      assertNotNull(message);
+      message.acknowledge();
+      assertTrue(message.containsProperty(Message.HDR_ORIGINAL_ADDRESS.concat("_0")));
+      assertEquals(moveFromAddress.toString(), message.getStringProperty(Message.HDR_ORIGINAL_ADDRESS.concat("_0")));
+   }
+
+   private void triggerDlaDelivery() throws Exception {
+      try {
+         server.createQueue(new QueueConfiguration(queueA).setAddress(addressA).setRoutingType(RoutingType.ANYCAST));
+      } catch (Exception e) {
+         // ignore
+      }
       ServerLocator locator = createInVMNonHALocator();
       ClientSessionFactory sessionFactory = createSessionFactory(locator);
       ClientSession session = addClientSession(sessionFactory.createSession(true, false));


### PR DESCRIPTION
ORIG message propertes like _AMQ_ORIG_ADDRESS are added to messages
during various broker operations (e.g. diverting a message, expiring a
message, etc.). However, if multiple operations set these properties on
the same message (e.g. administratively moving a message which
eventually gets sent to a dead-letter address) then important details
can be lost. This is particularly problematic when using auto-created
dead-letter or exipry resources which use filters based on
_AMQ_ORIG_ADDRESS and can lead to message loss.

This commit implements "breadcrumb" properties so that the full history
of the message is retained and the most recent information is stored in
the original ORIG properties.