### PR TITLE
ARTEMIS-2958 Timed out waiting pool stop on backup restart

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ChannelImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ChannelImpl.java
@@ -643,6 +643,10 @@ public final class ChannelImpl implements Channel {
          unlock();
       }
       closed = true;
+      // unblock any blocked call:
+      // don't move this one before closed = true, because
+      // unblocked calls need to check if (closed) to "gracefully" shutdown.
+      returnBlocking();
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/BackupManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/BackupManager.java
@@ -192,9 +192,9 @@ public class BackupManager implements ActiveMQComponent {
       private TransportConfiguration connector;
       protected long retryInterval;
       private ClusterManager clusterManager;
-      private boolean stopping = false;
-      private boolean announcingBackup;
-      private boolean backupAnnounced = false;
+      private volatile boolean stopping = false;
+      private volatile boolean announcingBackup;
+      private volatile boolean backupAnnounced = false;
 
       @Override
       public String toString() {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARTEMIS-2958

BackupManager::activated should correctly unblock
unauthorized blocking requests to allow a backup broker
to prompty restart in case of live failback