### PR TITLE
ARTEMIS-3118 Fix the expiration on converting from AMQP to core

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/converter/AmqpCoreConverter.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/converter/AmqpCoreConverter.java
@@ -210,6 +210,10 @@ public class AmqpCoreConverter {
          throw new RuntimeException("Unexpected body type: " + body.getClass());
       }
 
+      // Initialize the JMS expiration with the value calculated during the scan of the AMQP message
+      // to avoid a different value for each conversion based on System.currentTimeMillis() and ttl.
+      result.setJMSExpiration(message.getExpiration());
+
       processHeader(result, header);
       processMessageAnnotations(result, annotations);
       processApplicationProperties(result, applicationProperties);

--- a/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessageTest.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessageTest.java
@@ -993,6 +993,19 @@ public class AMQPMessageTest {
    }
 
    @Test
+   public void testGetExpirationFromCoreMessageUsingTTL() {
+      final long ttl = 100000;
+
+      MessageImpl protonMessage = (MessageImpl) Message.Factory.create();
+      protonMessage.setHeader(new Header());
+      protonMessage.setTtl(ttl);
+      AMQPStandardMessage decoded = encodeAndDecodeMessage(protonMessage);
+
+      ICoreMessage coreMessage = decoded.toCore();
+      assertEquals(decoded.getExpiration(), coreMessage.getExpiration());
+   }
+
+   @Test
    public void testGetExpirationFromMessageUsingAbsoluteExpiration() {
       final Date expirationTime = new Date(System.currentTimeMillis());
 


### PR DESCRIPTION
Initialize the JMS expiration with the value calculated during the scan
of the AMQP message to avoid a different value for each conversion based
on System.currentTimeMillis() and ttl.