### PR TITLE
ARTEMIS-3058 improper AddressSettings merge

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
@@ -934,7 +934,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
          pageMaxCache = merged.pageMaxCache;
       }
       if (pageSizeBytes == null) {
-         pageSizeBytes = merged.getPageSizeBytes();
+         pageSizeBytes = merged.pageSizeBytes;
       }
       if (messageCounterHistoryDayLimit == null) {
          messageCounterHistoryDayLimit = merged.messageCounterHistoryDayLimit;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/Match.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/Match.java
@@ -111,4 +111,9 @@ public class Match<T> {
       }
    }
 
+   @Override
+   public String toString() {
+      return value.toString();
+   }
+
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/AddressSettingsTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/AddressSettingsTest.java
@@ -285,6 +285,24 @@ public class AddressSettingsTest extends ActiveMQTestBase {
    }
 
    @Test
+   public void test3LevelHierarchyPageSizeBytes() throws Exception {
+      ActiveMQServer server = createServer(true);
+      server.start();
+
+      AddressSettings level1 = new AddressSettings().setPageSizeBytes(100 * 1024);
+      AddressSettings level2 = new AddressSettings();
+      AddressSettings level3 = new AddressSettings();
+      server.getAddressSettingsRepository().clear();
+      server.getAddressSettingsRepository().setDefault(null);
+      HierarchicalRepository<AddressSettings> repos = server.getAddressSettingsRepository();
+      repos.addMatch("test.foo.bar", level3);
+      repos.addMatch("test.foo.#", level2);
+      repos.addMatch("test.#", level1);
+
+      assertEquals(100 * 1024, server.getAddressSettingsRepository().getMatch("test.foo.bar").getPageSizeBytes());
+   }
+
+   @Test
    public void testOverrideHierarchyWithDLA() throws Exception {
       ActiveMQServer server = createServer(false);
 


### PR DESCRIPTION
The merge method in AddressSettings should *not* use any getters. It
should reference the relevant variables directly. Using any getters will
return default values in the underlying value is null. This can cause
problems for hierarchical settings.

Also fixed a few potential NPEs exposed by the test-case.