### PR TITLE
NO-JIRA: add a GitHub Actions build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: "Build"
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ 8, 11, 14 ]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/org/apache/activemq/artemis-*
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Install JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+
+      # use 'install' so smoke-tests will work
+      # use '-Pextra-tests' to ensure extra-tests compiles even though they won't actually run
+      # By setting anything to org.apache.activemq.artemis.core.io.aio.AIOSequentialFileFactory.DISABLED we are disabling libaio loading on the testsuite
+      - name: Build
+        run: |
+          set -e
+          mvn -Dorg.apache.activemq.artemis.core.io.aio.AIOSequentialFileFactory.DISABLED=AnythingNotNull -Djdk8-errorprone -Pfast-tests -Pextra-tests -Ptests-CI -B install -q
+          cd examples
+          mvn install -PnoRun -B -q
+

--- a/pom.xml
+++ b/pom.xml
@@ -1672,6 +1672,7 @@
                <excludes>
                   <exclude>.repository/**</exclude>
                   <exclude>.travis.yml</exclude>
+                  <exclude>.github/workflows/*</exclude>
                   <exclude>**/footer.html</exclude>
                   <exclude>**/*.txt</exclude>
                   <exclude>**/*.md</exclude>


### PR DESCRIPTION
This adds a GitHub Actions build. Its doing essentially the same as the TravisCI job for now, but could be expanded to do more or different things. So mainly its giving additional test runs in other environments, which can be useful for increased executions in identifying issues, or for faster feedback when one is backlogged (as sometimes happens for Travis within the apache github org), or for availability when one is having problems.