### PR TITLE
ARTEMIS-2797 - Reset queue properties by unsetting them in broker.xml

### DIFF
--- a/docs/user-manual/en/config-reload.md
+++ b/docs/user-manual/en/config-reload.md
@@ -244,8 +244,8 @@ attribute `name` | N/A | X | A queue with new name will be deployed and the queu
 attribute `max-consumers` | If max-consumers > current consumers max-consumers will update on reload | max-consumers will be set back to the default `-1` | If max-consumers > current consumers max-consumers will update on reload
 attribute `purge-on-no-consumers` | On reload purge-on-no-consumers will be updated | Will be set back to the default `false` | On reload purge-on-no-consumers will be updated
 attribute `address` | N/A | No effect unless starting broker | No effect unless starting broker
-attribute `filter` | N/A | No effect unless starting broker | No effect unless starting broker
-attribute `durable` | N/A | No effect unless starting broker | No effect unless starting broker
+attribute `filter` | The filter will be added after reloading | The filter will be removed after reloading | The filter will be updated after reloading
+attribute `durable` | The queue durability will be set to the given value after reloading | The queue durability will be set to the default `true` after reloading | The queue durability will be set to the new value after reloading
 
 ### `<jms>` *(Deprecated)*
 

--- a/docs/user-manual/en/versions.md
+++ b/docs/user-manual/en/versions.md
@@ -8,6 +8,17 @@ This chapter provides the following information for each release:
   - **Note:** Follow the general upgrade procedure outlined in the [Upgrading the Broker](upgrading.md) 
     chapter in addition to any version-specific upgrade instructions outlined here.
 
+## 2.14.0
+
+[Full release notes](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315920&version=12348290).
+
+Highlights:
+- Removing `broker.xml` queue parameters now causes these to be reset to their default values.
+
+#### Upgrading from older versions
+
+Make sure the existing queues have their parameters set according to the `broker.xml` values before upgrading.
+
 ## 2.11.0
 
 [Full release notes](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315920&version=12346258).

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/RedeployTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/RedeployTest.java
@@ -37,10 +37,13 @@ import javax.jms.MessageProducer;
 import javax.jms.Queue;
 import javax.jms.Session;
 import javax.jms.TextMessage;
+
+import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.postoffice.Binding;
 import org.apache.activemq.artemis.core.postoffice.QueueBinding;
+import org.apache.activemq.artemis.core.postoffice.impl.LocalQueueBinding;
 import org.apache.activemq.artemis.core.security.Role;
 import org.apache.activemq.artemis.core.server.cluster.impl.MessageLoadBalancingType;
 import org.apache.activemq.artemis.core.server.cluster.impl.RemoteQueueBindingImpl;
@@ -281,6 +284,164 @@ public class RedeployTest extends ActiveMQTestBase {
             assertNotNull(consumer.receive(2000));
             consumer.close();
          }
+
+      } finally {
+         embeddedActiveMQ.stop();
+      }
+   }
+
+   private void deployBrokerConfig(EmbeddedActiveMQ server, URL configFile) throws Exception {
+
+      Path brokerXML = getTestDirfile().toPath().resolve("broker.xml");
+      Files.copy(configFile.openStream(), brokerXML, StandardCopyOption.REPLACE_EXISTING);
+
+      final ReusableLatch latch = new ReusableLatch(1);
+      Runnable tick = latch::countDown;
+      server.getActiveMQServer().getReloadManager().setTick(tick);
+
+      latch.await(10, TimeUnit.SECONDS);
+   }
+
+   private void doTestRemoveFilter(URL testConfiguration) throws Exception {
+
+      Path brokerXML = getTestDirfile().toPath().resolve("broker.xml");
+
+      URL baseConfig = RedeployTest.class.getClassLoader().getResource("reload-queue-filter.xml");
+
+      Files.copy(baseConfig.openStream(), brokerXML, StandardCopyOption.REPLACE_EXISTING);
+
+      EmbeddedActiveMQ embeddedActiveMQ = new EmbeddedActiveMQ();
+      embeddedActiveMQ.setConfigResourcePath(brokerXML.toUri().toString());
+      embeddedActiveMQ.start();
+
+      deployBrokerConfig(embeddedActiveMQ, baseConfig);
+
+      try {
+
+         try (ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory();
+              Connection connection = factory.createConnection();
+              Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE)) {
+
+            connection.start();
+            Queue queue = session.createQueue("myFilterQueue");
+
+            // Test that the original filter has been set up
+            LocalQueueBinding queueBinding = (LocalQueueBinding) embeddedActiveMQ.getActiveMQServer().getPostOffice()
+                    .getBinding(new SimpleString("myFilterQueue"));
+            // The "x = 'x'" value is found in "reload-queue-filter.xml"
+            assertEquals("x = 'x'", queueBinding.getFilter().getFilterString().toString());
+
+            MessageProducer producer = session.createProducer(queue);
+
+            // Test that the original filter affects the flow
+            Message passingMessage = session.createMessage();
+            passingMessage.setStringProperty("x", "x");
+            producer.send(passingMessage);
+
+            Message filteredMessage = session.createMessage();
+            filteredMessage.setStringProperty("x", "y");
+            producer.send(filteredMessage);
+
+            MessageConsumer consumer = session.createConsumer(queue);
+            Message receivedMessage = consumer.receive(2000);
+            assertNotNull(receivedMessage);
+            assertEquals("x", receivedMessage.getStringProperty("x"));
+
+            assertNull(consumer.receive(2000));
+
+            consumer.close();
+         }
+
+         deployBrokerConfig(embeddedActiveMQ, testConfiguration);
+
+         try (ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory();
+              Connection connection = factory.createConnection();
+              Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE)) {
+
+            connection.start();
+            Queue queue = session.createQueue("myFilterQueue");
+
+            // Test that the filter has been removed
+            LocalQueueBinding queueBinding = (LocalQueueBinding) embeddedActiveMQ.getActiveMQServer().getPostOffice()
+                    .getBinding(new SimpleString("myFilterQueue"));
+            assertNull(queueBinding.getFilter());
+
+            MessageProducer producer = session.createProducer(queue);
+
+            // Test that the original filter no longer affects the flow
+            Message message1 = session.createMessage();
+            message1.setStringProperty("x", "x");
+            producer.send(message1);
+
+            Message message2 = session.createMessage();
+            message2.setStringProperty("x", "y");
+            producer.send(message2);
+
+            MessageConsumer consumer = session.createConsumer(queue);
+            assertNotNull(consumer.receive(2000));
+            assertNotNull(consumer.receive(2000));
+
+            consumer.close();
+         }
+
+      } finally {
+         embeddedActiveMQ.stop();
+      }
+   }
+
+   @Test
+   public void testRedeployRemoveFilter() throws Exception {
+      doTestRemoveFilter(RedeployTest.class.getClassLoader().getResource("reload-queue-filter-updated-empty.xml"));
+      doTestRemoveFilter(RedeployTest.class.getClassLoader().getResource("reload-queue-filter-removed.xml"));
+   }
+
+   @Test
+   public void testRedeployQueueDefaults() throws Exception {
+
+      Path brokerXML = getTestDirfile().toPath().resolve("broker.xml");
+      URL baseConfig = RedeployTest.class.getClassLoader().getResource("reload-queue-defaults-before.xml");
+      URL newConfig = RedeployTest.class.getClassLoader().getResource("reload-queue-defaults-after.xml");
+      Files.copy(baseConfig.openStream(), brokerXML, StandardCopyOption.REPLACE_EXISTING);
+      EmbeddedActiveMQ embeddedActiveMQ = new EmbeddedActiveMQ();
+      embeddedActiveMQ.setConfigResourcePath(brokerXML.toUri().toString());
+      embeddedActiveMQ.start();
+
+      try {
+         LocalQueueBinding queueBinding = (LocalQueueBinding) embeddedActiveMQ.getActiveMQServer().getPostOffice()
+                 .getBinding(new SimpleString("myQueue"));
+         org.apache.activemq.artemis.core.server.Queue queue = queueBinding.getQueue();
+
+         assertNotEquals(queue.getMaxConsumers(), ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers());
+         assertNotEquals(queue.getRoutingType(), RoutingType.MULTICAST);
+         assertNotEquals(queue.isPurgeOnNoConsumers(), ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers());
+         assertNotEquals(queue.isEnabled(), ActiveMQDefaultConfiguration.getDefaultEnabled());
+         assertNotEquals(queue.isExclusive(), ActiveMQDefaultConfiguration.getDefaultExclusive());
+         assertNotEquals(queue.isGroupRebalance(), ActiveMQDefaultConfiguration.getDefaultGroupRebalance());
+         assertNotEquals(queue.getGroupBuckets(), ActiveMQDefaultConfiguration.getDefaultGroupBuckets());
+         assertNotEquals(queue.getGroupFirstKey(), ActiveMQDefaultConfiguration.getDefaultGroupFirstKey());
+         assertNotEquals(queue.isNonDestructive(), ActiveMQDefaultConfiguration.getDefaultNonDestructive());
+         assertNotEquals(queue.getConsumersBeforeDispatch(), ActiveMQDefaultConfiguration.getDefaultConsumersBeforeDispatch());
+         assertNotEquals(queue.getDelayBeforeDispatch(), ActiveMQDefaultConfiguration.getDefaultDelayBeforeDispatch());
+         assertNotEquals(queue.getFilter(), null);
+         assertNotEquals(queue.getUser(), "jdoe");
+         assertNotEquals(queue.getRingSize(), ActiveMQDefaultConfiguration.getDefaultRingSize());
+
+         deployBrokerConfig(embeddedActiveMQ, newConfig);
+
+         assertEquals(queue.getMaxConsumers(), ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers());
+         assertEquals(queue.getRoutingType(), RoutingType.MULTICAST);
+         assertEquals(queue.isPurgeOnNoConsumers(), ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers());
+         assertEquals(queue.isEnabled(), ActiveMQDefaultConfiguration.getDefaultEnabled());
+         assertEquals(queue.isExclusive(), ActiveMQDefaultConfiguration.getDefaultExclusive());
+         assertEquals(queue.isGroupRebalance(), ActiveMQDefaultConfiguration.getDefaultGroupRebalance());
+         assertEquals(queue.getGroupBuckets(), ActiveMQDefaultConfiguration.getDefaultGroupBuckets());
+         assertEquals(queue.getGroupFirstKey(), ActiveMQDefaultConfiguration.getDefaultGroupFirstKey());
+         assertEquals(queue.isNonDestructive(), ActiveMQDefaultConfiguration.getDefaultNonDestructive());
+         assertEquals(queue.getConsumersBeforeDispatch(), ActiveMQDefaultConfiguration.getDefaultConsumersBeforeDispatch());
+         assertEquals(queue.getDelayBeforeDispatch(), ActiveMQDefaultConfiguration.getDefaultDelayBeforeDispatch());
+         assertEquals(queue.getFilter(), null);
+         assertEquals(queue.getUser(), null);
+         assertEquals(queue.getRingSize(), ActiveMQDefaultConfiguration.getDefaultRingSize());
 
       } finally {
          embeddedActiveMQ.stop();

--- a/tests/integration-tests/src/test/resources/reload-queue-defaults-after.xml
+++ b/tests/integration-tests/src/test/resources/reload-queue-defaults-after.xml
@@ -1,0 +1,43 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration xmlns="urn:activemq"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+
+   <core xmlns="urn:activemq:core">
+      <security-enabled>false</security-enabled>
+      <persistence-enabled>false</persistence-enabled>
+
+      <acceptors>
+         <acceptor name="artemis">tcp://0.0.0.0:61616</acceptor>
+      </acceptors>
+
+      <addresses>
+         <address name="myQueue">
+            <multicast>
+               <!-- Shoud reset queue according to org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration -->
+               <!-- some values cannot be changed: last-value -->
+               <queue name="myQueue" />
+            </multicast>
+         </address>
+      </addresses>
+   </core>
+</configuration>

--- a/tests/integration-tests/src/test/resources/reload-queue-defaults-before.xml
+++ b/tests/integration-tests/src/test/resources/reload-queue-defaults-before.xml
@@ -1,0 +1,59 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration xmlns="urn:activemq"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+
+   <core xmlns="urn:activemq:core">
+      <security-enabled>false</security-enabled>
+      <persistence-enabled>false</persistence-enabled>
+
+      <acceptors>
+         <acceptor name="artemis">tcp://0.0.0.0:61616</acceptor>
+      </acceptors>
+
+      <addresses>
+         <address name="myQueue">
+            <anycast>
+               <!-- non-default values based on org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration -->
+               <!-- some values cannot be changed: last-value -->
+               <queue name="myQueue"
+                      max-consumers="10"
+                      purge-on-no-consumers="true"
+                      exclusive="true"
+                      group-rebalance="true"
+                      group-buckets="10"
+                      group-first-key="foo"
+                      non-destructive="true"
+                      consumers-before-dispatch="10"
+                      delay-before-dispatch="10"
+                      ring-size="10"
+                      enabled="false"
+               >
+                  <durable>false</durable>
+                  <filter string="x = 'x'"/>
+                  <user>jdoe</user>
+               </queue>
+            </anycast>
+         </address>
+      </addresses>
+   </core>
+</configuration>

--- a/tests/integration-tests/src/test/resources/reload-queue-filter-removed.xml
+++ b/tests/integration-tests/src/test/resources/reload-queue-filter-removed.xml
@@ -1,0 +1,42 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration xmlns="urn:activemq"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+
+   <core xmlns="urn:activemq:core">
+      <security-enabled>false</security-enabled>
+      <persistence-enabled>false</persistence-enabled>
+
+      <acceptors>
+         <acceptor name="artemis">tcp://0.0.0.0:61616</acceptor>
+      </acceptors>
+
+      <addresses>
+         <address name="myFilterQueue">
+            <anycast>
+               <queue name="myFilterQueue">
+               </queue>
+            </anycast>
+         </address>
+      </addresses>
+   </core>
+</configuration>

--- a/tests/integration-tests/src/test/resources/reload-queue-filter-updated-empty.xml
+++ b/tests/integration-tests/src/test/resources/reload-queue-filter-updated-empty.xml
@@ -1,0 +1,43 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration xmlns="urn:activemq"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+
+   <core xmlns="urn:activemq:core">
+      <security-enabled>false</security-enabled>
+      <persistence-enabled>false</persistence-enabled>
+
+      <acceptors>
+         <acceptor name="artemis">tcp://0.0.0.0:61616</acceptor>
+      </acceptors>
+
+      <addresses>
+         <address name="myFilterQueue">
+            <anycast>
+               <queue name="myFilterQueue">
+                  <filter string=""/>
+               </queue>
+            </anycast>
+         </address>
+      </addresses>
+   </core>
+</configuration>


### PR DESCRIPTION
Now it is possible to remove queue filter by setting it to an empty string or null.
Before this commit the server would just ignore such request.

EDIT: This pull request turned out to cover the ability to reset all queue properties, not just the filter string.