### PR TITLE
ARTEMIS-3465 BufferSplitter::split shouldn't consume input buffer

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/BufferSplitter.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/BufferSplitter.java
@@ -28,7 +28,7 @@ public class BufferSplitter {
 
    public static void split(ActiveMQBuffer buffer, int splitSize, Consumer<EncodingSupport> target) {
       byte[] bytesBuffer = new byte[buffer.readableBytes()];
-      buffer.readBytes(bytesBuffer);
+      buffer.getBytes(buffer.readerIndex(), bytesBuffer);
       split(bytesBuffer, splitSize, target);
    }
 

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/persistence/impl/journal/BufferSplitterTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/persistence/impl/journal/BufferSplitterTest.java
@@ -33,10 +33,16 @@ public class BufferSplitterTest {
 
       ActiveMQBuffer outputBuffer = ActiveMQBuffers.fixedBuffer(1000 * DataConstants.SIZE_INT);
 
+      final int rdx = buffer.readerIndex();
+      final int readableBytes = buffer.readableBytes();
+
       BufferSplitter.split(buffer, 77, (c) -> {
          Assert.assertTrue(c.getEncodeSize() <= 77);
          c.encode(outputBuffer);
       });
+
+      Assert.assertEquals(rdx, buffer.readerIndex());
+      Assert.assertEquals(readableBytes, buffer.readableBytes());
 
       outputBuffer.resetReaderIndex();
       buffer.resetReaderIndex();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARTEMIS-3465