### PR TITLE
ARTEMIS-2671 NPE in LDAP security plugin listener

### DIFF
--- a/tests/integration-tests/src/test/resources/AMQauth.ldif
+++ b/tests/integration-tests/src/test/resources/AMQauth.ldif
@@ -61,62 +61,56 @@ objectclass: organizationalUnit
 objectclass: top
 ou: queues
 
-dn: uid=queue1,ou=queues,ou=destinations,o=ActiveMQ,ou=system
+dn: cn=queue1,ou=queues,ou=destinations,o=ActiveMQ,ou=system
 objectclass: applicationProcess
-objectclass: uidObject
 objectclass: top
-uid: queue1
 cn: queue1
 
-dn: uid=queue2,ou=queues,ou=destinations,o=ActiveMQ,ou=system
+dn: cn=queue2,ou=queues,ou=destinations,o=ActiveMQ,ou=system
 objectclass: applicationProcess
-objectclass: uidObject
 objectclass: top
-uid: queue2
 cn: queue2
 
-dn: uid=activemq.management,ou=queues,ou=destinations,o=ActiveMQ,ou=system
+dn: cn=activemq.management,ou=queues,ou=destinations,o=ActiveMQ,ou=system
 objectclass: applicationProcess
-objectclass: uidObject
 objectclass: top
-uid: activemq.management
 cn: activemq.management
 
-dn: cn=read,uid=queue1,ou=queues,ou=destinations,o=ActiveMQ,ou=system
+dn: cn=read,cn=queue1,ou=queues,ou=destinations,o=ActiveMQ,ou=system
 objectclass: groupOfUniqueNames
 objectclass: top
 cn: read
-uniquemember: uid=role1
+uniquemember: cn=role1
 
-dn: cn=write,uid=queue1,ou=queues,ou=destinations,o=ActiveMQ,ou=system
+dn: cn=write,cn=queue1,ou=queues,ou=destinations,o=ActiveMQ,ou=system
 objectclass: groupOfUniqueNames
 objectclass: top
 cn: write
-uniquemember: uid=role1
+uniquemember: cn=role1
 
-dn: cn=admin,uid=queue1,ou=queues,ou=destinations,o=ActiveMQ,ou=system
+dn: cn=admin,cn=queue1,ou=queues,ou=destinations,o=ActiveMQ,ou=system
 objectclass: groupOfUniqueNames
 objectclass: top
 cn: admin
-uniquemember: uid=role1
+uniquemember: cn=role1
 
-dn: cn=read,uid=activemq.management,ou=queues,ou=destinations,o=ActiveMQ,ou=system
+dn: cn=read,cn=activemq.management,ou=queues,ou=destinations,o=ActiveMQ,ou=system
 objectclass: groupOfUniqueNames
 objectclass: top
 cn: read
-uniquemember: uid=role1
+uniquemember: cn=role1
 
-dn: cn=write,uid=activemq.management,ou=queues,ou=destinations,o=ActiveMQ,ou=system
+dn: cn=write,cn=activemq.management,ou=queues,ou=destinations,o=ActiveMQ,ou=system
 objectclass: groupOfUniqueNames
 objectclass: top
 cn: write
-uniquemember: uid=role1
+uniquemember: cn=role1
 
-dn: cn=admin,uid=activemq.management,ou=queues,ou=destinations,o=ActiveMQ,ou=system
+dn: cn=admin,cn=activemq.management,ou=queues,ou=destinations,o=ActiveMQ,ou=system
 objectclass: groupOfUniqueNames
 objectclass: top
 cn: admin
-uniquemember: uid=role1
+uniquemember: cn=role1
 
 ## group with member identified just by DN from SASL external tls certificate subject DN
 dn: cn=widgets,ou=system


### PR DESCRIPTION
To get the name of the destination use the relative Rdn position rather than a
strict match of "uid". Also, improve logging.