### PR TITLE
ARTEMIS-2773 Dockerfile Improvements

### DIFF
--- a/artemis-docker/Dockerfile-debian
+++ b/artemis-docker/Dockerfile-debian
@@ -31,8 +31,7 @@ ENV CREATE_ARGUMENTS --user ${ARTEMIS_USER} --password ${ARTEMIS_PASSWORD} --sil
 # add user and group for artemis
 RUN groupadd -g 1000 -r artemis && useradd -r -u 1000 -g artemis artemis \
  && apt-get -qq -o=Dpkg::Use-Pty=0 update && \
-    apt-get -qq -o=Dpkg::Use-Pty=0 install -y --no-install-recommends \
-    libaio1=0.3.110-3 && \
+    apt-get -qq -o=Dpkg::Use-Pty=0 install -y libaio1 && \
     rm -rf /var/lib/apt/lists/*
 
 USER artemis

--- a/artemis-docker/prepare-docker.sh
+++ b/artemis-docker/prepare-docker.sh
@@ -51,6 +51,7 @@ then
   rm -rf $target/docker
 fi
 mkdir $target/docker
-cp ./{Dockerfile-centos,Dockerfile-ubuntu,docker-run.sh} $target/docker
+cp ./Dockerfile-* $target/docker
+cp ./docker-run.sh $target/docker
 
 echo "Docker file support files at : $target/docker"

--- a/artemis-docker/readme.md
+++ b/artemis-docker/readme.md
@@ -1,6 +1,6 @@
 # Docker Image Example
 
-This is an example on how you could create your own Docker Image For Apache ActiveMQ Artemis based on CentOS or Ubuntu.
+This is an example on how you could create your own Docker Image For Apache ActiveMQ Artemis based on CentOS or Debian.
 # Preparing
 
 Use the script ./prepare-docker.sh as it will copy the docker files under the binary distribution.
@@ -13,11 +13,11 @@ $ ./prepare-docker.sh $ARTEMIS_HOME
 
 Go to `$ARTEMIS_HOME` where you prepared the binary with Docker files.
 
-## For Ubuntu:
+## For Debian:
 
 From within the `$ARTEMIS_HOME` folder:
 ```
-$ docker build -f ./docker/Dockerfile-ubuntu -t artemis-ubuntu .
+$ docker build -f ./docker/Dockerfile-debian -t artemis-debian .
 ```
 
 ## For CentOS
@@ -28,7 +28,7 @@ $ docker build -f ./docker/Dockerfile-centos -t artemis-centos .
 ```
 
 **Note:**
-`-t artemis-ubuntu`,`-t artemis-centos` are just tag names for the purpose of this guide
+`-t artemis-debian`,`-t artemis-centos` are just tag names for the purpose of this guide
 
 # Variables:
 


### PR DESCRIPTION
The current Dockerfile based on openjdk:8 does not build due to an unavailable version of libaio1 specified. It explicitly references version 0.3.110-3 of libaio1 however, it appears that 0.3.112-3 is the current stable version and when attempting to build the Dockerfile the following error occurs:

```
Step 9/20 : RUN groupadd -g 1000 -r artemis && useradd -r -u 1000 -g artemis artemis && apt-get -qq -o=Dpkg::Use-Pty=0 update && apt-get -qq -o=Dpkg::Use-Pty=0 install -y --no-install-recommends libaio1=0.3.110-3 && rm -rf /var/lib/apt/lists/*
 ---> Running in f56ff568c477
E: Version '0.3.110-3' for 'libaio1' was not found
``` 

In addition, I received this error attempting to run prepare-docker.sh:

`cp: cannot stat './{Dockerfile-centos,Dockerfile-ubuntu,docker-run.sh}': No such file or directory`
 
Finally, the Dockerfile states it is Ubuntu, when in fact openjdk:8 is now Debian, so the names of the scripts and the readme should reflect this.
 