### PR TITLE
ARTEMIS-3409: consistently skip if preconditions aren't satisfied

### DIFF
--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/network/NetUtil.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/network/NetUtil.java
@@ -90,17 +90,27 @@ public class NetUtil extends ExecuteUtil {
       osUsed = osTmp;
    }
 
-   public static void failIfNotSudo() {
-      Assume.assumeTrue("non supported OS", osUsed != OS.NON_SUPORTED);
-      if (!canSudo()) {
+   public static void skipIfNotSudo() {
+      skipIfNotSupportedOS();
+
+      boolean canSudo = canSudo();
+      if (!canSudo) {
          StringWriter writer = new StringWriter();
          PrintWriter out = new PrintWriter(writer);
-         out.println("Add the following at the end of your /etc/sudoers (use the visudo command)");
+         out.println("In order to run this test you must be able to sudo ifconfig.");
+         out.println("E.g add the following at the end of your /etc/sudoers (use the visudo command)");
          out.println("# ------------------------------------------------------- ");
          out.println(user + " ALL = NOPASSWD: /sbin/ifconfig");
          out.println("# ------------------------------------------------------- ");
-         Assert.fail(writer.toString());
+
+         System.out.println(writer.toString());
+
+         Assume.assumeTrue("Not able to sudo ifconfig", canSudo);
       }
+   }
+
+   public static void skipIfNotSupportedOS() {
+      Assume.assumeTrue("non supported OS", osUsed != OS.NON_SUPORTED);
    }
 
    public static void cleanup() {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/NetworkFailureFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/NetworkFailureFailoverTest.java
@@ -55,8 +55,8 @@ import org.junit.Test;
 /**
  * This test will simulate a failure where the network card is gone.
  * On that case the server should fail (as in stop) and not hung.
- * If you don't have sudoer access to ifutil, this test will fail.
- * You should add sudoer on your environment. otherwise you will have to ignore failures here.
+ * If you don't have sudoer access to ifutil, this test will skip.
+ * You should add sudoer on your environment to run the test.
  */
 public class NetworkFailureFailoverTest extends FailoverTestBase {
 
@@ -65,7 +65,7 @@ public class NetworkFailureFailoverTest extends FailoverTestBase {
 
    @BeforeClass
    public static void start() {
-      NetUtil.failIfNotSudo();
+      NetUtil.skipIfNotSudo();
    }
 
    // 192.0.2.0 is reserved for documentation (and testing on this case).

--- a/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/dnsswitch/DNSSwitchTest.java
+++ b/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/dnsswitch/DNSSwitchTest.java
@@ -139,12 +139,17 @@ public class DNSSwitchTest extends SmokeTestBase {
 
    @BeforeClass
    public static void beforeClassMethod() throws Exception {
+      NetUtil.skipIfNotSupportedOS();
+
       if (USE_ETC_HOSTS) {
          if (!ETC_HOSTS.canWrite()) {
             System.out.println("If you want to run this test, you must do 'sudo chmod 666 " + ETC_HOSTS);
          }
          Assume.assumeTrue("If you want to run this test, you must do 'sudo chmod 666 " + ETC_HOSTS + "'", ETC_HOSTS.canWrite());
+      } else {
+         NetUtil.skipIfNotSudo();
       }
+
       serverLocation = getServerLocation(SERVER_NAME_0);
       // Before anything we must copy the jave security and change what we need for no cache
       // this will be used to spawn new tests
@@ -159,7 +164,6 @@ public class DNSSwitchTest extends SmokeTestBase {
             Files.copy(ETC_HOSTS.toPath(), ETC_BACKUP.toPath(), StandardCopyOption.COPY_ATTRIBUTES);
          }
       }
-      NetUtil.failIfNotSudo();
    }
 
    private static File getETCBackup() {


### PR DESCRIPTION
Make DNSSwitchTest consistent on Java8 and 11+. Splits the OS check out to allow running separately, updates test to do that first, avoiding followup notes/checks about sudo and etc-hosts where it doesnt make sense. Changes the 'failIfNotSudo' to 'skipIfNotSudo' and runs this earlier for the Java 11+ cases, making DNSSwitchTest consistently skip if needed and print out details on why.

Change also stops NetworkFailureFailoverTest failing for similar reasons, instead making it skip and print details. Updated its intro text accordingly.