### PR TITLE
ARTEMIS-2109: add StaticQualifiedUsingExpression check

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/server/impl/RemotingServiceImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/server/impl/RemotingServiceImpl.java
@@ -153,7 +153,7 @@ public class RemotingServiceImpl implements RemotingService, ServerConnectionLif
 
       CoreProtocolManagerFactory coreProtocolManagerFactory = new CoreProtocolManagerFactory();
 
-      MessagePersister.getInstance().registerProtocol(coreProtocolManagerFactory);
+      MessagePersister.registerProtocol(coreProtocolManagerFactory);
 
       this.flushExecutor = flushExecutor;
 

--- a/pom.xml
+++ b/pom.xml
@@ -927,7 +927,7 @@
                           <compilerArgs combine.children="append">
                               <arg>-XDcompilePolicy=simple</arg>
                               <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${javac.version}/javac-${javac.version}.jar</arg>
-                              <arg>-Xplugin:ErrorProne -Xep:MissingOverride:ERROR -Xep:NonAtomicVolatileUpdate:ERROR -Xep:SynchronizeOnNonFinalField:ERROR -Xep:WaitNotInLoop:ERROR -XepExcludedPaths:.*/generated-sources/.*</arg>
+                              <arg>-Xplugin:ErrorProne -Xep:MissingOverride:ERROR -Xep:NonAtomicVolatileUpdate:ERROR -Xep:SynchronizeOnNonFinalField:ERROR -Xep:StaticQualifiedUsingExpression:ERROR -Xep:WaitNotInLoop:ERROR -XepExcludedPaths:.*/generated-sources/.*</arg>
                           </compilerArgs>
                       </configuration>
                   </plugin>
@@ -954,7 +954,7 @@
                               <arg>-Xdiags:verbose</arg>
                               <arg>--add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED</arg>
                               <arg>-XDcompilePolicy=simple</arg>
-                              <arg>-Xplugin:ErrorProne -Xep:MissingOverride:ERROR -Xep:NonAtomicVolatileUpdate:ERROR -Xep:SynchronizeOnNonFinalField:ERROR -Xep:WaitNotInLoop:ERROR -XepExcludedPaths:.*/generated-sources/.*</arg>
+                              <arg>-Xplugin:ErrorProne -Xep:MissingOverride:ERROR -Xep:NonAtomicVolatileUpdate:ERROR -Xep:SynchronizeOnNonFinalField:ERROR -Xep:StaticQualifiedUsingExpression:ERROR -Xep:WaitNotInLoop:ERROR -XepExcludedPaths:.*/generated-sources/.*</arg>
                           </compilerArgs>
                       </configuration>
                   </plugin>


### PR DESCRIPTION
The ErrorProne checks configuration used to include 'StaticAccessedFromInstance' but this went away in https://github.com/apache/activemq-artemis/commit/efe0f468de2ffa0b354974d20df2087557b7cf7f#diff-600376dffeb79835ede4a0b285078036R1438 with the update to 2.4.0.

It turns out they actually replaced the check with 'StaticQualifiedUsingExpression' a few years ago, so this change puts that in place and fixes an instance it spots.