### PR TITLE
ARTEMIS-3334 suggest to use the etc directory for jgroups config, which is already in the classpath and also has all other config files

### DIFF
--- a/docs/user-manual/en/clusters.md
+++ b/docs/user-manual/en/clusters.md
@@ -163,6 +163,7 @@ following:
 - `jgroups-file` attribute. This is the name of JGroups configuration
   file. It will be used to initialize JGroups channels. Make sure the
   file is in the java resource path so that Apache ActiveMQ Artemis can load it.
+  The typical location for the file is the `etc` directory from the broker instance.
 
 - `jgroups-channel` attribute. The name that JGroups channels connect
   to for broadcasting.


### PR DESCRIPTION
The documentation suggests to place the jgroups configuration file in the "resource-path".
It is unclear what the resource-path is, or how it can be changed to support a custom directory.

The `etc` directory of a broker instance is already in the resource-path and is therefore a natural choice.

The PR updates the documentation so that the suggestion is to place the jgroups confile file in the `etc` directory.