### PR TITLE
ARTEMIS-3183: resolve various immediate warnings at build start

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/pom.xml
+++ b/artemis-protocols/artemis-amqp-protocol/pom.xml
@@ -78,14 +78,6 @@
           <artifactId>wildfly-common</artifactId>
          <scope>test</scope>
       </dependency>
-
-      <!-- this is for the log assertion -->
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-commons</artifactId>
-         <version>${project.version}</version>
-      </dependency>
-
       <dependency>
          <groupId>org.jboss.logging</groupId>
          <artifactId>jboss-logging</artifactId>

--- a/artemis-protocols/artemis-mqtt-protocol/pom.xml
+++ b/artemis-protocols/artemis-mqtt-protocol/pom.xml
@@ -113,7 +113,6 @@
       <dependency>
          <groupId>org.eclipse.paho</groupId>
          <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-         <version>1.2.0</version>
          <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -70,10 +70,6 @@
    <name>ActiveMQ Artemis Parent</name>
    <url>http://apache.org/activemq</url>
 
-   <prerequisites>
-      <maven>3.1.0</maven>
-   </prerequisites>
-
    <properties>
       <modular.jdk.surefire.arg />
       <javac.version>9+181-r4173-1</javac.version>
@@ -142,6 +138,7 @@
       <surefire.version>2.22.2</surefire.version>
       <version.jaxb.api>2.3.1</version.jaxb.api>
       <version.jaxb.runtime>2.3.3</version.jaxb.runtime>
+      <paho.client.mqttv3.version>1.2.5</paho.client.mqttv3.version>
       <!-- for JakrtaEE -->
       <version.batavia>1.0.5.Final</version.batavia>
 
@@ -287,6 +284,11 @@
          </dependency>
 
          <!-- ### For MQTT Tests && Examples -->
+	 <dependency>
+           <groupId>org.eclipse.paho</groupId>
+           <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
+           <version>${paho.client.mqttv3.version}</version>
+         </dependency>
          <dependency>
             <groupId>org.fusesource.mqtt-client</groupId>
             <artifactId>mqtt-client</artifactId>

--- a/tests/integration-tests/pom.xml
+++ b/tests/integration-tests/pom.xml
@@ -29,7 +29,6 @@
 
    <properties>
       <activemq.basedir>${project.basedir}/../..</activemq.basedir>
-      <paho.client.mqttv3.version>1.2.2</paho.client.mqttv3.version>
    </properties>
 
    <dependencies>
@@ -202,7 +201,6 @@
       <dependency>
          <groupId>org.eclipse.paho</groupId>
          <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-         <version>${paho.client.mqttv3.version}</version>
       </dependency>
       <dependency>
          <groupId>org.apache.geronimo.specs</groupId>

--- a/tests/smoke-tests/pom.xml
+++ b/tests/smoke-tests/pom.xml
@@ -118,7 +118,6 @@
       <dependency>
          <groupId>org.eclipse.paho</groupId>
          <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-         <version>RELEASE</version>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>


### PR DESCRIPTION
One of the first things seen when running the build is a bunch of warnings, some which could even break the build in future, so this looks to resolve them:

```
Warning:  
Warning:  Some problems were encountered while building the effective model for org.apache.activemq:artemis-amqp-protocol:bundle:2.18.0-SNAPSHOT
Warning:  'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.apache.activemq:artemis-commons:jar -> duplicate declaration of version ${project.version} @ line 83, column 19
Warning:  
Warning:  Some problems were encountered while building the effective model for org.apache.activemq.tests:smoke-tests:jar:2.18.0-SNAPSHOT
Warning:  'dependencies.dependency.version' for org.eclipse.paho:org.eclipse.paho.client.mqttv3:jar is either LATEST or RELEASE (both of them are being deprecated) @ line 121, column 19
Warning:  
Warning:  It is highly recommended to fix these problems because they threaten the stability of your build.
Warning:  
Warning:  For this reason, future Maven versions might no longer support building such malformed projects.
Warning:  
Warning:  The project org.apache.activemq:artemis-pom:pom:2.18.0-SNAPSHOT uses prerequisites which is only intended for maven-plugin projects but not for non maven-plugin projects. For such purposes you should use the maven-enforcer-plugin. See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html

```


The first is due to a dependency entry being duplicated in https://github.com/apache/activemq-artemis/commit/e7e3c71511770442cbb206cefcae25001566d75b. Fix is simply to remove one.

The second is due to use of the deprecated 'RELEASE' floating version in the smoke tests module, fix is jsut to stop using the deprecated name. It turns out the build currently uses 3 different versions of this client for tests in different places: 1.2.0, 1.2.2, and the floating RELEASE being 1.2.5 for several months. I introduced a dependency management entry and fixed them all to the 1.2.5 version, as I see no particular reason for it being a floating version and none of the others appear to be.

The last warning is about using the prerequisites element, and suggested fix is to use the enforcer plugin. That is actually already in place, so fix is simply removal.