### PR TITLE
ARTEMIS-2801 Fix ByteUtil.getHumanReadableByteCount() giving inconsistent results

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/ByteUtil.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/ByteUtil.java
@@ -21,6 +21,7 @@ import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -449,6 +450,7 @@ public class ByteUtil {
          i++;
       }
 
-      return String.format("%.1f%sB", bytes / BYTE_MAGNITUDES[i], BYTE_SUFFIXES[i]);
+      // Set locale to language/country neutral to avoid different behavior for non-US users
+      return String.format(Locale.ROOT, "%.1f%sB", bytes / BYTE_MAGNITUDES[i], BYTE_SUFFIXES[i]);
    }
 }


### PR DESCRIPTION
HumanReadableByteCountTest test is no longer failing under environments with locales defining different number format.
The function now returns values according to the Locale.ROOT locale specification.