### PR TITLE
ARTEMIS-2991 Removing HttpAcceptorHandler from HttpKeepAliveRunnable when upgrade to websocket connection

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/HttpAcceptorHandler.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/HttpAcceptorHandler.java
@@ -71,6 +71,12 @@ public class HttpAcceptorHandler extends ChannelDuplexHandler {
    }
 
    @Override
+   public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+      super.handlerRemoved(ctx);
+      httpKeepAliveTask.unregisterKeepAliveHandler(this);
+   }
+
+   @Override
    public void channelRead(final ChannelHandlerContext ctx, final Object msg) throws Exception {
       FullHttpRequest request = (FullHttpRequest) msg;
       HttpMethod method = request.method();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/HttpKeepAliveRunnable.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/HttpKeepAliveRunnable.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.core.remoting.impl.netty;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Future;
 
@@ -41,6 +42,10 @@ public class HttpKeepAliveRunnable implements Runnable {
       for (HttpAcceptorHandler handler : handlers) {
          handler.keepAlive(time);
       }
+   }
+
+   public List<HttpAcceptorHandler> getHandlers() {
+      return Collections.unmodifiableList(handlers);
    }
 
    public synchronized void registerKeepAliveHandler(final HttpAcceptorHandler httpAcceptorHandler) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptor.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptor.java
@@ -491,6 +491,11 @@ public class NettyAcceptor extends AbstractAcceptor {
       return connections;
    }
 
+   // Only for testing purposes
+   public ProtocolHandler getProtocolHandler() {
+      return protocolHandler;
+   }
+
    // only for testing purposes
    public void setKeyStorePath(String keyStorePath) {
       this.keyStorePath = keyStorePath;

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/remoting/impl/netty/HttpAcceptorHandlerTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/remoting/impl/netty/HttpAcceptorHandlerTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.remoting.impl.netty;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.spy;
+
+/**
+ * HttpAcceptorHandlerTest
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class HttpAcceptorHandlerTest {
+
+   private static final String HTTP_HANDLER = "http-handler";
+
+   private HttpKeepAliveRunnable spy;
+
+   @Before
+   public void setUp() throws Exception {
+      spy = spy(new HttpKeepAliveRunnable());
+   }
+
+   @Test
+   public void testUnregisterIsCalledTwiceWhenChannelIsInactive() {
+      EmbeddedChannel channel = new EmbeddedChannel();
+
+      HttpAcceptorHandler httpHandler = new HttpAcceptorHandler(spy, 1000, channel);
+      channel.pipeline().addLast(HTTP_HANDLER, httpHandler);
+
+      channel.close();
+
+      Mockito.verify(spy, Mockito.times(2)).unregisterKeepAliveHandler(httpHandler);
+   }
+
+   @Test
+   public void testUnregisterIsCalledWhenHandlerIsRemovedFromPipeline() {
+      EmbeddedChannel channel = new EmbeddedChannel();
+
+      HttpAcceptorHandler httpHandler = new HttpAcceptorHandler(spy, 1000, channel);
+      channel.pipeline().addLast(HTTP_HANDLER, httpHandler);
+
+      channel.pipeline().remove(HTTP_HANDLER);
+
+      Mockito.verify(spy).unregisterKeepAliveHandler(httpHandler);
+   }
+}

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpClientTestSupport.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpClientTestSupport.java
@@ -67,6 +67,7 @@ public class AmqpClientTestSupport extends AmqpTestSupport {
    protected static final Symbol GLOBAL = Symbol.getSymbol("global");
 
    protected static final String BROKER_NAME = "localhost";
+   protected static final String NETTY_ACCEPTOR = "netty-acceptor";
 
    protected String noprivUser = "noprivs";
    protected String noprivPass = "noprivs";
@@ -211,7 +212,7 @@ public class AmqpClientTestSupport extends AmqpTestSupport {
       params.put(TransportConstants.PROTOCOLS_PROP_NAME, getConfiguredProtocols());
       HashMap<String, Object> amqpParams = new HashMap<>();
       configureAMQPAcceptorParameters(amqpParams);
-      TransportConfiguration tc = new TransportConfiguration(NETTY_ACCEPTOR_FACTORY, params, "netty-acceptor", amqpParams);
+      TransportConfiguration tc = new TransportConfiguration(NETTY_ACCEPTOR_FACTORY, params, NETTY_ACCEPTOR, amqpParams);
       configureAMQPAcceptorParameters(tc);
       return tc;
    }
@@ -233,7 +234,7 @@ public class AmqpClientTestSupport extends AmqpTestSupport {
       server.getConfiguration().getAddressesSettings().put("#", addressSettings);
       Set<TransportConfiguration> acceptors = server.getConfiguration().getAcceptorConfigurations();
       for (TransportConfiguration tc : acceptors) {
-         if (tc.getName().equals("netty-acceptor")) {
+         if (tc.getName().equals(NETTY_ACCEPTOR)) {
             tc.getExtraParams().put("anycastPrefix", "anycast://");
             tc.getExtraParams().put("multicastPrefix", "multicast://");
          }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/WebSocketConnectionTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/WebSocketConnectionTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.amqp;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+
+import org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptor;
+import org.apache.qpid.jms.JmsConnection;
+import org.apache.qpid.jms.JmsConnectionFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test connections can be established to remote peers via WebSockets
+ */
+public class WebSocketConnectionTest extends JMSClientTestSupport {
+
+   @Override
+   public boolean isUseWebSockets() {
+      return true;
+   }
+
+   @Test
+   public void testSingleKeepAliveIsReleasedWhenWebSocketUpgradeHappens() throws Exception {
+      JmsConnectionFactory factory = new JmsConnectionFactory(getBrokerQpidJMSConnectionURI());
+
+      produceAndConsumeInNewConnection(factory);
+
+      assertKeepAliveCounterIsZero();
+   }
+
+   @Test
+   public void testMultipleKeepAliveAreReleasedWhenWebSocketUpgradeHappens() throws Exception {
+      JmsConnectionFactory factory = new JmsConnectionFactory(getBrokerQpidJMSConnectionURI());
+
+      produceAndConsumeInNewConnection(factory);
+      produceAndConsumeInNewConnection(factory);
+      produceAndConsumeInNewConnection(factory);
+      produceAndConsumeInNewConnection(factory);
+      produceAndConsumeInNewConnection(factory);
+
+      assertKeepAliveCounterIsZero();
+   }
+
+   private void produceAndConsumeInNewConnection(JmsConnectionFactory factory) throws JMSException {
+      JmsConnection connection = (JmsConnection) factory.createConnection();
+
+      try {
+         Session session = connection.createSession();
+         Queue queue = session.createQueue(getQueueName());
+
+         MessageProducer producer = session.createProducer(queue);
+         producer.send(session.createMessage());
+         producer.close();
+
+         connection.start();
+
+         MessageConsumer consumer = session.createConsumer(queue);
+         Message message = consumer.receive(1000);
+
+         assertNotNull(message);
+      } finally {
+         connection.close();
+      }
+   }
+
+   private void assertKeepAliveCounterIsZero() {
+      NettyAcceptor nettyAcceptor = (NettyAcceptor) server.getRemotingService().getAcceptor(NETTY_ACCEPTOR);
+
+      int httpAcceptorHandlerCount = nettyAcceptor.getProtocolHandler().getHttpKeepAliveRunnable().getHandlers().size();
+
+      Assert.assertEquals(0, httpAcceptorHandlerCount);
+   }
+}


### PR DESCRIPTION
Sending this small fix to resolve the ticket https://issues.apache.org/jira/browse/ARTEMIS-2991

# Implementation

The idea is to remove the HttpAcceptorHandler from the list of handlers when the upgrade is perform

# Test

1) Do you know a good way of testing this? I was thinking using JMSWebSocketConnectionTest to later get the NettyAcceptor but not sure about how to get it, I can check other approaches but I would like to know your opinion before creating the test

2) Also I need to test the the websocket connection keeps opens without the need of that handler.