### PR TITLE
ARTEMIS-2806 deployQueue missing address argument

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -952,7 +952,7 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
       clearIO();
       try {
          server.createQueue(new QueueConfiguration(name)
-                            .setName(name)
+                            .setAddress(address)
                             .setFilterString(filterStr)
                             .setDurable(durable));
       } finally {


### PR DESCRIPTION
In ActiveMQServerControlImpl, deployQueue method is missing address argument which results in creating non-matched addresses and queues. (For example, using deployQueue to create a subscriber A_0 under existing address A, it finally returns a new topic A_0 with a subscriber A_0 )