### PR TITLE
ARTEMIS-xxxx Fix wrong path to docker-run.sh in docker files

### DIFF
--- a/artemis-docker/Dockerfile-adoptopenjdk-11
+++ b/artemis-docker/Dockerfile-adoptopenjdk-11
@@ -57,7 +57,7 @@ USER root
 
 RUN mkdir /var/lib/artemis-instance && chown -R artemis.artemis /var/lib/artemis-instance
 
-COPY ./docker/docker-run.sh /
+COPY ./docker-run.sh /
 
 USER artemis
 

--- a/artemis-docker/Dockerfile-centos
+++ b/artemis-docker/Dockerfile-centos
@@ -57,7 +57,7 @@ USER root
 
 RUN mkdir /var/lib/artemis-instance && chown -R artemis.artemis /var/lib/artemis-instance
 
-COPY ./docker/docker-run.sh /
+COPY ./docker-run.sh /
 
 USER artemis
 

--- a/artemis-docker/Dockerfile-debian
+++ b/artemis-docker/Dockerfile-debian
@@ -57,7 +57,7 @@ USER root
 
 RUN mkdir /var/lib/artemis-instance && chown -R artemis.artemis /var/lib/artemis-instance
 
-COPY ./docker/docker-run.sh /
+COPY ./docker-run.sh /
 
 USER artemis
 


### PR DESCRIPTION
Docker images could not be built because of wrong path to the bash script docker-run.sh