### PR TITLE
NO-JIRA remove stale notification property

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -1686,12 +1686,8 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
 
       message.setAddress(queueName);
 
-      String uid = UUIDGenerator.getInstance().generateStringUUID();
-
       message.putStringProperty(ManagementHelper.HDR_NOTIFICATION_TYPE, new SimpleString(type.toString()));
       message.putLongProperty(ManagementHelper.HDR_NOTIFICATION_TIMESTAMP, System.currentTimeMillis());
-
-      message.putStringProperty(new SimpleString("foobar"), new SimpleString(uid));
 
       return message;
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/impl/ManagementServiceImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/impl/ManagementServiceImpl.java
@@ -693,10 +693,6 @@ public class ManagementServiceImpl implements ManagementService {
 
                notificationMessage.putLongProperty(ManagementHelper.HDR_NOTIFICATION_TIMESTAMP, System.currentTimeMillis());
 
-               if (notification.getUID() != null) {
-                  notificationMessage.putStringProperty(new SimpleString("foobar"), new SimpleString(notification.getUID()));
-               }
-
                postOffice.route(notificationMessage, false);
             }
          }


### PR DESCRIPTION
This appears to have been added to the code-base by mistake over 10
years ago. It seems related to debugging and I can't see anywhere where
it is actually used so I'm removing it.