### PR TITLE
Fix unecessary closes

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/ThreadDumpUtil.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/ThreadDumpUtil.java
@@ -34,8 +34,8 @@ public final class ThreadDumpUtil {
 
    public static String threadDump(final String msg) {
 
+      StringWriter str = new StringWriter();
       try (
-         StringWriter str = new StringWriter();
          PrintWriter out = new PrintWriter(str)
       ) {
 
@@ -65,11 +65,7 @@ public final class ThreadDumpUtil {
 
          return str.toString();
 
-      } catch (IOException e) {
-         ActiveMQUtilLogger.LOGGER.error("Exception thrown during generating of thread dump.", e);
       }
-
-      return "Generating of thread dump failed " + msg;
 
    }
 

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/utils/InflaterWriter.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/utils/InflaterWriter.java
@@ -76,7 +76,6 @@ public class InflaterWriter extends OutputStream {
                output.write(outputBuffer, 0, n);
                n = inflater.inflate(outputBuffer);
             }
-            output.close();
          } catch (DataFormatException e) {
             IOException io = new IOException(e.getMessage());
             io.initCause(e);


### PR DESCRIPTION
Meaningless Close: In several classes, close(), specified in Closeable interface, has no effect and other methods in those classes can be called after close() without IOException.


