### PR TITLE
ARTEMIS-3084 Fixing intermittent failures on testsuite. file.close() …

### DIFF
--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/aio/AIOSequentialFile.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/aio/AIOSequentialFile.java
@@ -111,7 +111,7 @@ public class AIOSequentialFile extends AbstractSequentialFile  {
 
    @Override
    public void close() throws IOException, InterruptedException, ActiveMQException {
-      close(true, false);
+      close(true, true);
    }
 
    private void actualClose() {


### PR DESCRIPTION
…should block

This fixed a failure I saw once at GroupingFailoverReplicationTest.testGroupingLocalHandlerFailsMultipleGroups