### PR TITLE
ARTEMIS-2649 always over-write ORIG message props

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/Message.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/Message.java
@@ -463,25 +463,9 @@ public interface Message {
    }
 
    default void referenceOriginalMessage(final Message original, String originalQueue) {
-      Object queueOnMessage = original.getBrokerProperty(Message.HDR_ORIGINAL_QUEUE);
-
-      if (queueOnMessage != null) {
-         setBrokerProperty(Message.HDR_ORIGINAL_QUEUE, queueOnMessage);
-      } else if (originalQueue != null) {
-         setBrokerProperty(Message.HDR_ORIGINAL_QUEUE, originalQueue);
-      }
-
-      Object originalID = original.getBrokerProperty(Message.HDR_ORIG_MESSAGE_ID);
-
-      if (originalID != null) {
-         setBrokerProperty(Message.HDR_ORIGINAL_ADDRESS, original.getBrokerProperty(Message.HDR_ORIGINAL_ADDRESS));
-
-         setBrokerProperty(Message.HDR_ORIG_MESSAGE_ID, originalID);
-      } else {
-         setBrokerProperty(Message.HDR_ORIGINAL_ADDRESS, original.getAddress());
-
-         setBrokerProperty(Message.HDR_ORIG_MESSAGE_ID, original.getMessageID());
-      }
+      setBrokerProperty(Message.HDR_ORIGINAL_QUEUE, originalQueue);
+      setBrokerProperty(Message.HDR_ORIGINAL_ADDRESS, original.getAddress());
+      setBrokerProperty(Message.HDR_ORIG_MESSAGE_ID, original.getMessageID());
 
       // reset expiry
       setExpiration(0);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1674,6 +1674,11 @@ public interface ActiveMQServerLogger extends BasicLogger {
       format = Message.Format.MESSAGE_FORMAT)
    void pageLookupError(int pageNr, int messageNr, int offset, int startNr);
 
+   @LogMessage(level = Logger.Level.WARN)
+   @Message(id = 222289, value = "Did not route to any matching bindings on dead-letter-address {0} and auto-create-dead-letter-resources is true; dropping message: {1}",
+      format = Message.Format.MESSAGE_FORMAT)
+   void noMatchingBindingsOnDLAWithAutoCreateDLAResources(SimpleString address, String message);
+
    @LogMessage(level = Logger.Level.ERROR)
    @Message(id = 224000, value = "Failure in initialisation", format = Message.Format.MESSAGE_FORMAT)
    void initializationError(@Cause Throwable e);

--- a/docs/user-manual/en/copied-message-properties.md
+++ b/docs/user-manual/en/copied-message-properties.md
@@ -1,0 +1,37 @@
+# Properties for Copied Messages
+
+There are several operations within the broker that result in copying a
+message. These include:
+
+- Diverting a message from one address to another.
+- Moving an expired message from a queue to the configured `expiry-address`
+- Moving a message which has exceeded its `max-delivery-attempts` from a queue
+  to the configured `dead-letter-address`
+- Using the management API to administratively move messages from one queue to
+  another
+
+When this happens the body and properties of the original message are copied to
+a new message. However, the copying process removes some potentially important
+pieces of data so those are preserved in the following special message
+properties:
+
+- `_AMQ_ORIG_ADDRESS`
+
+  a String property containing the *original address* of the message
+
+- `_AMQ_ORIG_QUEUE`
+
+  a String property containing the *original queue* of the message
+
+- `_AMQ_ORIG_MESSAGE_ID`
+
+  a String property containing the *original message ID* of the message
+
+It's possible for the aforementioned operations to be combined. For example, a
+message may be diverted from one address to another where it lands in a queue
+and a consumer tries & fails to consume it such that the message is then sent
+to a dead-letter address. Or a message may be administratively moved from one
+queue to another where it then expires.
+
+In cases like these the `ORIG` properties will contain the information from the
+_last_ (i.e. most recent) operation.

--- a/docs/user-manual/en/diverts.md
+++ b/docs/user-manual/en/diverts.md
@@ -57,12 +57,7 @@ geographically distributed servers, creating your global messaging mesh.
 Diverts are defined as xml in the `broker.xml` file at the `core` attribute level.
 There can be zero or more diverts in the file.
 
-Diverted message gets a new message ID, and its address is set to a forward
-address. To access original values, use message properties: original destination
-is stored in a String property `_AMQ_ORIG_ADDRESS` (`Message.HDR_ORIGINAL_ADDRESS`
-constant from the Core API), and the original message ID in a Long property
-`_AMQ_ORIG_MESSAGE_ID` (`Message.HDR_ORIG_MESSAGE_ID` constant from the
-Core API).
+Diverted messages get [special properties](copied-message-properties.md).
 
 Please see the examples for a full working example showing you how to
 configure and use diverts.

--- a/docs/user-manual/en/message-expiry.md
+++ b/docs/user-manual/en/message-expiry.md
@@ -28,18 +28,8 @@ JMS MessageProducer allows to set a TimeToLive for the messages it sent:
 producer.setTimeToLive(5000);
 ```
 
-Expired messages which are consumed from an expiry address have the following
-properties:
-
-- `_AMQ_ORIG_ADDRESS`
-
-  a String property containing the *original address* of the expired
-  message
-
-- `_AMQ_ORIG_QUEUE`
-
-  a String property containing the *original queue* of the expired
-  message
+Expired messages get [special properties](copied-message-properties.md) plus this
+additional property:
 
 - `_AMQ_ACTUAL_EXPIRY`
 
@@ -123,21 +113,20 @@ an `address-setting` to configure the `expiry-address` much less
 the actual `address` and `queue` to hold the expired messages.
 
 The solution to this problem is to set the `auto-create-expiry-resources`
-`address-setting` to `true` (it's `false` by default) so that the
-broker will create the `address` and `queue` to deal with the
-expired messages automatically. The `address` created will be the
-one defined by the `expiry-address`. A `MULTICAST` `queue` will be
-created on that `address`. It will be named by the `address` to which
-the message was originally sent, and it will have a filter defined using
-the aforementioned `_AMQ_ORIG_ADDRESS` property so that it will only
-receive messages sent to the relevant `address`. The `queue` name can be
-configured with a prefix and suffix. See the relevant settings in the
-table below:
+`address-setting` to `true` (it's `false` by default) so that the broker will
+create the `address` and `queue` to deal with the expired messages
+automatically. The `address` created will be the one defined by the
+`expiry-address`. A `MULTICAST` `queue` will be created on that `address`.
+It will be named by the `address` to which the message was previously sent, and
+it will have a filter defined using the property `_AMQ_ORIG_ADDRESS` so that it
+will only receive messages sent to the relevant `address`. The `queue` name can
+be configured with a prefix and suffix. See the relevant settings in the table
+below:
 
 `address-setting`|default
 ---|---
 `expiry-queue-prefix`|`EXP.`
-`expiry-queue-suffix`|`` (empty string)
+`expiry-queue-suffix`|(empty string)
 
 Here is an example configuration:
 

--- a/docs/user-manual/en/undelivered-messages.md
+++ b/docs/user-manual/en/undelivered-messages.md
@@ -165,18 +165,7 @@ set of addresses (see [Understanding the Wildcard Syntax](wildcard-syntax.md)).
 
 ### Dead Letter Properties
 
-Dead letter messages which are consumed from a dead letter address have
-the following properties:
-
-- `_AMQ_ORIG_ADDRESS`
-
-  a String property containing the *original address* of the dead
-  letter message
-
-- `_AMQ_ORIG_QUEUE`
-
-  a String property containing the *original queue* of the dead letter
-  message
+Dead letter messages get [special properties](copied-message-properties.md).
 
 ### Automatically Creating Dead Letter Resources
 
@@ -194,21 +183,20 @@ an `address-setting` to configure the `dead-letter-address` much less
 the actual `address` and `queue` to hold the undelivered messages.
 
 The solution to this problem is to set the `auto-create-dead-letter-resources`
-`address-setting` to `true` (it's `false` by default) so that the
-broker will create the `address` and `queue` to deal with the
-undelivered messages automatically. The `address` created will be the
-one defined by the `dead-letter-address`. A `MULTICAST` `queue` will be
-created on that `address`. It will be named by the `address` to which
-the message was originally sent, and it will have a filter defined using
-the aforementioned `_AMQ_ORIG_ADDRESS` property so that it will only
-receive messages sent to the relevant `address`. The `queue` name can be
-configured with a prefix and suffix. See the relevant settings in the
-table below:
+`address-setting` to `true` (it's `false` by default) so that the broker will
+create the `address` and `queue` to deal with the undelivered messages
+automatically. The `address` created will be the one defined by the
+`dead-letter-address`. A `MULTICAST` `queue` will be created on that `address`.
+It will be named by the `address` to which the message was previously sent, and
+it will have a filter defined using the property `_AMQ_ORIG_ADDRESS` so that it
+ will only receive messages sent to the relevant `address`. The `queue` name
+ can be configured with a prefix and suffix. See the relevant settings in the
+ table below:
 
 `address-setting`|default
 ---|---
 `dead-letter-queue-prefix`|`DLQ.`
-`dead-letter-queue-suffix`|`` (empty string)
+`dead-letter-queue-suffix`|(empty string)
 
 Here is an example configuration:
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/DLQAfterExpiredMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/DLQAfterExpiredMessageTest.java
@@ -137,17 +137,11 @@ public class DLQAfterExpiredMessageTest extends AmqpClientTestSupport {
 
 
          // Redo the selection
-         receiverDLQ = session.createReceiver(getDeadLetterAddress(), "\"m." + AMQPMessageSupport.HDR_ORIGINAL_ADDRESS_ANNOTATION + "\"='" + getQueueName() + "'");
+         receiverDLQ = session.createReceiver(getDeadLetterAddress(), "\"m." + AMQPMessageSupport.HDR_ORIGINAL_ADDRESS_ANNOTATION + "\"='" + getExpiryQueue() + "'");
          receiverDLQ.flow(1);
          received = receiverDLQ.receive(5, TimeUnit.SECONDS);
          Assert.assertNotNull(received);
          received.accept();
-
-         /** When moving to DLQ, the original headers shoudln't be touched. */
-         for (Map.Entry<String, Object> entry : annotations.entrySet()) {
-            log.debug("Checking " + entry.getKey() + " = " + entry.getValue());
-            Assert.assertEquals(entry.getKey() + " should be = " + entry.getValue(), entry.getValue(), received.getMessageAnnotation(entry.getKey()));
-         }
 
          assertEquals(0, received.getTimeToLive());
          assertNotNull(received);


### PR DESCRIPTION
ORIG message propertes like _AMQ_ORIG_ADDRESS are added to messages
during various broker operations (e.g. diverting a message, expiring a
message, etc.). However, if multiple operations try to set these
properties on the same message (e.g. administratively moving a message
which eventually gets sent to a dead-letter address) then important
details can be lost. This is particularly problematic when using
auto-created dead-letter or expiry resources which use filters based on
_AMQ_ORIG_ADDRESS and can lead to message loss.

This commit simply over-writes the existing ORIG properties rather than
preserving them so that the most recent information is available.