### PR TITLE
ARTEMIS-3174: Set new connection on ServerSession during reattachment

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/ServerSessionPacketHandler.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/ServerSessionPacketHandler.java
@@ -1018,6 +1018,8 @@ public class ServerSessionPacketHandler implements ChannelHandler {
 
       newConnection.syncIDGeneratorSequence(remotingConnection.getIDGeneratorSequence());
 
+      session.transferConnection(newConnection);
+
       Connection oldTransportConnection = remotingConnection.getTransportConnection();
 
       remotingConnection = newConnection;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ServerSession.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ServerSession.java
@@ -58,6 +58,8 @@ public interface ServerSession extends SecurityAuth {
    @Override
    RemotingConnection getRemotingConnection();
 
+   void transferConnection(RemotingConnection newConnection);
+
    Transaction newTransaction();
 
    boolean removeConsumer(long consumerID) throws Exception;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -136,7 +136,7 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
 
    protected final boolean strictUpdateDeliveryCount;
 
-   protected final RemotingConnection remotingConnection;
+   protected RemotingConnection remotingConnection;
 
    protected final Map<Long, ServerConsumer> consumers = new ConcurrentHashMap<>();
 
@@ -1071,6 +1071,11 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
    @Override
    public RemotingConnection getRemotingConnection() {
       return remotingConnection;
+   }
+
+   @Override
+   public void transferConnection(RemotingConnection newConnection) {
+      remotingConnection = newConnection;
    }
 
    @Override


### PR DESCRIPTION
During session reattachment, also set the new connection on the
"session" member of the ServerSessionPacketHandler. Until now,
the connected ServerSessionImpl instance still referenced the old
connection although it had already been transferred on the new connection.