### PR TITLE
ARTEMIS-2785 io.netty.util.internal.OutOfDirectMemoryError during uncompress

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/ActiveMQBuffer.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/ActiveMQBuffer.java
@@ -800,19 +800,6 @@ public interface ActiveMQBuffer extends DataInput {
    String readUTF();
 
    /**
-    * Transfers this buffer's data to a newly created buffer starting at
-    * the current {@code readerIndex} and increases the {@code readerIndex}
-    * by the number of the transferred bytes (= {@code length}).
-    * The returned buffer's {@code readerIndex} and {@code writerIndex} are
-    * {@code 0} and {@code length} respectively.
-    *
-    * @param length the number of bytes to transfer
-    * @return the newly created buffer which contains the transferred bytes
-    * @throws IndexOutOfBoundsException if {@code length} is greater than {@code this.readableBytes}
-    */
-   ActiveMQBuffer readBytes(int length);
-
-   /**
     * Returns a new slice of this buffer's sub-region starting at the current
     * {@code readerIndex} and increases the {@code readerIndex} by the size
     * of the new slice (= {@code length}).

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/core/buffers/impl/ChannelBufferWrapper.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/core/buffers/impl/ChannelBufferWrapper.java
@@ -331,11 +331,6 @@ public class ChannelBufferWrapper implements ActiveMQBuffer {
    }
 
    @Override
-   public ActiveMQBuffer readBytes(final int length) {
-      return new ChannelBufferWrapper(buffer.readBytes(length), releasable);
-   }
-
-   @Override
    public char readChar() {
       return (char) buffer.readShort();
    }

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/ByteUtil.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/ByteUtil.java
@@ -239,17 +239,6 @@ public class ByteUtil {
       return sb.toString();
    }
 
-   public static byte[] getActiveArray(ByteBuffer buffer) {
-      byte[] ret = new byte[buffer.remaining()];
-      if (buffer.hasArray()) {
-         byte[] array = buffer.array();
-         System.arraycopy(array, buffer.arrayOffset() + buffer.position(), ret, 0, ret.length);
-      } else {
-         buffer.slice().get(ret);
-      }
-      return ret;
-   }
-
    public static long convertTextBytes(final String text) {
       try {
          Matcher m = ONE.matcher(text);

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientConsumerImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientConsumerImpl.java
@@ -39,7 +39,6 @@ import org.apache.activemq.artemis.core.client.ActiveMQClientLogger;
 import org.apache.activemq.artemis.core.client.ActiveMQClientMessageBundle;
 import org.apache.activemq.artemis.spi.core.remoting.ConsumerContext;
 import org.apache.activemq.artemis.spi.core.remoting.SessionContext;
-import org.apache.activemq.artemis.utils.ByteUtil;
 import org.apache.activemq.artemis.utils.FutureLatch;
 import org.apache.activemq.artemis.utils.ReusableLatch;
 import org.apache.activemq.artemis.utils.TokenBucketLimiter;
@@ -655,9 +654,9 @@ public final class ClientConsumerImpl implements ClientConsumerInternal {
 
       //sets the packet
       ActiveMQBuffer qbuff = clMessage.toCore().getBodyBuffer();
-      int bytesToRead = qbuff.writerIndex() - qbuff.readerIndex();
-      final byte[] body = ByteUtil.getActiveArray(qbuff.readBytes(bytesToRead).toByteBuffer());
-
+      final int bytesToRead = qbuff.writerIndex() - qbuff.readerIndex();
+      final byte[] body = new byte[bytesToRead];
+      qbuff.readBytes(body);
       largeMessage.setLargeMessageController(new CompressedLargeMessageControllerImpl(currentLargeMessageController));
       currentLargeMessageController.addPacket(body, body.length, false);
 

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/CompressedLargeMessageControllerImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/CompressedLargeMessageControllerImpl.java
@@ -24,7 +24,6 @@ import java.nio.ByteBuffer;
 
 import io.netty.buffer.ByteBuf;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
-import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.client.ActiveMQClientLogger;
@@ -590,13 +589,6 @@ final class CompressedLargeMessageControllerImpl implements LargeMessageControll
    @Override
    public float getFloat(final int index) {
       return Float.intBitsToFloat(getInt(index));
-   }
-
-   @Override
-   public ActiveMQBuffer readBytes(final int length) {
-      byte[] bytesToGet = new byte[length];
-      readBytes(bytesToGet);
-      return ActiveMQBuffers.wrappedBuffer(bytesToGet);
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/LargeMessageControllerImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/LargeMessageControllerImpl.java
@@ -31,7 +31,6 @@ import java.util.concurrent.TimeUnit;
 
 import io.netty.buffer.ByteBuf;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
-import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
 import org.apache.activemq.artemis.api.core.ActiveMQInterruptedException;
@@ -973,14 +972,6 @@ public class LargeMessageControllerImpl implements LargeMessageController {
    @Override
    public float getFloat(final int index) {
       return Float.intBitsToFloat(getInt(index));
-   }
-
-   @Override
-   public ActiveMQBuffer readBytes(final int length) {
-      byte[] bytesToGet = new byte[length];
-      getBytes(readerIndex, bytesToGet);
-      readerIndex += length;
-      return ActiveMQBuffers.wrappedBuffer(bytesToGet);
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessage.java
@@ -44,7 +44,6 @@ import org.apache.activemq.artemis.core.persistence.CoreMessageObjectPools;
 import org.apache.activemq.artemis.core.persistence.Persister;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
 import org.apache.activemq.artemis.reader.MessageUtil;
-import org.apache.activemq.artemis.utils.ByteUtil;
 import org.apache.activemq.artemis.utils.DataConstants;
 import org.apache.activemq.artemis.utils.UUID;
 import org.apache.activemq.artemis.utils.collections.TypedProperties;
@@ -251,9 +250,11 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
    }
 
    private ActiveMQBuffer inflate(ActiveMQBuffer buffer) throws DataFormatException {
-      int bytesToRead = buffer.readableBytes();
+      final int bytesToRead = buffer.readableBytes();
       Inflater inflater = new Inflater();
-      inflater.setInput(ByteUtil.getActiveArray(buffer.readBytes(bytesToRead).toByteBuffer()));
+      final byte[] input = new byte[bytesToRead];
+      buffer.readBytes(input);
+      inflater.setInput(input);
 
       //get the real size of large message
       long sizeBody = getLongProperty(Message.HDR_LARGE_BODY_SIZE);


### PR DESCRIPTION
Netty's `UnreleasableByteBuf::readBytes(int length)` allocates a direct `ByteBuf` without `Cleaner` that can leak and cause OOM on `ChannelBufferWrapper::readBytes(final int length)`