### PR TITLE
use the parameter-name "ttl" that matches the value in documentation for REST

### DIFF
--- a/docs/user-manual/en/rest.md
+++ b/docs/user-manual/en/rest.md
@@ -627,7 +627,7 @@ another query parameter with an integer value between 0 and 9 expressing
 the priority of the message. i.e.:
 
 ```
-POST /queues/bar/create?expiration=30000&priority=3
+POST /queues/bar/create?ttl=30000&priority=3
 Host: example.com
 Content-Type: application/xml
 


### PR DESCRIPTION
The documentation says:
```
You can set the time to live, expiration, and/or the priority of the
message in the queue or topic by setting an additional query parameter.
The `expiration` query parameter is a long specifying the time in
milliseconds since epoch (a long date). The `ttl` query parameter is a
time in milliseconds you want the message active. The `priority` is
another query parameter with an integer value between 0 and 9 expressing
the priority of the message. i.e.:
```

but the code just below it uses parameter `expiration=30000`. `30000` is more a ttl than an absolute time. So, I assume that parametername `ttl` was intended.