### PR TITLE
ARTEMIS-2714 handle 'Address already in use' better

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptor.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptor.java
@@ -661,7 +661,12 @@ public class NettyAcceptor extends AbstractAcceptor {
          } else {
             address = new InetSocketAddress(h, port);
          }
-         Channel serverChannel = bootstrap.bind(address).syncUninterruptibly().channel();
+         Channel serverChannel = null;
+         try {
+            serverChannel = bootstrap.bind(address).syncUninterruptibly().channel();
+         } catch (Exception e) {
+            throw ActiveMQMessageBundle.BUNDLE.failedToBind(getName(), h + ":" + port, e);
+         }
          serverChannelGroup.add(serverChannel);
       }
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQMessageBundle.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQMessageBundle.java
@@ -485,4 +485,7 @@ public interface ActiveMQMessageBundle {
 
    @Message(id = 229229, value = "Failed to parse JSON queue configuration: {0}", format = Message.Format.MESSAGE_FORMAT)
    IllegalArgumentException failedToParseJson(String json);
+
+   @Message(id = 229230, value = "Failed to bind acceptor {0} to {1}", format = Message.Format.MESSAGE_FORMAT)
+   IllegalStateException failedToBind(String acceptor, String hostPort, @Cause Exception e);
 }


### PR DESCRIPTION
Instead of blowing up with a stack-trace when hitting the common
'Address already in use' the broker will now log an ERROR with the
salient details of the acceptor and keep going.