### PR TITLE
rename protocols page

### DIFF
--- a/docs/user-manual/en/SUMMARY.md
+++ b/docs/user-manual/en/SUMMARY.md
@@ -10,7 +10,7 @@
 * [Using the Server](using-server.md)
 * [Upgrading](upgrading.md)
 * [Address Model](address-model.md)
-* [Protocols and Interoperability](protocols-interoperability.md)
+* [Supported Protocols](supported-protocols.md)
 * [AMQP](amqp.md)
     * [Broker Connections](amqp-broker-connections.md)
 * [MQTT](mqtt.md)

--- a/docs/user-manual/en/amqp.md
+++ b/docs/user-manual/en/amqp.md
@@ -5,7 +5,7 @@ Apache ActiveMQ Artemis supports the [AMQP
 specification. By default there are `acceptor` elements configured to accept
 AMQP connections on ports `61616` and `5672`.
 
-See the general [Protocols and Interoperability](protocols-interoperability.md)
+See the [Supported Protocols](supported-protocols.md)
 chapter for details on configuring an `acceptor` for AMQP.
 
 You can use *any* AMQP 1.0 compatible clients.

--- a/docs/user-manual/en/mqtt.md
+++ b/docs/user-manual/en/mqtt.md
@@ -11,7 +11,7 @@ Apache ActiveMQ Artemis supports MQTT v3.1.1 (and also the older v3.1 code
 message format). By default there are `acceptor` elements configured to accept
 MQTT connections on ports `61616` and `1883`.
 
-See the general [Protocols and Interoperability](protocols-interoperability.md)
+See the [Supported Protocols](supported-protocols.md)
 chapter for details on configuring an `acceptor` for MQTT.
 
 The best source of information on the MQTT protocol is in the [3.1.1

--- a/docs/user-manual/en/openwire.md
+++ b/docs/user-manual/en/openwire.md
@@ -6,7 +6,7 @@ ActiveMQ 5.x JMS client can talk directly to an Apache ActiveMQ Artemis server.
 By default there is an `acceptor` configured to accept OpenWire connections on
 port `61616`.
 
-See the general [Protocols and Interoperability](protocols-interoperability.md)
+See the [Supported Protocols](supported-protocols.md)
 chapter for details on configuring an `acceptor` for OpenWire.
 
 Refer to the OpenWire examples for a look at this functionality in action.

--- a/docs/user-manual/en/stomp.md
+++ b/docs/user-manual/en/stomp.md
@@ -10,7 +10,7 @@ good choice for interoperability.
 By default there are `acceptor` elements configured to accept STOMP connections
 on ports `61616` and `61613`.
 
-See the general [Protocols and Interoperability](protocols-interoperability.md)
+See the [Supported Protocols](supported-protocols.md)
 chapter for details on configuring an `acceptor` for STOMP.
 
 Refer to the STOMP examples for a look at some of this functionality in action.

--- a/docs/user-manual/en/supported-protocols.md
+++ b/docs/user-manual/en/supported-protocols.md
@@ -1,4 +1,4 @@
-# Protocols and Interoperability
+# Supported Protocols
 
 Apache ActiveMQ Artemis has a powerful & flexible core which provides a foundation upon which other protocols can be
 implemented. Each protocol implementation translates the ideas of its specific protocol onto this core.
@@ -6,7 +6,7 @@ implemented. Each protocol implementation translates the ideas of its specific p
 The broker ships with a client implementation which interacts directly with this core. It uses what's called the ["core"
 API](core.md), and it communicates over the network using the "core" protocol.
 
-## Supported Protocols
+## Protocols
 
 The broker has a pluggable protocol architecture.  Protocol plugins come in the form of protocol modules.  Each protocol 
 module is included on the broker's class path and loaded by the broker at boot time. The broker ships with 5 protocol 

--- a/docs/user-manual/en/versions.md
+++ b/docs/user-manual/en/versions.md
@@ -474,7 +474,7 @@ Highlights:
 
 Highlights:
 - [JMX configuration via XML](management.md#role-based-authorisation-for-jmx) rather than having to use system properties via command line or start script.
-- Configuration of [max frame payload length for STOMP web-socket](protocols-interoperability.md#stomp-over-web-sockets).
+- Configuration of [max frame payload length for STOMP web-socket](supported-protocols.md#stomp-over-web-sockets).
 - Ability to configure HA using JDBC persistence.
 - Implement [role-based access control for management objects](management.md).
 


### PR DESCRIPTION
@clebertsuconic  as discussed, but I'm not sure if this makes sense given the content of the page, alternative might be 'Supported Protocols and APIs'?