### PR TITLE
ARTEMIS-3177 allow a NOT-CONTAINS filter

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/queue/StatQueue.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/queue/StatQueue.java
@@ -63,7 +63,7 @@ public class StatQueue extends AbstractAction {
    }
 
    public enum OPERATION {
-      CONTAINS, EQUALS, GREATER_THAN, LESS_THAN
+      CONTAINS, NOT_CONTAINS, EQUALS, GREATER_THAN, LESS_THAN
    }
 
    public static final int DEFAULT_MAX_ROWS = 50;
@@ -74,7 +74,7 @@ public class StatQueue extends AbstractAction {
    @Option(name = "--field", description = "field to use in filter. Possible values NAME, ADDRESS, MESSAGE_COUNT, MESSAGES_ADDED, DELIVERING_COUNT, MESSAGES_ACKED, SCHEDULED_COUNT, ROUTING_TYPE.")
    private String fieldName;
 
-   @Option(name = "--operation", description = "operation to use in filter. Possible values CONTAINS, EQUALS, GREATER_THAN, LESS_THAN.")
+   @Option(name = "--operation", description = "operation to use in filter. Possible values CONTAINS, NOT_CONTAINS, EQUALS, GREATER_THAN, LESS_THAN.")
    private String operationName;
 
    @Option(name = "--value", description = "value to use in the filter.")

--- a/artemis-cli/src/test/java/org/apache/activemq/cli/test/ArtemisTest.java
+++ b/artemis-cli/src/test/java/org/apache/activemq/cli/test/ArtemisTest.java
@@ -1384,6 +1384,19 @@ public class ArtemisTest extends CliTestBase {
          // Header line + 3 queues
          Assert.assertEquals("rows returned filtering by NAME ", 4, lines.size());
 
+         //check all queues NOT containing "management" are displayed using Filter field NAME
+         context = new TestActionContext();
+         statQueue = new StatQueue();
+         statQueue.setUser("admin");
+         statQueue.setPassword("admin");
+         statQueue.setFieldName("NAME");
+         statQueue.setOperationName("NOT_CONTAINS");
+         statQueue.setValue("management");
+         statQueue.execute(context);
+         lines = getOutputLines(context, false);
+         // Header line + 6 queues (Test1/11/12/20+DLQ+ExpiryQueue, but not activemq.management.d6dbba78-d76f-43d6-a2c9-fc0575ed6f5d)
+         Assert.assertEquals("rows returned filtering by NAME operation NOT_CONTAINS", 7, lines.size());
+
          //check only queue named "Test1" is displayed using Filter field NAME and operation EQUALS
          context = new TestActionContext();
          statQueue = new StatQueue();

--- a/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/components/addresses.js
+++ b/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/components/addresses.js
@@ -106,6 +106,7 @@ var Artemis;
             operationOptions: [
                 {id: 'EQUALS', name: 'Equals'},
                 {id: 'CONTAINS', name: 'Contains'},
+                {id: 'NOT_CONTAINS', name: 'Does Not Contain'},
                 {id: 'GREATER_THAN', name: 'Greater Than'},
                 {id: 'LESS_THAN', name: 'Less Than'}
             ],

--- a/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/components/connections.js
+++ b/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/components/connections.js
@@ -130,6 +130,7 @@ var Artemis;
             operationOptions: [
                 {id: 'EQUALS', name: 'Equals'},
                 {id: 'CONTAINS', name: 'Contains'},
+                {id: 'NOT_CONTAINS', name: 'Does Not Contain'},
                 {id: 'GREATER_THAN', name: 'Greater Than'},
                 {id: 'LESS_THAN', name: 'Less Than'}
             ],

--- a/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/components/consumers.js
+++ b/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/components/consumers.js
@@ -130,6 +130,7 @@ var Artemis;
             operationOptions: [
                 {id: 'EQUALS', name: 'Equals'},
                 {id: 'CONTAINS', name: 'Contains'},
+                {id: 'NOT_CONTAINS', name: 'Does Not Contain'},
                 {id: 'GREATER_THAN', name: 'Greater Than'},
                 {id: 'LESS_THAN', name: 'Less Than'}
             ],

--- a/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/components/queues.js
+++ b/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/components/queues.js
@@ -144,6 +144,7 @@ var Artemis;
             operationOptions: [
                 {id: 'EQUALS', name: 'Equals'},
                 {id: 'CONTAINS', name: 'Contains'},
+                {id: 'NOT_CONTAINS', name: 'Does Not Contain'},
                 {id: 'GREATER_THAN', name: 'Greater Than'},
                 {id: 'LESS_THAN', name: 'Less Than'}
             ],

--- a/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/components/sessions.js
+++ b/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/components/sessions.js
@@ -125,6 +125,7 @@ var Artemis;
             operationOptions: [
                 {id: 'EQUALS', name: 'Equals'},
                 {id: 'CONTAINS', name: 'Contains'},
+                {id: 'NOT_CONTAINS', name: 'Does Not Contain'},
                 {id: 'GREATER_THAN', name: 'Greater Than'},
                 {id: 'LESS_THAN', name: 'Less Than'}
             ],

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/predicate/ActiveMQFilterPredicate.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/predicate/ActiveMQFilterPredicate.java
@@ -23,7 +23,7 @@ import java.util.function.Predicate;
 public class ActiveMQFilterPredicate<T> implements Predicate<T> {
 
    enum Operation {
-      CONTAINS, EQUALS, GREATER_THAN, LESS_THAN;
+      CONTAINS, NOT_CONTAINS, EQUALS, GREATER_THAN, LESS_THAN;
    }
 
    protected String field;
@@ -77,6 +77,8 @@ public class ActiveMQFilterPredicate<T> implements Predicate<T> {
                return equals(field, value);
             case CONTAINS:
                return contains(field, value);
+            case NOT_CONTAINS:
+               return !contains(field, value);
             case GREATER_THAN:
                return false;
             case LESS_THAN:
@@ -110,6 +112,8 @@ public class ActiveMQFilterPredicate<T> implements Predicate<T> {
                return field == longValue;
             case CONTAINS:
                return false;
+            case NOT_CONTAINS:
+               return false;
             case LESS_THAN:
                return field < longValue;
             case GREATER_THAN:
@@ -135,6 +139,8 @@ public class ActiveMQFilterPredicate<T> implements Predicate<T> {
                return field == intValue;
             case CONTAINS:
                return false;
+            case NOT_CONTAINS:
+               return false;
             case LESS_THAN:
                return field < intValue;
             case GREATER_THAN:
@@ -159,6 +165,8 @@ public class ActiveMQFilterPredicate<T> implements Predicate<T> {
             case EQUALS:
                return field == floatValue;
             case CONTAINS:
+               return false;
+            case NOT_CONTAINS:
                return false;
             case LESS_THAN:
                return field < floatValue;


### PR DESCRIPTION
As a solution to quickly filter out internal queues; but implemented as a generic solution.
To filter out internal queues: "[Name] [Does Not Contain] [$]".

tested in all relevant web gui pages.
tested in commandline: `artemis queue stat --operation NOT_CONTAINS --field NAME --value '$'`

considerations:
I could have added NOT-EQUALS; but I did not find this useful (as is just removes 1 item from the list)