### PR TITLE
visually separate the controls in groups

### DIFF
--- a/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/services/toolbar.js
+++ b/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/services/toolbar.js
@@ -25,7 +25,7 @@ var Artemis;
                     <form class="toolbar-pf-actions">
                         <div class="form-group toolbar-pf-filter">
                             <div class="input-group">
-                                <div class="input-group-btn">
+                                <div class="input-group-btn" style="padding-left: 10px">
                                     <button id="filter.values.field" type="button" class="btn btn-default dropdown-toggle" id="filter" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{$ctrl.filter.text.fieldText}} <span class="caret"></span></button>
                                     <ul class="dropdown-menu">
                                         <li ng-repeat="option in $ctrl.filter.fieldOptions"
@@ -40,7 +40,7 @@ var Artemis;
                                       </ul>
                                 </div>
                                 <input type="text" class="form-control" ng-model="$ctrl.filter.values.value" placeholder="Value" autocomplete="off" id="filterInput">
-                                <div class="input-group-btn">
+                                <div class="input-group-btn" style="padding-left: 10px">
                                       <button type="button" class="btn btn-default dropdown-toggle" id="filter" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{$ctrl.filter.text.sortOrderText}}<span class="caret"></span></button>
                                       <ul class="dropdown-menu">
                                         <li ng-repeat="option in $ctrl.filter.sortOptions"
@@ -66,7 +66,7 @@ var Artemis;
                                         ng-click="$ctrl.reset()">Reset
                                     </button>
                                 </div>
-                                <div class="input-group-btn">
+                                <div class="input-group-btn" style="padding-left: 10px">
                                     <button class="btn btn-default primary-action ng-binding ng-scope"
                                         type="button"
                                         title=""


### PR DESCRIPTION
The "filter" toolbar above many pages has all controls without spacing.
This PR inserts a little bit of spacing to make the groups of controls more obvious.

old situation:
![afbeelding](https://user-images.githubusercontent.com/3663742/111339993-81fd7100-8678-11eb-852a-920b9ba40f4b.png)

new situation:
![afbeelding](https://user-images.githubusercontent.com/3663742/111341181-92621b80-8679-11eb-9e2f-d1810b26039c.png)

spacing is applied 3 times:
1) at the start of the row to separate it from the left margin
2) at "sort order" to separate the "filter" group from the "ordering" group
3) at "columns" to separate it from "reset"

since the "looking glass" being an icon, no extra spacing was needed there

note: I tried to use "1em" as spacing, but that did not work, so this PR uses "10px"