### PR TITLE
ARTEMIS-2937 Documentation improvements

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/AMQPBrokerConnection.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/AMQPBrokerConnection.java
@@ -289,13 +289,13 @@ public class AMQPBrokerConnection implements ClientConnectionLifeCycleListener, 
       if (bridgeManager.isStarted() && started) {
          if (brokerConnectConfiguration.getReconnectAttempts() < 0 || retryCounter < brokerConnectConfiguration.getReconnectAttempts()) {
             retryCounter++;
-            ActiveMQAMQPProtocolLogger.LOGGER.retryConnection(brokerConnectConfiguration.getName(), host, port, retryCounter, brokerConnectConfiguration.getReconnectAttempts());
+            ActiveMQAMQPProtocolLogger.LOGGER.retryConnection(brokerConnectConfiguration.getName(), host + ":" + port, retryCounter, brokerConnectConfiguration.getReconnectAttempts());
             if (logger.isDebugEnabled()) {
                logger.debug("Reconnecting in " + brokerConnectConfiguration.getRetryInterval() + ", this is the " + retryCounter + " of " + brokerConnectConfiguration.getReconnectAttempts());
             }
             reconnectFuture = scheduledExecutorService.schedule(() -> connectExecutor.execute(() -> doConnect()), brokerConnectConfiguration.getRetryInterval(), TimeUnit.MILLISECONDS);
          } else {
-            ActiveMQAMQPProtocolLogger.LOGGER.retryConnectionFailed(brokerConnectConfiguration.getName(), host, port, retryCounter, brokerConnectConfiguration.getReconnectAttempts());
+            ActiveMQAMQPProtocolLogger.LOGGER.retryConnectionFailed(brokerConnectConfiguration.getName(), host + ":" +  port, retryCounter);
             if (logger.isDebugEnabled()) {
                logger.debug("no more reconnections as the retry counter reached " + retryCounter + " out of " + brokerConnectConfiguration.getReconnectAttempts());
             }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/logger/ActiveMQAMQPProtocolLogger.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/logger/ActiveMQAMQPProtocolLogger.java
@@ -51,13 +51,13 @@ public interface ActiveMQAMQPProtocolLogger extends BasicLogger {
 
    @LogMessage(level = Logger.Level.WARN)
    @Message(id = 111001, value = "\n*******************************************************************************************************************************" +
-      "\nCould not re-establish AMQP Server Connection {0} on {1}:{2} after {3} retries with a total configured of {4}" +
+      "\nCould not re-establish AMQP Server Connection {0} on {1} after {2} retries" +
       "\n*******************************************************************************************************************************\n", format = Message.Format.MESSAGE_FORMAT)
-   void retryConnectionFailed(String name, String host, int port, int currentRetry, int maxRetry);
+   void retryConnectionFailed(String name, String hostAndPort, int currentRetry);
 
    @LogMessage(level = Logger.Level.INFO)
    @Message(id = 111002, value = "\n*******************************************************************************************************************************" +
-                                 "\nRetrying Server AMQP Connection {0} on {1}:{2} retry {3} of {4}" +
+                                 "\nRetrying Server AMQP Connection {0} on {1} retry {2} of {3}" +
                                  "\n*******************************************************************************************************************************\n", format = Message.Format.MESSAGE_FORMAT)
-   void retryConnection(String name, String host, int port, int currentRetry, int maxRetry);
+   void retryConnection(String name, String hostAndPort, int currentRetry, int maxRetry);
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -1911,7 +1911,7 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
                connectionElement = amqpMirrorConnectionElement;
                connectionElement.setType(AMQPBrokerConnectionAddressType.MIRROR);
             } else {
-               String match = getAttributeValue(e2, "match");
+               String match = getAttributeValue(e2, "address-match");
                String queue = getAttributeValue(e2, "queue-name");
                connectionElement = new AMQPBrokerConnectionElement();
                connectionElement.setMatchAddress(SimpleString.toSimpleString(match)).setType(nodeType);

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -972,7 +972,7 @@
                            <xsd:attribute name="match" type="xsd:string" use="required">
                               <xsd:annotation>
                                  <xsd:documentation>
-                                    pattern for matching security roles against addresses; can use wildards
+                                    pattern for matching security roles against addresses; can use wildcards
                                  </xsd:documentation>
                               </xsd:annotation>
                            </xsd:attribute>
@@ -2075,7 +2075,7 @@
    </xsd:complexType>
 
    <xsd:complexType name="amqp-address-match-type">
-      <xsd:attribute name="match" type="xsd:string" use="optional">
+      <xsd:attribute name="address-match" type="xsd:string" use="optional">
          <xsd:annotation>
             <xsd:documentation>
                address expression to match addresses
@@ -2083,12 +2083,12 @@
          </xsd:annotation>
       </xsd:attribute>
       <xsd:attribute name="queue-name" type="xsd:string" use="optional">
-      <xsd:annotation>
-         <xsd:documentation>
-            This is the exact queue name to be used.
-         </xsd:documentation>
-      </xsd:annotation>
-   </xsd:attribute>
+         <xsd:annotation>
+            <xsd:documentation>
+               This is the exact queue name to be used.
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
    </xsd:complexType>
    <xsd:complexType name="amqp-mirror-type">
       <xsd:annotation>
@@ -2097,15 +2097,6 @@
             All events will be send towards this AMQP connection acting like a replica.
          </xsd:documentation>
       </xsd:annotation>
-      <!--
-        TODO: comment this out when we start supporting matching on mirror.
-      <xsd:attribute name="match" type="xsd:string" use="required">
-         <xsd:annotation>
-            <xsd:documentation>
-               address expression to match addresses
-            </xsd:documentation>
-         </xsd:annotation>
-      </xsd:attribute> -->
 
       <xsd:attribute name="message-acknowledgements" type="xsd:boolean" use="optional" default="true">
          <xsd:annotation>
@@ -3871,7 +3862,7 @@
                   </xsd:documentation>
                </xsd:annotation>
             </xsd:element>
-            
+
          </xsd:all>
 
          <xsd:attribute name="match" type="xsd:string" use="required">

--- a/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
@@ -374,9 +374,9 @@
       </cluster-connections>
       <broker-connections>
          <amqp-connection uri="tcp://test1:111" name="test1" retry-interval="333" reconnect-attempts="33" user="testuser" password="testpassword">
-            <sender match="TEST-SENDER"  />
-            <receiver match="TEST-RECEIVER" />
-            <peer match="TEST-PEER"/>
+            <sender address-match="TEST-SENDER"  />
+            <receiver address-match="TEST-RECEIVER" />
+            <peer address-match="TEST-PEER"/>
             <receiver queue-name="TEST-WITH-QUEUE-NAME"/>
             <mirror message-acknowledgements="false" queue-creation="false" source-mirror-address="TEST-REPLICA" queue-removal="false"/>
          </amqp-connection>

--- a/artemis-tools/src/test/resources/artemis-configuration.xsd
+++ b/artemis-tools/src/test/resources/artemis-configuration.xsd
@@ -614,7 +614,7 @@
             <xsd:annotation>
                <xsd:documentation>
                   A list of connections the broker will make towards other servers.
-                  Currently the only connection type supported is amqp-connection
+                  Currently the only connection type supported is amqpConnection
                </xsd:documentation>
             </xsd:annotation>
          </xsd:element>
@@ -972,7 +972,7 @@
                            <xsd:attribute name="match" type="xsd:string" use="required">
                               <xsd:annotation>
                                  <xsd:documentation>
-                                    pattern for matching security roles against addresses; can use wildards
+                                    pattern for matching security roles against addresses; can use wildcards
                                  </xsd:documentation>
                               </xsd:annotation>
                            </xsd:attribute>
@@ -2028,6 +2028,13 @@
             </xsd:documentation>
          </xsd:annotation>
       </xsd:attribute>
+      <xsd:attribute name="auto-start" type="xsd:boolean" default="true">
+         <xsd:annotation>
+            <xsd:documentation>
+               should the broker connection be started when the server is started.
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
       <xsd:attribute name="reconnect-attempts" type="xsd:int" default="-1">
          <xsd:annotation>
             <xsd:documentation>
@@ -2068,7 +2075,7 @@
    </xsd:complexType>
 
    <xsd:complexType name="amqp-address-match-type">
-      <xsd:attribute name="match" type="xsd:string" use="optional">
+      <xsd:attribute name="address-match" type="xsd:string" use="optional">
          <xsd:annotation>
             <xsd:documentation>
                address expression to match addresses
@@ -2090,15 +2097,6 @@
             All events will be send towards this AMQP connection acting like a replica.
          </xsd:documentation>
       </xsd:annotation>
-      <!--
-        TODO: comment this out when we start supporting matching on mirror.
-      <xsd:attribute name="match" type="xsd:string" use="required">
-         <xsd:annotation>
-            <xsd:documentation>
-               address expression to match addresses
-            </xsd:documentation>
-         </xsd:annotation>
-      </xsd:attribute> -->
 
       <xsd:attribute name="message-acknowledgements" type="xsd:boolean" use="optional" default="true">
          <xsd:annotation>
@@ -3865,20 +3863,12 @@
                </xsd:annotation>
             </xsd:element>
 
-            <xsd:element name="page-store-name" type="xsd:string" maxOccurs="1" minOccurs="0">
-               <xsd:annotation>
-                  <xsd:documentation>
-                     the name of the page store to use, to allow the page store to coalesce for address hierarchies when wildcard routing is in play
-                  </xsd:documentation>
-               </xsd:annotation>
-            </xsd:element>
-
          </xsd:all>
 
          <xsd:attribute name="match" type="xsd:string" use="required">
             <xsd:annotation>
                <xsd:documentation>
-                  pattern for matching settings against addresses; can use wildcards
+                  pattern for matching settings against addresses; can use wildards
                </xsd:documentation>
             </xsd:annotation>
          </xsd:attribute>

--- a/examples/features/broker-connection/amqp-receiving-messages/src/main/resources/activemq/server0/broker.xml
+++ b/examples/features/broker-connection/amqp-receiving-messages/src/main/resources/activemq/server0/broker.xml
@@ -54,7 +54,7 @@ under the License.
       <broker-connections>
          <amqp-connection uri="tcp://localhost:5672" name="receiver" retry-interval="100">
             <!-- This will create one receiver for every queue matching this address expression -->
-            <receiver match="#"/>
+            <receiver address-match="#"/>
          </amqp-connection>
       </broker-connections>
 

--- a/examples/features/broker-connection/amqp-sending-messages/src/main/resources/activemq/server0/broker.xml
+++ b/examples/features/broker-connection/amqp-sending-messages/src/main/resources/activemq/server0/broker.xml
@@ -54,7 +54,7 @@ under the License.
       <broker-connections>
          <amqp-connection uri="tcp://localhost:5771" name="sender" retry-interval="100">
             <!-- This will create one sender for every queue matching this address expression -->
-            <sender match="#"/>
+            <sender address-match="#"/>
          </amqp-connection>
       </broker-connections>
 

--- a/examples/features/broker-connection/amqp-sending-overssl/src/main/resources/activemq/server0/broker.xml
+++ b/examples/features/broker-connection/amqp-sending-overssl/src/main/resources/activemq/server0/broker.xml
@@ -37,7 +37,7 @@ under the License.
 
       <broker-connections>
          <amqp-connection uri="tcp://localhost:5772?sslEnabled=true;trustStorePath=activemq.example.truststore;trustStorePassword=activemqexample" name="otherSSL" retry-interval="1000">
-            <sender match="#"/>
+            <sender address-match="#"/>
          </amqp-connection>
       </broker-connections>
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/QpidDispatchPeerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/QpidDispatchPeerTest.java
@@ -99,7 +99,7 @@ public class QpidDispatchPeerTest extends AmqpClientTestSupport {
    private void internalMultipleQueues(boolean useMatching, boolean distinctNaming) throws Exception {
       final int numberOfMessages = 100;
       final int numberOfQueues = 10;
-      AMQPBrokerConnectConfiguration amqpConnection = new AMQPBrokerConnectConfiguration("test", "tcp://localhost:24621").setRetryInterval(10).setReconnectAttempts(-1);
+      AMQPBrokerConnectConfiguration amqpConnection = new AMQPBrokerConnectConfiguration("test", "tcp://localhost:24622").setRetryInterval(10).setReconnectAttempts(-1);
       if (useMatching) {
          amqpConnection.addElement(new AMQPBrokerConnectionElement().setMatchAddress("queue.#").setType(AMQPBrokerConnectionAddressType.PEER));
       } else {

--- a/tests/integration-tests/src/test/resources/QpidRouterPeerTest-qpidr.conf
+++ b/tests/integration-tests/src/test/resources/QpidRouterPeerTest-qpidr.conf
@@ -25,21 +25,10 @@
     #outputFile: /tmp/qdrouterd.log
 #}
 
- # The broker connects into this port
- listener {
-     saslMechanisms: ANONYMOUS
-     host: 0.0.0.0
-     role: route-container
-     linkCapacity: 1123
-     authenticatePeer: no
-     port: 24621
- }
-
  # Clients connect to this port
  listener {
      saslMechanisms: ANONYMOUS
      host: 0.0.0.0
-     linkCapacity: 555
      role: normal
      authenticatePeer: no
      port: 24622


### PR DESCRIPTION
- Adding a paragraph about addressing and distinct queue names
- Renaming match on peers, senders and receivers as "address-match"