### PR TITLE
ARTEMIS-3270: update enforced minimum maven version to 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1449,7 +1449,7 @@
                   <configuration>
                     <rules>
                       <requireMavenVersion>
-                        <version>3.1</version>
+                        <version>3.5.0</version>
                       </requireMavenVersion>
                     </rules>
                   </configuration>


### PR DESCRIPTION
The existing 3.1 minimum value is stale and no longer reflects reality. From comments on the JIRA the Maven 3.5.x is the oldest stream the build now works with. I did a build (only) with 3.5.0 locally which worked, and so this updates the minimum value to 3.5.0.