### PR TITLE
ARTEMIS-3420: Target Java 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8, 11, 17 ]
+        java: [ 11, 17 ]
 
     steps:
       - uses: actions/checkout@v2
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8, 11, 17 ]
+        java: [ 11, 17 ]
 
     steps:
       - uses: actions/checkout@v2
@@ -75,24 +75,24 @@ jobs:
         run: |
           mvn -s .github/maven-settings.xml -DskipTests -Derrorprone -Pdev -Pextra-tests -Pjmh install
 
-      - name: Build Examples (JDK8 / -Prelease)
-        if: matrix.java == '8'
+      - name: Build Examples (JDK11 / -Prelease)
+        if: matrix.java == '11'
         run: |
           cd examples
           mvn -s ../.github/maven-settings.xml verify -Prelease
 
-      - name: Build Examples (JDK 11+ / -Pexamples,noRun)
-        if: matrix.java != '8'
+      - name: Build Examples (JDK >11 / -Pexamples,noRun)
+        if: matrix.java != '11'
         run: |
           cd examples
           mvn -s ../.github/maven-settings.xml verify -Pexamples,noRun
 
-      - name: Javadoc Check (JDK8 / -Prelease)
-        if: matrix.java == '8'
+      - name: Javadoc Check (JDK11 / -Prelease)
+        if: matrix.java == '11'
         run: |
           mvn -s .github/maven-settings.xml javadoc:javadoc -Prelease
 
-      - name: Javadoc Check (JDK 11+)
-        if: matrix.java != '8'
+      - name: Javadoc Check (JDK >11)
+        if: matrix.java != '11'
         run: |
           mvn -s .github/maven-settings.xml javadoc:javadoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,9 @@ install: true
 matrix:
   include:
     - os: linux
-      jdk: openjdk8
-      env:
-        - EXAMPLES_PROFILE="release"
-    - os: linux
       jdk: openjdk11
       env:
-        - EXAMPLES_PROFILE="examples,noRun"
+        - EXAMPLES_PROFILE="release"
     - os: linux
       jdk: openjdk16
       env:

--- a/artemis-dto/pom.xml
+++ b/artemis-dto/pom.xml
@@ -173,37 +173,4 @@
          </plugins>
       </pluginManagement>
    </build>
-
-   <profiles>
-      <profile>
-         <id>ibmjdk</id>
-         <activation>
-            <file>
-               <exists>${java.home}/../lib/tools.jar</exists>
-            </file>
-         </activation>
-         <build>
-            <pluginManagement>
-               <plugins>
-                  <plugin>
-                     <groupId>org.apache.maven.plugins</groupId>
-                     <artifactId>maven-antrun-plugin</artifactId>
-                     <dependencies>
-                        <dependency>
-                           <groupId>com.sun</groupId>
-                           <artifactId>tools</artifactId>
-                           <!--the real JDK version could be 1.5 or 1.6-->
-                           <version>1.5.0</version>
-                           <scope>system</scope>
-                           <optional>true</optional>
-                           <systemPath>${java.home}/../lib/tools.jar</systemPath>
-                        </dependency>
-                     </dependencies>
-                  </plugin>
-               </plugins>
-            </pluginManagement>
-         </build>
-      </profile>
-   </profiles>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -73,13 +73,15 @@
    <url>https://activemq.apache.org/components/artemis/</url>
 
    <properties>
-      <modular.jdk.surefire.arg />
-      <javac.version>9+181-r4173-1</javac.version>
+      <maven.compiler.source>11</maven.compiler.source>
+      <maven.compiler.target>11</maven.compiler.target>
+
        <!-- base url for site deployment.  See distribution management for full url.  Override this in settings.xml for staging -->
       <staging.siteURL>scp://people.apache.org/x1/www/activemq.apache.org</staging.siteURL>
 
       <retryTests>false</retryTests>
       <logging.config>logging.properties</logging.config>
+      <modular.jdk.surefire.arg>--add-modules java.sql,jdk.unsupported </modular.jdk.surefire.arg>
 
       <activemq-artemis-native-version>1.0.2</activemq-artemis-native-version>
       <karaf.version>4.3.3</karaf.version>
@@ -944,82 +946,7 @@
                <javac-compiler-id>javac</javac-compiler-id>
            </properties>
         </profile>
-      <!-- Google Error Prone has issues with IBM JDK 8 -->
-      <!-- See ARTEMIS-861 -->
-      <profile>
-         <id>ibm-jdk8</id>
-         <activation>
-            <jdk>1.8</jdk>
-            <property>
-               <name>java.vendor</name>
-               <value>IBM Corporation</value>
-            </property>
-         </activation>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-compiler-plugin</artifactId>
-                  <configuration combine.self="override" />
-               </plugin>
-               <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-surefire-plugin</artifactId>
-                  <configuration>
-                     <systemPropertyVariables>
-                        <com.ibm.jsse2.overrideDefaultTLS>true</com.ibm.jsse2.overrideDefaultTLS>
-                     </systemPropertyVariables>
-                  </configuration>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-      <profile>
-         <id>jdk8</id>
-         <activation>
-            <jdk>1.8</jdk>
-         </activation>
-          <properties>
-              <maven.compiler.source>1.8</maven.compiler.source>
-              <maven.compiler.target>1.8</maven.compiler.target>
-          </properties>
-      </profile>
-      <profile>
-          <id>jdk8-errorprone</id>
-          <activation>
-              <jdk>1.8</jdk>
-              <property>
-                  <name>errorprone</name>
-              </property>
-          </activation>
-          <build>
-              <plugins>
-                  <plugin>
-                      <groupId>org.apache.maven.plugins</groupId>
-                      <artifactId>maven-compiler-plugin</artifactId>
-                      <configuration>
-                          <fork>true</fork>
-                          <compilerArgs combine.children="append">
-                              <arg>-XDcompilePolicy=simple</arg>
-                              <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${javac.version}/javac-${javac.version}.jar</arg>
-                              <arg>-Xplugin:ErrorProne -Xep:MissingOverride:ERROR -Xep:NonAtomicVolatileUpdate:ERROR -Xep:SynchronizeOnNonFinalField:ERROR -Xep:StaticQualifiedUsingExpression:ERROR -Xep:WaitNotInLoop:ERROR -XepExcludedPaths:.*/generated-sources/.*</arg>
-                          </compilerArgs>
-                      </configuration>
-                  </plugin>
-              </plugins>
-          </build>
-      </profile>
-      <profile>
-          <id>jdk11on</id>
-          <activation>
-              <jdk>[11,)</jdk>
-          </activation>
-          <properties>
-              <maven.compiler.source>1.8</maven.compiler.source>
-              <maven.compiler.target>11</maven.compiler.target>
-              <modular.jdk.surefire.arg>--add-modules java.sql,jdk.unsupported </modular.jdk.surefire.arg>
-          </properties>
-      </profile>
+
       <profile>
           <id>jdk11to15-errorprone</id>
           <activation>
@@ -1138,8 +1065,8 @@
                         <configuration>
                            <rules>
                               <requireJavaVersion>
-                                 <version>[1.8, 9)</version>
-                                 <message>JDK 8 is required when building the release</message>
+                                 <version>[11, 12)</version>
+                                 <message>JDK 11 is required when building the release</message>
                               </requireJavaVersion>
                            </rules>
                         </configuration>
@@ -1712,8 +1639,8 @@
                <configuration>
                  <rules>
                    <requireJavaVersion>
-                     <version>[1.8, 9),[11,)</version>
-                     <message>You must use either JDK 8 or JDK 11+ when building</message>
+                     <version>[11,)</version>
+                     <message>You must use JDK 11+ when building</message>
                    </requireJavaVersion>
                  </rules>
                </configuration>

--- a/tests/activemq5-unit-tests/pom.xml
+++ b/tests/activemq5-unit-tests/pom.xml
@@ -41,7 +41,7 @@
       <jasypt-version>1.9.3</jasypt-version>
       <directory-version>2.0.0-M6</directory-version>
       <activeio-core-version>3.1.4</activeio-core-version>
-      <byteman.version>2.2.0</byteman.version>
+      <byteman.version>2.2.1</byteman.version>
 
    </properties>
 

--- a/tests/smoke-tests/pom.xml
+++ b/tests/smoke-tests/pom.xml
@@ -28,6 +28,7 @@
 
    <properties>
       <activemq.basedir>${project.basedir}/../../</activemq.basedir>
+      <sts-surefire-extra-args/>
    </properties>
 
    <dependencies>
@@ -224,6 +225,16 @@
                   </configuration>
                </execution>
             </executions>
+         </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+               <compilerArgs>
+                  <arg>--add-exports=java.rmi/sun.rmi.server=ALL-UNNAMED</arg>
+                  <arg>--add-exports=java.rmi/sun.rmi.transport=ALL-UNNAMED</arg>
+               </compilerArgs>
+            </configuration>
          </plugin>
          <plugin>
             <groupId>org.apache.activemq</groupId>
@@ -1294,10 +1305,22 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
                <skipTests>${skipSmokeTests}</skipTests>
-               <argLine>${activemq-surefire-argline}</argLine>
+               <argLine>${sts-surefire-extra-args} ${activemq-surefire-argline}</argLine>
             </configuration>
          </plugin>
       </plugins>
    </build>
+
+   <profiles>
+      <profile>
+         <id>jdk16on</id>
+         <activation>
+            <jdk>[16,)</jdk>
+         </activation>
+         <properties>
+            <sts-surefire-extra-args>--add-opens=java.management.rmi/javax.management.remote.rmi=ALL-UNNAMED --add-opens=java.rmi/sun.rmi.server=ALL-UNNAMED --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED</sts-surefire-extra-args>
+         </properties>
+      </profile>
+   </profiles>
 
 </project>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARTEMIS-3420

I have been extracting and dropping related isolated changes onto main for a while already that have just released with 2.18.0, since they improved various Java 11+ related issues without actually requiring it. These are my remaining changes to actually require and target Java 11, resolve new issues that creates, and clean up some bits that become stale as a result.