### PR TITLE
NO-JIRA: GHA workflow improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: "Build"
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
@@ -32,8 +32,15 @@ jobs:
       - name: Build Main
         run: |
           mvn -Dorg.apache.activemq.artemis.core.io.aio.AIOSequentialFileFactory.DISABLED=AnythingNotNull -Djdk8-errorprone -Pfast-tests -Pextra-tests -Ptests-CI -Pjmh install
-      - name: Build Examples
+
+      - name: Build Examples (JDK8 / -Prelease)
+        if: matrix.java == '8'
         run: |
           cd examples
-          mvn install -PnoRun
+          mvn install -Prelease
 
+      - name: Build Examples (JDK 11+ / -Pexamples,noRun)
+        if: matrix.java != '8'
+        run: |
+          cd examples
+          mvn install -Pexamples,noRun


### PR DESCRIPTION
- Builds the examples using the release profile on JDK8, as the Travis job does.
- Build the examples on JDK11+ using the -Pexamples,noRun profiles for equivalent build (release profile requires JDK8), which the Travis build doesnt do.
- Adds a workflow_dispatch trigger, allowing manual start of a new test runs (on any branch), without overwriting all the previous run logs like using the 'rerun all jobs' button within a particular run result.