### PR TITLE
ARTEMIS-3106 Fixing javadoc build for artemis-amqp-protocol

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/pom.xml
+++ b/artemis-protocols/artemis-amqp-protocol/pom.xml
@@ -39,6 +39,11 @@
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-server</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-core-client</artifactId>
          <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
The reference between AMQP Protocol and Server was Indirect.
Not having the dependency explictly set ill break Javadoc.

I am reapplying the commit reverted to fix the javadoc build.

Revert "ARTEMIS-3106: remove duplicate artemis-server dependency added in 5313a800a37a4174a43289457a8934266b50f96b"

This reverts commit 3c90c695f3ac1a77f7ec981980bcd8d50bd72f25.