### PR TITLE
ARTEMIS-975: Add transactional records to deletedRecords to check for committed transactions that also hold references to

### DIFF
--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalImpl.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalImpl.java
@@ -232,6 +232,7 @@ public class JDBCJournalImpl extends AbstractJDBCDriver implements Journal {
                   holder = transactions.get(record.getTxId());
                   for (RecordInfo info : holder.recordsToDelete) {
                      deletedRecords.add(record.getId());
+                     deletedRecords.add(info.id);
                      deleteJournalRecords.setLong(1, info.id);
                      deleteJournalRecords.addBatch();
                   }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jdbc/store/journal/JDBCJournalTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jdbc/store/journal/JDBCJournalTest.java
@@ -179,6 +179,19 @@ public class JDBCJournalTest extends ActiveMQTestBase {
    }
 
    @Test
+   public void testCleanupTxRecords4TransactionalRecords() throws Exception {
+      // add committed transactional record e.g. paging
+      journal.appendAddRecordTransactional(152, 154, (byte) 13, new byte[0]);
+      journal.appendCommitRecord(152, true);
+      assertEquals(2, journal.getNumberOfRecords());
+
+      // delete transactional record in new transaction e.g. depaging
+      journal.appendDeleteRecordTransactional(236, 154);
+      journal.appendCommitRecord(236, true);
+      assertEquals(0, journal.getNumberOfRecords());
+   }
+
+   @Test
    public void testCallbacks() throws Exception {
       final int noRecords = 10;
       final CountDownLatch done = new CountDownLatch(noRecords);


### PR DESCRIPTION
Especially needed for paging/depaging records that are hold in several transactions not getting cleaned up completely.