### PR TITLE
ARTEMIS-3328: assembly related improvements

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -140,18 +140,11 @@ scm.tag=1.4.0
 ```
 
 
-## Removing additional files
+## Closing the staging repository
 
-The last step before closing the staging repository is removing the `artemis-pom-&lt;version>-source-release.zip` file.  At 
-the moment this artifact is uploaded automatically by the Apache release plugin. In future versions the ActiveMQ Artemis
-pom will be updated to take this into account.
-
-The file will be located under ./artemis-pom/&lt;version>/
-
-Remove these files manually under Nexus (https://repository.apache.org/#stagingRepositories) while the repository is still open.
-
-Once the file is removed close the staging repo using the "Close" button on Nexus website.
-
+Give the staging repository contents a quick inspection using the content navigation area, then proceed to close the
+staging repo using the "Close" button on Nexus website, locking it from further modification and exposing its contents
+at a staging URL to allow testing. Set a description such as "ActiveMQ Artemis <version> (RC1)" while closing.
 
 ## Stage the release to the dist dev area
 

--- a/artemis-distribution/pom.xml
+++ b/artemis-distribution/pom.xml
@@ -264,19 +264,6 @@
          <plugin>
             <artifactId>maven-assembly-plugin</artifactId>
             <executions>
-              <execution>
-                  <id>source</id>
-                  <configuration>
-                     <descriptors>
-                       <descriptor>src/main/assembly/source-assembly.xml</descriptor>
-                     </descriptors>
-                     <tarLongFileMode>posix</tarLongFileMode>
-                  </configuration>
-                  <phase>package</phase>
-                  <goals>
-                     <goal>single</goal>
-                  </goals>
-               </execution>
                <execution>
                   <id>bin</id>
                   <configuration>
@@ -329,4 +316,31 @@
       </plugins>
    </build>
 
+   <profiles>
+      <profile>
+         <id>apache-release</id>
+         <build>
+            <plugins>
+               <plugin>
+                  <artifactId>maven-assembly-plugin</artifactId>
+                  <executions>
+                     <execution>
+                        <id>source</id>
+                        <configuration>
+                           <descriptors>
+                              <descriptor>src/main/assembly/source-assembly.xml</descriptor>
+                           </descriptors>
+                           <tarLongFileMode>posix</tarLongFileMode>
+                        </configuration>
+                        <phase>package</phase>
+                        <goals>
+                           <goal>single</goal>
+                        </goals>
+                     </execution>
+                  </executions>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+   </profiles>
 </project>

--- a/artemis-distribution/src/main/assembly/dep.xml
+++ b/artemis-distribution/src/main/assembly/dep.xml
@@ -21,8 +21,8 @@
 
    <dependencySets>
       <dependencySet>
-        <directoryMode>755</directoryMode>
-        <fileMode>644</fileMode>
+        <directoryMode>0755</directoryMode>
+        <fileMode>0644</fileMode>
         <outputDirectory>lib</outputDirectory>
         <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
         <unpack>false</unpack>
@@ -34,8 +34,8 @@
       </dependencySet>
 
       <dependencySet>
-         <directoryMode>755</directoryMode>
-         <fileMode>644</fileMode>
+         <directoryMode>0755</directoryMode>
+         <fileMode>0644</fileMode>
          <includes>
 
             <!-- modules -->
@@ -106,8 +106,8 @@
          <useProjectArtifact>false</useProjectArtifact>
       </dependencySet>
       <dependencySet>
-         <directoryMode>755</directoryMode>
-         <fileMode>644</fileMode>
+         <directoryMode>0755</directoryMode>
+         <fileMode>0644</fileMode>
          <includes>
             <include>org.apache.activemq:artemis-jms-client-all</include>
          </includes>
@@ -128,6 +128,8 @@
             </includes>
          </unpackOptions>
          <useProjectArtifact>false</useProjectArtifact>
+         <directoryMode>0755</directoryMode>
+         <fileMode>0644</fileMode>
       </dependencySet>
       <dependencySet>
          <includes>
@@ -139,6 +141,8 @@
          <outputDirectory>web</outputDirectory>
          <unpack>true</unpack>
          <useProjectArtifact>false</useProjectArtifact>
+         <directoryMode>0755</directoryMode>
+         <fileMode>0644</fileMode>
       </dependencySet>
       <dependencySet>
          <includes>
@@ -147,6 +151,8 @@
          <outputDirectory>web/api</outputDirectory>
          <unpack>true</unpack>
          <useProjectArtifact>false</useProjectArtifact>
+         <directoryMode>0755</directoryMode>
+         <fileMode>0644</fileMode>
       </dependencySet>
       
       <!-- Management Console Dependencies -->
@@ -158,6 +164,8 @@
          <unpack>false</unpack>
          <outputFileNameMapping>console.war</outputFileNameMapping>
          <useProjectArtifact>false</useProjectArtifact>
+         <directoryMode>0755</directoryMode>
+         <fileMode>0644</fileMode>
       </dependencySet>
       <dependencySet>
          <includes>
@@ -167,6 +175,8 @@
          <unpack>false</unpack>
          <outputFileNameMapping>activemq-branding.war</outputFileNameMapping>
          <useProjectArtifact>false</useProjectArtifact>
+         <directoryMode>0755</directoryMode>
+         <fileMode>0644</fileMode>
       </dependencySet>
       <dependencySet>
          <includes>
@@ -176,6 +186,8 @@
          <unpack>false</unpack>
          <outputFileNameMapping>artemis-plugin.war</outputFileNameMapping>
          <useProjectArtifact>false</useProjectArtifact>
+         <directoryMode>0755</directoryMode>
+         <fileMode>0644</fileMode>
       </dependencySet>
       
    </dependencySets>
@@ -185,16 +197,22 @@
          <directory>${activemq.basedir}/artemis-server/src/main/resources/schema/</directory>
          <outputDirectory>schema</outputDirectory>
          <lineEnding>keep</lineEnding>
+         <directoryMode>0755</directoryMode>
+         <fileMode>0644</fileMode>
       </fileSet>
       <fileSet>
          <directory>${activemq.basedir}/artemis-jms-server/src/main/resources/schema/</directory>
          <outputDirectory>schema</outputDirectory>
          <lineEnding>keep</lineEnding>
+         <directoryMode>0755</directoryMode>
+         <fileMode>0644</fileMode>
       </fileSet>
       <fileSet>
          <directory>${activemq.basedir}/artemis-dto/target/schema/org.apache.activemq/dto/</directory>
          <outputDirectory>schema</outputDirectory>
          <lineEnding>keep</lineEnding>
+         <directoryMode>0755</directoryMode>
+         <fileMode>0644</fileMode>
       </fileSet>
       <!-- resources -->
       <fileSet>
@@ -202,25 +220,21 @@
          <outputDirectory>${file.separator}</outputDirectory>
          <lineEnding>keep</lineEnding>
          <excludes>
-            <exclude>bin/activemq</exclude>
-            <exclude>bin/run.sh</exclude>
-            <exclude>bin/stop.sh</exclude>
+            <exclude>bin/artemis</exclude>
             <exclude>**/target/**</exclude>
             <exclude>**/**/*.iml</exclude>
             <exclude>**/**/*.dat</exclude>
             <exclude>**/licenses/**</exclude>
-            <exclude>docker/**</exclude>
          </excludes>
+         <directoryMode>0755</directoryMode>
+         <fileMode>0644</fileMode>
       </fileSet>
-      <!-- chmod to 755 on linux executables -->
       <fileSet>
          <directory>src/main/resources</directory>
          <outputDirectory>${file.separator}</outputDirectory>
          <lineEnding>keep</lineEnding>
          <includes>
-            <include>bin/activemq</include>
-            <include>bin/run.sh</include>
-            <include>bin/stop.sh</include>
+            <include>bin/artemis</include>
          </includes>
          <directoryMode>0755</directoryMode>
          <fileMode>0755</fileMode>
@@ -235,18 +249,38 @@
             <exclude>**/**/*.iml</exclude>
             <exclude>**/**/*.dat</exclude>
             <exclude>**/**/*.md</exclude>
+            <exclude>**/**/*.sh</exclude>
          </excludes>
+         <directoryMode>0755</directoryMode>
+         <fileMode>0644</fileMode>
+      </fileSet>
+      <fileSet>
+         <directory>${activemq.basedir}/examples</directory>
+         <outputDirectory>examples</outputDirectory>
+         <lineEnding>keep</lineEnding>
+         <includes>
+            <include>**/**/*.sh</include>
+         </includes>
+         <excludes>
+            <exclude>**/target/**</exclude>
+         </excludes>
+         <directoryMode>0755</directoryMode>
+         <fileMode>0755</fileMode>
       </fileSet>
       <fileSet>
          <directory>${project.build.directory}/markdown-pages/examples</directory>
          <outputDirectory>examples</outputDirectory>
          <lineEnding>keep</lineEnding>
+         <directoryMode>0755</directoryMode>
+         <fileMode>0644</fileMode>
       </fileSet>
       <!-- Include license and notice files -->
       <fileSet>
          <directory>${activemq.basedir}/artemis-distribution/src/main/resources/licenses/bin</directory>
          <outputDirectory>${file.separator}</outputDirectory>
          <useDefaultExcludes>true</useDefaultExcludes>
+         <directoryMode>0755</directoryMode>
+         <fileMode>0644</fileMode>
       </fileSet>
    </fileSets>
 </component>

--- a/artemis-distribution/src/main/assembly/source-assembly.xml
+++ b/artemis-distribution/src/main/assembly/source-assembly.xml
@@ -34,11 +34,17 @@
          <directory>${activemq.basedir}</directory>
          <outputDirectory>${file.separator}</outputDirectory>
          <useDefaultExcludes>true</useDefaultExcludes>
-         <!-- TODO These excludes were lifted from maven-resources-apache-source-release-assembly-descriptor-1.0.4. We
-         should use this descriptor directly in future -->
+         <directoryMode>0755</directoryMode>
+         <fileMode>0644</fileMode>
          <excludes>
             <exclude>tests/extra-tests/</exclude>
             <exclude>tests/performance-jmh/</exclude>
+
+            <exclude>artemis-distribution/src/main/resources/bin/artemis</exclude>
+            <exclude>artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis</exclude>
+            <exclude>artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis-service</exclude>
+            <exclude>scripts/*.sh</exclude>
+            <exclude>**/**/*.sh</exclude>
 
             <!-- in case some of the build generates data, this needs to be ignored -->
             <exclude>data/</exclude>
@@ -128,6 +134,23 @@
                %regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?release\.properties]
             </exclude>
 
+         </excludes>
+      </fileSet>
+      <fileSet>
+         <directory>${activemq.basedir}</directory>
+         <outputDirectory>${file.separator}</outputDirectory>
+         <useDefaultExcludes>true</useDefaultExcludes>
+         <directoryMode>0755</directoryMode>
+         <fileMode>0755</fileMode>
+         <includes>
+            <include>artemis-distribution/src/main/resources/bin/artemis</include>
+            <include>artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis</include>
+            <include>artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis-service</include>
+            <include>scripts/*.sh</include>
+            <include>**/**/*.sh</include>
+         </includes>
+         <excludes>
+            <exclude>**/target/**</exclude>
          </excludes>
       </fileSet>
    </fileSets>

--- a/pom.xml
+++ b/pom.xml
@@ -1100,6 +1100,26 @@
             </plugins>
          </build>
       </profile>
+      <!-- Override the apache-release profile from the parent to skip creating
+           a source-release archive here, it is done in artemis-distribution. -->
+      <profile>
+         <id>apache-release</id>
+         <build>
+            <plugins>
+               <plugin>
+                  <artifactId>maven-assembly-plugin</artifactId>
+                  <executions>
+                     <execution>
+                        <id>source-release-assembly</id>
+                        <configuration>
+                           <skipAssembly>true</skipAssembly>
+                        </configuration>
+                     </execution>
+                  </executions>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
       <profile>
          <!-- this will activate the property required to play with tests retry -->
          <id>tests-retry</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1013,63 +1013,15 @@
       </profile>
       <profile>
          <id>dev</id>
-         <modules>
-            <module>artemis-boot</module>
-            <module>artemis-dto</module>
-            <module>artemis-web</module>
-            <module>artemis-cli</module>
-            <module>artemis-commons</module>
-            <module>artemis-selector</module>
-            <module>artemis-core-client</module>
-            <module>artemis-server</module>
-            <module>artemis-jms-client</module>
-            <module>artemis-jms-server</module>
-            <module>artemis-protocols</module>
-            <module>artemis-journal</module>
-            <module>artemis-jdbc-store</module>
-            <module>artemis-ra</module>
-            <module>artemis-rest</module>
-            <module>artemis-service-extensions</module>
-            <module>artemis-maven-plugin</module>
-            <module>artemis-jdbc-store</module>
-            <module>integration/activemq-spring-integration</module>
-            <module>tests</module>
-         </modules>
          <properties>
             <skipStyleCheck>false</skipStyleCheck>
             <skipLicenseCheck>false</skipLicenseCheck>
          </properties>
       </profile>
       <profile>
-         <id>distro</id>
-         <activation>
-            <activeByDefault>true</activeByDefault>
-         </activation>
-      </profile>
-      <profile>
          <id>release</id>
          <modules>
-            <module>artemis-dto</module>
-            <module>artemis-web</module>
-            <module>artemis-website</module>
-            <module>artemis-cli</module>
-            <module>artemis-commons</module>
-            <module>artemis-selector</module>
-            <module>artemis-core-client</module>
-            <module>artemis-server</module>
-            <module>artemis-jms-client</module>
-            <module>artemis-jms-client-all</module>
-            <module>artemis-jms-server</module>
-            <module>artemis-journal</module>
-            <module>artemis-jdbc-store</module>
-            <module>artemis-ra</module>
-            <module>artemis-rest</module>
-            <module>artemis-service-extensions</module>
-            <module>artemis-maven-plugin</module>
-            <module>integration/activemq-spring-integration</module>
             <module>examples</module>
-            <module>tests</module>
-            <module>artemis-distribution</module>
          </modules>
          <properties>
             <skipStyleCheck>false</skipStyleCheck>
@@ -1139,26 +1091,6 @@
          <!-- tests is the profile we use to run the entire testsuite
                Running this entire build could take up to 2 hours -->
          <id>tests</id>
-         <modules>
-            <module>artemis-dto</module>
-            <module>artemis-web</module>
-            <module>artemis-website</module>
-            <module>artemis-cli</module>
-            <module>artemis-commons</module>
-            <module>artemis-selector</module>
-            <module>artemis-core-client</module>
-            <module>artemis-server</module>
-            <module>artemis-jms-client</module>
-            <module>artemis-jms-server</module>
-            <module>artemis-journal</module>
-            <module>artemis-jdbc-store</module>
-            <module>artemis-ra</module>
-            <module>artemis-rest</module>
-            <module>artemis-service-extensions</module>
-            <module>artemis-maven-plugin</module>
-            <module>integration/activemq-spring-integration</module>
-            <module>tests</module>
-         </modules>
          <properties>
             <skipUnitTests>false</skipUnitTests>
             <skipJmsTests>false</skipJmsTests>
@@ -1181,23 +1113,6 @@
          <!-- This will represent a subset of the tests
               This is used on PR checks -->
          <id>fast-tests</id>
-         <modules>
-            <module>artemis-dto</module>
-            <module>artemis-cli</module>
-            <module>artemis-commons</module>
-            <module>artemis-selector</module>
-            <module>artemis-core-client</module>
-            <module>artemis-server</module>
-            <module>artemis-jms-client</module>
-            <module>artemis-jms-server</module>
-            <module>artemis-journal</module>
-            <module>artemis-jdbc-store</module>
-            <module>artemis-ra</module>
-            <module>artemis-service-extensions</module>
-            <module>artemis-maven-plugin</module>
-            <module>integration/activemq-spring-integration</module>
-            <module>tests</module>
-         </modules>
          <properties>
             <skipUnitTests>false</skipUnitTests>
             <skipJmsTests>false</skipJmsTests>
@@ -1212,23 +1127,6 @@
       <profile>
          <id>examples</id>
          <modules>
-            <module>artemis-dto</module>
-            <module>artemis-web</module>
-            <module>artemis-cli</module>
-            <module>artemis-commons</module>
-            <module>artemis-selector</module>
-            <module>artemis-core-client</module>
-            <module>artemis-server</module>
-            <module>artemis-jms-client</module>
-            <module>artemis-jms-server</module>
-            <module>artemis-journal</module>
-            <module>artemis-jdbc-store</module>
-            <module>artemis-ra</module>
-            <module>artemis-rest</module>
-            <module>artemis-service-extensions</module>
-            <module>artemis-maven-plugin</module>
-            <module>integration/activemq-spring-integration</module>
-            <module>tests</module>
             <module>examples</module>
          </modules>
          <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -97,10 +97,6 @@
       <jetty.version>9.4.40.v20210413</jetty.version>
       <jgroups.version>3.6.13.Final</jgroups.version>
       <errorprone.version>2.6.0</errorprone.version>
-      <!-- Overrides the parent pom to downgrade to assembly plugin to < 3.2.0, and
-        keep the old file permission copying behaviour until such time as the assembly
-        descriptor properly defines them. See also MASSEMBLY-941. -->
-      <maven.assembly.plugin.version>3.1.1</maven.assembly.plugin.version>
       <maven.enforcer.plugin.version>3.0.0-M3</maven.enforcer.plugin.version>
       <maven.bundle.plugin.version>5.1.2</maven.bundle.plugin.version>
       <mockito.version>3.9.0</mockito.version>
@@ -1481,11 +1477,6 @@
                <configuration>
                    <showWarnings>true</showWarnings>
                </configuration>
-            </plugin>
-            <plugin>
-               <groupId>org.apache.maven.plugins</groupId>
-               <artifactId>maven-assembly-plugin</artifactId>
-               <version>${maven.assembly.plugin.version}</version>
             </plugin>
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARTEMIS-3328

- Fix assembly descriptors and stop downgrading the assembly plugin.
- Only build the source-release assembly during release (or on explicit request).
- Suppress creating and deploying (then deleting) unused assembly file configured by parent pom.