### PR TITLE
ARTEMIS-2679 deprecate message-expiry-thread-priority

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
@@ -228,6 +228,7 @@ public final class ActiveMQDefaultConfiguration {
    private static long DEFAULT_ADDRESS_QUEUE_SCAN_PERIOD = 30000;
 
    // the priority of the thread expiring messages
+   @Deprecated
    private static int DEFAULT_MESSAGE_EXPIRY_THREAD_PRIORITY = 3;
 
    // the size of the cache for pre-creating message ID's
@@ -817,6 +818,7 @@ public final class ActiveMQDefaultConfiguration {
    /**
     * the priority of the thread expiring messages
     */
+   @Deprecated
    public static int getDefaultMessageExpiryThreadPriority() {
       return DEFAULT_MESSAGE_EXPIRY_THREAD_PRIORITY;
    }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
@@ -366,6 +366,7 @@ public interface ActiveMQServerControl {
     * Returns the priority of the thread used to scan message expiration.
     */
    @Attribute(desc = "Priority of the thread used to scan message expiration")
+   @Deprecated
    long getMessageExpiryThreadPriority();
 
    /**

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
@@ -981,11 +981,13 @@ public interface Configuration {
     * Returns the priority of the thread used to scan message expiration. <br>
     * Default value is {@link org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration#DEFAULT_MESSAGE_EXPIRY_THREAD_PRIORITY}.
     */
+   @Deprecated
    int getMessageExpiryThreadPriority();
 
    /**
     * Sets the priority of the thread used to scan message expiration.
     */
+   @Deprecated
    Configuration setMessageExpiryThreadPriority(int messageExpiryThreadPriority);
 
    /**

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -379,8 +379,6 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
       config.setMessageExpiryScanPeriod(getLong(e, "message-expiry-scan-period", config.getMessageExpiryScanPeriod(), Validators.MINUS_ONE_OR_GT_ZERO));
 
-      config.setMessageExpiryThreadPriority(getInteger(e, "message-expiry-thread-priority", config.getMessageExpiryThreadPriority(), Validators.THREAD_PRIORITY_RANGE));
-
       config.setAddressQueueScanPeriod(getLong(e, "address-queue-scan-period", config.getAddressQueueScanPeriod(), Validators.MINUS_ONE_OR_GT_ZERO));
 
       config.setIDCacheSize(getInteger(e, "id-cache-size", config.getIDCacheSize(), Validators.GT_ZERO));

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -3773,6 +3773,7 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
    }
 
    @Override
+   @Deprecated
    public long getMessageExpiryThreadPriority() {
       if (AuditLogger.isEnabled()) {
          AuditLogger.getMessageExpiryThreadPriority(this.server);

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -331,7 +331,7 @@
          <xsd:element name="message-expiry-thread-priority" type="xsd:int" default="3" maxOccurs="1" minOccurs="0">
             <xsd:annotation>
                <xsd:documentation>
-                  the priority of the thread expiring messages
+                  DEPRECATED: the priority of the thread expiring messages
                </xsd:documentation>
             </xsd:annotation>
          </xsd:element>

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImplTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImplTest.java
@@ -57,7 +57,6 @@ public class ConfigurationImplTest extends ActiveMQTestBase {
       Assert.assertEquals(ActiveMQDefaultConfiguration.isDefaultWildcardRoutingEnabled(), conf.isWildcardRoutingEnabled());
       Assert.assertEquals(ActiveMQDefaultConfiguration.getDefaultTransactionTimeout(), conf.getTransactionTimeout());
       Assert.assertEquals(ActiveMQDefaultConfiguration.getDefaultMessageExpiryScanPeriod(), conf.getMessageExpiryScanPeriod()); // OK
-      Assert.assertEquals(ActiveMQDefaultConfiguration.getDefaultMessageExpiryThreadPriority(), conf.getMessageExpiryThreadPriority()); // OK
       Assert.assertEquals(ActiveMQDefaultConfiguration.getDefaultTransactionTimeoutScanPeriod(), conf.getTransactionTimeoutScanPeriod()); // OK
       Assert.assertEquals(ActiveMQDefaultConfiguration.getDefaultManagementAddress(), conf.getManagementAddress()); // OK
       Assert.assertEquals(ActiveMQDefaultConfiguration.getDefaultManagementNotificationAddress(), conf.getManagementNotificationAddress()); // OK
@@ -162,10 +161,6 @@ public class ConfigurationImplTest extends ActiveMQTestBase {
          s = RandomUtil.randomString();
          conf.setManagementAddress(new SimpleString(s));
          Assert.assertEquals(s, conf.getManagementAddress().toString());
-
-         i = RandomUtil.randomInt();
-         conf.setMessageExpiryThreadPriority(i);
-         Assert.assertEquals(i, conf.getMessageExpiryThreadPriority());
 
          l = RandomUtil.randomLong();
          conf.setMessageExpiryScanPeriod(l);
@@ -364,10 +359,6 @@ public class ConfigurationImplTest extends ActiveMQTestBase {
       s = RandomUtil.randomString();
       conf.setManagementAddress(new SimpleString(s));
       Assert.assertEquals(s, conf.getManagementAddress().toString());
-
-      i = RandomUtil.randomInt();
-      conf.setMessageExpiryThreadPriority(i);
-      Assert.assertEquals(i, conf.getMessageExpiryThreadPriority());
 
       l = RandomUtil.randomLong();
       conf.setMessageExpiryScanPeriod(l);

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/DefaultsFileConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/DefaultsFileConfigurationTest.java
@@ -128,8 +128,6 @@ public class DefaultsFileConfigurationTest extends ConfigurationImplTest {
 
       Assert.assertEquals(ActiveMQDefaultConfiguration.getDefaultAddressQueueScanPeriod(), conf.getAddressQueueScanPeriod());
 
-      Assert.assertEquals(ActiveMQDefaultConfiguration.getDefaultMessageExpiryThreadPriority(), conf.getMessageExpiryThreadPriority());
-
       Assert.assertTrue(conf.getHAPolicyConfiguration() instanceof LiveOnlyPolicyConfiguration);
 
       Assert.assertEquals(ActiveMQDefaultConfiguration.isDefaultGracefulShutdownEnabled(), conf.isGracefulShutdownEnabled());

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
@@ -114,7 +114,6 @@ public class FileConfigurationTest extends ConfigurationImplTest {
       Assert.assertEquals(98765, conf.getTransactionTimeout());
       Assert.assertEquals(56789, conf.getTransactionTimeoutScanPeriod());
       Assert.assertEquals(10111213, conf.getMessageExpiryScanPeriod());
-      Assert.assertEquals(8, conf.getMessageExpiryThreadPriority());
       Assert.assertEquals(25000, conf.getAddressQueueScanPeriod());
       Assert.assertEquals(127, conf.getIDCacheSize());
       Assert.assertEquals(true, conf.isPersistIDCache());

--- a/artemis-tools/src/test/resources/artemis-configuration.xsd
+++ b/artemis-tools/src/test/resources/artemis-configuration.xsd
@@ -331,7 +331,7 @@
          <xsd:element name="message-expiry-thread-priority" type="xsd:int" default="3" maxOccurs="1" minOccurs="0">
             <xsd:annotation>
                <xsd:documentation>
-                  the priority of the thread expiring messages
+                  DEPRECATED: the priority of the thread expiring messages
                </xsd:documentation>
             </xsd:annotation>
          </xsd:element>

--- a/docs/user-manual/en/configuration-index.md
+++ b/docs/user-manual/en/configuration-index.md
@@ -153,7 +153,7 @@ log-delegate-factory-class-name | **deprecated** the name of the factory class t
 [message-counter-max-day-history](management.md#message-counters)| how many days to keep message counter history. | 10
 [message-counter-sample-period](management.md#message-counters) | the sample period (in ms) to use for message counters. | 10000
 [message-expiry-scan-period](message-expiry.md#configuring-the-expiry-reaper-thread) | how often (in ms) to scan for expired messages. | 30000
-[message-expiry-thread-priority](message-expiry.md#configuring-the-expiry-reaper-thread)| the priority of the thread expiring messages. | 3
+[message-expiry-thread-priority](message-expiry.md#configuring-the-expiry-reaper-thread)| **deprecated** the priority of the thread expiring messages. | 3
 [metrics-plugin](metrics.md) | [a plugin to export metrics](#metrics-plugin-type) | n/a
 [address-queue-scan-period](address-model.md#configuring-addresses-and-queues-via-address-settings) | how often (in ms) to scan for addresses & queues that should be removed. | 30000
 name | node name; used in topology notifications if set. | n/a

--- a/docs/user-manual/en/message-expiry.md
+++ b/docs/user-manual/en/message-expiry.md
@@ -146,11 +146,6 @@ The reaper thread can be configured with the following properties in
   How often the queues will be scanned to detect expired messages (in
   milliseconds, default is 30000ms, set to `-1` to disable the reaper thread)
 
-- `message-expiry-thread-priority`
-
-  The reaper thread priority (it must be between 1 and 10, 10 being the highest
-  priority, default is 3)
-
 ## Example
 
 See the [Message Expiration Example](examples.md#message-expiration) which

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
@@ -166,7 +166,6 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       Assert.assertEquals(conf.isMessageCounterEnabled(), serverControl.isMessageCounterEnabled());
       Assert.assertEquals(conf.getTransactionTimeoutScanPeriod(), serverControl.getTransactionTimeoutScanPeriod());
       Assert.assertEquals(conf.getMessageExpiryScanPeriod(), serverControl.getMessageExpiryScanPeriod());
-      Assert.assertEquals(conf.getMessageExpiryThreadPriority(), serverControl.getMessageExpiryThreadPriority());
       Assert.assertEquals(conf.getJournalCompactMinFiles(), serverControl.getJournalCompactMinFiles());
       Assert.assertEquals(conf.getJournalCompactPercentage(), serverControl.getJournalCompactPercentage());
       Assert.assertEquals(conf.isPersistenceEnabled(), serverControl.isPersistenceEnabled());


### PR DESCRIPTION
Due to the changes in 6b5fff40cb105053db7de043b9f6927d29ecc7b7 the
config parameter message-expiry-thread-priority is no longer needed. The
code now uses a ScheduledExecutorService and a thread pool rather than
dedicating a thread 100% to the expiry scanner. The pool's size can be
controlled via scheduled-thread-pool-max-size.