### PR TITLE
NO-JIRA artemis.data system property 

### DIFF
--- a/artemis-server-osgi/src/main/java/org/apache/activemq/artemis/osgi/OsgiBroker.java
+++ b/artemis-server-osgi/src/main/java/org/apache/activemq/artemis/osgi/OsgiBroker.java
@@ -75,10 +75,17 @@ public class OsgiBroker {
          security.setRolePrincipalClass(rolePrincipalClass);
       }
       String brokerInstance = null;
-      String karafDataDir = System.getProperty("karaf.data");
-      if (karafDataDir != null) {
-         brokerInstance = karafDataDir + "/artemis/" + name;
-      }
+
+      String artemisDataDir = System.getProperty("artemis.data");
+      if (artemisDataDir != null) {
+         brokerInstance = artemisDataDir + "/artemis/" + name;
+      } else {
+         String karafDataDir = System.getProperty("karaf.data");
+         if (karafDataDir != null) {
+            brokerInstance = karafDataDir + "/artemis/" + name;
+         }
+      }     
+
 
       // todo if we start to pullout more configs from the main config then we
       // should pull out the configuration objects from factories if available


### PR DESCRIPTION
Within the artemis.xml the locations for storing the data can be configured (paging-directory, bindings-directory, journal-directory, large-messages-directory). Would it be possible to additionally support the system property artemis.data? The configuration would then be much easier.