### PR TITLE
NO-JIRA Fix #3172 mechanism

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/PersistentQueueBindingEncoding.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/PersistentQueueBindingEncoding.java
@@ -538,7 +538,9 @@ public class PersistentQueueBindingEncoding implements EncodingSupport, QueueBin
 
    private SimpleString createMetadata() {
       StringBuilder metadata = new StringBuilder();
-      metadata.append("user=").append(user).append(";");
+      if (user != null) {
+         metadata.append("user=").append(user).append(";");
+      }
       return SimpleString.toSimpleString(metadata.toString());
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/PostOffice.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/PostOffice.java
@@ -101,6 +101,14 @@ public interface PostOffice extends ActiveMQComponent {
 
    QueueBinding updateQueue(QueueConfiguration queueConfiguration) throws Exception;
 
+   /**
+    * @param queueConfiguration
+    * @param forceUpdate Setting to <code>true</code> will make <code>null</code> values override current values too
+    * @return
+    * @throws Exception
+    */
+   QueueBinding updateQueue(QueueConfiguration queueConfiguration, boolean forceUpdate) throws Exception;
+
    List<Queue> listQueuesForAddress(SimpleString address) throws Exception;
 
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -63,7 +63,6 @@ import org.apache.activemq.artemis.core.server.RoutingContext;
 import org.apache.activemq.artemis.core.server.cluster.impl.MessageLoadBalancingType;
 import org.apache.activemq.artemis.core.server.group.GroupingHandler;
 import org.apache.activemq.artemis.core.server.impl.AddressInfo;
-import org.apache.activemq.artemis.core.server.impl.QueueConfigurationUtils;
 import org.apache.activemq.artemis.core.server.impl.QueueManagerImpl;
 import org.apache.activemq.artemis.core.server.impl.RoutingContextImpl;
 import org.apache.activemq.artemis.core.server.management.ManagementService;
@@ -619,6 +618,11 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
 
    @Override
    public QueueBinding updateQueue(QueueConfiguration queueConfiguration) throws Exception {
+      return updateQueue(queueConfiguration, false);
+   }
+
+   @Override
+   public QueueBinding updateQueue(QueueConfiguration queueConfiguration, boolean forceUpdate) throws Exception {
       synchronized (this) {
          final QueueBinding queueBinding = (QueueBinding) addressManager.getBinding(queueConfiguration.getName());
          if (queueBinding == null) {
@@ -649,91 +653,71 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
                }
             }
 
-            QueueConfigurationUtils.applyDynamicQueueDefaults(queueConfiguration, addressSettingsRepository.getMatch(queueConfiguration.getAddress().toString()));
-
-            // atomic update, reset to defaults if value == null
-            // maxConsumers
-            if (queue.getMaxConsumers() != queueConfiguration.getMaxConsumers()) {
+            //atomic update
+            if ((forceUpdate || queueConfiguration.getMaxConsumers() != null) && !Objects.equals(queue.getMaxConsumers(), queueConfiguration.getMaxConsumers())) {
                changed = true;
                queue.setMaxConsumer(queueConfiguration.getMaxConsumers());
             }
-            // routingType
-            if (queue.getRoutingType() != queueConfiguration.getRoutingType()) {
+            if ((forceUpdate || queueConfiguration.getRoutingType() != null) && !Objects.equals(queue.getRoutingType(), queueConfiguration.getRoutingType())) {
                changed = true;
                queue.setRoutingType(queueConfiguration.getRoutingType());
             }
-            // purgeOnNoConsumers
-            if (queue.isPurgeOnNoConsumers() != queueConfiguration.isPurgeOnNoConsumers()) {
+            if ((forceUpdate || queueConfiguration.isPurgeOnNoConsumers() != null) && !Objects.equals(queue.isPurgeOnNoConsumers(), queueConfiguration.isPurgeOnNoConsumers())) {
                changed = true;
                queue.setPurgeOnNoConsumers(queueConfiguration.isPurgeOnNoConsumers());
             }
-            // enabled
-            if (queue.isEnabled() != queueConfiguration.isEnabled()) {
+            if ((forceUpdate || queueConfiguration.isEnabled() != null) && !Objects.equals(queue.isEnabled(), queueConfiguration.isEnabled())) {
                changed = true;
                queue.setEnabled(queueConfiguration.isEnabled());
             }
-            // exclusive
-            if (queue.isExclusive() != queueConfiguration.isExclusive()) {
+            if ((forceUpdate || queueConfiguration.isExclusive() != null) && !Objects.equals(queue.isExclusive(), queueConfiguration.isExclusive())) {
                changed = true;
                queue.setExclusive(queueConfiguration.isExclusive());
             }
-            // groupRebalance
-            if (queue.isGroupRebalance() != queueConfiguration.isGroupRebalance()) {
+            if ((forceUpdate || queueConfiguration.isGroupRebalance() != null) && !Objects.equals(queue.isGroupRebalance(), queueConfiguration.isGroupRebalance())) {
                changed = true;
                queue.setGroupRebalance(queueConfiguration.isGroupRebalance());
             }
-            // groupBuckets
-            if (queue.getGroupBuckets() != queueConfiguration.getGroupBuckets()) {
+            if ((forceUpdate || queueConfiguration.getGroupBuckets() != null) && !Objects.equals(queue.getGroupBuckets(), queueConfiguration.getGroupBuckets())) {
                changed = true;
                queue.setGroupBuckets(queueConfiguration.getGroupBuckets());
             }
-            // groupFirstKey
-            // Objects.equals() performs the null check for us
-            if (!Objects.equals(queue.getGroupFirstKey(), queueConfiguration.getGroupFirstKey())) {
+            if ((forceUpdate || queueConfiguration.getGroupFirstKey() != null) && !Objects.equals(queueConfiguration.getGroupFirstKey(), queue.getGroupFirstKey())) {
                changed = true;
                queue.setGroupFirstKey(queueConfiguration.getGroupFirstKey());
             }
-            // nonDestructive
-            if (queue.isNonDestructive() != queueConfiguration.isNonDestructive()) {
+            if ((forceUpdate || queueConfiguration.isNonDestructive() != null) && !Objects.equals(queue.isNonDestructive(), queueConfiguration.isNonDestructive())) {
                changed = true;
                queue.setNonDestructive(queueConfiguration.isNonDestructive());
             }
-            // consumersBeforeDispatch
-            if (queue.getConsumersBeforeDispatch() != queueConfiguration.getConsumersBeforeDispatch()) {
+            if ((forceUpdate || queueConfiguration.getConsumersBeforeDispatch() != null) && !Objects.equals(queueConfiguration.getConsumersBeforeDispatch(), queue.getConsumersBeforeDispatch())) {
                changed = true;
                queue.setConsumersBeforeDispatch(queueConfiguration.getConsumersBeforeDispatch());
             }
-            // delayBeforeDispatch
-            if (queue.getDelayBeforeDispatch() != queueConfiguration.getDelayBeforeDispatch()) {
+            if ((forceUpdate || queueConfiguration.getDelayBeforeDispatch() != null) && !Objects.equals(queueConfiguration.getDelayBeforeDispatch(), queue.getDelayBeforeDispatch())) {
                changed = true;
                queue.setDelayBeforeDispatch(queueConfiguration.getDelayBeforeDispatch());
             }
-            // filter
-            // There's no default ActiveMQDefaultConfiguration setting for a filter
-            final Filter newFilter = FilterImpl.createFilter(queueConfiguration.getFilterString());
-            if (!Objects.equals(queue.getFilter(), newFilter)) {
+            final SimpleString empty = new SimpleString("");
+            Filter oldFilter = FilterImpl.createFilter(queue.getFilter() == null ? empty : queue.getFilter().getFilterString());
+            Filter newFilter = FilterImpl.createFilter(queueConfiguration.getFilterString() == null ? empty : queueConfiguration.getFilterString());
+            if ((forceUpdate || newFilter != null) && !Objects.equals(oldFilter, newFilter)) {
                changed = true;
                queue.setFilter(newFilter);
             }
-            // configurationManaged
-            if (queueConfiguration.isConfigurationManaged() != queue.isConfigurationManaged()) {
-               queue.setConfigurationManaged(queueConfiguration.isConfigurationManaged());
+            if ((forceUpdate || queueConfiguration.isConfigurationManaged() != null) && !Objects.equals(queueConfiguration.isConfigurationManaged(), queue.isConfigurationManaged())) {
                changed = true;
+               queue.setConfigurationManaged(queueConfiguration.isConfigurationManaged());
             }
-            if (logger.isDebugEnabled()) {
-               if (queueConfiguration.getUser() == null && queue.getUser() != null) {
-                  logger.debug("Ignoring updating Queue to a NULL user");
-               }
-            }
-            if (queueConfiguration.getUser() != null && !queueConfiguration.getUser().equals(queue.getUser())) {
+            if ((forceUpdate || queueConfiguration.getUser() != null) && !Objects.equals(queueConfiguration.getUser(), queue.getUser())) {
                changed = true;
                queue.setUser(queueConfiguration.getUser());
             }
-            // ringSize
-            if (queue.getRingSize() != queueConfiguration.getRingSize()) {
+            if ((forceUpdate || queueConfiguration.getRingSize() != null) && !Objects.equals(queueConfiguration.getRingSize(), queue.getRingSize())) {
                changed = true;
                queue.setRingSize(queueConfiguration.getRingSize());
             }
+
             if (changed) {
                final long txID = storageManager.generateID();
                try {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServer.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServer.java
@@ -790,6 +790,15 @@ public interface ActiveMQServer extends ServiceComponent {
     */
    Queue updateQueue(QueueConfiguration queueConfiguration) throws Exception;
 
+   /**
+    * @param queueConfiguration the {@code QueueConfiguration} to use
+    * @param forceUpdate If <code>true</code>, no <code>null</code> check is performed and unset queueConfiguration values are reset to <code>null</code>
+    * @return the updated {@code Queue} instance
+    * @throws Exception
+    * @see #updateQueue(QueueConfiguration)
+    */
+   Queue updateQueue(QueueConfiguration queueConfiguration, boolean forceUpdate) throws Exception;
+
    /*
             * add a ProtocolManagerFactory to be used. Note if @see Configuration#isResolveProtocols is tur then this factory will
             * replace any factories with the same protocol

--- a/tests/integration-tests/src/test/resources/reload-empty.xml
+++ b/tests/integration-tests/src/test/resources/reload-empty.xml
@@ -1,0 +1,80 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration xmlns="urn:activemq"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+
+   <core xmlns="urn:activemq:core">
+
+      <name>0.0.0.0</name>
+
+      <configuration-file-refresh-period>100</configuration-file-refresh-period>
+
+      <persistence-enabled>false</persistence-enabled>
+
+      <security-enabled>false</security-enabled>
+
+      <!-- this could be ASYNCIO or NIO
+       -->
+      <journal-type>NIO</journal-type>
+
+      <paging-directory>./data/paging</paging-directory>
+
+      <bindings-directory>./data/bindings</bindings-directory>
+
+      <journal-directory>./data/journal</journal-directory>
+
+      <large-messages-directory>./data/large-messages</large-messages-directory>
+
+      <journal-min-files>2</journal-min-files>
+
+      <journal-pool-files>-1</journal-pool-files>
+
+      <!--
+       This value was determined through a calculation.
+       Your system could perform 25 writes per millisecond
+       on the current journal configuration.
+       That translates as a sync write every 40000 nanoseconds
+      -->
+      <journal-buffer-timeout>40000</journal-buffer-timeout>
+
+
+      <acceptors>
+         <!-- Default ActiveMQ Artemis Acceptor.  Multi-protocol adapter.  Currently supports ActiveMQ Artemis Core, OpenWire, STOMP, AMQP, MQTT, and HornetQ Core. -->
+         <!-- performance tests have shown that openWire performs best with these buffer sizes -->
+         <acceptor name="artemis">tcp://0.0.0.0:61616?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576</acceptor>
+
+         <!-- AMQP Acceptor.  Listens on default AMQP port for AMQP traffic.-->
+         <acceptor name="amqp">tcp://0.0.0.0:5672?protocols=AMQP</acceptor>
+
+         <!-- STOMP Acceptor. -->
+         <acceptor name="stomp">tcp://0.0.0.0:61613?protocols=STOMP</acceptor>
+
+         <!-- HornetQ Compatibility Acceptor.  Enables HornetQ Core and STOMP for legacy HornetQ clients. -->
+         <acceptor name="hornetq">tcp://0.0.0.0:5445?protocols=HORNETQ,STOMP</acceptor>
+
+         <!-- MQTT Acceptor -->
+         <acceptor name="mqtt">tcp://0.0.0.0:1883?protocols=MQTT</acceptor>
+
+      </acceptors>
+
+    </core>
+</configuration>

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/impl/fakes/FakePostOffice.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/impl/fakes/FakePostOffice.java
@@ -84,6 +84,11 @@ public class FakePostOffice implements PostOffice {
 
    @Override
    public QueueBinding updateQueue(QueueConfiguration queueConfiguration) throws Exception {
+      return updateQueue(queueConfiguration, false);
+   }
+
+   @Override
+   public QueueBinding updateQueue(QueueConfiguration queueConfiguration, boolean forceUpdate) throws Exception {
       return null;
    }
 


### PR DESCRIPTION
Queue settings are reset to their default values upon broker.xml reload ONLY.
Regular calls to PostOfficeImpl#updateQueue are no longer affected.