### PR TITLE
added space to separate 2 words that otherwise appear joined

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1048,7 +1048,7 @@ public interface ActiveMQServerLogger extends BasicLogger {
    void errorExpiringReferencesNoBindings(SimpleString expiryAddress);
 
    @LogMessage(level = Logger.Level.WARN)
-   @Message(id = 222147, value = "Messages are being expired on queue{0}. However there is no expiry queue configured, hence messages will be dropped.", format = Message.Format.MESSAGE_FORMAT)
+   @Message(id = 222147, value = "Messages are being expired on queue {0}. However there is no expiry queue configured, hence messages will be dropped.", format = Message.Format.MESSAGE_FORMAT)
    void errorExpiringReferencesNoQueue(SimpleString name);
 
    @LogMessage(level = Logger.Level.WARN)


### PR DESCRIPTION
Error message 222147 does not have a space between the word "queue" and the actual queue name. this simple PR fixes that.

I noticed other small opportunities for improvement with the messages:
* there are 3(!) spellings of cannot/can not/can't. none of then wrong, just inconsistent;
* some message are a full sentence and still do not start with a capital;
* the last sentence does not always end with '.' when there are multiple sentences in the message. (and how should a single sentence end?);
* a few messages have multiple consecutive spaces;
* some messages have leading/trailing spaces.

shall I change (some/all) of these in a next PR?