### PR TITLE
ARTEMIS-3031 add new callback for broker deactivation

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActivateCallback.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActivateCallback.java
@@ -38,6 +38,12 @@ public interface ActivateCallback {
    }
 
    /*
+    * this is called when the server is stopping, before any resources or clients are closed/stopped
+    */
+   default void preDeActivate() {
+   }
+
+   /*
     * this is called when all resources have been started including any JMS resources
     */
    default void activationComplete() {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1459,8 +1459,8 @@ public interface ActiveMQServerLogger extends BasicLogger {
    void unableDestroyConnectionWithSessionMetadata(@Cause Throwable e);
 
    @LogMessage(level = Logger.Level.WARN)
-   @Message(id = 222234, value = "Unable to deactivate a callback", format = Message.Format.MESSAGE_FORMAT)
-   void unableToDeactiveCallback(@Cause Throwable e);
+   @Message(id = 222234, value = "Unable to invoke a callback", format = Message.Format.MESSAGE_FORMAT)
+   void unableToInvokeCallback(@Cause Throwable e);
 
    @LogMessage(level = Logger.Level.WARN)
    @Message(id = 222235, value = "Unable to inject a monitor", format = Message.Format.MESSAGE_FORMAT)

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -1186,6 +1186,8 @@ public class ActiveMQServerImpl implements ActiveMQServer {
          }
          state = SERVER_STATE.STOPPING;
 
+         callPreDeActiveCallbacks();
+
          if (criticalIOError) {
             final ManagementService managementService = this.managementService;
             if (managementService != null) {
@@ -2899,7 +2901,18 @@ public class ActiveMQServerImpl implements ActiveMQServer {
          } catch (Throwable e) {
             // https://bugzilla.redhat.com/show_bug.cgi?id=1009530:
             // we won't interrupt the shutdown sequence because of a failed callback here
-            ActiveMQServerLogger.LOGGER.unableToDeactiveCallback(e);
+            ActiveMQServerLogger.LOGGER.unableToInvokeCallback(e);
+         }
+      }
+   }
+
+   private void callPreDeActiveCallbacks() {
+      for (ActivateCallback callback : activateCallbacks) {
+         try {
+            callback.preDeActivate();
+         } catch (Throwable e) {
+            // we won't interrupt the shutdown sequence because of a failed callback here
+            ActiveMQServerLogger.LOGGER.unableToInvokeCallback(e);
          }
       }
    }


### PR DESCRIPTION
The existing deactivation callback happens *after* several important
services are shutdown (e.g. the remoting service which allows client
connectivity). This commit adds a new callback which is invoked *before*
any services are stopped. This is useful for embedded use-cases where
applications want to stop gracefully before any part of the broker is
stopped.

A default, empty method implementation is provided so that existing
callback implementations don't need to change.