### PR TITLE
ARTEMIS-2875 - Failed to handle re-establish connection failover

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionFactoryImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionFactoryImpl.java
@@ -632,7 +632,21 @@ public class ClientSessionFactoryImpl implements ClientSessionFactoryInternal, C
 
                connector = null;
 
-               reconnectSessions(oldConnection, reconnectAttempts, me);
+               boolean allSessionReconnected;
+               int failedReconnectSessionsCounter = 0;
+               do {
+                  allSessionReconnected = reconnectSessions(oldConnection, reconnectAttempts, me);
+                  if (oldConnection != null) {
+                     oldConnection.destroy();
+                  }
+
+                  if (!allSessionReconnected) {
+                     failedReconnectSessionsCounter++;
+                     oldConnection = connection;
+                     connection = null;
+                  }
+               }
+               while ((reconnectAttempts == -1 || failedReconnectSessionsCounter < reconnectAttempts) && !allSessionReconnected);
 
                if (oldConnection != null) {
                   oldConnection.destroy();
@@ -750,7 +764,7 @@ public class ClientSessionFactoryImpl implements ClientSessionFactoryInternal, C
    /*
     * Re-attach sessions all pre-existing sessions to the new remoting connection
     */
-   private void reconnectSessions(final RemotingConnection oldConnection,
+   private boolean reconnectSessions(final RemotingConnection oldConnection,
                                   final int reconnectAttempts,
                                   final ActiveMQException cause) {
       HashSet<ClientSessionInternal> sessionsToFailover;
@@ -768,7 +782,7 @@ public class ClientSessionFactoryImpl implements ClientSessionFactoryInternal, C
          if (!clientProtocolManager.isAlive())
             ActiveMQClientLogger.LOGGER.failedToConnectToServer();
 
-         return;
+         return true;
       }
 
       List<FailureListener> oldListeners = oldConnection.getFailureListeners();
@@ -790,11 +804,11 @@ public class ClientSessionFactoryImpl implements ClientSessionFactoryInternal, C
 
       for (ClientSessionInternal session : sessionsToFailover) {
          if (!session.handleFailover(connection, cause)) {
-            connection.destroy();
-            this.connection = null;
-            return;
+            return false;
          }
       }
+
+      return true;
    }
 
    private void getConnectionWithRetry(final int reconnectAttempts, RemotingConnection oldConnection) {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/remoting/ReconnectTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/remoting/ReconnectTest.java
@@ -361,7 +361,7 @@ public class ReconnectTest extends ActiveMQTestBase {
 
       final long retryInterval = 50;
       final double retryMultiplier = 1d;
-      final int reconnectAttempts = 10;
+      final int reconnectAttempts = 1;
       ServerLocator locator = createFactory(true).setCallTimeout(2000).setRetryInterval(retryInterval).setRetryIntervalMultiplier(retryMultiplier).setReconnectAttempts(reconnectAttempts).setConfirmationWindowSize(-1);
       ClientSessionFactoryInternal sf = (ClientSessionFactoryInternal) createSessionFactory(locator);
       final CountDownLatch latch = new CountDownLatch(1);


### PR DESCRIPTION
While handling a re-establish connection on failover it can happen that the client can connect to the broker and re-establish a connection, but while reattaching all sessions to the new connection another connection loss can happen and there the failover fails without any possibility to recover on its own.