### PR TITLE
ARTEMIS-2862 activation failure can cause zombie broker

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/integration/Broker.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/integration/Broker.java
@@ -24,5 +24,7 @@ import org.apache.activemq.artemis.core.server.ServiceComponent;
  */
 public interface Broker extends ServiceComponent {
 
+   void createComponents() throws Exception;
+
    ActiveMQServer getServer();
 }

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/integration/FileBroker.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/integration/FileBroker.java
@@ -51,18 +51,9 @@ public class FileBroker implements Broker {
          return;
       }
 
-      //todo if we start to pullout more configs from the main config then we should pull out the configuration objects from factories if available
-      FileConfiguration configuration = new FileConfiguration();
-
-      LegacyJMSConfiguration legacyJMSConfiguration = new LegacyJMSConfiguration(configuration);
-
-      FileDeploymentManager fileDeploymentManager = new FileDeploymentManager(configurationUrl);
-      fileDeploymentManager.addDeployable(configuration).addDeployable(legacyJMSConfiguration);
-      fileDeploymentManager.readConfiguration();
-
-      createDirectories(configuration);
-
-      components = fileDeploymentManager.buildService(securityManager, ManagementFactory.getPlatformMBeanServer());
+      if (components == null) {
+         createComponents();
+      }
 
       ArrayList<ActiveMQComponent> componentsByStartOrder = getComponentsByStartOrder(components);
       ActiveMQBootstrapLogger.LOGGER.serverStarting();
@@ -110,6 +101,22 @@ public class FileBroker implements Broker {
 
    public Map<String, ActiveMQComponent> getComponents() {
       return components;
+   }
+
+   @Override
+   public void createComponents() throws Exception {
+      //todo if we start to pullout more configs from the main config then we should pull out the configuration objects from factories if available
+      FileConfiguration configuration = new FileConfiguration();
+
+      LegacyJMSConfiguration legacyJMSConfiguration = new LegacyJMSConfiguration(configuration);
+
+      FileDeploymentManager fileDeploymentManager = new FileDeploymentManager(configurationUrl);
+      fileDeploymentManager.addDeployable(configuration).addDeployable(legacyJMSConfiguration);
+      fileDeploymentManager.readConfiguration();
+
+      createDirectories(configuration);
+
+      components = fileDeploymentManager.buildService(securityManager, ManagementFactory.getPlatformMBeanServer());
    }
 
    /*


### PR DESCRIPTION
In certain cases with shared-store HA a broker's activation can fail but
the broker will still be holding the journal lock. This results in a
"zombie" broker which can't actually service clients and prevents the
backup from activating.

This commit adds an ActivationFailureListener to catch activation
failures and stop the broker completely.