### PR TITLE
ARTEMIS-2823 Use datasource with JDBC store db connections fixes

### DIFF
--- a/artemis-distribution/src/main/assembly/dep.xml
+++ b/artemis-distribution/src/main/assembly/dep.xml
@@ -83,6 +83,8 @@
             <include>org.jboss.logging:jboss-logging</include>
             <include>org.jboss.slf4j:slf4j-jboss-logmanager</include>
             <include>org.jctools:jctools-core</include>
+            <include>org.apache.commons:commons-dbcp2</include>
+            <include>org.apache.commons:commons-pool2</include>
             <include>io.netty:netty-all</include>
             <include>org.apache.qpid:proton-j</include>
             <include>org.apache.activemq:activemq-client</include>

--- a/artemis-features/src/main/resources/features.xml
+++ b/artemis-features/src/main/resources/features.xml
@@ -72,6 +72,8 @@
 		<bundle dependency="true">mvn:org.apache.commons/commons-lang3/${commons.lang.version}</bundle>
 		<bundle dependency="true">mvn:org.jctools/jctools-core/${jctools.version}</bundle>
 		<bundle dependency="true">mvn:com.google.guava/guava/${guava.version}</bundle>
+		<bundle dependency="true">mvn:org.apache.commons/commons-dbcp2/${commons.dbcp2.version}</bundle>
+		<bundle dependency="true">mvn:org.apache.commons/commons-pool2/${commons.dbcp2.version}</bundle>
 		<!-- Micrometer can't be included until it supports OSGi. It is currently an "optional" Maven dependency. -->
 		<!--bundle dependency="true">mvn:io.micrometer/micrometer-core/${version.micrometer}</bundle-->
 

--- a/artemis-jdbc-store/pom.xml
+++ b/artemis-jdbc-store/pom.xml
@@ -85,7 +85,6 @@
       <dependency>
          <groupId>org.apache.commons</groupId>
          <artifactId>commons-dbcp2</artifactId>
-         <version>2.1.1</version>
       </dependency>
 
       <!-- Database driver support -->

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/storage/DatabaseStorageConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/storage/DatabaseStorageConfiguration.java
@@ -17,15 +17,15 @@
 package org.apache.activemq.artemis.core.config.storage;
 
 import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executor;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.core.config.StoreConfiguration;
 import org.apache.activemq.artemis.jdbc.store.drivers.JDBCConnectionProvider;
 import org.apache.activemq.artemis.jdbc.store.drivers.JDBCDataSourceUtils;
 import org.apache.activemq.artemis.jdbc.store.sql.SQLProvider;
-
-import java.util.HashMap;
-import java.util.Map;
 
 public class DatabaseStorageConfiguration implements StoreConfiguration {
 
@@ -183,6 +183,19 @@ public class DatabaseStorageConfiguration implements StoreConfiguration {
       }
       return connectionProvider;
    }
+
+   public DatabaseStorageConfiguration setConnectionProviderNetworkTimeout(Executor executor, int ms) {
+      getConnectionProvider().setNetworkTimeout(executor, ms);
+      return this;
+   }
+
+   public DatabaseStorageConfiguration clearConnectionProviderNetworkTimeout() {
+      if (connectionProvider != null) {
+         connectionProvider.setNetworkTimeout(null, -1);
+      }
+      return this;
+   }
+
    public void addDataSourceProperty(String key, String value) {
       if (value.toLowerCase().equals("true") || value.toLowerCase().equals("false")) {
          dataSourceProperties.put(key, Boolean.parseBoolean(value.toLowerCase()));

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -1746,7 +1746,6 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
             conf.addDataSourceProperty(propertyNode.getAttributeNode("key").getValue(), propertyNode.getAttributeNode("value").getValue());
          }
       }
-      //conf.initDataSource();
 
       return conf;
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JDBCJournalStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JDBCJournalStorageManager.java
@@ -57,10 +57,6 @@ public class JDBCJournalStorageManager extends JournalStorageManager {
       try {
          final DatabaseStorageConfiguration dbConf = (DatabaseStorageConfiguration) config.getStoreConfiguration();
          final JDBCConnectionProvider connectionProvider = dbConf.getConnectionProvider();
-         final int networkTimeout = dbConf.getJdbcNetworkTimeout();
-         if (networkTimeout >= 0) {
-            connectionProvider.setNetworkTimeout(executorFactory.getExecutor(), networkTimeout);
-         }
          final JDBCJournalImpl bindingsJournal;
          final JDBCJournalImpl messageJournal;
          final JDBCSequentialFileFactory largeMessagesFactory;

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
       <activemq5-version>5.14.5</activemq5-version>
       <apache.derby.version>10.11.1.1</apache.derby.version>
       <commons.beanutils.version>1.9.4</commons.beanutils.version>
+      <commons.dbcp2.version>2.7.0</commons.dbcp2.version>
       <commons.collections.version>3.2.2</commons.collections.version>
       <commons.text.version>1.8</commons.text.version>
       <fuse.mqtt.client.version>1.16</fuse.mqtt.client.version>
@@ -751,7 +752,16 @@
          <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-dbcp2</artifactId>
-            <version>2.1.1</version>
+            <version>${commons.dbcp2.version}</version>
+            <!-- license Apache 2 -->
+         </dependency>
+         <!-- used by commons-dbcp2 -->
+         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-pool2</artifactId>
+            <version>${commons.dbcp2.version}</version>
+            <!-- license Apache 2 -->
+            <scope>runtime</scope>
          </dependency>
 
          <!-- Needed for Micrometer -->

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jdbc/store/journal/JDBCJournalTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jdbc/store/journal/JDBCJournalTest.java
@@ -116,6 +116,8 @@ public class JDBCJournalTest extends ActiveMQTestBase {
       if (useAuthentication) {
          System.setProperty("derby.connection.requireAuthentication", "true");
          System.setProperty("derby.user." + getJdbcUser(), getJdbcPassword());
+         dbConf.setJdbcUser(getJdbcUser());
+         dbConf.setJdbcPassword(getJdbcPassword());
       }
       sqlProvider = JDBCUtils.getSQLProvider(
          dbConf.getJdbcDriverClassName(),


### PR DESCRIPTION
It add additional required fixes:
- Fixed uncommitted deleted tx records
- Fixed JDBC authorization on test
- Using property-based version for commons-dbcp2
- stopping thread pool after activation to allow JDBC lease locks to release the lock
- centralize JDBC network timeout configuration and save repeating it
- adding dbcp2 as the default pooled DataSource to be used