### PR TITLE
ARTEMIS-2742 Warn complete XA transaction on the wrong session

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -2073,4 +2073,16 @@ public interface ActiveMQServerLogger extends BasicLogger {
    @LogMessage(level = Logger.Level.ERROR)
    @Message(id = 224104, value = "Error starting the Acceptor {0} {1}", format = Message.Format.MESSAGE_FORMAT)
    void errorStartingAcceptor(String name, Object configuration);
+
+   @LogMessage(level = Logger.Level.WARN)
+   @Message(id = 224105, value = "prepare the transaction with xid {0} on wrong session {1}", format = Message.Format.MESSAGE_FORMAT)
+   void prepareXIDOnWrongSession(Xid xid, String sessionName);
+
+   @LogMessage(level = Logger.Level.WARN)
+   @Message(id = 224106, value = "commit the transaction with xid {0} on wrong session {1}", format = Message.Format.MESSAGE_FORMAT)
+   void commitXIDOnWrongSession(Xid xid, String sessionName);
+
+   @LogMessage(level = Logger.Level.WARN)
+   @Message(id = 224107, value = "rollback the transaction with xid {0} on wrong session {1}", format = Message.Format.MESSAGE_FORMAT)
+   void rollbackXIDOnWrongSession(Xid xid, String sessionName);
 }


### PR DESCRIPTION
Add warnings for XA transaction completed on a session different from the one
on which they started, making these situations easier to investigate.