### PR TITLE
ARTEMIS-3440: separate effect of -Pdev from test profiles, make them independent

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,8 @@ name: "Build"
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  build:
+  test:
+    name: Test (${{ matrix.java }})
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
@@ -17,9 +18,11 @@ jobs:
           path: |
             ~/.m2/repository
             !~/.m2/repository/org/apache/activemq/artemis-*
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+            !~/.m2/repository/org/apache/activemq/*-artemis
+            !~/.m2/repository/org/apache/activemq/examples
+          key: ${{ runner.os }}-maven-test-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-maven-
+            ${{ runner.os }}-maven-test-
 
       - name: Install JDK ${{ matrix.java }}
         uses: actions/setup-java@v2
@@ -28,23 +31,55 @@ jobs:
           distribution: 'adopt'
 
       # use 'install' so smoke-tests will work
-      # use '-Pextra-tests' to ensure extra-tests compiles even though they won't actually run
       # By setting anything to org.apache.activemq.artemis.core.io.aio.AIOSequentialFileFactory.DISABLED we are disabling libaio loading on the testsuite
+      - name: Fast Tests
+        run: |
+          mvn -s .github/maven-settings.xml -Dorg.apache.activemq.artemis.core.io.aio.AIOSequentialFileFactory.DISABLED=AnythingNotNull -Pfast-tests -Ptests-CI install
+
+
+  checks:
+    name: Checks (${{ matrix.java }})
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ 8, 11, 16 ]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/org/apache/activemq/artemis-*
+            !~/.m2/repository/org/apache/activemq/*-artemis
+            !~/.m2/repository/org/apache/activemq/examples
+          key: ${{ runner.os }}-maven-checks-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-checks-
+            ${{ runner.os }}-maven-test-
+
+      - name: Install JDK ${{ matrix.java }}
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'adopt'
+
       - name: Build Main
         run: |
-          mvn -s .github/maven-settings.xml -Dorg.apache.activemq.artemis.core.io.aio.AIOSequentialFileFactory.DISABLED=AnythingNotNull -Derrorprone -Pdev -Pfast-tests -Pextra-tests -Ptests-CI -Pjmh install
+          mvn -s .github/maven-settings.xml -DskipTests -Derrorprone -Pdev -Pextra-tests -Pjmh install
 
       - name: Build Examples (JDK8 / -Prelease)
         if: matrix.java == '8'
         run: |
           cd examples
-          mvn -s ../.github/maven-settings.xml install -Prelease
+          mvn -s ../.github/maven-settings.xml verify -Prelease
 
       - name: Build Examples (JDK 11+ / -Pexamples,noRun)
         if: matrix.java != '8'
         run: |
           cd examples
-          mvn -s ../.github/maven-settings.xml install -Pexamples,noRun
+          mvn -s ../.github/maven-settings.xml verify -Pexamples,noRun
 
       - name: Javadoc Check (JDK8 / -Prelease)
         if: matrix.java == '8'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       # By setting anything to org.apache.activemq.artemis.core.io.aio.AIOSequentialFileFactory.DISABLED we are disabling libaio loading on the testsuite
       - name: Build Main
         run: |
-          mvn -s .github/maven-settings.xml -Dorg.apache.activemq.artemis.core.io.aio.AIOSequentialFileFactory.DISABLED=AnythingNotNull -Derrorprone -Pfast-tests -Pextra-tests -Ptests-CI -Pjmh install
+          mvn -s .github/maven-settings.xml -Dorg.apache.activemq.artemis.core.io.aio.AIOSequentialFileFactory.DISABLED=AnythingNotNull -Derrorprone -Pdev -Pfast-tests -Pextra-tests -Ptests-CI -Pjmh install
 
       - name: Build Examples (JDK8 / -Prelease)
         if: matrix.java == '8'

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
 # By setting anything to org.apache.activemq.artemis.core.io.aio.AIOSequentialFileFactory.DISABLED we are disabling libaio loading on the testsuite
 script: 
 - set -e
-- mvn -s .github/maven-settings.xml -ntp -Dorg.apache.activemq.artemis.core.io.aio.AIOSequentialFileFactory.DISABLED=AnythingNotNull -Dmaven.test.redirectTestOutputToFile=true -Derrorprone -Pfast-tests -Pextra-tests -Ptests-CI -Pjmh -B install
+- mvn -s .github/maven-settings.xml -ntp -Dorg.apache.activemq.artemis.core.io.aio.AIOSequentialFileFactory.DISABLED=AnythingNotNull -Dmaven.test.redirectTestOutputToFile=true -Derrorprone -Pdev -Pfast-tests -Pextra-tests -Ptests-CI -Pjmh -B install
 - cd examples
 - mvn -s ../.github/maven-settings.xml verify -P${EXAMPLES_PROFILE} -B -q
 

--- a/pom.xml
+++ b/pom.xml
@@ -208,8 +208,6 @@
          -Djava.net.preferIPv4Stack=true -Dbasedir=${basedir}
       </activemq-surefire-argline>
       <activemq.basedir>${project.basedir}</activemq.basedir>
-      <skipLicenseCheck>true</skipLicenseCheck>
-      <skipStyleCheck>true</skipStyleCheck>
       <skipOWASP>true</skipOWASP>
 
       <directory-version>2.0.0.AM25</directory-version>
@@ -1044,20 +1042,40 @@
       </profile>
       <profile>
          <id>dev</id>
-         <properties>
-            <skipStyleCheck>false</skipStyleCheck>
-            <skipLicenseCheck>false</skipLicenseCheck>
-         </properties>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>org.apache.rat</groupId>
+                  <artifactId>apache-rat-plugin</artifactId>
+                  <executions>
+                     <execution>
+                        <phase>compile</phase>
+                        <goals>
+                           <goal>check</goal>
+                        </goals>
+                     </execution>
+                  </executions>
+               </plugin>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-checkstyle-plugin</artifactId>
+                  <executions>
+                     <execution>
+                        <phase>compile</phase>
+                        <goals>
+                           <goal>check</goal>
+                        </goals>
+                     </execution>
+                  </executions>
+               </plugin>
+            </plugins>
+         </build>
       </profile>
       <profile>
          <id>release</id>
          <modules>
             <module>examples</module>
          </modules>
-         <properties>
-            <skipStyleCheck>false</skipStyleCheck>
-            <skipLicenseCheck>false</skipLicenseCheck>
-         </properties>
          <build>
             <plugins>
                <plugin>
@@ -1077,6 +1095,30 @@
                               </requireJavaVersion>
                            </rules>
                         </configuration>
+                     </execution>
+                  </executions>
+               </plugin>
+               <plugin>
+                  <groupId>org.apache.rat</groupId>
+                  <artifactId>apache-rat-plugin</artifactId>
+                  <executions>
+                     <execution>
+                        <phase>compile</phase>
+                        <goals>
+                           <goal>check</goal>
+                        </goals>
+                     </execution>
+                  </executions>
+               </plugin>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-checkstyle-plugin</artifactId>
+                  <executions>
+                     <execution>
+                        <phase>compile</phase>
+                        <goals>
+                           <goal>check</goal>
+                        </goals>
                      </execution>
                   </executions>
                </plugin>
@@ -1136,8 +1178,6 @@
             <skipSoakTests>true</skipSoakTests>
             <skipPerformanceTests>true</skipPerformanceTests>
             <skipExtraTests>false</skipExtraTests>
-            <skipStyleCheck>false</skipStyleCheck>
-            <skipLicenseCheck>false</skipLicenseCheck>
          </properties>
       </profile>
       <profile>
@@ -1149,8 +1189,6 @@
             <skipJmsTests>false</skipJmsTests>
             <skipJoramTests>false</skipJoramTests>
             <skipConcurrentTests>false</skipConcurrentTests>
-            <skipStyleCheck>false</skipStyleCheck>
-            <skipLicenseCheck>false</skipLicenseCheck>
             <skipCompatibilityTests>false</skipCompatibilityTests>
             <testFailureIgnore>false</testFailureIgnore>
             <!-- This enables the karaf-client-integration-tests and
@@ -1513,6 +1551,104 @@
                <artifactId>maven-war-plugin</artifactId>
                <version>3.3.1</version>
             </plugin>
+            <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-checkstyle-plugin</artifactId>
+               <version>${maven.checkstyle.plugin.version}</version>
+               <dependencies>
+                  <dependency>
+                     <groupId>com.github.sevntu-checkstyle</groupId>
+                     <artifactId>sevntu-checks</artifactId>
+                     <version>${sevntu.checks.version}</version>
+                  </dependency>
+                  <dependency>
+                     <groupId>com.puppycrawl.tools</groupId>
+                     <artifactId>checkstyle</artifactId>
+                     <version>${checkstyle.version}</version>
+                  </dependency>
+               </dependencies>
+               <configuration>
+                  <configLocation>${activemq.basedir}/etc/checkstyle.xml</configLocation>
+                  <suppressionsLocation>${activemq.basedir}/etc/checkstyle-suppressions.xml</suppressionsLocation>
+                  <failsOnError>false</failsOnError>
+                  <failOnViolation>true</failOnViolation>
+                  <consoleOutput>true</consoleOutput>
+                  <includeTestSourceDirectory>true</includeTestSourceDirectory>
+               </configuration>
+            </plugin>
+            <plugin>
+               <groupId>org.apache.rat</groupId>
+               <artifactId>apache-rat-plugin</artifactId>
+               <configuration>
+                  <reportFile>${activemq.basedir}/ratReport.txt</reportFile>
+                  <excludes>
+                     <exclude>**/src/main/webapp/hawtconfig.json</exclude>
+                     <exclude>.repository/**</exclude>
+                     <exclude>.travis.yml</exclude>
+                     <exclude>.github/workflows/*</exclude>
+                     <exclude>**/footer.html</exclude>
+                     <exclude>**/*.txt</exclude>
+                     <exclude>**/*.md</exclude>
+                     <exclude>etc/ide-settings/**</exclude>
+                     <exclude>**/*.json</exclude>
+                     <exclude>docs/**/*.json</exclude>
+                     <exclude>docs/**/_book/</exclude>
+                     <exclude>docs/**/_layouts/</exclude>
+                     <exclude>**/target/</exclude>
+                     <exclude>**/META-INF/services/*</exclude>
+                     <exclude>**/META-INF/MANIFEST.MF</exclude>
+                     <exclude>**/*.iml</exclude>
+                     <exclude>**/*.jceks</exclude>
+                     <exclude>**/*.jks</exclude>
+                     <exclude>**/*.p12</exclude>
+                     <exclude>**/xml.xsd</exclude>
+                     <exclude>**/org/apache/activemq/artemis/utils/json/**</exclude>
+                     <exclude>**/org/apache/activemq/artemis/utils/Base64.java</exclude>
+                     <exclude>**/.settings/**</exclude>
+                     <exclude>**/.project</exclude>
+                     <exclude>**/.classpath</exclude>
+                     <exclude>**/.editorconfig</exclude>
+                     <exclude>**/.checkstyle</exclude>
+                     <exclude>**/.factorypath</exclude>
+                     <exclude>**/org.apache.activemq.artemis.cfg</exclude>
+                     <exclude>**/nb-configuration.xml</exclude>
+                     <exclude>**/nbactions-tests.xml</exclude>
+                     <exclude>**/.vscode/settings.json</exclude>
+                     <!-- activemq5 unit tests exclude -->
+                     <exclude>**/*.data</exclude>
+                     <exclude>**/*.bin</exclude>
+                     <exclude>**/src/test/resources/keystore</exclude>
+                     <exclude>**/src/test/java/org/apache/activemq/security/*.ts</exclude>
+                     <exclude>**/*.log</exclude>
+                     <exclude>**/*.redo</exclude>
+
+                      <!-- NPM files -->
+                     <exclude>**/node/**</exclude>
+                     <exclude>**/node_modules/**</exclude>
+                     <exclude>**/package.json</exclude>
+                     <exclude>**/npm-shrinkwrap.json</exclude>
+
+                     <!-- Build time overlay folder -->
+                     <exclude>**/overlays/**</exclude>
+
+                     <!-- things from cmake on the native build -->
+                     <exclude>**/CMakeFiles/</exclude>
+                     <exclude>**/Makefile</exclude>
+                     <exclude>**/cmake_install.cmake</exclude>
+                     <exclude>activemq-artemis-native/src/main/c/org_apache_activemq_artemis_jlibaio_LibaioContext.h</exclude>
+                     <exclude>**/dependency-reduced-pom.xml</exclude>
+
+                     <!-- Mockito -->
+                     <exclude>**/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker</exclude>
+
+                     <!-- .NET Examples-->
+                     <exclude>examples/protocols/amqp/dotnet/**/obj/**/*</exclude>
+                     <exclude>examples/protocols/amqp/dotnet/**/bin/**/*</exclude>
+                     <exclude>examples/protocols/amqp/dotnet/**/readme.md</exclude>
+                     <exclude>examples/protocols/amqp/**/readme.md</exclude>
+                  </excludes>
+               </configuration>
+            </plugin>
          </plugins>
       </pluginManagement>
 
@@ -1571,41 +1707,6 @@
             <version>2.2</version>
          </plugin>
          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>${maven.checkstyle.plugin.version}</version>
-            <dependencies>
-               <dependency>
-                  <groupId>com.github.sevntu-checkstyle</groupId>
-                  <artifactId>sevntu-checks</artifactId>
-                  <version>${sevntu.checks.version}</version>
-               </dependency>
-               <dependency>
-                  <groupId>com.puppycrawl.tools</groupId>
-                  <artifactId>checkstyle</artifactId>
-                  <version>${checkstyle.version}</version>
-               </dependency>
-            </dependencies>
-            <configuration>
-               <skip>${skipStyleCheck}</skip>
-               <configLocation>${activemq.basedir}/etc/checkstyle.xml</configLocation>
-               <suppressionsLocation>${activemq.basedir}/etc/checkstyle-suppressions.xml</suppressionsLocation>
-               <failsOnError>false</failsOnError>
-               <failOnViolation>true</failOnViolation>
-               <consoleOutput>true</consoleOutput>
-               <includeTestSourceDirectory>true</includeTestSourceDirectory>
-            </configuration>
-            <executions>
-               <execution>
-                  <phase>compile</phase>
-                  <goals>
-                     <goal>check</goal>
-                  </goals>
-               </execution>
-            </executions>
-         </plugin>
-
-         <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>findbugs-maven-plugin</artifactId>
             <version>2.5.2</version>
@@ -1616,88 +1717,6 @@
                <effort>Max</effort>
                <failOnError>false</failOnError>
             </configuration>
-         </plugin>
-         <plugin>
-            <groupId>org.apache.rat</groupId>
-            <artifactId>apache-rat-plugin</artifactId>
-            <configuration>
-               <reportFile>${activemq.basedir}/ratReport.txt</reportFile>
-               <skip>${skipLicenseCheck}</skip>
-               <excludes>
-                  <exclude>**/src/main/webapp/hawtconfig.json</exclude>
-                  <exclude>.repository/**</exclude>
-                  <exclude>.travis.yml</exclude>
-                  <exclude>.github/workflows/*</exclude>
-                  <exclude>**/footer.html</exclude>
-                  <exclude>**/*.txt</exclude>
-                  <exclude>**/*.md</exclude>
-                  <exclude>etc/ide-settings/**</exclude>
-                  <exclude>**/*.json</exclude>
-                  <exclude>docs/**/*.json</exclude>
-                  <exclude>docs/**/_book/</exclude>
-                  <exclude>docs/**/_layouts/</exclude>
-                  <exclude>**/target/</exclude>
-                  <exclude>**/META-INF/services/*</exclude>
-                  <exclude>**/META-INF/MANIFEST.MF</exclude>
-                  <exclude>**/*.iml</exclude>
-                  <exclude>**/*.jceks</exclude>
-                  <exclude>**/*.jks</exclude>
-                  <exclude>**/*.p12</exclude>
-                  <exclude>**/xml.xsd</exclude>
-                  <exclude>**/org/apache/activemq/artemis/utils/json/**</exclude>
-                  <exclude>**/org/apache/activemq/artemis/utils/Base64.java</exclude>
-                  <exclude>**/.settings/**</exclude>
-                  <exclude>**/.project</exclude>
-                  <exclude>**/.classpath</exclude>
-                  <exclude>**/.editorconfig</exclude>
-                  <exclude>**/.checkstyle</exclude>
-                  <exclude>**/.factorypath</exclude>
-                  <exclude>**/org.apache.activemq.artemis.cfg</exclude>
-                  <exclude>**/nb-configuration.xml</exclude>
-                  <exclude>**/nbactions-tests.xml</exclude>
-                  <exclude>**/.vscode/settings.json</exclude>
-                  <!-- activemq5 unit tests exclude -->
-                  <exclude>**/*.data</exclude>
-                  <exclude>**/*.bin</exclude>
-                  <exclude>**/src/test/resources/keystore</exclude>
-                  <exclude>**/src/test/java/org/apache/activemq/security/*.ts</exclude>
-                  <exclude>**/*.log</exclude>
-                  <exclude>**/*.redo</exclude>
-
-                  <!-- NPM files -->
-                  <exclude>**/node/**</exclude>
-                  <exclude>**/node_modules/**</exclude>
-                  <exclude>**/package.json</exclude>
-                  <exclude>**/npm-shrinkwrap.json</exclude>
-
-                  <!-- Build time overlay folder -->
-                  <exclude>**/overlays/**</exclude>
-
-                  <!-- things from cmake on the native build -->
-                  <exclude>**/CMakeFiles/</exclude>
-                  <exclude>**/Makefile</exclude>
-                  <exclude>**/cmake_install.cmake</exclude>
-                  <exclude>activemq-artemis-native/src/main/c/org_apache_activemq_artemis_jlibaio_LibaioContext.h</exclude>
-                  <exclude>**/dependency-reduced-pom.xml</exclude>
-
-                  <!-- Mockito -->
-                  <exclude>**/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker</exclude>
-
-                  <!-- .NET Examples-->
-                  <exclude>examples/protocols/amqp/dotnet/**/obj/**/*</exclude>
-                  <exclude>examples/protocols/amqp/dotnet/**/bin/**/*</exclude>
-                  <exclude>examples/protocols/amqp/dotnet/**/readme.md</exclude>
-                  <exclude>examples/protocols/amqp/**/readme.md</exclude>
-               </excludes>
-            </configuration>
-            <executions>
-               <execution>
-                  <phase>compile</phase>
-                  <goals>
-                     <goal>check</goal>
-                  </goals>
-               </execution>
-            </executions>
          </plugin>
          <plugin>
             <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARTEMIS-3440

The JIRA changes are in the first commit.

The PR also includes a second commit building on the first, to improve the GHA job config so various checks are run independently, ensuring the actual test suite finishes quicker, happens even if the checks fail (and more typically, vice versa), and the checks start and finish sooner. All together aiming to getting earlier and more complete feedback on the changes, with the overall runs sometimes ~10 minutes faster than before.

(This first run wont be as fast as it will most of the time, as the cache fixups will mean it has it to repopulate - though comparing, this scenario still looks to be ~15 minutes faster than it was before the changes, as the main branch cache happened to repopulate this morning, which is when I noticed some of the issues with its use that I also fixed here)