### PR TITLE
ARTEMIS-3314: fix some warnigns while creating assembly

### DIFF
--- a/artemis-distribution/src/main/assembly/dep.xml
+++ b/artemis-distribution/src/main/assembly/dep.xml
@@ -39,6 +39,7 @@
         <includes>
            <include>org.apache.activemq:artemis-boot</include>
         </includes>
+        <useProjectArtifact>false</useProjectArtifact>
       </dependencySet>
 
       <dependencySet>
@@ -111,6 +112,7 @@
          </excludes-->
          <outputDirectory>lib</outputDirectory>
          <unpack>false</unpack>
+         <useProjectArtifact>false</useProjectArtifact>
       </dependencySet>
       <dependencySet>
          <directoryMode>755</directoryMode>
@@ -120,6 +122,7 @@
          </includes>
          <outputDirectory>lib/client</outputDirectory>
          <unpack>false</unpack>
+         <useProjectArtifact>false</useProjectArtifact>
       </dependencySet>
       <!-- native -->
       <dependencySet>
@@ -133,6 +136,7 @@
                <include>**/*.so</include>
             </includes>
          </unpackOptions>
+         <useProjectArtifact>false</useProjectArtifact>
       </dependencySet>
       <dependencySet>
          <includes>
@@ -143,6 +147,7 @@
          </excludes>
          <outputDirectory>web</outputDirectory>
          <unpack>true</unpack>
+         <useProjectArtifact>false</useProjectArtifact>
       </dependencySet>
       <dependencySet>
          <includes>
@@ -150,6 +155,7 @@
          </includes>
          <outputDirectory>web/api</outputDirectory>
          <unpack>true</unpack>
+         <useProjectArtifact>false</useProjectArtifact>
       </dependencySet>
       
       <!-- Management Console Dependencies -->
@@ -160,6 +166,7 @@
          <outputDirectory>web</outputDirectory>
          <unpack>false</unpack>
          <outputFileNameMapping>console.war</outputFileNameMapping>
+         <useProjectArtifact>false</useProjectArtifact>
       </dependencySet>
       <dependencySet>
          <includes>
@@ -168,6 +175,7 @@
          <outputDirectory>web</outputDirectory>
          <unpack>false</unpack>
          <outputFileNameMapping>activemq-branding.war</outputFileNameMapping>
+         <useProjectArtifact>false</useProjectArtifact>
       </dependencySet>
       <dependencySet>
          <includes>
@@ -176,6 +184,7 @@
          <outputDirectory>web</outputDirectory>
          <unpack>false</unpack>
          <outputFileNameMapping>artemis-plugin.war</outputFileNameMapping>
+         <useProjectArtifact>false</useProjectArtifact>
       </dependencySet>
       
    </dependencySets>

--- a/artemis-distribution/src/main/assembly/dep.xml
+++ b/artemis-distribution/src/main/assembly/dep.xml
@@ -103,7 +103,6 @@
             <include>org.apache.johnzon:johnzon-core</include>
             <include>jakarta.xml.bind:jakarta.xml.bind-api</include>
             <include>com.sun.xml.bind:jaxb-impl</include>
-            <include>com.sun.xml.bind:jaxb-core</include>
             <include>jakarta.activation:jakarta.activation-api</include>
             <include>jakarta.security.auth.message:jakarta.security.auth.message-api</include>
          </includes>


### PR DESCRIPTION
Fixes some of the warnings while creating an assembly, make it easier to see actual issues in future.

- Fixes 27 warnings about not including the project arifact (i.e pom file) while building the assemblies.
- Fixes 3 warnings about not triggering inclusion filter for a jar as it isnt included in the assembly anymore (from 2.17.0)