### PR TITLE
ARTEMIS-2691 Improve critical analyzer LOG policy

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/critical/CriticalAnalyzerImpl.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/critical/CriticalAnalyzerImpl.java
@@ -136,8 +136,8 @@ public class CriticalAnalyzerImpl implements CriticalAnalyzer {
          try {
             for (CriticalComponent component : components) {
 
-               if (component.isExpired(timeoutNanoSeconds)) {
-                  fireAction(component);
+               if (component.checkExpiration(timeoutNanoSeconds, true)) {
+                  fireActions(component);
                   // no need to keep running if there's already a component failed
                   return;
                }
@@ -149,7 +149,7 @@ public class CriticalAnalyzerImpl implements CriticalAnalyzer {
       }
    }
 
-   private void fireAction(CriticalComponent component) {
+   private void fireActions(CriticalComponent component) {
       for (CriticalAction action : actions) {
          try {
             action.run(component);
@@ -157,14 +157,11 @@ public class CriticalAnalyzerImpl implements CriticalAnalyzer {
             logger.warn(e.getMessage(), e);
          }
       }
-
-      actions.clear();
    }
 
    @Override
    public void start() {
       scheduledComponent.start();
-
    }
 
    @Override

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/critical/CriticalComponent.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/critical/CriticalComponent.java
@@ -49,9 +49,10 @@ public interface CriticalComponent {
    }
 
    /**
-    * Is this Component expired at a given timeout.. on any of its paths.
-    * @param timeout
+    * Check if the component is expired at a given timeout.. on any of its paths.
+    * @param timeout - the timeout to check if the component is expired
+    * @param reset - true to reset the component timer if it is expired
     * @return -1 if it's ok, or the number of the path it failed
     */
-   boolean isExpired(long timeout);
+   boolean checkExpiration(long timeout, boolean reset);
 }

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/critical/CriticalComponentImpl.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/critical/CriticalComponentImpl.java
@@ -62,9 +62,9 @@ public class CriticalComponentImpl implements CriticalComponent {
    }
 
    @Override
-   public boolean isExpired(long timeout) {
+   public boolean checkExpiration(long timeout, boolean reset) {
       for (int i = 0; i < measures.length; i++) {
-         if (measures[i].isExpired(timeout)) {
+         if (measures[i].checkExpiration(timeout, reset)) {
             return true;
          }
       }

--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/critical/CriticalMeasureTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/critical/CriticalMeasureTest.java
@@ -30,7 +30,7 @@ public class CriticalMeasureTest {
       long time = System.nanoTime();
       CriticalMeasure.TIME_ENTER_UPDATER.set(measure, time - TimeUnit.MINUTES.toNanos(5));
       CriticalMeasure.TIME_LEFT_UPDATER.set(measure, time);
-      Assert.assertFalse(measure.isExpired(TimeUnit.SECONDS.toNanos(30)));
+      Assert.assertFalse(measure.checkExpiration(TimeUnit.SECONDS.toNanos(30), false));
    }
 
    @Test
@@ -41,7 +41,7 @@ public class CriticalMeasureTest {
       long time = System.nanoTime();
       CriticalMeasure.TIME_ENTER_UPDATER.set(measure, time - TimeUnit.MINUTES.toNanos(5));
       measure.leaveCritical();
-      Assert.assertFalse(measure.isExpired(TimeUnit.SECONDS.toNanos(30)));
+      Assert.assertFalse(measure.checkExpiration(TimeUnit.SECONDS.toNanos(30), false));
    }
 
    @Test
@@ -53,7 +53,7 @@ public class CriticalMeasureTest {
       measure.enterCritical();
       CriticalMeasure.TIME_ENTER_UPDATER.set(measure, time - TimeUnit.MINUTES.toNanos(5));
       CriticalMeasure.TIME_LEFT_UPDATER.set(measure, time - TimeUnit.MINUTES.toNanos(10));
-      Assert.assertTrue(measure.isExpired(TimeUnit.SECONDS.toNanos(30)));
+      Assert.assertTrue(measure.checkExpiration(TimeUnit.SECONDS.toNanos(30), false));
       measure.leaveCritical();
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -1265,6 +1265,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
       }
 
       try {
+         this.analyzer.clear();
          this.analyzer.stop();
       } catch (Exception e) {
          logger.warn(e.getMessage(), e);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/critical/CriticalSimpleTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/critical/CriticalSimpleTest.java
@@ -54,7 +54,7 @@ public class CriticalSimpleTest extends ActiveMQTestBase {
 
          server.getCriticalAnalyzer().add(new CriticalComponent() {
             @Override
-            public boolean isExpired(long timeout) {
+            public boolean checkExpiration(long timeout, boolean reset) {
                return true;
             }
          });
@@ -83,7 +83,7 @@ public class CriticalSimpleTest extends ActiveMQTestBase {
       try {
          server.getCriticalAnalyzer().add(new CriticalComponent() {
             @Override
-            public boolean isExpired(long timeout) {
+            public boolean checkExpiration(long timeout, boolean reset) {
                return true;
             }
          });


### PR DESCRIPTION
Reset the critical component timer after the expiration to allow further LOG
actions after the first expiration.