### PR TITLE
Stop the timeout future when channel is closed

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/ProtocolHandler.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/ProtocolHandler.java
@@ -101,7 +101,7 @@ public class ProtocolHandler {
 
       private final boolean httpEnabled;
 
-      private ScheduledFuture timeoutFuture;
+      private ScheduledFuture<?> timeoutFuture;
 
       private int handshakeTimeout;
 
@@ -119,6 +119,15 @@ public class ProtocolHandler {
                ActiveMQServerLogger.LOGGER.handshakeTimeout(handshakeTimeout, nettyAcceptor.getName(), ctx.channel().remoteAddress().toString());
                ctx.channel().close();
             }, handshakeTimeout, TimeUnit.SECONDS);
+         }
+      }
+
+      @Override
+      public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+         super.channelInactive(ctx);
+         if (handshakeTimeout > 0 && timeoutFuture != null) {
+            timeoutFuture.cancel(true);
+            timeoutFuture = null;
          }
       }
 


### PR DESCRIPTION
Solves a small issue we are having with the AWS load balancer doing a health check. The logging explodes with warnings I think.
The cause is that there is no event handling the graceful closure of a connection. This fix should solve it.