### PR TITLE
ARTEMIS-2790 Fix no examples documentation in the bin archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ ratReport.txt
 .factorypath
 **/.editorconfig
 **/derby.log
-examples/**/readme.html
 **/.DS_Store
 
 # for native build

--- a/artemis-distribution/pom.xml
+++ b/artemis-distribution/pom.xml
@@ -287,4 +287,34 @@
       </plugins>
    </build>
 
+   <profiles>
+      <profile>
+         <id>release</id>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>com.vladsch.flexmark</groupId>
+                  <artifactId>markdown-page-generator-plugin</artifactId>
+                  <version>0.27.0</version>
+                  <executions>
+                     <execution>
+                        <phase>compile</phase>
+                        <goals>
+                           <goal>generate</goal>
+                        </goals>
+                     </execution>
+                  </executions>
+                  <configuration>
+                     <headerHtmlFile>${activemq.basedir}/examples/common/header.html</headerHtmlFile>
+                     <footerHtmlFile>${activemq.basedir}/examples/common/footer.html</footerHtmlFile>
+                     <inputDirectory>${activemq.basedir}/examples</inputDirectory>
+                     <outputDirectory>${project.build.directory}/markdown-pages/examples</outputDirectory>
+                     <recursiveInput>true</recursiveInput>
+                  </configuration>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+   </profiles>
+
 </project>

--- a/artemis-distribution/src/main/assembly/dep.xml
+++ b/artemis-distribution/src/main/assembly/dep.xml
@@ -228,6 +228,7 @@
          <directoryMode>0755</directoryMode>
          <fileMode>0755</fileMode>
       </fileSet>
+      <!-- examples -->
       <fileSet>
          <directory>${activemq.basedir}/examples</directory>
          <outputDirectory>examples</outputDirectory>
@@ -238,6 +239,11 @@
             <exclude>**/**/*.dat</exclude>
             <exclude>**/**/*.md</exclude>
          </excludes>
+      </fileSet>
+      <fileSet>
+         <directory>${project.build.directory}/markdown-pages/examples</directory>
+         <outputDirectory>examples</outputDirectory>
+         <lineEnding>keep</lineEnding>
       </fileSet>
       <!-- Include license and notice files -->
       <fileSet>

--- a/examples/features/clustered/client-side-load-balancing/pom.xml
+++ b/examples/features/clustered/client-side-load-balancing/pom.xml
@@ -215,17 +215,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/clustered/clustered-durable-subscription/pom.xml
+++ b/examples/features/clustered/clustered-durable-subscription/pom.xml
@@ -161,17 +161,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/clustered/clustered-grouping/pom.xml
+++ b/examples/features/clustered/clustered-grouping/pom.xml
@@ -199,17 +199,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/clustered/clustered-jgroups/pom.xml
+++ b/examples/features/clustered/clustered-jgroups/pom.xml
@@ -164,17 +164,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/clustered/clustered-queue/pom.xml
+++ b/examples/features/clustered/clustered-queue/pom.xml
@@ -157,17 +157,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/clustered/clustered-static-discovery-uri/pom.xml
+++ b/examples/features/clustered/clustered-static-discovery-uri/pom.xml
@@ -244,17 +244,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/clustered/clustered-static-discovery/pom.xml
+++ b/examples/features/clustered/clustered-static-discovery/pom.xml
@@ -244,17 +244,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/clustered/clustered-static-oneway/pom.xml
+++ b/examples/features/clustered/clustered-static-oneway/pom.xml
@@ -204,17 +204,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/clustered/clustered-topic-uri/pom.xml
+++ b/examples/features/clustered/clustered-topic-uri/pom.xml
@@ -157,17 +157,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/clustered/clustered-topic/pom.xml
+++ b/examples/features/clustered/clustered-topic/pom.xml
@@ -157,17 +157,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/clustered/queue-message-redistribution/pom.xml
+++ b/examples/features/clustered/queue-message-redistribution/pom.xml
@@ -158,17 +158,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/clustered/shared-storage-static-cluster/pom.xml
+++ b/examples/features/clustered/shared-storage-static-cluster/pom.xml
@@ -145,17 +145,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/clustered/symmetric-cluster/pom.xml
+++ b/examples/features/clustered/symmetric-cluster/pom.xml
@@ -319,17 +319,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/federation/federated-address-divert/pom.xml
+++ b/examples/features/federation/federated-address-divert/pom.xml
@@ -157,17 +157,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/federation/federated-address-downstream-upstream/pom.xml
+++ b/examples/features/federation/federated-address-downstream-upstream/pom.xml
@@ -199,17 +199,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/federation/federated-address-downstream/pom.xml
+++ b/examples/features/federation/federated-address-downstream/pom.xml
@@ -199,17 +199,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/federation/federated-address/pom.xml
+++ b/examples/features/federation/federated-address/pom.xml
@@ -199,17 +199,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/federation/federated-queue-downstream-upstream/pom.xml
+++ b/examples/features/federation/federated-queue-downstream-upstream/pom.xml
@@ -199,17 +199,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/federation/federated-queue-downstream/pom.xml
+++ b/examples/features/federation/federated-queue-downstream/pom.xml
@@ -199,17 +199,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/federation/federated-queue/pom.xml
+++ b/examples/features/federation/federated-queue/pom.xml
@@ -199,17 +199,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/ha/application-layer-failover/pom.xml
+++ b/examples/features/ha/application-layer-failover/pom.xml
@@ -105,17 +105,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/ha/client-side-failoverlistener/pom.xml
+++ b/examples/features/ha/client-side-failoverlistener/pom.xml
@@ -112,17 +112,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/ha/colocated-failover-scale-down/pom.xml
+++ b/examples/features/ha/colocated-failover-scale-down/pom.xml
@@ -106,17 +106,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/ha/colocated-failover/pom.xml
+++ b/examples/features/ha/colocated-failover/pom.xml
@@ -106,17 +106,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/ha/ha-policy-autobackup/pom.xml
+++ b/examples/features/ha/ha-policy-autobackup/pom.xml
@@ -106,17 +106,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/ha/multiple-failover-failback/pom.xml
+++ b/examples/features/ha/multiple-failover-failback/pom.xml
@@ -126,17 +126,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/ha/multiple-failover/pom.xml
+++ b/examples/features/ha/multiple-failover/pom.xml
@@ -126,17 +126,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/ha/non-transaction-failover/pom.xml
+++ b/examples/features/ha/non-transaction-failover/pom.xml
@@ -112,17 +112,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/ha/replicated-failback-static/pom.xml
+++ b/examples/features/ha/replicated-failback-static/pom.xml
@@ -108,17 +108,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/ha/replicated-failback/pom.xml
+++ b/examples/features/ha/replicated-failback/pom.xml
@@ -107,17 +107,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/ha/replicated-multiple-failover/pom.xml
+++ b/examples/features/ha/replicated-multiple-failover/pom.xml
@@ -121,17 +121,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/ha/replicated-transaction-failover/pom.xml
+++ b/examples/features/ha/replicated-transaction-failover/pom.xml
@@ -104,17 +104,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/ha/scale-down/pom.xml
+++ b/examples/features/ha/scale-down/pom.xml
@@ -104,17 +104,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/ha/stop-server-failover/pom.xml
+++ b/examples/features/ha/stop-server-failover/pom.xml
@@ -161,17 +161,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/ha/transaction-failover/pom.xml
+++ b/examples/features/ha/transaction-failover/pom.xml
@@ -103,17 +103,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/perf/perf/pom.xml
+++ b/examples/features/perf/perf/pom.xml
@@ -179,16 +179,5 @@ under the License.
             </plugins>
          </build>
       </profile>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
    </profiles>
 </project>

--- a/examples/features/perf/soak/pom.xml
+++ b/examples/features/perf/soak/pom.xml
@@ -166,16 +166,5 @@ under the License.
             </plugins>
          </build>
       </profile>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
    </profiles>
 </project>

--- a/examples/features/standard/auto-closeable/pom.xml
+++ b/examples/features/standard/auto-closeable/pom.xml
@@ -105,17 +105,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/broker-plugin/pom.xml
+++ b/examples/features/standard/broker-plugin/pom.xml
@@ -126,17 +126,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/browser/pom.xml
+++ b/examples/features/standard/browser/pom.xml
@@ -109,17 +109,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/client-kickoff/pom.xml
+++ b/examples/features/standard/client-kickoff/pom.xml
@@ -111,17 +111,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/completion-listener/pom.xml
+++ b/examples/features/standard/completion-listener/pom.xml
@@ -109,17 +109,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/consumer-rate-limit/pom.xml
+++ b/examples/features/standard/consumer-rate-limit/pom.xml
@@ -108,17 +108,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/context/pom.xml
+++ b/examples/features/standard/context/pom.xml
@@ -108,17 +108,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/core-bridge/pom.xml
+++ b/examples/features/standard/core-bridge/pom.xml
@@ -166,17 +166,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/database/pom.xml
+++ b/examples/features/standard/database/pom.xml
@@ -115,17 +115,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/dead-letter/pom.xml
+++ b/examples/features/standard/dead-letter/pom.xml
@@ -109,17 +109,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/delayed-redelivery/pom.xml
+++ b/examples/features/standard/delayed-redelivery/pom.xml
@@ -109,17 +109,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/divert/pom.xml
+++ b/examples/features/standard/divert/pom.xml
@@ -158,17 +158,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/durable-subscription/pom.xml
+++ b/examples/features/standard/durable-subscription/pom.xml
@@ -109,17 +109,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/embedded-simple/pom.xml
+++ b/examples/features/standard/embedded-simple/pom.xml
@@ -83,17 +83,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/embedded/pom.xml
+++ b/examples/features/standard/embedded/pom.xml
@@ -83,17 +83,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/exclusive-queue/pom.xml
+++ b/examples/features/standard/exclusive-queue/pom.xml
@@ -118,17 +118,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/expiry/pom.xml
+++ b/examples/features/standard/expiry/pom.xml
@@ -109,17 +109,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/http-transport/pom.xml
+++ b/examples/features/standard/http-transport/pom.xml
@@ -109,17 +109,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/instantiate-connection-factory/pom.xml
+++ b/examples/features/standard/instantiate-connection-factory/pom.xml
@@ -110,17 +110,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/interceptor-amqp/pom.xml
+++ b/examples/features/standard/interceptor-amqp/pom.xml
@@ -121,17 +121,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/interceptor-client/pom.xml
+++ b/examples/features/standard/interceptor-client/pom.xml
@@ -115,17 +115,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/interceptor-mqtt/pom.xml
+++ b/examples/features/standard/interceptor-mqtt/pom.xml
@@ -120,17 +120,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/interceptor/pom.xml
+++ b/examples/features/standard/interceptor/pom.xml
@@ -110,17 +110,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/jms-bridge/pom.xml
+++ b/examples/features/standard/jms-bridge/pom.xml
@@ -158,17 +158,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/jmx-ssl/pom.xml
+++ b/examples/features/standard/jmx-ssl/pom.xml
@@ -117,17 +117,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/jmx/pom.xml
+++ b/examples/features/standard/jmx/pom.xml
@@ -114,17 +114,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/large-message/pom.xml
+++ b/examples/features/standard/large-message/pom.xml
@@ -88,17 +88,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/last-value-queue/pom.xml
+++ b/examples/features/standard/last-value-queue/pom.xml
@@ -108,17 +108,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/management-notifications/pom.xml
+++ b/examples/features/standard/management-notifications/pom.xml
@@ -108,17 +108,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/management/pom.xml
+++ b/examples/features/standard/management/pom.xml
@@ -108,17 +108,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/message-counters/pom.xml
+++ b/examples/features/standard/message-counters/pom.xml
@@ -114,17 +114,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/message-group/pom.xml
+++ b/examples/features/standard/message-group/pom.xml
@@ -108,17 +108,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/message-group2/pom.xml
+++ b/examples/features/standard/message-group2/pom.xml
@@ -108,17 +108,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/message-priority/pom.xml
+++ b/examples/features/standard/message-priority/pom.xml
@@ -108,17 +108,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/netty-openssl/pom.xml
+++ b/examples/features/standard/netty-openssl/pom.xml
@@ -115,17 +115,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/no-consumer-buffering/pom.xml
+++ b/examples/features/standard/no-consumer-buffering/pom.xml
@@ -108,17 +108,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/paging/pom.xml
+++ b/examples/features/standard/paging/pom.xml
@@ -108,17 +108,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/pre-acknowledge/pom.xml
+++ b/examples/features/standard/pre-acknowledge/pom.xml
@@ -108,17 +108,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/producer-rate-limit/pom.xml
+++ b/examples/features/standard/producer-rate-limit/pom.xml
@@ -108,17 +108,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/queue-requestor/pom.xml
+++ b/examples/features/standard/queue-requestor/pom.xml
@@ -103,17 +103,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/queue-selector/pom.xml
+++ b/examples/features/standard/queue-selector/pom.xml
@@ -108,17 +108,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/queue/pom.xml
+++ b/examples/features/standard/queue/pom.xml
@@ -108,17 +108,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/reattach-node/pom.xml
+++ b/examples/features/standard/reattach-node/pom.xml
@@ -110,17 +110,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/request-reply/pom.xml
+++ b/examples/features/standard/request-reply/pom.xml
@@ -112,17 +112,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/rest/dup-send/pom.xml
+++ b/examples/features/standard/rest/dup-send/pom.xml
@@ -161,16 +161,5 @@ under the License.
             </plugins>
          </build>
       </profile>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
    </profiles>
 </project>

--- a/examples/features/standard/rest/javascript-chat/pom.xml
+++ b/examples/features/standard/rest/javascript-chat/pom.xml
@@ -175,16 +175,5 @@ under the License.
             </plugins>
          </build>
       </profile>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
    </profiles>
 </project>

--- a/examples/features/standard/rest/jms-to-rest/pom.xml
+++ b/examples/features/standard/rest/jms-to-rest/pom.xml
@@ -161,16 +161,5 @@ under the License.
             </plugins>
          </build>
       </profile>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
    </profiles>
 </project>

--- a/examples/features/standard/rest/push/pom.xml
+++ b/examples/features/standard/rest/push/pom.xml
@@ -161,16 +161,5 @@ under the License.
             </plugins>
          </build>
       </profile>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
    </profiles>
 </project>

--- a/examples/features/standard/scheduled-message/pom.xml
+++ b/examples/features/standard/scheduled-message/pom.xml
@@ -113,17 +113,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/security-ldap/pom.xml
+++ b/examples/features/standard/security-ldap/pom.xml
@@ -150,17 +150,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/security-manager/pom.xml
+++ b/examples/features/standard/security-manager/pom.xml
@@ -121,17 +121,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/security/pom.xml
+++ b/examples/features/standard/security/pom.xml
@@ -111,17 +111,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/send-acknowledgements/pom.xml
+++ b/examples/features/standard/send-acknowledgements/pom.xml
@@ -103,17 +103,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/shared-consumer/pom.xml
+++ b/examples/features/standard/shared-consumer/pom.xml
@@ -110,17 +110,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/slow-consumer/pom.xml
+++ b/examples/features/standard/slow-consumer/pom.xml
@@ -117,17 +117,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/spring-boot-integration/pom.xml
+++ b/examples/features/standard/spring-boot-integration/pom.xml
@@ -77,17 +77,4 @@
 			</plugin>
 		</plugins>
 	</build>
-	<profiles>
-		<profile>
-			<id>release</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>com.vladsch.flexmark</groupId>
-						<artifactId>markdown-page-generator-plugin</artifactId>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
 </project>

--- a/examples/features/standard/spring-integration/pom.xml
+++ b/examples/features/standard/spring-integration/pom.xml
@@ -85,17 +85,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/ssl-enabled-dual-authentication/pom.xml
+++ b/examples/features/standard/ssl-enabled-dual-authentication/pom.xml
@@ -110,17 +110,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/ssl-enabled/pom.xml
+++ b/examples/features/standard/ssl-enabled/pom.xml
@@ -108,17 +108,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/static-selector/pom.xml
+++ b/examples/features/standard/static-selector/pom.xml
@@ -108,17 +108,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/temp-queue/pom.xml
+++ b/examples/features/standard/temp-queue/pom.xml
@@ -108,17 +108,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/topic-hierarchies/pom.xml
+++ b/examples/features/standard/topic-hierarchies/pom.xml
@@ -112,17 +112,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/topic-selector1/pom.xml
+++ b/examples/features/standard/topic-selector1/pom.xml
@@ -108,17 +108,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/topic-selector2/pom.xml
+++ b/examples/features/standard/topic-selector2/pom.xml
@@ -108,17 +108,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/topic/pom.xml
+++ b/examples/features/standard/topic/pom.xml
@@ -108,17 +108,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/transactional/pom.xml
+++ b/examples/features/standard/transactional/pom.xml
@@ -108,17 +108,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/xa-heuristic/pom.xml
+++ b/examples/features/standard/xa-heuristic/pom.xml
@@ -110,17 +110,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/xa-receive/pom.xml
+++ b/examples/features/standard/xa-receive/pom.xml
@@ -108,17 +108,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/standard/xa-send/pom.xml
+++ b/examples/features/standard/xa-send/pom.xml
@@ -108,17 +108,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/sub-modules/artemis-ra-rar/pom.xml
+++ b/examples/features/sub-modules/artemis-ra-rar/pom.xml
@@ -101,17 +101,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/sub-modules/inter-broker-bridge/artemis-jms-bridge/pom.xml
+++ b/examples/features/sub-modules/inter-broker-bridge/artemis-jms-bridge/pom.xml
@@ -95,17 +95,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/features/sub-modules/tomcat/pom.xml
+++ b/examples/features/sub-modules/tomcat/pom.xml
@@ -122,17 +122,4 @@ under the License.
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>release</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.vladsch.flexmark</groupId>
-                        <artifactId>markdown-page-generator-plugin</artifactId>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-</project>
+ </project>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -49,28 +49,6 @@ under the License.
       </repository>
    </repositories>
 
-   <build>
-      <pluginManagement>
-         <plugins>
-            <plugin>
-               <groupId>org.apache.maven.plugins</groupId>
-               <artifactId>maven-clean-plugin</artifactId>
-               <version>3.0.0</version>
-               <configuration>
-                  <filesets>
-                     <fileset>
-                        <directory>${basedir}</directory>
-                        <includes>
-                           <include>readme.html</include>
-                        </includes>
-                     </fileset>
-                  </filesets>
-               </configuration>
-            </plugin>
-         </plugins>
-      </pluginManagement>
-   </build>
-
    <pluginRepositories>
       <pluginRepository>
          <id>apache.snapshots</id>
@@ -104,31 +82,6 @@ under the License.
             <noServer>true</noServer>
             <noClient>true</noClient>
          </properties>
-         <build>
-            <pluginManagement>
-               <plugins>
-                  <plugin>
-                     <groupId>com.vladsch.flexmark</groupId>
-                     <artifactId>markdown-page-generator-plugin</artifactId>
-                     <version>0.27.0</version>
-                     <executions>
-                        <execution>
-                           <phase>package</phase>
-                           <goals>
-                              <goal>generate</goal>
-                           </goals>
-                        </execution>
-                     </executions>
-                     <configuration>
-                        <headerHtmlFile>${activemq.basedir}/examples/common/header.html</headerHtmlFile>
-                        <footerHtmlFile>${activemq.basedir}/examples/common/footer.html</footerHtmlFile>
-                        <inputDirectory>${basedir}</inputDirectory>
-                        <outputDirectory>${basedir}</outputDirectory>
-                     </configuration>
-                  </plugin>
-               </plugins>
-            </pluginManagement>
-         </build>
       </profile>
       <profile>
          <!-- the profile release won't execute anything. just compile and whatever else is needed -->

--- a/examples/protocols/amqp/proton-clustered-cpp/pom.xml
+++ b/examples/protocols/amqp/proton-clustered-cpp/pom.xml
@@ -166,17 +166,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/protocols/amqp/proton-cpp/pom.xml
+++ b/examples/protocols/amqp/proton-cpp/pom.xml
@@ -117,17 +117,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/protocols/amqp/proton-ruby/pom.xml
+++ b/examples/protocols/amqp/proton-ruby/pom.xml
@@ -66,17 +66,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/protocols/amqp/queue/pom.xml
+++ b/examples/protocols/amqp/queue/pom.xml
@@ -108,17 +108,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/protocols/mqtt/clustered-queue-mqtt/pom.xml
+++ b/examples/protocols/mqtt/clustered-queue-mqtt/pom.xml
@@ -161,17 +161,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/protocols/mqtt/publish-subscribe/pom.xml
+++ b/examples/protocols/mqtt/publish-subscribe/pom.xml
@@ -104,17 +104,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/protocols/openwire/chat/pom.xml
+++ b/examples/protocols/openwire/chat/pom.xml
@@ -204,17 +204,6 @@ under the License.
             </plugins>
          </build>
       </profile>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
    </profiles>
 
 </project>

--- a/examples/protocols/openwire/message-listener/pom.xml
+++ b/examples/protocols/openwire/message-listener/pom.xml
@@ -114,17 +114,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/protocols/openwire/message-recovery/pom.xml
+++ b/examples/protocols/openwire/message-recovery/pom.xml
@@ -100,17 +100,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/protocols/openwire/queue/pom.xml
+++ b/examples/protocols/openwire/queue/pom.xml
@@ -117,17 +117,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/protocols/openwire/virtual-topic-mapping/pom.xml
+++ b/examples/protocols/openwire/virtual-topic-mapping/pom.xml
@@ -117,17 +117,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/protocols/stomp/stomp-dual-authentication/pom.xml
+++ b/examples/protocols/stomp/stomp-dual-authentication/pom.xml
@@ -113,17 +113,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/protocols/stomp/stomp-embedded-interceptor/pom.xml
+++ b/examples/protocols/stomp/stomp-embedded-interceptor/pom.xml
@@ -130,17 +130,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/protocols/stomp/stomp-jms/pom.xml
+++ b/examples/protocols/stomp/stomp-jms/pom.xml
@@ -113,17 +113,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/protocols/stomp/stomp-websockets/pom.xml
+++ b/examples/protocols/stomp/stomp-websockets/pom.xml
@@ -108,17 +108,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/protocols/stomp/stomp/pom.xml
+++ b/examples/protocols/stomp/stomp/pom.xml
@@ -108,17 +108,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/protocols/stomp/stomp1.1/pom.xml
+++ b/examples/protocols/stomp/stomp1.1/pom.xml
@@ -108,17 +108,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>

--- a/examples/protocols/stomp/stomp1.2/pom.xml
+++ b/examples/protocols/stomp/stomp1.2/pom.xml
@@ -108,17 +108,4 @@ under the License.
          </plugin>
       </plugins>
    </build>
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>com.vladsch.flexmark</groupId>
-                  <artifactId>markdown-page-generator-plugin</artifactId>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
 </project>


### PR DESCRIPTION
Move the markdown generator for the examples to artemis-distribution.