### PR TITLE
Divert fix

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -271,6 +271,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
    private static final String CONFIG_DELETE_ADDRESSES = "config-delete-addresses";
 
+   private static final String CONFIG_DELETE_DIVERTS = "config-delete-diverts";
+
    private static final String DEFAULT_PURGE_ON_NO_CONSUMERS = "default-purge-on-no-consumers";
 
    private static final String DEFAULT_MAX_CONSUMERS = "default-max-consumers";
@@ -1250,6 +1252,11 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
             Validators.DELETION_POLICY_TYPE.validate(CONFIG_DELETE_ADDRESSES, value);
             DeletionPolicy policy = Enum.valueOf(DeletionPolicy.class, value);
             addressSettings.setConfigDeleteAddresses(policy);
+         } else if (CONFIG_DELETE_DIVERTS.equalsIgnoreCase(name)) {
+            String value = getTrimmedTextContent(child);
+            Validators.DELETION_POLICY_TYPE.validate(CONFIG_DELETE_DIVERTS, value);
+            DeletionPolicy policy = Enum.valueOf(DeletionPolicy.class, value);
+            addressSettings.setConfigDeleteDiverts(policy);
          } else if (MANAGEMENT_BROWSE_PAGE_SIZE.equalsIgnoreCase(name)) {
             addressSettings.setManagementBrowsePageSize(XMLUtil.parseInt(child));
          } else if (MANAGEMENT_MESSAGE_ATTRIBUTE_SIZE_LIMIT.equalsIgnoreCase(name)) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -82,7 +82,6 @@ import org.apache.activemq.artemis.core.messagecounter.MessageCounterManager;
 import org.apache.activemq.artemis.core.messagecounter.impl.MessageCounterManagerImpl;
 import org.apache.activemq.artemis.core.persistence.StorageManager;
 import org.apache.activemq.artemis.core.persistence.config.PersistedAddressSetting;
-import org.apache.activemq.artemis.core.persistence.config.PersistedDivertConfiguration;
 import org.apache.activemq.artemis.core.persistence.config.PersistedSecuritySetting;
 import org.apache.activemq.artemis.core.postoffice.Binding;
 import org.apache.activemq.artemis.core.postoffice.Bindings;
@@ -3590,7 +3589,6 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
          TransformerConfiguration transformerConfiguration = transformerClassName == null || transformerClassName.isEmpty() ? null : new TransformerConfiguration(transformerClassName).setProperties(transformerProperties);
          DivertConfiguration config = new DivertConfiguration().setName(name).setRoutingName(routingName).setAddress(address).setForwardingAddress(forwardingAddress).setExclusive(exclusive).setFilterString(filterString).setTransformerConfiguration(transformerConfiguration).setRoutingType(ComponentConfigurationRoutingType.valueOf(routingType));
          server.deployDivert(config);
-         storageManager.storeDivertConfiguration(new PersistedDivertConfiguration(config));
       } finally {
          blockOnIO();
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
@@ -90,6 +90,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
    public static final DeletionPolicy DEFAULT_CONFIG_DELETE_ADDRESSES = DeletionPolicy.OFF;
 
+   public static final DeletionPolicy DEFAULT_CONFIG_DELETE_DIVERTS = DeletionPolicy.OFF;
+
    public static final long DEFAULT_REDISTRIBUTION_DELAY = -1;
 
    public static final boolean DEFAULT_AUTO_CREATE_EXPIRY_RESOURCES = false;
@@ -222,6 +224,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    private Long autoDeleteAddressesDelay = null;
 
    private DeletionPolicy configDeleteAddresses = null;
+
+   private DeletionPolicy configDeleteDiverts = null;
 
    private Integer managementBrowsePageSize = AddressSettings.MANAGEMENT_BROWSE_PAGE_SIZE;
 
@@ -462,6 +466,15 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    public AddressSettings setConfigDeleteAddresses(DeletionPolicy configDeleteAddresses) {
       this.configDeleteAddresses = configDeleteAddresses;
       return this;
+   }
+
+   public AddressSettings setConfigDeleteDiverts(DeletionPolicy configDeleteDiverts) {
+      this.configDeleteDiverts = configDeleteDiverts;
+      return this;
+   }
+
+   public DeletionPolicy getConfigDeleteDiverts() {
+      return configDeleteDiverts != null ? configDeleteDiverts : AddressSettings.DEFAULT_CONFIG_DELETE_DIVERTS;
    }
 
    public int getDefaultMaxConsumers() {
@@ -1581,6 +1594,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       result = prime * result + ((autoDeleteAddresses == null) ? 0 : autoDeleteAddresses.hashCode());
       result = prime * result + ((autoDeleteAddressesDelay == null) ? 0 : autoDeleteAddressesDelay.hashCode());
       result = prime * result + ((configDeleteAddresses == null) ? 0 : configDeleteAddresses.hashCode());
+      result = prime * result + ((configDeleteDiverts == null) ? 0 : configDeleteDiverts.hashCode());
       result = prime * result + ((managementBrowsePageSize == null) ? 0 : managementBrowsePageSize.hashCode());
       result = prime * result + ((queuePrefetch == null) ? 0 : queuePrefetch.hashCode());
       result = prime * result + ((maxSizeBytesRejectThreshold == null) ? 0 : maxSizeBytesRejectThreshold.hashCode());
@@ -1815,6 +1829,11 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
             return false;
       } else if (!configDeleteAddresses.equals(other.configDeleteAddresses))
          return false;
+      if (configDeleteDiverts == null) {
+         if (other.configDeleteDiverts != null)
+            return false;
+      } else if (!configDeleteDiverts.equals(other.configDeleteDiverts))
+         return false;
       if (managementBrowsePageSize == null) {
          if (other.managementBrowsePageSize != null)
             return false;
@@ -2043,7 +2062,9 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
          ", autoDeleteAddressesDelay=" +
          autoDeleteAddressesDelay +
          ", configDeleteAddresses=" +
-         configDeleteAddresses +
+         configDeleteAddresses  +
+         ", configDeleteDiverts=" +
+         configDeleteDiverts +
          ", managementBrowsePageSize=" +
          managementBrowsePageSize +
          ", managementMessageAttributeSizeLimit=" +

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -3801,6 +3801,22 @@
                </xsd:simpleType>
             </xsd:element>
 
+            <xsd:element name="config-delete-diverts" default="OFF" maxOccurs="1" minOccurs="0">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     What to do when a divert is no longer in broker.xml.
+                     OFF = will do nothing queues will remain,
+                     FORCE = delete queues even if messages remaining.
+                  </xsd:documentation>
+               </xsd:annotation>
+               <xsd:simpleType>
+                  <xsd:restriction base="xsd:string">
+                     <xsd:enumeration value="OFF"/>
+                     <xsd:enumeration value="FORCE"/>
+                  </xsd:restriction>
+               </xsd:simpleType>
+            </xsd:element>
+
             <xsd:element name="management-browse-page-size" type="xsd:int" default="200" maxOccurs="1" minOccurs="0">
                <xsd:annotation>
                   <xsd:documentation>

--- a/docs/user-manual/en/address-model.md
+++ b/docs/user-manual/en/address-model.md
@@ -672,6 +672,7 @@ that would be found in the `broker.xml` file.
       <auto-delete-queues-delay>0</auto-delete-queues-delay>
       <auto-delete-queues-message-count>0</auto-delete-queues-message-count>
       <config-delete-queues>OFF</config-delete-queues>
+      <config-delete-diverts>OFF</config-delete-diverts>
       <auto-create-addresses>true</auto-create-addresses>
       <auto-delete-addresses>true</auto-delete-addresses>
       <auto-delete-addresses-delay>0</auto-delete-addresses-delay>
@@ -900,6 +901,9 @@ For Core JMS you can set it using the destination queue attributes
 reload, by delete policy: `OFF` or `FORCE`.  Default is `OFF`. Read more about
 [configuration reload](config-reload.md).
 
+`config-delete-diverts`. How the broker should handle diverts deleted on config
+reload, by delete policy: `OFF` or `FORCE`.  Default is `OFF`. Read more about
+[configuration reload](config-reload.md).
 `auto-create-addresses`. Whether or not the broker should automatically create
 an address when a message is sent to or a consumer tries to consume from a
 queue which is mapped to an address whose name fits the address `match`.

--- a/docs/user-manual/en/config-reload.md
+++ b/docs/user-manual/en/config-reload.md
@@ -16,7 +16,7 @@ If using [modulised broker.xml](configuration-index.md#modularising-broker.xml) 
 
 **Note:**
 
-Deletion of Address's and Queue's, not auto created is controlled by Address Settings
+Deletion of Address's Queue's and diverts not auto created is controlled by Address Settings
 
 * config-delete-addresses
    * OFF (DEFAULT) - will not remove upon config reload.
@@ -26,6 +26,9 @@ Deletion of Address's and Queue's, not auto created is controlled by Address Set
    * OFF (DEFAULT) - will not remove upon config reload.
    * FORCE - will remove the queue upon config reload, even if messages remains, losing the messages in the queue.
 
+* config-delete-diverts
+   * OFF (DEFAULT) - will not remove upon config reload.
+   * FORCE - will remove the queue upon config reload, even if messages remains, losing the messages in the queue.
 
 By default both settings are OFF as such address & queues won't be removed upon
 reload, given the risk of losing messages.

--- a/docs/user-manual/en/configuration-index.md
+++ b/docs/user-manual/en/configuration-index.md
@@ -249,6 +249,7 @@ Name | Description | Default
 [auto-delete-addresses](address-model.md#configuring-addresses-and-queues-via-address-settings) | Delete auto-created addresses automatically | `true`
 [auto-delete-addresses-delay](address-model.md#configuring-addresses-and-queues-via-address-settings) | Delay for deleting auto-created addresses | 0
 [config-delete-addresses](config-reload.md) | How to deal with addresses deleted from XML at runtime | `OFF`
+[config-delete-diverts](config-reload.md) | How to deal with diverts deleted from XML at runtime | `OFF`
 [management-browse-page-size]() | Number of messages a management resource can browse| 200
 [default-purge-on-no-consumers](address-model.md#non-durable-subscription-queue) | `purge-on-no-consumers` value if none is set on the queue | `false`
 [default-max-consumers](address-model.md#shared-durable-subscription-queue-using-max-consumers) | `max-consumers` value if none is set on the queue | -1

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/divert/DivertTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/divert/DivertTest.java
@@ -742,6 +742,101 @@ public class DivertTest extends ActiveMQTestBase {
    }
 
    @Test
+   public void testSinglePersistedDivert() throws Exception {
+      final String testAddress = "testAddress";
+
+      final String forwardAddress = "forwardAddress";
+
+      DivertConfiguration divertConf = new DivertConfiguration().setName("divert1").setRoutingName("divert1").setAddress(testAddress).setForwardingAddress(forwardAddress).setExclusive(true);
+
+
+      QueueConfiguration q1 = new QueueConfiguration("forwardAddress1").setDurable(true).setRoutingType(RoutingType.ANYCAST);
+
+      Configuration config = createDefaultInVMConfig().addDivertConfiguration(divertConf).addQueueConfiguration(q1);
+
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(config, true));
+
+      server.start();
+
+      server.stop();
+
+      divertConf.setRoutingName("divert2");
+
+      server.start();
+
+      Binding divert1 = server.getPostOffice().getBinding(new SimpleString("divert1"));
+
+      Assert.assertNotNull(divert1);
+
+      Assert.assertEquals(divert1.getRoutingName(), new SimpleString("divert2"));
+   }
+
+   @Test
+   public void testSinglePersistedNewDivert() throws Exception {
+      final String testAddress = "testAddress";
+
+      final String forwardAddress = "forwardAddress";
+
+      DivertConfiguration divertConf = new DivertConfiguration().setName("divert1").setRoutingName("divert1").setAddress(testAddress).setForwardingAddress(forwardAddress).setExclusive(true);
+
+
+      QueueConfiguration q1 = new QueueConfiguration("forwardAddress1").setDurable(true).setRoutingType(RoutingType.ANYCAST);
+
+      Configuration config = createDefaultInVMConfig().addDivertConfiguration(divertConf).addQueueConfiguration(q1);
+
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(config, true));
+
+      server.start();
+
+      server.stop();
+
+      divertConf = new DivertConfiguration().setName("divert1").setRoutingName("divert2").setAddress(testAddress).setForwardingAddress(forwardAddress).setExclusive(true);
+
+      config.getDivertConfigurations().clear();
+
+      config.getDivertConfigurations().add(divertConf);
+
+      server.start();
+
+      Binding divert1 = server.getPostOffice().getBinding(new SimpleString("divert1"));
+
+      Assert.assertNotNull(divert1);
+
+      Assert.assertEquals(divert1.getRoutingName(), new SimpleString("divert2"));
+   }
+
+   @Test
+   public void testSinglePersistedNoDeleteDivert() throws Exception {
+      final String testAddress = "testAddress";
+
+      final String forwardAddress = "forwardAddress";
+
+      DivertConfiguration divertConf = new DivertConfiguration().setName("divert1").setRoutingName("divert1").setAddress(testAddress).setForwardingAddress(forwardAddress).setExclusive(true);
+
+
+      QueueConfiguration q1 = new QueueConfiguration("forwardAddress1").setDurable(true).setRoutingType(RoutingType.ANYCAST);
+
+      Configuration config = createDefaultInVMConfig().addDivertConfiguration(divertConf).addQueueConfiguration(q1);
+
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(config, true));
+
+      server.start();
+
+      server.stop();
+
+      config.getDivertConfigurations().clear();
+
+      server.start();
+
+      Binding divert1 = server.getPostOffice().getBinding(new SimpleString("divert1"));
+
+      Assert.assertNotNull(divert1);
+
+      Assert.assertEquals(divert1.getRoutingName(), new SimpleString("divert1"));
+   }
+
+
+   @Test
    public void testMultipleNonExclusiveDivert() throws Exception {
       final String testAddress = "testAddress";
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
@@ -66,6 +66,7 @@ import org.apache.activemq.artemis.core.config.ClusterConnectionConfiguration;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.impl.SecurityConfiguration;
 import org.apache.activemq.artemis.core.messagecounter.impl.MessageCounterManagerImpl;
+import org.apache.activemq.artemis.core.persistence.config.PersistedDivertConfiguration;
 import org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory;
 import org.apache.activemq.artemis.core.remoting.impl.invm.TransportConstants;
 import org.apache.activemq.artemis.core.security.Role;
@@ -1770,6 +1771,9 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       divertNames = serverControl.getDivertNames();
       assertEquals(1, divertNames.length);
       assertEquals(name, divertNames[0]);
+      //now check its been persisted
+      PersistedDivertConfiguration pdc = server.getStorageManager().recoverDivertConfigurations().get(0);
+      assertEquals(pdc.getDivertConfiguration().getForwardingAddress(), updatedForwardingAddress);
 
       // check that a message is no longer exclusively diverted
       message = session.createMessage(false);


### PR DESCRIPTION
This is 2 commits, the first is a bug around persisting diverts the second an enhancement to configure deleting when removed the configuration similar to how config-delete-queue/addresses works.