### PR TITLE
NO-JIRA: make errorprone consistently opt-in on all JDKs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -947,6 +947,9 @@
           <id>jdk11to15-errorprone</id>
           <activation>
               <jdk>[11,16)</jdk>
+              <property>
+                  <name>errorprone</name>
+              </property>
           </activation>
           <build>
               <plugins>
@@ -967,7 +970,6 @@
       </profile>
       <profile>
           <id>jdk16-errorprone</id>
-          <!-- This is very slow due to all the compiler forking required, so made it opt-in with -Derrorprone -->
           <!-- TODO: MissingOverride check only warns in this profile for now, as JDK15+ added a toString method to CharSequence -->
           <activation>
               <jdk>16</jdk>


### PR DESCRIPTION
The use of errorprone compiler plugin is opt-in on JDK8 and JDK16 already (due to the very slow compiler forking needed there) but is on by default in JDK11 etc with no easy way to disable it (still adds 2 minutes of build overhead running on Java 11 without forking). It would be good to make it consistently opt-in, making it easier to see the core build detail locally without it present (it emits a lot of added output) and not incurring the build overhead unless actually requested.

It will still always be run in CI as that always sets -Derrorprone when running.