### PR TITLE
ARTEMIS-3182 remove defunct repo

### DIFF
--- a/artemis-protocols/artemis-mqtt-protocol/pom.xml
+++ b/artemis-protocols/artemis-mqtt-protocol/pom.xml
@@ -136,17 +136,4 @@
          <type>jar</type>
       </dependency>
    </dependencies>
-
-   <repositories>
-      <repository>
-         <id>bintray</id>
-         <url>https://jcenter.bintray.com</url>
-         <releases>
-            <enabled>true</enabled>
-         </releases>
-         <snapshots>
-            <enabled>false</enabled>
-         </snapshots>
-      </repository>
-   </repositories>
 </project>


### PR DESCRIPTION
This repo is no longer operative. See
https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/
for more info. All dependencies are in Maven Central.