### PR TITLE
ARTEMIS-2878 Add numberOfPages as metric

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/AddressControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/AddressControl.java
@@ -26,6 +26,7 @@ public interface AddressControl {
    String ROUTED_MESSAGE_COUNT_DESCRIPTION = "number of messages routed to one or more bindings";
    String UNROUTED_MESSAGE_COUNT_DESCRIPTION = "number of messages not routed to any bindings";
    String ADDRESS_SIZE_DESCRIPTION = "the number of estimated bytes being used by all the queue(s) bound to this address; used to control paging and blocking";
+   String NUMBER_OF_PAGES_DESCRIPTION = "number of pages used by this address";
 
    /**
     * Returns the managed address.
@@ -93,8 +94,8 @@ public interface AddressControl {
    /**
     * Returns the number of pages used by this address.
     */
-   @Attribute(desc = "number of pages used by this address")
-   int getNumberOfPages() throws Exception;
+   @Attribute(desc = NUMBER_OF_PAGES_DESCRIPTION)
+   int getNumberOfPages();
 
    /**
     * Returns whether this address is paging.

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/AddressControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/AddressControlImpl.java
@@ -324,7 +324,7 @@ public class AddressControlImpl extends AbstractControl implements AddressContro
    }
 
    @Override
-   public int getNumberOfPages() throws Exception {
+   public int getNumberOfPages() {
       if (AuditLogger.isEnabled()) {
          AuditLogger.getNumberOfPages(this.addressInfo);
       }
@@ -337,6 +337,9 @@ public class AddressControlImpl extends AbstractControl implements AddressContro
          } else {
             return pageStore.getNumberOfPages();
          }
+      } catch (Exception e) {
+         ActiveMQServerLogger.LOGGER.debug("Failed to get number of pages", e);
+         return -1;
       } finally {
          blockOnIO();
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/impl/ManagementServiceImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/impl/ManagementServiceImpl.java
@@ -270,6 +270,7 @@ public class ManagementServiceImpl implements ManagementService {
                builder.register(AddressMetricNames.ROUTED_MESSAGE_COUNT, this, metrics -> Double.valueOf(addressInfo.getRoutedMessageCount()), AddressControl.ROUTED_MESSAGE_COUNT_DESCRIPTION);
                builder.register(AddressMetricNames.UNROUTED_MESSAGE_COUNT, this, metrics -> Double.valueOf(addressInfo.getUnRoutedMessageCount()), AddressControl.UNROUTED_MESSAGE_COUNT_DESCRIPTION);
                builder.register(AddressMetricNames.ADDRESS_SIZE, this, metrics -> Double.valueOf(addressControl.getAddressSize()), AddressControl.ADDRESS_SIZE_DESCRIPTION);
+               builder.register(AddressMetricNames.PAGES_COUNT, this, metrics -> Double.valueOf(addressControl.getNumberOfPages()), AddressControl.NUMBER_OF_PAGES_DESCRIPTION);
             });
          }
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/metrics/AddressMetricNames.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/metrics/AddressMetricNames.java
@@ -22,5 +22,6 @@ public class AddressMetricNames {
    public static final String ROUTED_MESSAGE_COUNT = "routed.message.count";
    public static final String UNROUTED_MESSAGE_COUNT = "unrouted.message.count";
    public static final String ADDRESS_SIZE = "address.size";
+   public static final String PAGES_COUNT = "number.of.pages";
 
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/AddressControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/AddressControlUsingCoreTest.java
@@ -89,7 +89,7 @@ public class AddressControlUsingCoreTest extends AddressControlTest {
          }
 
          @Override
-         public int getNumberOfPages() throws Exception {
+         public int getNumberOfPages() {
             return (int) proxy.retrieveAttributeValue("numberOfPages", Integer.class);
          }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/plugin/MetricsPluginTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/plugin/MetricsPluginTest.java
@@ -167,7 +167,9 @@ public class MetricsPluginTest extends ActiveMQTestBase {
               new Metric("artemis.unrouted.message.count", "number of messages not routed to any bindings", 0.0),
               new Metric("artemis.unrouted.message.count", "number of messages not routed to any bindings", 2.0),
               new Metric("artemis.address.size", "the number of estimated bytes being used by all the queue(s) bound to this address; used to control paging and blocking", 0.0),
-              new Metric("artemis.address.size", "the number of estimated bytes being used by all the queue(s) bound to this address; used to control paging and blocking", 0.0)
+              new Metric("artemis.address.size", "the number of estimated bytes being used by all the queue(s) bound to this address; used to control paging and blocking", 0.0),
+              new Metric("artemis.number.of.pages", "number of pages used by this address", 0.0),
+              new Metric("artemis.number.of.pages", "number of pages used by this address", 0.0)
       ));
    }
 


### PR DESCRIPTION
Added metric 'pages.count' to provide numberOfPages for an address.

Please let me know if 'pages.count' is OK or if I should rename the metric to something different.
I felt that a metric name like 'number.of.pages' or 'pages.numberof' looked strange.
