### PR TITLE
ARTEMIS-3068 Fix HierarchicalRepository matcher comparator

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/HierarchicalObjectRepository.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/HierarchicalObjectRepository.java
@@ -487,13 +487,15 @@ public class HierarchicalObjectRepository<T> implements HierarchicalRepository<T
             String[] leftSplits = o1.split(quotedDelimiter);
             String[] rightSplits = o2.split(quotedDelimiter);
             for (int i = 0; i < leftSplits.length; i++) {
+               if (i >= rightSplits.length) {
+                  return -1;
+               }
                String left = leftSplits[i];
-               if (left.equals(singleWord)) {
-                  if (rightSplits.length < i || !rightSplits[i].equals(singleWord)) {
-                     return -1;
-                  } else {
-                     return +1;
-                  }
+               String right = rightSplits[i];
+               if (left.equals(singleWord) && !right.equals(singleWord)) {
+                  return +1;
+               } else if (!left.equals(singleWord) && right.equals(singleWord)) {
+                  return -1;
                }
             }
          }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/settings/RepositoryTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/settings/RepositoryTest.java
@@ -76,6 +76,29 @@ public class RepositoryTest extends ActiveMQTestBase {
       Assert.assertEquals("leaf", repo.getMatch("b"));
    }
 
+   @Test
+   public void testMultipleMatchesHasRightOrder() {
+      HierarchicalRepository<String> repository = new HierarchicalObjectRepository<>();
+      repository.addMatch("a.b.c.d.e.f", "a.b.c.d.e.f");//1
+      repository.addMatch("a.b.c.d.e.*", "a.b.c.d.e.*");//2
+      repository.addMatch("a.*.*.*.*.*", "a.*.*.*.*.*");//3
+      repository.addMatch("*.b.c.d.*.f", "*.b.c.d.*.f");//4
+      repository.addMatch("*.b.*.d.*.f", "*.b.*.d.*.f");//5
+      repository.addMatch("a.b.c.d.e.#", "a.b.c.d.e.#");//6
+
+      String val = repository.getMatch("a.b.c.d.e.f");//matches all
+      Assert.assertEquals("a.b.c.d.e.f", val);
+      val = repository.getMatch("a.b.c.d.e.x");//matches 2,3,6
+      Assert.assertEquals("a.b.c.d.e.*", val);
+      val = repository.getMatch("a.b.x.d.x.f");//matches 3,5
+      Assert.assertEquals("a.*.*.*.*.*", val);
+      val = repository.getMatch("x.b.c.d.e.f");//matches 4,5
+      Assert.assertEquals("*.b.c.d.*.f", val);
+      val = repository.getMatch("x.b.x.d.e.f");//matches 5
+      Assert.assertEquals("*.b.*.d.*.f", val);
+      val = repository.getMatch("a.b.c.d.e.f.g");//matches 6
+      Assert.assertEquals("a.b.c.d.e.#", val);
+   }
 
    @Test
    public void testMatchingDocsCustomUnderscorDelimiter() throws Throwable {


### PR DESCRIPTION
The comparator implemented in the HierarchicalObjectRepository is ordering the matches in a wrong order.
Specifically the last case where the 2 addresses has anyWord wildcards.
It should order from more specific (less wildcard) to more generic (more wildcard).

Added a tests in the RepositoryTests (testMultipleMatchesHasRightOrder) to prove the error and the fix

https://issues.apache.org/jira/browse/ARTEMIS-3068