### PR TITLE
ARTEMIS-2813 Update MiniKDC and fix Kerberos tests on JDK 11+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
       <karaf.version>4.3.0</karaf.version>
       <pax.exam.version>4.9.1</pax.exam.version>
       <commons.config.version>2.7</commons.config.version>
-      <commons.lang.version>3.0</commons.lang.version>
+      <commons.lang.version>3.12.0</commons.lang.version>
       <activemq5-version>5.16.0</activemq5-version>
       <apache.derby.version>10.11.1.1</apache.derby.version>
       <commons.beanutils.version>1.9.4</commons.beanutils.version>
@@ -199,7 +199,7 @@
       <skipStyleCheck>true</skipStyleCheck>
       <skipOWASP>true</skipOWASP>
 
-      <directory-version>2.0.0-M15</directory-version>
+      <directory-version>2.0.0.AM26</directory-version>
       <directory-jdbm2-version>2.0.0-M1</directory-jdbm2-version>
 
       <netty-transport-native-epoll-classifier>linux-x86_64</netty-transport-native-epoll-classifier>
@@ -280,7 +280,7 @@
          </dependency>
 
          <!-- ### For MQTT Tests && Examples -->
-	 <dependency>
+    <dependency>
            <groupId>org.eclipse.paho</groupId>
            <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
            <version>${paho.client.mqttv3.version}</version>

--- a/tests/integration-tests/pom.xml
+++ b/tests/integration-tests/pom.xml
@@ -335,6 +335,11 @@
             </exclusion>
          </exclusions>
       </dependency>
+      <dependency>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+          <scope>test</scope>
+      </dependency>
 
       <!-- karaf test -->
 
@@ -560,9 +565,6 @@
                      <artifactId>maven-surefire-plugin</artifactId>
                      <configuration>
                         <excludes combine.children="append">
-                           <!-- This fails, likely due to due to issues of compatibility with newer KDC updates -->
-                           <exclude>**/SaslKrb5LDAPSecurityTest.java</exclude>
-
                            <!-- This is no longer possible on JDK11 because the old KRB5 cipher suites it requires were
                                 removed from JDK11 while adding TLS 1.3 support http://openjdk.java.net/jeps/332 -->
                            <exclude>**/CoreClientOverOneWaySSLKerb5Test.java</exclude>

--- a/tests/integration-tests/pom.xml
+++ b/tests/integration-tests/pom.xml
@@ -390,7 +390,13 @@
       <dependency>
          <groupId>org.apache.hadoop</groupId>
          <artifactId>hadoop-minikdc</artifactId>
-         <version>2.8.1</version>
+         <version>3.3.0</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.directory.server</groupId>
+         <artifactId>apacheds-interceptor-kerberos</artifactId>
+         <version>${directory-version}</version>
          <scope>test</scope>
       </dependency>
       <dependency>
@@ -554,8 +560,7 @@
                      <artifactId>maven-surefire-plugin</artifactId>
                      <configuration>
                         <excludes combine.children="append">
-                           <!-- These fail, likely due to due to isues with the old Kerberos test harness bits -->
-                           <exclude>**/JMSSaslGssapiTest.java</exclude>
+                           <!-- This fails, likely due to due to issues of compatibility with newer KDC updates -->
                            <exclude>**/SaslKrb5LDAPSecurityTest.java</exclude>
 
                            <!-- This is no longer possible on JDK11 because the old KRB5 cipher suites it requires were

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/metrics/JournalPendingMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/metrics/JournalPendingMessageTest.java
@@ -42,7 +42,7 @@ import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.jms.client.ActiveMQTextMessage;
 import org.apache.activemq.artemis.utils.Wait;
 import org.apache.activemq.artemis.utils.Wait.Condition;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/StompWebSocketMaxFrameTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/StompWebSocketMaxFrameTest.java
@@ -24,7 +24,7 @@ import org.apache.activemq.artemis.tests.util.Wait;
 import org.apache.activemq.artemis.tests.integration.stomp.util.ClientStompFrame;
 import org.apache.activemq.artemis.tests.integration.stomp.util.StompClientConnection;
 import org.apache.activemq.artemis.tests.integration.stomp.util.StompClientConnectionFactory;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/tests/integration-tests/src/test/resources/minikdc-krb5-template.conf
+++ b/tests/integration-tests/src/test/resources/minikdc-krb5-template.conf
@@ -1,0 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+[libdefaults]
+    kdc_realm = EXAMPLE.COM
+    default_realm = EXAMPLE.COM
+    udp_preference_limit = 1
+    kdc_tcp_port = MINI_KDC_PORT
+    default_keytab_name = FILE:target/test.krb5.keytab
+
+[realms]
+    EXAMPLE.COM = {
+        kdc = localhost:MINI_KDC_PORT
+    }
+


### PR DESCRIPTION
Updates the MiniKDC dependency and adds another now needed dep in order
to get the Kerberos tests working on JDK 11+ builds.