### PR TITLE
ARTEMIS-3117 Provide CachingOpenSSLContextFactory

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/ssl/CachingOpenSSLContextFactory.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/ssl/CachingOpenSSLContextFactory.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.remoting.impl.ssl;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import io.netty.handler.ssl.SslContext;
+import org.apache.activemq.artemis.spi.core.remoting.ssl.OpenSSLContextFactory;
+import org.apache.activemq.artemis.spi.core.remoting.ssl.SSLContextConfig;
+
+/**
+ * {@link OpenSSLContextFactory} providing a cache of {@link SslContext}.
+ * Since {@link SslContext} should be reused instead of recreated and are thread safe.
+ * To activate it you need to allow this Service to be discovered by having a
+ * <code>META-INF/services/org.apache.activemq.artemis.spi.core.remoting.ssl.OpenSSLContextFactory</code>
+ * file with <code>org.apache.activemq.artemis.core.remoting.impl.ssl.CachingOpenSSLContextFactory</code>
+ * as value.
+ */
+public class CachingOpenSSLContextFactory extends DefaultOpenSSLContextFactory {
+
+   private final ConcurrentMap<SSLContextConfig, SslContext> clientSslContextCache = new ConcurrentHashMap<>(2);
+   private final ConcurrentMap<SSLContextConfig, SslContext> serversSslContextCache = new ConcurrentHashMap<>(2);
+
+   @Override
+   public void clearSslContexts() {
+      clientSslContextCache.clear();
+      serversSslContextCache.clear();
+   }
+
+   @Override
+   public SslContext getClientSslContext(final SSLContextConfig config, final Map<String, Object> additionalOpts) throws Exception {
+      return clientSslContextCache.computeIfAbsent(config, this::getClientSslContext);
+   }
+
+   private SslContext getClientSslContext(final SSLContextConfig config) {
+      try {
+         return super.getClientSslContext(config, null);
+      } catch (final Exception ex) {
+         throw new RuntimeException("An unexpected exception occured while creating Client OpenSSL Context with " + config, ex);
+      }
+   }
+
+   @Override
+   public SslContext getServerSslContext(final SSLContextConfig config, final Map<String, Object> additionalOpts) throws Exception {
+      return clientSslContextCache.computeIfAbsent(config, this::getServerSslContext);
+   }
+
+   private SslContext getServerSslContext(final SSLContextConfig config) {
+      try {
+         return super.getServerSslContext(config, null);
+      } catch (final Exception ex) {
+         throw new RuntimeException("An unexpected exception occured while creating Server OpenSSL Context " + config, ex);
+      }
+   }
+
+   @Override
+   public int getPriority() {
+      return 10;
+   }
+}

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/ssl/DefaultOpenSSLContextFactory.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/ssl/DefaultOpenSSLContextFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.remoting.impl.ssl;
+
+import java.util.Map;
+
+import io.netty.handler.ssl.SslContext;
+import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnector;
+import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
+import org.apache.activemq.artemis.spi.core.remoting.ssl.OpenSSLContextFactory;
+import org.apache.activemq.artemis.spi.core.remoting.ssl.SSLContextConfig;
+
+/**
+ * Default {@link OpenSSLContextFactory} for use in {@link NettyConnector} and NettyAcceptor.
+ */
+public class DefaultOpenSSLContextFactory implements OpenSSLContextFactory {
+
+   /**
+    * @param additionalOpts not used by this implementation
+    *
+    * @return an {@link SslContext} instance for the given configuration.
+    */
+   @Override
+   public SslContext getClientSslContext(final SSLContextConfig config, final Map<String, Object> additionalOpts) throws Exception {
+      log.debugf("Creating Client OpenSSL Context with %s", config);
+      return new SSLSupport(config)
+         .setSslProvider(TransportConstants.OPENSSL_PROVIDER)
+         .createNettyClientContext();
+   }
+
+   /**
+    * @param additionalOpts not used by this implementation
+    *
+    * @return an {@link SslContext} instance for the given configuration.
+    */
+   @Override
+   public SslContext getServerSslContext(final SSLContextConfig config, final Map<String, Object> additionalOpts) throws Exception {
+      log.debugf("Creating Server OpenSSL Context with %s", config);
+      return new SSLSupport(config)
+         .setSslProvider(TransportConstants.OPENSSL_PROVIDER)
+         .createNettyContext();
+   }
+
+   @Override
+   public int getPriority() {
+      return 5;
+   }
+}

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/ssl/SSLSupport.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/ssl/SSLSupport.java
@@ -46,6 +46,7 @@ import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import org.apache.activemq.artemis.api.core.TrustManagerFactoryPlugin;
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
+import org.apache.activemq.artemis.spi.core.remoting.ssl.SSLContextConfig;
 import org.apache.activemq.artemis.utils.ClassloadingUtil;
 
 /**
@@ -65,6 +66,21 @@ public class SSLSupport {
    private String sslProvider = TransportConstants.DEFAULT_SSL_PROVIDER;
    private boolean trustAll = TransportConstants.DEFAULT_TRUST_ALL;
    private String trustManagerFactoryPlugin = TransportConstants.DEFAULT_TRUST_MANAGER_FACTORY_PLUGIN;
+
+   public SSLSupport() {
+   }
+
+   public SSLSupport(final SSLContextConfig config) {
+      keystoreProvider = config.getKeystoreProvider();
+      keystorePath = config.getKeystorePath();
+      keystorePassword = config.getKeystorePassword();
+      truststoreProvider = config.getTruststoreProvider();
+      truststorePath = config.getTruststorePath();
+      truststorePassword = config.getTruststorePassword();
+      crlPath = config.getCrlPath();
+      trustAll = config.isTrustAll();
+      trustManagerFactoryPlugin = config.getTrustManagerFactoryPlugin();
+   }
 
    public String getKeystoreProvider() {
       return keystoreProvider;

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/ssl/OpenSSLContextFactory.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/ssl/OpenSSLContextFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.spi.core.remoting.ssl;
+
+import java.util.Map;
+
+import io.netty.handler.ssl.SslContext;
+import org.jboss.logging.Logger;
+
+/**
+ * Service interface to create an {@link SslContext} for a configuration.
+ * This is ONLY used with OpenSSL.
+ * To create and use your own implementation you need to create a file
+ * <code>META-INF/services/org.apache.activemq.artemis.spi.core.remoting.ssl.OpenSSLContextFactory</code>
+ * in your jar and fill it with the full qualified name of your implementation.
+ */
+public interface OpenSSLContextFactory extends Comparable<OpenSSLContextFactory> {
+
+   Logger log = Logger.getLogger(OpenSSLContextFactory.class);
+
+   /**
+    * Release any cached {@link SslContext} instances.
+    */
+   default void clearSslContexts() {
+   }
+
+   @Override
+   default int compareTo(final OpenSSLContextFactory other) {
+      return this.getPriority() - other.getPriority();
+   }
+
+   /**
+    * @param additionalOpts implementation specific additional options.
+    *
+    * @return an {@link SslContext} instance for the given configuration.
+    */
+   SslContext getClientSslContext(SSLContextConfig config, Map<String, Object> additionalOpts) throws Exception;
+
+   /**
+    * @param additionalOpts implementation specific additional options.
+    *
+    * @return an {@link SslContext} instance for the given configuration.
+    */
+   SslContext getServerSslContext(SSLContextConfig config, Map<String, Object> additionalOpts) throws Exception;
+
+   /**
+    * The priority for the {@link OpenSSLContextFactory} when resolving the service to get the implementation.
+    * This is used when selecting the implementation when several implementations are loaded.
+    * The highest priority implementation will be used.
+    */
+   int getPriority();
+}

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/ssl/OpenSSLContextFactoryProvider.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/ssl/OpenSSLContextFactoryProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.spi.core.remoting.ssl;
+
+import java.util.ServiceLoader;
+
+/**
+ * Provider that loads all registered {@link OpenSSLContextFactory} services and returns the one with the highest priority.
+ */
+public class OpenSSLContextFactoryProvider {
+
+   private static final OpenSSLContextFactory FACTORY;
+   static {
+      OpenSSLContextFactory factoryWithHighestPrio = null;
+      for (OpenSSLContextFactory factory : ServiceLoader.load(OpenSSLContextFactory.class)) {
+         if (factoryWithHighestPrio == null || factory.getPriority() > factoryWithHighestPrio.getPriority()) {
+            factoryWithHighestPrio = factory;
+         }
+      }
+
+      if (factoryWithHighestPrio == null)
+         throw new IllegalStateException("No OpenSSLContextFactory registered!");
+
+      FACTORY = factoryWithHighestPrio;
+   }
+
+   /**
+    * @return the {@link OpenSSLContextFactory} with the higher priority.
+    */
+   public static OpenSSLContextFactory getOpenSSLContextFactory() {
+      return FACTORY;
+   }
+}

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/ssl/SSLContextConfig.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/ssl/SSLContextConfig.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2021 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.spi.core.remoting.ssl;
+
+import java.util.Objects;
+
+import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
+
+/**
+ * This class holds configuration parameters for SSL context initialization.
+ * To be used with {@link SSLContextFactory} and {@link OpenSSLContextFactory}.
+ * <br>
+ * Use {@link SSLContextConfig#builder()} to create new immutable instances.
+ */
+public final class SSLContextConfig {
+
+   public static final class Builder {
+      private String keystorePath = TransportConstants.DEFAULT_KEYSTORE_PATH;
+      private String keystorePassword = TransportConstants.DEFAULT_KEYSTORE_PASSWORD;
+      private String keystoreProvider = TransportConstants.DEFAULT_KEYSTORE_PROVIDER;
+      private String truststorePath = TransportConstants.DEFAULT_TRUSTSTORE_PATH;
+      private String truststorePassword = TransportConstants.DEFAULT_TRUSTSTORE_PASSWORD;
+      private String truststoreProvider = TransportConstants.DEFAULT_TRUSTSTORE_PROVIDER;
+      private String crlPath = TransportConstants.DEFAULT_CRL_PATH;
+      private String trustManagerFactoryPlugin = TransportConstants.DEFAULT_TRUST_MANAGER_FACTORY_PLUGIN;
+      private boolean trustAll = TransportConstants.DEFAULT_TRUST_ALL;
+
+      private Builder() {
+      }
+
+      public Builder from(final SSLContextConfig config) {
+         if (config == null)
+            return this;
+
+         keystorePath = config.getKeystorePath();
+         keystorePassword = config.getKeystorePassword();
+         keystoreProvider = config.getKeystoreProvider();
+         truststorePath = config.getTruststorePath();
+         truststorePassword = config.getTruststorePassword();
+         crlPath = config.getCrlPath();
+         truststoreProvider = config.getTruststoreProvider();
+         trustAll = config.trustAll;
+         return this;
+      }
+
+      public SSLContextConfig build() {
+         return new SSLContextConfig(
+            keystoreProvider, keystorePath, keystorePassword,
+            truststoreProvider, truststorePath, truststorePassword,
+            crlPath, trustManagerFactoryPlugin, trustAll
+         );
+      }
+
+      public Builder keystorePath(final String keystorePath) {
+         this.keystorePath = keystorePath;
+         return this;
+      }
+
+      public Builder keystorePassword(final String keystorePassword) {
+         this.keystorePassword = keystorePassword;
+         return this;
+      }
+
+      public Builder keystoreProvider(final String keystoreProvider) {
+         this.keystoreProvider = keystoreProvider;
+         return this;
+      }
+
+      public Builder truststorePath(final String truststorePath) {
+         this.truststorePath = truststorePath;
+         return this;
+      }
+
+      public Builder truststorePassword(final String truststorePassword) {
+         this.truststorePassword = truststorePassword;
+         return this;
+      }
+
+      public Builder truststoreProvider(final String truststoreProvider) {
+         this.truststoreProvider = truststoreProvider;
+         return this;
+      }
+
+      public Builder crlPath(final String crlPath) {
+         this.crlPath = crlPath;
+         return this;
+      }
+
+      public Builder trustAll(final boolean trustAll) {
+         this.trustAll = trustAll;
+         return this;
+      }
+
+      public Builder trustManagerFactoryPlugin(final String trustManagerFactoryPlugin) {
+         this.trustManagerFactoryPlugin = trustManagerFactoryPlugin;
+         return this;
+      }
+   }
+
+   public static  Builder builder() {
+      return new Builder();
+   }
+
+   private final String keystorePath;
+   private final String keystorePassword;
+   private final String keystoreProvider;
+   private final String truststorePath;
+   private final String truststorePassword;
+   private final String truststoreProvider;
+   private final String trustManagerFactoryPlugin;
+   private final String crlPath;
+   private final boolean trustAll;
+   private final int hashCode;
+
+   private SSLContextConfig(
+      final String keystoreProvider, final String keystorePath, final String keystorePassword,
+      final String truststoreProvider, final String truststorePath, final String truststorePassword,
+      final String crlPath, final String trustManagerFactoryPlugin, final boolean trustAll
+   ) {
+      this.keystorePath = keystorePath;
+      this.keystoreProvider = keystoreProvider;
+      this.keystorePassword = keystorePassword;
+      this.truststorePath = truststorePath;
+      this.truststorePassword = truststorePassword;
+      this.truststoreProvider = truststoreProvider;
+      this.trustManagerFactoryPlugin = trustManagerFactoryPlugin;
+      this.crlPath = crlPath;
+      this.trustAll = trustAll;
+      hashCode = Objects.hash(
+         keystorePath, keystoreProvider,
+         truststorePath, truststoreProvider,
+         crlPath, trustManagerFactoryPlugin, trustAll
+      );
+   }
+
+   @Override
+   public boolean equals(final Object obj) {
+      if (this == obj)
+         return true;
+      if (obj == null || getClass() != obj.getClass())
+         return false;
+      final SSLContextConfig other = (SSLContextConfig) obj;
+      return Objects.equals(keystorePath, other.keystorePath)
+         && Objects.equals(keystoreProvider, other.keystoreProvider)
+         && Objects.equals(truststorePath, other.truststorePath)
+         && Objects.equals(truststoreProvider, other.truststoreProvider)
+         && Objects.equals(crlPath, other.crlPath)
+         && Objects.equals(trustManagerFactoryPlugin, other.trustManagerFactoryPlugin)
+         && trustAll == other.trustAll;
+   }
+
+   public String getCrlPath() {
+      return crlPath;
+   }
+
+   public String getKeystorePassword() {
+      return keystorePassword;
+   }
+
+   public String getKeystorePath() {
+      return keystorePath;
+   }
+
+   public String getKeystoreProvider() {
+      return keystoreProvider;
+   }
+
+   public String getTrustManagerFactoryPlugin() {
+      return trustManagerFactoryPlugin;
+   }
+
+   public String getTruststorePassword() {
+      return truststorePassword;
+   }
+
+   public String getTruststorePath() {
+      return truststorePath;
+   }
+
+   public String getTruststoreProvider() {
+      return truststoreProvider;
+   }
+
+   @Override
+   public int hashCode() {
+      return hashCode;
+   }
+
+   public boolean isTrustAll() {
+      return trustAll;
+   }
+
+   @Override
+   public String toString() {
+      return "SSLSupport [" +
+         "keystoreProvider=" + keystoreProvider +
+         ", keystorePath=" + keystorePath +
+         ", keystorePassword=" + (keystorePassword == null ? null : "******") +
+         ", truststoreProvider=" + truststoreProvider +
+         ", truststorePath=" + truststorePath +
+         ", truststorePassword=" + (truststorePassword == null ? null : "******") +
+         ", crlPath=" + crlPath +
+         ", trustAll=" + trustAll +
+         ", trustManagerFactoryPlugin=" + trustManagerFactoryPlugin +
+         "]";
+   }
+}

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/ssl/SSLContextFactory.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/ssl/SSLContextFactory.java
@@ -30,24 +30,43 @@ public interface SSLContextFactory extends Comparable<SSLContextFactory> {
    Logger log = Logger.getLogger(SSLContextFactory.class);
 
    /**
-    * Obtain a SSLContext from the configuration.
-    * @param configuration
-    * @param keystoreProvider
-    * @param keystorePath
-    * @param keystorePassword
-    * @param truststoreProvider
-    * @param truststorePath
-    * @param truststorePassword
-    * @param crlPath
-    * @param trustManagerFactoryPlugin
-    * @param trustAll
-    * @return a SSLContext instance.
-    * @throws Exception
+    * @return an {@link SSLContext} for the given configuration.
+    *
+    * @deprecated use {@link #getSSLContext(SSLContextConfig, Map)} instead
     */
-   SSLContext getSSLContext(Map<String, Object> configuration,
+   @SuppressWarnings("unused")
+   @Deprecated
+   default SSLContext getSSLContext(Map<String, Object> configuration,
            String keystoreProvider, String keystorePath, String keystorePassword,
            String truststoreProvider, String truststorePath, String truststorePassword,
-           String crlPath, String trustManagerFactoryPlugin, boolean trustAll) throws Exception;
+           String crlPath, String trustManagerFactoryPlugin, boolean trustAll) throws Exception {
+
+      final SSLContextConfig sslContextConfig = SSLContextConfig.builder()
+         .keystoreProvider(keystoreProvider)
+         .keystorePath(keystorePath)
+         .keystorePassword(keystorePassword)
+         .truststoreProvider(truststoreProvider)
+         .truststorePath(truststorePath)
+         .truststorePassword(truststorePassword)
+         .trustManagerFactoryPlugin(trustManagerFactoryPlugin)
+         .crlPath(crlPath)
+         .build();
+
+      return getSSLContext(sslContextConfig, configuration);
+   }
+
+   /**
+    * @param additionalOpts implementation specific additional options.
+    *
+    * @return an {@link SSLContext} for the given configuration.
+    */
+   default SSLContext getSSLContext(SSLContextConfig config, Map<String, Object> additionalOpts) throws Exception {
+      return getSSLContext(additionalOpts,
+         config.getKeystoreProvider(), config.getKeystorePath(), config.getKeystorePassword(),
+         config.getTruststoreProvider(), config.getTruststorePath(), config.getTruststorePassword(),
+         config.getCrlPath(), config.getTrustManagerFactoryPlugin(), config.isTrustAll()
+      );
+   }
 
    default void clearSSLContexts() {
    }

--- a/artemis-core-client/src/main/resources/META-INF/services/org.apache.activemq.artemis.spi.core.remoting.ssl.OpenSSLContextFactory
+++ b/artemis-core-client/src/main/resources/META-INF/services/org.apache.activemq.artemis.spi.core.remoting.ssl.OpenSSLContextFactory
@@ -1,0 +1,1 @@
+org.apache.activemq.artemis.core.remoting.impl.ssl.DefaultOpenSSLContextFactory

--- a/artemis-core-client/src/test/java/org/apache/activemq/artemis/spi/core/remoting/ssl/OpenSSLContextFactoryProviderTest.java
+++ b/artemis-core-client/src/test/java/org/apache/activemq/artemis/spi/core/remoting/ssl/OpenSSLContextFactoryProviderTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.spi.core.remoting.ssl;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+
+public class OpenSSLContextFactoryProviderTest {
+
+   /**
+    * Test to retrieve a {@link OpenSSLContextFactory} registered via META-INF/services.
+    */
+   @Test
+   public void testGetOpenSSLContextFactory() {
+      assertNotNull(OpenSSLContextFactoryProvider.getOpenSSLContextFactory());
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/server/impl/RemotingServiceImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/server/impl/RemotingServiceImpl.java
@@ -71,6 +71,7 @@ import org.apache.activemq.artemis.spi.core.remoting.AcceptorFactory;
 import org.apache.activemq.artemis.spi.core.remoting.BufferHandler;
 import org.apache.activemq.artemis.spi.core.remoting.Connection;
 import org.apache.activemq.artemis.spi.core.remoting.ServerConnectionLifeCycleListener;
+import org.apache.activemq.artemis.spi.core.remoting.ssl.OpenSSLContextFactoryProvider;
 import org.apache.activemq.artemis.spi.core.remoting.ssl.SSLContextFactoryProvider;
 import org.apache.activemq.artemis.utils.ActiveMQThreadFactory;
 import org.apache.activemq.artemis.utils.ConfigurationHelper;
@@ -386,6 +387,7 @@ public class RemotingServiceImpl implements RemotingService, ServerConnectionLif
          return;
       }
       SSLContextFactoryProvider.getSSLContextFactory().clearSSLContexts();
+      OpenSSLContextFactoryProvider.getOpenSSLContextFactory().clearSslContexts();
 
       failureCheckAndFlushThread.close(criticalError);
 

--- a/docs/user-manual/en/configuring-transports.md
+++ b/docs/user-manual/en/configuring-transports.md
@@ -318,9 +318,12 @@ additional properties:
 
 - `sslContext`
 
-A key that can be used in conjunction with `org.apache.activemq.artemis.core.remoting.impl.ssl.CachingSSLContextFactory`
-to cache created SSLContext and avoid recreating. Look [Configuring a SSLContextFactory](#Configuring a SSLContextFactory)
-for more details.
+  An optional cache key only evaluated if `org.apache.activemq.artemis.core.remoting.impl.ssl.CachingSSLContextFactory`
+  is active, to cache the initial created SSL context and reuse it. If not
+  specified CachingSSLContextFactory will automatically calculate a cache key based on
+  the given keystore/truststore parameters.
+  See [Configuring an SSLContextFactory](#Configuring an SSLContextFactory)
+  for more details.
 
 - `sslEnabled`
 
@@ -499,22 +502,34 @@ for more details.
   [broker's classpath](using-server.md#adding-runtime-dependencies).
 
 
-#### Configuring a SSLContextFactory
+#### Configuring an SSLContextFactory
 
-If you have a `JDK` provider you can configure which SSLContextFactory to use.
-Currently we provide two implementations: 
+If you use `JDK` as SSL provider (the default), you can configure which
+SSLContextFactory to use.
+Currently the following two implementations are provided:
 - `org.apache.activemq.artemis.core.remoting.impl.ssl.DefaultSSLContextFactory`
+  (registered by the default)
 - `org.apache.activemq.artemis.core.remoting.impl.ssl.CachingSSLContextFactory`
-but you can also add your own implementation of `org.apache.activemq.artemis.spi.core.remoting.ssl.SSLContextFactory`.
 
-The implementations are loaded by a ServiceLoader, thus you need to declare your implementation in
+You may also create your own implementation of 
+`org.apache.activemq.artemis.spi.core.remoting.ssl.SSLContextFactory`.
+
+The implementations are loaded by a `java.util.ServiceLoader`, thus you need to declare your implementation in
 a `META-INF/services/org.apache.activemq.artemis.spi.core.remoting.ssl.SSLContextFactory` file.
 If several implementations are available, the one with the highest `priority` will be selected.
+
 So for example, if you want to use `org.apache.activemq.artemis.core.remoting.impl.ssl.CachingSSLContextFactory`
 you need to add a `META-INF/services/org.apache.activemq.artemis.spi.core.remoting.ssl.SSLContextFactory` file
 to your classpath with the content `org.apache.activemq.artemis.core.remoting.impl.ssl.CachingSSLContextFactory`.
 
-**Note:** This mechanism doesn't work if you have selected `OPENSSL` as provider.
+A similar mechanism exists for the `OPENSSL` SSL provider in which case you can configure an OpenSSLContextFactory.
+Currently the following two implementations are provided:
+- `org.apache.activemq.artemis.core.remoting.impl.ssl.DefaultOpenSSLContextFactory`
+  (registered by the default)
+- `org.apache.activemq.artemis.core.remoting.impl.ssl.CachingOpenSSLContextFactory`
+
+You may also create your own implementation of 
+`org.apache.activemq.artemis.spi.core.remoting.ssl.OpenSSLContextFactory`.
 
 
 ### Configuring Netty HTTP


### PR DESCRIPTION
to mitigate performance degradation in JDK 11 during TLS connection initialization.

See https://issues.apache.org/jira/browse/ARTEMIS-3117

This is an alternative to https://github.com/apache/activemq-artemis/pull/3456 based on feedback by @franz1981

This PR introduces an additional `SSLContextConfig` object that can be passed around instead of having to provide 6-7 parameters on each method invocation throughout the call chain.