### PR TITLE
ARTEMIS-2943 fix static selector example

### DIFF
--- a/examples/features/standard/static-selector/src/main/resources/activemq/server0/broker.xml
+++ b/examples/features/standard/static-selector/src/main/resources/activemq/server0/broker.xml
@@ -50,11 +50,11 @@ under the License.
 
       <addresses>
          <address name="exampleQueue">
-            <multicast>
+            <anycast>
                <queue name="exampleQueue">
                   <filter string="color='red'"/>
                </queue>
-            </multicast>
+            </anycast>
          </address>
       </addresses>
    </core>


### PR DESCRIPTION
The static-selector example was using a multicast queue instead of an
anycast queue which meant that the consumer never actually received any
of the messages. Furthermore, it wasn't actually verifying that it
received the proper messages so there was no failure. This commit
resolves these issues.