### PR TITLE
Remove deprecated sudo setting.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: java
 install: true
 jdk:


### PR DESCRIPTION
[Travis are now recommending removing the sudo tag.](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)

_"If you currently specify sudo: false in your .travis.yml, we recommend removing that configuration"_