### PR TITLE
ARTEMIS-2709: Fix LiveToLiveFailoverTest::scaleDownDelay

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/LiveToLiveFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/LiveToLiveFailoverTest.java
@@ -32,8 +32,10 @@ import org.apache.activemq.artemis.core.config.ha.ColocatedPolicyConfiguration;
 import org.apache.activemq.artemis.core.config.ha.SharedStoreMasterPolicyConfiguration;
 import org.apache.activemq.artemis.core.config.ha.SharedStoreSlavePolicyConfiguration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.server.impl.InVMNodeManager;
 import org.apache.activemq.artemis.tests.util.TransportConfigurationUtils;
+import org.apache.activemq.artemis.tests.util.Wait;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -206,6 +208,11 @@ public class LiveToLiveFailoverTest extends FailoverTest {
       sendMessages(session, producer, 1000);
 
       crash(session);
+
+      // Wait for failover to happen
+      Queue serverQueue = backupServer.getServer().locateQueue(ADDRESS);
+
+      Wait.assertEquals(1000, serverQueue::getMessageCount);
 
       ClientConsumer consumer = session.createConsumer(ADDRESS);
 


### PR DESCRIPTION
Test fails with the primary server being killed by the crash and the backup server is killed
by the tearDown before ScaleDownHandler can kick in. This commit adds a wait method to allow
ScaleDownHandler to process before the test completes.