### PR TITLE
removed flag ' -l qpidtypes' from proton-cpp example

### DIFF
--- a/examples/protocols/amqp/proton-cpp/compile.sh
+++ b/examples/protocols/amqp/proton-cpp/compile.sh
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 # This requires g++ and qpid-cpp-client-devel
-g++ src/main/cpp/hello.cpp  -o hello -l qpid-proton-cpp -l qpidtypes
+g++ src/main/cpp/hello.cpp  -o hello -l qpid-proton-cpp


### PR DESCRIPTION
With '-l qpidtypes', error "/usr/bin/ld: cannot find -lqpidtypes" is received in console while executing compile.sh script.