### PR TITLE
fixed debug message

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/Page.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/Page.java
@@ -528,7 +528,7 @@ public final class Page implements Comparable<Page> {
       }
 
       if (logger.isDebugEnabled()) {
-         logger.debugf("Deleting pageNr=%d on store %d", pageId, storeName);
+         logger.debugf("Deleting pageNr=%d on store %s", pageId, storeName);
       }
 
       final List<Long> largeMessageIds;


### PR DESCRIPTION
When placing Artemis in debug-logging, I stumbled on this logging error.

The format-specifier in Page.java:531 specifies 2 numbers (%d), where the arguments are a number and a string. This PR updates the format-string. I did not bother to run a test for it.

FYI: note that the another logger.debug statement in the same file Page.java:256 uses 3 %-clauses in the format string, but it has 4 parameters. It seems that the %-clause for the first parameter is missing.

```
LogManager error of type FORMAT_FAILURE: Formatting error
java.util.IllegalFormatConversionException: d != org.apache.activemq.artemis.api.core.SimpleString
   at java.util.Formatter$FormatSpecifier.failConversion(Formatter.java:4302)
   at java.util.Formatter$FormatSpecifier.printInteger(Formatter.java:2793)
   at java.util.Formatter$FormatSpecifier.print(Formatter.java:2747)
   at java.util.Formatter.format(Formatter.java:2520)
   at java.util.Formatter.format(Formatter.java:2455)
   at java.lang.String.format(String.java:2940)
   at org.jboss.logmanager.ExtLogRecord.formatRecord(ExtLogRecord.java:505)
   at org.jboss.logmanager.ExtLogRecord.getFormattedMessage(ExtLogRecord.java:468)
   at org.jboss.logmanager.formatters.Formatters$16.renderRaw(Formatters.java:737)
   at org.jboss.logmanager.formatters.Formatters$JustifyingFormatStep.render(Formatters.java:215)
   at org.jboss.logmanager.formatters.MultistepFormatter.format(MultistepFormatter.java:89)
   at org.jboss.logmanager.ExtFormatter.format(ExtFormatter.java:32)
   at org.jboss.logmanager.handlers.WriterHandler.doPublish(WriterHandler.java:46)
   at org.jboss.logmanager.ExtHandler.publish(ExtHandler.java:77)
   at org.jboss.logmanager.LoggerNode.publish(LoggerNode.java:333)
   at org.jboss.logmanager.LoggerNode.publish(LoggerNode.java:341)
   at org.jboss.logmanager.LoggerNode.publish(LoggerNode.java:341)
   at org.jboss.logmanager.LoggerNode.publish(LoggerNode.java:341)
   at org.jboss.logmanager.LoggerNode.publish(LoggerNode.java:341)
   at org.jboss.logmanager.LoggerNode.publish(LoggerNode.java:341)
   at org.jboss.logmanager.LoggerNode.publish(LoggerNode.java:341)
   at org.jboss.logmanager.LoggerNode.publish(LoggerNode.java:341)
   at org.jboss.logmanager.LoggerNode.publish(LoggerNode.java:341)
   at org.jboss.logmanager.Logger.logRaw(Logger.java:850)
   at org.jboss.logmanager.Logger.log(Logger.java:802)
   at org.jboss.logging.JBossLogManagerLogger.doLogf(JBossLogManagerLogger.java:53)
   at org.jboss.logging.Logger.debugf(Logger.java:810)
   at org.apache.activemq.artemis.core.paging.impl.Page.delete(Page.java:531)
   at org.apache.activemq.artemis.core.replication.ReplicationEndpoint.handlePageEvent(ReplicationEndpoint.java:784)
   at org.apache.activemq.artemis.core.replication.ReplicationEndpoint.handlePageEvent(ReplicationEndpoint.java:777)
   at org.apache.activemq.artemis.core.replication.ReplicationEndpoint.handlePacket(ReplicationEndpoint.java:221)
   at org.apache.activemq.artemis.core.protocol.core.impl.ChannelImpl.handlePacket(ChannelImpl.java:806)
   at org.apache.activemq.artemis.core.protocol.core.impl.RemotingConnectionImpl.doBufferReceived(RemotingConnectionImpl.java:417)
   at org.apache.activemq.artemis.core.protocol.core.impl.RemotingConnectionImpl.bufferReceived(RemotingConnectionImpl.java:385)
   at org.apache.activemq.artemis.core.client.impl.ClientSessionFactoryImpl$DelegatingBufferHandler.bufferReceived(ClientSessionFactoryImpl.java:1230)
   at org.apache.activemq.artemis.core.remoting.impl.netty.ActiveMQChannelHandler.channelRead(ActiveMQChannelHandler.java:73)
   at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
   at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
   at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
   at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:324)
   at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:311)
   at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:425)
   at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:276)
   at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
   at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
   at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
   at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
   at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
   at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
   at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
   at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:792)
   at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:475)
   at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:378)
   at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
   at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
   at org.apache.activemq.artemis.utils.ActiveMQThreadFactory$1.run(ActiveMQThreadFactory.java:118)
```