### PR TITLE
ARTEMIS-2696 Releasing ByteBuf after reading content

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/protocol/websocket/WebSocketFrameEncoder.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/protocol/websocket/WebSocketFrameEncoder.java
@@ -63,5 +63,7 @@ public class WebSocketFrameEncoder extends ChannelOutboundHandlerAdapter {
          byteBuf.readBytes(fragment, length);
          ctx.writeAndFlush(new ContinuationWebSocketFrame(finalFragment, 0, fragment), promise);
       }
+
+      byteBuf.release();
    }
 }


### PR DESCRIPTION
We try to migrate from Artemis 2.9.0 to 2.13.0 and we got a OutOfDirectMemoryError. After some investigation we found the issue https://issues.apache.org/jira/projects/ARTEMIS/issues/ARTEMIS-2696 which points out to WebSocketFrameEncoder. So we include a log line in netty to track PlatformDependent#incrementMemoryCounter and PlatformDependent#decrementMemoryCounter but we only see calls to incrementMemoryCounter without any "decrementMemoryCounter". 

The WebSocketFrameEncoder was added in https://github.com/apache/activemq-artemis/commit/9fac4b866cf9cefbb6f7c13b820e07455b6649f5#diff-924a36a0e320185d284c29e46ddfdb75 changing the logic of wrapping the buffer into BinaryWebSocketFrame now the buffer is copied and the copy is wrapped in BinaryWebSocketFrame and if the size is bigger than the max using a continuation frame but the original buffer is not release.

I did this small change a run "mvn clean package" now I am creating the PR to check if this change breaks something because when trying to execute the build locally using "mvn -Dorg.apache.activemq.artemis.core.io.aio.AIOSequentialFileFactory.DISABLED=AnythingNotNull -Djdk8-errorprone -Pfast-tests -Pextra-tests -Ptests-CI -B install -q" it was not working for me even without doing any change.

I will also testing this change in our current env

