### PR TITLE
ARTEMIS-2910: reuse routing type value for fixed-address producers

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPSessionCallback.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPSessionCallback.java
@@ -466,9 +466,11 @@ public class AMQPSessionCallback implements SessionCallback {
 
       RoutingType routingType = null;
       if (address != null) {
+         // Fixed-address producer
          message.setAddress(address);
+         routingType = context.getDefRoutingType();
       } else {
-         // Anonymous relay must set a To value
+         // Anonymous-relay producer, message must carry a To value
          address = message.getAddressSimpleString();
          if (address == null) {
             // Errors are not currently handled as required by AMQP 1.0 anonterm-v1.0
@@ -477,13 +479,12 @@ public class AMQPSessionCallback implements SessionCallback {
          }
 
          routingType = message.getRoutingType();
+         if (routingType == null) {
+            routingType = context.getRoutingType(receiver, address);
+         }
       }
 
       //here check queue-autocreation
-      if (routingType == null) {
-         routingType = context.getRoutingType(receiver, address);
-      }
-
       if (!checkAddressAndAutocreateIfPossible(address, routingType)) {
          throw ActiveMQAMQPProtocolMessageBundle.BUNDLE.addressDoesntExist();
       }


### PR DESCRIPTION
Followup for #3269 after reading my own PR comments from an old JIRA (ARTEMIS 1859). The routing type for fixed-address producers is determined while they are initialised, but the value is then evaluated again upon every message arrival even though it will be the same. Update things to reuse the value determined for these fixed-producers, only do the evaluation on arrival for anonymous-producers if the message didnt convey any detail itself (as in the previous PR).