### PR TITLE
ARTEMIS-1322 Add a ServerLocator option to ignore topology for load-balancing

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorImpl.java
@@ -707,9 +707,11 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       // ATM topology is never != null. Checking here just to be consistent with
       // how the sendSubscription happens.
       // in case this ever changes.
-      if (topology != null && !factory.waitForTopology(config.callTimeout, TimeUnit.MILLISECONDS)) {
-         factory.cleanup();
-         throw ActiveMQClientMessageBundle.BUNDLE.connectionTimedOutOnReceiveTopology(discoveryGroup);
+      if (useTopologyForLoadBalancing) {
+         if (topology != null && !factory.waitForTopology(config.callTimeout, TimeUnit.MILLISECONDS)) {
+            factory.cleanup();
+            throw ActiveMQClientMessageBundle.BUNDLE.connectionTimedOutOnReceiveTopology(discoveryGroup);
+         }
       }
 
       addFactory(factory);


### PR DESCRIPTION

(2nd commit) Disable wait for topolocy when ignore topology for
load-balancing option is true.