### PR TITLE
ARTEMIS-2765 Fix parsing error in XMLUtil

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/utils/XMLUtil.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/utils/XMLUtil.java
@@ -255,23 +255,27 @@ public final class XMLUtil {
    public static String replaceSystemPropsInString(String xml) {
       while (xml.contains("${")) {
          int start = xml.indexOf("${");
-         int end = xml.indexOf("}") + 1;
-         if (end < 0) {
+         int end = xml.indexOf("}", start) + 1;
+
+         if (start < 0 || end <= 0) {
             break;
          }
+
          String subString = xml.substring(start, end);
          String prop = subString.substring(2, subString.length() - 1).trim();
          String val = "";
+
          if (prop.contains(":")) {
             String[] parts = prop.split(":", 2);
             prop = parts[0].trim();
             val = parts[1].trim();
          }
+
          String sysProp = System.getProperty(prop, val);
          logger.debug("replacing " + subString + " with " + sysProp);
          xml = xml.replace(subString, sysProp);
-
       }
+
       return xml;
    }
 

--- a/artemis-core-client/src/test/java/org/apache/activemq/artemis/util/XMLUtilTest.java
+++ b/artemis-core-client/src/test/java/org/apache/activemq/artemis/util/XMLUtilTest.java
@@ -219,6 +219,26 @@ public class XMLUtilTest extends SilentTestCase {
    }
 
    @Test
+   public void testReplaceSystemPropertiesWithUnclosedPropertyReferenceInXML() {
+      String before = "<configuration>\n" + "   <test name=\"${sysprop1}\">content1</test>\n" + "   <test name=\"test2\">content2</test>\n" + "   <test name=\"test3\">content3</test>\n" + "   <test name=\"test4\">${sysprop2</test>\n" + "   <test name=\"test5\">content5</test>\n" + "   <test name=\"test6\">content6</test>\n" + "</configuration>";
+      String after = "<configuration>\n" + "   <test name=\"test1\">content1</test>\n" + "   <test name=\"test2\">content2</test>\n" + "   <test name=\"test3\">content3</test>\n" + "   <test name=\"test4\">${sysprop2</test>\n" + "   <test name=\"test5\">content5</test>\n" + "   <test name=\"test6\">content6</test>\n" + "</configuration>";
+      System.setProperty("sysprop1", "test1");
+      System.setProperty("sysprop2", "content4");
+      String replaced = XMLUtil.replaceSystemPropsInString(before);
+      Assert.assertEquals(after, replaced);
+   }
+
+   @Test
+   public void testReplaceSystemPropertiesWithMiscCurlyBracesInXML() {
+      String before = "<configuration>\n" + "   <test name=\"${sysprop1}\">content1{ }</test>\n" + "   <test name=\"test2\">content2 {</test>\n" + "   <test name=\"test3\">content3 }</test>\n" + "   <test name=\"test4\">${sysprop2}</test>\n" + "   <test name=\"test5\">content5{ }</test>\n" + "   <test name=\"test6\">content6 }</test>\n" + "</configuration>";
+      String after = "<configuration>\n" + "   <test name=\"test1\">content1{ }</test>\n" + "   <test name=\"test2\">content2 {</test>\n" + "   <test name=\"test3\">content3 }</test>\n" + "   <test name=\"test4\">content4</test>\n" + "   <test name=\"test5\">content5{ }</test>\n" + "   <test name=\"test6\">content6 }</test>\n" + "</configuration>";
+      System.setProperty("sysprop1", "test1");
+      System.setProperty("sysprop2", "content4");
+      String replaced = XMLUtil.replaceSystemPropsInString(before);
+      Assert.assertEquals(after, replaced);
+   }
+
+   @Test
    public void testStripCDATA() throws Exception {
       String xml = "<![CDATA[somedata]]>";
       String stripped = XMLUtil.stripCDATA(xml);


### PR DESCRIPTION
Fix a StringIndexOutOfBoundsException in XMLUtil while parsing system
properties in XML that contains curly braces or unterminated property
references