### PR TITLE
ARTEMIS-2669 not durable AMQP messages cannot became durable on depaging

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
@@ -836,15 +836,6 @@ public abstract class AMQPMessage extends RefCountMessage implements org.apache.
       scanMessageData();
       messageDataScanned = MessageDataScanningStatus.SCANNED.code;
       modified = false;
-
-      // Message state should reflect that is came from persistent storage which
-      // can happen when moved to a durable location.  We must re-encode here to
-      // avoid a subsequent redelivery from suddenly appearing with a durable header
-      // tag when the initial delivery did not.
-      if (!isDurable()) {
-         setDurable(true);
-         reencode();
-      }
    }
 
    @Override


### PR DESCRIPTION
Currently depaging AMQP not durable messages turn them into durable ones and reencoded again: this shouldn't really happen, hence the mentioned code should be deleted.