### PR TITLE
removed the single quotes around a title on the Status screen

### DIFF
--- a/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/components/status.js
+++ b/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/components/status.js
@@ -30,7 +30,7 @@ var Artemis;
                 <div class="container-fluid">
                      <div class="row">
                         <div class="col-md-3 text-center">
-                            <label>'Address Memory Used'</label>
+                            <label>Address Memory Used</label>
                             <p class="text-left">
                             <pf-donut-pct-chart config="$ctrl.addressMemoryConfig" data="$ctrl.addressMemoryData" center-label="$ctrl.addressMemoryLabel"></pf-donut-pct-chart>
                             </p>


### PR DESCRIPTION
The title "Address Memory Used" on the Status page has superfluous single-quotes around it.
This PR removes those.
No other title uses visible quotes (I search both visually and in source-code); so it was an exception.
The source code does not mention any special reason to have these quotes and they were not separately introduced earlier.