### PR TITLE
[ARTEMIS-2791]: ArrayIndexOutOfBoundsException in SSLContextFactoryProvider.

### DIFF
--- a/artemis-core-client/src/test/java/org/apache/activemq/artemis/spi/core/remoting/ssl/SSLContextFactoryProviderTest.java
+++ b/artemis-core-client/src/test/java/org/apache/activemq/artemis/spi/core/remoting/ssl/SSLContextFactoryProviderTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.spi.core.remoting.ssl;
+
+public class SSLContextFactoryProviderTest {
+   /**
+    * Test to access a SSLContextfactory without providing any implmentation via ServiceLaoder
+    */
+   public void testLoadSSLContextFactoryProviderWithoutAnyServices() {
+      SSLContextFactoryProvider.getSSLContextFactory().clearSSLContexts();
+   }
+}


### PR DESCRIPTION
 * Making the SSLContextFactoryProvider working even without any
   SSLContextfactory service.

Iusse: https://issues.apache.org/jira/browse/ARTEMIS-2791