### PR TITLE
NO-JIRA remove ordering constraint from <broadcast-group> tag in XML

### DIFF
--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -1297,7 +1297,7 @@
    <!-- BROADCAST GROUP CONFIGURATION -->
    <xsd:element name="broadcast-group">
       <xsd:complexType>
-         <xsd:sequence>
+         <xsd:all>
             <xsd:element ref="local-bind-address" maxOccurs="1" minOccurs="0">
                <xsd:annotation>
                   <xsd:documentation>
@@ -1353,7 +1353,7 @@
             </xsd:element>
 
             <xsd:element name="connector-ref" type="xsd:string" maxOccurs="unbounded" minOccurs="0"/>
-         </xsd:sequence>
+         </xsd:all>
 
          <xsd:attribute name="name" type="xsd:ID" use="required">
             <xsd:annotation>

--- a/examples/features/clustered/clustered-jgroups/src/main/resources/activemq/server1/broker.xml
+++ b/examples/features/clustered/clustered-jgroups/src/main/resources/activemq/server1/broker.xml
@@ -42,9 +42,9 @@ under the License.
 
       <broadcast-groups>
          <broadcast-group name="my-broadcast-group">
-            <broadcast-period>5000</broadcast-period>
             <jgroups-file>test-jgroups-file_ping.xml</jgroups-file>
             <jgroups-channel>active_broadcast_channel</jgroups-channel>
+            <broadcast-period>5000</broadcast-period>
             <connector-ref>netty-connector</connector-ref>
          </broadcast-group>
       </broadcast-groups>


### PR DESCRIPTION
It seems like the XSD requires the elements of the `<broadcast-group>` tags to be in order. Based on my investigation, I cannot see a reason for this, as it has been so since the HornetQ donation. `<discovery-group>` [is not ordered](https://github.com/apache/activemq-artemis/blob/f491651fdbc911e11c470afb3c0f7f6da1d74063/artemis-server/src/main/resources/schema/artemis-configuration.xsd#L1371). 

Without this change, users may encounter cryptic error messages such as the below if they apply configuration [as in the documentation](https://github.com/apache/activemq-artemis/blame/f491651fdbc911e11c470afb3c0f7f6da1d74063/docs/user-manual/en/clusters.md#L153)

```
 java.lang.IllegalStateException: Invalid configuration
 	at org.apache.activemq.artemis.utils.XMLUtil.validate(XMLUtil.java:365)
 	at org.apache.activemq.artemis.core.config.FileDeploymentManager.readConfiguration(FileDeploymentManager.java:80)
 	at org.apache.activemq.artemis.integration.FileBroker.createComponents(FileBroker.java:118)
 	at org.apache.activemq.artemis.cli.commands.Run.execute(Run.java:112)
 	at org.apache.activemq.artemis.cli.Artemis.internalExecute(Artemis.java:154)
 	at org.apache.activemq.artemis.cli.Artemis.execute(Artemis.java:102)
 	at org.apache.activemq.artemis.cli.Artemis.execute(Artemis.java:129)
 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
 	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
 	at org.apache.activemq.artemis.boot.Artemis.execute(Artemis.java:134)
 	at org.apache.activemq.artemis.boot.Artemis.main(Artemis.java:50)
 Caused by: org.xml.sax.SAXParseException; cvc-complex-type.2.4.a: Invalid content was found starting with element '{"urn:activemq:core":broadcast-period}'. One of '{"urn:activemq:core":connector-ref}' is expected.
 	at java.xml/com.sun.org.apache.xerces.internal.util.ErrorHandlerWrapper.createSAXParseException(Unknown Source)
 	at java.xml/com.sun.org.apache.xerces.internal.util.ErrorHandlerWrapper.error(Unknown Source)
 	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLErrorReporter.reportError(Unknown Source)
 	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLErrorReporter.reportError(Unknown Source)
 	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLErrorReporter.reportError(Unknown Source)
 	at java.xml/com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator$XSIErrorReporter.reportError(Unknown Source)
 	at java.xml/com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator.reportSchemaError(Unknown Source)
 	at java.xml/com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator.handleStartElement(Unknown Source)
 	at java.xml/com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator.startElement(Unknown Source)
 	at java.xml/com.sun.org.apache.xerces.internal.jaxp.validation.DOMValidatorHelper.beginNode(Unknown Source)
 	at java.xml/com.sun.org.apache.xerces.internal.jaxp.validation.DOMValidatorHelper.validate(Unknown Source)
 	at java.xml/com.sun.org.apache.xerces.internal.jaxp.validation.DOMValidatorHelper.validate(Unknown Source)
 	at java.xml/com.sun.org.apache.xerces.internal.jaxp.validation.ValidatorImpl.validate(Unknown Source)
 	at java.xml/javax.xml.validation.Validator.validate(Unknown Source)
 	at org.apache.activemq.artemis.utils.XMLUtil.validate(XMLUtil.java:361)
```