### PR TITLE
ARTEMIS-2686 Fix MQTT connect message rejection

### DIFF
--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTSession.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTSession.java
@@ -77,6 +77,8 @@ public class MQTTSession {
       subscriptionManager = new MQTTSubscriptionManager(this);
       retainMessageManager = new MQTTRetainMessageManager(this);
 
+      state = MQTTSessionState.DEFAULT;
+
       log.debug("SESSION CREATED: " + id);
    }
 

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTSessionState.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTSessionState.java
@@ -32,6 +32,8 @@ import org.apache.activemq.artemis.core.config.WildcardConfiguration;
 
 public class MQTTSessionState {
 
+   public static final MQTTSessionState DEFAULT = new MQTTSessionState(null);
+
    private String clientId;
 
    private final ConcurrentMap<String, MqttTopicSubscription> subscriptions = new ConcurrentHashMap<>();


### PR DESCRIPTION
Initialize the session state with a default value to fix a NPE, when an incoming
MQTT interceptor rejects a MqttConnectMessage.