### PR TITLE
NO-JIRA: undo addition of module-specific resources-plugin version

### DIFF
--- a/tests/integration-tests/pom.xml
+++ b/tests/integration-tests/pom.xml
@@ -478,7 +478,11 @@
       <plugins>
          <plugin>
             <artifactId>maven-resources-plugin</artifactId>
-            <version>${maven-resources-plugin-version}</version>
+            <configuration>
+               <nonFilteredFileExtensions>
+                  <nonFilteredFileExtension>jks</nonFilteredFileExtension>
+               </nonFilteredFileExtensions>
+            </configuration>
             <executions>
                <execution>
                   <id>copy-security-resources</id>
@@ -569,15 +573,6 @@
                   </goals>
                </execution>
             </executions>
-         </plugin>
-         <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-resources-plugin</artifactId>
-            <configuration>
-               <nonFilteredFileExtensions>
-                  <nonFilteredFileExtension>jks</nonFilteredFileExtension>
-               </nonFilteredFileExtensions>
-            </configuration>
          </plugin>
       </plugins>
    </build>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -29,7 +29,6 @@
 
    <properties>
       <activemq.basedir>${project.basedir}/..</activemq.basedir>
-      <maven-resources-plugin-version>2.6</maven-resources-plugin-version>
    </properties>
 
    <dependencyManagement>

--- a/tests/smoke-tests/pom.xml
+++ b/tests/smoke-tests/pom.xml
@@ -203,7 +203,6 @@
       <plugins>
          <plugin>
             <artifactId>maven-resources-plugin</artifactId>
-            <version>${maven-resources-plugin-version}</version>
             <executions>
                <execution>
                   <id>copy-security-resources</id>

--- a/tests/unit-tests/pom.xml
+++ b/tests/unit-tests/pom.xml
@@ -181,7 +181,6 @@
       <plugins>
          <plugin>
             <artifactId>maven-resources-plugin</artifactId>
-            <version>${maven-resources-plugin-version}</version>
             <executions>
                <execution>
                   <id>copy-security-resources</id>


### PR DESCRIPTION
Commit 97e84bb0d12cd2ce51571032ec3a946a97e6589d added in some explicit uses of the maven-resources plugin, and specifically configured use of version 2.6 for these. The build is otherwise already using version 3.1.0 of the resources-plugin, via pluginManagement from the apache parent pom. Its not clear the specific older version was needed, so this would remove it and keep the version config consistent and consolidated in the parents.

@brusdev ^

(Original change should probably have a JIRA that this could have gone against also)