### PR TITLE
ARTEMIS-2614 Create queues based on FQQN for AMQP protocol

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPSessionCallback.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPSessionCallback.java
@@ -301,6 +301,16 @@ public class AMQPSessionCallback implements SessionCallback {
       }
    }
 
+   public void createQueue(QueueConfiguration queueConfiguration) throws Exception {
+      try {
+         serverSession.createQueue(queueConfiguration);
+      } catch (ActiveMQSecurityException se) {
+         throw ActiveMQAMQPProtocolMessageBundle.BUNDLE.securityErrorCreatingConsumer(se.getMessage());
+      } catch (ActiveMQQueueExistsException e) {
+         // ignore as may be caused by multiple, concurrent clients
+      }
+   }
+
    public QueueQueryResult queueQuery(SimpleString queueName, RoutingType routingType, boolean autoCreate) throws Exception {
       QueueQueryResult queueQueryResult = serverSession.executeQueueQuery(queueName);
 
@@ -323,8 +333,6 @@ public class AMQPSessionCallback implements SessionCallback {
 
       return queueQueryResult;
    }
-
-
 
    public boolean checkAddressAndAutocreateIfPossible(SimpleString address, RoutingType routingType) throws Exception {
       boolean result = false;


### PR DESCRIPTION
This is my attempt to address the problem of the auto-creation of queues based on FQQN. The simple scenario seems to work, but some decisions need to be made before I can move forward with this. 

1) There is a problem with the `RoutingType` mismatch. Previously it didn't matter what `RoutingType` receiver tries to attach to, as the implementation assumed pre-existence of the queue. Now the routing type matters, as we need to create a properly configured queue if it doesn't exist. That's why `testQueueConsumerReceiveTopicUsingFQQN
` test fails currently. To make it pass I would need to subscribe to a topic instead of a queue. I'm not sure but is this a breaking change or not? 
2) I'm not sure what is the expected behavior when durability configuration mismatches. The problem is described in a test `testAttachToPreConfiguredNonDurableQueueUsingDurableFQQN
`. Should we reject the attempt to attach when the pre-configured queue is non-durable and attach request has the source with `TerminusDurability
` of `UNSETTLED_STATE` or `CONFIGURATION`? And what about the opposite, pre-configured queue is durable and we received source with `NONE` value for `TerminusDurability`?

I would greatly appreciate your help. :)
