### PR TITLE
[ARTEMIS-2954]: RA doesn't use the RA specified prefix when setting u…

### DIFF
--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQActivation.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQActivation.java
@@ -597,12 +597,12 @@ public class ActiveMQActivation {
       if (spec.getTopicPrefix() == null) {
          if (spec.isEnable1xPrefixes() == null) {
             if (ra.isEnable1xPrefixes() != null && ra.isEnable1xPrefixes() && !topic.startsWith(PacketImpl.OLD_TOPIC_PREFIX.toString())) {
-               return PacketImpl.OLD_TOPIC_PREFIX.toString();
+               return PacketImpl.OLD_TOPIC_PREFIX.toString() + topic;
             }
             return topic;
          }
          if (spec.isEnable1xPrefixes() && !topic.startsWith(PacketImpl.OLD_TOPIC_PREFIX.toString())) {
-            return PacketImpl.OLD_TOPIC_PREFIX.toString();
+            return PacketImpl.OLD_TOPIC_PREFIX.toString() + topic;
          }
          return topic;
       }
@@ -613,12 +613,12 @@ public class ActiveMQActivation {
       if (spec.getQueuePrefix() == null) {
          if (spec.isEnable1xPrefixes() == null) {
             if (ra.isEnable1xPrefixes() != null && ra.isEnable1xPrefixes() && !queue.startsWith(PacketImpl.OLD_QUEUE_PREFIX.toString())) {
-               return PacketImpl.OLD_QUEUE_PREFIX.toString();
+               return PacketImpl.OLD_QUEUE_PREFIX.toString() + queue;
             }
             return queue;
          }
          if (spec.isEnable1xPrefixes() && !queue.startsWith(PacketImpl.OLD_QUEUE_PREFIX.toString())) {
-            return PacketImpl.OLD_QUEUE_PREFIX.toString();
+            return PacketImpl.OLD_QUEUE_PREFIX.toString() + queue;
          }
          return queue;
       }


### PR DESCRIPTION
…p a destination.

* Fixing the fix for double prefix issue as the destiantion name wasn't
  appended when the old prefix wasn't present.

Issue: https://issues.apache.org/jira/browse/ARTEMIS-2954