### PR TITLE
spacing in logmessage

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/TopologyMemberImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/TopologyMemberImpl.java
@@ -154,7 +154,7 @@ public final class TopologyMemberImpl implements TopologyMember {
 
    @Override
    public String toString() {
-      return "TopologyMember[id = " + nodeId + ", connector=" + connector + ", backupGroupName=" + backupGroupName + ", scaleDownGroupName=" + scaleDownGroupName + "]";
+      return "TopologyMember[id=" + nodeId + ", connector=" + connector + ", backupGroupName=" + backupGroupName + ", scaleDownGroupName=" + scaleDownGroupName + "]";
    }
 
 

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnectionFactory.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnectionFactory.java
@@ -934,7 +934,7 @@ public class ActiveMQConnectionFactory extends JNDIStorable implements Connectio
       return "ActiveMQConnectionFactory [serverLocator=" + serverLocator +
          ", clientID=" +
          clientID +
-         ", consumerWindowSize = " +
+         ", consumerWindowSize=" +
          getConsumerWindowSize() +
          ", dupsOKBatchSize=" +
          dupsOKBatchSize +
@@ -942,7 +942,7 @@ public class ActiveMQConnectionFactory extends JNDIStorable implements Connectio
          transactionBatchSize +
          ", readOnly=" +
          readOnly +
-         "EnableSharedClientID=" +
+         ", EnableSharedClientID=" +
          enableSharedClientID +
          "]";
    }


### PR DESCRIPTION
a specific log message lists a few terms. 2 of these terms do not have any spacing between them as I noticed in actual output,
2 additional spacing adjustments for consistency.