### PR TITLE
ARTEMIS-3302: enable some integration tests in the fast-tests profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1120,6 +1120,10 @@
             <skipLicenseCheck>false</skipLicenseCheck>
             <skipCompatibilityTests>false</skipCompatibilityTests>
             <testFailureIgnore>false</testFailureIgnore>
+            <!-- This enables the karaf-client-integration-tests and
+                 integration-tests module tests, see fast-tests profile
+                 in the latter for specific tests it then runs -->
+            <skipIntegrationTests>false</skipIntegrationTests>
          </properties>
       </profile>
       <profile>

--- a/tests/integration-tests/pom.xml
+++ b/tests/integration-tests/pom.xml
@@ -565,6 +565,28 @@
    </build>
    <profiles>
       <profile>
+         <!-- Quick subset of tests, used on PR checks -->
+         <id>fast-tests</id>
+         <build>
+            <pluginManagement>
+               <plugins>
+                  <plugin>
+                     <groupId>org.apache.maven.plugins</groupId>
+                     <artifactId>maven-surefire-plugin</artifactId>
+                     <configuration>
+                        <includes combine.children="override">
+                           <include>**/integration/security/*Test.java</include>
+                           <include>**/integration/ssl/*Test.java</include>
+                           <include>**/integration/amqp/JMSSaslExternalTest.java</include>
+                           <include>**/integration/amqp/connect/AMQPConnectSaslTest.java</include>
+                        </includes>
+                     </configuration>
+                  </plugin>
+               </plugins>
+            </pluginManagement>
+         </build>
+      </profile>
+      <profile>
          <id>jdk16on</id>
             <activation>
          <jdk>[16,)</jdk>


### PR DESCRIPTION
Enables some integration tests in the PR build, to help catch issues for important areas such as TLS and security handling without needing the full 3hr+ build. I tried it out with some reverts to ensure this would have meant PRs would have caught both the JDK15+ SSL runtime breakage (throwing UOE for previously deprecated-for-removal method), and the OpenSSL related issue with the changes made to remove use of those deprecated methods. It would also have caught the karaf tests not working on JDK 11.