### PR TITLE
 ARTEMIS-2109: fix ErrorProne for JDK8, move to profile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
 # By setting anything to org.apache.activemq.artemis.core.io.aio.AIOSequentialFileFactory.DISABLED we are disabling libaio loading on the testsuite
 script: 
 - set -e
-- mvn -Dorg.apache.activemq.artemis.core.io.aio.AIOSequentialFileFactory.DISABLED=AnythingNotNull -Pfast-tests -Pextra-tests -Ptests-CI -B install -q
+- mvn -Dorg.apache.activemq.artemis.core.io.aio.AIOSequentialFileFactory.DISABLED=AnythingNotNull -Djdk8-errorprone -Pfast-tests -Pextra-tests -Ptests-CI -B install -q
 - cd examples
 - mvn install -P${EXAMPLES_PROFILE} -B -q
 

--- a/artemis-selector/pom.xml
+++ b/artemis-selector/pom.xml
@@ -90,27 +90,6 @@
             </plugins>
          </build>
       </profile>
-<!--      <profile>
-          <id>java9on</id>
-          <activation>
-              <jdk>[9,)</jdk>
-          </activation>
-          <build>
-              <plugins>
-                  <plugin>
-                      <groupId>org.apache.maven.plugins</groupId>
-                      <artifactId>maven-compiler-plugin</artifactId>
-                      <configuration>
-                          <compilerArgs>
-                              <arg>-XDcompilePolicy=simple</arg>
-                               TODO: do this only for generated-sources 
-                              <arg>-Xplugin:ErrorProne -Xep:MissingOverride:WARN</arg>
-                          </compilerArgs>
-                      </configuration>
-                  </plugin>
-              </plugins>
-          </build>
-      </profile>-->
    </profiles>
 
    <build>
@@ -121,17 +100,6 @@
          </resource>
       </resources>
       <plugins>
-<!--         <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-               <compilerArgs>
-                    <arg>-XDcompilePolicy=simple</arg>
-                   TODO: do this only for generated-sources 
-                  <arg>-Xplugin:ErrorProne -Xep:MissingOverride:WARN</arg>
-               </compilerArgs>
-            </configuration>
-         </plugin>-->
          <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>javacc-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -885,7 +885,6 @@
                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-compiler-plugin</artifactId>
-                  <version>3.8.1</version>
                   <configuration combine.self="override" />
                </plugin>
                <plugin>
@@ -911,6 +910,31 @@
           </properties>
       </profile>
       <profile>
+          <id>jdk8-errorprone</id>
+          <activation>
+              <jdk>1.8</jdk>
+              <property>
+                  <name>jdk8-errorprone</name>
+              </property>
+          </activation>
+          <build>
+              <plugins>
+                  <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-compiler-plugin</artifactId>
+                      <configuration>
+                          <fork>true</fork>
+                          <compilerArgs combine.children="append">
+                              <arg>-XDcompilePolicy=simple</arg>
+                              <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${javac.version}/javac-${javac.version}.jar</arg>
+                              <arg>-Xplugin:ErrorProne -Xep:MissingOverride:ERROR -Xep:NonAtomicVolatileUpdate:ERROR -Xep:SynchronizeOnNonFinalField:ERROR -Xep:WaitNotInLoop:ERROR -XepExcludedPaths:.*/generated-sources/.*</arg>
+                          </compilerArgs>
+                      </configuration>
+                  </plugin>
+              </plugins>
+          </build>
+      </profile>
+      <profile>
           <id>jdk11on</id>
           <activation>
               <jdk>[11,)</jdk>
@@ -926,12 +950,11 @@
                       <groupId>org.apache.maven.plugins</groupId>
                       <artifactId>maven-compiler-plugin</artifactId>
                       <configuration>
-                          <showWarnings>true</showWarnings>
                           <compilerArgs>
                               <arg>-Xdiags:verbose</arg>
                               <arg>--add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED</arg>
                               <arg>-XDcompilePolicy=simple</arg>
-                              <arg>-Xplugin:ErrorProne -Xep:MissingOverride:ERROR -Xep:NonAtomicVolatileUpdate:ERROR -Xep:SynchronizeOnNonFinalField:ERROR  -Xep:SynchronizeOnNonFinalField:ERROR -Xep:WaitNotInLoop:ERROR -XepExcludedPaths:.*/generated-sources/.*</arg>
+                              <arg>-Xplugin:ErrorProne -Xep:MissingOverride:ERROR -Xep:NonAtomicVolatileUpdate:ERROR -Xep:SynchronizeOnNonFinalField:ERROR -Xep:WaitNotInLoop:ERROR -XepExcludedPaths:.*/generated-sources/.*</arg>
                           </compilerArgs>
                       </configuration>
                   </plugin>
@@ -1410,16 +1433,9 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-compiler-plugin</artifactId>
-               <!-- version 3.2 is having problems with the APT processor resulting in
-                    java.lang.IllegalStateException: endPosTable already set  -->
                <version>3.8.1</version>
-               <!-- Enable Google's Error-Prone https://github.com/google/error-prone -->
                <configuration>
                    <showWarnings>true</showWarnings>
-                   <compilerArgs combine.children="append">
-                       <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${javac.version}/javac-${javac.version}.jar -Xep:MissingOverride:ERROR -Xep:NonAtomicVolatileUpdate:ERROR -Xep:SynchronizeOnNonFinalField:ERROR -Xep:StaticAccessedFromInstance:ERROR -Xep:SynchronizeOnNonFinalField:ERROR -Xep:WaitNotInLoop:ERROR</arg>
-                       <arg>-Xdiags:verbose</arg>
-                   </compilerArgs>
                </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Fixes the updated configuration for ErrorProne so it can actually run on JDK8.

Also moves it to a specific profile for optional use on JDK8, as the 2.4.0+ javac plugin approach requires forking the compiler on JDK8, which is slow and adds a couple of minutes to the build from all the modules. On JDK8 Error Prone is activated on request. On JDK11+ it is still enabled by default. 

Updates the CI job config as well to still enable ErrorProne for JDK8  (i.e. on all JDKs being used).


Follows the changes in #3179 (and #3183).