### PR TITLE
ARTEMIS-2931: Resolving potential NPEs detected by eclipse

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingStoreImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingStoreImpl.java
@@ -565,11 +565,12 @@ public class PagingStoreImpl implements PagingStore {
       SequentialFileFactory factory = null;
       try {
          factory = checkFileFactory();
+         SequentialFile file = factory.createSequentialFile(fileName);
+         return file.exists();
       } catch (Exception ignored) {
+         assert false : "PagingStoreFactory::newFileFactory never-throws assumption failed.";
+         return false;
       }
-
-      SequentialFile file = factory.createSequentialFile(fileName);
-      return file.exists();
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/replication/ReplicationEndpoint.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/replication/ReplicationEndpoint.java
@@ -405,7 +405,7 @@ public final class ReplicationEndpoint implements ChannelHandler, ActiveMQCompon
          }
       }
 
-      if (this.channel != null && outgoingInterceptors != null) {
+      if (channel != null && outgoingInterceptors != null) {
          if (channel.getConnection() instanceof RemotingConnectionImpl)  {
             try {
                RemotingConnectionImpl impl = (RemotingConnectionImpl) channel.getConnection();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -1262,7 +1262,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
          try {
             securityStore.stop();
          } catch (Throwable t) {
-            ActiveMQServerLogger.LOGGER.errorStoppingComponent(t, managementService.getClass().getName());
+            ActiveMQServerLogger.LOGGER.errorStoppingComponent(t, securityStore.getClass().getName());
          }
       }
 


### PR DESCRIPTION
WARNING: the eclipse static analyser is pretty limited and it cannot cope with cases like: correlated variables, exception paths, .... 70% of eclipse warnings on artemis codebase is a false alarm.

Anyway some variable correlations can be eliminated and code becomes more readable for humans too.

For "never-throws", the assumption is made explicit. If you disagree with the reverse-engineered assumption then it is likely an indication of a true potential NPE.

Last but not least, copy&paste is a common source of bugs. I suspect eclipse indirectly detected one such case.

Hope it helps