### PR TITLE
ARTEMIS-2877 Fix journal replication scalability

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionFactoryImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionFactoryImpl.java
@@ -1227,6 +1227,27 @@ public class ClientSessionFactoryImpl implements ClientSessionFactoryInternal, C
             logger.debug("TheConn == null on ClientSessionFactoryImpl::DelegatingBufferHandler, ignoring packet");
          }
       }
+
+      @Override
+      public void endOfBatch(final Object connectionID) {
+         RemotingConnection theConn = connection;
+
+         if (theConn != null && connectionID.equals(theConn.getID())) {
+            try {
+               theConn.endOfBatch(connectionID);
+            } catch (final RuntimeException e) {
+               ActiveMQClientLogger.LOGGER.disconnectOnErrorDecoding(e);
+               threadPool.execute(new Runnable() {
+                  @Override
+                  public void run() {
+                     theConn.fail(new ActiveMQException(e.getMessage()));
+                  }
+               });
+            }
+         } else {
+            logger.debug("TheConn == null on ClientSessionFactoryImpl::DelegatingBufferHandler, ignoring packet");
+         }
+      }
    }
 
    private final class DelegatingFailureListener implements FailureListener {

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/Channel.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/Channel.java
@@ -85,6 +85,18 @@ public interface Channel {
    boolean sendBatched(Packet packet);
 
    /**
+    * Sends a packet on this channel, but request it to be flushed (along with the un-flushed previous ones) only iff
+    * {@code flushConnection} is {@code true}.
+    *
+    * @param packet       the packet to send
+    * @param flushConnection if {@code true} requests this {@code packet} and any un-flushed previous sent one to be flushed
+    *                     to the underlying connection
+    * @return false if the packet was rejected by an outgoing interceptor; true if the send was
+    * successful
+    */
+   boolean send(Packet packet, boolean flushConnection);
+
+   /**
     * Sends a packet on this channel and then blocks until it has been written to the connection.
     *
     * @param packet the packet to send
@@ -130,6 +142,8 @@ public interface Channel {
     * @return the current channel handler
     */
    ChannelHandler getHandler();
+
+   void endOfBatch();
 
    /**
     * Closes this channel.

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/ChannelHandler.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/ChannelHandler.java
@@ -28,4 +28,8 @@ public interface ChannelHandler {
     * @param packet the packet received
     */
    void handlePacket(Packet packet);
+
+   default void endOfBatch() {
+
+   }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/RemotingConnectionImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/RemotingConnectionImpl.java
@@ -392,6 +392,15 @@ public class RemotingConnectionImpl extends AbstractRemotingConnection implement
    }
 
    @Override
+   public void endOfBatch(Object connectionID) {
+      super.endOfBatch(connectionID);
+      // TODO we really need a lock here?
+      synchronized (transferLock) {
+         channels.forEach((channelID, channel) -> channel.endOfBatch());
+      }
+   }
+
+   @Override
    public String getTransportLocalAddress() {
       return getTransportConnection().getLocalAddress();
    }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/ActiveMQChannelHandler.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/ActiveMQChannelHandler.java
@@ -77,6 +77,12 @@ public class ActiveMQChannelHandler extends ChannelDuplexHandler {
    }
 
    @Override
+   public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+      super.channelReadComplete(ctx);
+      handler.endOfBatch(channelId(ctx.channel()));
+   }
+
+   @Override
    public void channelInactive(final ChannelHandlerContext ctx) throws Exception {
       synchronized (this) {
          if (active) {

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnection.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnection.java
@@ -282,6 +282,17 @@ public class NettyConnection implements Connection {
    }
 
    @Override
+   public void write(ActiveMQBuffer buffer, boolean requestFlush) {
+      final Channel channel = this.channel;
+      final ByteBuf bytes = buffer.byteBuf();
+      if (requestFlush) {
+         channel.writeAndFlush(bytes, channel.voidPromise());
+      } else {
+         channel.write(bytes, channel.voidPromise());
+      }
+   }
+
+   @Override
    public final void write(ActiveMQBuffer buffer, final boolean flush, final boolean batched) {
       write(buffer, flush, batched, null);
    }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/BufferHandler.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/BufferHandler.java
@@ -32,4 +32,8 @@ public interface BufferHandler {
     * @param buffer       the buffer to decode
     */
    void bufferReceived(Object connectionID, ActiveMQBuffer buffer);
+
+   default void endOfBatch(Object connectionID) {
+
+   }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/Connection.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/Connection.java
@@ -77,6 +77,15 @@ public interface Connection {
    Object getID();
 
    /**
+    * writes the buffer to the connection and if flush is true request to flush the buffer
+    * (and any previous un-flushed ones) into the wire.
+    *
+    * @param buffer       the buffer to write
+    * @param requestFlush whether to request flush onto the wire
+    */
+   void write(ActiveMQBuffer buffer, boolean requestFlush);
+
+   /**
     * writes the buffer to the connection and if flush is true returns only when the buffer has been physically written to the connection.
     *
     * @param buffer  the buffer to write

--- a/artemis-core-client/src/test/java/org/apache/activemq/artemis/core/protocol/core/impl/ChannelImplTest.java
+++ b/artemis-core-client/src/test/java/org/apache/activemq/artemis/core/protocol/core/impl/ChannelImplTest.java
@@ -375,6 +375,11 @@ public class ChannelImplTest {
             }
 
             @Override
+            public void write(ActiveMQBuffer buffer, boolean requestFlush) {
+
+            }
+
+            @Override
             public void write(ActiveMQBuffer buffer, boolean flush, boolean batched) {
 
             }

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalFilesRepository.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalFilesRepository.java
@@ -444,11 +444,11 @@ public class JournalFilesRepository {
          pushOpen();
 
          nextFile = openedFiles.poll(journalFileOpenTimeout, TimeUnit.SECONDS);
-      } else {
-         if (openedFiles.isEmpty()) {
-            // if empty, push to open one.
-            pushOpen();
-         }
+      }
+
+      if (openedFiles.isEmpty()) {
+         // if empty, push to open one.
+         pushOpen();
       }
 
       if (nextFile == null) {

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalFilesRepository.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalFilesRepository.java
@@ -88,11 +88,14 @@ public class JournalFilesRepository {
    private final Runnable pushOpenRunnable = new Runnable() {
       @Override
       public void run() {
-         try {
-            pushOpenedFile();
-         } catch (Exception e) {
-            ActiveMQJournalLogger.LOGGER.errorPushingFile(e);
-            fileFactory.onIOError(e, "unable to open ", null);
+         // if there's already an opened file there is no need to push a new one
+         if (openedFiles.isEmpty()) {
+            try {
+               pushOpenedFile();
+            } catch (Exception e) {
+               ActiveMQJournalLogger.LOGGER.errorPushingFile(e);
+               fileFactory.onIOError(e, "unable to open ", null);
+            }
          }
       }
    };
@@ -444,11 +447,11 @@ public class JournalFilesRepository {
          pushOpen();
 
          nextFile = openedFiles.poll(journalFileOpenTimeout, TimeUnit.SECONDS);
-      }
-
-      if (openedFiles.isEmpty()) {
-         // if empty, push to open one.
-         pushOpen();
+      } else {
+         if (openedFiles.isEmpty()) {
+            // if empty, push to open one.
+            pushOpen();
+         }
       }
 
       if (nextFile == null) {

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalImpl.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalImpl.java
@@ -47,7 +47,6 @@ import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
 import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
 import org.apache.activemq.artemis.api.core.ActiveMQShutdownException;
 import org.apache.activemq.artemis.api.core.Pair;
-import org.apache.activemq.artemis.core.io.DummyCallback;
 import org.apache.activemq.artemis.core.io.IOCallback;
 import org.apache.activemq.artemis.core.io.IOCriticalErrorListener;
 import org.apache.activemq.artemis.core.io.SequentialFile;
@@ -841,7 +840,7 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
          throw ActiveMQJournalBundle.BUNDLE.recordLargerThanStoreMax(addRecordEncodeSize, maxRecordSize);
       }
 
-      final SimpleFuture<Boolean> result = newSyncAndCallbackResult(callback);
+      final SimpleFuture<Boolean> result = newSyncAndCallbackResult(sync, callback);
       appendExecutor.execute(new Runnable() {
          @Override
          public void run() {
@@ -933,7 +932,7 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
                                            Object record,
                                            boolean sync,
                                            IOCompletion callback) throws InterruptedException, java.util.concurrent.ExecutionException {
-      final SimpleFuture<Boolean> result = newSyncAndCallbackResult(callback);
+      final SimpleFuture<Boolean> result = newSyncAndCallbackResult(sync, callback);
       appendExecutor.execute(new Runnable() {
          @Override
          public void run() {
@@ -1017,7 +1016,7 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
    private void internalAppendDeleteRecord(long id,
                                            boolean sync,
                                            IOCompletion callback) throws InterruptedException, java.util.concurrent.ExecutionException {
-      final SimpleFuture<Boolean> result = newSyncAndCallbackResult(callback);
+      final SimpleFuture<Boolean> result = newSyncAndCallbackResult(sync, callback);
       appendExecutor.execute(new Runnable() {
          @Override
          public void run() {
@@ -1064,12 +1063,8 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
       result.get();
    }
 
-   private static SimpleFuture newSyncAndCallbackResult(IOCompletion callback) {
-      if (callback != null && callback != DummyCallback.getInstance()) {
-         return SimpleFuture.dumb();
-      } else {
-         return new SimpleFutureImpl<>();
-      }
+   private static SimpleFuture newSyncAndCallbackResult(boolean sync, IOCompletion callback) {
+      return (sync && callback == null) ? new SimpleFutureImpl<>() : SimpleFuture.dumb();
    }
 
    @Override
@@ -1295,7 +1290,7 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
          logger.trace("scheduling appendPrepareRecord::txID=" + txID);
       }
 
-      final SimpleFuture<JournalTransaction> result = newSyncAndCallbackResult(callback);
+      final SimpleFuture<JournalTransaction> result = newSyncAndCallbackResult(sync, callback);
 
       appendExecutor.execute(new Runnable() {
          @Override
@@ -1381,7 +1376,7 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
       }
 
 
-      final SimpleFuture<JournalTransaction> result = newSyncAndCallbackResult(callback);
+      final SimpleFuture<JournalTransaction> result = newSyncAndCallbackResult(sync, callback);
 
       appendExecutor.execute(new Runnable() {
          @Override
@@ -1435,7 +1430,7 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
 
 
 
-      final SimpleFuture<JournalTransaction> result = newSyncAndCallbackResult(callback);
+      final SimpleFuture<JournalTransaction> result = newSyncAndCallbackResult(sync, callback);
       appendExecutor.execute(new Runnable() {
          @Override
          public void run() {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMConnection.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMConnection.java
@@ -176,6 +176,11 @@ public class InVMConnection implements Connection {
    }
 
    @Override
+   public void write(ActiveMQBuffer buffer, boolean requestFlush) {
+      write(buffer, false, false, null);
+   }
+
+   @Override
    public void write(final ActiveMQBuffer buffer) {
       write(buffer, false, false, null);
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/util/BackupSyncDelay.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/util/BackupSyncDelay.java
@@ -195,6 +195,11 @@ public class BackupSyncDelay implements Interceptor {
       }
 
       @Override
+      public boolean send(Packet packet, boolean flushConnection) {
+         return channel.send(packet, flushConnection);
+      }
+
+      @Override
       public String toString() {
          return "ChannelWrapper(" + channel + ")";
       }
@@ -234,6 +239,11 @@ public class BackupSyncDelay implements Interceptor {
 
       @Override
       public ChannelHandler getHandler() {
+         throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void endOfBatch() {
          throw new UnsupportedOperationException();
       }
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/JournalImplTestUnit.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/JournalImplTestUnit.java
@@ -118,31 +118,6 @@ public abstract class JournalImplTestUnit extends JournalImplTestBase {
    }
 
    @Test
-   public void testFlushAppendsAndDeletes() throws Exception {
-      setup(10, 10 * 1024, true);
-      createJournal();
-      startJournal();
-      load();
-      byte[] record = new byte[1000];
-      for (int i = 0; i < record.length; i++) {
-         record[i] = (byte) 'a';
-      }
-      // Appending records after restart should be valid (not throwing any
-      // exceptions)
-      for (int i = 0; i < 10_000; i++) {
-         journal.appendAddRecord(i, (byte) 1, new SimpleEncoding(2, (byte) 'a'), false);
-         journal.appendDeleteRecord(i, false);
-      }
-      stopJournal();
-
-      List<String> files = fileFactory.listFiles(fileExtension);
-
-      // I am allowing one extra as a possible race with pushOpenFiles. I have not seen it happening on my test
-      // but it wouldn't be a problem if it happened
-      Assert.assertTrue("Supposed to have up to 10 files", files.size() <= 11);
-   }
-
-   @Test
    public void testParams() throws Exception {
       try {
          new JournalImpl(JournalImpl.MIN_FILE_SIZE - 1, 10, 10, 0, 0, fileFactory, filePrefix, fileExtension, 1);

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/JournalImplTestUnit.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/JournalImplTestUnit.java
@@ -118,6 +118,31 @@ public abstract class JournalImplTestUnit extends JournalImplTestBase {
    }
 
    @Test
+   public void testFlushAppendsAndDeletes() throws Exception {
+      setup(10, 10 * 1024, true);
+      createJournal();
+      startJournal();
+      load();
+      byte[] record = new byte[1000];
+      for (int i = 0; i < record.length; i++) {
+         record[i] = (byte) 'a';
+      }
+      // Appending records after restart should be valid (not throwing any
+      // exceptions)
+      for (int i = 0; i < 10_000; i++) {
+         journal.appendAddRecord(i, (byte) 1, new SimpleEncoding(2, (byte) 'a'), false);
+         journal.appendDeleteRecord(i, false);
+      }
+      stopJournal();
+
+      List<String> files = fileFactory.listFiles(fileExtension);
+
+      // I am allowing one extra as a possible race with pushOpenFiles. I have not seen it happening on my test
+      // but it wouldn't be a problem if it happened
+      Assert.assertTrue("Supposed to have up to 10 files", files.size() <= 11);
+   }
+
+   @Test
    public void testParams() throws Exception {
       try {
          new JournalImpl(JournalImpl.MIN_FILE_SIZE - 1, 10, 10, 0, 0, fileFactory, filePrefix, fileExtension, 1);


### PR DESCRIPTION
This will include:

- reverting ARTEMIS-2837 Avoiding bursts on writes and pending callbacks
- reimplementing it by limiting the amount of opened files (@clebertsuconic need you here: probably limiting the capacity of `openedFiles` is fine too?)
- using netty batching to allow bursty journal appends during replication (this one should both help with https://issues.apache.org/jira/browse/ARTEMIS-2852 and @michaelandrepearce concern of perf regression on replication, so please take a look)