### PR TITLE
NO-JIRA Adding quorum paging & large msg BackupSyncJournalTest

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/BackupSyncJournalTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/BackupSyncJournalTest.java
@@ -22,7 +22,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
@@ -51,6 +50,7 @@ import org.apache.activemq.artemis.core.server.files.FileMoveManager;
 import org.apache.activemq.artemis.tests.integration.cluster.util.BackupSyncDelay;
 import org.apache.activemq.artemis.tests.integration.cluster.util.TestableServer;
 import org.apache.activemq.artemis.tests.util.TransportConfigurationUtils;
+import org.apache.activemq.artemis.utils.ReusableLatch;
 import org.apache.activemq.artemis.utils.UUID;
 import org.jboss.logging.Logger;
 import org.junit.Assert;
@@ -419,10 +419,14 @@ public class BackupSyncJournalTest extends FailoverTestBase {
 
    private class FailoverWaiter implements FailoverEventListener {
 
-      private CountDownLatch latch;
+      private final ReusableLatch latch;
+
+      FailoverWaiter() {
+         latch = new ReusableLatch(1);
+      }
 
       public void reset() {
-         latch = new CountDownLatch(1);
+         latch.setCount(0);
       }
 
       @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/quorum/PluggableQuorumBackupSyncLargeMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/quorum/PluggableQuorumBackupSyncLargeMessageTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.cluster.failover.quorum;
+
+import org.apache.activemq.artemis.core.config.ha.ReplicationBackupPolicyConfiguration;
+import org.apache.activemq.artemis.tests.integration.cluster.failover.BackupSyncLargeMessageTest;
+
+public class PluggableQuorumBackupSyncLargeMessageTest extends BackupSyncLargeMessageTest {
+
+   @Override
+   protected void createConfigs() throws Exception {
+      createPluggableReplicatedConfigs();
+   }
+
+   @Override
+   protected void setupHAPolicyConfiguration() {
+      ((ReplicationBackupPolicyConfiguration) backupConfig.getHAPolicyConfiguration())
+         .setMaxSavedReplicatedJournalsSize(2)
+         .setAllowFailBack(true);
+   }
+
+}

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/quorum/PluggableQuorumBackupSyncPagingTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/quorum/PluggableQuorumBackupSyncPagingTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.cluster.failover.quorum;
+
+import org.apache.activemq.artemis.core.config.ha.ReplicationBackupPolicyConfiguration;
+import org.apache.activemq.artemis.tests.integration.cluster.failover.BackupSyncPagingTest;
+
+public class PluggableQuorumBackupSyncPagingTest extends BackupSyncPagingTest {
+
+   @Override
+   protected void createConfigs() throws Exception {
+      createPluggableReplicatedConfigs();
+   }
+
+   @Override
+   protected void setupHAPolicyConfiguration() {
+      ((ReplicationBackupPolicyConfiguration) backupConfig.getHAPolicyConfiguration())
+         .setMaxSavedReplicatedJournalsSize(2)
+         .setAllowFailBack(true);
+   }
+
+}


### PR DESCRIPTION
@clebertsuconic This is just adding support to other 2 scenarios, but given that replication process is 1:1 with the `classic` replication I'm not sure yet if makes sense to have both tests in (pluggable quorum + classic); maybe I can get rid of the original one and replace with this? 
I'm opened to suggestions