### PR TITLE
ARTEMIS-2729 JdbcLeaseLock won't work on SQL Server

### DIFF
--- a/artemis-jdbc-store/src/main/resources/journal-sql.properties
+++ b/artemis-jdbc-store/src/main/resources/journal-sql.properties
@@ -97,4 +97,6 @@ table-names-case.db2=upper
 # MSSQL SQL statements
 create-file-table.mssql=CREATE TABLE %s (ID BIGINT NOT NULL IDENTITY, FILENAME VARCHAR(255), EXTENSION VARCHAR(10), DATA VARBINARY(max), PRIMARY KEY(ID))
 create-journal-table.mssql=CREATE TABLE %s(id BIGINT,recordType SMALLINT,compactCount SMALLINT,txId BIGINT,userRecordType SMALLINT,variableSize INTEGER,record VARBINARY(max),txDataSize INTEGER,txData VARBINARY(max),txCheckNoRecords INTEGER,seq BIGINT NOT NULL, PRIMARY KEY(seq))
+create-node-manager-store-table.mssql=CREATE TABLE %s (ID INT NOT NULL, HOLDER_ID VARCHAR(128), HOLDER_EXPIRATION_TIME DATETIME, NODE_ID CHAR(36),STATE CHAR(1), PRIMARY KEY(ID))
+current-timestamp.mssql=SELECT CURRENT_TIMESTAMP
 max-blob-size.mssql=2147483647


### PR DESCRIPTION
Interestingly TIMESTAMP is not a proper MSSQL data type for instants, but is used for table versioning instead: MSSQL should use DATATIME type instead.