### PR TITLE
ARTEMIS-2886 optimize security auth

### DIFF
--- a/artemis-cli/src/test/java/org/apache/activemq/cli/test/ArtemisTest.java
+++ b/artemis-cli/src/test/java/org/apache/activemq/cli/test/ArtemisTest.java
@@ -69,6 +69,7 @@ import org.apache.activemq.artemis.core.client.impl.ServerLocatorImpl;
 import org.apache.activemq.artemis.core.config.FileDeploymentManager;
 import org.apache.activemq.artemis.core.config.impl.FileConfiguration;
 import org.apache.activemq.artemis.core.security.CheckType;
+import org.apache.activemq.artemis.core.security.impl.SecurityStoreImpl;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.JournalType;
 import org.apache.activemq.artemis.core.server.management.ManagementContext;
@@ -621,6 +622,7 @@ public class ArtemisTest extends CliTestBase {
          activeMQServerControl.addSecuritySettings("myAddress", "myRole", "myRole", "myRole", "myRole", "myRole", "myRole", "myRole", "myRole", "myRole", "myRole");
          // change properties files which should cause another "reload" event
          activeMQServerControl.addUser("foo", "bar", "myRole", true);
+         ((SecurityStoreImpl)activeMQServer.getSecurityStore()).invalidateAuthenticationCache();
          ClientSession session = sessionFactory.createSession("foo", "bar", false, false, false, false, 0);
          session.createQueue("myAddress", RoutingType.ANYCAST, "myQueue", true);
          ClientProducer producer = session.createProducer("myAddress");

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/logs/AuditLogger.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/logs/AuditLogger.java
@@ -2737,4 +2737,20 @@ public interface AuditLogger extends BasicLogger {
    @LogMessage(level = Logger.Level.INFO)
    @Message(id = 601735, value = "User {0} is getting group rebalance pause dispatch property on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
    void isGroupRebalancePauseDispatch(String user, Object source, Object... args);
+
+   static void getAuthenticationCacheSize(Object source) {
+      LOGGER.getAuthenticationCacheSize(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601736, value = "User {0} is getting authentication cache size on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getAuthenticationCacheSize(String user, Object source, Object... args);
+
+   static void getAuthorizationCacheSize(Object source) {
+      LOGGER.getAuthorizationCacheSize(getCaller(), source);
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601737, value = "User {0} is getting authorization cache size on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void getAuthorizationCacheSize(String user, Object source, Object... args);
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
@@ -160,6 +160,12 @@ public final class ActiveMQDefaultConfiguration {
    // how long (in ms) to wait before invalidating the security cache
    private static long DEFAULT_SECURITY_INVALIDATION_INTERVAL = 10000;
 
+   // how large to make the authentication cache
+   private static long DEFAULT_AUTHENTICATION_CACHE_SIZE = 1000;
+
+   // how large to make the authorization cache
+   private static long DEFAULT_AUTHORIZATION_CACHE_SIZE = 1000;
+
    // how long (in ms) to wait to acquire a file lock on the journal
    private static long DEFAULT_JOURNAL_LOCK_ACQUISITION_TIMEOUT = -1;
 
@@ -678,6 +684,20 @@ public final class ActiveMQDefaultConfiguration {
     */
    public static long getDefaultSecurityInvalidationInterval() {
       return DEFAULT_SECURITY_INVALIDATION_INTERVAL;
+   }
+
+   /**
+    * how large to make the authentication cache
+    */
+   public static long getDefaultAuthenticationCacheSize() {
+      return DEFAULT_AUTHENTICATION_CACHE_SIZE;
+   }
+
+   /**
+    * how large to make the authorization cache
+    */
+   public static long getDefaultAuthorizationCacheSize() {
+      return DEFAULT_AUTHORIZATION_CACHE_SIZE;
    }
 
    /**

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
@@ -460,6 +460,18 @@ public interface ActiveMQServerControl {
    @Attribute(desc = ADDRESS_MEMORY_USAGE_PERCENTAGE_DESCRIPTION)
    int getAddressMemoryUsagePercentage();
 
+   /**
+    * Returns the runtime size of the authentication cache
+    */
+   @Attribute(desc = "The runtime size of the authentication cache")
+   long getAuthenticationCacheSize();
+
+   /**
+    * Returns the runtime size of the authorization cache
+    */
+   @Attribute(desc = "The runtime size of the authorization cache")
+   long getAuthorizationCacheSize();
+
    // Operations ----------------------------------------------------
    @Operation(desc = "Isolate the broker", impact = MBeanOperationInfo.ACTION)
    boolean freezeReplication();

--- a/artemis-features/src/main/resources/features.xml
+++ b/artemis-features/src/main/resources/features.xml
@@ -71,6 +71,7 @@
 		<bundle dependency="true">mvn:org.apache.commons/commons-text/${commons.text.version}</bundle>
 		<bundle dependency="true">mvn:org.apache.commons/commons-lang3/${commons.lang.version}</bundle>
 		<bundle dependency="true">mvn:org.jctools/jctools-core/${jctools.version}</bundle>
+		<bundle dependency="true">mvn:com.google.guava/guava/${guava.version}</bundle>
 		<!-- Micrometer can't be included until it supports OSGi. It is currently an "optional" Maven dependency. -->
 		<!--bundle dependency="true">mvn:io.micrometer/micrometer-core/${version.micrometer}</bundle-->
 

--- a/artemis-server/pom.xml
+++ b/artemis-server/pom.xml
@@ -45,8 +45,12 @@
          <optional>true</optional>
       </dependency>
       <dependency>
-          <groupId>com.google.errorprone</groupId>
-          <artifactId>error_prone_core</artifactId>
+         <groupId>com.google.errorprone</groupId>
+         <artifactId>error_prone_core</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>com.google.guava</groupId>
+         <artifactId>guava</artifactId>
       </dependency>
       <dependency>
          <groupId>org.jboss.logging</groupId>

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
@@ -212,6 +212,28 @@ public interface Configuration {
    Configuration setSecurityInvalidationInterval(long interval);
 
    /**
+    * Sets the size of the authentication cache.
+    */
+   Configuration setAuthenticationCacheSize(long size);
+
+   /**
+    * Returns the configured size of the authentication cache. <br>
+    * Default value is {@link org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration#DEFAULT_AUTHENTICATION_CACHE_SIZE}.
+    */
+   long getAuthenticationCacheSize();
+
+   /**
+    * Sets the size of the authorization cache.
+    */
+   Configuration setAuthorizationCacheSize(long size);
+
+   /**
+    * Returns the configured size of the authorization cache. <br>
+    * Default value is {@link org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration#DEFAULT_AUTHORIZATION_CACHE_SIZE}.
+    */
+   long getAuthorizationCacheSize();
+
+   /**
     * Returns whether security is enabled for this server. <br>
     * Default value is {@link org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration#DEFAULT_SECURITY_ENABLED}.
     */

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
@@ -122,6 +122,10 @@ public class ConfigurationImpl implements Configuration, Serializable {
 
    private long securityInvalidationInterval = ActiveMQDefaultConfiguration.getDefaultSecurityInvalidationInterval();
 
+   private long authenticationCacheSize = ActiveMQDefaultConfiguration.getDefaultAuthenticationCacheSize();
+
+   private long authorizationCacheSize = ActiveMQDefaultConfiguration.getDefaultAuthorizationCacheSize();
+
    private boolean securityEnabled = ActiveMQDefaultConfiguration.isDefaultSecurityEnabled();
 
    private boolean gracefulShutdownEnabled = ActiveMQDefaultConfiguration.isDefaultGracefulShutdownEnabled();
@@ -503,6 +507,28 @@ public class ConfigurationImpl implements Configuration, Serializable {
    @Override
    public ConfigurationImpl setSecurityInvalidationInterval(final long interval) {
       securityInvalidationInterval = interval;
+      return this;
+   }
+
+   @Override
+   public long getAuthenticationCacheSize() {
+      return authenticationCacheSize;
+   }
+
+   @Override
+   public ConfigurationImpl setAuthenticationCacheSize(final long size) {
+      authenticationCacheSize = size;
+      return this;
+   }
+
+   @Override
+   public long getAuthorizationCacheSize() {
+      return authorizationCacheSize;
+   }
+
+   @Override
+   public ConfigurationImpl setAuthorizationCacheSize(final long size) {
+      authorizationCacheSize = size;
       return this;
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -370,7 +370,11 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
       config.setJMXUseBrokerName(getBoolean(e, "jmx-use-broker-name", config.isJMXUseBrokerName()));
 
-      config.setSecurityInvalidationInterval(getLong(e, "security-invalidation-interval", config.getSecurityInvalidationInterval(), Validators.GT_ZERO));
+      config.setSecurityInvalidationInterval(getLong(e, "security-invalidation-interval", config.getSecurityInvalidationInterval(), Validators.GE_ZERO));
+
+      config.setAuthenticationCacheSize(getLong(e, "authentication-cache-size", config.getAuthenticationCacheSize(), Validators.GE_ZERO));
+
+      config.setAuthorizationCacheSize(getLong(e, "authorization-cache-size", config.getAuthorizationCacheSize(), Validators.GE_ZERO));
 
       config.setConnectionTTLOverride(getLong(e, "connection-ttl-override", config.getConnectionTTLOverride(), Validators.MINUS_ONE_OR_GT_ZERO));
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -91,6 +91,7 @@ import org.apache.activemq.artemis.core.postoffice.impl.LocalQueueBinding;
 import org.apache.activemq.artemis.core.remoting.server.RemotingService;
 import org.apache.activemq.artemis.core.security.CheckType;
 import org.apache.activemq.artemis.core.security.Role;
+import org.apache.activemq.artemis.core.security.impl.SecurityStoreImpl;
 import org.apache.activemq.artemis.core.server.ActiveMQMessageBundle;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
@@ -755,6 +756,22 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
       }
       double result = (100D * memoryUsed) / globalMaxSize;
       return (int) result;
+   }
+
+   @Override
+   public long getAuthenticationCacheSize() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getAuthenticationCacheSize(this.server);
+      }
+      return ((SecurityStoreImpl)server.getSecurityStore()).getAuthenticationCacheSize();
+   }
+
+   @Override
+   public long getAuthorizationCacheSize() {
+      if (AuditLogger.isEnabled()) {
+         AuditLogger.getAuthorizationCacheSize(this.server);
+      }
+      return ((SecurityStoreImpl)server.getSecurityStore()).getAuthorizationCacheSize();
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -2884,7 +2884,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
          ActiveMQServerLogger.LOGGER.clusterSecurityRisk();
       }
 
-      securityStore = new SecurityStoreImpl(securityRepository, securityManager, configuration.getSecurityInvalidationInterval(), configuration.isSecurityEnabled(), configuration.getClusterUser(), configuration.getClusterPassword(), managementService);
+      securityStore = new SecurityStoreImpl(securityRepository, securityManager, configuration.getSecurityInvalidationInterval(), configuration.isSecurityEnabled(), configuration.getClusterUser(), configuration.getClusterPassword(), managementService, configuration.getAuthenticationCacheSize(), configuration.getAuthorizationCacheSize());
 
       queueFactory = new QueueFactoryImpl(executorFactory, scheduledPool, addressSettingsRepository, storageManager, this);
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/ActiveMQSecurityManager5.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/ActiveMQSecurityManager5.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.spi.core.security;
+
+import javax.security.auth.Subject;
+import java.util.Set;
+
+import org.apache.activemq.artemis.core.security.CheckType;
+import org.apache.activemq.artemis.core.security.Role;
+import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
+
+/**
+ * Used to validate whether a user is authorized to connect to the
+ * server and perform certain functions on certain addresses
+ *
+ * This is an evolution of {@link ActiveMQSecurityManager4}
+ * that integrates with the new Subject caching functionality.
+ */
+public interface ActiveMQSecurityManager5 extends ActiveMQSecurityManager {
+
+   /**
+    * is this a valid user.
+    *
+    * This method is called instead of
+    * {@link ActiveMQSecurityManager#validateUser(String, String)}.
+    *
+    * @param user     the user
+    * @param password the user's password
+    * @param remotingConnection the user's connection which contains any corresponding SSL certs
+    * @param securityDomain the name of the JAAS security domain to use (can be null)
+    * @return the Subject of the authenticated user or null if the user isn't authenticated
+    */
+   Subject authenticate(String user, String password, RemotingConnection remotingConnection, String securityDomain);
+
+   /**
+    * Determine whether the given user has the correct role for the given check type.
+    *
+    * This method is called instead of
+    * {@link ActiveMQSecurityManager#validateUserAndRole(String, String, Set, CheckType)}.
+    *
+    * @param subject    the Subject to authorize
+    * @param roles      the roles configured in the security-settings
+    * @param checkType  which permission to validate
+    * @return true if the user is authorized, else false
+    */
+   boolean authorize(Subject subject, Set<Role> roles, CheckType checkType);
+}

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -134,7 +134,23 @@
          <xsd:element name="security-invalidation-interval" type="xsd:long" default="10000" maxOccurs="1" minOccurs="0">
             <xsd:annotation>
                <xsd:documentation>
-                  how long (in ms) to wait before invalidating the security cache
+                  how long (in ms) to wait before invalidating an entry in the authentication or authorization cache
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="authentication-cache-size" type="xsd:long" default="1000" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  how large to make the authentication cache
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="authorization-cache-size" type="xsd:long" default="1000" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  how large to make the authorization cache
                </xsd:documentation>
             </xsd:annotation>
          </xsd:element>

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
@@ -102,6 +102,8 @@ public class FileConfigurationTest extends ConfigurationImplTest {
       Assert.assertEquals(54321, conf.getThreadPoolMaxSize());
       Assert.assertEquals(false, conf.isSecurityEnabled());
       Assert.assertEquals(5423, conf.getSecurityInvalidationInterval());
+      Assert.assertEquals(333, conf.getAuthenticationCacheSize());
+      Assert.assertEquals(444, conf.getAuthorizationCacheSize());
       Assert.assertEquals(true, conf.isWildcardRoutingEnabled());
       Assert.assertEquals(new SimpleString("Giraffe"), conf.getManagementAddress());
       Assert.assertEquals(new SimpleString("Whatever"), conf.getManagementNotificationAddress());

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/security/jaas/JAASSecurityManagerTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/security/jaas/JAASSecurityManagerTest.java
@@ -16,8 +16,11 @@
  */
 package org.apache.activemq.artemis.core.security.jaas;
 
+import javax.security.auth.Subject;
+
 import org.apache.activemq.artemis.core.security.CheckType;
 import org.apache.activemq.artemis.core.security.Role;
+import org.apache.activemq.artemis.core.security.impl.SecurityStoreImpl;
 import org.apache.activemq.artemis.spi.core.security.ActiveMQJAASSecurityManager;
 import org.jboss.logging.Logger;
 import org.junit.Rule;
@@ -38,6 +41,7 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
 public class JAASSecurityManagerTest {
@@ -80,18 +84,17 @@ public class JAASSecurityManagerTest {
          }
          ActiveMQJAASSecurityManager securityManager = new ActiveMQJAASSecurityManager("PropertiesLogin");
 
-         String result = securityManager.validateUser("first", "secret", null, null);
+         Subject result = securityManager.authenticate("first", "secret", null, null);
 
          assertNotNull(result);
-         assertEquals("first", result);
+         assertEquals("first", SecurityStoreImpl.getUserFromSubject(result));
 
          Role role = new Role("programmers", true, true, true, true, true, true, true, true, true, true);
          Set<Role> roles = new HashSet<>();
          roles.add(role);
-         result = securityManager.validateUserAndRole("first", "secret", roles, CheckType.SEND, "someaddress", null, null);
+         boolean authorizationResult = securityManager.authorize(result, roles, CheckType.SEND);
 
-         assertNotNull(result);
-         assertEquals("first", result);
+         assertTrue(authorizationResult);
 
       } finally {
          Thread.currentThread().setContextClassLoader(existingLoader);

--- a/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
@@ -28,6 +28,8 @@
       <graceful-shutdown-enabled>true</graceful-shutdown-enabled>
       <graceful-shutdown-timeout>12345</graceful-shutdown-timeout>
       <security-invalidation-interval>5423</security-invalidation-interval>
+      <authentication-cache-size>333</authentication-cache-size>
+      <authorization-cache-size>444</authorization-cache-size>
       <journal-lock-acquisition-timeout>123</journal-lock-acquisition-timeout>
       <wild-card-routing-enabled>true</wild-card-routing-enabled>
       <management-address>Giraffe</management-address>

--- a/artemis-server/src/test/resources/ConfigurationTest-xinclude-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-xinclude-config.xml
@@ -29,6 +29,8 @@
       <graceful-shutdown-enabled>true</graceful-shutdown-enabled>
       <graceful-shutdown-timeout>12345</graceful-shutdown-timeout>
       <security-invalidation-interval>5423</security-invalidation-interval>
+      <authentication-cache-size>333</authentication-cache-size>
+      <authorization-cache-size>444</authorization-cache-size>
       <journal-lock-acquisition-timeout>123</journal-lock-acquisition-timeout>
       <wild-card-routing-enabled>true</wild-card-routing-enabled>
       <management-address>Giraffe</management-address>

--- a/docs/user-manual/en/security.md
+++ b/docs/user-manual/en/security.md
@@ -6,9 +6,17 @@ you can configure it.
 To disable security completely simply set the `security-enabled` property to
 `false` in the `broker.xml` file.
 
-For performance reasons security is cached and invalidated every so long. To
-change this period set the property `security-invalidation-interval`, which is
-in milliseconds. The default is `10000` ms.
+For performance reasons both **authentication and authorization is cached**
+independently. Entries are removed from the caches (i.e. invalidated) either
+when the cache reaches its maximum size in which case the least-recently used
+entry is removed or when an entry has been in the cache "too long".
+
+The size of the caches are controlled by the `authentication-cache-size` and
+`authorization-cache-size` configuration parameters. Both deafult to `1000`.
+
+How long cache entries are valid is controlled by
+`security-invalidation-interval`, which is in milliseconds. Using `0` will
+disable caching. The default is `10000` ms.
 
 ## Tracking the Validated User
 

--- a/examples/features/standard/security-manager/src/main/java/org/apache/activemq/artemis/jms/example/JAASSecurityManagerWrapper.java
+++ b/examples/features/standard/security-manager/src/main/java/org/apache/activemq/artemis/jms/example/JAASSecurityManagerWrapper.java
@@ -17,6 +17,7 @@
 
 package org.apache.activemq.artemis.jms.example;
 
+import javax.security.auth.Subject;
 import java.util.Map;
 import java.util.Set;
 
@@ -25,28 +26,23 @@ import org.apache.activemq.artemis.core.security.Role;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
 import org.apache.activemq.artemis.spi.core.security.ActiveMQJAASSecurityManager;
 import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager;
-import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager4;
+import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager5;
 
-public class JAASSecurityManagerWrapper implements ActiveMQSecurityManager4 {
+public class JAASSecurityManagerWrapper implements ActiveMQSecurityManager5 {
    ActiveMQJAASSecurityManager activeMQJAASSecurityManager;
 
    @Override
-   public String validateUser(String user, String password, RemotingConnection remotingConnection, String securityDomain) {
-      System.out.println("validateUser(" + user + ", " + password + ", " + remotingConnection.getRemoteAddress() + ")");
-      return activeMQJAASSecurityManager.validateUser(user, password, remotingConnection, securityDomain);
+   public Subject authenticate(String user, String password, RemotingConnection remotingConnection, String securityDomain) {
+      System.out.println("authenticate(" + user + ", " + password + ", " + remotingConnection.getRemoteAddress() + ")");
+      return activeMQJAASSecurityManager.authenticate(user, password, remotingConnection, securityDomain);
    }
 
-
    @Override
-   public String validateUserAndRole(String user,
-                              String password,
-                              Set<Role> roles,
-                              CheckType checkType,
-                              String address,
-                              RemotingConnection remotingConnection,
-                              String securityDomain) {
-      System.out.println("validateUserAndRole(" + user + ", " + password + ", " + roles + ", " + checkType + ", " + address + ", " + remotingConnection.getRemoteAddress() + ")");
-      return activeMQJAASSecurityManager.validateUserAndRole(user, password, roles, checkType, address, remotingConnection, securityDomain);
+   public boolean authorize(Subject subject,
+                            Set<Role> roles,
+                            CheckType checkType) {
+      System.out.println("authorize(" + subject + ", " + roles + ", " + checkType + ")");
+      return activeMQJAASSecurityManager.authorize(subject, roles, checkType);
    }
 
    @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
@@ -198,6 +198,32 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
    }
 
    @Test
+   public void testSecurityCacheSizes() throws Exception {
+      ActiveMQServerControl serverControl = createManagementControl();
+
+      Assert.assertEquals(usingCore() ? 1 : 0, serverControl.getAuthenticationCacheSize());
+      Assert.assertEquals(usingCore() ? 7 : 0, serverControl.getAuthorizationCacheSize());
+
+      ServerLocator loc = createInVMNonHALocator();
+      ClientSessionFactory csf = createSessionFactory(loc);
+      ClientSession session = csf.createSession("myUser", "myPass", false, true, false, false, 0);
+      session.start();
+
+      final String address = "ADDRESS";
+
+      serverControl.createAddress(address, "MULTICAST");
+
+      ClientProducer producer = session.createProducer(address);
+
+      ClientMessage m = session.createMessage(true);
+      m.putStringProperty("hello", "world");
+      producer.send(m);
+
+      Assert.assertEquals(usingCore() ? 2 : 1, serverControl.getAuthenticationCacheSize());
+      Assert.assertEquals(usingCore() ? 8 : 1, serverControl.getAuthorizationCacheSize());
+   }
+
+   @Test
    public void testGetConnectors() throws Exception {
       ActiveMQServerControl serverControl = createManagementControl();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
@@ -769,6 +769,16 @@ public class ActiveMQServerControlUsingCoreTest extends ActiveMQServerControlTes
          }
 
          @Override
+         public long getAuthenticationCacheSize() {
+            return (Long) proxy.retrieveAttributeValue("AuthenticationCacheSize", Long.class);
+         }
+
+         @Override
+         public long getAuthorizationCacheSize() {
+            return (Long) proxy.retrieveAttributeValue("AuthorizationCacheSize", Long.class);
+         }
+
+         @Override
          public double getDiskStoreUsage() {
             try {
                return (Double) proxy.invokeOperation("getDiskStoreUsage");

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/StompWithClientIdValidationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/StompWithClientIdValidationTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.activemq.artemis.tests.integration.stomp;
 
+import javax.security.auth.Subject;
 import java.lang.management.ManagementFactory;
 
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
@@ -46,13 +47,14 @@ public class StompWithClientIdValidationTest extends StompTestBase {
          .setSecurityEnabled(isSecurityEnabled())
          .setPersistenceEnabled(isPersistenceEnabled())
          .addAcceptorConfiguration("stomp", "tcp://localhost:61613?enabledProtocols=STOMP")
-         .addAcceptorConfiguration(new TransportConfiguration(InVMAcceptorFactory.class.getName()));
+         .addAcceptorConfiguration(new TransportConfiguration(InVMAcceptorFactory.class.getName()))
+         .setSecurityInvalidationInterval(0); // disable caching
 
       ActiveMQJAASSecurityManager securityManager = new ActiveMQJAASSecurityManager(InVMLoginModule.class.getName(), new SecurityConfiguration()) {
          @Override
-         public String validateUser(String user, String password, RemotingConnection remotingConnection, String securityDomain) {
+         public Subject authenticate(String user, String password, RemotingConnection remotingConnection, String securityDomain) {
 
-            String validatedUser = super.validateUser(user, password, remotingConnection, securityDomain);
+            Subject validatedUser = super.authenticate(user, password, remotingConnection, securityDomain);
             if (validatedUser == null) {
                return null;
             }


### PR DESCRIPTION
Both authentication and authorization will hit the underlying security
repository (e.g. files, LDAP, etc.). For example, creating a JMS
connection and a consumer will result in 2 hits with the *same*
authentication request. This can cause unwanted (and unnecessary)
resource utilization, especially in the case of networked configuration
like LDAP.

There is already a rudimentary cache for authorization, but it is
cleared *totally* every 10 seconds by default (controlled via the
security-invalidation-interval setting), and it must be populated
initially which still results in duplicate auth requests.

This commit optimizes authentication and authorization via the following
changes:

 - Replace our home-grown cache with Google Guava's cache. This provides
simple caching with both time-based and size-based LRU eviction. See more
at https://github.com/google/guava/wiki/CachesExplained. I also thought
about using Caffeine, but we already have a dependency on Guava and the
cache implementions look to be negligibly different for this use-case.
 - Add caching for authentication. Both successful and unsuccessful
authentication attempts will be cached to spare the underlying security
repository as much as possible. Authenticated Subjects will be cached
and re-used whenever possible.
 - Authorization will used Subjects cached during authentication. If the
required Subject is not in the cache it will be fetched from the
underlying security repo.
 - Caching can be disabled by setting the security-invalidation-interval
to 0.
 - Cache sizes are configurable.
 - Management operations exist to inspect cache sizes at runtime.