### PR TITLE
ARTEMIS-2659: address some more sporadic test failures

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpDeliveryAnnotationsTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpDeliveryAnnotationsTest.java
@@ -19,6 +19,7 @@ package org.apache.activemq.artemis.tests.integration.amqp;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.activemq.artemis.core.server.Queue;
+import org.apache.activemq.artemis.utils.Wait;
 import org.apache.activemq.transport.amqp.client.AmqpClient;
 import org.apache.activemq.transport.amqp.client.AmqpConnection;
 import org.apache.activemq.transport.amqp.client.AmqpMessage;
@@ -52,7 +53,7 @@ public class AmqpDeliveryAnnotationsTest extends AmqpClientTestSupport {
       receiver.flow(1);
 
       Queue queue = getProxyToQueue(getQueueName());
-      assertEquals(1, queue.getMessageCount());
+      Wait.assertEquals(1L, queue::getMessageCount, 5000L, 25L);
 
       AmqpMessage received = receiver.receive(5, TimeUnit.SECONDS);
       assertNotNull(received);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpReceiverPriorityTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpReceiverPriorityTest.java
@@ -124,8 +124,8 @@ public class AmqpReceiverPriorityTest extends AmqpClientTestSupport {
 
 
       for (int i = 0; i < 2; i++) {
-         AmqpMessage message1 = receiver1.receiveNoWait();
-         assertNotNull("did not receive message first time", message1);
+         AmqpMessage message1 = receiver1.receive(3000, TimeUnit.MILLISECONDS);
+         assertNotNull("did not receive message" + i, message1);
          assertEquals("MessageID:" + i, message1.getMessageId());
          message1.accept();
       }


### PR DESCRIPTION
Fixes another couple races within the tests leading to sporafic failures:

The JMX checks of the queue count need a Wait to repeat where needed, as they aren't necessarily visible by the time the send returns.

The AMQP test clients recieveNoWait is a simple poll of a local queue, so there is no guarantee a message would have arrived at a consumer just because its producer send completed, a timed receive attempt should be used.