### PR TITLE
NO-JIRA: web-server.md documentation typos

### DIFF
--- a/docs/user-manual/en/web-server.md
+++ b/docs/user-manual/en/web-server.md
@@ -30,15 +30,15 @@ The `web` element has the following attributes:
 - `clientAuth` Whether or not clients should present an SSL certificate when
   they connect. Only applicable when using `https`.
 - `passwordCodec` The custom coded to use for unmasking the `keystorePassword`
-  and `truststorePassword`.
-- `keystorePath` The location on disk of the keystore. Only applicable when
+  and `trustStorePassword`.
+- `keyStorePath` The location on disk of the keystore. Only applicable when
   using `https`.
-- `keystorePassword` The password to the keystore. Only applicable when using
+- `keyStorePassword` The password to the keystore. Only applicable when using
   `https`. Can be masked using `ENC()` syntax or by defining `passwordCodec`.
   See more in the [password masking](masking-passwords.md) chapter.
-- `truststorePath` The location on disk fo the truststore. Only applicable when
+- `trustStorePath` The location on disk for the truststore. Only applicable when
   using `https`.
-- `truststorePassword` The password to the truststore. Only applicable when
+- `trustStorePassword` The password to the truststore. Only applicable when
   using `https`. Can be masked using `ENC()` syntax or by defining
   `passwordCodec`. See more in the [password masking](masking-passwords.md)
   chapter.


### PR DESCRIPTION
Fixing case for `trustStorePath`, `trustStorePassword`, `keyStorePath`
and `keyStorePassword` to prevent org.xml.sax.SAXParseException.

The sax parser does not like the case as mentioned in the documentation for web-server.md. Using the lower case `s` in store results in these exceptions:
* `[org.xml.sax.SAXParseException; lineNumber: 39; columnNumber: 5; cvc-complex-type.3.2.2: Attribute 'keystorePath' is not allowed to appear in element 'web'.]`
* `[org.xml.sax.SAXParseException; lineNumber: 39; columnNumber: 5; cvc-complex-type.3.2.2: Attribute 'keystorePassword' is not allowed to appear in element 'web'.]`
* `[org.xml.sax.SAXParseException; lineNumber: 39; columnNumber: 5; cvc-complex-type.3.2.2: Attribute 'truststorePath' is not allowed to appear in element 'web'.]`
* `[org.xml.sax.SAXParseException; lineNumber: 39; columnNumber: 5; cvc-complex-type.3.2.2: Attribute 'truststorePassword' is not allowed to appear in element 'web'.]`

Occurs in releases `2.13.0`, `2.14.0` and `2.15.0`