### PR TITLE
ARTEMIS-33 Generic integration with SASL Frameworks

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPConnectionCallback.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPConnectionCallback.java
@@ -17,7 +17,6 @@
 package org.apache.activemq.artemis.protocol.amqp.broker;
 
 import java.net.URI;
-import java.security.Principal;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -29,7 +28,6 @@ import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.core.buffers.impl.ChannelBufferWrapper;
 import org.apache.activemq.artemis.core.client.impl.TopologyMemberImpl;
-import org.apache.activemq.artemis.core.remoting.CertificateUtil;
 import org.apache.activemq.artemis.core.remoting.CloseListener;
 import org.apache.activemq.artemis.core.remoting.FailureListener;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
@@ -44,10 +42,7 @@ import org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport;
 import org.apache.activemq.artemis.protocol.amqp.proton.handler.ExtCapability;
 import org.apache.activemq.artemis.protocol.amqp.proton.transaction.ProtonTransactionImpl;
 import org.apache.activemq.artemis.protocol.amqp.sasl.AnonymousServerSASL;
-import org.apache.activemq.artemis.protocol.amqp.sasl.ExternalServerSASL;
-import org.apache.activemq.artemis.protocol.amqp.sasl.GSSAPIServerSASL;
 import org.apache.activemq.artemis.protocol.amqp.sasl.MechanismFinder;
-import org.apache.activemq.artemis.protocol.amqp.sasl.PlainSASL;
 import org.apache.activemq.artemis.protocol.amqp.sasl.SASLResult;
 import org.apache.activemq.artemis.protocol.amqp.sasl.ServerSASL;
 import org.apache.activemq.artemis.protocol.amqp.sasl.ServerSASLFactory;
@@ -65,7 +60,7 @@ public class AMQPConnectionCallback implements FailureListener, CloseListener {
 
    private static final Logger logger = Logger.getLogger(AMQPConnectionCallback.class);
 
-   private ConcurrentMap<Binary, Transaction> transactions = new ConcurrentHashMap<>();
+   private final ConcurrentMap<Binary, Transaction> transactions = new ConcurrentHashMap<>();
 
    private final ProtonProtocolManager manager;
 
@@ -107,41 +102,11 @@ public class AMQPConnectionCallback implements FailureListener, CloseListener {
    public ServerSASL getServerSASL(final String mechanism) {
       ServerSASL result = null;
       if (isPermittedMechanism(mechanism)) {
-         switch (mechanism) {
-            case PlainSASL.NAME:
-               result = new PlainSASL(server.getSecurityStore(), manager.getSecurityDomain(), connection.getProtocolConnection());
-               break;
-
-            case AnonymousServerSASL.NAME:
-               result = new AnonymousServerSASL();
-               break;
-
-            case GSSAPIServerSASL.NAME:
-               GSSAPIServerSASL gssapiServerSASL = new GSSAPIServerSASL();
-               gssapiServerSASL.setLoginConfigScope(manager.getSaslLoginConfigScope());
-               result = gssapiServerSASL;
-               break;
-
-            case ExternalServerSASL.NAME:
-               // validate ssl cert present
-               Principal principal = CertificateUtil.getPeerPrincipalFromConnection(protonConnectionDelegate);
-               if (principal != null) {
-                  ExternalServerSASL externalServerSASL = new ExternalServerSASL();
-                  externalServerSASL.setPrincipal(principal);
-                  result = externalServerSASL;
-               } else {
-                  logger.debug("SASL EXTERNAL mechanism requires a TLS peer principal");
-               }
-               break;
-
-            default:
-               ServerSASLFactory factory = MechanismFinder.getFactory(mechanism);
-               if (factory != null) {
-                  result = factory.create(server, manager, connection, protonConnectionDelegate);
-               } else {
-                  logger.debug("Mo matching mechanism found for: " + mechanism);
-               }
-               break;
+         ServerSASLFactory factory = MechanismFinder.getFactory(mechanism);
+         if (factory != null) {
+            result = factory.create(server, manager, connection, protonConnectionDelegate);
+         } else {
+            logger.debug("Mo matching mechanism found for: " + mechanism);
          }
       }
       return result;

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPConnectionCallback.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPConnectionCallback.java
@@ -46,9 +46,11 @@ import org.apache.activemq.artemis.protocol.amqp.proton.transaction.ProtonTransa
 import org.apache.activemq.artemis.protocol.amqp.sasl.AnonymousServerSASL;
 import org.apache.activemq.artemis.protocol.amqp.sasl.ExternalServerSASL;
 import org.apache.activemq.artemis.protocol.amqp.sasl.GSSAPIServerSASL;
+import org.apache.activemq.artemis.protocol.amqp.sasl.MechanismFinder;
 import org.apache.activemq.artemis.protocol.amqp.sasl.PlainSASL;
 import org.apache.activemq.artemis.protocol.amqp.sasl.SASLResult;
 import org.apache.activemq.artemis.protocol.amqp.sasl.ServerSASL;
+import org.apache.activemq.artemis.protocol.amqp.sasl.ServerSASLFactory;
 import org.apache.activemq.artemis.spi.core.remoting.Connection;
 import org.apache.activemq.artemis.spi.core.remoting.ReadyListener;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
@@ -133,7 +135,12 @@ public class AMQPConnectionCallback implements FailureListener, CloseListener {
                break;
 
             default:
-               logger.debug("Mo matching mechanism found for: " + mechanism);
+               ServerSASLFactory factory = MechanismFinder.getFactory(mechanism);
+               if (factory != null) {
+                  result = factory.create(server, manager, connection, protonConnectionDelegate);
+               } else {
+                  logger.debug("Mo matching mechanism found for: " + mechanism);
+               }
                break;
          }
       }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/ProtonProtocolManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/ProtonProtocolManager.java
@@ -88,7 +88,7 @@ public class ProtonProtocolManager extends AbstractProtocolManager<AMQPMessage, 
 
    private int initialRemoteMaxFrameSize = 4 * 1024;
 
-   private String[] saslMechanisms = MechanismFinder.getKnownMechanisms();
+   private String[] saslMechanisms = MechanismFinder.getDefaultMechanisms();
 
    private String saslLoginConfigScope = "amqp-sasl-gssapi";
 

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/sasl/AnonymousServerSASLFactory.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/sasl/AnonymousServerSASLFactory.java
@@ -22,37 +22,27 @@ import org.apache.activemq.artemis.spi.core.protocol.ProtocolManager;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
 import org.apache.activemq.artemis.spi.core.remoting.Connection;
 
-/**
- * A {@link ServerSASLFactory} is responsible for instantiating a given SASL mechanism
- */
-public interface ServerSASLFactory {
+public class AnonymousServerSASLFactory implements ServerSASLFactory {
 
-   /**
-    * @return the name of the scheme to offer
-    */
-   String getMechanism();
+   @Override
+   public String getMechanism() {
+      return AnonymousServerSASL.NAME;
+   }
 
-   /**
-    * creates a new {@link ServerSASL} for the provided context
-    * @param server
-    * @param manager
-    * @param connection
-    * @param remotingConnection
-    * @return a new instance of {@link ServerSASL} that implements the provided mechanism
-    */
-   ServerSASL create(ActiveMQServer server, ProtocolManager<AmqpInterceptor> manager, Connection connection,
-                     RemotingConnection remotingConnection);
+   @Override
+   public ServerSASL create(ActiveMQServer server, ProtocolManager<AmqpInterceptor> manager, Connection connection,
+                            RemotingConnection remotingConnection) {
+      return new AnonymousServerSASL();
+   }
 
-   /**
-    * returns the precedence of the given SASL mechanism, the default precedence is zero, where
-    * higher means better
-    * @return the precedence of this mechanism
-    */
-   int getPrecedence();
+   @Override
+   public int getPrecedence() {
+      return Integer.MIN_VALUE;
+   }
 
-   /**
-    * @return <code>true</code> if this mechanism should be part of the servers default permitted
-    *         protocols or <code>false</code> if it must be explicitly configured
-    */
-   boolean isDefaultPermitted();
+   @Override
+   public boolean isDefaultPermitted() {
+      return true;
+   }
+
 }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/sasl/GSSAPIServerSASLFactory.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/sasl/GSSAPIServerSASLFactory.java
@@ -18,41 +18,41 @@ package org.apache.activemq.artemis.protocol.amqp.sasl;
 
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.protocol.amqp.broker.AmqpInterceptor;
+import org.apache.activemq.artemis.protocol.amqp.broker.ProtonProtocolManager;
 import org.apache.activemq.artemis.spi.core.protocol.ProtocolManager;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
 import org.apache.activemq.artemis.spi.core.remoting.Connection;
+import org.jboss.logging.Logger;
 
-/**
- * A {@link ServerSASLFactory} is responsible for instantiating a given SASL mechanism
- */
-public interface ServerSASLFactory {
+public class GSSAPIServerSASLFactory implements ServerSASLFactory {
 
-   /**
-    * @return the name of the scheme to offer
-    */
-   String getMechanism();
+   private static final Logger logger = Logger.getLogger(GSSAPIServerSASLFactory.class);
 
-   /**
-    * creates a new {@link ServerSASL} for the provided context
-    * @param server
-    * @param manager
-    * @param connection
-    * @param remotingConnection
-    * @return a new instance of {@link ServerSASL} that implements the provided mechanism
-    */
-   ServerSASL create(ActiveMQServer server, ProtocolManager<AmqpInterceptor> manager, Connection connection,
-                     RemotingConnection remotingConnection);
+   @Override
+   public String getMechanism() {
+      return GSSAPIServerSASL.NAME;
+   }
 
-   /**
-    * returns the precedence of the given SASL mechanism, the default precedence is zero, where
-    * higher means better
-    * @return the precedence of this mechanism
-    */
-   int getPrecedence();
+   @Override
+   public ServerSASL create(ActiveMQServer server, ProtocolManager<AmqpInterceptor> manager, Connection connection,
+                            RemotingConnection remotingConnection) {
+      if (manager instanceof ProtonProtocolManager) {
+         GSSAPIServerSASL gssapiServerSASL = new GSSAPIServerSASL();
+         gssapiServerSASL.setLoginConfigScope(((ProtonProtocolManager) manager).getSaslLoginConfigScope());
+         return gssapiServerSASL;
+      }
+      logger.debug("SASL GSSAPI requires ProtonProtocolManager");
+      return null;
+   }
 
-   /**
-    * @return <code>true</code> if this mechanism should be part of the servers default permitted
-    *         protocols or <code>false</code> if it must be explicitly configured
-    */
-   boolean isDefaultPermitted();
+   @Override
+   public int getPrecedence() {
+      return 0;
+   }
+
+   @Override
+   public boolean isDefaultPermitted() {
+      return false;
+   }
+
 }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/sasl/MechanismFinder.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/sasl/MechanismFinder.java
@@ -27,6 +27,7 @@ public class MechanismFinder {
    private static final Map<String, ServerSASLFactory> FACTORY_MAP = new HashMap<>();
    private static final Comparator<? super ServerSASLFactory> PRECEDENCE_COMPARATOR =
       (f1, f2) -> Integer.compare(f1.getPrecedence(), f2.getPrecedence());
+   private static final String[] DEFAULT_MECHANISMS;
 
    static {
       ServiceLoader<ServerSASLFactory> serviceLoader =
@@ -40,15 +41,16 @@ public class MechanismFinder {
             }
          });
       }
+      DEFAULT_MECHANISMS = FACTORY_MAP.values()
+                                      .stream()
+                                      .filter(ServerSASLFactory::isDefaultPermitted)
+                                      .sorted(PRECEDENCE_COMPARATOR.reversed())
+                                      .map(ServerSASLFactory::getMechanism)
+                                      .toArray(String[]::new);
    }
 
    public static String[] getDefaultMechanisms() {
-      return FACTORY_MAP.values()
-            .stream()
-            .filter(ServerSASLFactory::isDefaultPermitted)
-            .sorted(PRECEDENCE_COMPARATOR.reversed())
-            .map(ServerSASLFactory::getMechanism)
-            .toArray(String[]::new);
+      return DEFAULT_MECHANISMS;
    }
 
    public static ServerSASLFactory getFactory(String mechanism) {

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/sasl/PlainServerSASLFactory.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/sasl/PlainServerSASLFactory.java
@@ -22,37 +22,27 @@ import org.apache.activemq.artemis.spi.core.protocol.ProtocolManager;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
 import org.apache.activemq.artemis.spi.core.remoting.Connection;
 
-/**
- * A {@link ServerSASLFactory} is responsible for instantiating a given SASL mechanism
- */
-public interface ServerSASLFactory {
+public class PlainServerSASLFactory implements ServerSASLFactory {
 
-   /**
-    * @return the name of the scheme to offer
-    */
-   String getMechanism();
+   @Override
+   public String getMechanism() {
+      return ServerSASLPlain.NAME;
+   }
 
-   /**
-    * creates a new {@link ServerSASL} for the provided context
-    * @param server
-    * @param manager
-    * @param connection
-    * @param remotingConnection
-    * @return a new instance of {@link ServerSASL} that implements the provided mechanism
-    */
-   ServerSASL create(ActiveMQServer server, ProtocolManager<AmqpInterceptor> manager, Connection connection,
-                     RemotingConnection remotingConnection);
+   @Override
+   public ServerSASL create(ActiveMQServer server, ProtocolManager<AmqpInterceptor> manager, Connection connection,
+                            RemotingConnection remotingConnection) {
+      return new PlainSASL(server.getSecurityStore(), manager.getSecurityDomain(), connection.getProtocolConnection());
+   }
 
-   /**
-    * returns the precedence of the given SASL mechanism, the default precedence is zero, where
-    * higher means better
-    * @return the precedence of this mechanism
-    */
-   int getPrecedence();
+   @Override
+   public int getPrecedence() {
+      return 0;
+   }
 
-   /**
-    * @return <code>true</code> if this mechanism should be part of the servers default permitted
-    *         protocols or <code>false</code> if it must be explicitly configured
-    */
-   boolean isDefaultPermitted();
+   @Override
+   public boolean isDefaultPermitted() {
+      return true;
+   }
+
 }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/sasl/ServerSASLFactory.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/sasl/ServerSASLFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.sasl;
+
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.protocol.amqp.broker.AmqpInterceptor;
+import org.apache.activemq.artemis.spi.core.protocol.ProtocolManager;
+import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
+import org.apache.activemq.artemis.spi.core.remoting.Connection;
+
+/**
+ * A {@link ServerSASLFactory} is responsible for instantiating a given SASL mechanism
+ */
+public interface ServerSASLFactory {
+
+   /**
+    * @return the name of the scheme to offer
+    */
+   String getMechanism();
+
+   /**
+    * creates a new {@link ServerSASL} for the provided context
+    * @param server
+    * @param manager
+    * @param connection
+    * @param remotingConnection
+    * @return a new instance of {@link ServerSASL} that implements the provided mechanism
+    */
+   ServerSASL create(ActiveMQServer server, ProtocolManager<AmqpInterceptor> manager, Connection connection,
+                     RemotingConnection remotingConnection);
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/resources/META-INF/services/org.apache.activemq.artemis.protocol.amqp.sasl.ServerSASLFactory
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/resources/META-INF/services/org.apache.activemq.artemis.protocol.amqp.sasl.ServerSASLFactory
@@ -1,0 +1,4 @@
+org.apache.activemq.artemis.protocol.amqp.sasl.AnonymousServerSASLFactory
+org.apache.activemq.artemis.protocol.amqp.sasl.PlainServerSASLFactory
+org.apache.activemq.artemis.protocol.amqp.sasl.GSSAPIServerSASLFactory
+org.apache.activemq.artemis.protocol.amqp.sasl.ExternalServerSASLFactory


### PR DESCRIPTION
This adds the opportunity to register new SASL schemes via the default
java service-loader mechanism.
Implementors have to provide an implementation of the ServerSASLFactory
that is responsible for providing instances of the actual scheme.