### PR TITLE
ARTEMIS-3026 Allow "re-encode" of amqp large messages

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPLargeMessage.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPLargeMessage.java
@@ -87,6 +87,8 @@ public class AMQPLargeMessage extends AMQPMessage implements LargeServerMessage 
       }
    }
 
+   private boolean reencoded = false;
+
    /**
     * AMQPLargeMessagePersister will save the buffer here.
     * */
@@ -622,7 +624,15 @@ public class AMQPLargeMessage extends AMQPMessage implements LargeServerMessage 
 
    @Override
    public void reencode() {
+      reencoded = true;
+   }
 
+   public void setReencoded(boolean reencoded) {
+      this.reencoded = reencoded;
+   }
+
+   public boolean isReencoded() {
+      return reencoded;
    }
 
    @Override

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
@@ -242,7 +242,7 @@ public abstract class AMQPMessage extends RefCountMessage implements org.apache.
    /** This will return application properties without attempting to decode it.
     * That means, if applicationProperties were never parsed before, this will return null, even if there is application properties.
     *  This was created as an internal method for testing, as we need to validate if the application properties are not decoded until needed. */
-   public ApplicationProperties getDecodedApplicationProperties() {
+   protected ApplicationProperties getDecodedApplicationProperties() {
       return applicationProperties;
    }
 

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessageBrokerAccessor.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessageBrokerAccessor.java
@@ -18,6 +18,7 @@
 package org.apache.activemq.artemis.protocol.amqp.broker;
 
 import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
 import org.apache.qpid.proton.amqp.messaging.Header;
 import org.apache.qpid.proton.amqp.messaging.Properties;
 
@@ -38,6 +39,16 @@ public class AMQPMessageBrokerAccessor {
    /** Warning: this is a method specific to the broker. Do not use it on user's application. */
    public static Header getCurrentHeader(AMQPMessage message) {
       return message.getCurrentHeader();
+   }
+
+   /** Warning: this is a method specific to the broker. Do not use it on user's application. */
+   public static ApplicationProperties getDecodedApplicationProperties(AMQPMessage message) {
+      return message.getDecodedApplicationProperties();
+   }
+
+   /** Warning: this is a method specific to the broker. Do not use it on user's application. */
+   public static int getRemainingBodyPosition(AMQPMessage message) {
+      return message.remainingBodyPosition;
    }
 
    /** Warning: this is a method specific to the broker. Do not use it on user's application. */

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpMessageDivertsTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpMessageDivertsTest.java
@@ -17,20 +17,41 @@
 package org.apache.activemq.artemis.tests.integration.amqp;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
+import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.QueueConfiguration;
 import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.server.ComponentConfigurationRoutingType;
 import org.apache.activemq.artemis.core.server.Queue;
+import org.apache.activemq.artemis.core.server.transformer.Transformer;
+import org.apache.activemq.artemis.tests.util.Wait;
 import org.apache.activemq.transport.amqp.client.AmqpClient;
 import org.apache.activemq.transport.amqp.client.AmqpConnection;
+import org.apache.activemq.transport.amqp.client.AmqpMessage;
 import org.apache.activemq.transport.amqp.client.AmqpReceiver;
+import org.apache.activemq.transport.amqp.client.AmqpSender;
 import org.apache.activemq.transport.amqp.client.AmqpSession;
+import org.junit.Assert;
 import org.junit.Test;
 
-public class AmqpMessageDivertsTest extends AmqpClientTestSupport {
+public class AmqpMessageDivertsTest extends AmqpClientTestSupport implements Transformer {
+
+   static final AtomicInteger divertCount = new AtomicInteger(0);
+
+   String largeString = createLargeString();
+
+   protected String createLargeString() {
+      StringBuffer bufferLarge = new StringBuffer();
+      for (int i = 0; i < 500 * 1024; i++) {
+         bufferLarge.append((char) ('a' + (i % 20)));
+      }
+      String largeString = bufferLarge.toString();
+      return largeString;
+   }
+
 
    @Test(timeout = 60000)
    public void testQueueReceiverReadMessageWithDivert() throws Exception {
@@ -66,5 +87,110 @@ public class AmqpMessageDivertsTest extends AmqpClientTestSupport {
       assertEquals(1, queueView.getMessageCount());
 
       connection.close();
+   }
+
+   @Test
+   public void testDivertTransformerWithProperties() throws Exception {
+      testDivertTransformerWithProperties(false);
+   }
+
+   @Test
+   public void testDivertTransformerWithPropertiesRebootServer() throws Exception {
+      testDivertTransformerWithProperties(true);
+   }
+
+   public void testDivertTransformerWithProperties(boolean rebootServer) throws Exception {
+      divertCount.set(0);
+      final String forwardingAddress = getQueueName() + "Divert";
+      final SimpleString simpleForwardingAddress = SimpleString.toSimpleString(forwardingAddress);
+      server.createQueue(new QueueConfiguration(simpleForwardingAddress).setRoutingType(RoutingType.ANYCAST));
+      server.getActiveMQServerControl().createDivert("name", "routingName", getQueueName(),
+                                                     forwardingAddress, true, null, AmqpMessageDivertsTest.class.getName(),
+                                                     ComponentConfigurationRoutingType.ANYCAST.toString());
+
+      AmqpClient client = createAmqpClient();
+      AmqpConnection connection = addConnection(client.connect());
+      AmqpSession session = connection.createSession();
+
+      Queue queueView = getProxyToQueue(forwardingAddress);
+      AmqpSender sender = session.createSender(getQueueName());
+      AmqpMessage message = new AmqpMessage();
+      message.setDurable(true);
+      message.setApplicationProperty("addLarge", false);
+      message.setApplicationProperty("always", "here");
+      message.setBytes(new byte[10]); // one small
+      sender.send(message);
+      Wait.assertEquals(1, queueView::getMessageCount);
+
+      message = new AmqpMessage();
+      message.setDurable(true);
+      message.setApplicationProperty("addLarge", false);
+      message.setApplicationProperty("always", "here");
+      message.setBytes(new byte[300 * 1024]); // one large
+      sender.send(message);
+      Wait.assertEquals(2, queueView::getMessageCount);
+
+      if (rebootServer) {
+         Wait.assertEquals(2, divertCount::get);
+         connection.close();
+         server.stop();
+         server.start();
+
+         // reopen connections
+         client = createAmqpClient();
+         connection = addConnection(client.connect());
+         session = connection.createSession();
+      } else {
+         message = new AmqpMessage();
+         message.setDurable(false);
+         message.setBytes(new byte[300 * 1024]); // one large
+         message.setApplicationProperty("addLarge", true);
+         message.setApplicationProperty("always", "here");
+         sender.send(message);
+         Wait.assertEquals(3, divertCount::get);
+      }
+
+
+      AmqpReceiver receiver = session.createReceiver(forwardingAddress);
+
+      queueView = getProxyToQueue(forwardingAddress);
+      assertEquals(rebootServer ? 2 : 3, queueView.getMessageCount());
+
+      receiver.flow(2);
+      for (int i = 0; i < 2; i++) {
+         AmqpMessage receivedMessage = receiver.receive(5, TimeUnit.SECONDS);
+         Assert.assertNotNull(receivedMessage);
+         Assert.assertEquals("here", receivedMessage.getApplicationProperty("always"));
+         Assert.assertEquals("mundo", receivedMessage.getApplicationProperty("oi"));
+         receivedMessage.accept();
+      }
+
+      if (!rebootServer) {
+         // if we did not reboot the server a third message was sent
+         receiver.flow(1);
+         AmqpMessage receivedMessage = receiver.receive(5, TimeUnit.SECONDS);
+         receivedMessage.accept();
+         Assert.assertEquals("mundo", receivedMessage.getApplicationProperty("oi"));
+         Assert.assertEquals(largeString, receivedMessage.getApplicationProperty("largeString"));
+
+      }
+
+      receiver.close();
+
+      Wait.assertEquals(0, queueView::getMessageCount);
+
+      connection.close();
+   }
+
+   @Override
+   public Message transform(Message message) {
+      divertCount.incrementAndGet();
+      if (message.getBooleanProperty("addLarge")) {
+         message.putStringProperty("largeString", largeString);
+      }
+      message.putBooleanProperty("oi", true);
+      message.putStringProperty("oi", "mundo");
+      message.reencode();
+      return message;
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/PropertyParseOptimizationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/PropertyParseOptimizationTest.java
@@ -24,6 +24,7 @@ import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.MessageReference;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.protocol.amqp.broker.AMQPMessage;
+import org.apache.activemq.artemis.protocol.amqp.broker.AMQPMessageBrokerAccessor;
 import org.apache.activemq.artemis.tests.util.Wait;
 import org.apache.activemq.artemis.utils.collections.LinkedListIterator;
 import org.apache.activemq.transport.amqp.client.AmqpClient;
@@ -93,7 +94,7 @@ public class PropertyParseOptimizationTest extends AmqpClientTestSupport {
          // if this rule fails it means something is requesting the application property for the message,
          // or the optimization is gone.
          // be careful if you decide to change this rule, as we have done extensive test to get this in place.
-         Assert.assertNull("Application properties on AMQP Messages should only be parsed over demand", message.getDecodedApplicationProperties());
+         Assert.assertNull("Application properties on AMQP Messages should only be parsed over demand", AMQPMessageBrokerAccessor.getDecodedApplicationProperties(message));
       }
 
       AmqpReceiver receiver = session.createReceiver(getQueueName(), "odd=true");


### PR DESCRIPTION
notice the quotes on "re-encode", as this is just replacing the set of application properties, properties and headers by a new set
if a flag reEncoded is set to true on AMQPLargeMessage