### PR TITLE
Closing the directbytebuffer locally to prevent leaks

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/handler/ProtonHandler.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/handler/ProtonHandler.java
@@ -276,12 +276,17 @@ public class ProtonHandler extends ProtonInitializable implements SaslListener {
                break;
             }
 
-            // We allocated a Pooled Direct Buffer, that will be sent down the stream
             ByteBuf buffer = PooledByteBufAllocator.DEFAULT.directBuffer(pending);
-            buffer.writeBytes(head);
+            try {
+               // We allocated a Pooled Direct Buffer, that will be sent down the stream
+               buffer.writeBytes(head);
 
-            for (EventHandler handler : handlers) {
-               handler.pushBytes(buffer);
+               for (EventHandler handler : handlers) {
+                  handler.pushBytes(buffer);
+               }
+            } finally {
+               // We need to release the buffer when it has been sent downstream
+               buffer.release();
             }
 
             transport.pop(pending);


### PR DESCRIPTION
Related to the jira issue: 
https://issues.apache.org/jira/browse/ARTEMIS-2696
Assuming this can be done locally, this could be a fix for the above issue.

