### PR TITLE
ARTEMIS-3286 do not use comma in queue name as it upsets the web-console

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/ConsumerThread.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/ConsumerThread.java
@@ -54,7 +54,7 @@ public class ConsumerThread extends Thread {
    MessageListener listener;
 
    public ConsumerThread(Session session, Destination destination, int threadNr) {
-      super("Consumer " + destination.toString() + ", thread=" + threadNr);
+      super("Consumer " + destination.toString() + "; thread=" + threadNr);
       this.destination = destination;
       this.session = session;
    }

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/ProducerThread.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/ProducerThread.java
@@ -60,7 +60,7 @@ public class ProducerThread extends Thread {
    final ReusableLatch paused = new ReusableLatch(0);
 
    public ProducerThread(Session session, Destination destination, int threadNr) {
-      super("Producer " + destination.toString() + ", thread=" + threadNr);
+      super("Producer " + destination.toString() + "; thread=" + threadNr);
       this.destination = destination;
       this.session = session;
    }


### PR DESCRIPTION
solve ARTEMIS-3286 by replacing the comma with a semicolon
(as a comma upsets the webgui)

tested as follows:
`artemis consumer --destination topic://foobar --durable --clientID myclientid`

![afbeelding](https://user-images.githubusercontent.com/3663742/122217486-c124a380-cead-11eb-84f1-920f3547c1be.png)

See https://issues.apache.org/jira/browse/ARTEMIS-3286 for original result.