### PR TITLE
ARTEMIS-2697 Avoid using raw types for Persister<T>

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/core/persistence/Persister.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/core/persistence/Persister.java
@@ -19,7 +19,7 @@ package org.apache.activemq.artemis.core.persistence;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 
-public interface Persister<T extends Object> {
+public interface Persister<T> {
 
 
    /** This is to be used to store the protocol-id on Messages.

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalImpl.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalImpl.java
@@ -447,7 +447,11 @@ public class JDBCJournalImpl extends AbstractJDBCDriver implements Journal {
    }
 
    @Override
-   public void appendAddRecord(long id, byte recordType, Persister persister, Object record, boolean sync) throws Exception {
+   public <T> void appendAddRecord(long id,
+                                   byte recordType,
+                                   Persister<T> persister,
+                                   T record,
+                                   boolean sync) throws Exception {
       JDBCJournalRecord r = new JDBCJournalRecord(id, JDBCJournalRecord.ADD_RECORD, seq.incrementAndGet());
       r.setUserRecordType(recordType);
       r.setRecord(persister, record);
@@ -457,17 +461,16 @@ public class JDBCJournalImpl extends AbstractJDBCDriver implements Journal {
          logger.trace("appendAddRecord (encoding) " + r + " with record = " + record);
       }
 
-
       appendRecord(r);
    }
 
    @Override
-   public void appendAddRecord(long id,
-                               byte recordType,
-                               Persister persister,
-                               Object record,
-                               boolean sync,
-                               IOCompletion completionCallback) throws Exception {
+   public <T> void appendAddRecord(long id,
+                                   byte recordType,
+                                   Persister<T> persister,
+                                   T record,
+                                   boolean sync,
+                                   IOCompletion completionCallback) throws Exception {
       checkStatus(completionCallback);
 
       JDBCJournalRecord r = new JDBCJournalRecord(id, JDBCJournalRecord.ADD_RECORD, seq.incrementAndGet());
@@ -502,7 +505,11 @@ public class JDBCJournalImpl extends AbstractJDBCDriver implements Journal {
    }
 
    @Override
-   public void appendUpdateRecord(long id, byte recordType, Persister persister, Object record, boolean sync) throws Exception {
+   public <T> void appendUpdateRecord(long id,
+                                      byte recordType,
+                                      Persister<T> persister,
+                                      T record,
+                                      boolean sync) throws Exception {
       JDBCJournalRecord r = new JDBCJournalRecord(id, JDBCJournalRecord.UPDATE_RECORD, seq.incrementAndGet());
       r.setUserRecordType(recordType);
       r.setRecord(persister, record);
@@ -517,12 +524,12 @@ public class JDBCJournalImpl extends AbstractJDBCDriver implements Journal {
    }
 
    @Override
-   public void appendUpdateRecord(long id,
-                                  byte recordType,
-                                  Persister persister,
-                                  Object record,
-                                  boolean sync,
-                                  IOCompletion completionCallback) throws Exception {
+   public <T> void appendUpdateRecord(long id,
+                                      byte recordType,
+                                      Persister<T> persister,
+                                      T record,
+                                      boolean sync,
+                                      IOCompletion completionCallback) throws Exception {
       checkStatus(completionCallback);
 
       JDBCJournalRecord r = new JDBCJournalRecord(id, JDBCJournalRecord.ADD_RECORD, seq.incrementAndGet());
@@ -587,11 +594,11 @@ public class JDBCJournalImpl extends AbstractJDBCDriver implements Journal {
    }
 
    @Override
-   public void appendAddRecordTransactional(long txID,
-                                            long id,
-                                            byte recordType,
-                                            Persister persister,
-                                            Object record) throws Exception {
+   public <T> void appendAddRecordTransactional(long txID,
+                                                long id,
+                                                byte recordType,
+                                                Persister<T> persister,
+                                                T record) throws Exception {
       JDBCJournalRecord r = new JDBCJournalRecord(id, JDBCJournalRecord.ADD_RECORD_TX, seq.incrementAndGet());
       r.setUserRecordType(recordType);
       r.setRecord(persister, record);
@@ -623,11 +630,11 @@ public class JDBCJournalImpl extends AbstractJDBCDriver implements Journal {
    }
 
    @Override
-   public void appendUpdateRecordTransactional(long txID,
-                                               long id,
-                                               byte recordType,
-                                               Persister persister,
-                                               Object record) throws Exception {
+   public <T> void appendUpdateRecordTransactional(long txID,
+                                                   long id,
+                                                   byte recordType,
+                                                   Persister<T> persister,
+                                                   T record) throws Exception {
       JDBCJournalRecord r = new JDBCJournalRecord(id, JDBCJournalRecord.UPDATE_RECORD_TX, seq.incrementAndGet());
       r.setUserRecordType(recordType);
       r.setRecord(persister, record);

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalRecord.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/journal/JDBCJournalRecord.java
@@ -240,7 +240,7 @@ class JDBCJournalRecord {
       this.record = record;
    }
 
-   public void setRecord(Persister persister, Object record) {
+   public <T> void setRecord(Persister<T> persister, T record) {
       this.variableSize = persister.getEncodeSize(record);
 
       ActiveMQBuffer encodedBuffer = ActiveMQBuffers.fixedBuffer(variableSize);

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/Journal.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/Journal.java
@@ -66,14 +66,14 @@ public interface Journal extends ActiveMQComponent {
       appendAddRecord(id, recordType, EncoderPersister.getInstance(), record, sync);
    }
 
-   void appendAddRecord(long id, byte recordType, Persister persister, Object record, boolean sync) throws Exception;
+   <T> void appendAddRecord(long id, byte recordType, Persister<T> persister, T record, boolean sync) throws Exception;
 
-   void appendAddRecord(long id,
-                        byte recordType,
-                        Persister persister,
-                        Object record,
-                        boolean sync,
-                        IOCompletion completionCallback) throws Exception;
+   <T> void appendAddRecord(long id,
+                            byte recordType,
+                            Persister<T> persister,
+                            T record,
+                            boolean sync,
+                            IOCompletion completionCallback) throws Exception;
 
    default void appendAddRecord(long id,
                         byte recordType,
@@ -89,7 +89,7 @@ public interface Journal extends ActiveMQComponent {
       appendUpdateRecord(id, recordType, EncoderPersister.getInstance(), record, sync);
    }
 
-   void appendUpdateRecord(long id, byte recordType, Persister persister, Object record, boolean sync) throws Exception;
+   <T> void appendUpdateRecord(long id, byte recordType, Persister<T> persister, T record, boolean sync) throws Exception;
 
    default void appendUpdateRecord(long id,
                            byte recordType,
@@ -99,12 +99,12 @@ public interface Journal extends ActiveMQComponent {
       appendUpdateRecord(id, recordType, EncoderPersister.getInstance(), record, sync, completionCallback);
    }
 
-   void appendUpdateRecord(long id,
-                           byte recordType,
-                           Persister persister,
-                           Object record,
-                           boolean sync,
-                           IOCompletion callback) throws Exception;
+   <T> void appendUpdateRecord(long id,
+                               byte recordType,
+                               Persister<T> persister,
+                               T record,
+                               boolean sync,
+                               IOCompletion callback) throws Exception;
 
    void appendDeleteRecord(long id, boolean sync) throws Exception;
 
@@ -118,11 +118,11 @@ public interface Journal extends ActiveMQComponent {
       appendAddRecordTransactional(txID, id, recordType, EncoderPersister.getInstance(), record);
    }
 
-   void appendAddRecordTransactional(long txID,
-                                     long id,
-                                     byte recordType,
-                                     Persister persister,
-                                     Object record) throws Exception;
+   <T> void appendAddRecordTransactional(long txID,
+                                         long id,
+                                         byte recordType,
+                                         Persister<T> persister,
+                                         T record) throws Exception;
 
    void appendUpdateRecordTransactional(long txID, long id, byte recordType, byte[] record) throws Exception;
 
@@ -130,7 +130,11 @@ public interface Journal extends ActiveMQComponent {
       appendUpdateRecordTransactional(txID, id, recordType, EncoderPersister.getInstance(), record);
    }
 
-   void appendUpdateRecordTransactional(long txID, long id, byte recordType, Persister persister, Object record) throws Exception;
+   <T> void appendUpdateRecordTransactional(long txID,
+                                            long id,
+                                            byte recordType,
+                                            Persister<T> persister,
+                                            T record) throws Exception;
 
    void appendDeleteRecordTransactional(long txID, long id, byte[] record) throws Exception;
 

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/AbstractJournalUpdateTask.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/AbstractJournalUpdateTask.java
@@ -131,7 +131,7 @@ public abstract class AbstractJournalUpdateTask implements JournalReaderCallback
             }
          }
 
-         JournalInternalRecord controlRecord = new JournalAddRecord(true, 1, (byte) 0, EncoderPersister.getInstance(), new ByteArrayEncoding(filesToRename.toByteBuffer().array()));
+         JournalInternalRecord controlRecord = new JournalAddRecord<>(true, 1, (byte) 0, EncoderPersister.getInstance(), new ByteArrayEncoding(filesToRename.toByteBuffer().array()));
 
          ActiveMQBuffer renameBuffer = ActiveMQBuffers.dynamicBuffer(filesToRename.writerIndex());
 

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/FileWrapperJournal.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/FileWrapperJournal.java
@@ -89,13 +89,13 @@ public final class FileWrapperJournal extends JournalBase {
    // ------------------------
 
    @Override
-   public void appendAddRecord(long id,
-                               byte recordType,
-                               Persister persister,
-                               Object record,
-                               boolean sync,
-                               IOCompletion callback) throws Exception {
-      JournalInternalRecord addRecord = new JournalAddRecord(true, id, recordType, persister, record);
+   public <T> void appendAddRecord(long id,
+                                   byte recordType,
+                                   Persister<T> persister,
+                                   T record,
+                                   boolean sync,
+                                   IOCompletion callback) throws Exception {
+      JournalInternalRecord addRecord = new JournalAddRecord<>(true, id, recordType, persister, record);
 
       writeRecord(addRecord, false, -1, false, callback);
    }
@@ -179,33 +179,33 @@ public final class FileWrapperJournal extends JournalBase {
    }
 
    @Override
-   public void appendAddRecordTransactional(long txID,
-                                            long id,
-                                            byte recordType,
-                                            Persister persister,
-                                            Object record) throws Exception {
-      JournalInternalRecord addRecord = new JournalAddRecordTX(true, txID, id, recordType, persister, record);
+   public <T> void appendAddRecordTransactional(long txID,
+                                                long id,
+                                                byte recordType,
+                                                Persister<T> persister,
+                                                T record) throws Exception {
+      JournalInternalRecord addRecord = new JournalAddRecordTX<>(true, txID, id, recordType, persister, record);
       writeRecord(addRecord, false, txID, false, null);
    }
 
    @Override
-   public void appendUpdateRecord(long id,
-                                  byte recordType,
-                                  Persister persister,
-                                  Object record,
-                                  boolean sync,
-                                  IOCompletion callback) throws Exception {
-      JournalInternalRecord updateRecord = new JournalAddRecord(false, id, recordType, persister, record);
+   public <T> void appendUpdateRecord(long id,
+                                      byte recordType,
+                                      Persister<T> persister,
+                                      T record,
+                                      boolean sync,
+                                      IOCompletion callback) throws Exception {
+      JournalInternalRecord updateRecord = new JournalAddRecord<>(false, id, recordType, persister, record);
       writeRecord(updateRecord, false, -1, false, callback);
    }
 
    @Override
-   public void appendUpdateRecordTransactional(long txID,
-                                               long id,
-                                               byte recordType,
-                                               Persister persister,
-                                               Object record) throws Exception {
-      JournalInternalRecord updateRecordTX = new JournalAddRecordTX(false, txID, id, recordType, persister, record);
+   public <T> void appendUpdateRecordTransactional(long txID,
+                                                   long id,
+                                                   byte recordType,
+                                                   Persister<T> persister,
+                                                   T record) throws Exception {
+      JournalInternalRecord updateRecordTX = new JournalAddRecordTX<>(false, txID, id, recordType, persister, record);
       writeRecord(updateRecordTX, false, txID, false, null);
    }
 

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalBase.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalBase.java
@@ -43,7 +43,11 @@ abstract class JournalBase implements Journal {
    }
 
    @Override
-   public void appendAddRecord(long id, byte recordType, Persister persister, Object record, boolean sync) throws Exception {
+   public <T> void appendAddRecord(long id,
+                                   byte recordType,
+                                   Persister<T> persister,
+                                   T record,
+                                   boolean sync) throws Exception {
       SyncIOCompletion callback = getSyncCallback(sync);
 
       appendAddRecord(id, recordType, persister, record, sync, callback);
@@ -122,11 +126,11 @@ abstract class JournalBase implements Journal {
    }
 
    @Override
-   public void appendUpdateRecord(final long id,
-                                  final byte recordType,
-                                  final Persister persister,
-                                  final Object record,
-                                  final boolean sync) throws Exception {
+   public <T> void appendUpdateRecord(final long id,
+                                      final byte recordType,
+                                      final Persister<T> persister,
+                                      final T record,
+                                      final boolean sync) throws Exception {
       SyncIOCompletion callback = getSyncCallback(sync);
 
       appendUpdateRecord(id, recordType, persister, record, sync, callback);

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalCompactor.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalCompactor.java
@@ -222,7 +222,7 @@ public class JournalCompactor extends AbstractJournalUpdateTask implements Journ
          logger.trace("Read Record " + info);
       }
       if (containsRecord(info.id)) {
-         JournalInternalRecord addRecord = new JournalAddRecord(true, info.id, info.getUserRecordType(), EncoderPersister.getInstance(), new ByteArrayEncoding(info.data));
+         JournalInternalRecord addRecord = new JournalAddRecord<>(true, info.id, info.getUserRecordType(), EncoderPersister.getInstance(), new ByteArrayEncoding(info.data));
          addRecord.setCompactCount((short) (info.compactCount + 1));
 
          checkSize(addRecord.getEncodeSize(), info.compactCount);
@@ -241,7 +241,7 @@ public class JournalCompactor extends AbstractJournalUpdateTask implements Journ
       if (pendingTransactions.get(transactionID) != null || containsRecord(info.id)) {
          JournalTransaction newTransaction = getNewJournalTransaction(transactionID);
 
-         JournalInternalRecord record = new JournalAddRecordTX(true, transactionID, info.id, info.getUserRecordType(), EncoderPersister.getInstance(),new ByteArrayEncoding(info.data));
+         JournalInternalRecord record = new JournalAddRecordTX<>(true, transactionID, info.id, info.getUserRecordType(), EncoderPersister.getInstance(),new ByteArrayEncoding(info.data));
 
          record.setCompactCount((short) (info.compactCount + 1));
 
@@ -371,7 +371,7 @@ public class JournalCompactor extends AbstractJournalUpdateTask implements Journ
       }
 
       if (containsRecord(info.id)) {
-         JournalInternalRecord updateRecord = new JournalAddRecord(false, info.id, info.userRecordType, EncoderPersister.getInstance(), new ByteArrayEncoding(info.data));
+         JournalInternalRecord updateRecord = new JournalAddRecord<>(false, info.id, info.userRecordType, EncoderPersister.getInstance(), new ByteArrayEncoding(info.data));
 
          updateRecord.setCompactCount((short) (info.compactCount + 1));
 
@@ -398,7 +398,7 @@ public class JournalCompactor extends AbstractJournalUpdateTask implements Journ
       if (pendingTransactions.get(transactionID) != null || containsRecord(info.id)) {
          JournalTransaction newTransaction = getNewJournalTransaction(transactionID);
 
-         JournalInternalRecord updateRecordTX = new JournalAddRecordTX(false, transactionID, info.id, info.userRecordType, EncoderPersister.getInstance(), new ByteArrayEncoding(info.data));
+         JournalInternalRecord updateRecordTX = new JournalAddRecordTX<>(false, transactionID, info.id, info.userRecordType, EncoderPersister.getInstance(), new ByteArrayEncoding(info.data));
 
          updateRecordTX.setCompactCount((short) (info.compactCount + 1));
 

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalImpl.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalImpl.java
@@ -814,12 +814,12 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
    // ----------------------------------------------------------------
 
    @Override
-   public void appendAddRecord(final long id,
-                               final byte recordType,
-                               final Persister persister,
-                               final Object record,
-                               final boolean sync,
-                               final IOCompletion callback) throws Exception {
+   public <T> void appendAddRecord(final long id,
+                                   final byte recordType,
+                                   final Persister<T> persister,
+                                   final T record,
+                                   final boolean sync,
+                                   final IOCompletion callback) throws Exception {
       checkJournalIsLoaded();
       lineUpContext(callback);
       pendingRecords.add(id);
@@ -832,7 +832,7 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
       }
 
       final long maxRecordSize = getMaxRecordSize();
-      final JournalInternalRecord addRecord = new JournalAddRecord(true, id, recordType, persister, record);
+      final JournalInternalRecord addRecord = new JournalAddRecord<>(true, id, recordType, persister, record);
       final int addRecordEncodeSize = addRecord.getEncodeSize();
 
       if (addRecordEncodeSize > maxRecordSize) {
@@ -876,12 +876,12 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
    }
 
    @Override
-   public void appendUpdateRecord(final long id,
-                                  final byte recordType,
-                                  final Persister persister,
-                                  final Object record,
-                                  final boolean sync,
-                                  final IOCompletion callback) throws Exception {
+   public <T> void appendUpdateRecord(final long id,
+                                      final byte recordType,
+                                      final Persister<T> persister,
+                                      final T record,
+                                      final boolean sync,
+                                      final IOCompletion callback) throws Exception {
       checkJournalIsLoaded();
       lineUpContext(callback);
       checkKnownRecordID(id);
@@ -900,7 +900,7 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
             journalLock.readLock().lock();
             try {
                JournalRecord jrnRecord = records.get(id);
-               JournalInternalRecord updateRecord = new JournalAddRecord(false, id, recordType, persister, record);
+               JournalInternalRecord updateRecord = new JournalAddRecord<>(false, id, recordType, persister, record);
                JournalFile usedFile = appendRecord(updateRecord, false, sync, null, callback);
 
                if (logger.isTraceEnabled()) {
@@ -1000,11 +1000,11 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
    }
 
    @Override
-   public void appendAddRecordTransactional(final long txID,
-                                            final long id,
-                                            final byte recordType,
-                                            final Persister persister,
-                                            final Object record) throws Exception {
+   public <T> void appendAddRecordTransactional(final long txID,
+                                                final long id,
+                                                final byte recordType,
+                                                final Persister<T> persister,
+                                                final T record) throws Exception {
       checkJournalIsLoaded();
       if (logger.isTraceEnabled()) {
          logger.trace("scheduling appendAddRecordTransactional:txID=" + txID +
@@ -1028,7 +1028,7 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
                if (tx != null) {
                   tx.checkErrorCondition();
                }
-               JournalInternalRecord addRecord = new JournalAddRecordTX(true, txID, id, recordType, persister, record);
+               JournalInternalRecord addRecord = new JournalAddRecordTX<>(true, txID, id, recordType, persister, record);
                // we need to calculate the encodeSize here, as it may use caches that are eliminated once the record is written
                int encodeSize = addRecord.getEncodeSize();
                JournalFile usedFile = appendRecord(addRecord, false, false, tx, null);
@@ -1094,11 +1094,11 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
    }
 
    @Override
-   public void appendUpdateRecordTransactional(final long txID,
-                                               final long id,
-                                               final byte recordType,
-                                               final Persister persister,
-                                               final Object record) throws Exception {
+   public <T> void appendUpdateRecordTransactional(final long txID,
+                                                   final long id,
+                                                   final byte recordType,
+                                                   final Persister<T> persister,
+                                                   final T record) throws Exception {
       if ( logger.isTraceEnabled() ) {
          logger.trace( "scheduling appendUpdateRecordTransactional::txID=" + txID +
                           ",id=" +
@@ -1122,7 +1122,7 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
             try {
                tx.checkErrorCondition();
 
-               JournalInternalRecord updateRecordTX = new JournalAddRecordTX( false, txID, id, recordType, persister, record );
+               JournalInternalRecord updateRecordTX = new JournalAddRecordTX<>( false, txID, id, recordType, persister, record );
                JournalFile usedFile = appendRecord( updateRecordTX, false, false, tx, null );
 
                if ( logger.isTraceEnabled() ) {

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/dataformat/JournalAddRecord.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/dataformat/JournalAddRecord.java
@@ -20,13 +20,13 @@ import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.core.persistence.Persister;
 import org.apache.activemq.artemis.core.journal.impl.JournalImpl;
 
-public class JournalAddRecord extends JournalInternalRecord {
+public class JournalAddRecord<T> extends JournalInternalRecord {
 
    protected final long id;
 
-   protected final Persister persister;
+   protected final Persister<T> persister;
 
-   protected final Object record;
+   protected final T record;
 
    protected final byte recordType;
 
@@ -37,7 +37,7 @@ public class JournalAddRecord extends JournalInternalRecord {
     * @param recordType
     * @param record
     */
-   public JournalAddRecord(final boolean add, final long id, final byte recordType, final Persister persister, Object record) {
+   public JournalAddRecord(final boolean add, final long id, final byte recordType, final Persister<T> persister, T record) {
       this.id = id;
 
       this.record = record;

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/dataformat/JournalAddRecordTX.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/dataformat/JournalAddRecordTX.java
@@ -20,15 +20,15 @@ import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.core.persistence.Persister;
 import org.apache.activemq.artemis.core.journal.impl.JournalImpl;
 
-public class JournalAddRecordTX extends JournalInternalRecord {
+public class JournalAddRecordTX<T> extends JournalInternalRecord {
 
    private final long txID;
 
    private final long id;
 
-   protected final Persister persister;
+   protected final Persister<T> persister;
 
-   protected final Object record;
+   protected final T record;
 
    private final byte recordType;
 
@@ -43,8 +43,8 @@ public class JournalAddRecordTX extends JournalInternalRecord {
                              final long txID,
                              final long id,
                              final byte recordType,
-                             final Persister persister,
-                             Object record) {
+                             final Persister<T> persister,
+                             T record) {
 
       this.txID = txID;
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AbstractJournalStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AbstractJournalStorageManager.java
@@ -361,7 +361,7 @@ public abstract class AbstractJournalStorageManager extends CriticalComponentImp
          // appropriate
 
          if (message.isLargeMessage() && message instanceof LargeServerMessageImpl) {
-            messageJournal.appendAddRecord(message.getMessageID(), JournalRecordIds.ADD_LARGE_MESSAGE, LargeMessagePersister.getInstance(), message, false, getContext(false));
+            messageJournal.appendAddRecord(message.getMessageID(), JournalRecordIds.ADD_LARGE_MESSAGE, LargeMessagePersister.getInstance(), (LargeServerMessageImpl) message, false, getContext(false));
          } else {
             messageJournal.appendAddRecord(message.getMessageID(), JournalRecordIds.ADD_MESSAGE_PROTOCOL, message.getPersister(), message, false, getContext(false));
          }
@@ -483,7 +483,7 @@ public abstract class AbstractJournalStorageManager extends CriticalComponentImp
       try {
          if (message.isLargeMessage() && message instanceof LargeServerMessageImpl) {
             // this is a core large message
-            messageJournal.appendAddRecordTransactional(txID, message.getMessageID(), JournalRecordIds.ADD_LARGE_MESSAGE, LargeMessagePersister.getInstance(), message);
+            messageJournal.appendAddRecordTransactional(txID, message.getMessageID(), JournalRecordIds.ADD_LARGE_MESSAGE, LargeMessagePersister.getInstance(), (LargeServerMessageImpl) message);
          } else {
             messageJournal.appendAddRecordTransactional(txID, message.getMessageID(), JournalRecordIds.ADD_MESSAGE_PROTOCOL, message.getPersister(), message);
          }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationAddMessage.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationAddMessage.java
@@ -24,7 +24,7 @@ import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
 import org.apache.activemq.artemis.core.replication.ReplicationManager.ADD_OPERATION_TYPE;
 import org.apache.activemq.artemis.utils.DataConstants;
 
-public final class ReplicationAddMessage extends PacketImpl {
+public final class ReplicationAddMessage<T> extends PacketImpl {
 
    private long id;
 
@@ -37,9 +37,9 @@ public final class ReplicationAddMessage extends PacketImpl {
 
    private byte journalRecordType;
 
-   private Persister persister;
+   private Persister<T> persister;
 
-   private Object encodingData;
+   private T encodingData;
 
    private byte[] recordData;
 
@@ -51,8 +51,8 @@ public final class ReplicationAddMessage extends PacketImpl {
                                 final ADD_OPERATION_TYPE operation,
                                 final long id,
                                 final byte journalRecordType,
-                                final Persister persister,
-                                final Object encodingData) {
+                                final Persister<T> persister,
+                                final T encodingData) {
       this();
       this.journalID = journalID;
       this.operation = operation;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationAddTXMessage.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationAddTXMessage.java
@@ -24,7 +24,7 @@ import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
 import org.apache.activemq.artemis.core.replication.ReplicationManager.ADD_OPERATION_TYPE;
 import org.apache.activemq.artemis.utils.DataConstants;
 
-public class ReplicationAddTXMessage extends PacketImpl {
+public class ReplicationAddTXMessage<T> extends PacketImpl {
 
    private long txId;
 
@@ -37,9 +37,9 @@ public class ReplicationAddTXMessage extends PacketImpl {
 
    private byte recordType;
 
-   private Persister persister;
+   private Persister<T> persister;
 
-   private Object encodingData;
+   private T encodingData;
 
    private byte[] recordData;
 
@@ -54,8 +54,8 @@ public class ReplicationAddTXMessage extends PacketImpl {
                                   final long txId,
                                   final long id,
                                   final byte recordType,
-                                  final Persister persister,
-                                  final Object encodingData) {
+                                  final Persister<T> persister,
+                                  final T encodingData) {
       this();
       this.journalID = journalID;
       this.operation = operation;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/replication/ReplicatedJournal.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/replication/ReplicatedJournal.java
@@ -85,11 +85,11 @@ public class ReplicatedJournal implements Journal {
    }
 
    @Override
-   public void appendAddRecord(final long id,
-                               final byte recordType,
-                               Persister persister,
-                               final Object record,
-                               final boolean sync) throws Exception {
+   public <T> void appendAddRecord(final long id,
+                                   final byte recordType,
+                                   Persister<T> persister,
+                                   final T record,
+                                   final boolean sync) throws Exception {
       if (log.isTraceEnabled()) {
          log.trace("Append record id = " + id + " recordType = " + recordType);
       }
@@ -106,12 +106,12 @@ public class ReplicatedJournal implements Journal {
     * @see org.apache.activemq.artemis.core.journal.Journal#appendAddRecord(long, byte, org.apache.activemq.artemis.core.journal.EncodingSupport, boolean)
     */
    @Override
-   public void appendAddRecord(final long id,
-                               final byte recordType,
-                               Persister persister,
-                               final Object record,
-                               final boolean sync,
-                               final IOCompletion completionCallback) throws Exception {
+   public <T> void appendAddRecord(final long id,
+                                   final byte recordType,
+                                   Persister<T> persister,
+                                   final T record,
+                                   final boolean sync,
+                                   final IOCompletion completionCallback) throws Exception {
       if (log.isTraceEnabled()) {
          log.trace("Append record id = " + id + " recordType = " + recordType);
       }
@@ -144,11 +144,11 @@ public class ReplicatedJournal implements Journal {
     * @see org.apache.activemq.artemis.core.journal.Journal#appendAddRecordTransactional(long, long, byte, org.apache.activemq.artemis.core.journal.EncodingSupport)
     */
    @Override
-   public void appendAddRecordTransactional(final long txID,
-                                            final long id,
-                                            final byte recordType,
-                                            final Persister persister,
-                                            final Object record) throws Exception {
+   public <T> void appendAddRecordTransactional(final long txID,
+                                                final long id,
+                                                final byte recordType,
+                                                final Persister<T> persister,
+                                                final T record) throws Exception {
       if (log.isTraceEnabled()) {
          log.trace("Append record txID=" + id + " recordType = " + recordType);
       }
@@ -354,11 +354,11 @@ public class ReplicatedJournal implements Journal {
     * @see org.apache.activemq.artemis.core.journal.Journal#appendUpdateRecord(long, byte, org.apache.activemq.artemis.core.journal.EncodingSupport, boolean)
     */
    @Override
-   public void appendUpdateRecord(final long id,
-                                  final byte recordType,
-                                  final Persister persister,
-                                  final Object record,
-                                  final boolean sync) throws Exception {
+   public <T> void appendUpdateRecord(final long id,
+                                      final byte recordType,
+                                      final Persister<T> persister,
+                                      final T record,
+                                      final boolean sync) throws Exception {
       if (log.isTraceEnabled()) {
          log.trace("AppendUpdateRecord id = " + id + " , recordType = " + recordType);
       }
@@ -367,12 +367,12 @@ public class ReplicatedJournal implements Journal {
    }
 
    @Override
-   public void appendUpdateRecord(final long id,
-                                  final byte journalRecordType,
-                                  final Persister persister,
-                                  final Object record,
-                                  final boolean sync,
-                                  final IOCompletion completionCallback) throws Exception {
+   public <T> void appendUpdateRecord(final long id,
+                                      final byte journalRecordType,
+                                      final Persister<T> persister,
+                                      final T record,
+                                      final boolean sync,
+                                      final IOCompletion completionCallback) throws Exception {
       if (log.isTraceEnabled()) {
          log.trace("AppendUpdateRecord id = " + id + " , recordType = " + journalRecordType);
       }
@@ -405,11 +405,11 @@ public class ReplicatedJournal implements Journal {
     * @see org.apache.activemq.artemis.core.journal.Journal#appendUpdateRecordTransactional(long, long, byte, org.apache.activemq.artemis.core.journal.EncodingSupport)
     */
    @Override
-   public void appendUpdateRecordTransactional(final long txID,
-                                               final long id,
-                                               final byte recordType,
-                                               final Persister persister,
-                                               final Object record) throws Exception {
+   public <T> void appendUpdateRecordTransactional(final long txID,
+                                                   final long id,
+                                                   final byte recordType,
+                                                   final Persister<T> persister,
+                                                   final T record) throws Exception {
       if (log.isTraceEnabled()) {
          log.trace("AppendUpdateRecord txid=" + txID + " id = " + id + " , recordType = " + recordType);
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/replication/ReplicationManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/replication/ReplicationManager.java
@@ -157,14 +157,14 @@ public final class ReplicationManager implements ActiveMQComponent {
       this.timeout = timeout;
    }
 
-   public void appendUpdateRecord(final byte journalID,
-                                  final ADD_OPERATION_TYPE operation,
-                                  final long id,
-                                  final byte recordType,
-                                  final Persister persister,
-                                  final Object record) throws Exception {
+   public <T> void appendUpdateRecord(final byte journalID,
+                                      final ADD_OPERATION_TYPE operation,
+                                      final long id,
+                                      final byte recordType,
+                                      final Persister<T> persister,
+                                      final T record) throws Exception {
       if (enabled) {
-         sendReplicatePacket(new ReplicationAddMessage(journalID, operation, id, recordType, persister, record));
+         sendReplicatePacket(new ReplicationAddMessage<>(journalID, operation, id, recordType, persister, record));
       }
    }
 
@@ -174,15 +174,15 @@ public final class ReplicationManager implements ActiveMQComponent {
       }
    }
 
-   public void appendAddRecordTransactional(final byte journalID,
-                                            final ADD_OPERATION_TYPE operation,
-                                            final long txID,
-                                            final long id,
-                                            final byte recordType,
-                                            final Persister persister,
-                                            final Object record) throws Exception {
+   public <T> void appendAddRecordTransactional(final byte journalID,
+                                                final ADD_OPERATION_TYPE operation,
+                                                final long txID,
+                                                final long id,
+                                                final byte recordType,
+                                                final Persister<T> persister,
+                                                final T record) throws Exception {
       if (enabled) {
-         sendReplicatePacket(new ReplicationAddTXMessage(journalID, operation, txID, id, recordType, persister, record));
+         sendReplicatePacket(new ReplicationAddTXMessage<>(journalID, operation, txID, id, recordType, persister, record));
       }
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/protocol/EmbedMessageUtil.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/protocol/EmbedMessageUtil.java
@@ -58,7 +58,7 @@ public class EmbedMessageUtil {
             largeServerMessage.setParentRef((RefCountMessage)source);
             return (ICoreMessage) largeServerMessage.toMessage();
          } else {
-            Persister persister = source.getPersister();
+            Persister<Message> persister = source.getPersister();
 
             CoreMessage message = new CoreMessage(source.getMessageID(), persister.getEncodeSize(source) + signature.length + CoreMessage.BODY_OFFSET).setType(Message.EMBEDDED_TYPE);
             message.setDurable(source.isDurable());

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/protocol/MessagePersister.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/protocol/MessagePersister.java
@@ -59,7 +59,7 @@ public class MessagePersister implements Persister<Message> {
       if (messagePersisters == null || messagePersisters.length == 0) {
          logger.debug("Cannot find persister for " + manager);
       } else {
-         for (Persister p : messagePersisters) {
+         for (Persister<Message> p : messagePersisters) {
             registerPersister(p);
          }
       }
@@ -71,7 +71,7 @@ public class MessagePersister implements Persister<Message> {
       }
    }
 
-   public static Persister getPersister(byte id) {
+   public static Persister<Message> getPersister(byte id) {
       if (id == 0 || id > MAX_PERSISTERS) {
          return null;
       }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/replication/ReplicationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/replication/ReplicationTest.java
@@ -622,58 +622,58 @@ public final class ReplicationTest extends ActiveMQTestBase {
    static final class FakeJournal implements Journal {
 
       @Override
-      public void appendAddRecord(long id,
-                                  byte recordType,
-                                  Persister persister,
-                                  Object record,
-                                  boolean sync) throws Exception {
+      public <T> void appendAddRecord(long id,
+                                      byte recordType,
+                                      Persister<T> persister,
+                                      T record,
+                                      boolean sync) throws Exception {
 
       }
 
       @Override
-      public void appendAddRecord(long id,
-                                  byte recordType,
-                                  Persister persister,
-                                  Object record,
-                                  boolean sync,
-                                  IOCompletion completionCallback) throws Exception {
+      public <T> void appendAddRecord(long id,
+                                      byte recordType,
+                                      Persister<T> persister,
+                                      T record,
+                                      boolean sync,
+                                      IOCompletion completionCallback) throws Exception {
 
       }
 
       @Override
-      public void appendUpdateRecord(long id,
-                                     byte recordType,
-                                     Persister persister,
-                                     Object record,
-                                     boolean sync) throws Exception {
+      public <T> void appendUpdateRecord(long id,
+                                         byte recordType,
+                                         Persister<T> persister,
+                                         T record,
+                                         boolean sync) throws Exception {
 
       }
 
       @Override
-      public void appendUpdateRecord(long id,
-                                     byte recordType,
-                                     Persister persister,
-                                     Object record,
-                                     boolean sync,
-                                     IOCompletion callback) throws Exception {
+      public <T> void appendUpdateRecord(long id,
+                                         byte recordType,
+                                         Persister<T> persister,
+                                         T record,
+                                         boolean sync,
+                                         IOCompletion callback) throws Exception {
 
       }
 
       @Override
-      public void appendAddRecordTransactional(long txID,
-                                               long id,
-                                               byte recordType,
-                                               Persister persister,
-                                               Object record) throws Exception {
+      public <T> void appendAddRecordTransactional(long txID,
+                                                   long id,
+                                                   byte recordType,
+                                                   Persister<T> persister,
+                                                   T record) throws Exception {
 
       }
 
       @Override
-      public void appendUpdateRecordTransactional(long txID,
-                                                  long id,
-                                                  byte recordType,
-                                                  Persister persister,
-                                                  Object record) throws Exception {
+      public <T> void appendUpdateRecordTransactional(long txID,
+                                                      long id,
+                                                      byte recordType,
+                                                      Persister<T> persister,
+                                                      T record) throws Exception {
 
       }
 


### PR DESCRIPTION
This commit, despite the big number of changes, is just fixing raw type usages for `Persister<T>`.