### PR TITLE
ARTEMIS-3258 added warning for url parameters that are explicitly ignored

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/ActiveMQClientLogger.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/ActiveMQClientLogger.java
@@ -574,4 +574,8 @@ public interface ActiveMQClientLogger extends BasicLogger {
    @Message(id = 214033, value = "Cannot resolve host ",
            format = Message.Format.MESSAGE_FORMAT)
    void unableToResolveHost(@Cause UnknownHostException e);
+
+   @LogMessage(level = Logger.Level.WARN)
+   @Message(id = 212079, value = "The upstream connector from the downstream federation will ignore url parameter {0}", format = Message.Format.MESSAGE_FORMAT)
+   void ignoredParameterForDownstreamFederation(String name);
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/config/federation/FederationDownstreamConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/config/federation/FederationDownstreamConfiguration.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Objects;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.apache.activemq.artemis.core.client.ActiveMQClientLogger;
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 
 public class FederationDownstreamConfiguration extends FederationStreamConfiguration<FederationDownstreamConfiguration> {
@@ -40,23 +41,30 @@ public class FederationDownstreamConfiguration extends FederationStreamConfigura
       return upstreamConfiguration;
    }
 
+   private void stripParam(Map<String, Object> params, String name) {
+      Object oldValue = params.remove(name);
+      if (oldValue != null) {
+         ActiveMQClientLogger.LOGGER.ignoredParameterForDownstreamFederation(name);
+      }
+   }
+
    public void setUpstreamConfiguration(TransportConfiguration transportConfiguration) {
 
       final Map<String, Object> params = new HashMap<>(transportConfiguration.getParams());
 
       //clear any TLS settings as they won't apply to the federated server that uses this config
       //The federated server that creates the upstream back will rely on its config from the acceptor for TLS
-      params.remove(TransportConstants.SSL_ENABLED_PROP_NAME);
-      params.remove(TransportConstants.SSL_PROVIDER);
-      params.remove(TransportConstants.SSL_KRB5_CONFIG_PROP_NAME);
-      params.remove(TransportConstants.KEYSTORE_PATH_PROP_NAME);
-      params.remove(TransportConstants.KEYSTORE_PASSWORD_PROP_NAME);
-      params.remove(TransportConstants.KEYSTORE_PROVIDER_PROP_NAME);
-      params.remove(TransportConstants.KEYSTORE_TYPE_PROP_NAME);
-      params.remove(TransportConstants.TRUSTSTORE_PATH_PROP_NAME);
-      params.remove(TransportConstants.TRUSTSTORE_PASSWORD_PROP_NAME);
-      params.remove(TransportConstants.TRUSTSTORE_PROVIDER_PROP_NAME);
-      params.remove(TransportConstants.TRUSTSTORE_TYPE_PROP_NAME);
+      stripParam(params, TransportConstants.SSL_ENABLED_PROP_NAME);
+      stripParam(params, TransportConstants.SSL_PROVIDER);
+      stripParam(params, TransportConstants.SSL_KRB5_CONFIG_PROP_NAME);
+      stripParam(params, TransportConstants.KEYSTORE_PATH_PROP_NAME);
+      stripParam(params, TransportConstants.KEYSTORE_PASSWORD_PROP_NAME);
+      stripParam(params, TransportConstants.KEYSTORE_PROVIDER_PROP_NAME);
+      stripParam(params, TransportConstants.KEYSTORE_TYPE_PROP_NAME);
+      stripParam(params, TransportConstants.TRUSTSTORE_PATH_PROP_NAME);
+      stripParam(params, TransportConstants.TRUSTSTORE_PASSWORD_PROP_NAME);
+      stripParam(params, TransportConstants.TRUSTSTORE_PROVIDER_PROP_NAME);
+      stripParam(params, TransportConstants.TRUSTSTORE_TYPE_PROP_NAME);
 
       this.upstreamConfiguration = new TransportConfiguration(transportConfiguration.getFactoryClassName(), params,
                                                               transportConfiguration.getName(), transportConfiguration.getExtraParams());


### PR DESCRIPTION
When setting up a downstream-federation, several ssl-related parameters are silently stripped from the provided URL.
This PR causes a warning to be shown for each parameter that was removed.

Only parameter name is mentioned, but not the given value as that is not needed and even insecure since that information then ends up in the logfile.

This helps to solve connection problems in this area; and it encourages a cleaner configuration file.

a test gave the following output:
```
2021-05-01 00:49:09,971 WARN  [org.apache.activemq.artemis.core.client] AMQ212079: The upstream connector from the downstream federation will ignore url parameter sslEnabled
2021-05-01 00:49:09,971 WARN  [org.apache.activemq.artemis.core.client] AMQ212079: The upstream connector from the downstream federation will ignore url parameter trustStorePath
2021-05-01 00:49:09,971 WARN  [org.apache.activemq.artemis.core.client] AMQ212079: The upstream connector from the downstream federation will ignore url parameter trustStorePassword
```