### PR TITLE
ARTEMIS-3199 Upgrade postgresql to 42.2.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -312,7 +312,7 @@
          <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>9.4-1205-jdbc4</version>
+            <version>42.2.19</version>
             <scope>provided</scope>
             <!-- postgresql license -->
          </dependency>


### PR DESCRIPTION
According to the [postgresql documentation](https://jdbc.postgresql.org/documentation/faq.html#42-is-not), the 42.x.x releases are not a rewrite of the driver, are not using a new architecture, nor are using something special, they are the continuation of the same driver following a better versioning policy.