### PR TITLE
ARTEMIS-2881 deadlock when destroying q and depaging

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/TransientQueueManagerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/TransientQueueManagerImpl.java
@@ -52,6 +52,8 @@ public class TransientQueueManagerImpl extends ReferenceCounterUtil implements T
    }
 
    public TransientQueueManagerImpl(ActiveMQServer server, SimpleString queueName) {
+      super(server.getExecutorFactory().getExecutor());
+
       this.server = server;
 
       this.queueName = queueName;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/TransientQueueTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/TransientQueueTest.java
@@ -27,6 +27,7 @@ import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.tests.util.SingleServerTestBase;
 import org.apache.activemq.artemis.utils.RandomUtil;
+import org.apache.activemq.artemis.utils.Wait;
 import org.junit.Test;
 
 public class TransientQueueTest extends SingleServerTestBase {
@@ -115,18 +116,20 @@ public class TransientQueueTest extends SingleServerTestBase {
 
       consumer2.close();
 
+      // validate if the queue was deleted after the consumer was closed
+      Wait.assertTrue(() -> server.locateQueue(queue) == null, 2000, 100);
+
       session.createSharedQueue(new QueueConfiguration(queue).setAddress(address).setDurable(false));
 
       consumer1 = session.createConsumer(queue);
 
-      // validate if the queue was deleted after the consumer was closed
-      assertNotNull(server.locateQueue(queue));
+      Wait.assertTrue(() -> server.locateQueue(queue) != null, 2000, 100);
 
       assertNull(consumer1.receiveImmediate());
 
       consumer1.close();
 
-      assertNull(server.locateQueue(queue));
+      Wait.assertTrue(() -> server.locateQueue(queue) == null, 2000, 100);
 
    }
 
@@ -171,7 +174,7 @@ public class TransientQueueTest extends SingleServerTestBase {
       // forcing a consumer close to make the queue go away
       session.createConsumer(queue).close();
 
-      assertNull(server.locateQueue(queue));
+      Wait.assertTrue(() -> server.locateQueue(queue) == null, 2000, 100);
 
       session.createSharedQueue(new QueueConfiguration(queue).setAddress(address).setFilterString(SimpleString.toSimpleString("q=1")).setDurable(false));
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/jms2client/SharedConsumerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/jms2client/SharedConsumerTest.java
@@ -27,6 +27,7 @@ import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.postoffice.Binding;
 import org.apache.activemq.artemis.core.postoffice.impl.LocalQueueBinding;
 import org.apache.activemq.artemis.tests.util.JMSTestBase;
+import org.apache.activemq.artemis.utils.Wait;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -111,8 +112,7 @@ public class SharedConsumerTest extends JMSTestBase {
          Binding binding = server.getPostOffice().getBinding(new SimpleString("nonDurable.mySharedCon"));
          assertNotNull(binding);
          con2.close();
-         binding = server.getPostOffice().getBinding(new SimpleString("nonDurable.mySharedCon"));
-         assertNull(binding);
+         Wait.assertTrue(() -> server.getPostOffice().getBinding(new SimpleString("nonDurable.mySharedCon")) == null, 2000, 100);
          con1 = context.createSharedConsumer(topic2, "mySharedCon");
       } finally {
          context.close();


### PR DESCRIPTION
I couldn't reproduce this with a test, but static code analysis led me
to this solution which is similar to the fix done for ARTEMIS-2592 via
e397a177967bcf431b9fa82463a61b152ba82fb0.