### PR TITLE
ARTEMIS-2955 commons-dbcp2 performance issue with Derby Embedded DBMS

### DIFF
--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/drivers/AbstractJDBCDriver.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/drivers/AbstractJDBCDriver.java
@@ -132,6 +132,7 @@ public abstract class AbstractJDBCDriver {
                         logger.tracef("Table %s did exist but is empty. Starting initialization.", tableName);
                      } else {
                         logger.tracef("Table %s did exist but is empty. Initialization completed: no initialization statements left.", tableName);
+                        connection.commit();
                      }
                   }
                } catch (SQLException e) {

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
@@ -258,6 +258,10 @@ public abstract class ActiveMQTestBase extends Assert {
    @After
    public void shutdownDerby() {
       try {
+         DriverManager.getConnection("jdbc:derby:" + getEmbeddedDataBaseName() + ";destroy=true");
+      } catch (Exception ignored) {
+      }
+      try {
          DriverManager.getConnection("jdbc:derby:;shutdown=true");
       } catch (Exception ignored) {
       }
@@ -837,8 +841,12 @@ public abstract class ActiveMQTestBase extends Assert {
       return testDir;
    }
 
+   private String getEmbeddedDataBaseName() {
+      return "memory:" + getTestDir();
+   }
+
    protected final String getTestJDBCConnectionUrl() {
-      return System.getProperty("jdbc.connection.url", "jdbc:derby:" + getTestDir() + File.separator + "derby;create=true");
+      return System.getProperty("jdbc.connection.url", "jdbc:derby:" + getEmbeddedDataBaseName() + ";create=true");
    }
 
    protected final String getJDBCClassName() {


### PR DESCRIPTION
This commit is fixing:
- a missing commit that can make leak a connection
- restricting default specific commons-dbcp2 to the default data source
- setting poolPreparedStatements true by default
- configured embedded Derby to be in-memory to speedup tests