### PR TITLE
ARTEMIS-2109: require JDK 8 for release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,19 @@
 language: java
 install: true
-jdk:
-  - openjdk8
-  - openjdk11
-  - openjdk14
+matrix:
+  include:
+    - os: linux
+      jdk: openjdk8
+      env:
+        - EXAMPLES_PROFILE="release"
+    - os: linux
+      jdk: openjdk11
+      env:
+        - EXAMPLES_PROFILE="noRun"
+    - os: linux
+      jdk: openjdk14
+      env:
+        - EXAMPLES_PROFILE="noRun"
 
 # clean out Artemis artifacts from the cache
 before_install:
@@ -16,7 +26,7 @@ script:
 - set -e
 - mvn -Dorg.apache.activemq.artemis.core.io.aio.AIOSequentialFileFactory.DISABLED=AnythingNotNull -Pfast-tests -Pextra-tests -Ptests-CI -B install -q
 - cd examples
-- mvn install -Prelease install -B -q
+- mvn install -P${EXAMPLES_PROFILE} -B -q
 
 cache:
   directories:

--- a/pom.xml
+++ b/pom.xml
@@ -901,7 +901,7 @@
          </build>
       </profile>
       <profile>
-         <id>jdk18</id>
+         <id>jdk8</id>
          <activation>
             <jdk>1.8</jdk>
          </activation>
@@ -911,9 +911,9 @@
           </properties>
       </profile>
       <profile>
-          <id>java9on</id>
+          <id>jdk11on</id>
           <activation>
-              <jdk>[9,)</jdk>
+              <jdk>[11,)</jdk>
           </activation>
           <properties>
               <maven.compiler.source>8</maven.compiler.source>
@@ -1013,7 +1013,6 @@
                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-enforcer-plugin</artifactId>
-                  <version>1.4</version>
                   <executions>
                      <execution>
                         <id>enforce-java</id>
@@ -1022,9 +1021,9 @@
                         </goals>
                         <configuration>
                            <rules>
-                              <!-- we need java8 when building the release -->
                               <requireJavaVersion>
-                                 <version>1.8.0</version>
+                                 <version>[1.8, 9)</version>
+                                 <message>JDK 8 is required when building the release</message>
                               </requireJavaVersion>
                            </rules>
                         </configuration>
@@ -1562,7 +1561,6 @@
          <plugin>
            <groupId>org.apache.maven.plugins</groupId>
            <artifactId>maven-enforcer-plugin</artifactId>
-           <version>1.4</version>
            <executions>
              <execution>
                <id>enforce-java</id>
@@ -1572,7 +1570,8 @@
                <configuration>
                  <rules>
                    <requireJavaVersion>
-                     <version>1.8.0</version>
+                     <version>[1.8, 9),[11,)</version>
+                     <message>You must use either JDK 8 or JDK 11+ when building</message>
                    </requireJavaVersion>
                  </rules>
                </configuration>


### PR DESCRIPTION
Requires JDK 8 for the 'release' profile. This is the same requirement as before, but the existing profile check only set an '8 minimum' requirement. Now that it can build on 11+ (but, targetting 11 while doing so currently) unlike before, the check needs to be specifically 8-only. 

Enforces use of JDK8 or 11+ in regular non-release builds, giving 9 or 10 users a clearer error.

Renames profiles for consistency and clarity.

Updates CI to not use the release profile for examples on 11 or 14, only 8.