### PR TITLE
ARTEMIS-3107 - Extension of the artemis-docker module

### DIFF
--- a/artemis-docker/Dockerfile-adoptopenjdk-11
+++ b/artemis-docker/Dockerfile-adoptopenjdk-11
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# ActiveMQ Artemis
+
+FROM adoptopenjdk:11-jre-hotspot
+LABEL maintainer="Apache ActiveMQ Team"
+# Make sure pipes are considered to determine success, see: https://github.com/hadolint/hadolint/wiki/DL4006
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+WORKDIR /opt
+
+ENV ARTEMIS_USER artemis
+ENV ARTEMIS_PASSWORD artemis
+ENV ANONYMOUS_LOGIN false
+ENV EXTRA_ARGS --http-host 0.0.0.0 --relax-jolokia
+
+# add user and group for artemis
+RUN groupadd -g 1000 -r artemis && useradd -r -u 1000 -g artemis artemis \
+ && apt-get -qq -o=Dpkg::Use-Pty=0 update && \
+    apt-get -qq -o=Dpkg::Use-Pty=0 install -y libaio1 && \
+    rm -rf /var/lib/apt/lists/*
+
+USER artemis
+
+ADD . /opt/activemq-artemis
+
+# Web Server
+EXPOSE 8161 \
+# JMX Exporter
+    9404 \
+# Port for CORE,MQTT,AMQP,HORNETQ,STOMP,OPENWIRE
+    61616 \
+# Port for HORNETQ,STOMP
+    5445 \
+# Port for AMQP
+    5672 \
+# Port for MQTT
+    1883 \
+#Port for STOMP
+    61613
+
+USER root
+
+RUN mkdir /var/lib/artemis-instance && chown -R artemis.artemis /var/lib/artemis-instance
+
+COPY ./docker/docker-run.sh /
+
+USER artemis
+
+# Expose some outstanding folders
+VOLUME ["/var/lib/artemis-instance"]
+WORKDIR /var/lib/artemis-instance
+
+ENTRYPOINT ["/docker-run.sh"]
+CMD ["run"]

--- a/artemis-docker/prepare-docker.sh
+++ b/artemis-docker/prepare-docker.sh
@@ -22,36 +22,163 @@ set -e
 #This is a script to Prepare an artemis folder to generate the Release.
 
 
-error () {
-   echo ""
-   echo "$@"
-   echo ""
-   echo "Usage: ./prepare-docker.sh ARTEMIS_HOME_LOCATION"
-   echo ""
-   echo "example:"
-   echo "./prepare-docker.sh ../artemis-distribution/target/apache-artemis-2.7.0-SNAPSHOT-bin/apache-artemis-2.7.0-SNAPSHOT"
-   echo ""
-   exit 64
+usage () {
+  cat <<HERE
+
+$@
+
+Usage:
+  # Prepare for build the Docker Image from the local distribution
+  ./prepare-docker.sh --from-local-dist --local-dist-path {local-distribution-directory}
+
+  # Prepare for build the Docker Image from the release version
+  ./prepare-docker.sh --from-release --artemis-version {release-version}
+
+  # Show the usage command
+  ./prepare-docker.sh --help
+
+Example:
+  ./prepare-docker.sh --from-local-dist --local-dist-path ../artemis-distribution/target/apache-artemis-2.17.0-SNAPSHOT-bin/apache-artemis-2.17.0-SNAPSHOT
+  ./prepare-docker.sh --from-release --artemis-version 2.16.0  
+
+HERE
+  exit 1
 }
 
-if [ ! "$#" -eq 1 ]
-then
-   error "Cannot match arguments"
+next_step () {
+  cat <<HERE
+
+Well done! Now you can continue with the Docker image build.
+Building the Docker Image:
+  Go to $ARTEMIS_DIST where you prepared the binary with Docker files.
+  
+  # Go to $ARTEMIS_DIST
+  $ cd $ARTEMIS_DIST
+
+  # For Debian
+  $ docker build -f ./docker/Dockerfile-debian -t artemis-debian .
+
+  # For CentOS
+  $ docker build -f ./docker/Dockerfile-centos -t artemis-centos .
+
+  # For AdoptOpen JDK 11
+  $ docker build -f ./docker/Dockerfile-adoptopenjdk-11 -t artemis-adoptopenjdk-11 .
+
+  # For AdoptOpen JDK 11 (Build for linux ARMv7/ARM64)
+  $ docker buildx build --platform linux/arm64,linux/arm/v7 --push -t {your-repository}/apache-artemis:2.17.0-SNAPSHOT -f ./docker/Dockerfile-adoptopenjdk-11 .
+
+Note: -t artemis-debian, -t artemis-centos and artemis-adoptopenjdk-11 are just 
+tag names for the purpose of this guide
+
+For more info read the readme.md
+
+HERE
+  exit 1
+}
+
+while [ "$#" -ge 1 ]
+do
+key="$1"
+  case $key in
+    --help)
+    usage
+    ;;
+    --from-local-dist)
+    FROM_LOCAL="true"
+    ;;
+    --from-release)
+    FROM_RELEASE="true"
+    ;;
+    --local-dist-path)
+    LOCAL_DIST_PATH="$2"
+    shift
+    ;;
+    --artemis-version)
+    ARTEMIS_VERSION="$2"
+    shift
+    ;;
+    *)
+    # unknown option
+    usage "Unknown option"
+    ;;
+  esac
+  shift
+done
+
+# TMPDIR must be contained within the working directory so it is part of the
+# Docker context. (i.e. it can't be mktemp'd in /tmp)
+BASE_TMPDIR="_TMP_/artemis"
+
+cleanup() {
+  if [ -d "${BASE_TMPDIR}/${ARTEMIS_VERSION}" ]
+  then
+    echo "Clean up the ${BASE_TMPDIR}/${ARTEMIS_VERSION} directory"
+    find "${BASE_TMPDIR}" -name "${ARTEMIS_VERSION}" -type d -mmin +60 -exec rm -rf "{}" \;
+  else
+    mkdir -p "${BASE_TMPDIR}/${ARTEMIS_VERSION}"
+  fi
+}
+
+if [ -n "${FROM_RELEASE}" ]; then
+  [ -n "${ARTEMIS_VERSION}" ] || usage "You must specify the release version (es.: --artemis-version 2.16.0)"
+
+  cleanup
+  
+  ARTEMIS_BASE_URL="$(curl -s https://www.apache.org/dyn/closer.cgi\?preferred=true)activemq/activemq-artemis/${ARTEMIS_VERSION}/"
+  ARTEMIS_DIST_FILE_NAME="apache-artemis-${ARTEMIS_VERSION}-bin.tar.gz"
+  CURL_OUTPUT="${BASE_TMPDIR}/${ARTEMIS_VERSION}/${ARTEMIS_DIST_FILE_NAME}"
+
+  if [ -z "$(ls -A ${BASE_TMPDIR}/${ARTEMIS_VERSION})" ]
+  then
+    echo "Downloading ${ARTEMIS_DIST_FILE_NAME} from ${ARTEMIS_BASE_URL}..."
+    curl --progress-bar "${ARTEMIS_BASE_URL}${ARTEMIS_DIST_FILE_NAME}" --output "${CURL_OUTPUT}"
+
+    echo "Expanding ${BASE_TMPDIR}/${ARTEMIS_VERSION}/${ARTEMIS_DIST_FILE_NAME}..."
+    tar xzf "$CURL_OUTPUT" --directory "${BASE_TMPDIR}/${ARTEMIS_VERSION}" --strip 1
+
+    echo "Removing ${BASE_TMPDIR}/${ARTEMIS_VERSION}/${ARTEMIS_DIST_FILE_NAME}..."
+    rm -rf "${BASE_TMPDIR}/${ARTEMIS_VERSION}"/"${ARTEMIS_DIST_FILE_NAME}"
+  fi
+
+  ARTEMIS_DIST="${BASE_TMPDIR}/${ARTEMIS_VERSION}"
+  
+  echo "Using Artemis dist: ${ARTEMIS_DIST}"
+
+elif [ -n "${FROM_LOCAL}" ]; then
+  
+  if [ -n "${LOCAL_DIST_PATH}" ]; then
+    ARTEMIS_DIST=${LOCAL_DIST_PATH}
+    echo "Using Artemis dist: ${ARTEMIS_DIST}"
+  else 
+     usage "You must specify the local distribution directory"
+  fi
+
+  if [ ! -d "${ARTEMIS_DIST}" ]
+  then
+    usage "Directory ${ARTEMIS_DIST} does not exist"
+  fi
+
+  if [ -d "${ARTEMIS_DIST}/docker" ]
+  then
+    echo "Clean up the ${ARTEMIS_DIST}/docker directory"
+    rm -rf "${ARTEMIS_DIST}/docker"
+  fi
+
+else
+
+  usage
+
 fi
 
-target=$1
-
-if [ ! -d $target ]
+if [ ! -d "${ARTEMIS_DIST}/docker" ]
 then
-  error "Directory $target does not exist"
+  mkdir "${ARTEMIS_DIST}/docker"
 fi
 
-if [ -d $target/docker ]
-then
-  rm -rf $target/docker
-fi
-mkdir $target/docker
-cp ./Dockerfile-* $target/docker
-cp ./docker-run.sh $target/docker
+cp ./Dockerfile-* "$ARTEMIS_DIST/docker"
+cp ./docker-run.sh "$ARTEMIS_DIST/docker"
 
-echo "Docker file support files at : $target/docker"
+echo "Docker file support files at : $ARTEMIS_DIST/docker"
+tree "$ARTEMIS_DIST/docker"
+
+next_step

--- a/artemis-docker/readme.md
+++ b/artemis-docker/readme.md
@@ -1,34 +1,141 @@
 # Docker Image Example
 
-This is an example on how you could create your own Docker Image For Apache ActiveMQ Artemis based on CentOS or Debian.
+This is an example on how you could create your own Docker Image For Apache 
+ActiveMQ Artemis based on CentOS or Debian (JDK 8) or AdoptOpen JDK 11 (Ubuntu).
+
 # Preparing
 
-Use the script ./prepare-docker.sh as it will copy the docker files under the binary distribution.
+Use the script ./prepare-docker.sh as it will copy the docker files under the 
+binary distribution.
+
+Below is shown the command to prepare the build of the Docker Image starting 
+from the local distribution (from the source codes of ActiveMQ Artemis)
+```
+# Prepare for build the Docker Image from the local distribution. Replace the 
+# {local-distribution-directory} with your directory.
+$ ./prepare-docker.sh --from-local-dist --local-dist-path {local-distribution-directory}
+```
+
+The output of the previous command is shown below.
 
 ```
-$ ./prepare-docker.sh $ARTEMIS_HOME
+$ ./prepare-docker.sh --from-local-dist --local-dist-path ../artemis-distribution/target/apache-artemis-2.17.0-SNAPSHOT-bin/apache-artemis-2.17.0-SNAPSHOT
+
+Using Artemis dist: ../artemis-distribution/target/apache-artemis-2.17.0-SNAPSHOT-bin/apache-artemis-2.17.0-SNAPSHOT
+Clean up the ../artemis-distribution/target/apache-artemis-2.17.0-SNAPSHOT-bin/apache-artemis-2.17.0-SNAPSHOT/docker directory
+Docker file support files at : ../artemis-distribution/target/apache-artemis-2.17.0-SNAPSHOT-bin/apache-artemis-2.17.0-SNAPSHOT/docker
+../artemis-distribution/target/apache-artemis-2.17.0-SNAPSHOT-bin/apache-artemis-2.17.0-SNAPSHOT/docker
+├── Dockerfile-adoptopenjdk-11
+├── Dockerfile-centos
+├── Dockerfile-debian
+└── docker-run.sh
+
+0 directories, 4 files
+
+Well done! Now you can continue with the Docker image build.
+Building the Docker Image:
+  Go to ../artemis-distribution/target/apache-artemis-2.17.0-SNAPSHOT-bin/apache-artemis-2.17.0-SNAPSHOT where you prepared the binary with Docker files.
+
+  # Go to ../artemis-distribution/target/apache-artemis-2.17.0-SNAPSHOT-bin/apache-artemis-2.17.0-SNAPSHOT
+  $ cd ../artemis-distribution/target/apache-artemis-2.17.0-SNAPSHOT-bin/apache-artemis-2.17.0-SNAPSHOT
+
+  # For Debian
+  $ docker build -f ./docker/Dockerfile-debian -t artemis-debian .
+
+  # For CentOS
+  $ docker build -f ./docker/Dockerfile-centos -t artemis-centos .
+
+  # For AdoptOpen JDK 11
+  $ docker build -f ./docker/Dockerfile-adoptopenjdk-11 -t artemis-adoptopenjdk-11 .
+
+Note: -t artemis-debian, -t artemis-centos and artemis-adoptopenjdk-11 are just
+tag names for the purpose of this guide
+
+For more info read the readme.md
+
+```
+
+The command to prepare the build of the Docker Image starting from the official 
+release of ActiveMQ Artemis is shown below
+```
+# Prepare for build the Docker Image from the release version. Replace the
+# {release-version} with the version that you want 
+$ ./prepare-docker.sh --from-release --artemis-version {release-version}
+```
+
+The output of the previous command is shown below.
+
+```
+$ ./prepare-docker.sh --from-release --artemis-version 2.16.0
+
+Downloading apache-artemis-2.16.0-bin.tar.gz from https://downloads.apache.org/activemq/activemq-artemis/2.16.0/...
+################################################################################################################################################################################################################################ 100,0%
+Expanding _TMP_/artemis/2.16.0/apache-artemis-2.16.0-bin.tar.gz...
+Removing _TMP_/artemis/2.16.0/apache-artemis-2.16.0-bin.tar.gz...
+Using Artemis dist: _TMP_/artemis/2.16.0
+Docker file support files at : _TMP_/artemis/2.16.0/docker
+_TMP_/artemis/2.16.0/docker
+├── Dockerfile-adoptopenjdk-11
+├── Dockerfile-centos
+├── Dockerfile-debian
+└── docker-run.sh
+
+0 directories, 4 files
+
+Well done! Now you can continue with the Docker image build.
+Building the Docker Image:
+  Go to _TMP_/artemis/2.16.0 where you prepared the binary with Docker files.
+
+  # Go to _TMP_/artemis/2.16.0
+  $ cd _TMP_/artemis/2.16.0
+
+  # For Debian
+  $ docker build -f ./docker/Dockerfile-debian -t artemis-debian .
+
+  # For CentOS
+  $ docker build -f ./docker/Dockerfile-centos -t artemis-centos .
+
+  # For AdoptOpen JDK 11
+  $ docker build -f ./docker/Dockerfile-adoptopenjdk-11 -t artemis-adoptopenjdk-11 .
+
+Note: -t artemis-debian, -t artemis-centos and artemis-adoptopenjdk-11 are just
+tag names for the purpose of this guide
+
+For more info read the readme.md
 ```
 
 # Building
 
-Go to `$ARTEMIS_HOME` where you prepared the binary with Docker files.
+Go to `$ARTEMIS_DIST` where you prepared the binary with Docker files.
 
 ## For Debian
 
-From within the `$ARTEMIS_HOME` folder:
+From within the `$ARTEMIS_DIST` folder:
 ```
 $ docker build -f ./docker/Dockerfile-debian -t artemis-debian .
 ```
 
 ## For CentOS
 
-From within the `$ARTEMIS_HOME` folder:
+From within the `$ARTEMIS_DIST` folder:
 ```
 $ docker build -f ./docker/Dockerfile-centos -t artemis-centos .
 ```
 
+## For AdoptOpen JDK 11
+From within the `$ARTEMIS_DIST` folder:
+```
+$ docker build -f ./docker/Dockerfile-adoptopenjdk-11 -t artemis-adoptopenjdk-11 .
+```
+
+# For AdoptOpen JDK 11 (Build for linux ARMv7/ARM64)
+```
+$ docker buildx build --platform linux/arm64,linux/arm/v7 --push -t {your-repository}/apache-artemis:2.17.0-SNAPSHOT -f ./docker/Dockerfile-adoptopenjdk-11 .
+```
+
 **Note:**
-`-t artemis-debian`,`-t artemis-centos` are just tag names for the purpose of this guide
+`-t artemis-debian`,`-t artemis-centos`,`artemis-adoptopenjdk-11` are just tag 
+names for the purpose of this guide
 
 
 # Environment Variables


### PR DESCRIPTION
I often use ActiveMQ Artemis on ARM devices and in particular on **Raspberry Pi** (3 and 4). The runtime environment is based on Docker. For this reason some time ago I extended the module in artemis-docker. I'd like to share this contribution.

I have extended the particular prepare-docker.sh script so that it is able to prepare scripts for build docker image, for both SNAPSHOT and release versions.

I also introduced a new docker file to produce a Docker image based on AdoptOpen JDK 11.

I have updated the readme.md with instructions for using the script and how to generate the Docker image for ARM.

My Docker Hub account already has the [ActiveMQ Artemis 2.16.0](https://hub.docker.com/r/amusarra/apache-artemis/tags?page=1&ordering=last_updated) Docker Image for ARM64.

I hope this contribution will be useful.

Relate issue ARTEMIS-3107 - https://issues.apache.org/jira/browse/ARTEMIS-3107 