### PR TITLE
ARTEMIS-3237 logging OpenWire producer exception is confusing

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQSession.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQSession.java
@@ -454,7 +454,7 @@ public class AMQSession implements SessionCallback {
          try {
             getCoreSession().send(coreMsg, false, dest.isTemporary());
          } catch (Exception e) {
-            logger.warn(e.getMessage(), e);
+            logger.debug("Sending exception to the client", e);
             exceptionToSend = e;
          }
          connection.enableTtl();


### PR DESCRIPTION
Logging the exception here is potentially confusing for two main
reasons:
 1. It's not clear the exception is specifically for the client.
 2. There is likely other logging that identifies the problem.