### PR TITLE
NO-JIRA Specifying Maven Deploy Plugin as 2.4

### DIFF
--- a/artemis-distribution/pom.xml
+++ b/artemis-distribution/pom.xml
@@ -263,6 +263,8 @@
          </plugin>
          <plugin>
             <artifactId>maven-assembly-plugin</artifactId>
+            <!-- if I don't specify version 2.4, the deploy is not setting the executables as expected -->
+            <version>2.4</version>
             <executions>
               <execution>
                   <id>source</id>


### PR DESCRIPTION
Using the latest (3.2.0) here will break the executables authorization for some reason