### PR TITLE
[ARTEMIS-3494]: ActiveMQClientProtocolManagerFactory shouldn't have a…

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorImpl.java
@@ -95,7 +95,7 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
    private static final long serialVersionUID = -1615857864410205260L;
 
    // This is the default value
-   private ClientProtocolManagerFactory protocolManagerFactory = ActiveMQClientProtocolManagerFactory.getInstance(this);
+   private ClientProtocolManagerFactory protocolManagerFactory = new ActiveMQClientProtocolManagerFactory().setLocator(this);
 
    private final boolean ha;
 
@@ -506,7 +506,7 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
    public ClientProtocolManagerFactory getProtocolManagerFactory() {
       if (protocolManagerFactory == null) {
          // Default one in case it's null
-         protocolManagerFactory = ActiveMQClientProtocolManagerFactory.getInstance(this);
+         protocolManagerFactory = new ActiveMQClientProtocolManagerFactory().setLocator(this);
       }
       return protocolManagerFactory;
    }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ActiveMQClientProtocolManagerFactory.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ActiveMQClientProtocolManagerFactory.java
@@ -25,9 +25,6 @@ public class ActiveMQClientProtocolManagerFactory implements ClientProtocolManag
 
    private static final long serialVersionUID = 1;
 
-   private ActiveMQClientProtocolManagerFactory() {
-   }
-
    ServerLocator locator;
 
    @Override
@@ -36,8 +33,9 @@ public class ActiveMQClientProtocolManagerFactory implements ClientProtocolManag
    }
 
    @Override
-   public void setLocator(ServerLocator locator) {
+   public ClientProtocolManagerFactory setLocator(ServerLocator locator) {
       this.locator = locator;
+      return this;
    }
 
    public static final ActiveMQClientProtocolManagerFactory getInstance(ServerLocator locator) {

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/ClientProtocolManagerFactory.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/ClientProtocolManagerFactory.java
@@ -23,7 +23,7 @@ public interface ClientProtocolManagerFactory {
 
    ClientProtocolManager newProtocolManager();
 
-   void setLocator(ServerLocator locator);
+   ClientProtocolManagerFactory setLocator(ServerLocator locator);
 
    ServerLocator getLocator();
 

--- a/artemis-protocols/artemis-hqclient-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/hornetq/client/HornetQClientProtocolManagerFactory.java
+++ b/artemis-protocols/artemis-hqclient-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/hornetq/client/HornetQClientProtocolManagerFactory.java
@@ -36,10 +36,11 @@ public class HornetQClientProtocolManagerFactory implements ClientProtocolManage
    }
 
    @Override
-   public void setLocator(ServerLocator locator) {
+   public ClientProtocolManagerFactory setLocator(ServerLocator locator) {
       this.locator = locator;
       locator.addIncomingInterceptor(new HQPropertiesConversionInterceptor(true));
       locator.addOutgoingInterceptor(new HQPropertiesConversionInterceptor(false));
+      return this;
    }
 
    /**

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ActiveMQServerSideProtocolManagerFactory.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ActiveMQServerSideProtocolManagerFactory.java
@@ -44,8 +44,9 @@ public class ActiveMQServerSideProtocolManagerFactory implements ClientProtocolM
    }
 
    @Override
-   public void setLocator(ServerLocator locator) {
+   public ClientProtocolManagerFactory setLocator(ServerLocator locator) {
       this.locator = locator;
+      return this;
    }
 
    public static ActiveMQServerSideProtocolManagerFactory getInstance(ServerLocator locator, StorageManager storageManager) {


### PR DESCRIPTION
… private constructor.

* Removing the 'private' constructor
* Removing the use of a static getInstance

Issue: https://issues.apache.org/jira/browse/ARTEMIS-3494