### PR TITLE
ARTEMIS-2721 Activation keeps retrying even after server.stop()

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -1059,7 +1059,9 @@ public class ActiveMQServerImpl implements ActiveMQServer {
     */
    void stop(boolean failoverOnServerShutdown, final boolean criticalIOError, boolean restarting, boolean isShutdown) {
 
-      logger.debug("Stopping server");
+      if (logger.isDebugEnabled()) {
+         logger.debug("Stopping server " + this);
+      }
 
       synchronized (this) {
          if (state == SERVER_STATE.STOPPED || state == SERVER_STATE.STOPPING) {
@@ -3899,7 +3901,9 @@ public class ActiveMQServerImpl implements ActiveMQServer {
       public void run() {
          lockActivation();
          try {
-            runnable.run();
+            if (state != SERVER_STATE.STOPPED && state != SERVER_STATE.STOPPING) {
+               runnable.run();
+            }
          } finally {
             unlockActivation();
          }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/SharedNothingBackupActivation.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/SharedNothingBackupActivation.java
@@ -275,8 +275,11 @@ public final class SharedNothingBackupActivation extends Activation {
                         if (logger.isTraceEnabled()) {
                            logger.trace("Calling activeMQServer.stop() and start() to restart the server");
                         }
-                        activeMQServer.stop();
-                        activeMQServer.start();
+                        if (activeMQServer.getState() != ActiveMQServer.SERVER_STATE.STOPPED &&
+                            activeMQServer.getState() != ActiveMQServer.SERVER_STATE.STOPPING) {
+                           activeMQServer.stop();
+                           activeMQServer.start();
+                        }
                      } catch (Exception e) {
                         ActiveMQServerLogger.LOGGER.errorRestartingBackupServer(e, activeMQServer);
                      }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/BackupAuthenticationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/BackupAuthenticationTest.java
@@ -44,7 +44,8 @@ public class BackupAuthenticationTest extends FailoverTestBase {
    }
 
    @Test
-   public void testPasswordSetting() throws Exception {
+   public void testWrongPasswordSetting() throws Exception {
+      Wait.assertTrue(liveServer.getServer()::isActive);
       waitForServerToStart(liveServer.getServer());
       backupServer.start();
       assertTrue(latch.await(5, TimeUnit.SECONDS));
@@ -54,9 +55,8 @@ public class BackupAuthenticationTest extends FailoverTestBase {
        */
       Wait.waitFor(() -> !backupServer.isStarted());
       assertFalse("backup should have stopped", backupServer.isStarted());
-      backupConfig.setClusterPassword(CLUSTER_PASSWORD);
-      backupServer.start();
-      waitForRemoteBackup(null, 5, true, backupServer.getServer());
+      backupServer.stop();
+      liveServer.stop();
    }
 
    @Override


### PR DESCRIPTION
This won't be an issue on a real server (Production system)

however, on the testsuite or while embedded this could cause issues,
if a same instance is stopped then started.

This is the reason why BackupAuthenticationTest was intermittently failing.

I also adapted the test since I would need to stop the server and reactivate it in order to change the configuration.
The previous test wasn't acting like a real server.