### PR TITLE
ARTEMIS-2933 Upgrade com.sun.winsw to 2.7.0-net4

### DIFF
--- a/artemis-cli/pom.xml
+++ b/artemis-cli/pom.xml
@@ -192,7 +192,7 @@
                    <groupId>com.sun.winsw</groupId>
                    <artifactId>winsw</artifactId>
                    <version>${winsw.version}</version>
-                   <classifier>bin</classifier>
+                   <classifier>net4</classifier>
                    <type>exe</type>
                    <outputDirectory>${basedir}/target/classes/org/apache/activemq/artemis/cli/commands/bin/</outputDirectory>
                    <destFileName>artemis-service.exe</destFileName>


### PR DESCRIPTION
The only executable included in the broker bin package that depends on .NET Framework 3.5 is artemis-service.exe/winsw. Using winsw for .NET Framework 4 we should remove any dependency on .NET Framework 3.5.

This would simplify the installation on Windows because .NET Framework 4 is installed by default on the last versions of Windows.