### PR TITLE
mention in documentation that a multiple values are allowed for anycastPrefix/multicastPrefix

### DIFF
--- a/docs/user-manual/en/address-model.md
+++ b/docs/user-manual/en/address-model.md
@@ -394,7 +394,7 @@ of the message to **one** of the `ANYCAST` queues and to **all** of the
 However, clients can specify a special prefix when connecting to an address to
 indicate which kind of routing type to use. The prefixes are custom values that
 are designated using the anycastPrefix and multicastPrefix parameters within
-the URL of an acceptor.
+the URL of an acceptor. When multiple values are needed, these can be separated by a comma.
 
 ### Configuring an Anycast Prefix
 


### PR DESCRIPTION
Documentation page http://activemq.apache.org/components/artemis/documentation/latest/address-model.html#using-prefixes-to-determine-routing-type explains the existence of the configuration values anycastPrefix/multicastPrefix for certain acceptors.

The code in ProtonProtocolManager.java, OpenWireProtocolManager.java, CoreProtocolManager.java and AbstractProtocolManager.java clearly supports multiple values that are separated by a comma.

However, the documentation barely explains this feature. Except for the plural word "prefixes", there is no indication that multiple values are allowed. Suggestion is in this PR.