### PR TITLE
ARTEMIS-2705 Test Artemis on aarch64 CPU architecture

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -15,4 +15,4 @@
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
 
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.3.9/apache-maven-3.3.9-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.6.2/apache-maven-3.6.2-bin.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ matrix:
       env:
         - EXAMPLES_PROFILE="release"
     - os: linux
+      jdk: openjdk8
+      arch: arm64
+      env:
+        - EXAMPLES_PROFILE="release"
+    - os: linux
       jdk: openjdk11
       env:
         - EXAMPLES_PROFILE="noRun"
@@ -24,9 +29,9 @@ before_install:
 # By setting anything to org.apache.activemq.artemis.core.io.aio.AIOSequentialFileFactory.DISABLED we are disabling libaio loading on the testsuite
 script: 
 - set -e
-- mvn -Dorg.apache.activemq.artemis.core.io.aio.AIOSequentialFileFactory.DISABLED=AnythingNotNull -Djdk8-errorprone -Pfast-tests -Pextra-tests -Ptests-CI -B install -q
+- ./mvnw -Dorg.apache.activemq.artemis.core.io.aio.AIOSequentialFileFactory.DISABLED=AnythingNotNull -Dnetty-transport-native-epoll-classifier=linux-`uname -m` -Djdk8-errorprone -Pfast-tests -Pextra-tests -Ptests-CI -B install -q
 - cd examples
-- mvn install -P${EXAMPLES_PROFILE} -B -q
+- ../mvnw install -P${EXAMPLES_PROFILE} -B -q
 
 cache:
   directories:

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
       <netty.version>4.1.50.Final</netty.version>
 
       <!-- this is basically for tests -->
-      <netty-tcnative-version>2.0.29.Final</netty-tcnative-version>
+      <netty-tcnative-version>2.0.31.Final</netty-tcnative-version>
       <proton.version>0.33.5</proton.version>
       <resteasy.version>3.0.19.Final</resteasy.version>
       <slf4j.version>1.7.21</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
       <maven.assembly.plugin.version>2.4</maven.assembly.plugin.version>
       <mockito.version>3.3.3</mockito.version>
       <jctools.version>2.1.2</jctools.version>
-      <netty.version>4.1.48.Final</netty.version>
+      <netty.version>4.1.50.Final</netty.version>
 
       <!-- this is basically for tests -->
       <netty-tcnative-version>2.0.29.Final</netty-tcnative-version>


### PR DESCRIPTION
1) Update Netty to 4.1.50 that includes aarch64 binaries

2) Use Maven wrapper

This way it will use the preferred version of Maven.
Also it seems Maven is not coming pre-installed on ARM64

3) Update netty-tcnative to 2.0.31.Final

4) Update Maven to 3.6.2 because artemis-console fails with 3.3.9

5) travis_wait the build of 'examples'

because it takes more time and Travis kills it: https://travis-ci.org/github/martin-g/activemq-artemis/jobs/697514020

"The job exceeded the maximum time limit for jobs, and has been terminated."