### PR TITLE
ARTEMIS-3314: fix remaining warnings during assembly build

### DIFF
--- a/artemis-distribution/pom.xml
+++ b/artemis-distribution/pom.xml
@@ -281,7 +281,21 @@
                   <id>bin</id>
                   <configuration>
                      <descriptors>
-                       <descriptor>src/main/assembly/dep.xml</descriptor>
+                       <descriptor>src/main/assembly/bin.xml</descriptor>
+                     </descriptors>
+                     <tarLongFileMode>posix</tarLongFileMode>
+                  </configuration>
+                  <phase>package</phase>
+                  <goals>
+                     <goal>single</goal>
+                  </goals>
+               </execution>
+               <execution>
+                  <id>dir</id>
+                  <configuration>
+                     <attach>false</attach>
+                     <descriptors>
+                       <descriptor>src/main/assembly/dir.xml</descriptor>
                      </descriptors>
                      <tarLongFileMode>posix</tarLongFileMode>
                   </configuration>

--- a/artemis-distribution/src/main/assembly/bin.xml
+++ b/artemis-distribution/src/main/assembly/bin.xml
@@ -1,0 +1,32 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License. You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+
+   <id>bin</id>
+   <formats>
+      <format>zip</format>
+      <format>tar.gz</format>
+   </formats>
+   <includeBaseDirectory>true</includeBaseDirectory>
+
+   <componentDescriptors>
+       <componentDescriptor>dep.xml</componentDescriptor>
+   </componentDescriptors>
+</assembly>

--- a/artemis-distribution/src/main/assembly/dep.xml
+++ b/artemis-distribution/src/main/assembly/dep.xml
@@ -208,7 +208,7 @@
       <!-- resources -->
       <fileSet>
          <directory>src/main/resources</directory>
-         <outputDirectory>/</outputDirectory>
+         <outputDirectory>${file.separator}</outputDirectory>
          <lineEnding>keep</lineEnding>
          <excludes>
             <exclude>bin/activemq</exclude>
@@ -224,7 +224,7 @@
       <!-- chmod to 755 on linux executables -->
       <fileSet>
          <directory>src/main/resources</directory>
-         <outputDirectory>/</outputDirectory>
+         <outputDirectory>${file.separator}</outputDirectory>
          <lineEnding>keep</lineEnding>
          <includes>
             <include>bin/activemq</include>
@@ -254,7 +254,7 @@
       <!-- Include license and notice files -->
       <fileSet>
          <directory>${activemq.basedir}/artemis-distribution/src/main/resources/licenses/bin</directory>
-         <outputDirectory>/</outputDirectory>
+         <outputDirectory>${file.separator}</outputDirectory>
          <useDefaultExcludes>true</useDefaultExcludes>
       </fileSet>
    </fileSets>

--- a/artemis-distribution/src/main/assembly/dep.xml
+++ b/artemis-distribution/src/main/assembly/dep.xml
@@ -15,18 +15,9 @@
   ~ limitations under the License.
   -->
 
-<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
-
-   <id>bin</id>
-   <formats>
-      <format>dir</format>
-      <format>zip</format>
-      <format>tar.gz</format>
-   </formats>
-   <includeBaseDirectory>true</includeBaseDirectory>
-
+<component xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
 
    <dependencySets>
       <dependencySet>
@@ -258,4 +249,4 @@
          <useDefaultExcludes>true</useDefaultExcludes>
       </fileSet>
    </fileSets>
-</assembly>
+</component>

--- a/artemis-distribution/src/main/assembly/dir.xml
+++ b/artemis-distribution/src/main/assembly/dir.xml
@@ -1,0 +1,31 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License. You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+
+   <id>bin</id>
+   <formats>
+      <format>dir</format>
+   </formats>
+   <includeBaseDirectory>true</includeBaseDirectory>
+
+   <componentDescriptors>
+       <componentDescriptor>dep.xml</componentDescriptor>
+   </componentDescriptors>
+</assembly>

--- a/artemis-distribution/src/main/assembly/source-assembly.xml
+++ b/artemis-distribution/src/main/assembly/source-assembly.xml
@@ -32,7 +32,7 @@
       <!--  main project directory structure  -->
       <fileSet>
          <directory>${activemq.basedir}</directory>
-         <outputDirectory>/</outputDirectory>
+         <outputDirectory>${file.separator}</outputDirectory>
          <useDefaultExcludes>true</useDefaultExcludes>
          <!-- TODO These excludes were lifted from maven-resources-apache-source-release-assembly-descriptor-1.0.4. We
          should use this descriptor directly in future -->


### PR DESCRIPTION
Carrying on after #3593, these changes fix all the remaining warnings emitted while building the assemblies, simplifying picking up on any future warnings issued.