### PR TITLE
ARTEMIS-2372 / ARTEMIS-2740 Improving Message Annotations support in AMQP

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/collections/TypedProperties.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/collections/TypedProperties.java
@@ -148,6 +148,11 @@ public class TypedProperties {
       otherProps.forEachInternal(this::doPutValue);
    }
 
+   public TypedProperties putProperty(final SimpleString key, final Object value) {
+      setObjectProperty(key, value, this);
+      return this;
+   }
+
    public Object getProperty(final SimpleString key) {
       return doGetProperty(key);
    }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/Message.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/Message.java
@@ -463,24 +463,24 @@ public interface Message {
    }
 
    default void referenceOriginalMessage(final Message original, String originalQueue) {
-      String queueOnMessage = original.getAnnotationString(Message.HDR_ORIGINAL_QUEUE);
+      Object queueOnMessage = original.getBrokerProperty(Message.HDR_ORIGINAL_QUEUE);
 
       if (queueOnMessage != null) {
-         setAnnotation(Message.HDR_ORIGINAL_QUEUE, queueOnMessage);
+         setBrokerProperty(Message.HDR_ORIGINAL_QUEUE, queueOnMessage);
       } else if (originalQueue != null) {
-         setAnnotation(Message.HDR_ORIGINAL_QUEUE, originalQueue);
+         setBrokerProperty(Message.HDR_ORIGINAL_QUEUE, originalQueue);
       }
 
-      Object originalID = original.getAnnotation(Message.HDR_ORIG_MESSAGE_ID);
+      Object originalID = original.getBrokerProperty(Message.HDR_ORIG_MESSAGE_ID);
 
       if (originalID != null) {
-         setAnnotation(Message.HDR_ORIGINAL_ADDRESS, original.getAnnotationString(Message.HDR_ORIGINAL_ADDRESS));
+         setBrokerProperty(Message.HDR_ORIGINAL_ADDRESS, original.getBrokerProperty(Message.HDR_ORIGINAL_ADDRESS));
 
-         setAnnotation(Message.HDR_ORIG_MESSAGE_ID, originalID);
+         setBrokerProperty(Message.HDR_ORIG_MESSAGE_ID, originalID);
       } else {
-         setAnnotation(Message.HDR_ORIGINAL_ADDRESS, original.getAddress());
+         setBrokerProperty(Message.HDR_ORIGINAL_ADDRESS, original.getAddress());
 
-         setAnnotation(Message.HDR_ORIG_MESSAGE_ID, original.getMessageID());
+         setBrokerProperty(Message.HDR_ORIG_MESSAGE_ID, original.getMessageID());
       }
 
       // reset expiry
@@ -639,6 +639,17 @@ public interface Message {
    default Message setAnnotation(SimpleString key, Object value) {
       putObjectProperty(key, value);
       return this;
+   }
+
+   /** To be called by the broker on ocasions such as DLQ and expiry.
+    * When the broker is adding additional properties. */
+   default Message setBrokerProperty(SimpleString key, Object value) {
+      putObjectProperty(key, value);
+      return this;
+   }
+
+   default Object getBrokerProperty(SimpleString key) {
+      return getObjectProperty(key);
    }
 
    Short getShortProperty(SimpleString key) throws ActiveMQPropertyConversionException;

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/converter/AMQPMessageSupport.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/converter/AMQPMessageSupport.java
@@ -35,6 +35,7 @@ import javax.jms.TemporaryQueue;
 import javax.jms.TemporaryTopic;
 import javax.jms.Topic;
 
+import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.message.impl.CoreMessage;
 import org.apache.activemq.artemis.core.persistence.CoreMessageObjectPools;
 import org.apache.activemq.artemis.jms.client.ActiveMQDestination;
@@ -62,6 +63,9 @@ import org.jboss.logging.Logger;
 public final class AMQPMessageSupport {
 
    private static final Logger logger = Logger.getLogger(AMQPMessageSupport.class);
+
+
+   public static SimpleString HDR_ORIGINAL_ADDRESS_ANNOTATION = SimpleString.toSimpleString("x-opt-ORIG-ADDRESS");
 
    public static final String JMS_REPLY_TO_TYPE_MSG_ANNOTATION_SYMBOL_NAME = "x-opt-jms-reply-to";
 
@@ -178,6 +182,9 @@ public final class AMQPMessageSupport {
    public static final Binary EMPTY_BINARY = new Binary(new byte[0]);
    public static final Data EMPTY_BODY = new Data(EMPTY_BINARY);
 
+   public static final String X_OPT_PREFIX = "x-opt-";
+   public static final String AMQ_PROPERTY_PREFIX = "_AMQ_";
+
    public static final short AMQP_UNKNOWN = 0;
    public static final short AMQP_NULL = 1;
    public static final short AMQP_DATA = 2;
@@ -284,6 +291,18 @@ public final class AMQPMessageSupport {
          return null;
       }
    }
+
+   public static String toAnnotationName(String key) {
+      if (!key.startsWith(X_OPT_PREFIX.toString())) {
+         if (key.startsWith(AMQ_PROPERTY_PREFIX)) {
+            return X_OPT_PREFIX.concat(key.substring(AMQ_PROPERTY_PREFIX.length()).replace('_', '-'));
+         }
+
+         return key;
+      }
+      return  key;
+   }
+
 
    public static String toAddress(Destination destination) {
       try {

--- a/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/converter/AnnotationNameConveterTest.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/converter/AnnotationNameConveterTest.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.protocol.amqp.converter;
+
+import org.apache.activemq.artemis.api.core.Message;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AnnotationNameConveterTest {
+
+   @Test
+   public void testAnnotationName() {
+      try {
+         Assert.assertEquals("x-opt-ORIG-QUEUE", AMQPMessageSupport.toAnnotationName(Message.HDR_ORIGINAL_QUEUE.toString()));
+         Assert.assertEquals("x-opt-ORIG-MESSAGE-ID", AMQPMessageSupport.toAnnotationName(Message.HDR_ORIG_MESSAGE_ID.toString()));
+      } catch (Exception e) {
+         e.printStackTrace();
+      }
+   }
+
+}

--- a/artemis-selector/src/main/javacc/StrictParser.jj
+++ b/artemis-selector/src/main/javacc/StrictParser.jj
@@ -131,6 +131,7 @@ TOKEN [IGNORE_CASE] :
 TOKEN [IGNORE_CASE] :
 {
     < ID : ["a"-"z", "_", "$"] (["a"-"z","0"-"9","_", "$"])* >
+    | < QUOTED_ID : "\"" ( ("\"\"") | ~["\""] )*  "\""  >
 }
 
 // ----------------------------------------------------------------------------
@@ -555,6 +556,20 @@ PropertyExpression variable() :
         t=<ID>
         {
             left = new PropertyExpression(t.image);
+        }
+        |
+        t = <QUOTED_ID>
+        {
+            // Decode the string value.
+            StringBuffer rc = new StringBuffer();
+            String image = t.image;
+            for( int i=1; i < image.length()-1; i++ ) {
+                char c = image.charAt(i);
+                if( c == '"' )
+                    i++;
+                rc.append(c);
+            }
+            return new PropertyExpression(rc.toString());
         }
     )
     {

--- a/artemis-selector/src/test/java/org/apache/activemq/artemis/selector/SelectorTest.java
+++ b/artemis-selector/src/test/java/org/apache/activemq/artemis/selector/SelectorTest.java
@@ -193,6 +193,16 @@ public class SelectorTest {
    }
 
    @Test
+   public void testDottedProperty() throws Exception {
+      MockMessage message = createMessage();
+      message.setJMSType("selector-test");
+      message.setStringProperty("a.test", "value");
+      message.setJMSMessageID("id:test:1:1:1:1");
+
+      assertSelector(message, "\"a.test\" = 'value'", true);
+   }
+
+   @Test
    public void testBasicSelectors() throws Exception {
       MockMessage message = createMessage();
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
@@ -3384,7 +3384,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
       copy.setExpiration(0);
 
       if (expiry) {
-         copy.setAnnotation(Message.HDR_ACTUAL_EXPIRY_TIME, System.currentTimeMillis());
+         copy.setBrokerProperty(Message.HDR_ACTUAL_EXPIRY_TIME, System.currentTimeMillis());
       }
 
       copy.reencode();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpSendReceiveTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpSendReceiveTest.java
@@ -396,19 +396,19 @@ public class AmqpSendReceiveTest extends AmqpClientTestSupport {
       AmqpMessage message = new AmqpMessage();
 
       message.setMessageId("msg" + 1);
-      message.setMessageAnnotation("serialNo", 1);
+      message.setMessageAnnotation("x-opt-serialNo", 1);
       message.setText("Test-Message");
       sender.send(message);
 
       message = new AmqpMessage();
       message.setMessageId("msg" + 2);
-      message.setMessageAnnotation("serialNo", 2);
+      message.setMessageAnnotation("x-opt-serialNo", 2);
       message.setText("Test-Message 2");
       sender.send(message);
       sender.close();
 
       LOG.debug("Attempting to read message with receiver");
-      AmqpReceiver receiver = session.createReceiver(getQueueName(), "serialNo=2");
+      AmqpReceiver receiver = session.createReceiver(getQueueName(), "\"m.x-opt-serialNo\"=2");
       receiver.flow(2);
       AmqpMessage received = receiver.receive(10, TimeUnit.SECONDS);
       assertNotNull("Should have read message", received);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/DLQAfterExpiredMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/DLQAfterExpiredMessageTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.amqp;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.activemq.artemis.api.core.QueueConfiguration;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.Queue;
+import org.apache.activemq.artemis.core.server.impl.AddressInfo;
+import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
+import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
+import org.apache.activemq.artemis.protocol.amqp.converter.AMQPMessageSupport;
+import org.apache.activemq.artemis.tests.util.Wait;
+import org.apache.activemq.transport.amqp.client.AmqpClient;
+import org.apache.activemq.transport.amqp.client.AmqpConnection;
+import org.apache.activemq.transport.amqp.client.AmqpMessage;
+import org.apache.activemq.transport.amqp.client.AmqpReceiver;
+import org.apache.activemq.transport.amqp.client.AmqpSender;
+import org.apache.activemq.transport.amqp.client.AmqpSession;
+import org.apache.qpid.proton.amqp.Symbol;
+import org.jboss.logging.Logger;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * This is testing a double transfer (copy).
+ * First messages will expire, then DLQ.
+ * This will validate the data added to the queues.
+ */
+public class DLQAfterExpiredMessageTest extends AmqpClientTestSupport {
+   private static final Logger log = Logger.getLogger(DLQAfterExpiredMessageTest.class);
+
+   protected String getExpiryQueue() {
+      return "ActiveMQ.Expiry";
+   }
+
+   @Override
+   protected void createAddressAndQueues(ActiveMQServer server) throws Exception {
+      // Default Queue
+      server.addAddressInfo(new AddressInfo(SimpleString.toSimpleString(getQueueName()), RoutingType.ANYCAST));
+      server.createQueue(new QueueConfiguration(getQueueName()).setRoutingType(RoutingType.ANYCAST));
+
+      // Default DLQ
+      server.addAddressInfo(new AddressInfo(SimpleString.toSimpleString(getDeadLetterAddress()), RoutingType.ANYCAST));
+      server.createQueue(new QueueConfiguration(getDeadLetterAddress()).setRoutingType(RoutingType.ANYCAST));
+
+      // Expiry
+      server.addAddressInfo(new AddressInfo(SimpleString.toSimpleString(getExpiryQueue()), RoutingType.ANYCAST));
+      server.createQueue(new QueueConfiguration(getExpiryQueue()).setRoutingType(RoutingType.ANYCAST));
+
+      // Default Topic
+      server.addAddressInfo(new AddressInfo(SimpleString.toSimpleString(getTopicName()), RoutingType.MULTICAST));
+      server.createQueue(new QueueConfiguration(getTopicName()));
+
+      // Additional Test Queues
+      for (int i = 0; i < getPrecreatedQueueSize(); ++i) {
+         server.addAddressInfo(new AddressInfo(SimpleString.toSimpleString(getQueueName(i)), RoutingType.ANYCAST));
+         server.createQueue(new QueueConfiguration(getQueueName(i)).setRoutingType(RoutingType.ANYCAST));
+      }
+   }
+
+   @Override
+   protected void configureAddressPolicy(ActiveMQServer server) {
+      // Address configuration
+      AddressSettings addressSettings = new AddressSettings();
+
+      addressSettings.setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
+      addressSettings.setAutoCreateQueues(isAutoCreateQueues());
+      addressSettings.setAutoCreateAddresses(isAutoCreateAddresses());
+      addressSettings.setDeadLetterAddress(SimpleString.toSimpleString(getDeadLetterAddress()));
+      addressSettings.setExpiryAddress(SimpleString.toSimpleString(getExpiryQueue()));
+      addressSettings.setMaxDeliveryAttempts(1);
+      server.getConfiguration().getAddressesSettings().put("#", addressSettings);
+      server.getConfiguration().getAddressesSettings().put(getExpiryQueue(), addressSettings);
+   }
+
+   @Test
+   public void testDoubleTransfer() throws Throwable {
+
+      AmqpClient client = createAmqpClient();
+      AmqpConnection connection = addConnection(client.connect());
+      try {
+         AmqpSession session = connection.createSession();
+
+         AmqpSender sender = session.createSender(getQueueName());
+
+         // Get the Queue View early to avoid racing the delivery.
+         final Queue queueView = getProxyToQueue(getQueueName());
+         assertNotNull(queueView);
+
+         AmqpMessage message = new AmqpMessage();
+         message.setTimeToLive(1);
+         message.setText("Test-Message");
+         message.setDurable(true);
+         message.setApplicationProperty("key1", "Value1");
+         sender.send(message);
+         sender.close();
+
+         Wait.assertEquals(1, queueView::getMessagesExpired);
+         Wait.assertEquals(0, queueView::getConsumerCount);
+
+         final Queue expiryView = getProxyToQueue(getExpiryQueue());
+         assertNotNull(expiryView);
+         Wait.assertEquals(1, expiryView::getMessageCount);
+
+         HashMap<String, Object> annotations = new HashMap<>();
+
+         AmqpReceiver receiverDLQ = session.createReceiver(getExpiryQueue(), "\"m." + AMQPMessageSupport.HDR_ORIGINAL_ADDRESS_ANNOTATION + "\"='" + getQueueName() + "'");
+         receiverDLQ.flow(1);
+         AmqpMessage received = receiverDLQ.receive(5, TimeUnit.SECONDS);
+         Assert.assertNotNull(received);
+         Map<Symbol, Object> avAnnotations = received.getWrappedMessage().getMessageAnnotations().getValue();
+         avAnnotations.forEach((key, value) -> {
+            annotations.put(key.toString(), value);
+         });
+         received.reject();
+         receiverDLQ.close();
+
+
+         // Redo the selection
+         receiverDLQ = session.createReceiver(getDeadLetterAddress(), "\"m." + AMQPMessageSupport.HDR_ORIGINAL_ADDRESS_ANNOTATION + "\"='" + getQueueName() + "'");
+         receiverDLQ.flow(1);
+         received = receiverDLQ.receive(5, TimeUnit.SECONDS);
+         Assert.assertNotNull(received);
+         received.accept();
+
+         /** When moving to DLQ, the original headers shoudln't be touched. */
+         for (Map.Entry<String, Object> entry : annotations.entrySet()) {
+            log.debug("Checking " + entry.getKey() + " = " + entry.getValue());
+            Assert.assertEquals(entry.getKey() + " should be = " + entry.getValue(), entry.getValue(), received.getMessageAnnotation(entry.getKey()));
+         }
+
+         assertEquals(0, received.getTimeToLive());
+         assertNotNull(received);
+         assertEquals("Value1", received.getApplicationProperty("key1"));
+      } catch (Throwable e) {
+         e.printStackTrace();
+         throw e;
+      } finally {
+         connection.close();
+      }
+   }
+}


### PR DESCRIPTION
- when sending messages to DLQ or Expiry we now use x-opt legal names
- we now support filtering thorugh annotations if using m. as a prefix.
- enabling hyphenated_props: to allow m. as a prefix