### PR TITLE
ARTEMIS-2693 Improve log of starting acceptor errors

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/server/impl/RemotingServiceImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/server/impl/RemotingServiceImpl.java
@@ -308,7 +308,12 @@ public class RemotingServiceImpl implements RemotingService, ServerConnectionLif
    public synchronized void startAcceptors() throws Exception {
       if (isStarted()) {
          for (Acceptor a : acceptors.values()) {
-            a.start();
+            try {
+               a.start();
+            } catch (Throwable t) {
+               ActiveMQServerLogger.LOGGER.errorStartingAcceptor(a.getName(), a.getConfiguration());
+               throw t;
+            }
          }
       }
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -2064,4 +2064,8 @@ public interface ActiveMQServerLogger extends BasicLogger {
    @LogMessage(level = Logger.Level.INFO)
    @Message(id = 224103, value = "unable to undeploy queue {0} : reason {1}", format = Message.Format.MESSAGE_FORMAT)
    void unableToUndeployQueue(SimpleString queueName, String reason);
+
+   @LogMessage(level = Logger.Level.ERROR)
+   @Message(id = 224104, value = "Error starting the Acceptor {0} {1}", format = Message.Format.MESSAGE_FORMAT)
+   void errorStartingAcceptor(String name, Object configuration);
 }


### PR DESCRIPTION
Add the log of starting acceptor errors to simplify the detection of the
failing acceptor in case of multiple acceptors.