### PR TITLE
ARTEMIS-3256 internalqueue and internaladdress get their own color in the broker diagram

### DIFF
--- a/artemis-hawtio/activemq-branding/src/main/webapp/plugin/css/activemq.css
+++ b/artemis-hawtio/activemq-branding/src/main/webapp/plugin/css/activemq.css
@@ -69,6 +69,14 @@ svg text {
    fill: #78932c;
 }
 
+.pf-topology-svg g.InternalAddress circle {
+   stroke:  #2b326e;
+}
+
+.pf-topology-svg g.InternalQueue circle {
+   stroke:  #50621d;
+}
+
 /*Adds a border to top of page*/
 .pf-c-page__header {
     border-top: 3px solid #B21054;


### PR DESCRIPTION
In the broker diagram, the icons for InternalAddress and InternalQueue are the same, as they each have the default style.
This PR explicitly assigns the same border colour as Address/Queue, but still leaves the fill colour white/transparent.

the new result:
![broker-diagram](https://user-images.githubusercontent.com/3663742/115128926-8ef7e200-9fe1-11eb-8f18-b1c2e8dc1736.png)
as produced by the code from this branch (and configuring a cluster so that there are actually internal objects)

previously both were same colour:
![afbeelding](https://user-images.githubusercontent.com/3663742/115128985-0463b280-9fe2-11eb-8ee4-283c6aba3387.png)

See also https://issues.apache.org/jira/browse/ARTEMIS-3256