### PR TITLE
ARTEMIS-3012 incorrect fallback consumer authorization

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -541,8 +541,17 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
       try {
          securityCheck(address, unPrefixedQueueName, browseOnly ? CheckType.BROWSE : CheckType.CONSUME, this);
       } catch (Exception e) {
-         // this is here for backwards compatibility with the pre-FQQN syntax from ARTEMIS-592
-         securityCheck(address.concat(".").concat(unPrefixedQueueName), queueName, browseOnly ? CheckType.BROWSE : CheckType.CONSUME, this);
+         /*
+          * This is here for backwards compatibility with the pre-FQQN syntax from ARTEMIS-592.
+          * We only want to do this check if an exact match exists in the security-settings.
+          * This code is deprecated and should be removed at the release of the next major version.
+          */
+         SimpleString exactMatch = address.concat(".").concat(unPrefixedQueueName);
+         if (server.getSecurityRepository().containsExactMatch(exactMatch.toString())) {
+            securityCheck(exactMatch, unPrefixedQueueName, browseOnly ? CheckType.BROWSE : CheckType.CONSUME, this);
+         } else {
+            throw e;
+         }
       }
 
       Filter filter = FilterImpl.createFilter(filterString);

--- a/tests/integration-tests/src/test/resources/roles.properties
+++ b/tests/integration-tests/src/test/resources/roles.properties
@@ -20,3 +20,4 @@ accounting=second
 employees=first,second
 a=a
 b=b
+amq=x

--- a/tests/integration-tests/src/test/resources/users.properties
+++ b/tests/integration-tests/src/test/resources/users.properties
@@ -19,3 +19,4 @@ first=secret
 second=password
 a=a
 b=b
+x=x


### PR DESCRIPTION
The fallback consumer authorization implemented in ARTEMIS-592 needs to
check for an *exact* security-settings match otherwise in certain
configurations a more general and more permissive setting might
be used instead of the intended more specific and more restrictive
setting.