### PR TITLE
ARTEMIS-3453: exclude log4j transitive dep from zookeeper

### DIFF
--- a/artemis-quorum-ri/pom.xml
+++ b/artemis-quorum-ri/pom.xml
@@ -43,12 +43,6 @@
       <dependency>
          <groupId>org.apache.zookeeper</groupId>
          <artifactId>zookeeper</artifactId>
-         <exclusions>
-            <exclusion>
-               <groupId>org.slf4j</groupId>
-               <artifactId>slf4j-log4j12</artifactId>
-            </exclusion>
-         </exclusions>
       </dependency>
       <dependency>
          <groupId>org.apache.curator</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -886,6 +886,16 @@
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
             <version>${zookeeper.version}</version>
+            <exclusions>
+               <exclusion>
+                  <groupId>org.slf4j</groupId>
+                  <artifactId>slf4j-log4j12</artifactId>
+               </exclusion>
+               <exclusion>
+                  <groupId>log4j</groupId>
+                  <artifactId>log4j</artifactId>
+               </exclusion>
+            </exclusions>
          </dependency>
          <dependency>
             <groupId>org.apache.zookeeper</groupId>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARTEMIS-3453

Didnt test this at all yet other than seeing its effect on the main build. Seems the way to go though so raising for a PR run and any input from others.

In particular, by excluding sl4fj-log4j and log4j across the board, it may be necessary to add other dependencies to some modules (examples?) if they lack a another means of output such as another slf4j bridge.