### PR TITLE
ARTEMIS-3375 fix for helptext for 'artemis address'

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/address/HelpAddress.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/address/HelpAddress.java
@@ -56,7 +56,7 @@ public class HelpAddress extends Help implements Action {
    @Override
    public Object execute(ActionContext context) throws Exception {
       List<String> commands = new ArrayList<>(1);
-      commands.add("queue");
+      commands.add("address");
       help(global, commands);
       return null;
    }


### PR DESCRIPTION
fixes the help text for `artemis address`, which currently shows the same text as for `artemis queue`.

tested ok, test result:
```
$ artemis address
OpenJDK 64-Bit Server VM warning: If the number of processors is expected to increase from one, then you should configure the number of parallel GC threads appropriately using -XX:ParallelGCThreads=N
NAME
        artemis address - Address tools group (create|delete|update|show)
        (example ./artemis address create)

SYNOPSIS
        artemis address
        artemis address create [--user <user>] [--no-anycast]
                [--protocol <protocol>] [--name <name>] [--multicast] [--silent]
                [--password <password>] [--clientID <clientID>] [--url <brokerURL>]
                [--anycast] [--no-multicast] [--verbose]
        artemis address delete [--user <user>] [--no-anycast]
                [--protocol <protocol>] [--name <name>] [--multicast] [--silent]
                [--password <password>] [--clientID <clientID>] [--url <brokerURL>]
                [--anycast] [--no-multicast] [--verbose]
        artemis address show [--user <user>] [--no-anycast]
                [--protocol <protocol>] [--name <name>] [--multicast] [--silent]
                [--password <password>] [--clientID <clientID>] [--url <brokerURL>]
                [--anycast] [--no-multicast] [--verbose] [--bindings]
        artemis address update [--user <user>] [--no-anycast]
                [--protocol <protocol>] [--name <name>] [--multicast] [--silent]
                [--password <password>] [--clientID <clientID>] [--url <brokerURL>]
                [--anycast] [--no-multicast] [--verbose]

COMMANDS
        With no arguments, Display help information

        create
            create an address

            With --user option, User used to connect
...
```