### PR TITLE
ARTEMIS-2918 Support Server restart on I/O errors

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
@@ -495,6 +495,8 @@ public final class ActiveMQDefaultConfiguration {
 
    public static final int DEFAULT_MAX_DISK_USAGE;
 
+   public static final boolean DEFAULT_RESTART_ALLOWED = false;
+
    static {
       int maxDisk;
       try {
@@ -777,6 +779,13 @@ public final class ActiveMQDefaultConfiguration {
     */
    public static Boolean isDefaultMaskPassword() {
       return DEFAULT_MASK_PASSWORD;
+   }
+
+   /**
+    * This option controls whether the server is allowed to restart itself in case of I/O failures.
+    */
+   public static boolean isDefaultRestartAllowed() {
+      return DEFAULT_RESTART_ALLOWED;
    }
 
    /**

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
@@ -105,6 +105,9 @@ public interface Configuration {
 
    Configuration setCriticalAnalyzerPolicy(CriticalAnalyzerPolicy policy);
 
+   Configuration setRestartAllowed(boolean value);
+
+   boolean isRestartAllowed();
 
    /**
     * Returns whether this server is clustered. <br>

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
@@ -346,6 +346,8 @@ public class ConfigurationImpl implements Configuration, Serializable {
 
    private CriticalAnalyzerPolicy criticalAnalyzerPolicy = ActiveMQDefaultConfiguration.getCriticalAnalyzerPolicy();
 
+   private boolean restartAllowed = ActiveMQDefaultConfiguration.isDefaultRestartAllowed();
+
    private long criticalAnalyzerTimeout = ActiveMQDefaultConfiguration.getCriticalAnalyzerTimeout();
 
    private long criticalAnalyzerCheckPeriod = 0; // non set
@@ -2452,6 +2454,17 @@ public class ConfigurationImpl implements Configuration, Serializable {
    @Override
    public Configuration setCriticalAnalyzerPolicy(CriticalAnalyzerPolicy policy) {
       this.criticalAnalyzerPolicy = policy;
+      return this;
+   }
+
+   @Override
+   public boolean isRestartAllowed() {
+      return restartAllowed;
+   }
+
+   @Override
+   public Configuration setRestartAllowed(boolean value) {
+      restartAllowed = value;
       return this;
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -630,6 +630,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
          }
       }
 
+      config.setRestartAllowed(getBoolean(e, "restart-allowed", config.isRestartAllowed()));
+
       config.setJournalDatasync(getBoolean(e, "journal-datasync", config.isJournalDatasync()));
 
       config.setJournalSyncTransactional(getBoolean(e, "journal-sync-transactional", config.isJournalSyncTransactional()));

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -509,6 +509,10 @@ public interface ActiveMQServerLogger extends BasicLogger {
    void errorStoppingReplication(@Cause Exception e);
 
    @LogMessage(level = Logger.Level.WARN)
+   @Message(id = 222015, value = "Error restarting server: stopping forever", format = Message.Format.MESSAGE_FORMAT)
+   void errorRestartingServer(@Cause Throwable e);
+
+   @LogMessage(level = Logger.Level.WARN)
    @Message(id = 222016, value = "Cannot deploy a connector with no name specified.", format = Message.Format.MESSAGE_FORMAT)
    void connectorWithNoName();
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/NodeManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/NodeManager.java
@@ -16,52 +16,55 @@
  */
 package org.apache.activemq.artemis.core.server;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
 
-import org.apache.activemq.artemis.api.core.ActiveMQIllegalStateException;
 import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.server.impl.FileLockNodeManager;
 import org.apache.activemq.artemis.utils.UUID;
-import org.apache.activemq.artemis.utils.UUIDGenerator;
+import org.jboss.logging.Logger;
 
 public abstract class NodeManager implements ActiveMQComponent {
 
-   protected static final byte FIRST_TIME_START = '0';
-   public static final String SERVER_LOCK_NAME = "server.lock";
-   private static final String ACCESS_MODE = "rw";
+   @FunctionalInterface
+   public interface LockListener {
 
+      void lostLock();
+   }
+
+   private static final Logger LOGGER = Logger.getLogger(NodeManager.class);
    protected final boolean replicatedBackup;
-   private final File directory;
-   private final Object nodeIDGuard = new Object();
+   protected final Object nodeIDGuard = new Object();
    private SimpleString nodeID;
    private UUID uuid;
    private boolean isStarted = false;
+   private final Set<FileLockNodeManager.LockListener> lockListeners;
 
-   protected FileChannel channel;
-
-   public NodeManager(final boolean replicatedBackup, final File directory) {
-      this.directory = directory;
+   public NodeManager(final boolean replicatedBackup) {
       this.replicatedBackup = replicatedBackup;
+      this.lockListeners = new HashSet<>();
    }
 
    // --------------------------------------------------------------------
 
-   public abstract void awaitLiveNode() throws Exception;
+   public abstract void awaitLiveNode() throws NodeManagerException, InterruptedException;
 
-   public abstract void awaitLiveStatus() throws Exception;
+   public abstract void awaitLiveStatus() throws NodeManagerException, InterruptedException;
 
-   public abstract void startBackup() throws Exception;
+   public abstract void startBackup() throws NodeManagerException, InterruptedException;
 
-   public abstract ActivateCallback startLiveNode() throws Exception;
+   public abstract ActivateCallback startLiveNode() throws NodeManagerException, InterruptedException;
 
-   public abstract void pauseLiveServer() throws Exception;
+   public abstract void pauseLiveServer() throws NodeManagerException;
 
-   public abstract void crashLiveServer() throws Exception;
+   public abstract void crashLiveServer() throws NodeManagerException;
 
-   public abstract void releaseBackup() throws Exception;
+   public abstract void releaseBackup() throws NodeManagerException;
+
+   public Duration lingerTimeBeforeRestart() {
+      return Duration.ZERO;
+   }
 
    // --------------------------------------------------------------------
 
@@ -81,7 +84,7 @@ public abstract class NodeManager implements ActiveMQComponent {
       }
    }
 
-   public abstract SimpleString readNodeId() throws ActiveMQIllegalStateException, IOException;
+   public abstract SimpleString readNodeId() throws NodeManagerException;
 
    public UUID getUUID() {
       synchronized (nodeIDGuard) {
@@ -113,119 +116,63 @@ public abstract class NodeManager implements ActiveMQComponent {
       }
    }
 
-   public abstract boolean isAwaitingFailback() throws Exception;
+   public abstract boolean isAwaitingFailback() throws NodeManagerException;
 
-   public abstract boolean isBackupLive() throws Exception;
+   public abstract boolean isBackupLive() throws NodeManagerException;
 
    public abstract void interrupt();
 
    @Override
    public synchronized void stop() throws Exception {
-      FileChannel channelCopy = channel;
-      if (channelCopy != null)
-         channelCopy.close();
+      // force any running threads on node manager to stop
       isStarted = false;
+      lockListeners.clear();
    }
 
-   public void stopBackup() throws Exception {
-      if (replicatedBackup && getNodeId() != null) {
-         setUpServerLockFile();
-      }
+   public void stopBackup() throws NodeManagerException {
       releaseBackup();
    }
 
-   /**
-    * Ensures existence of persistent information about the server's nodeID.
-    * <p>
-    * Roughly the different use cases are:
-    * <ol>
-    * <li>old live server restarts: a server.lock file already exists and contains a nodeID.
-    * <li>new live server starting for the first time: no file exists, and we just *create* a new
-    * UUID to use as nodeID
-    * <li>replicated backup received its nodeID from its live: no file exists, we need to persist
-    * the *current* nodeID
-    * </ol>
-    */
-   protected synchronized void setUpServerLockFile() throws IOException {
-      File serverLockFile = newFile(SERVER_LOCK_NAME);
+   protected synchronized void checkStarted() {
+      if (!isStarted) {
+         throw new IllegalStateException("the node manager is supposed to be started");
+      }
+   }
 
-      boolean fileCreated = false;
-
-      int count = 0;
-      while (!serverLockFile.exists()) {
+   protected synchronized void notifyLostLock() {
+      if (!isStarted) {
+         return;
+      }
+      lockListeners.forEach(lockListener -> {
          try {
-            fileCreated = serverLockFile.createNewFile();
-         } catch (RuntimeException e) {
-            ActiveMQServerLogger.LOGGER.nodeManagerCantOpenFile(e, serverLockFile);
-            throw e;
-         } catch (IOException e) {
-            /*
-            * on some OS's this may fail weirdly even tho the parent dir exists, retrying will work, some weird timing issue i think
-            * */
-            if (count < 5) {
-               try {
-                  Thread.sleep(100);
-               } catch (InterruptedException e1) {
-               }
-               count++;
-               continue;
-            }
-            ActiveMQServerLogger.LOGGER.nodeManagerCantOpenFile(e, serverLockFile);
-            throw e;
+            lockListener.lostLock();
+         } catch (Exception e) {
+            LOGGER.warn("On notify lost lock", e);
+            // Need to notify everyone so ignore any exception
          }
-      }
-
-      @SuppressWarnings("resource")
-      RandomAccessFile raFile = new RandomAccessFile(serverLockFile, ACCESS_MODE);
-
-      channel = raFile.getChannel();
-
-      if (fileCreated) {
-         ByteBuffer id = ByteBuffer.allocateDirect(3);
-         byte[] bytes = new byte[3];
-         bytes[0] = FIRST_TIME_START;
-         bytes[1] = FIRST_TIME_START;
-         bytes[2] = FIRST_TIME_START;
-         id.put(bytes, 0, 3);
-         id.position(0);
-         channel.write(id, 0);
-         channel.force(true);
-      }
-
-      createNodeId();
+      });
    }
 
-   /**
-    * @return
-    */
-   protected final File newFile(final String fileName) {
-      File file = new File(directory, fileName);
-      return file;
+   public synchronized void registerLockListener(FileLockNodeManager.LockListener lockListener) {
+      lockListeners.add(lockListener);
    }
 
-   protected final synchronized void createNodeId() throws IOException {
-      synchronized (nodeIDGuard) {
-         ByteBuffer id = ByteBuffer.allocateDirect(16);
-         int read = channel.read(id, 3);
-         if (replicatedBackup) {
-            id.position(0);
-            id.put(getUUID().asBytes(), 0, 16);
-            id.position(0);
-            channel.write(id, 3);
-            channel.force(true);
-         } else if (read != 16) {
-            setUUID(UUIDGenerator.getInstance().generateUUID());
-            id.put(getUUID().asBytes(), 0, 16);
-            id.position(0);
-            channel.write(id, 3);
-            channel.force(true);
-         } else {
-            byte[] bytes = new byte[16];
-            id.position(0);
-            id.get(bytes);
-            setUUID(new UUID(UUID.TYPE_TIME_BASED, bytes));
-         }
+   public synchronized void unregisterLockListener(FileLockNodeManager.LockListener lockListener) {
+      lockListeners.remove(lockListener);
+   }
+
+   public static final class NodeManagerException extends RuntimeException {
+
+      public NodeManagerException(String message) {
+         super(message);
+      }
+
+      public NodeManagerException(Throwable cause) {
+         super(cause);
+      }
+
+      public NodeManagerException(String message, Throwable cause) {
+         super(message, cause);
       }
    }
-
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ha/ColocatedPolicy.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ha/ColocatedPolicy.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
+import org.apache.activemq.artemis.core.io.IOCriticalErrorListener;
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl;
 import org.apache.activemq.artemis.core.server.impl.ColocatedActivation;
 import org.apache.activemq.artemis.core.server.impl.LiveActivation;
@@ -91,8 +92,8 @@ public class ColocatedPolicy implements HAPolicy<LiveActivation> {
    public LiveActivation createActivation(ActiveMQServerImpl server,
                                           boolean wasLive,
                                           Map<String, Object> activationParams,
-                                          ActiveMQServerImpl.ShutdownOnCriticalErrorListener shutdownOnCriticalIO) throws Exception {
-      return new ColocatedActivation(server, this, livePolicy.createActivation(server, wasLive, activationParams, shutdownOnCriticalIO));
+                                          IOCriticalErrorListener ioCriticalErrorListener) throws Exception {
+      return new ColocatedActivation(server, this, livePolicy.createActivation(server, wasLive, activationParams, ioCriticalErrorListener));
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ha/HAPolicy.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ha/HAPolicy.java
@@ -19,6 +19,7 @@ package org.apache.activemq.artemis.core.server.cluster.ha;
 import java.util.Map;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
+import org.apache.activemq.artemis.core.io.IOCriticalErrorListener;
 import org.apache.activemq.artemis.core.server.impl.Activation;
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl;
 
@@ -34,7 +35,7 @@ public interface HAPolicy<T extends Activation> {
    T createActivation(ActiveMQServerImpl server,
                       boolean wasLive,
                       Map<String, Object> activationParams,
-                      ActiveMQServerImpl.ShutdownOnCriticalErrorListener shutdownOnCriticalIO) throws Exception;
+                      IOCriticalErrorListener shutdownOnCriticalIO) throws Exception;
 
    boolean isSharedStore();
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ha/LiveOnlyPolicy.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ha/LiveOnlyPolicy.java
@@ -18,6 +18,7 @@ package org.apache.activemq.artemis.core.server.cluster.ha;
 
 import java.util.Map;
 
+import org.apache.activemq.artemis.core.io.IOCriticalErrorListener;
 import org.apache.activemq.artemis.core.server.impl.Activation;
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl;
 import org.apache.activemq.artemis.core.server.impl.LiveOnlyActivation;
@@ -37,7 +38,7 @@ public class LiveOnlyPolicy implements HAPolicy<Activation> {
    public Activation createActivation(ActiveMQServerImpl server,
                                       boolean wasLive,
                                       Map<String, Object> activationParams,
-                                      ActiveMQServerImpl.ShutdownOnCriticalErrorListener shutdownOnCriticalIO) {
+                                      IOCriticalErrorListener ioCriticalErrorListener) {
       return new LiveOnlyActivation(server, this);
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ha/ReplicaPolicy.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ha/ReplicaPolicy.java
@@ -19,6 +19,7 @@ package org.apache.activemq.artemis.core.server.cluster.ha;
 import java.util.Map;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
+import org.apache.activemq.artemis.core.io.IOCriticalErrorListener;
 import org.apache.activemq.artemis.core.server.NetworkHealthCheck;
 import org.apache.activemq.artemis.core.server.impl.Activation;
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl;
@@ -211,8 +212,8 @@ public class ReplicaPolicy extends BackupPolicy {
    public Activation createActivation(ActiveMQServerImpl server,
                                       boolean wasLive,
                                       Map<String, Object> activationParams,
-                                      ActiveMQServerImpl.ShutdownOnCriticalErrorListener shutdownOnCriticalIO) throws Exception {
-      SharedNothingBackupActivation backupActivation = new SharedNothingBackupActivation(server, wasLive, activationParams, shutdownOnCriticalIO, this, networkHealthCheck);
+                                      IOCriticalErrorListener ioCriticalErrorListener) throws Exception {
+      SharedNothingBackupActivation backupActivation = new SharedNothingBackupActivation(server, wasLive, activationParams, ioCriticalErrorListener, this, networkHealthCheck);
       backupActivation.init();
       return backupActivation;
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ha/ReplicatedPolicy.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ha/ReplicatedPolicy.java
@@ -19,6 +19,7 @@ package org.apache.activemq.artemis.core.server.cluster.ha;
 import java.util.Map;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
+import org.apache.activemq.artemis.core.io.IOCriticalErrorListener;
 import org.apache.activemq.artemis.core.server.NetworkHealthCheck;
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl;
 import org.apache.activemq.artemis.core.server.impl.LiveActivation;
@@ -231,7 +232,7 @@ public class ReplicatedPolicy implements HAPolicy<LiveActivation> {
    public LiveActivation createActivation(ActiveMQServerImpl server,
                                           boolean wasLive,
                                           Map<String, Object> activationParams,
-                                          ActiveMQServerImpl.ShutdownOnCriticalErrorListener shutdownOnCriticalIO) {
+                                          IOCriticalErrorListener ioCriticalErrorListener) {
       return new SharedNothingLiveActivation(server, this);
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ha/SharedStoreMasterPolicy.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ha/SharedStoreMasterPolicy.java
@@ -19,6 +19,7 @@ package org.apache.activemq.artemis.core.server.cluster.ha;
 import java.util.Map;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
+import org.apache.activemq.artemis.core.io.IOCriticalErrorListener;
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl;
 import org.apache.activemq.artemis.core.server.impl.LiveActivation;
 import org.apache.activemq.artemis.core.server.impl.SharedStoreLiveActivation;
@@ -91,8 +92,8 @@ public class SharedStoreMasterPolicy implements HAPolicy<LiveActivation> {
    public LiveActivation createActivation(ActiveMQServerImpl server,
                                           boolean wasLive,
                                           Map<String, Object> activationParams,
-                                          ActiveMQServerImpl.ShutdownOnCriticalErrorListener shutdownOnCriticalIO) {
-      return new SharedStoreLiveActivation(server, this);
+                                          IOCriticalErrorListener ioCriticalErrorListener) {
+      return new SharedStoreLiveActivation(server, this, ioCriticalErrorListener);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ha/SharedStoreSlavePolicy.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ha/SharedStoreSlavePolicy.java
@@ -19,6 +19,7 @@ package org.apache.activemq.artemis.core.server.cluster.ha;
 import java.util.Map;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
+import org.apache.activemq.artemis.core.io.IOCriticalErrorListener;
 import org.apache.activemq.artemis.core.server.impl.Activation;
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl;
 import org.apache.activemq.artemis.core.server.impl.SharedStoreBackupActivation;
@@ -101,8 +102,8 @@ public class SharedStoreSlavePolicy extends BackupPolicy {
    public Activation createActivation(ActiveMQServerImpl server,
                                       boolean wasLive,
                                       Map<String, Object> activationParams,
-                                      ActiveMQServerImpl.ShutdownOnCriticalErrorListener shutdownOnCriticalIO) {
-      return new SharedStoreBackupActivation(server, this);
+                                      IOCriticalErrorListener ioCriticalErrorListener) {
+      return new SharedStoreBackupActivation(server, this, ioCriticalErrorListener);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/FileBasedNodeManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/FileBasedNodeManager.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.server.impl;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+
+import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
+import org.apache.activemq.artemis.core.server.NodeManager;
+import org.apache.activemq.artemis.utils.UUID;
+import org.apache.activemq.artemis.utils.UUIDGenerator;
+
+public abstract class FileBasedNodeManager extends NodeManager {
+
+   protected static final byte FIRST_TIME_START = '0';
+   public static final String SERVER_LOCK_NAME = "server.lock";
+   private static final String ACCESS_MODE = "rw";
+   private final File directory;
+   protected FileChannel channel;
+
+   public FileBasedNodeManager(boolean replicatedBackup, File directory) {
+      super(replicatedBackup);
+      this.directory = directory;
+   }
+
+   /**
+    * Ensures existence of persistent information about the server's nodeID.
+    * <p>
+    * Roughly the different use cases are:
+    * <ol>
+    * <li>old live server restarts: a server.lock file already exists and contains a nodeID.
+    * <li>new live server starting for the first time: no file exists, and we just *create* a new
+    * UUID to use as nodeID
+    * <li>replicated backup received its nodeID from its live: no file exists, we need to persist
+    * the *current* nodeID
+    * </ol>
+    */
+   protected synchronized void setUpServerLockFile() throws IOException {
+      File serverLockFile = newFile(SERVER_LOCK_NAME);
+
+      boolean fileCreated = false;
+
+      int count = 0;
+      while (!serverLockFile.exists()) {
+         try {
+            fileCreated = serverLockFile.createNewFile();
+         } catch (RuntimeException e) {
+            ActiveMQServerLogger.LOGGER.nodeManagerCantOpenFile(e, serverLockFile);
+            throw e;
+         } catch (IOException e) {
+            /*
+             * on some OS's this may fail weirdly even tho the parent dir exists, retrying will work, some weird timing issue i think
+             * */
+            if (count < 5) {
+               try {
+                  Thread.sleep(100);
+               } catch (InterruptedException e1) {
+               }
+               count++;
+               continue;
+            }
+            ActiveMQServerLogger.LOGGER.nodeManagerCantOpenFile(e, serverLockFile);
+            throw e;
+         }
+      }
+
+      @SuppressWarnings("resource")
+      RandomAccessFile raFile = new RandomAccessFile(serverLockFile, ACCESS_MODE);
+
+      channel = raFile.getChannel();
+
+      if (fileCreated) {
+         ByteBuffer id = ByteBuffer.allocateDirect(3);
+         byte[] bytes = new byte[3];
+         bytes[0] = FIRST_TIME_START;
+         bytes[1] = FIRST_TIME_START;
+         bytes[2] = FIRST_TIME_START;
+         id.put(bytes, 0, 3);
+         id.position(0);
+         channel.write(id, 0);
+         channel.force(true);
+      }
+
+      createNodeId();
+   }
+
+   /**
+    * @return
+    */
+   protected final File newFile(final String fileName) {
+      File file = new File(directory, fileName);
+      return file;
+   }
+
+   protected final synchronized void createNodeId() throws IOException {
+      synchronized (nodeIDGuard) {
+         ByteBuffer id = ByteBuffer.allocateDirect(16);
+         int read = channel.read(id, 3);
+         if (replicatedBackup) {
+            id.position(0);
+            id.put(getUUID().asBytes(), 0, 16);
+            id.position(0);
+            channel.write(id, 3);
+            channel.force(true);
+         } else if (read != 16) {
+            setUUID(UUIDGenerator.getInstance().generateUUID());
+            id.put(getUUID().asBytes(), 0, 16);
+            id.position(0);
+            channel.write(id, 3);
+            channel.force(true);
+         } else {
+            byte[] bytes = new byte[16];
+            id.position(0);
+            id.get(bytes);
+            setUUID(new UUID(UUID.TYPE_TIME_BASED, bytes));
+         }
+      }
+   }
+
+   @Override
+   public synchronized void stop() throws Exception {
+      FileChannel channelCopy = channel;
+      if (channelCopy != null)
+         channelCopy.close();
+      super.stop();
+   }
+
+   @Override
+   public void stopBackup() throws NodeManagerException {
+      if (replicatedBackup && getNodeId() != null) {
+         try {
+            setUpServerLockFile();
+         } catch (IOException e) {
+            throw new NodeManagerException(e);
+         }
+      }
+      super.stopBackup();
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/FileLockNodeManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/FileLockNodeManager.java
@@ -22,23 +22,18 @@ import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.activemq.artemis.api.core.ActiveMQIllegalStateException;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.server.ActivateCallback;
 import org.apache.activemq.artemis.core.server.ActiveMQLockAcquisitionTimeoutException;
 import org.apache.activemq.artemis.core.server.ActiveMQScheduledComponent;
 import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
-import org.apache.activemq.artemis.core.server.NodeManager;
 import org.apache.activemq.artemis.utils.UUID;
 import org.jboss.logging.Logger;
 
-public class FileLockNodeManager extends NodeManager {
+public class FileLockNodeManager extends FileBasedNodeManager {
 
    private static final Logger logger = Logger.getLogger(FileLockNodeManager.class);
 
@@ -58,9 +53,9 @@ public class FileLockNodeManager extends NodeManager {
 
    private static final byte NOT_STARTED = 'N';
 
-   private static final long LOCK_ACCESS_FAILURE_WAIT_TIME = 2000;
+   private static final long LOCK_ACCESS_FAILURE_WAIT_TIME_NANOS = TimeUnit.SECONDS.toNanos(2);
 
-   private static final int LOCK_MONITOR_TIMEOUT_MILLIES = 2000;
+   private static final long LOCK_MONITOR_TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(2);
 
    private volatile FileLock liveLock;
 
@@ -68,28 +63,31 @@ public class FileLockNodeManager extends NodeManager {
 
    private final FileChannel[] lockChannels = new FileChannel[3];
 
-   protected long lockAcquisitionTimeout = -1;
+   private final long lockAcquisitionTimeoutNanos;
 
    protected boolean interrupted = false;
 
-   private ScheduledExecutorService scheduledPool;
+   private final ScheduledExecutorService scheduledPool;
 
    public FileLockNodeManager(final File directory, boolean replicatedBackup, ScheduledExecutorService scheduledPool) {
       super(replicatedBackup, directory);
       this.scheduledPool = scheduledPool;
+      this.lockAcquisitionTimeoutNanos = -1;
    }
 
    public FileLockNodeManager(final File directory, boolean replicatedBackup) {
       super(replicatedBackup, directory);
       this.scheduledPool = null;
+      this.lockAcquisitionTimeoutNanos = -1;
    }
 
-   public FileLockNodeManager(final File directory, boolean replicatedBackup, long lockAcquisitionTimeout,
-         ScheduledExecutorService scheduledPool) {
+   public FileLockNodeManager(final File directory,
+                              boolean replicatedBackup,
+                              long lockAcquisitionTimeout,
+                              ScheduledExecutorService scheduledPool) {
       super(replicatedBackup, directory);
-
       this.scheduledPool = scheduledPool;
-      this.lockAcquisitionTimeout = lockAcquisitionTimeout;
+      this.lockAcquisitionTimeoutNanos = lockAcquisitionTimeout == -1 ? -1 : TimeUnit.MILLISECONDS.toNanos(lockAcquisitionTimeout);
    }
 
    @Override
@@ -141,19 +139,23 @@ public class FileLockNodeManager extends NodeManager {
    }
 
    @Override
-   public boolean isAwaitingFailback() throws Exception {
+   public boolean isAwaitingFailback() throws NodeManagerException {
       return getState() == FileLockNodeManager.FAILINGBACK;
    }
 
    @Override
-   public boolean isBackupLive() throws Exception {
-      FileLock liveAttemptLock;
-      liveAttemptLock = tryLock(FileLockNodeManager.LIVE_LOCK_POS);
-      if (liveAttemptLock == null) {
-         return true;
-      } else {
-         liveAttemptLock.release();
-         return false;
+   public boolean isBackupLive() throws NodeManagerException {
+      try {
+         FileLock liveAttemptLock;
+         liveAttemptLock = tryLock(FileLockNodeManager.LIVE_LOCK_POS);
+         if (liveAttemptLock == null) {
+            return true;
+         } else {
+            liveAttemptLock.release();
+            return false;
+         }
+      } catch (IOException e) {
+         throw new NodeManagerException(e);
       }
    }
 
@@ -167,182 +169,218 @@ public class FileLockNodeManager extends NodeManager {
    }
 
    @Override
-   public final void releaseBackup() throws Exception {
-      if (backupLock != null) {
-         backupLock.release();
-         backupLock = null;
+   public final void releaseBackup() throws NodeManagerException {
+      try {
+         if (backupLock != null) {
+            backupLock.release();
+            backupLock = null;
+         }
+      } catch (IOException e) {
+         throw new NodeManagerException(e);
       }
    }
 
    @Override
-   public void awaitLiveNode() throws Exception {
-      logger.debug("awaiting live node...");
-      do {
-         byte state = getState();
-         while (state == FileLockNodeManager.NOT_STARTED || state == FIRST_TIME_START) {
-            logger.debug("awaiting live node startup state='" + state + "'");
-            Thread.sleep(2000);
+   public void awaitLiveNode() throws NodeManagerException, InterruptedException {
+      try {
+         logger.debug("awaiting live node...");
+         do {
+            byte state = getState();
+            while (state == FileLockNodeManager.NOT_STARTED || state == FIRST_TIME_START) {
+               logger.debug("awaiting live node startup state='" + state + "'");
+               Thread.sleep(2000);
+               state = getState();
+            }
+
+            liveLock = lock(FileLockNodeManager.LIVE_LOCK_POS);
+            if (interrupted) {
+               interrupted = false;
+               throw new InterruptedException("Lock was interrupted");
+            }
             state = getState();
+            if (state == FileLockNodeManager.PAUSED) {
+               liveLock.release();
+               logger.debug("awaiting live node restarting");
+               Thread.sleep(2000);
+            } else if (state == FileLockNodeManager.FAILINGBACK) {
+               liveLock.release();
+               logger.debug("awaiting live node failing back");
+               Thread.sleep(2000);
+            } else if (state == FileLockNodeManager.LIVE) {
+               logger.debug("acquired live node lock state = " + (char) state);
+               break;
+            }
          }
-
-         liveLock = lock(FileLockNodeManager.LIVE_LOCK_POS);
-         if (interrupted) {
-            interrupted = false;
-            throw new InterruptedException("Lock was interrupted");
-         }
-         state = getState();
-         if (state == FileLockNodeManager.PAUSED) {
-            liveLock.release();
-            logger.debug("awaiting live node restarting");
-            Thread.sleep(2000);
-         } else if (state == FileLockNodeManager.FAILINGBACK) {
-            liveLock.release();
-            logger.debug("awaiting live node failing back");
-            Thread.sleep(2000);
-         } else if (state == FileLockNodeManager.LIVE) {
-            logger.debug("acquired live node lock state = " + (char) state);
-            break;
-         }
+         while (true);
+      } catch (IOException | ActiveMQLockAcquisitionTimeoutException e) {
+         throw new NodeManagerException(e);
       }
-      while (true);
    }
 
    @Override
-   public void startBackup() throws Exception {
+   public void startBackup() throws NodeManagerException, InterruptedException {
       assert !replicatedBackup; // should not be called if this is a replicating backup
       ActiveMQServerLogger.LOGGER.waitingToBecomeBackup();
-
-      backupLock = lock(FileLockNodeManager.BACKUP_LOCK_POS);
+      try {
+         backupLock = lock(FileLockNodeManager.BACKUP_LOCK_POS);
+      } catch (ActiveMQLockAcquisitionTimeoutException e) {
+         throw new NodeManagerException(e);
+      }
       ActiveMQServerLogger.LOGGER.gotBackupLock();
       if (getUUID() == null)
          readNodeId();
    }
 
    @Override
-   public ActivateCallback startLiveNode() throws Exception {
-      setFailingBack();
+   public ActivateCallback startLiveNode() throws NodeManagerException, InterruptedException {
+      try {
+         setFailingBack();
 
-      String timeoutMessage = lockAcquisitionTimeout == -1 ? "indefinitely" : lockAcquisitionTimeout + " milliseconds";
+         String timeoutMessage = lockAcquisitionTimeoutNanos == -1 ? "indefinitely" : TimeUnit.NANOSECONDS.toMillis(lockAcquisitionTimeoutNanos) + " milliseconds";
 
-      ActiveMQServerLogger.LOGGER.waitingToObtainLiveLock(timeoutMessage);
+         ActiveMQServerLogger.LOGGER.waitingToObtainLiveLock(timeoutMessage);
 
-      liveLock = lock(FileLockNodeManager.LIVE_LOCK_POS);
+         liveLock = lock(FileLockNodeManager.LIVE_LOCK_POS);
 
-      ActiveMQServerLogger.LOGGER.obtainedLiveLock();
+         ActiveMQServerLogger.LOGGER.obtainedLiveLock();
 
-      return new CleaningActivateCallback() {
-         @Override
-         public void activationComplete() {
-            try {
-               setLive();
-               startLockMonitoring();
-            } catch (Exception e) {
-               ActiveMQServerLogger.LOGGER.warn(e.getMessage(), e);
+         return new CleaningActivateCallback() {
+            @Override
+            public void activationComplete() {
+               try {
+                  setLive();
+                  startLockMonitoring();
+               } catch (Exception e) {
+                  ActiveMQServerLogger.LOGGER.warn(e.getMessage(), e);
+                  // that allows to restart/stop the broker if needed
+                  throw e;
+               }
             }
-         }
-      };
+         };
+      } catch (ActiveMQLockAcquisitionTimeoutException e) {
+         throw new NodeManagerException(e);
+      }
    }
 
    @Override
-   public void pauseLiveServer() throws Exception {
+   public void pauseLiveServer() throws NodeManagerException {
       stopLockMonitoring();
       setPaused();
-      if (liveLock != null) {
-         liveLock.release();
+      try {
+         if (liveLock != null) {
+            liveLock.release();
+         }
+      } catch (IOException e) {
+         throw new NodeManagerException(e);
       }
    }
 
    @Override
-   public void crashLiveServer() throws Exception {
+   public void crashLiveServer() throws NodeManagerException {
       stopLockMonitoring();
       if (liveLock != null) {
-         liveLock.release();
-         liveLock = null;
+         try {
+            liveLock.release();
+         } catch (IOException e) {
+            throw new NodeManagerException(e);
+         } finally {
+            liveLock = null;
+         }
       }
    }
 
    @Override
-   public void awaitLiveStatus() throws Exception {
+   public void awaitLiveStatus() throws NodeManagerException, InterruptedException {
       while (getState() != LIVE) {
          Thread.sleep(2000);
       }
    }
 
-   private void setLive() throws Exception {
+   private void setLive() throws NodeManagerException {
       writeFileLockStatus(FileLockNodeManager.LIVE);
    }
 
-   private void setFailingBack() throws Exception {
+   private void setFailingBack() throws NodeManagerException {
       writeFileLockStatus(FAILINGBACK);
    }
 
-   private void setPaused() throws Exception {
+   private void setPaused() throws NodeManagerException {
       writeFileLockStatus(PAUSED);
    }
 
    /**
     * @param status
-    * @throws IOException
+    * @throws ActiveMQLockAcquisitionTimeoutException,IOException
     */
-   private void writeFileLockStatus(byte status) throws Exception {
+   private void writeFileLockStatus(byte status) throws NodeManagerException {
       if (replicatedBackup && channel == null)
          return;
       logger.debug("writing status: " + status);
       ByteBuffer bb = ByteBuffer.allocateDirect(1);
       bb.put(status);
       bb.position(0);
-      if (!channel.isOpen()) {
-         setUpServerLockFile();
-      }
-      FileLock lock = null;
       try {
-         lock = lock(STATE_LOCK_POS);
-         channel.write(bb, 0);
-         channel.force(true);
-      } finally {
-         if (lock != null) {
-            lock.release();
+         if (!channel.isOpen()) {
+            setUpServerLockFile();
          }
+         FileLock lock = null;
+         try {
+            lock = lock(STATE_LOCK_POS);
+            channel.write(bb, 0);
+            channel.force(true);
+         } finally {
+            if (lock != null) {
+               lock.release();
+            }
+         }
+      } catch (InterruptedException | IOException | ActiveMQLockAcquisitionTimeoutException e) {
+         throw new NodeManagerException(e);
       }
    }
 
-   private byte getState() throws Exception {
-      byte result;
-      logger.debug("getting state...");
-      ByteBuffer bb = ByteBuffer.allocateDirect(1);
-      int read;
-      FileLock lock = null;
+   private byte getState() throws NodeManagerException {
       try {
-         lock = lock(STATE_LOCK_POS);
-         read = channel.read(bb, 0);
-         if (read <= 0) {
-            result = FileLockNodeManager.NOT_STARTED;
-         } else {
-            result = bb.get(0);
+         byte result;
+         logger.debug("getting state...");
+         ByteBuffer bb = ByteBuffer.allocateDirect(1);
+         int read;
+         FileLock lock = null;
+         try {
+            lock = lock(STATE_LOCK_POS);
+            read = channel.read(bb, 0);
+            if (read <= 0) {
+               result = FileLockNodeManager.NOT_STARTED;
+            } else {
+               result = bb.get(0);
+            }
+         } finally {
+            if (lock != null) {
+               lock.release();
+            }
          }
-      } finally {
-         if (lock != null) {
-            lock.release();
-         }
+         logger.debug("state: " + result);
+         return result;
+      } catch (InterruptedException | IOException | ActiveMQLockAcquisitionTimeoutException e) {
+         throw new NodeManagerException(e);
       }
-
-      logger.debug("state: " + result);
-
-      return result;
    }
 
    @Override
-   public final SimpleString readNodeId() throws ActiveMQIllegalStateException, IOException {
-      ByteBuffer id = ByteBuffer.allocateDirect(16);
-      int read = channel.read(id, 3);
-      if (read != 16) {
-         throw new ActiveMQIllegalStateException("live server did not write id to file");
+   public final SimpleString readNodeId() throws NodeManagerException {
+      try {
+         ByteBuffer id = ByteBuffer.allocateDirect(16);
+         int read = channel.read(id, 3);
+         if (read != 16) {
+            throw new IOException("live server did not write id to file");
+         }
+         byte[] bytes = new byte[16];
+         id.position(0);
+         id.get(bytes);
+         setUUID(new UUID(UUID.TYPE_TIME_BASED, bytes));
+         return getNodeId();
+      } catch (IOException e) {
+         throw new NodeManagerException(e);
       }
-      byte[] bytes = new byte[16];
-      id.position(0);
-      id.get(bytes);
-      setUUID(new UUID(UUID.TYPE_TIME_BASED, bytes));
-      return getNodeId();
    }
 
    protected FileLock tryLock(final int lockPos) throws IOException {
@@ -361,8 +399,8 @@ public class FileLockNodeManager extends NodeManager {
       }
    }
 
-   protected FileLock lock(final int lockPosition) throws Exception {
-      long start = System.currentTimeMillis();
+   protected FileLock lock(final int lockPosition) throws ActiveMQLockAcquisitionTimeoutException, InterruptedException {
+      long start = System.nanoTime();
       boolean isRecurringFailure = false;
 
       while (!interrupted) {
@@ -377,7 +415,7 @@ public class FileLockNodeManager extends NodeManager {
                   return null;
                }
 
-               if (lockAcquisitionTimeout != -1 && (System.currentTimeMillis() - start) > lockAcquisitionTimeout) {
+               if (this.lockAcquisitionTimeoutNanos != -1 && (System.nanoTime() - start) > this.lockAcquisitionTimeoutNanos) {
                   throw new ActiveMQLockAcquisitionTimeoutException("timed out waiting for lock");
                }
             } else {
@@ -386,13 +424,12 @@ public class FileLockNodeManager extends NodeManager {
          } catch (IOException e) {
             // IOException during trylock() may be a temporary issue, e.g. NFS volume not being accessible
 
-            logger.log(isRecurringFailure ? Logger.Level.DEBUG : Logger.Level.WARN,
-                    "Failure when accessing a lock file", e);
+            logger.log(isRecurringFailure ? Logger.Level.DEBUG : Logger.Level.WARN, "Failure when accessing a lock file", e);
             isRecurringFailure = true;
 
-            long waitTime = LOCK_ACCESS_FAILURE_WAIT_TIME;
-            if (lockAcquisitionTimeout != -1) {
-               final long remainingTime = lockAcquisitionTimeout - (System.currentTimeMillis() - start);
+            long waitTime = LOCK_ACCESS_FAILURE_WAIT_TIME_NANOS;
+            if (this.lockAcquisitionTimeoutNanos != -1) {
+               final long remainingTime = this.lockAcquisitionTimeoutNanos - (System.nanoTime() - start);
                if (remainingTime <= 0) {
                   throw new ActiveMQLockAcquisitionTimeoutException("timed out waiting for lock");
                }
@@ -400,21 +437,20 @@ public class FileLockNodeManager extends NodeManager {
             }
 
             try {
-               Thread.sleep(waitTime);
+               TimeUnit.NANOSECONDS.sleep(waitTime);
             } catch (InterruptedException interrupt) {
-               return null;
+               throw new InterruptedException();
             }
          }
       }
 
-      // presumed interrupted
-      return null;
+      throw new InterruptedException();
    }
 
    private synchronized void startLockMonitoring() {
       logger.debug("Starting the lock monitor");
       if (monitorLock == null) {
-         monitorLock = new MonitorLock(scheduledPool, LOCK_MONITOR_TIMEOUT_MILLIES, LOCK_MONITOR_TIMEOUT_MILLIES, TimeUnit.MILLISECONDS, false);
+         monitorLock = new MonitorLock(scheduledPool, LOCK_MONITOR_TIMEOUT_NANOS, LOCK_MONITOR_TIMEOUT_NANOS, TimeUnit.NANOSECONDS, false);
          monitorLock.start();
       } else {
          logger.debug("Lock monitor was already started");
@@ -431,48 +467,21 @@ public class FileLockNodeManager extends NodeManager {
       }
    }
 
-   private void notifyLostLock() {
-      // Additional check we are not initializing or have no locking object anymore
-      // because of a shutdown
-      if (lockListeners != null && liveLock != null) {
-         Set<LockListener> lockListenersSnapshot = null;
-
-         // Snapshot of the set because I'm not sure if we can trigger concurrent
-         // modification exception here if we don't
-         synchronized (lockListeners) {
-            lockListenersSnapshot = new HashSet<>(lockListeners);
-         }
-
-         lockListenersSnapshot.forEach(lockListener -> {
-            try {
-               lockListener.lostLock();
-            } catch (Exception e) {
-               // Need to notify everyone so ignore any exception
-            }
-         });
+   @Override
+   protected synchronized void notifyLostLock() {
+      if (liveLock != null) {
+         super.notifyLostLock();
       }
    }
 
-   public void registerLockListener(LockListener lockListener) {
-      lockListeners.add(lockListener);
+   // This has been introduced to help ByteMan test testLockMonitorInvalid on JDK 11: sun.nio.ch.FileLockImpl::isValid
+   // can affecting setLive, causing an infinite loop due to java.nio.channels.OverlappingFileLockException on tryLock
+   private boolean isLiveLockLost() {
+      final FileLock lock = this.liveLock;
+      return (lock != null && !lock.isValid()) || lock == null;
    }
-
-   public void unregisterLockListener(LockListener lockListener) {
-      lockListeners.remove(lockListener);
-   }
-
-   protected final Set<LockListener> lockListeners = Collections.synchronizedSet(new HashSet<LockListener>());
 
    private MonitorLock monitorLock;
-
-   public abstract class LockListener {
-      protected abstract void lostLock() throws Exception;
-
-      protected void unregisterListener() {
-         lockListeners.remove(this);
-      }
-   }
-
 
    public class MonitorLock extends ActiveMQScheduledComponent {
       public MonitorLock(ScheduledExecutorService scheduledExecutorService,
@@ -492,7 +501,7 @@ public class FileLockNodeManager extends NodeManager {
             if (liveLock == null) {
                logger.debug("Livelock is null");
             }
-            lostLock = (liveLock != null && !liveLock.isValid()) || liveLock == null;
+            lostLock = isLiveLockLost();
             if (!lostLock) {
                logger.debug("Server still has the lock, double check status is live");
                // Java always thinks the lock is still valid even when there is no filesystem

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/SharedNothingBackupActivation.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/SharedNothingBackupActivation.java
@@ -25,6 +25,7 @@ import org.apache.activemq.artemis.api.core.Pair;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.TopologyMember;
 import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.io.IOCriticalErrorListener;
 import org.apache.activemq.artemis.core.paging.PagingManager;
 import org.apache.activemq.artemis.core.persistence.StorageManager;
 import org.apache.activemq.artemis.core.postoffice.PostOffice;
@@ -67,7 +68,7 @@ public final class SharedNothingBackupActivation extends Activation {
    private SharedNothingBackupQuorum backupQuorum;
    private final boolean attemptFailBack;
    private final Map<String, Object> activationParams;
-   private final ActiveMQServerImpl.ShutdownOnCriticalErrorListener shutdownOnCriticalIO;
+   private final IOCriticalErrorListener ioCriticalErrorListener;
    private String nodeID;
    ClusterControl clusterControl;
    private boolean closed;
@@ -79,13 +80,13 @@ public final class SharedNothingBackupActivation extends Activation {
    public SharedNothingBackupActivation(ActiveMQServerImpl activeMQServer,
                                         boolean attemptFailBack,
                                         Map<String, Object> activationParams,
-                                        ActiveMQServerImpl.ShutdownOnCriticalErrorListener shutdownOnCriticalIO,
+                                        IOCriticalErrorListener ioCriticalErrorListener,
                                         ReplicaPolicy replicaPolicy,
                                         NetworkHealthCheck networkHealthCheck) {
       this.activeMQServer = activeMQServer;
       this.attemptFailBack = attemptFailBack;
       this.activationParams = activationParams;
-      this.shutdownOnCriticalIO = shutdownOnCriticalIO;
+      this.ioCriticalErrorListener = ioCriticalErrorListener;
       this.replicaPolicy = replicaPolicy;
       backupSyncLatch.setCount(1);
       this.networkHealthCheck = networkHealthCheck;
@@ -95,7 +96,7 @@ public final class SharedNothingBackupActivation extends Activation {
       assert replicationEndpoint == null;
       activeMQServer.resetNodeManager();
       backupUpToDate = false;
-      replicationEndpoint = new ReplicationEndpoint(activeMQServer, shutdownOnCriticalIO, attemptFailBack, this);
+      replicationEndpoint = new ReplicationEndpoint(activeMQServer, ioCriticalErrorListener, attemptFailBack, this);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/SharedNothingLiveActivation.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/SharedNothingLiveActivation.java
@@ -317,7 +317,7 @@ public class SharedNothingLiveActivation extends LiveActivation {
       SimpleString nodeId0;
       try {
          nodeId0 = activeMQServer.getNodeManager().readNodeId();
-      } catch (ActiveMQIllegalStateException e) {
+      } catch (NodeManager.NodeManagerException e) {
          nodeId0 = null;
       }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/SharedStoreBackupActivation.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/SharedStoreBackupActivation.java
@@ -16,18 +16,24 @@
  */
 package org.apache.activemq.artemis.core.server.impl;
 
+import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.io.IOCriticalErrorListener;
 import org.apache.activemq.artemis.core.paging.PagingManager;
 import org.apache.activemq.artemis.core.persistence.StorageManager;
 import org.apache.activemq.artemis.core.postoffice.PostOffice;
+import org.apache.activemq.artemis.core.server.ActiveMQLockAcquisitionTimeoutException;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
 import org.apache.activemq.artemis.core.server.NodeManager;
+import org.apache.activemq.artemis.core.server.NodeManager.LockListener;
+import org.apache.activemq.artemis.core.server.NodeManager.NodeManagerException;
 import org.apache.activemq.artemis.core.server.QueueFactory;
 import org.apache.activemq.artemis.core.server.cluster.ha.ScaleDownPolicy;
 import org.apache.activemq.artemis.core.server.cluster.ha.SharedStoreSlavePolicy;
@@ -40,17 +46,24 @@ public final class SharedStoreBackupActivation extends Activation {
    private static final Logger logger = Logger.getLogger(SharedStoreBackupActivation.class);
 
    //this is how we act as a backup
-   private SharedStoreSlavePolicy sharedStoreSlavePolicy;
+   private final SharedStoreSlavePolicy sharedStoreSlavePolicy;
 
-   private ActiveMQServerImpl activeMQServer;
+   private final ActiveMQServerImpl activeMQServer;
 
    private final Object failbackCheckerGuard = new Object();
 
    private boolean cancelFailBackChecker;
 
-   public SharedStoreBackupActivation(ActiveMQServerImpl server, SharedStoreSlavePolicy sharedStoreSlavePolicy) {
+   private LockListener activeLockListener;
+
+   private final IOCriticalErrorListener ioCriticalErrorListener;
+
+   public SharedStoreBackupActivation(ActiveMQServerImpl server,
+                                      SharedStoreSlavePolicy sharedStoreSlavePolicy,
+                                      IOCriticalErrorListener ioCriticalErrorListener) {
       this.activeMQServer = server;
       this.sharedStoreSlavePolicy = sharedStoreSlavePolicy;
+      this.ioCriticalErrorListener = ioCriticalErrorListener;
       synchronized (failbackCheckerGuard) {
          cancelFailBackChecker = false;
       }
@@ -59,6 +72,8 @@ public final class SharedStoreBackupActivation extends Activation {
    @Override
    public void run() {
       try {
+         registerActiveLockListener(activeMQServer.getNodeManager());
+
          activeMQServer.getNodeManager().startBackup();
 
          ScaleDownPolicy scaleDownPolicy = sharedStoreSlavePolicy.getScaleDownPolicy();
@@ -92,6 +107,15 @@ public final class SharedStoreBackupActivation extends Activation {
          activeMQServer.completeActivation(false);
 
          if (scalingDown) {
+
+            // a racing lost lock could try to restart the server too:
+            // handling it like this is suboptimal, because loosing a lock
+            // should take precedence over scaling down
+            if (!restarting.compareAndSet(false, true)) {
+               return;
+            }
+            unregisterActiveLockListener(activeMQServer.getNodeManager());
+
             ActiveMQServerLogger.LOGGER.backupServerScaledDown();
             Thread t = new Thread(new Runnable() {
                @Override
@@ -117,6 +141,17 @@ public final class SharedStoreBackupActivation extends Activation {
          if (sharedStoreSlavePolicy.isAllowAutoFailBack() && ActiveMQServerImpl.SERVER_STATE.STOPPING != activeMQServer.getState() && ActiveMQServerImpl.SERVER_STATE.STOPPED != activeMQServer.getState()) {
             startFailbackChecker();
          }
+      } catch (NodeManagerException nodeManagerException) {
+         if (nodeManagerException.getCause() instanceof ClosedChannelException) {
+            // this is ok, we are being stopped
+            return;
+         }
+         if (nodeManagerException.getCause() instanceof ActiveMQLockAcquisitionTimeoutException) {
+            ActiveMQServerLogger.LOGGER.initializationError(nodeManagerException.getCause());
+            return;
+         }
+         unregisterActiveLockListener(activeMQServer.getNodeManager());
+         ioCriticalErrorListener.onIOException(nodeManagerException, nodeManagerException.getMessage(), null);
       } catch (ClosedChannelException | InterruptedException e) {
          // these are ok, we are being stopped
       } catch (Exception e) {
@@ -144,20 +179,50 @@ public final class SharedStoreBackupActivation extends Activation {
          activeMQServer.interruptActivationThread(nodeManagerInUse);
 
          if (nodeManagerInUse != null) {
+            unregisterActiveLockListener(nodeManagerInUse);
             nodeManagerInUse.stopBackup();
          }
       } else {
 
          if (nodeManagerInUse != null) {
+            unregisterActiveLockListener(nodeManagerInUse);
             // if we are now live, behave as live
             // We need to delete the file too, otherwise the backup will failover when we shutdown or if the backup is
             // started before the live
             if (sharedStoreSlavePolicy.isFailoverOnServerShutdown() || permanently) {
-               nodeManagerInUse.crashLiveServer();
+               try {
+                  nodeManagerInUse.crashLiveServer();
+               } catch (Throwable t) {
+                  if (!permanently) {
+                     throw t;
+                  }
+                  logger.warn("Errored while closing activation: can be ignored because of permanent close", t);
+               }
             } else {
                nodeManagerInUse.pauseLiveServer();
             }
          }
+      }
+   }
+
+   private void registerActiveLockListener(NodeManager nodeManager) {
+      LockListener lockListener = () -> {
+         if (!restarting.compareAndSet(false, true)) {
+            logger.warn("Restarting already happening on lost lock");
+            return;
+         }
+         unregisterActiveLockListener(nodeManager);
+         ioCriticalErrorListener.onIOException(new IOException("lost lock"), "Lost NodeManager lock", null);
+      };
+      activeLockListener = lockListener;
+      nodeManager.registerLockListener(lockListener);
+   }
+
+   private void unregisterActiveLockListener(NodeManager nodeManager) {
+      LockListener activeLockListener = this.activeLockListener;
+      if (activeLockListener != null) {
+         nodeManager.unregisterLockListener(activeLockListener);
+         this.activeLockListener = null;
       }
    }
 
@@ -178,6 +243,8 @@ public final class SharedStoreBackupActivation extends Activation {
       }
    }
 
+   private final AtomicBoolean restarting = new AtomicBoolean(false);
+
    /**
     * To be called by backup trying to fail back the server
     */
@@ -195,47 +262,50 @@ public final class SharedStoreBackupActivation extends Activation {
          activeMQServer.getClusterManager().getDefaultConnection(null).addClusterTopologyListener(backupListener);
       }
 
-      private boolean restarting = false;
-
       @Override
       public void run() {
          try {
-            if (!restarting && activeMQServer.getNodeManager().isAwaitingFailback()) {
-               if (backupListener.waitForBackup()) {
-                  ActiveMQServerLogger.LOGGER.awaitFailBack();
-                  restarting = true;
-                  Thread t = new Thread(new Runnable() {
-                     @Override
-                     public void run() {
-                        try {
-                           logger.debug(activeMQServer + "::Stopping live node in favor of failback");
-
-                           NodeManager nodeManager = activeMQServer.getNodeManager();
-                           activeMQServer.stop(true, false, true);
-
-                           // ensure that the server to which we are failing back actually starts fully before we restart
-                           nodeManager.start();
-                           try {
-                              nodeManager.awaitLiveStatus();
-                           } finally {
-                              nodeManager.stop();
-                           }
-
-                           synchronized (failbackCheckerGuard) {
-                              if (cancelFailBackChecker || !sharedStoreSlavePolicy.isRestartBackup())
-                                 return;
-
-                              activeMQServer.setHAPolicy(sharedStoreSlavePolicy);
-                              logger.debug(activeMQServer + "::Starting backup node now after failback");
-                              activeMQServer.start();
-                           }
-                        } catch (Exception e) {
-                           ActiveMQServerLogger.LOGGER.serverRestartWarning(e);
-                        }
-                     }
-                  });
-                  t.start();
+            if (!restarting.get() && activeMQServer.getNodeManager().isAwaitingFailback() && backupListener.waitForBackup()) {
+               if (!restarting.compareAndSet(false, true)) {
+                  return;
                }
+               ActiveMQServerLogger.LOGGER.awaitFailBack();
+               Thread t = new Thread(new Runnable() {
+                  @Override
+                  public void run() {
+                     try {
+                        logger.debug(activeMQServer + "::Stopping live node in favor of failback");
+
+                        NodeManager nodeManager = activeMQServer.getNodeManager();
+                        activeMQServer.stop(true, false, true);
+
+                        // ensure that the server to which we are failing back actually starts fully before we restart
+                        nodeManager.start();
+                        try {
+                           nodeManager.awaitLiveStatus();
+                        } finally {
+                           nodeManager.stop();
+                        }
+
+                        synchronized (failbackCheckerGuard) {
+                           if (cancelFailBackChecker || !sharedStoreSlavePolicy.isRestartBackup())
+                              return;
+
+                           activeMQServer.setHAPolicy(sharedStoreSlavePolicy);
+                           logger.debug(activeMQServer + "::Starting backup node now after failback");
+                           activeMQServer.start();
+
+                           LockListener lockListener = activeLockListener;
+                           if (lockListener != null) {
+                              activeMQServer.getNodeManager().registerLockListener(lockListener);
+                           }
+                        }
+                     } catch (Exception e) {
+                        ActiveMQServerLogger.LOGGER.serverRestartWarning(e);
+                     }
+                  }
+               });
+               t.start();
             }
          } catch (Exception e) {
             ActiveMQServerLogger.LOGGER.serverRestartWarning(e);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/SharedStoreLiveActivation.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/SharedStoreLiveActivation.java
@@ -16,11 +16,17 @@
  */
 package org.apache.activemq.artemis.core.server.impl;
 
+import java.io.IOException;
+import java.nio.channels.ClosedChannelException;
+
+import org.apache.activemq.artemis.core.io.IOCriticalErrorListener;
 import org.apache.activemq.artemis.core.server.ActivateCallback;
+import org.apache.activemq.artemis.core.server.ActiveMQLockAcquisitionTimeoutException;
 import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
 import org.apache.activemq.artemis.core.server.NodeManager;
+import org.apache.activemq.artemis.core.server.NodeManager.LockListener;
+import org.apache.activemq.artemis.core.server.NodeManager.NodeManagerException;
 import org.apache.activemq.artemis.core.server.cluster.ha.SharedStoreMasterPolicy;
-import org.apache.activemq.artemis.core.server.impl.FileLockNodeManager.LockListener;
 import org.jboss.logging.Logger;
 
 public final class SharedStoreLiveActivation extends LiveActivation {
@@ -28,17 +34,22 @@ public final class SharedStoreLiveActivation extends LiveActivation {
    private static final Logger logger = Logger.getLogger(SharedStoreLiveActivation.class);
 
    // this is how we act when we initially start as live
-   private SharedStoreMasterPolicy sharedStoreMasterPolicy;
+   private final SharedStoreMasterPolicy sharedStoreMasterPolicy;
 
-   private ActiveMQServerImpl activeMQServer;
+   private final ActiveMQServerImpl activeMQServer;
 
-   private volatile FileLockNodeManager.LockListener activeLockListener;
+   private volatile LockListener activeLockListener;
 
    private volatile ActivateCallback nodeManagerActivateCallback;
 
-   public SharedStoreLiveActivation(ActiveMQServerImpl server, SharedStoreMasterPolicy sharedStoreMasterPolicy) {
+   private final IOCriticalErrorListener ioCriticalErrorListener;
+
+   public SharedStoreLiveActivation(ActiveMQServerImpl server,
+                                    SharedStoreMasterPolicy sharedStoreMasterPolicy,
+                                    IOCriticalErrorListener ioCriticalErrorListener) {
       this.activeMQServer = server;
       this.sharedStoreMasterPolicy = sharedStoreMasterPolicy;
+      this.ioCriticalErrorListener = ioCriticalErrorListener;
    }
 
    @Override
@@ -71,73 +82,52 @@ public final class SharedStoreLiveActivation extends LiveActivation {
             activeMQServer.getBackupManager().announceBackup();
          }
 
+         registerActiveLockListener(activeMQServer.getNodeManager());
          nodeManagerActivateCallback = activeMQServer.getNodeManager().startLiveNode();
          activeMQServer.registerActivateCallback(nodeManagerActivateCallback);
-         addLockListener(activeMQServer, activeMQServer.getNodeManager());
 
-         if (activeMQServer.getState() == ActiveMQServerImpl.SERVER_STATE.STOPPED
-               || activeMQServer.getState() == ActiveMQServerImpl.SERVER_STATE.STOPPING) {
+         if (activeMQServer.getState() == ActiveMQServerImpl.SERVER_STATE.STOPPED || activeMQServer.getState() == ActiveMQServerImpl.SERVER_STATE.STOPPING) {
             return;
          }
-
          activeMQServer.initialisePart2(false);
 
          activeMQServer.completeActivation(false);
 
          ActiveMQServerLogger.LOGGER.serverIsLive();
+      } catch (NodeManagerException nodeManagerException) {
+         if (nodeManagerException.getCause() instanceof ClosedChannelException) {
+            // this is ok, we are being stopped
+            return;
+         }
+         if (nodeManagerException.getCause() instanceof ActiveMQLockAcquisitionTimeoutException) {
+            onActivationFailure((ActiveMQLockAcquisitionTimeoutException) nodeManagerException.getCause());
+            return;
+         }
+         unregisterActiveLockListener(activeMQServer.getNodeManager());
+         ioCriticalErrorListener.onIOException(nodeManagerException, nodeManagerException.getMessage(), null);
       } catch (Exception e) {
-         ActiveMQServerLogger.LOGGER.initializationError(e);
-         activeMQServer.callActivationFailureListeners(e);
+         onActivationFailure(e);
       }
    }
 
-   private void addLockListener(ActiveMQServerImpl activeMQServer, NodeManager nodeManager) {
-      if (nodeManager instanceof FileLockNodeManager) {
-         FileLockNodeManager fileNodeManager = (FileLockNodeManager) nodeManager;
-
-         activeLockListener = fileNodeManager.new LockListener() {
-
-            @Override
-            public void lostLock() {
-               stopStartServerInSeperateThread(activeMQServer);
-            }
-
-         };
-         fileNodeManager.registerLockListener(activeLockListener);
-      } // else no business registering a listener
+   private void onActivationFailure(Exception e) {
+      unregisterActiveLockListener(activeMQServer.getNodeManager());
+      ActiveMQServerLogger.LOGGER.initializationError(e);
+      activeMQServer.callActivationFailureListeners(e);
    }
 
-   /**
-    * We need to do this in a new thread because this takes to long to finish in
-    * the scheduled thread Also this is not the responsibility of the scheduled
-    * thread
-    * @param activeMQServer
-    */
-   private void stopStartServerInSeperateThread(ActiveMQServerImpl activeMQServer) {
-      try {
+   private void registerActiveLockListener(NodeManager nodeManager) {
+      LockListener lockListener = () ->
+         ioCriticalErrorListener.onIOException(new IOException("lost lock"), "Lost NodeManager lock", null);
+      activeLockListener = lockListener;
+      nodeManager.registerLockListener(lockListener);
+   }
 
-         Runnable startServerRunnable = new Runnable() {
-
-            @Override
-            public void run() {
-               try {
-                  activeMQServer.stop(true, false);
-               } catch (Exception e) {
-                  logger.warn("Failed to stop artemis server after loosing the lock", e);
-               }
-
-               try {
-                  activeMQServer.start();
-               } catch (Exception e) {
-                  logger.error("Failed to start artemis server after recovering from loosing the lock", e);
-               }
-            }
-
-         };
-         Thread startServer = new Thread(startServerRunnable);
-         startServer.start();
-      } catch (Exception e) {
-         logger.error(e.getMessage());
+   private void unregisterActiveLockListener(NodeManager nodeManager) {
+      LockListener activeLockListener = this.activeLockListener;
+      if (activeLockListener != null) {
+         nodeManager.unregisterLockListener(activeLockListener);
+         this.activeLockListener = null;
       }
    }
 
@@ -147,16 +137,20 @@ public final class SharedStoreLiveActivation extends LiveActivation {
       NodeManager nodeManagerInUse = activeMQServer.getNodeManager();
 
       if (nodeManagerInUse != null) {
-         LockListener closeLockListener = activeLockListener;
-         if (closeLockListener != null) {
-            closeLockListener.unregisterListener();
-         }
+         unregisterActiveLockListener(nodeManagerInUse);
          ActivateCallback activateCallback = nodeManagerActivateCallback;
          if (activateCallback != null) {
             activeMQServer.unregisterActivateCallback(activateCallback);
          }
          if (sharedStoreMasterPolicy.isFailoverOnServerShutdown() || permanently) {
-            nodeManagerInUse.crashLiveServer();
+            try {
+               nodeManagerInUse.crashLiveServer();
+            } catch (Throwable t) {
+               if (!permanently) {
+                  throw t;
+               }
+               logger.warn("Errored while closing activation: can be ignored because of permanent close", t);
+            }
          } else {
             nodeManagerInUse.pauseLiveServer();
          }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/jdbc/ActiveMQScheduledLeaseLock.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/jdbc/ActiveMQScheduledLeaseLock.java
@@ -20,13 +20,13 @@ package org.apache.activemq.artemis.core.server.impl.jdbc;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.activemq.artemis.core.io.IOCriticalErrorListener;
 import org.apache.activemq.artemis.core.server.ActiveMQScheduledComponent;
+import org.apache.activemq.artemis.core.server.NodeManager.LockListener;
 import org.apache.activemq.artemis.utils.actors.ArtemisExecutor;
 import org.jboss.logging.Logger;
 
 /**
- * Default implementation of a {@link ScheduledLeaseLock}: see {@link ScheduledLeaseLock#of(ScheduledExecutorService, ArtemisExecutor, String, LeaseLock, long, IOCriticalErrorListener)}.
+ * Default implementation of a {@link ScheduledLeaseLock}: see {@link ScheduledLeaseLock#of(ScheduledExecutorService, ArtemisExecutor, String, LeaseLock, long, LockListener)}.
  */
 final class ActiveMQScheduledLeaseLock extends ActiveMQScheduledComponent implements ScheduledLeaseLock {
 
@@ -36,14 +36,14 @@ final class ActiveMQScheduledLeaseLock extends ActiveMQScheduledComponent implem
    private final LeaseLock lock;
    private long lastLockRenewStart;
    private final long renewPeriodMillis;
-   private final IOCriticalErrorListener ioCriticalErrorListener;
+   private final LockListener lockListener;
 
    ActiveMQScheduledLeaseLock(ScheduledExecutorService scheduledExecutorService,
                               ArtemisExecutor executor,
                               String lockName,
                               LeaseLock lock,
                               long renewPeriodMillis,
-                              IOCriticalErrorListener ioCriticalErrorListener) {
+                              LockListener lockListener) {
       super(scheduledExecutorService, executor, 0, renewPeriodMillis, TimeUnit.MILLISECONDS, false);
       if (renewPeriodMillis >= lock.expirationMillis()) {
          throw new IllegalArgumentException("renewPeriodMillis must be < lock's expirationMillis");
@@ -53,7 +53,12 @@ final class ActiveMQScheduledLeaseLock extends ActiveMQScheduledComponent implem
       this.renewPeriodMillis = renewPeriodMillis;
       //already expired start time
       this.lastLockRenewStart = System.nanoTime() - TimeUnit.MILLISECONDS.toNanos(lock.expirationMillis());
-      this.ioCriticalErrorListener = ioCriticalErrorListener;
+      this.lockListener = lockListener;
+   }
+
+   @Override
+   public String lockName() {
+      return lockName;
    }
 
    @Override
@@ -84,37 +89,48 @@ final class ActiveMQScheduledLeaseLock extends ActiveMQScheduledComponent implem
    }
 
    @Override
-   public void run() {
+   public synchronized void run() {
+      if (!isStarted()) {
+         return;
+      }
       final long lastRenewStart = this.lastLockRenewStart;
       final long renewStart = System.nanoTime();
+      boolean lockLost = true;
       try {
-         if (!this.lock.renew()) {
-            ioCriticalErrorListener.onIOException(new IllegalStateException(lockName + " lock can't be renewed"), "Critical error while on " + lockName + " renew", null);
-         }
+         lockLost = !this.lock.renew();
       } catch (Throwable t) {
-         ioCriticalErrorListener.onIOException(t, "Critical error while on " + lockName + " renew", null);
-         throw t;
+         LOGGER.warnf(t, "%s lock renew has failed", lockName);
+      }
+      // a failed attempt to renew is treated as a lost lock
+      if (lockLost) {
+         try {
+            lockListener.lostLock();
+         } catch (Throwable t) {
+            LOGGER.warnf(t, "Errored while notifying %s lock listener", lockName);
+         }
       }
       //logic to detect slowness of DB and/or the scheduled executor service
-      detectAndReportRenewSlowness(lockName, lastRenewStart, renewStart, renewPeriodMillis, lock.expirationMillis());
+      detectAndReportRenewSlowness(lockName, lockLost, lastRenewStart,
+                                   renewStart, renewPeriodMillis, lock.expirationMillis());
       this.lastLockRenewStart = renewStart;
    }
 
    private static void detectAndReportRenewSlowness(String lockName,
+                                                    boolean lostLock,
                                                     long lastRenewStart,
                                                     long renewStart,
                                                     long expectedRenewPeriodMillis,
                                                     long expirationMillis) {
       final long elapsedMillisToRenew = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - renewStart);
       if (elapsedMillisToRenew > expectedRenewPeriodMillis) {
-         LOGGER.error(lockName + " lock renew tooks " + elapsedMillisToRenew + " ms, while is supposed to take <" + expectedRenewPeriodMillis + " ms");
+         LOGGER.errorf("%s lock %s renew tooks %d ms, while is supposed to take <%d ms", lockName, lostLock ? "failed" : "successful", elapsedMillisToRenew, expectedRenewPeriodMillis);
       }
       final long measuredRenewPeriodNanos = renewStart - lastRenewStart;
       final long measuredRenewPeriodMillis = TimeUnit.NANOSECONDS.toMillis(measuredRenewPeriodNanos);
       if (measuredRenewPeriodMillis - expirationMillis > 100) {
-         LOGGER.error(lockName + " lock renew period lasted " + measuredRenewPeriodMillis + " ms instead of " + expectedRenewPeriodMillis + " ms");
+         LOGGER.errorf("%s lock %s renew period lasted %d ms instead of %d ms", lockName, lostLock ? "failed" : "successful", measuredRenewPeriodMillis, expectedRenewPeriodMillis);
       } else if (measuredRenewPeriodMillis - expectedRenewPeriodMillis > 100) {
-         LOGGER.warn(lockName + " lock renew period lasted " + measuredRenewPeriodMillis + " ms instead of " + expectedRenewPeriodMillis + " ms");
+         LOGGER.warnf("%s lock %s renew period lasted %d ms instead of %d ms", lockName, lostLock ? "failed" : "successful", measuredRenewPeriodMillis, expectedRenewPeriodMillis);
       }
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/jdbc/ScheduledLeaseLock.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/jdbc/ScheduledLeaseLock.java
@@ -19,8 +19,8 @@ package org.apache.activemq.artemis.core.server.impl.jdbc;
 
 import java.util.concurrent.ScheduledExecutorService;
 
-import org.apache.activemq.artemis.core.io.IOCriticalErrorListener;
 import org.apache.activemq.artemis.core.server.ActiveMQComponent;
+import org.apache.activemq.artemis.core.server.NodeManager.LockListener;
 import org.apache.activemq.artemis.utils.actors.ArtemisExecutor;
 
 /**
@@ -28,17 +28,25 @@ import org.apache.activemq.artemis.utils.actors.ArtemisExecutor;
  */
 interface ScheduledLeaseLock extends ActiveMQComponent {
 
+   @Override
+   void start();
+
+   @Override
+   void stop();
+
    LeaseLock lock();
 
    long renewPeriodMillis();
+
+   String lockName();
 
    static ScheduledLeaseLock of(ScheduledExecutorService scheduledExecutorService,
                                 ArtemisExecutor executor,
                                 String lockName,
                                 LeaseLock lock,
                                 long renewPeriodMillis,
-                                IOCriticalErrorListener ioCriticalErrorListener) {
-      return new ActiveMQScheduledLeaseLock(scheduledExecutorService, executor, lockName, lock, renewPeriodMillis, ioCriticalErrorListener);
+                                LockListener lockListener) {
+      return new ActiveMQScheduledLeaseLock(scheduledExecutorService, executor, lockName, lock, renewPeriodMillis, lockListener);
    }
 
 }

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -75,6 +75,14 @@
             </xsd:annotation>
          </xsd:element>
 
+         <xsd:element name="restart-allowed" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  that means the server can restart itself in case of I/O critical errors.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
          <xsd:element name="journal-datasync" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
             <xsd:annotation>
                <xsd:documentation>

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/jdbc/JdbcNodeManagerTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/jdbc/JdbcNodeManagerTest.java
@@ -23,7 +23,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.activemq.artemis.core.config.storage.DatabaseStorageConfiguration;
 import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
@@ -105,17 +104,9 @@ public class JdbcNodeManagerTest extends ActiveMQTestBase {
 
    @Test
    public void shouldStartAndStopGracefullyTest() throws Exception {
-      final AtomicReference<String> criticalError = new AtomicReference<>();
-      final JdbcNodeManager nodeManager = JdbcNodeManager.with(dbConf, leaseLockExecutor, null, (code, message, file) -> criticalError.lazySet(message));
-      try {
-         nodeManager.start();
-      } finally {
-         nodeManager.stop();
-         final String error = criticalError.get();
-         if (error != null) {
-            Assert.fail(error);
-         }
-      }
+      final JdbcNodeManager nodeManager = JdbcNodeManager.with(dbConf, leaseLockExecutor, null);
+      nodeManager.start();
+      nodeManager.stop();
    }
 
 }

--- a/artemis-tools/src/test/resources/artemis-configuration.xsd
+++ b/artemis-tools/src/test/resources/artemis-configuration.xsd
@@ -75,6 +75,14 @@
             </xsd:annotation>
          </xsd:element>
 
+         <xsd:element name="restart-allowed" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  that means the server can restart itself in case of I/O critical errors.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
          <xsd:element name="journal-datasync" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
             <xsd:annotation>
                <xsd:documentation>

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/FileLockMonitorTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/FileLockMonitorTest.java
@@ -18,12 +18,11 @@
 package org.apache.activemq.artemis.tests.extras.byteman;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import org.apache.activemq.artemis.core.server.ActivateCallback;
+import org.apache.activemq.artemis.core.server.NodeManager.LockListener;
 import org.apache.activemq.artemis.core.server.impl.FileLockNodeManager;
-import org.apache.activemq.artemis.core.server.impl.FileLockNodeManager.LockListener;
 import org.apache.activemq.artemis.utils.Wait;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMRules;
@@ -42,20 +41,19 @@ public class FileLockMonitorTest {
    private ScheduledThreadPoolExecutor executor;
 
    @Before
-   public void handleLockFile() throws IOException {
+   public void handleLockFile() throws Exception {
       sharedDir = File.createTempFile("shared-dir", "");
       sharedDir.delete();
       Assert.assertTrue(sharedDir.mkdir());
-      lostLock = false;
    }
 
    @Test
    @BMRules(rules = {
-         @BMRule(name = "lock is invalid", targetClass = "sun.nio.ch.FileLockImpl", targetMethod = "isValid", action = "return false;") })
+         @BMRule(name = "lock is invalid", targetClass = "org.apache.activemq.artemis.core.server.impl.FileLockNodeManager", targetMethod = "isLiveLockLost", action = "return true;") })
    public void testLockMonitorInvalid() throws Exception {
       lostLock = false;
       startServer();
-      Wait.assertTrue("The FileLockNodeManager should have lost the lock", () -> lostLock, 5000, 100);
+      Wait.assertTrue("The FileLockNodeManager should have lost the lock", () -> lostLock, 20_000, 100);
       nodeManager.isStarted();
       nodeManager.crashLiveServer();
       executor.shutdown();
@@ -95,14 +93,13 @@ public class FileLockMonitorTest {
    public LockListener startServer() throws Exception {
       executor = new ScheduledThreadPoolExecutor(2);
       nodeManager = new FileLockNodeManager(sharedDir, false, executor);
-      LockListener listener = nodeManager.new LockListener() {
-
-         @Override
-         protected void lostLock() throws Exception {
-            lostLock = true;
+      LockListener listener = () -> {
+         lostLock = true;
+         try {
             nodeManager.crashLiveServer();
+         } catch (Throwable t) {
+            t.printStackTrace();
          }
-
       };
       nodeManager.registerLockListener(listener);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/FileLockNodeManagerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/FileLockNodeManagerTest.java
@@ -18,34 +18,23 @@ package org.apache.activemq.artemis.tests.integration.cluster;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
-import org.apache.activemq.artemis.core.server.NodeManager;
 import org.apache.activemq.artemis.core.server.impl.FileLockNodeManager;
-import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.SpawnedVMSupport;
-import org.apache.activemq.artemis.utils.UUID;
 import org.junit.Assert;
-import org.junit.Test;
 
-public class RealNodeManagerTest extends NodeManagerTest {
-
-   @Test
-   public void testId() throws Exception {
-      NodeManager nodeManager = new FileLockNodeManager(new File(getTemporaryDir()), false);
-      nodeManager.start();
-      UUID id1 = nodeManager.getUUID();
-      nodeManager.stop();
-      nodeManager.start();
-      ActiveMQTestBase.assertEqualsByteArrays(id1.asBytes(), nodeManager.getUUID().asBytes());
-      nodeManager.stop();
-   }
+public class FileLockNodeManagerTest extends NodeManagerTest {
 
    @Override
    public void performWork(NodeManagerAction... actions) throws Exception {
       List<Process> processes = new ArrayList<>();
       for (NodeManagerAction action : actions) {
-         Process p = SpawnedVMSupport.spawnVM(NodeManagerAction.class.getName(), "-Xms512m", "-Xmx512m", new String[0], true, true, true, action.getWork());
+         final String[] args = new String[action.works() + 1];
+         args[0] = getTemporaryDir();
+         action.getWork(args, 1);
+         Process p = SpawnedVMSupport.spawnVM(this.getClass().getName(), "-Xms50m", "-Xmx512m", new String[0], true, true, true, args);
          processes.add(p);
       }
       for (Process process : processes) {
@@ -57,5 +46,9 @@ public class RealNodeManagerTest extends NodeManagerTest {
          }
       }
 
+   }
+
+   public static void main(String[] args) throws Exception {
+      NodeManagerAction.execute(Arrays.copyOfRange(args, 1, args.length), new FileLockNodeManager(new File(args[0]), false));
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/JdbcNodeManagerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/JdbcNodeManagerTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.cluster;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.activemq.artemis.core.config.storage.DatabaseStorageConfiguration;
+import org.apache.activemq.artemis.core.server.NodeManager;
+import org.apache.activemq.artemis.core.server.impl.jdbc.JdbcNodeManager;
+import org.apache.activemq.artemis.utils.ExecutorFactory;
+import org.apache.activemq.artemis.utils.actors.OrderedExecutorFactory;
+import org.junit.Assert;
+
+public class JdbcNodeManagerTest extends NodeManagerTest {
+
+   @Override
+   public void performWork(NodeManagerAction... actions) throws Exception {
+      List<NodeRunner> nodeRunners = new ArrayList<>();
+      final ThreadFactory daemonThreadFactory = t -> {
+         final Thread th = new Thread(t);
+         th.setDaemon(true);
+         return th;
+      };
+      Thread[] threads = new Thread[actions.length];
+      List<ExecutorService> executors = new ArrayList<>(actions.length);
+      List<NodeManager> nodeManagers = new ArrayList<>(actions.length * 2);
+      AtomicBoolean failedRenew = new AtomicBoolean(false);
+      for (NodeManagerAction action : actions) {
+         final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(daemonThreadFactory);
+         final ExecutorService executor = Executors.newFixedThreadPool(2, daemonThreadFactory);
+         final DatabaseStorageConfiguration dbConf = createDefaultDatabaseStorageConfiguration();
+         final ExecutorFactory executorFactory = new OrderedExecutorFactory(executor);
+         JdbcNodeManager nodeManager = JdbcNodeManager.with(dbConf, scheduledExecutorService, executorFactory);
+         nodeManager.start();
+         NodeRunner nodeRunner = new NodeRunner(nodeManager, action);
+         nodeRunners.add(nodeRunner);
+         nodeManagers.add(nodeManager);
+         executors.add(scheduledExecutorService);
+         executors.add(executor);
+      }
+      for (int i = 0, nodeRunnersSize = nodeRunners.size(); i < nodeRunnersSize; i++) {
+         NodeRunner nodeRunner = nodeRunners.get(i);
+         threads[i] = new Thread(nodeRunner);
+         threads[i].start();
+      }
+      boolean isDebug = isDebug();
+      for (Thread thread : threads) {
+         try {
+            if (isDebug) {
+               thread.join();
+            } else {
+               thread.join(60_000);
+            }
+         } catch (InterruptedException e) {
+            //
+         }
+         if (thread.isAlive()) {
+            thread.interrupt();
+            fail("thread still running");
+         }
+      }
+      // forcibly stop node managers
+      nodeManagers.forEach(nodeManager -> {
+         try {
+            nodeManager.stop();
+         } catch (Exception e) {
+            // won't prevent the test to complete
+            e.printStackTrace();
+         }
+      });
+
+      // stop executors
+      executors.forEach(ExecutorService::shutdownNow);
+
+      for (NodeRunner nodeRunner : nodeRunners) {
+         if (nodeRunner.e != null) {
+            nodeRunner.e.printStackTrace();
+            fail(nodeRunner.e.getMessage());
+         }
+      }
+      Assert.assertFalse("Some of the lease locks has failed to renew the locks", failedRenew.get());
+   }
+
+}

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/NodeManagerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/NodeManagerTest.java
@@ -24,7 +24,9 @@ import org.apache.activemq.artemis.core.server.impl.InVMNodeManager;
 import org.apache.activemq.artemis.tests.util.SpawnedTestBase;
 import org.junit.Test;
 
+import static java.lang.management.ManagementFactory.getRuntimeMXBean;
 import static org.apache.activemq.artemis.tests.integration.cluster.NodeManagerAction.AWAIT_LIVE;
+import static org.apache.activemq.artemis.tests.integration.cluster.NodeManagerAction.CHECK_ID;
 import static org.apache.activemq.artemis.tests.integration.cluster.NodeManagerAction.CRASH_LIVE;
 import static org.apache.activemq.artemis.tests.integration.cluster.NodeManagerAction.DOESNT_HAVE_BACKUP;
 import static org.apache.activemq.artemis.tests.integration.cluster.NodeManagerAction.DOESNT_HAVE_LIVE;
@@ -37,6 +39,12 @@ import static org.apache.activemq.artemis.tests.integration.cluster.NodeManagerA
 import static org.apache.activemq.artemis.tests.integration.cluster.NodeManagerAction.STOP_BACKUP;
 
 public class NodeManagerTest extends SpawnedTestBase {
+
+   @Test
+   public void testID() throws Exception {
+      NodeManagerAction live1 = new NodeManagerAction(CHECK_ID);
+      performWork(live1);
+   }
 
    @Test
    public void testLive() throws Exception {
@@ -153,6 +161,10 @@ public class NodeManagerTest extends SpawnedTestBase {
             fail(nodeRunner.e.getMessage());
          }
       }
+   }
+
+   protected static boolean isDebug() {
+      return getRuntimeMXBean().getInputArguments().toString().contains("jdwp");
    }
 
    static class NodeRunner implements Runnable {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FileLockNodeManagerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FileLockNodeManagerTest.java
@@ -147,10 +147,7 @@ public class FileLockNodeManagerTest extends FailoverTestBase {
             executors.add(executor);
             final DatabaseStorageConfiguration dbConf = createDefaultDatabaseStorageConfiguration();
             final ExecutorFactory executorFactory = new OrderedExecutorFactory(executor);
-            return JdbcNodeManager.with(dbConf, scheduledExecutorService, executorFactory, (code, message, file) -> {
-               code.printStackTrace();
-               Assert.fail(message);
-            });
+            return JdbcNodeManager.with(dbConf, scheduledExecutorService, executorFactory);
          case File:
             final Configuration config = createDefaultInVMConfig();
             if (useSeparateLockFolder) {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/NettyFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/NettyFailoverTest.java
@@ -116,10 +116,7 @@ public class NettyFailoverTest extends FailoverTest {
             executors.add(executor);
             final DatabaseStorageConfiguration dbConf = createDefaultDatabaseStorageConfiguration();
             final ExecutorFactory executorFactory = new OrderedExecutorFactory(executor);
-            return JdbcNodeManager.with(dbConf, scheduledExecutorService, executorFactory, (code, message, file) -> {
-               code.printStackTrace();
-               Assert.fail(message);
-            });
+            return JdbcNodeManager.with(dbConf, scheduledExecutorService, executorFactory);
          default:
             throw new AssertionError("enum type not supported!");
       }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/critical/CriticalCrashTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/critical/CriticalCrashTest.java
@@ -100,7 +100,7 @@ public class CriticalCrashTest extends SpawnedTestBase {
          @Override
          protected StorageManager createStorageManager() {
 
-            JournalStorageManager storageManager = new JournalStorageManager(conf, getCriticalAnalyzer(), executorFactory, scheduledPool, ioExecutorFactory, shutdownOnCriticalIO) {
+            JournalStorageManager storageManager = new JournalStorageManager(conf, getCriticalAnalyzer(), executorFactory, scheduledPool, ioExecutorFactory, ioCriticalErrorListener) {
                @Override
                public void readLock() {
                   super.readLock();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/critical/ShutdownOnCriticalIOErrorMoveNextTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/critical/ShutdownOnCriticalIOErrorMoveNextTest.java
@@ -91,7 +91,7 @@ public class ShutdownOnCriticalIOErrorMoveNextTest extends ActiveMQTestBase {
          @Override
          protected StorageManager createStorageManager() {
 
-            JournalStorageManager storageManager = new JournalStorageManager(conf, getCriticalAnalyzer(), executorFactory, scheduledPool, ioExecutorFactory, shutdownOnCriticalIO) {
+            JournalStorageManager storageManager = new JournalStorageManager(conf, getCriticalAnalyzer(), executorFactory, scheduledPool, ioExecutorFactory, ioCriticalErrorListener) {
 
                @Override
                protected Journal createMessageJournal(Configuration config,

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/discovery/DiscoveryBaseTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/discovery/DiscoveryBaseTest.java
@@ -175,38 +175,38 @@ public class DiscoveryBaseTest extends ActiveMQTestBase {
    protected final class FakeNodeManager extends NodeManager {
 
       public FakeNodeManager(String nodeID) {
-         super(false, null);
+         super(false);
          this.setNodeID(nodeID);
       }
 
       @Override
-      public void awaitLiveNode() throws Exception {
+      public void awaitLiveNode() {
       }
 
       @Override
-      public void awaitLiveStatus() throws Exception {
+      public void awaitLiveStatus() {
       }
 
       @Override
-      public void startBackup() throws Exception {
+      public void startBackup() {
       }
 
       @Override
-      public ActivateCallback startLiveNode() throws Exception {
+      public ActivateCallback startLiveNode() {
          return new CleaningActivateCallback() {
          };
       }
 
       @Override
-      public void pauseLiveServer() throws Exception {
+      public void pauseLiveServer() {
       }
 
       @Override
-      public void crashLiveServer() throws Exception {
+      public void crashLiveServer() {
       }
 
       @Override
-      public void releaseBackup() throws Exception {
+      public void releaseBackup() {
       }
 
       @Override
@@ -215,12 +215,12 @@ public class DiscoveryBaseTest extends ActiveMQTestBase {
       }
 
       @Override
-      public boolean isAwaitingFailback() throws Exception {
+      public boolean isAwaitingFailback() {
          return false;
       }
 
       @Override
-      public boolean isBackupLive() throws Exception {
+      public boolean isBackupLive() {
          return false;
       }
 


### PR DESCRIPTION
This PR include several changes:

- refactor node managers to allow a unified handling of lost lock events and I/O errors while dealing with the shared state
- improve granularity of the file lock acquisition timeout
- introduce the `restart-allowed` configuration parameter (`false` by default`) to allow the broker to restart itself in case of I/O critical failure