### PR TITLE
ARTEMIS-2804 Human readable timestamp is incorrectly parsed in web console

### DIFF
--- a/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/browse.js
+++ b/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/browse.js
@@ -197,7 +197,7 @@ var ARTEMIS = (function(ARTEMIS) {
          var d = new Date(timestamp);
          // "yyyy-MM-dd HH:mm:ss"
          //add 1 to month as getmonth returns the position not the actual month
-         return d.getFullYear() + "-" + pad2(d.getMonth() + 1) + "-" + pad2(d.getDay()) + " " + pad2(d.getHours()) + ":" + pad2(d.getMinutes()) + ":" + pad2(d.getSeconds());
+         return d.getFullYear() + "-" + pad2(d.getMonth() + 1) + "-" + pad2(d.getDate()) + " " + pad2(d.getHours()) + ":" + pad2(d.getMinutes()) + ":" + pad2(d.getSeconds());
       }
 
       var typeLabels = ["default", "1", "object", "text", "bytes", "map", "stream", "embedded"];


### PR DESCRIPTION
The web console displays the day of the week instead of the day of the month in the timestamp column while browsing a queue from the web console. 