### PR TITLE
ARTEMIS-2676 PageCursorProviderImpl::cleanup can save decoding pages without large messages

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageCursorProviderImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageCursorProviderImpl.java
@@ -544,7 +544,7 @@ public class PageCursorProviderImpl implements PageCursorProvider {
                List<PagedMessage> pgdMessagesList = null;
                try {
                   depagedPage.open();
-                  pgdMessagesList = depagedPage.read(storageManager);
+                  pgdMessagesList = depagedPage.read(storageManager, true);
                } finally {
                   try {
                      depagedPage.close(false, false);
@@ -553,7 +553,8 @@ public class PageCursorProviderImpl implements PageCursorProvider {
 
                   storageManager.afterPageRead();
                }
-               pgdMessages = pgdMessagesList.toArray(new PagedMessage[pgdMessagesList.size()]);
+               pgdMessages = pgdMessagesList.isEmpty() ? null :
+                  pgdMessagesList.toArray(new PagedMessage[pgdMessagesList.size()]);
             } else {
                pgdMessages = cache.getMessages();
             }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/paging/impl/PageTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/paging/impl/PageTest.java
@@ -150,7 +150,7 @@ public class PageTest extends ActiveMQTestBase {
       file.open();
       page = new Page(new SimpleString("something"), storageManager, factory, file, 10);
 
-      List<PagedMessage> msgs = page.read(storageManager);
+      List<PagedMessage> msgs = page.read(storageManager, largeMessages);
 
       Assert.assertEquals(numberOfElements, msgs.size());
 
@@ -162,6 +162,12 @@ public class PageTest extends ActiveMQTestBase {
          Assert.assertEquals(largeMessages, pagedMessage.getMessage().isLargeMessage());
          Assert.assertEquals(startMessageID + i, pagedMessage.getMessage().getMessageID());
          Assert.assertEquals(largeMessages ? 1 : 0, pagedMessage.getMessage().getUsage());
+      }
+
+      if (!largeMessages) {
+         Page tmpPage = new Page(new SimpleString("something"), storageManager, factory, file, 10);
+         Assert.assertEquals(0, tmpPage.read(storageManager, true).size());
+         Assert.assertEquals(numberOfElements, tmpPage.getNumberOfMessages());
       }
 
       Assert.assertTrue(page.delete(msgs.toArray(new PagedMessage[msgs.size()])));


### PR DESCRIPTION
PageCursorProviderImpl::cleanup is calling PageCursorProviderImpl::finishCleanup that's fully reading pages (when not present in the PageCache), just to trigger large messages delete.
The decoding phase could be skipped and possibly the page read as well.