### PR TITLE
Fix description of DiskStoreUsage

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
@@ -29,7 +29,7 @@ public interface ActiveMQServerControl {
    String TOTAL_CONNECTION_COUNT_DESCRIPTION = "Number of clients which have connected to this server since it was started";
    String ADDRESS_MEMORY_USAGE_DESCRIPTION = "Memory used by all the addresses on broker for in-memory messages";
    String ADDRESS_MEMORY_USAGE_PERCENTAGE_DESCRIPTION = "Memory used by all the addresses on broker as a percentage of the global-max-size";
-   String DISK_STORE_USAGE_DESCRIPTION = "Percentage of total disk store used";
+   String DISK_STORE_USAGE_DESCRIPTION = "Fraction of total disk store used";
 
    /**
     * Returns this server's version.

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/plugin/MetricsPluginTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/plugin/MetricsPluginTest.java
@@ -148,7 +148,7 @@ public class MetricsPluginTest extends ActiveMQTestBase {
               new Metric("artemis.delivering.durable.persistent.size", "persistent size of durable messages that this queue is currently delivering to its consumers", 0.0),
               new Metric("artemis.delivering.message.count", "number of messages that this queue is currently delivering to its consumers", 0.0),
               new Metric("artemis.delivering.persistent_size", "persistent size of messages that this queue is currently delivering to its consumers", 0.0),
-              new Metric("artemis.disk.store.usage", "Percentage of total disk store used", 0.0),
+              new Metric("artemis.disk.store.usage", "Fraction of total disk store used", 0.0),
               new Metric("artemis.durable.message.count", "number of durable messages currently in this queue (includes scheduled, paged, and in-delivery messages)", 0.0),
               new Metric("artemis.durable.persistent.size", "persistent size of durable messages currently in this queue (includes scheduled, paged, and in-delivery messages)", 0.0),
               new Metric("artemis.message.count", "number of messages currently in this queue (includes scheduled, paged, and in-delivery messages)", 0.0),


### PR DESCRIPTION
In 73c4e399d9c2e8401f2034ffb0c5e42b4a70b053 a description is added to DiskStoreUsage. It incorrectly describes the diskStoreUsage as a percentage. This commit changes it to a fraction which it is (also before the description change). A percentage would be better, since MaxDiskUsage is also specified as percentage.