### PR TITLE
ARTEMIS-3240 - ensure acked messages in transactions are returned to …

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
@@ -682,6 +682,10 @@ public class OpenWireConnection extends AbstractRemotingConnection implements Se
    @Override
    public void fail(ActiveMQException me, String message) {
 
+      for (Transaction tx : txMap.values()) {
+         tx.rollbackIfPossible();
+      }
+
       if (me != null) {
          //filter it like the other protocols
          if (!(me instanceof ActiveMQRemoteDisconnectException)) {


### PR DESCRIPTION
…the sessions on connection failure, prior to rollback processing. Fix and test