### PR TITLE
ARTEMIS-2886 put address/FQQN into new security manager interface

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/security/impl/SecurityStoreImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/security/impl/SecurityStoreImpl.java
@@ -270,7 +270,7 @@ public class SecurityStoreImpl implements SecurityStore, HierarchicalRepositoryC
          final Boolean validated;
          if (securityManager instanceof ActiveMQSecurityManager5) {
             Subject subject = getSubjectForAuthorization(session, ((ActiveMQSecurityManager5) securityManager));
-            validated = ((ActiveMQSecurityManager5) securityManager).authorize(subject, roles, checkType);
+            validated = ((ActiveMQSecurityManager5) securityManager).authorize(subject, roles, checkType, isFullyQualified ? fqqn.toString() : bareAddress.toString());
          } else if (securityManager instanceof ActiveMQSecurityManager4) {
             validated = ((ActiveMQSecurityManager4) securityManager).validateUserAndRole(user, session.getPassword(), roles, checkType, bareAddress.toString(), session.getRemotingConnection(), session.getSecurityDomain()) != null;
          } else if (securityManager instanceof ActiveMQSecurityManager3) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/ActiveMQJAASSecurityManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/ActiveMQJAASSecurityManager.java
@@ -113,7 +113,8 @@ public class ActiveMQJAASSecurityManager implements ActiveMQSecurityManager5 {
    @Override
    public boolean authorize(final Subject subject,
                             final Set<Role> roles,
-                            final CheckType checkType) {
+                            final CheckType checkType,
+                            final String address) {
       boolean authorized = false;
 
       if (subject != null) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/ActiveMQSecurityManager5.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/ActiveMQSecurityManager5.java
@@ -42,7 +42,7 @@ public interface ActiveMQSecurityManager5 extends ActiveMQSecurityManager {
     * @param password the user's password
     * @param remotingConnection the user's connection which contains any corresponding SSL certs
     * @param securityDomain the name of the JAAS security domain to use (can be null)
-    * @return the Subject of the authenticated user or null if the user isn't authenticated
+    * @return the Subject of the authenticated user, else null
     */
    Subject authenticate(String user, String password, RemotingConnection remotingConnection, String securityDomain);
 
@@ -55,7 +55,8 @@ public interface ActiveMQSecurityManager5 extends ActiveMQSecurityManager {
     * @param subject    the Subject to authorize
     * @param roles      the roles configured in the security-settings
     * @param checkType  which permission to validate
+    * @param address    the address (or FQQN) to grant access to
     * @return true if the user is authorized, else false
     */
-   boolean authorize(Subject subject, Set<Role> roles, CheckType checkType);
+   boolean authorize(Subject subject, Set<Role> roles, CheckType checkType, String address);
 }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/security/jaas/JAASSecurityManagerTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/security/jaas/JAASSecurityManagerTest.java
@@ -92,7 +92,7 @@ public class JAASSecurityManagerTest {
          Role role = new Role("programmers", true, true, true, true, true, true, true, true, true, true);
          Set<Role> roles = new HashSet<>();
          roles.add(role);
-         boolean authorizationResult = securityManager.authorize(result, roles, CheckType.SEND);
+         boolean authorizationResult = securityManager.authorize(result, roles, CheckType.SEND, "someaddress");
 
          assertTrue(authorizationResult);
 

--- a/examples/features/standard/security-manager/src/main/java/org/apache/activemq/artemis/jms/example/JAASSecurityManagerWrapper.java
+++ b/examples/features/standard/security-manager/src/main/java/org/apache/activemq/artemis/jms/example/JAASSecurityManagerWrapper.java
@@ -33,16 +33,17 @@ public class JAASSecurityManagerWrapper implements ActiveMQSecurityManager5 {
 
    @Override
    public Subject authenticate(String user, String password, RemotingConnection remotingConnection, String securityDomain) {
-      System.out.println("authenticate(" + user + ", " + password + ", " + remotingConnection.getRemoteAddress() + ")");
+      System.out.println("authenticate(" + user + ", " + password + ", " + remotingConnection.getRemoteAddress() + ", " + securityDomain + ")");
       return activeMQJAASSecurityManager.authenticate(user, password, remotingConnection, securityDomain);
    }
 
    @Override
    public boolean authorize(Subject subject,
                             Set<Role> roles,
-                            CheckType checkType) {
-      System.out.println("authorize(" + subject + ", " + roles + ", " + checkType + ")");
-      return activeMQJAASSecurityManager.authorize(subject, roles, checkType);
+                            CheckType checkType,
+                            String address) {
+      System.out.println("authorize(" + subject + ", " + roles + ", " + checkType + ", " + address + ")");
+      return activeMQJAASSecurityManager.authorize(subject, roles, checkType, address);
    }
 
    @Override


### PR DESCRIPTION
The default JAAS security manager doesn't need the address/FQQN for
authorization, but I'm putting it back into the interface because there
are other use cases which *do* need it.