### PR TITLE
Updating text casing on connectionTtl

### DIFF
--- a/docs/user-manual/en/connection-ttl.md
+++ b/docs/user-manual/en/connection-ttl.md
@@ -95,7 +95,7 @@ closing it down. If the server doesn't receive any packets on a connection
 for the connection TTL time, then it will automatically close all the
 sessions on the server that relate to that connection.
 
-The connection TTL is configured on the URI using the `connectionTtl`
+The connection TTL is configured on the URI using the `connectionTTL`
 parameter.
 
 The default value for connection ttl on an "unreliable" connection (e.g.


### PR DESCRIPTION
Updating the text from `connectionTtl` to `connectionTTL` 

I actually copied and pasted `connectionTtl` in my configuration and spent time trying to figure out what was wrong. I finally realized it was the casing, so I'm proposing this change just in case someone faces the same issue.