### PR TITLE
NO-JIRA Update the tar format for long files to posix

### DIFF
--- a/artemis-distribution/pom.xml
+++ b/artemis-distribution/pom.xml
@@ -270,7 +270,7 @@
                      <descriptors>
                        <descriptor>src/main/assembly/source-assembly.xml</descriptor>
                      </descriptors>
-                     <tarLongFileMode>gnu</tarLongFileMode>
+                     <tarLongFileMode>posix</tarLongFileMode>
                   </configuration>
                   <phase>package</phase>
                   <goals>
@@ -283,7 +283,7 @@
                      <descriptors>
                        <descriptor>src/main/assembly/dep.xml</descriptor>
                      </descriptors>
-                     <tarLongFileMode>gnu</tarLongFileMode>
+                     <tarLongFileMode>posix</tarLongFileMode>
                   </configuration>
                   <phase>package</phase>
                   <goals>


### PR DESCRIPTION
The gnu tar format causes some issues on some platforms because of some
restrictions instead the posix format is the most flexible format.