### PR TITLE
ARTEMIS-3341 update checkstyle to latest + update code

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/TypedProperties.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/TypedProperties.java
@@ -23,7 +23,8 @@ package org.apache.activemq.artemis.utils;
 @Deprecated
 public class TypedProperties extends org.apache.activemq.artemis.utils.collections.TypedProperties {
 
-   public TypedProperties() { }
+   public TypedProperties() {
+   }
 
    public TypedProperties(final org.apache.activemq.artemis.utils.collections.TypedProperties other) {
       super(other);

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/drivers/AbstractJDBCDriver.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/drivers/AbstractJDBCDriver.java
@@ -39,7 +39,8 @@ public abstract class AbstractJDBCDriver {
 
    protected JDBCConnectionProvider connectionProvider;
 
-   public AbstractJDBCDriver() { }
+   public AbstractJDBCDriver() {
+   }
 
    public AbstractJDBCDriver(JDBCConnectionProvider connectionProvider, SQLProvider provider) {
       this.connectionProvider = connectionProvider;

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/handler/EventHandler.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/handler/EventHandler.java
@@ -29,63 +29,92 @@ import org.apache.qpid.proton.engine.Transport;
  */
 public interface EventHandler {
 
-   default void onAuthInit(ProtonHandler handler, Connection connection, boolean sasl) { }
+   default void onAuthInit(ProtonHandler handler, Connection connection, boolean sasl) {
+   }
 
-   default void onSaslRemoteMechanismChosen(ProtonHandler handler, String mech) { }
+   default void onSaslRemoteMechanismChosen(ProtonHandler handler, String mech) {
+   }
 
-   default void onAuthFailed(ProtonHandler protonHandler, Connection connection) { }
+   default void onAuthFailed(ProtonHandler protonHandler, Connection connection) {
+   }
 
-   default void onAuthSuccess(ProtonHandler protonHandler, Connection connection) { }
+   default void onAuthSuccess(ProtonHandler protonHandler, Connection connection) {
+   }
 
-   default void onSaslMechanismsOffered(ProtonHandler handler, String[] mechanisms) { }
+   default void onSaslMechanismsOffered(ProtonHandler handler, String[] mechanisms) {
+   }
 
-   default void onInit(Connection connection) throws Exception { }
+   default void onInit(Connection connection) throws Exception {
+   }
 
-   default void onLocalOpen(Connection connection) throws Exception { }
+   default void onLocalOpen(Connection connection) throws Exception {
+   }
 
-   default void onRemoteOpen(Connection connection) throws Exception { }
+   default void onRemoteOpen(Connection connection) throws Exception {
+   }
 
-   default void onLocalClose(Connection connection) throws Exception { }
+   default void onLocalClose(Connection connection) throws Exception {
+   }
 
-   default void onRemoteClose(Connection connection) throws Exception { }
+   default void onRemoteClose(Connection connection) throws Exception {
+   }
 
-   default void onFinal(Connection connection) throws Exception { }
+   default void onFinal(Connection connection) throws Exception {
+   }
 
-   default void onInit(Session session) throws Exception { }
+   default void onInit(Session session) throws Exception {
+   }
 
-   default void onLocalOpen(Session session) throws Exception { }
+   default void onLocalOpen(Session session) throws Exception {
+   }
 
-   default void onRemoteOpen(Session session) throws Exception { }
+   default void onRemoteOpen(Session session) throws Exception {
+   }
 
-   default void onLocalClose(Session session) throws Exception { }
+   default void onLocalClose(Session session) throws Exception {
+   }
 
-   default void onRemoteClose(Session session) throws Exception { }
+   default void onRemoteClose(Session session) throws Exception {
+   }
 
-   default void onFinal(Session session) throws Exception { }
+   default void onFinal(Session session) throws Exception {
+   }
 
-   default void onInit(Link link) throws Exception { }
+   default void onInit(Link link) throws Exception {
+   }
 
-   default void onLocalOpen(Link link) throws Exception { }
+   default void onLocalOpen(Link link) throws Exception {
+   }
 
-   default void onRemoteOpen(Link link) throws Exception { }
+   default void onRemoteOpen(Link link) throws Exception {
+   }
 
-   default void onLocalClose(Link link) throws Exception { }
+   default void onLocalClose(Link link) throws Exception {
+   }
 
-   default void onRemoteClose(Link link) throws Exception { }
+   default void onRemoteClose(Link link) throws Exception {
+   }
 
-   default void onFlow(Link link) throws Exception { }
+   default void onFlow(Link link) throws Exception {
+   }
 
-   default void onFinal(Link link) throws Exception { }
+   default void onFinal(Link link) throws Exception {
+   }
 
-   default void onRemoteDetach(Link link) throws Exception { }
+   default void onRemoteDetach(Link link) throws Exception {
+   }
 
-   default void onLocalDetach(Link link) throws Exception { }
+   default void onLocalDetach(Link link) throws Exception {
+   }
 
-   default void onDelivery(Delivery delivery) throws Exception { }
+   default void onDelivery(Delivery delivery) throws Exception {
+   }
 
-   default void onTransport(Transport transport) throws Exception { }
+   default void onTransport(Transport transport) throws Exception {
+   }
 
-   default void pushBytes(ByteBuf bytes) { }
+   default void pushBytes(ByteBuf bytes) {
+   }
 
    default boolean flowControl(ReadyListener readyListener) {
       return true;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/PostOfficeJournalLoader.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/PostOfficeJournalLoader.java
@@ -167,7 +167,7 @@ public class PostOfficeJournalLoader implements JournalLoader {
          if (queueBindingInfo.getQueueStatusEncodings() != null) {
             for (QueueStatusEncoding encoding : queueBindingInfo.getQueueStatusEncodings()) {
                if (encoding.getStatus() == AddressQueueStatus.PAUSED)
-               queue.reloadPause(encoding.getId());
+                  queue.reloadPause(encoding.getId());
             }
          }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/transformer/Transformer.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/transformer/Transformer.java
@@ -22,7 +22,8 @@ import org.apache.activemq.artemis.api.core.Message;
 
 public interface Transformer {
 
-   default void init(Map<String, String> properties) { }
+   default void init(Map<String, String> properties) {
+   }
 
    Message transform(Message message);
 }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/jdbc/TestJDBCDriver.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/jdbc/TestJDBCDriver.java
@@ -48,7 +48,8 @@ public class TestJDBCDriver extends AbstractJDBCDriver {
    }
 
    @Override
-   protected void prepareStatements() { }
+   protected void prepareStatements() {
+   }
 
    @Override
    protected void createSchema() {

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/NoProcessFilesBehind.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/NoProcessFilesBehind.java
@@ -93,7 +93,7 @@ public class NoProcessFilesBehind extends TestWatcher {
             processInput.readLine();
             while ((outputLine = processInput.readLine()) != null) {
                if (!filtered || (!outputLine.endsWith(".jar") && !outputLine.endsWith(".so") && !outputLine.contains("type=STREAM")))
-               openFiles.add(outputLine);
+                  openFiles.add(outputLine);
             }
          }
       } catch (Exception ignore) {

--- a/etc/checkstyle.xml
+++ b/etc/checkstyle.xml
@@ -69,11 +69,7 @@ under the License.
       <module name="RightCurly"/>
       <module name="RightCurly">
          <property name="option" value="alone"/>
-         <property name="tokens" value="CLASS_DEF, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT"/>
-      </module>
-      <module name="RightCurly">
-         <property name="option" value="alone_or_singleline"/>
-         <property name="tokens" value="METHOD_DEF, CTOR_DEF"/>
+         <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT"/>
       </module>
       <!-- Checks that there is no whitespace after certain tokens; e.g. "." and "!". -->
       <module name="NoWhitespaceAfter"/>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
       <maven.bundle.plugin.version>5.1.2</maven.bundle.plugin.version>
       <maven.checkstyle.plugin.version>3.1.1</maven.checkstyle.plugin.version>
       <sevntu.checks.version>1.39.0</sevntu.checks.version>
-      <checkstyle.version>8.29</checkstyle.version>
+      <checkstyle.version>8.43</checkstyle.version>
       <mockito.version>3.9.0</mockito.version>
       <jctools.version>2.1.2</jctools.version>
       <netty.version>4.1.65.Final</netty.version>

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/ActiveMQMessageHandlerTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/ActiveMQMessageHandlerTest.java
@@ -65,12 +65,13 @@ public class ActiveMQMessageHandlerTest extends ActiveMQRATestBase {
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "interrupt",
-         targetClass = "org.apache.activemq.artemis.core.protocol.core.impl.ActiveMQSessionContext",
-         targetMethod = "xaEnd",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.ActiveMQMessageHandlerTest.interrupt();")})
+      rules = {
+         @BMRule(
+            name = "interrupt",
+            targetClass = "org.apache.activemq.artemis.core.protocol.core.impl.ActiveMQSessionContext",
+            targetMethod = "xaEnd",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.ActiveMQMessageHandlerTest.interrupt();")})
    public void testSimpleMessageReceivedOnQueue() throws Exception {
       ActiveMQResourceAdapter qResourceAdapter = newResourceAdapter();
       resourceAdapter = qResourceAdapter;
@@ -134,12 +135,13 @@ public class ActiveMQMessageHandlerTest extends ActiveMQRATestBase {
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "interrupt",
-         targetClass = "org.apache.activemq.artemis.core.protocol.core.impl.ActiveMQSessionContext",
-         targetMethod = "xaEnd",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.ActiveMQMessageHandlerTest.interrupt();")})
+      rules = {
+         @BMRule(
+            name = "interrupt",
+            targetClass = "org.apache.activemq.artemis.core.protocol.core.impl.ActiveMQSessionContext",
+            targetMethod = "xaEnd",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.ActiveMQMessageHandlerTest.interrupt();")})
    public void testSimpleMessageReceivedOnQueueTwoPhase() throws Exception {
       ActiveMQResourceAdapter qResourceAdapter = newResourceAdapter();
       resourceAdapter = qResourceAdapter;

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/ActiveMQServerControlMultiThreadTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/ActiveMQServerControlMultiThreadTest.java
@@ -64,11 +64,12 @@ public class ActiveMQServerControlMultiThreadTest extends ManagementTestBase {
     */
 
    @Test
-   @BMRules(rules = {@BMRule(name = "Delay listAddress() by 2 secs ",
-      targetClass = "org.apache.activemq.artemis.core.postoffice.impl.PostOfficeImpl",
-      targetMethod = "getAddressInfo(org.apache.activemq.artemis.api.core.SimpleString)",
-      targetLocation = "ENTRY",
-      action = "org.apache.activemq.artemis.tests.extras.byteman.ActiveMQServerControlMultiThreadTest.delay(2)")})
+   @BMRules(rules = {
+      @BMRule(name = "Delay listAddress() by 2 secs ",
+         targetClass = "org.apache.activemq.artemis.core.postoffice.impl.PostOfficeImpl",
+         targetMethod = "getAddressInfo(org.apache.activemq.artemis.api.core.SimpleString)",
+         targetLocation = "ENTRY",
+         action = "org.apache.activemq.artemis.tests.extras.byteman.ActiveMQServerControlMultiThreadTest.delay(2)")})
 
    public void listAddressDuringDeleteAddress() throws Exception {
 
@@ -125,11 +126,12 @@ public class ActiveMQServerControlMultiThreadTest extends ManagementTestBase {
     */
 
    @Test
-   @BMRules(rules = {@BMRule(name = "Delay listConsumers() by 2 secs ",
-      targetClass = "org.apache.activemq.artemis.core.management.impl.view.ConsumerView",
-      targetMethod = "toJson(org.apache.activemq.artemis.core.server.ServerConsumer)",
-      targetLocation = "ENTRY",
-      action = "org.apache.activemq.artemis.tests.extras.byteman.ActiveMQServerControlMultiThreadTest.delay(2)")})
+   @BMRules(rules = {
+      @BMRule(name = "Delay listConsumers() by 2 secs ",
+         targetClass = "org.apache.activemq.artemis.core.management.impl.view.ConsumerView",
+         targetMethod = "toJson(org.apache.activemq.artemis.core.server.ServerConsumer)",
+         targetLocation = "ENTRY",
+         action = "org.apache.activemq.artemis.tests.extras.byteman.ActiveMQServerControlMultiThreadTest.delay(2)")})
 
    public void listConsumersDuringSessionClose() throws Exception {
 

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/BMFailoverTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/BMFailoverTest.java
@@ -90,12 +90,13 @@ public class BMFailoverTest extends FailoverTestBase {
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "trace ActiveMQSessionContext xaEnd",
-         targetClass = "org.apache.activemq.artemis.core.protocol.core.impl.ActiveMQSessionContext",
-         targetMethod = "xaEnd",
-         targetLocation = "AT EXIT",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.BMFailoverTest.stopAndThrow()")})
+      rules = {
+         @BMRule(
+            name = "trace ActiveMQSessionContext xaEnd",
+            targetClass = "org.apache.activemq.artemis.core.protocol.core.impl.ActiveMQSessionContext",
+            targetMethod = "xaEnd",
+            targetLocation = "AT EXIT",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.BMFailoverTest.stopAndThrow()")})
    //https://bugzilla.redhat.com/show_bug.cgi?id=1152410
    public void testFailOnEndAndRetry() throws Exception {
       serverToStop = liveServer;
@@ -161,12 +162,13 @@ public class BMFailoverTest extends FailoverTestBase {
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "trace clientsessionimpl commit",
-         targetClass = "org.apache.activemq.artemis.core.client.impl.ClientSessionImpl",
-         targetMethod = "start(javax.transaction.xa.Xid, int)",
-         targetLocation = "AT EXIT",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.BMFailoverTest.serverToStop.getServer().stop(true)")})
+      rules = {
+         @BMRule(
+            name = "trace clientsessionimpl commit",
+            targetClass = "org.apache.activemq.artemis.core.client.impl.ClientSessionImpl",
+            targetMethod = "start(javax.transaction.xa.Xid, int)",
+            targetLocation = "AT EXIT",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.BMFailoverTest.serverToStop.getServer().stop(true)")})
    public void testFailoverOnCommit2() throws Exception {
       serverToStop = liveServer;
       locator = getServerLocator();
@@ -248,12 +250,13 @@ public class BMFailoverTest extends FailoverTestBase {
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "trace clientsessionimpl commit",
-         targetClass = "org.apache.activemq.artemis.core.client.impl.ClientSessionImpl",
-         targetMethod = "commit",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.BMFailoverTest.serverToStop.getServer().stop(true)")})
+      rules = {
+         @BMRule(
+            name = "trace clientsessionimpl commit",
+            targetClass = "org.apache.activemq.artemis.core.client.impl.ClientSessionImpl",
+            targetMethod = "commit",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.BMFailoverTest.serverToStop.getServer().stop(true)")})
    public void testFailoverOnCommit() throws Exception {
       serverToStop = liveServer;
       locator = getServerLocator();
@@ -277,12 +280,13 @@ public class BMFailoverTest extends FailoverTestBase {
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "trace clientsessionimpl commit",
-         targetClass = "org.apache.activemq.artemis.core.client.impl.ClientSessionImpl",
-         targetMethod = "commit",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.BMFailoverTest.serverToStop.getServer().stop(true)")})
+      rules = {
+         @BMRule(
+            name = "trace clientsessionimpl commit",
+            targetClass = "org.apache.activemq.artemis.core.client.impl.ClientSessionImpl",
+            targetMethod = "commit",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.BMFailoverTest.serverToStop.getServer().stop(true)")})
    public void testFailoverOnReceiveCommit() throws Exception {
       serverToStop = liveServer;
       locator = getServerLocator();

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/ClusteredBridgeReconnectTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/ClusteredBridgeReconnectTest.java
@@ -71,24 +71,25 @@ public class ClusteredBridgeReconnectTest extends ClusterTestBase {
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "enter",
-         targetClass = "org.apache.activemq.artemis.core.server.cluster.impl.BridgeImpl",
-         targetMethod = "connect",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.ClusteredBridgeReconnectTest.enterConnect();"), @BMRule(
-         name = "exit",
-         targetClass = "org.apache.activemq.artemis.core.server.cluster.impl.BridgeImpl",
-         targetMethod = "connect",
-         targetLocation = "EXIT",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.ClusteredBridgeReconnectTest.exitConnect();"), @BMRule(
-         name = "send",
-         targetClass = "org.apache.activemq.artemis.core.protocol.core.impl.ChannelImpl",
-         targetMethod = "send(org.apache.activemq.artemis.core.protocol.core.Packet)",
-         targetLocation = "EXIT",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.ClusteredBridgeReconnectTest.send();")
-
-      })
+      rules = {
+         @BMRule(
+            name = "enter",
+            targetClass = "org.apache.activemq.artemis.core.server.cluster.impl.BridgeImpl",
+            targetMethod = "connect",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.ClusteredBridgeReconnectTest.enterConnect();"),
+         @BMRule(
+            name = "exit",
+            targetClass = "org.apache.activemq.artemis.core.server.cluster.impl.BridgeImpl",
+            targetMethod = "connect",
+            targetLocation = "EXIT",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.ClusteredBridgeReconnectTest.exitConnect();"),
+         @BMRule(
+            name = "send",
+            targetClass = "org.apache.activemq.artemis.core.protocol.core.impl.ChannelImpl",
+            targetMethod = "send(org.apache.activemq.artemis.core.protocol.core.Packet)",
+            targetLocation = "EXIT",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.ClusteredBridgeReconnectTest.send();")})
    public void testReconnectBridge() throws Exception {
       setupServer(0, isFileStorage(), isNetty());
       setupServer(1, isFileStorage(), isNetty());

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/ClusteredGroupingTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/ClusteredGroupingTest.java
@@ -41,17 +41,19 @@ public class ClusteredGroupingTest extends ClusterTestBase {
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "blow-up",
-         targetClass = "org.apache.activemq.artemis.core.server.group.impl.LocalGroupingHandler",
-         targetMethod = "removeGrouping",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.ClusteredGroupingTest.pause($1);"), @BMRule(
-         name = "blow-up2",
-         targetClass = "org.apache.activemq.artemis.core.server.group.impl.GroupHandlingAbstract",
-         targetMethod = "forceRemove",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.ClusteredGroupingTest.restart2();")})
+      rules = {
+         @BMRule(
+            name = "blow-up",
+            targetClass = "org.apache.activemq.artemis.core.server.group.impl.LocalGroupingHandler",
+            targetMethod = "removeGrouping",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.ClusteredGroupingTest.pause($1);"),
+         @BMRule(
+            name = "blow-up2",
+            targetClass = "org.apache.activemq.artemis.core.server.group.impl.GroupHandlingAbstract",
+            targetMethod = "forceRemove",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.ClusteredGroupingTest.restart2();")})
    public void test2serversLocalGoesDown() throws Exception {
       setupServer(0, isFileStorage(), isNetty());
       setupServer(1, isFileStorage(), isNetty());
@@ -101,16 +103,18 @@ public class ClusteredGroupingTest extends ClusterTestBase {
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "blow-up",
-         targetClass = "org.apache.activemq.artemis.core.server.group.impl.RemoteGroupingHandler",
-         targetMethod = "onNotification",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.ClusteredGroupingTest.pause2($1);"), @BMRule(name = "blow-up2",
-         targetClass = "org.apache.activemq.artemis.core.server.group.impl.RemoteGroupingHandler",
-         targetMethod = "remove",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.ClusteredGroupingTest.restart2();")})
+      rules = {
+         @BMRule(
+            name = "blow-up",
+            targetClass = "org.apache.activemq.artemis.core.server.group.impl.RemoteGroupingHandler",
+            targetMethod = "onNotification",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.ClusteredGroupingTest.pause2($1);"),
+         @BMRule(name = "blow-up2",
+            targetClass = "org.apache.activemq.artemis.core.server.group.impl.RemoteGroupingHandler",
+            targetMethod = "remove",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.ClusteredGroupingTest.restart2();")})
    public void test3serversLocalGoesDown() throws Exception {
       setupServer(0, isFileStorage(), isNetty());
       setupServer(1, isFileStorage(), isNetty());
@@ -171,16 +175,18 @@ public class ClusteredGroupingTest extends ClusterTestBase {
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "blow-up",
-         targetClass = "org.apache.activemq.artemis.core.server.group.impl.LocalGroupingHandler",
-         targetMethod = "onNotification",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.ClusteredGroupingTest.pause2($1);"), @BMRule(name = "blow-up2",
-         targetClass = "org.apache.activemq.artemis.core.server.group.impl.LocalGroupingHandler",
-         targetMethod = "remove",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.ClusteredGroupingTest.restart2();")})
+      rules = {
+         @BMRule(
+            name = "blow-up",
+            targetClass = "org.apache.activemq.artemis.core.server.group.impl.LocalGroupingHandler",
+            targetMethod = "onNotification",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.ClusteredGroupingTest.pause2($1);"),
+         @BMRule(name = "blow-up2",
+            targetClass = "org.apache.activemq.artemis.core.server.group.impl.LocalGroupingHandler",
+            targetMethod = "remove",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.ClusteredGroupingTest.restart2();")})
    public void testLocal3serversLocalGoesDown() throws Exception {
       setupServer(0, isFileStorage(), isNetty());
       setupServer(1, isFileStorage(), isNetty());
@@ -241,16 +247,18 @@ public class ClusteredGroupingTest extends ClusterTestBase {
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "blow-up",
-         targetClass = "org.apache.activemq.artemis.core.server.group.impl.LocalGroupingHandler",
-         targetMethod = "onNotification",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.ClusteredGroupingTest.pause2($1);"), @BMRule(name = "blow-up2",
-         targetClass = "org.apache.activemq.artemis.core.server.group.impl.LocalGroupingHandler",
-         targetMethod = "remove",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.ClusteredGroupingTest.restart2();")})
+      rules = {
+         @BMRule(
+            name = "blow-up",
+            targetClass = "org.apache.activemq.artemis.core.server.group.impl.LocalGroupingHandler",
+            targetMethod = "onNotification",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.ClusteredGroupingTest.pause2($1);"),
+         @BMRule(name = "blow-up2",
+            targetClass = "org.apache.activemq.artemis.core.server.group.impl.LocalGroupingHandler",
+            targetMethod = "remove",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.ClusteredGroupingTest.restart2();")})
    public void testLocal4serversLocalGoesDown() throws Exception {
       setupServer(0, isFileStorage(), isNetty());
       setupServer(1, isFileStorage(), isNetty());

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/ConcurrentDeliveryCancelTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/ConcurrentDeliveryCancelTest.java
@@ -83,12 +83,13 @@ public class ConcurrentDeliveryCancelTest extends JMSTestBase {
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "enterCancel-holdThere",
-         targetClass = "org.apache.activemq.artemis.core.server.impl.ServerConsumerImpl",
-         targetMethod = "close",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.ConcurrentDeliveryCancelTest.enterCancel();")})
+      rules = {
+         @BMRule(
+            name = "enterCancel-holdThere",
+            targetClass = "org.apache.activemq.artemis.core.server.impl.ServerConsumerImpl",
+            targetMethod = "close",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.ConcurrentDeliveryCancelTest.enterCancel();")})
    public void testConcurrentCancels() throws Exception {
 
       log.debug(server.getConfiguration().getJournalLocation().toString());

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/CriticalAnalyzerFaultInjectionTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/CriticalAnalyzerFaultInjectionTest.java
@@ -76,12 +76,13 @@ public class CriticalAnalyzerFaultInjectionTest extends JMSTestBase {
    }
 
    @BMRules(
-      rules = {@BMRule(
-         name = "Sync file data hangs",
-         targetClass = "org.apache.activemq.artemis.core.io.nio.NIOSequentialFile",
-         targetMethod = "sync",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.CriticalAnalyzerFaultInjectionTest.methodHang();")})
+      rules = {
+         @BMRule(
+            name = "Sync file data hangs",
+            targetClass = "org.apache.activemq.artemis.core.io.nio.NIOSequentialFile",
+            targetMethod = "sync",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.CriticalAnalyzerFaultInjectionTest.methodHang();")})
    @Test(timeout = 60000)
    public void testSlowDiskSync() throws Exception {
       sendConsumeDurableMessage();

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/DisconnectOnCriticalFailureTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/DisconnectOnCriticalFailureTest.java
@@ -56,12 +56,13 @@ public class DisconnectOnCriticalFailureTest extends JMSTestBase {
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "Corrupt Decoding",
-         targetClass = "org.apache.activemq.artemis.core.protocol.core.impl.PacketDecoder",
-         targetMethod = "decode(byte)",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.DisconnectOnCriticalFailureTest.doThrow();")})
+      rules = {
+         @BMRule(
+            name = "Corrupt Decoding",
+            targetClass = "org.apache.activemq.artemis.core.protocol.core.impl.PacketDecoder",
+            targetMethod = "decode(byte)",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.DisconnectOnCriticalFailureTest.doThrow();")})
    public void testSendDisconnect() throws Exception {
       createQueue("queue1");
       final Connection producerConnection = nettyCf.createConnection();
@@ -90,12 +91,13 @@ public class DisconnectOnCriticalFailureTest extends JMSTestBase {
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "Corrupt Decoding",
-         targetClass = "org.apache.activemq.artemis.core.protocol.ClientPacketDecoder",
-         targetMethod = "decode(org.apache.activemq.artemis.api.core.ActiveMQBuffer)",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.DisconnectOnCriticalFailureTest.doThrow($1);")})
+      rules = {
+         @BMRule(
+            name = "Corrupt Decoding",
+            targetClass = "org.apache.activemq.artemis.core.protocol.ClientPacketDecoder",
+            targetMethod = "decode(org.apache.activemq.artemis.api.core.ActiveMQBuffer)",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.DisconnectOnCriticalFailureTest.doThrow($1);")})
    public void testClientDisconnect() throws Exception {
       Queue q1 = createQueue("queue1");
       final Connection connection = nettyCf.createConnection();
@@ -132,12 +134,13 @@ public class DisconnectOnCriticalFailureTest extends JMSTestBase {
 
    @Test(timeout = 60000)
    @BMRules(
-      rules = {@BMRule(
-         name = "Corrupt Decoding",
-         targetClass = "org.apache.activemq.artemis.core.protocol.ClientPacketDecoder",
-         targetMethod = "decode(org.apache.activemq.artemis.api.core.ActiveMQBuffer)",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.DisconnectOnCriticalFailureTest.doThrow($1);")})
+      rules = {
+         @BMRule(
+            name = "Corrupt Decoding",
+            targetClass = "org.apache.activemq.artemis.core.protocol.ClientPacketDecoder",
+            targetMethod = "decode(org.apache.activemq.artemis.api.core.ActiveMQBuffer)",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.DisconnectOnCriticalFailureTest.doThrow($1);")})
    public void testClientDisconnectLarge() throws Exception {
       Queue q1 = createQueue("queue1");
       final Connection connection = nettyCf.createConnection();

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/FailureXATest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/FailureXATest.java
@@ -63,25 +63,27 @@ public class FailureXATest extends ActiveMQTestBase {
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "Crash after onephase committed",
-         targetClass = "org.apache.activemq.artemis.core.server.impl.ServerSessionImpl",
-         targetMethod = "xaCommit(javax.transaction.xa.Xid, boolean)",
-         targetLocation = "EXIT",
-         action = "throw new RuntimeException()")})
+      rules = {
+         @BMRule(
+            name = "Crash after onephase committed",
+            targetClass = "org.apache.activemq.artemis.core.server.impl.ServerSessionImpl",
+            targetMethod = "xaCommit(javax.transaction.xa.Xid, boolean)",
+            targetLocation = "EXIT",
+            action = "throw new RuntimeException()")})
    public void testCrashServerAfterOnePhaseCommit() throws Exception {
       doTestCrashServerAfterXACommit(true);
    }
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "Crash after onephase committed",
-         targetClass = "org.apache.activemq.artemis.core.server.impl.ServerSessionImpl",
-         targetMethod = "xaCommit(javax.transaction.xa.Xid, boolean)",
-         targetLocation = "EXIT",
-         //helper = "org.apache.activemq.artemis.tests.extras.byteman.FailureXATest",
-         action = "throw new RuntimeException()")})
+      rules = {
+         @BMRule(
+            name = "Crash after onephase committed",
+            targetClass = "org.apache.activemq.artemis.core.server.impl.ServerSessionImpl",
+            targetMethod = "xaCommit(javax.transaction.xa.Xid, boolean)",
+            targetLocation = "EXIT",
+            //helper = "org.apache.activemq.artemis.tests.extras.byteman.FailureXATest",
+            action = "throw new RuntimeException()")})
    public void testCrashServerAfterTwoPhaseCommit() throws Exception {
       doTestCrashServerAfterXACommit(false);
    }

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/FileLockMonitorTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/FileLockMonitorTest.java
@@ -50,7 +50,7 @@ public class FileLockMonitorTest {
 
    @Test
    @BMRules(rules = {
-         @BMRule(name = "lock is invalid", targetClass = "org.apache.activemq.artemis.core.server.impl.FileLockNodeManager", targetMethod = "isLiveLockLost", action = "return true;") })
+      @BMRule(name = "lock is invalid", targetClass = "org.apache.activemq.artemis.core.server.impl.FileLockNodeManager", targetMethod = "isLiveLockLost", action = "return true;") })
    public void testLockMonitorInvalid() throws Exception {
       lostLock = false;
       startServer();
@@ -66,7 +66,7 @@ public class FileLockMonitorTest {
 
    @Test
    @BMRules(rules = {
-         @BMRule(name = "lock is invalid", targetClass = "org.apache.activemq.artemis.core.server.impl.FileLockNodeManager",
+      @BMRule(name = "lock is invalid", targetClass = "org.apache.activemq.artemis.core.server.impl.FileLockNodeManager",
             targetMethod = "getState",
             action = "org.apache.activemq.artemis.tests.extras.byteman.FileLockMonitorTest.throwNodeManagerException(\"EFS is disconnected\");") })
    public void testLockMonitorIOException() throws Exception {
@@ -88,7 +88,7 @@ public class FileLockMonitorTest {
 
    @Test
    @BMRules(rules = {
-         @BMRule(name = "lock is invalid", targetClass = "org.apache.activemq.artemis.core.server.impl.FileLockNodeManager", targetMethod = "getState", action = "return 70;") })
+      @BMRule(name = "lock is invalid", targetClass = "org.apache.activemq.artemis.core.server.impl.FileLockNodeManager", targetMethod = "getState", action = "return 70;") })
    public void testLockMonitorHasLockWrongState() throws Exception {
       lostLock = false;
       startServer();

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/FileLockNodeManagerTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/FileLockNodeManagerTest.java
@@ -45,7 +45,8 @@ public class FileLockNodeManagerTest {
 
    @Test
    @BMRules(
-         rules = {@BMRule(
+         rules = {
+            @BMRule(
                name = "throw IOException during activation",
                targetClass = "org.apache.activemq.artemis.core.server.impl.FileLockNodeManager",
                targetMethod = "tryLock",

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/GroupingTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/GroupingTest.java
@@ -61,12 +61,13 @@ public class GroupingTest extends JMSTestBase {
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "trace clientsessionimpl commit",
-         targetClass = "org.apache.activemq.artemis.core.server.impl.ServerSessionImpl",
-         targetMethod = "rollback",
-         targetLocation = "EXIT",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.GroupingTest.pause();")})
+      rules = {
+         @BMRule(
+            name = "trace clientsessionimpl commit",
+            targetClass = "org.apache.activemq.artemis.core.server.impl.ServerSessionImpl",
+            targetMethod = "rollback",
+            targetLocation = "EXIT",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.GroupingTest.pause();")})
    public void testGroupingRollbackOnClose() throws Exception {
       Connection sendConnection = null;
       Connection connection = null;

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/HierarchicalObjectRepositoryTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/HierarchicalObjectRepositoryTest.java
@@ -33,10 +33,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(BMUnitRunner.class)
-@BMRules(rules = {@BMRule(name = "modify map during iteration",
-   targetClass = "org.apache.activemq.artemis.core.settings.impl.HierarchicalObjectRepository",
-   targetMethod = "getPossibleMatches(String)", targetLocation = "AT INVOKE java.util.HashMap.put",
-   action = "org.apache.activemq.artemis.tests.extras.byteman.HierarchicalObjectRepositoryTest.bum()"),})
+@BMRules(rules = {
+   @BMRule(name = "modify map during iteration",
+      targetClass = "org.apache.activemq.artemis.core.settings.impl.HierarchicalObjectRepository",
+      targetMethod = "getPossibleMatches(String)",
+      targetLocation = "AT INVOKE java.util.HashMap.put",
+      action = "org.apache.activemq.artemis.tests.extras.byteman.HierarchicalObjectRepositoryTest.bum()"),})
 public class HierarchicalObjectRepositoryTest {
 
    private static final String A = "a.";

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/InterruptedMessageHandlerTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/InterruptedMessageHandlerTest.java
@@ -63,17 +63,19 @@ public class InterruptedMessageHandlerTest extends ActiveMQRATestBase {
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "throw ActiveMQException(CONNETION_TIMEOUT) during rollback",
-         targetClass = "org.apache.activemq.artemis.core.client.impl.ClientSessionImpl",
-         targetMethod = "flushAcks",
-         targetLocation = "AFTER INVOKE flushAcks",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.InterruptedMessageHandlerTest.throwActiveMQQExceptionConnectionTimeout();"), @BMRule(
-         name = "check that outcome of XA transaction is TwoPhaseOutcome.FINISH_ERROR=8",
-         targetClass = "com.arjuna.ats.internal.jta.resources.arjunacore.XAResourceRecord",
-         targetMethod = "topLevelAbort",
-         targetLocation = "AT EXIT",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.InterruptedMessageHandlerTest.assertTxOutComeIsOfStatusFinishedError($!);")})
+      rules = {
+         @BMRule(
+            name = "throw ActiveMQException(CONNETION_TIMEOUT) during rollback",
+            targetClass = "org.apache.activemq.artemis.core.client.impl.ClientSessionImpl",
+            targetMethod = "flushAcks",
+            targetLocation = "AFTER INVOKE flushAcks",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.InterruptedMessageHandlerTest.throwActiveMQQExceptionConnectionTimeout();"),
+         @BMRule(
+            name = "check that outcome of XA transaction is TwoPhaseOutcome.FINISH_ERROR=8",
+            targetClass = "com.arjuna.ats.internal.jta.resources.arjunacore.XAResourceRecord",
+            targetMethod = "topLevelAbort",
+            targetLocation = "AT EXIT",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.InterruptedMessageHandlerTest.assertTxOutComeIsOfStatusFinishedError($!);")})
    public void testSimpleMessageReceivedOnQueueTwoPhaseFailPrepareByConnectionTimout() throws Exception {
       ActiveMQResourceAdapter qResourceAdapter = newResourceAdapter();
       resourceAdapter = qResourceAdapter;

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/JMSBridgeReconnectionTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/JMSBridgeReconnectionTest.java
@@ -40,17 +40,19 @@ public class JMSBridgeReconnectionTest extends BridgeTestBase {
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "trace clientsessionimpl send",
-         targetClass = "org.apache.activemq.artemis.core.protocol.core.impl.ChannelImpl",
-         targetMethod = "send",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.JMSBridgeReconnectionTest.pause($1);"), @BMRule(
-         name = "trace sendRegularMessage",
-         targetClass = "org.apache.activemq.artemis.core.client.impl.ClientProducerImpl",
-         targetMethod = "sendRegularMessage",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.JMSBridgeReconnectionTest.pause2($2,$3,$4);")})
+      rules = {
+         @BMRule(
+            name = "trace clientsessionimpl send",
+            targetClass = "org.apache.activemq.artemis.core.protocol.core.impl.ChannelImpl",
+            targetMethod = "send",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.JMSBridgeReconnectionTest.pause($1);"),
+         @BMRule(
+            name = "trace sendRegularMessage",
+            targetClass = "org.apache.activemq.artemis.core.client.impl.ClientProducerImpl",
+            targetMethod = "sendRegularMessage",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.JMSBridgeReconnectionTest.pause2($2,$3,$4);")})
    public void performCrashDestinationStopBridge() throws Exception {
       activeMQServer = server1;
       ConnectionFactoryFactory factInUse0 = cff0;

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/JournalImplConcurrencyTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/JournalImplConcurrencyTest.java
@@ -43,14 +43,14 @@ public class JournalImplConcurrencyTest extends JournalImplTestBase {
     */
    @Test(timeout = 2000)
    @BMRules(rules = {
-         @BMRule(
-               name = "BlockOnFinalLargeMessagePacket",
-               targetClass = "java.util.concurrent.locks.ReentrantReadWriteLock",
-               targetMethod = "readLock()",
-               targetLocation = "EXIT",
-               condition = "Thread.currentThread().getName().contains(\"ArtemisIOThread\")",
-               action = "throw RuntimeException(\"Injected exception\");"
-         )
+      @BMRule(
+         name = "BlockOnFinalLargeMessagePacket",
+         targetClass = "java.util.concurrent.locks.ReentrantReadWriteLock",
+         targetMethod = "readLock()",
+         targetLocation = "EXIT",
+         condition = "Thread.currentThread().getName().contains(\"ArtemisIOThread\")",
+         action = "throw RuntimeException(\"Injected exception\");"
+      )
    })
    public void testTryDelete() throws Exception {
       setup(10, 10 * 1024, true);

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/LargeMessageOnShutdownTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/LargeMessageOnShutdownTest.java
@@ -74,15 +74,13 @@ public class LargeMessageOnShutdownTest extends ActiveMQTestBase {
             action =
                "org.apache.activemq.artemis.tests.extras.byteman.LargeMessageOnShutdownTest.stopServer();" +
                "waitFor(\"testLargeMessageOnShutdown\", 5000);" +
-               "flag(\"testLargeMessageOnShutdown\")"
-         ),
+               "flag(\"testLargeMessageOnShutdown\")"),
          @BMRule(
             name = "ReleaseBlockOnSessionCleanup",
             targetClass = "org.apache.activemq.artemis.core.protocol.core.ServerSessionPacketHandler",
             targetMethod = "clearLargeMessage()",
             targetLocation = "EXIT",
-            action = "signalWake(\"testLargeMessageOnShutdown\")"
-         )
+            action = "signalWake(\"testLargeMessageOnShutdown\")")
       }
    )
    public void testLargeMessageOnShutdown() throws Exception {

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/LargeMessageOverReplicationTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/LargeMessageOverReplicationTest.java
@@ -133,12 +133,13 @@ public class LargeMessageOverReplicationTest extends ActiveMQTestBase {
   */
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "InterruptSending",
-         targetClass = "org.apache.activemq.artemis.core.protocol.core.impl.ActiveMQSessionContext",
-         targetMethod = "sendLargeMessageChunk",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.LargeMessageOverReplicationTest.messageChunkSent();")})
+      rules = {
+         @BMRule(
+            name = "InterruptSending",
+            targetClass = "org.apache.activemq.artemis.core.protocol.core.impl.ActiveMQSessionContext",
+            targetMethod = "sendLargeMessageChunk",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.LargeMessageOverReplicationTest.messageChunkSent();")})
    public void testSendLargeMessage() throws Exception {
 
       MapMessage message = createLargeMessage();
@@ -168,12 +169,13 @@ public class LargeMessageOverReplicationTest extends ActiveMQTestBase {
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "InterruptReceive",
-         targetClass = "org.apache.activemq.artemis.core.protocol.core.impl.CoreSessionCallback",
-         targetMethod = "sendLargeMessageContinuation",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.LargeMessageOverReplicationTest.messageChunkReceived();")})
+      rules = {
+         @BMRule(
+            name = "InterruptReceive",
+            targetClass = "org.apache.activemq.artemis.core.protocol.core.impl.CoreSessionCallback",
+            targetMethod = "sendLargeMessageContinuation",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.LargeMessageOverReplicationTest.messageChunkReceived();")})
    public void testReceiveLargeMessage() throws Exception {
 
       MapMessage message = createLargeMessage();

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/LargeMessageReplicationTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/LargeMessageReplicationTest.java
@@ -111,23 +111,26 @@ public class LargeMessageReplicationTest extends FailoverTestBase {
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "record large message copy thread",
-         targetClass = "org.apache.activemq.artemis.core.persistence.impl.journal.LargeServerMessageImpl",
-         targetMethod = "copy(long)",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.LargeMessageReplicationTest.copyThread()"), @BMRule(
-         name = "record byte array in addBytes",
-         targetClass = "org.apache.activemq.artemis.core.persistence.impl.journal.LargeServerMessageImpl",
-         targetMethod = "addBytes(byte[])",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.LargeMessageReplicationTest.addBytesIn($1)"), @BMRule(
-         name = "record byte array used for reading large message",
-         targetClass = "^org.apache.activemq.artemis.core.io.SequentialFile",
-         isInterface = true,
-         targetMethod = "read(java.nio.ByteBuffer)",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.LargeMessageReplicationTest.originBuff($1)")})
+      rules = {
+         @BMRule(
+            name = "record large message copy thread",
+            targetClass = "org.apache.activemq.artemis.core.persistence.impl.journal.LargeServerMessageImpl",
+            targetMethod = "copy(long)",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.LargeMessageReplicationTest.copyThread()"),
+         @BMRule(
+            name = "record byte array in addBytes",
+            targetClass = "org.apache.activemq.artemis.core.persistence.impl.journal.LargeServerMessageImpl",
+            targetMethod = "addBytes(byte[])",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.LargeMessageReplicationTest.addBytesIn($1)"),
+         @BMRule(
+            name = "record byte array used for reading large message",
+            targetClass = "^org.apache.activemq.artemis.core.io.SequentialFile",
+            isInterface = true,
+            targetMethod = "read(java.nio.ByteBuffer)",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.LargeMessageReplicationTest.originBuff($1)")})
    //https://issues.apache.org/jira/browse/ARTEMIS-1220
    public void testDivertCopyMessageBuffer() throws Exception {
       Map<String, Object> params = new HashMap<>();

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/LatencyTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/LatencyTest.java
@@ -41,17 +41,19 @@ public class LatencyTest extends ActiveMQTestBase {
    * */
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "trace ClientBootstrap.connect",
-         targetClass = "org.jboss.netty.bootstrap.ClientBootstrap",
-         targetMethod = "connect",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.LatencyTest.debugLog(\"netty connecting\")"), @BMRule(
-         name = "sleep OioWorker.run",
-         targetClass = "org.jboss.netty.channel.socket.oio.OioWorker",
-         targetMethod = "run",
-         targetLocation = "ENTRY",
-         action = "Thread.sleep(500)")})
+      rules = {
+         @BMRule(
+            name = "trace ClientBootstrap.connect",
+            targetClass = "org.jboss.netty.bootstrap.ClientBootstrap",
+            targetMethod = "connect",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.LatencyTest.debugLog(\"netty connecting\")"),
+         @BMRule(
+            name = "sleep OioWorker.run",
+            targetClass = "org.jboss.netty.channel.socket.oio.OioWorker",
+            targetMethod = "run",
+            targetLocation = "ENTRY",
+            action = "Thread.sleep(500)")})
    public void testLatency() throws Exception {
       ActiveMQServer server = createServer(createDefaultNettyConfig());
       server.start();

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/LoggingActiveMQServerPluginAMQPTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/LoggingActiveMQServerPluginAMQPTest.java
@@ -48,11 +48,12 @@ public class LoggingActiveMQServerPluginAMQPTest extends LoggingActiveMQServerPl
     */
    @Override
    @Test
-   @BMRules(rules = {@BMRule(name = "test logAll EVENT",
-      targetClass = "org.jboss.logging.Logger",
-      targetMethod = "logv",
-      targetLocation = "ENTRY",
-      action = "org.apache.activemq.artemis.tests.extras.byteman.LoggingActiveMQServerPluginTest.infoLog($2, $4, $0)")})
+   @BMRules(rules = {
+      @BMRule(name = "test logAll EVENT",
+         targetClass = "org.jboss.logging.Logger",
+         targetMethod = "logv",
+         targetLocation = "ENTRY",
+         action = "org.apache.activemq.artemis.tests.extras.byteman.LoggingActiveMQServerPluginTest.infoLog($2, $4, $0)")})
    public void testLogAll() throws Exception {
 
       //initial plugin
@@ -94,11 +95,12 @@ public class LoggingActiveMQServerPluginAMQPTest extends LoggingActiveMQServerPl
     */
    @Override
    @Test
-   @BMRules(rules = {@BMRule(name = "test LOG_CONSUMER_EVENTS",
-      targetClass = "org.jboss.logging.Logger",
-      targetMethod = "logv",
-      targetLocation = "ENTRY",
-      action = "org.apache.activemq.artemis.tests.extras.byteman.LoggingActiveMQServerPluginTest.infoLog($2, $4, $0)")})
+   @BMRules(rules = {
+      @BMRule(name = "test LOG_CONSUMER_EVENTS",
+         targetClass = "org.jboss.logging.Logger",
+         targetMethod = "logv",
+         targetLocation = "ENTRY",
+         action = "org.apache.activemq.artemis.tests.extras.byteman.LoggingActiveMQServerPluginTest.infoLog($2, $4, $0)")})
    public void testLogConsumerEvents() throws Exception {
 
       ActiveMQServer activeMQServer = createServerWithLoggingPlugin(LoggingActiveMQServerPlugin.LOG_CONSUMER_EVENTS);
@@ -140,12 +142,12 @@ public class LoggingActiveMQServerPluginAMQPTest extends LoggingActiveMQServerPl
     */
    @Override
    @Test
-   @BMRules(rules = {@BMRule(name = "test LOG_SESSION_EVENTS",
-      targetClass = "org.jboss.logging.Logger",
-      targetMethod = "logv",
-      targetLocation = "ENTRY",
-      action = "org.apache.activemq.artemis.tests.extras.byteman.LoggingActiveMQServerPluginTest.infoLog($2, $4, $0)")})
-
+   @BMRules(rules = {
+      @BMRule(name = "test LOG_SESSION_EVENTS",
+         targetClass = "org.jboss.logging.Logger",
+         targetMethod = "logv",
+         targetLocation = "ENTRY",
+         action = "org.apache.activemq.artemis.tests.extras.byteman.LoggingActiveMQServerPluginTest.infoLog($2, $4, $0)")})
    public void testLogSessionEvents() throws Exception {
 
       ActiveMQServer activeMQServer  = createServerWithLoggingPlugin(LoggingActiveMQServerPlugin.LOG_SESSION_EVENTS);

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/LoggingActiveMQServerPluginOpenWireTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/LoggingActiveMQServerPluginOpenWireTest.java
@@ -52,11 +52,12 @@ public class LoggingActiveMQServerPluginOpenWireTest extends LoggingActiveMQServ
     */
    @Override
    @Test
-   @BMRules(rules = {@BMRule(name = "test queue creation log",
-      targetClass = "org.jboss.logging.Logger",
-      targetMethod = "logv",
-      targetLocation = "ENTRY",
-      action = "org.apache.activemq.artemis.tests.extras.byteman.LoggingActiveMQServerPluginTest.infoLog($2, $4, $0)")})
+   @BMRules(rules = {
+      @BMRule(name = "test queue creation log",
+         targetClass = "org.jboss.logging.Logger",
+         targetMethod = "logv",
+         targetLocation = "ENTRY",
+         action = "org.apache.activemq.artemis.tests.extras.byteman.LoggingActiveMQServerPluginTest.infoLog($2, $4, $0)")})
    public void testQueueCreationLog() throws Exception {
 
       //initial plugin
@@ -100,12 +101,12 @@ public class LoggingActiveMQServerPluginOpenWireTest extends LoggingActiveMQServ
     */
    @Override
    @Test
-   @BMRules(rules = {@BMRule(name = "test LOG_SESSION_EVENTS",
-      targetClass = "org.jboss.logging.Logger",
-      targetMethod = "logv",
-      targetLocation = "ENTRY",
-      action = "org.apache.activemq.artemis.tests.extras.byteman.LoggingActiveMQServerPluginTest.infoLog($2, $4, $0)")})
-
+   @BMRules(rules = {
+      @BMRule(name = "test LOG_SESSION_EVENTS",
+         targetClass = "org.jboss.logging.Logger",
+         targetMethod = "logv",
+         targetLocation = "ENTRY",
+         action = "org.apache.activemq.artemis.tests.extras.byteman.LoggingActiveMQServerPluginTest.infoLog($2, $4, $0)")})
    public void testLogSessionEvents() throws Exception {
 
       ActiveMQServer activeMQServer  = createServerWithLoggingPlugin(LoggingActiveMQServerPlugin.LOG_SESSION_EVENTS);
@@ -141,11 +142,12 @@ public class LoggingActiveMQServerPluginOpenWireTest extends LoggingActiveMQServ
     */
    @Override
    @Test
-   @BMRules(rules = {@BMRule(name = "test logAll EVENT",
-      targetClass = "org.jboss.logging.Logger",
-      targetMethod = "logv",
-      targetLocation = "ENTRY",
-      action = "org.apache.activemq.artemis.tests.extras.byteman.LoggingActiveMQServerPluginTest.infoLog($2, $4, $0)")})
+   @BMRules(rules = {
+      @BMRule(name = "test logAll EVENT",
+         targetClass = "org.jboss.logging.Logger",
+         targetMethod = "logv",
+         targetLocation = "ENTRY",
+         action = "org.apache.activemq.artemis.tests.extras.byteman.LoggingActiveMQServerPluginTest.infoLog($2, $4, $0)")})
    public void testLogAll() throws Exception {
 
       //initial plugin

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/LoggingActiveMQServerPluginTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/LoggingActiveMQServerPluginTest.java
@@ -78,11 +78,12 @@ public class LoggingActiveMQServerPluginTest extends ActiveMQTestBase {
     */
 
    @Test
-   @BMRules(rules = {@BMRule(name = "test LOG_CONNECTION_EVENTS",
-      targetClass = "org.jboss.logging.Logger",
-      targetMethod = "logv",
-      targetLocation = "ENTRY",
-      action = "org.apache.activemq.artemis.tests.extras.byteman.LoggingActiveMQServerPluginTest.infoLog($2, $4, $0)")})
+   @BMRules(rules = {
+      @BMRule(name = "test LOG_CONNECTION_EVENTS",
+         targetClass = "org.jboss.logging.Logger",
+         targetMethod = "logv",
+         targetLocation = "ENTRY",
+         action = "org.apache.activemq.artemis.tests.extras.byteman.LoggingActiveMQServerPluginTest.infoLog($2, $4, $0)")})
    public void testLogConnectEvents() throws Exception {
 
       ActiveMQServer activeMQServer = createServerWithLoggingPlugin(LoggingActiveMQServerPlugin.LOG_CONNECTION_EVENTS);
@@ -129,11 +130,12 @@ public class LoggingActiveMQServerPluginTest extends ActiveMQTestBase {
     * @throws Exception
     */
    @Test
-   @BMRules(rules = {@BMRule(name = "test LOG_SESSION_EVENTS",
-      targetClass = "org.jboss.logging.Logger",
-      targetMethod = "logv",
-      targetLocation = "ENTRY",
-      action = "org.apache.activemq.artemis.tests.extras.byteman.LoggingActiveMQServerPluginTest.infoLog($2, $4, $0)")})
+   @BMRules(rules = {
+      @BMRule(name = "test LOG_SESSION_EVENTS",
+         targetClass = "org.jboss.logging.Logger",
+         targetMethod = "logv",
+         targetLocation = "ENTRY",
+         action = "org.apache.activemq.artemis.tests.extras.byteman.LoggingActiveMQServerPluginTest.infoLog($2, $4, $0)")})
    public void testLogSessionEvents() throws Exception {
 
       ActiveMQServer activeMQServer = createServerWithLoggingPlugin(LoggingActiveMQServerPlugin.LOG_SESSION_EVENTS);
@@ -165,11 +167,12 @@ public class LoggingActiveMQServerPluginTest extends ActiveMQTestBase {
     */
 
    @Test
-   @BMRules(rules = {@BMRule(name = "test LOG_CONSUMER_EVENTS",
-      targetClass = "org.jboss.logging.Logger",
-      targetMethod = "logv",
-      targetLocation = "ENTRY",
-      action = "org.apache.activemq.artemis.tests.extras.byteman.LoggingActiveMQServerPluginTest.infoLog($2, $4, $0)")})
+   @BMRules(rules = {
+      @BMRule(name = "test LOG_CONSUMER_EVENTS",
+         targetClass = "org.jboss.logging.Logger",
+         targetMethod = "logv",
+         targetLocation = "ENTRY",
+         action = "org.apache.activemq.artemis.tests.extras.byteman.LoggingActiveMQServerPluginTest.infoLog($2, $4, $0)")})
    public void testLogConsumerEvents() throws Exception {
 
       ActiveMQServer activeMQServer = createServerWithLoggingPlugin(LoggingActiveMQServerPlugin.LOG_CONSUMER_EVENTS);
@@ -207,11 +210,12 @@ public class LoggingActiveMQServerPluginTest extends ActiveMQTestBase {
     * @throws Exception
     */
    @Test
-   @BMRules(rules = {@BMRule(name = "test LOG_DELIVERING_EVENTS",
-      targetClass = "org.jboss.logging.Logger",
-      targetMethod = "logv",
-      targetLocation = "ENTRY",
-      action = "org.apache.activemq.artemis.tests.extras.byteman.LoggingActiveMQServerPluginTest.infoLog($2, $4, $0)")})
+   @BMRules(rules = {
+      @BMRule(name = "test LOG_DELIVERING_EVENTS",
+         targetClass = "org.jboss.logging.Logger",
+         targetMethod = "logv",
+         targetLocation = "ENTRY",
+         action = "org.apache.activemq.artemis.tests.extras.byteman.LoggingActiveMQServerPluginTest.infoLog($2, $4, $0)")})
    public void testLogDeliveringEvents() throws Exception {
 
       ActiveMQServer activeMQServer = createServerWithLoggingPlugin(LoggingActiveMQServerPlugin.LOG_DELIVERING_EVENTS);
@@ -249,11 +253,12 @@ public class LoggingActiveMQServerPluginTest extends ActiveMQTestBase {
     * @throws Exception
     */
    @Test
-   @BMRules(rules = {@BMRule(name = "test LOG_SENDING_EVENTS",
-      targetClass = "org.jboss.logging.Logger",
-      targetMethod = "logv",
-      targetLocation = "ENTRY",
-      action = "org.apache.activemq.artemis.tests.extras.byteman.LoggingActiveMQServerPluginTest.infoLog($2, $4, $0)")})
+   @BMRules(rules = {
+      @BMRule(name = "test LOG_SENDING_EVENTS",
+         targetClass = "org.jboss.logging.Logger",
+         targetMethod = "logv",
+         targetLocation = "ENTRY",
+         action = "org.apache.activemq.artemis.tests.extras.byteman.LoggingActiveMQServerPluginTest.infoLog($2, $4, $0)")})
    public void testLogSendingEvents() throws Exception {
 
       //initial plugin
@@ -293,11 +298,12 @@ public class LoggingActiveMQServerPluginTest extends ActiveMQTestBase {
     * @throws Exception
     */
    @Test
-   @BMRules(rules = {@BMRule(name = "test queue creation log",
-      targetClass = "org.jboss.logging.Logger",
-      targetMethod = "logv",
-      targetLocation = "ENTRY",
-      action = "org.apache.activemq.artemis.tests.extras.byteman.LoggingActiveMQServerPluginTest.infoLog($2, $4, $0)")})
+   @BMRules(rules = {
+      @BMRule(name = "test queue creation log",
+         targetClass = "org.jboss.logging.Logger",
+         targetMethod = "logv",
+         targetLocation = "ENTRY",
+         action = "org.apache.activemq.artemis.tests.extras.byteman.LoggingActiveMQServerPluginTest.infoLog($2, $4, $0)")})
    public void testQueueCreationLog() throws Exception {
 
       //initial plugin
@@ -336,11 +342,12 @@ public class LoggingActiveMQServerPluginTest extends ActiveMQTestBase {
     * @throws Exception
     */
    @Test
-   @BMRules(rules = {@BMRule(name = "test queue creation log",
-      targetClass = "org.jboss.logging.Logger",
-      targetMethod = "logv",
-      targetLocation = "ENTRY",
-      action = "org.apache.activemq.artemis.tests.extras.byteman.LoggingActiveMQServerPluginTest.infoLog($2, $4, $0)")})
+   @BMRules(rules = {
+      @BMRule(name = "test queue creation log",
+         targetClass = "org.jboss.logging.Logger",
+         targetMethod = "logv",
+         targetLocation = "ENTRY",
+         action = "org.apache.activemq.artemis.tests.extras.byteman.LoggingActiveMQServerPluginTest.infoLog($2, $4, $0)")})
    public void testExpireMessageLog() throws Exception {
 
       //initial plugin
@@ -381,11 +388,12 @@ public class LoggingActiveMQServerPluginTest extends ActiveMQTestBase {
     * @throws Exception
     */
    @Test
-   @BMRules(rules = {@BMRule(name = "test logAll EVENT",
-      targetClass = "org.jboss.logging.Logger",
-      targetMethod = "logv",
-      targetLocation = "ENTRY",
-      action = "org.apache.activemq.artemis.tests.extras.byteman.LoggingActiveMQServerPluginTest.infoLog($2, $4, $0)")})
+   @BMRules(rules = {
+      @BMRule(name = "test logAll EVENT",
+         targetClass = "org.jboss.logging.Logger",
+         targetMethod = "logv",
+         targetLocation = "ENTRY",
+         action = "org.apache.activemq.artemis.tests.extras.byteman.LoggingActiveMQServerPluginTest.infoLog($2, $4, $0)")})
    public void testLogAll() throws Exception {
 
       //initial plugin

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/ManagementExceptionHandlingTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/ManagementExceptionHandlingTest.java
@@ -63,12 +63,13 @@ public class ManagementExceptionHandlingTest extends ActiveMQTestBase {
 
    @Test
    @BMRules(
-           rules = {@BMRule(
-                   name = "checking ActiveMQServerControl methods",
-                   targetClass = "org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl",
-                   targetMethod = "createQueue(org.apache.activemq.artemis.api.core.SimpleString, org.apache.activemq.artemis.api.core.RoutingType, org.apache.activemq.artemis.api.core.SimpleString, org.apache.activemq.artemis.api.core.SimpleString, boolean, boolean, int, boolean, boolean)",
-                   targetLocation = "EXIT",
-                   action = "throw new org.apache.activemq.artemis.api.core.ActiveMQException(\"gotcha\")")})
+     rules = {
+        @BMRule(
+          name = "checking ActiveMQServerControl methods",
+          targetClass = "org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl",
+          targetMethod = "createQueue(org.apache.activemq.artemis.api.core.SimpleString, org.apache.activemq.artemis.api.core.RoutingType, org.apache.activemq.artemis.api.core.SimpleString, org.apache.activemq.artemis.api.core.SimpleString, boolean, boolean, int, boolean, boolean)",
+          targetLocation = "EXIT",
+          action = "throw new org.apache.activemq.artemis.api.core.ActiveMQException(\"gotcha\")")})
    public void testActiveMQServerControl() throws Exception {
       try {
          server.getActiveMQServerControl().createQueue(new QueueConfiguration("some.queue").setAddress("some.address").setRoutingType(RoutingType.ANYCAST).toJSON());
@@ -82,12 +83,13 @@ public class ManagementExceptionHandlingTest extends ActiveMQTestBase {
 
    @Test
    @BMRules(
-           rules = {@BMRule(
-                   name = "checking ActiveMQServerControl methods",
-                   targetClass = "org.apache.activemq.artemis.core.postoffice.impl.PostOfficeImpl",
-                   targetMethod = "route(org.apache.activemq.artemis.api.core.Message, boolean)",
-                   targetLocation = "ENTRY",
-                   action = "throw new org.apache.activemq.artemis.api.core.ActiveMQException(\"gotcha\")")})
+     rules = {
+        @BMRule(
+          name = "checking ActiveMQServerControl methods",
+          targetClass = "org.apache.activemq.artemis.core.postoffice.impl.PostOfficeImpl",
+          targetMethod = "route(org.apache.activemq.artemis.api.core.Message, boolean)",
+          targetLocation = "ENTRY",
+          action = "throw new org.apache.activemq.artemis.api.core.ActiveMQException(\"gotcha\")")})
    public void testAddressControl() throws Exception {
       server.getActiveMQServerControl().createAddress("test.address", "ANYCAST");
       MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/OrphanedConsumerTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/OrphanedConsumerTest.java
@@ -109,19 +109,21 @@ public class OrphanedConsumerTest extends ActiveMQTestBase {
     */
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "closeExit",
-         targetClass = "org.apache.activemq.artemis.core.server.impl.ServerConsumerImpl",
-         targetMethod = "close",
-         targetLocation = "AT EXIT",
-         condition = "org.apache.activemq.artemis.tests.extras.byteman.OrphanedConsumerTest.isConditionActive()",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.OrphanedConsumerTest.debugLog(\"throwing stuff\");throw new InterruptedException()"), @BMRule(
-         name = "closeEnter",
-         targetClass = "org.apache.activemq.artemis.core.server.impl.ServerConsumerImpl",
-         targetMethod = "close",
-         targetLocation = "ENTRY",
-         condition = "org.apache.activemq.artemis.tests.extras.byteman.OrphanedConsumerTest.isConditionActive()",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.OrphanedConsumerTest.leavingCloseOnTestCountersWhileClosing()")})
+      rules = {
+         @BMRule(
+            name = "closeExit",
+            targetClass = "org.apache.activemq.artemis.core.server.impl.ServerConsumerImpl",
+            targetMethod = "close",
+            targetLocation = "AT EXIT",
+            condition = "org.apache.activemq.artemis.tests.extras.byteman.OrphanedConsumerTest.isConditionActive()",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.OrphanedConsumerTest.debugLog(\"throwing stuff\");throw new InterruptedException()"),
+         @BMRule(
+            name = "closeEnter",
+            targetClass = "org.apache.activemq.artemis.core.server.impl.ServerConsumerImpl",
+            targetMethod = "close",
+            targetLocation = "ENTRY",
+            condition = "org.apache.activemq.artemis.tests.extras.byteman.OrphanedConsumerTest.isConditionActive()",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.OrphanedConsumerTest.leavingCloseOnTestCountersWhileClosing()")})
    public void testOrphanedConsumers() throws Exception {
       internalTestOrphanedConsumers(false);
    }
@@ -136,19 +138,21 @@ public class OrphanedConsumerTest extends ActiveMQTestBase {
     */
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "closeExit",
-         targetClass = "org.apache.activemq.artemis.core.server.impl.ServerConsumerImpl",
-         targetMethod = "close",
-         targetLocation = "AT EXIT",
-         condition = "org.apache.activemq.artemis.tests.extras.byteman.OrphanedConsumerTest.isConditionActive()",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.OrphanedConsumerTest.debugLog(\"throwing stuff\");throw new InterruptedException()"), @BMRule(
-         name = "closeEnter",
-         targetClass = "org.apache.activemq.artemis.core.server.impl.ServerConsumerImpl",
-         targetMethod = "close",
-         targetLocation = "ENTRY",
-         condition = "org.apache.activemq.artemis.tests.extras.byteman.OrphanedConsumerTest.isConditionActive()",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.OrphanedConsumerTest.leavingCloseOnTestCountersWhileClosing()")})
+      rules = {
+         @BMRule(
+            name = "closeExit",
+            targetClass = "org.apache.activemq.artemis.core.server.impl.ServerConsumerImpl",
+            targetMethod = "close",
+            targetLocation = "AT EXIT",
+            condition = "org.apache.activemq.artemis.tests.extras.byteman.OrphanedConsumerTest.isConditionActive()",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.OrphanedConsumerTest.debugLog(\"throwing stuff\");throw new InterruptedException()"),
+         @BMRule(
+            name = "closeEnter",
+            targetClass = "org.apache.activemq.artemis.core.server.impl.ServerConsumerImpl",
+            targetMethod = "close",
+            targetLocation = "ENTRY",
+            condition = "org.apache.activemq.artemis.tests.extras.byteman.OrphanedConsumerTest.isConditionActive()",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.OrphanedConsumerTest.leavingCloseOnTestCountersWhileClosing()")})
    public void testOrphanedConsumersByManagement() throws Exception {
       internalTestOrphanedConsumers(true);
    }

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/PagingLeakTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/PagingLeakTest.java
@@ -66,17 +66,19 @@ public class PagingLeakTest extends ActiveMQTestBase {
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "newPosition",
-         targetClass = "org.apache.activemq.artemis.core.paging.cursor.impl.PagePositionImpl",
-         targetMethod = "<init>()",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.PagingLeakTest.newPosition()"), @BMRule(
-         name = "finalPosition",
-         targetClass = "org.apache.activemq.artemis.core.paging.cursor.impl.PagePositionImpl",
-         targetMethod = "finalize",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.PagingLeakTest.deletePosition()")})
+      rules = {
+         @BMRule(
+            name = "newPosition",
+            targetClass = "org.apache.activemq.artemis.core.paging.cursor.impl.PagePositionImpl",
+            targetMethod = "<init>()",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.PagingLeakTest.newPosition()"),
+         @BMRule(
+            name = "finalPosition",
+            targetClass = "org.apache.activemq.artemis.core.paging.cursor.impl.PagePositionImpl",
+            targetMethod = "finalize",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.PagingLeakTest.deletePosition()")})
    public void testValidateLeak() throws Throwable {
       log.debug("location::" + getBindingsDir());
 

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/PagingOMETest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/PagingOMETest.java
@@ -77,12 +77,13 @@ public class PagingOMETest extends ActiveMQTestBase {
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "fakeOME",
-         targetClass = "org.apache.activemq.artemis.core.paging.cursor.PagedReferenceImpl",
-         targetMethod = "getPagedMessage",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.PagingOMETest.refCheck()")})
+      rules = {
+         @BMRule(
+            name = "fakeOME",
+            targetClass = "org.apache.activemq.artemis.core.paging.cursor.PagedReferenceImpl",
+            targetMethod = "getPagedMessage",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.PagingOMETest.refCheck()")})
    public void testPageCleanup() throws Exception {
       clearDataRecreateServerDirs();
 

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/QueueDeploymentFailedTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/QueueDeploymentFailedTest.java
@@ -32,6 +32,7 @@ import org.junit.runner.RunWith;
 public class QueueDeploymentFailedTest extends ActiveMQTestBase {
 
    @Test
+
    @BMRule(name = "blow up queue deployment",
       targetClass = "org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl",
       targetMethod = "createQueue(SimpleString,RoutingType,SimpleString,SimpleString,SimpleString,boolean,boolean,boolean,boolean,boolean,int,boolean,boolean,boolean,int,long,boolean",

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/RaceOnClosingConsumerWhileReconnecting.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/RaceOnClosingConsumerWhileReconnecting.java
@@ -97,12 +97,13 @@ public class RaceOnClosingConsumerWhileReconnecting extends ActiveMQTestBase {
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "session.removeConsumer wait",
-         targetClass = "org.apache.activemq.artemis.core.client.impl.ClientSessionImpl",
-         targetMethod = "removeConsumer(org.apache.activemq.artemis.core.client.impl.ClientConsumerInternal)",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.RaceOnClosingConsumerWhileReconnecting.waitForReconnection();")})
+      rules = {
+         @BMRule(
+            name = "session.removeConsumer wait",
+            targetClass = "org.apache.activemq.artemis.core.client.impl.ClientSessionImpl",
+            targetMethod = "removeConsumer(org.apache.activemq.artemis.core.client.impl.ClientConsumerInternal)",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.RaceOnClosingConsumerWhileReconnecting.waitForReconnection();")})
    public void testClosingConsumerBeforeReconnecting() throws Exception {
       conn = session.getConnection();
 
@@ -119,12 +120,13 @@ public class RaceOnClosingConsumerWhileReconnecting extends ActiveMQTestBase {
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "session.closeConsumer before recreating consumer",
-         targetClass = "org.apache.activemq.artemis.core.client.impl.ClientSessionImpl",
-         targetMethod = "handleFailover",
-         targetLocation = "AFTER WRITE $consumerInternal 1",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.RaceOnClosingConsumerWhileReconnecting.closeConsumer();")})
+      rules = {
+         @BMRule(
+            name = "session.closeConsumer before recreating consumer",
+            targetClass = "org.apache.activemq.artemis.core.client.impl.ClientSessionImpl",
+            targetMethod = "handleFailover",
+            targetLocation = "AFTER WRITE $consumerInternal 1",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.RaceOnClosingConsumerWhileReconnecting.closeConsumer();")})
    public void testClosingConsumerBeforeRecreatingOneConsumer() throws Exception {
       RemotingConnection conn = session.getConnection();
 
@@ -139,12 +141,13 @@ public class RaceOnClosingConsumerWhileReconnecting extends ActiveMQTestBase {
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "session.closeConsumer before recreating consumer",
-         targetClass = "org.apache.activemq.artemis.core.client.impl.ClientSessionImpl",
-         targetMethod = "handleFailover",
-         targetLocation = "AFTER WRITE $consumerInternal 1",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.RaceOnClosingConsumerWhileReconnecting.closeConsumer();")})
+      rules = {
+         @BMRule(
+            name = "session.closeConsumer before recreating consumer",
+            targetClass = "org.apache.activemq.artemis.core.client.impl.ClientSessionImpl",
+            targetMethod = "handleFailover",
+            targetLocation = "AFTER WRITE $consumerInternal 1",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.RaceOnClosingConsumerWhileReconnecting.closeConsumer();")})
    public void testClosingConsumerBeforeRecreatingTwoConsumers() throws Exception {
       RemotingConnection conn = session.getConnection();
 

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/RaceOnCursorIteratorTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/RaceOnCursorIteratorTest.java
@@ -143,12 +143,13 @@ public class RaceOnCursorIteratorTest extends ActiveMQTestBase {
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "raceLiveCache",
-         targetClass = "org.apache.activemq.artemis.core.paging.cursor.impl.PageSubscriptionImpl",
-         targetMethod = "moveNextPage",
-         targetLocation = "EXIT",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.RaceOnCursorIteratorTest.raceAddLivePageCache()")})
+      rules = {
+         @BMRule(
+            name = "raceLiveCache",
+            targetClass = "org.apache.activemq.artemis.core.paging.cursor.impl.PageSubscriptionImpl",
+            targetMethod = "moveNextPage",
+            targetLocation = "EXIT",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.RaceOnCursorIteratorTest.raceAddLivePageCache()")})
    public void testSkipLivePageCache() {
       skipLivePageCache = true;
       // Simulate scenario #1 depicted in https://issues.apache.org/jira/browse/ARTEMIS-2418
@@ -159,12 +160,13 @@ public class RaceOnCursorIteratorTest extends ActiveMQTestBase {
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "raceLiveCache",
-         targetClass = "org.apache.activemq.artemis.core.paging.cursor.impl.PageSubscriptionImpl",
-         targetMethod = "moveNextPage",
-         targetLocation = "EXIT",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.RaceOnCursorIteratorTest.raceAddLivePageCache()"),
+      rules = {
+         @BMRule(
+            name = "raceLiveCache",
+            targetClass = "org.apache.activemq.artemis.core.paging.cursor.impl.PageSubscriptionImpl",
+            targetMethod = "moveNextPage",
+            targetLocation = "EXIT",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.RaceOnCursorIteratorTest.raceAddLivePageCache()"),
          @BMRule(
             name = "raceNullCache",
             targetClass = "org.apache.activemq.artemis.core.paging.cursor.impl.PageCursorProviderImpl",

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/RaceOnSyncLargeMessageOverReplication2Test.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/RaceOnSyncLargeMessageOverReplication2Test.java
@@ -160,17 +160,19 @@ public class RaceOnSyncLargeMessageOverReplication2Test extends ActiveMQTestBase
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "InterruptSending",
-         targetClass = "org.apache.activemq.artemis.core.protocol.core.impl.ActiveMQSessionContext",
-         targetMethod = "sendLargeMessageChunk",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.RaceOnSyncLargeMessageOverReplication2Test.messageChunkSent();"), @BMRule(
-         name = "InterruptSync",
-         targetClass = "org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager",
-         targetMethod = "sendLargeMessageFiles",
-         targetLocation = "ENTRY",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.RaceOnSyncLargeMessageOverReplication2Test.syncLargeMessage();")})
+      rules = {
+         @BMRule(
+            name = "InterruptSending",
+            targetClass = "org.apache.activemq.artemis.core.protocol.core.impl.ActiveMQSessionContext",
+            targetMethod = "sendLargeMessageChunk",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.RaceOnSyncLargeMessageOverReplication2Test.messageChunkSent();"),
+         @BMRule(
+            name = "InterruptSync",
+            targetClass = "org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager",
+            targetMethod = "sendLargeMessageFiles",
+            targetLocation = "ENTRY",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.RaceOnSyncLargeMessageOverReplication2Test.syncLargeMessage();")})
    public void testSendLargeMessage() throws Exception {
 
       final CountDownLatch failedOver = new CountDownLatch(1);

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/RaceOnSyncLargeMessageOverReplicationTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/RaceOnSyncLargeMessageOverReplicationTest.java
@@ -150,12 +150,13 @@ public class RaceOnSyncLargeMessageOverReplicationTest extends ActiveMQTestBase 
   */
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "InterruptSync",
-         targetClass = "org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager",
-         targetMethod = "createLargeMessage(long,org.apache.activemq.artemis.core.message.impl.MessageInternal)",
-         targetLocation = "EXIT",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.RaceOnSyncLargeMessageOverReplicationTest.syncLargeMessage();")})
+      rules = {
+         @BMRule(
+            name = "InterruptSync",
+            targetClass = "org.apache.activemq.artemis.core.persistence.impl.journal.JournalStorageManager",
+            targetMethod = "createLargeMessage(long,org.apache.activemq.artemis.core.message.impl.MessageInternal)",
+            targetLocation = "EXIT",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.RaceOnSyncLargeMessageOverReplicationTest.syncLargeMessage();")})
    public void testSendLargeMessage() throws Exception {
 
       final CountDownLatch failedOver = new CountDownLatch(1);

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/ReplicationBackupTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/ReplicationBackupTest.java
@@ -43,12 +43,13 @@ public class ReplicationBackupTest extends ActiveMQTestBase {
    */
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "prevent backup annoucement",
-         targetClass = "org.apache.activemq.artemis.core.server.impl.SharedNothingLiveActivation",
-         targetMethod = "run",
-         targetLocation = "AT EXIT",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.ReplicationBackupTest.breakIt();")})
+      rules = {
+         @BMRule(
+            name = "prevent backup annoucement",
+            targetClass = "org.apache.activemq.artemis.core.server.impl.SharedNothingLiveActivation",
+            targetMethod = "run",
+            targetLocation = "AT EXIT",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.ReplicationBackupTest.breakIt();")})
    public void testReplicatedBackupAnnouncement() throws Exception {
       TransportConfiguration liveConnector = TransportConfigurationUtils.getNettyConnector(true, 0);
       TransportConfiguration liveAcceptor = TransportConfigurationUtils.getNettyAcceptor(true, 0);

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/StartStopDeadlockTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/StartStopDeadlockTest.java
@@ -52,23 +52,26 @@ public class StartStopDeadlockTest extends ActiveMQTestBase {
    @Test
    @BMRules(
 
-      rules = {@BMRule(
-         name = "Server.start wait-init",
-         targetClass = "org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl",
-         targetMethod = "initialisePart2",
-         targetLocation = "ENTRY",
-         condition = "incrementCounter(\"server-Init\") == 2",
-         action = "org.apache.activemq.artemis.tests.extras.byteman.StartStopDeadlockTest.debugLog(\"server backup init\"), waitFor(\"start-init\")"), @BMRule(
-         name = "JMSServer.stop wait-init",
-         targetClass = "org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl",
-         targetMethod = "stop",
-         targetLocation = "ENTRY",
-         action = "signalWake(\"start-init\", true)"), @BMRule(
-         name = "StartStopDeadlockTest tearDown",
-         targetClass = "org.apache.activemq.artemis.tests.extras.byteman.StartStopDeadlockTest",
-         targetMethod = "tearDown",
-         targetLocation = "ENTRY",
-         action = "deleteCounter(\"server-Init\")")})
+      rules = {
+         @BMRule(
+            name = "Server.start wait-init",
+            targetClass = "org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl",
+            targetMethod = "initialisePart2",
+            targetLocation = "ENTRY",
+            condition = "incrementCounter(\"server-Init\") == 2",
+            action = "org.apache.activemq.artemis.tests.extras.byteman.StartStopDeadlockTest.debugLog(\"server backup init\"), waitFor(\"start-init\")"),
+         @BMRule(
+            name = "JMSServer.stop wait-init",
+            targetClass = "org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl",
+            targetMethod = "stop",
+            targetLocation = "ENTRY",
+            action = "signalWake(\"start-init\", true)"),
+         @BMRule(
+            name = "StartStopDeadlockTest tearDown",
+            targetClass = "org.apache.activemq.artemis.tests.extras.byteman.StartStopDeadlockTest",
+            targetMethod = "tearDown",
+            targetLocation = "ENTRY",
+            action = "deleteCounter(\"server-Init\")")})
    public void testDeadlock() throws Exception {
 
       // A live server that will always be crashed

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/StompInternalStateTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/StompInternalStateTest.java
@@ -51,13 +51,14 @@ public class StompInternalStateTest extends ActiveMQTestBase {
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "StompProtocolManager Leak Server Rule",
-         targetClass = "org.apache.activemq.artemis.core.protocol.stomp.StompProtocolManager",
-         targetMethod = "onNotification(org.apache.activemq.artemis.core.server.management.Notification)",
-         targetLocation = "EXIT",
-         helper = "org.apache.activemq.artemis.tests.extras.byteman.StompInternalStateTest",
-         action = "verifyBindingAddRemove($1, $0.destinations)")})
+      rules = {
+         @BMRule(
+            name = "StompProtocolManager Leak Server Rule",
+            targetClass = "org.apache.activemq.artemis.core.protocol.stomp.StompProtocolManager",
+            targetMethod = "onNotification(org.apache.activemq.artemis.core.server.management.Notification)",
+            targetLocation = "EXIT",
+            helper = "org.apache.activemq.artemis.tests.extras.byteman.StompInternalStateTest",
+            action = "verifyBindingAddRemove($1, $0.destinations)")})
    public void testStompProtocolManagerLeak() throws Exception {
       ClientSession session = null;
       try {

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/TimeoutXATest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/TimeoutXATest.java
@@ -82,19 +82,21 @@ public class TimeoutXATest extends ActiveMQTestBase {
 
    @Test
    @BMRules(
-      rules = {@BMRule(
-         name = "removing TX",
-         targetClass = "org.apache.activemq.artemis.core.transaction.impl.ResourceManagerImpl",
-         targetMethod = "removeTransaction(javax.transaction.xa.Xid)",
-         targetLocation = "ENTRY",
-         helper = "org.apache.activemq.artemis.tests.extras.byteman.TimeoutXATest",
-         action = "removingTX()"), @BMRule(
-         name = "afterRollback TX",
-         targetClass = "org.apache.activemq.artemis.core.transaction.impl.TransactionImpl",
-         targetMethod = "afterRollback",
-         targetLocation = "ENTRY",
-         helper = "org.apache.activemq.artemis.tests.extras.byteman.TimeoutXATest",
-         action = "afterRollback()")})
+      rules = {
+         @BMRule(
+            name = "removing TX",
+            targetClass = "org.apache.activemq.artemis.core.transaction.impl.ResourceManagerImpl",
+            targetMethod = "removeTransaction(javax.transaction.xa.Xid)",
+            targetLocation = "ENTRY",
+            helper = "org.apache.activemq.artemis.tests.extras.byteman.TimeoutXATest",
+            action = "removingTX()"),
+         @BMRule(
+            name = "afterRollback TX",
+            targetClass = "org.apache.activemq.artemis.core.transaction.impl.TransactionImpl",
+            targetMethod = "afterRollback",
+            targetLocation = "ENTRY",
+            helper = "org.apache.activemq.artemis.tests.extras.byteman.TimeoutXATest",
+            action = "afterRollback()")})
    public void testTimeoutOnTX2() throws Exception {
       ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory();
       XAConnection connection = connectionFactory.createXAConnection();

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/critical/analyzer/FileSystemSyncBlockedTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/critical/analyzer/FileSystemSyncBlockedTest.java
@@ -33,11 +33,21 @@ import org.junit.runner.RunWith;
 public class FileSystemSyncBlockedTest extends CriticalAnalyzerFaultInjectionTestBase {
    private static final Logger log = Logger.getLogger(FileSystemSyncBlockedTest.class);
 
-   @BMRules(rules = {@BMRule(name = "Simulate Slow Disk Sync", targetClass = "org.apache.activemq.artemis.core.io.nio.NIOSequentialFile", targetMethod = "sync", targetLocation = "ENTRY", condition = "!flagged(\"testSlowDiskSync\")",  // Once the server shutdowns we stop applying this rule.
-      action = "waitFor(\"testSlowDiskSync\")"), @BMRule(
-      // We ensure that no more
-      name = "Release Suspended Thread during Server Shutdown", // Releases wakes up suspended threads to allow shutdown to complete
-      targetClass = "org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl", targetMethod = "stop", targetLocation = "ENTRY", action = "flag(\"testSlowDiskSync\"); signalWake(\"testSlowDiskSync\")")})
+   @BMRules(rules = {
+      @BMRule(
+         name = "Simulate Slow Disk Sync",
+         targetClass = "org.apache.activemq.artemis.core.io.nio.NIOSequentialFile",
+         targetMethod = "sync",
+         targetLocation = "ENTRY",
+         condition = "!flagged(\"testSlowDiskSync\")",  // Once the server shutdowns we stop applying this rule.
+         action = "waitFor(\"testSlowDiskSync\")"),
+      @BMRule(
+         // We ensure that no more
+         name = "Release Suspended Thread during Server Shutdown", // Releases wakes up suspended threads to allow shutdown to complete
+         targetClass = "org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl",
+         targetMethod = "stop",
+         targetLocation = "ENTRY",
+         action = "flag(\"testSlowDiskSync\"); signalWake(\"testSlowDiskSync\")")})
    @Test(timeout = 60000)
    public void testSlowDiskSync() throws Exception {
       testSendDurableMessage();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/SaslKrb5LDAPSecurityTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/SaslKrb5LDAPSecurityTest.java
@@ -107,8 +107,8 @@ import static org.apache.activemq.artemis.tests.util.ActiveMQTestBase.NETTY_ACCE
 @RunWith(FrameworkRunner.class)
 @CreateDS(name = "Example",
    partitions = {@CreatePartition(name = "example", suffix = "dc=example,dc=com",
-      contextEntry = @ContextEntry(entryLdif = "dn: dc=example,dc=com\n" + "dc: example\n" + "objectClass: top\n" + "objectClass: domain\n\n"),
-      indexes = {@CreateIndex(attribute = "objectClass"), @CreateIndex(attribute = "dc"), @CreateIndex(attribute = "ou")})},
+         contextEntry = @ContextEntry(entryLdif = "dn: dc=example,dc=com\n" + "dc: example\n" + "objectClass: top\n" + "objectClass: domain\n\n"),
+         indexes = {@CreateIndex(attribute = "objectClass"), @CreateIndex(attribute = "dc"), @CreateIndex(attribute = "ou")})},
       additionalInterceptors = { KeyDerivationInterceptor.class })
 
 @CreateLdapServer(transports = {@CreateTransport(protocol = "LDAP", port = 1024)},

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/bridge/BridgeTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/bridge/BridgeTest.java
@@ -1494,7 +1494,7 @@ public class BridgeTest extends ActiveMQTestBase {
             msgCount.incrementAndGet();
 
             if (i % 500 == 0)
-              instanceLog.debug("received " + i);
+               instanceLog.debug("received " + i);
          }
 
          boolean failed = false;


### PR DESCRIPTION
As a follow-up to dc7de893747b90b627d729f9f18a758bb4dad9d5 I'm updating
checkstyle to the latest version, restoring the originally intended
"RightCurly" style, and updating all the code to properly adhere to the
style as enforced by the new checkstyle version.

The version of checkstyle we used before the aforementioned commit had
a bug which didn't properly enforced our intended "RightCurly" style
(see https://github.com/checkstyle/checkstyle/issues/6345). That commit
changed the style to accommodate the handful of unintended style
violations. This commit reverts that change for 2 main reasons:
 - The style was always intended to use `alone` for both `METHOD_DEF`
and `CTOR_DEF`.
 - There are over 1,000 existing uses of the intended style and around
30 violations of this style which were unintentionally allowed.

Reverting the style back to the original and cleaning up the unintented
violations makes the code more consistent and prevents further style
inconsistencies in the future.

There were a handful of other changes related to checkstyle bugs which
allowed unintended style violations. These were related to indentation
levels.