### PR TITLE
ARTEMIS-2846 Cannot define hawtio.role with whitespace

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
@@ -634,6 +634,7 @@ public class Create extends InputAbstract {
       filters.put("${user}", getUser());
       filters.put("${password}", getPassword());
       filters.put("${role}", role);
+      filters.put("${encoded.role}", role.replaceAll(" ", "\\\\ "));
 
 
       if (globalMaxSize == null || globalMaxSize.trim().equals("")) {

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis
@@ -119,6 +119,7 @@ fi
 
 exec "$JAVACMD" \
     $JAVA_ARGS \
+    -Dhawtio.role="$HAWTIO_ROLE" \
     -Xbootclasspath/a:"$LOG_MANAGER:$WILDFLY_COMMON" \
     -Djava.security.auth.login.config="$ARTEMIS_INSTANCE_ETC/login.config" \
     $ARTEMIS_CLUSTER_PROPS \

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis-roles.properties
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis-roles.properties
@@ -15,4 +15,4 @@
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
 
-${role} = ${user}
+${encoded.role} = ${user}

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile
@@ -31,9 +31,13 @@ ARTEMIS_INSTANCE_ETC_URI='${artemis.instance.etc.uri}'
 #ARTEMIS_CLUSTER_PROPS="-Dactivemq.remoting.default.port=61617 -Dactivemq.remoting.amqp.port=5673 -Dactivemq.remoting.stomp.port=61614 -Dactivemq.remoting.hornetq.port=5446"
 
 
+# Hawtio Properties
+HAWTIO_ROLE='${role}'
+
+
 # Java Opts
 if [ -z "$JAVA_ARGS" ]; then
-    JAVA_ARGS="${java-opts} -XX:+PrintClassHistogram -XX:+UseG1GC -XX:+UseStringDeduplication -Xms512M -Xmx2G -Dhawtio.realm=activemq  -Dhawtio.offline=true -Dhawtio.role=${role} -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal -Djolokia.policyLocation=${ARTEMIS_INSTANCE_ETC_URI}jolokia-access.xml"
+    JAVA_ARGS="${java-opts} -XX:+PrintClassHistogram -XX:+UseG1GC -XX:+UseStringDeduplication -Xms512M -Xmx2G -Dhawtio.realm=activemq -Dhawtio.offline=true -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal -Djolokia.policyLocation=${ARTEMIS_INSTANCE_ETC_URI}jolokia-access.xml"
 fi
 
 #

--- a/artemis-cli/src/test/java/org/apache/activemq/cli/test/ArtemisTest.java
+++ b/artemis-cli/src/test/java/org/apache/activemq/cli/test/ArtemisTest.java
@@ -780,6 +780,29 @@ public class ArtemisTest extends CliTestBase {
    }
 
    @Test
+   public void testRoleWithSpaces() throws Exception {
+      String roleWithSpaces = "amq with spaces";
+      Run.setEmbedded(true);
+      File instanceRole = new File(temporaryFolder.getRoot(), "instance_role");
+      System.setProperty("java.security.auth.login.config", instanceRole.getAbsolutePath() + "/etc/login.config");
+      Artemis.main("create", instanceRole.getAbsolutePath(), "--silent", "--no-autotune", "--role", roleWithSpaces);
+      System.setProperty("artemis.instance", instanceRole.getAbsolutePath());
+
+      File roleFile = new File(instanceRole.getAbsolutePath() + "/etc/artemis-roles.properties");
+
+      ListUser listCmd = new ListUser();
+      TestActionContext context = new TestActionContext();
+      listCmd.execute(context);
+
+      String result = context.getStdout();
+      log.debug("output1:\n" + result);
+
+      assertTrue(result.contains("\"admin\"(" + roleWithSpaces + ")"));
+
+      checkRole("admin", roleFile, roleWithSpaces);
+   }
+
+   @Test
    public void testUserCommandResetViaManagementPlaintext() throws Exception {
       internalTestUserCommandResetViaManagement(true);
    }

--- a/artemis-distribution/src/test/scripts/validate-spaces.sh
+++ b/artemis-distribution/src/test/scripts/validate-spaces.sh
@@ -18,4 +18,4 @@
 
 # This script will validate the distribution works with folders with spaces on Linux machines
 
-./validate-instalation.sh with\ spaces\ And\ Weird\ %26\ Characters\ Čeština\ 漢字\ водка\ 昨夜のコ\ ﷹ‬ﷸ‬
+./validate-instalation.sh with\ spaces\ And\ Weird\ %26\ Characters\ Čeština\ 漢字\ водка\ 昨夜のコ\ ﷹ‬ﷸ‬ amq\ with\ spaces


### PR DESCRIPTION
Move the `hawtio.role` property definition to avoid the word splitting.