### PR TITLE
NO-JIRA: use a consistent version for the surefire and failsafe plugi…

### DIFF
--- a/artemis-hawtio/pom.xml
+++ b/artemis-hawtio/pom.xml
@@ -45,7 +45,6 @@
         <maven-plugin-version>3.3</maven-plugin-version>
         <maven-source-plugin-version>2.1.2</maven-source-plugin-version>
         <maven-resources-plugin-version>2.6</maven-resources-plugin-version>
-        <maven-surefire-plugin-version>2.19.1</maven-surefire-plugin-version>
         <servlet-api-version>2.5</servlet-api-version>
 
         <!-- use slf4j-api 1.6.x to be easy compatible with older Karaf/Camel releases -->

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,7 @@
       <version.maven.jar.plugin>2.4</version.maven.jar.plugin>
       <version.micrometer>1.1.4</version.micrometer>
       <hamcrest.version>2.1</hamcrest.version>
+      <surefire.version>2.22.2</surefire.version>
 
       <!-- used on tests -->
       <groovy.version>2.5.10</groovy.version>
@@ -1502,7 +1503,6 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-surefire-plugin</artifactId>
-               <version>2.18.1</version>
                <configuration>
                   <forkMode>once</forkMode>
                   <testFailureIgnore>${testFailureIgnore}</testFailureIgnore>
@@ -1514,7 +1514,6 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-surefire-report-plugin</artifactId>
-               <version>2.18.1</version>
             </plugin>
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>

--- a/tests/extra-tests/pom.xml
+++ b/tests/extra-tests/pom.xml
@@ -252,7 +252,6 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>2.18.1</version>
             <configuration>
                <skipTests>${skipExtraTests}</skipTests>
                <!-- ensure we don't inherit a byteman jar form any env settings -->

--- a/tests/karaf-client-integration-tests/pom.xml
+++ b/tests/karaf-client-integration-tests/pom.xml
@@ -192,7 +192,6 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.20.1</version>
             <executions>
                <execution>
                   <goals>


### PR DESCRIPTION
Use a consistent version for the surefire and failsafe plugins, which should generally be kept in step. Right now there are different versions specified in various places, some different. Remove those and rely on the parent pom managed versions everywhere. Override that to a more recent version.