### PR TITLE
ARTEMIS-3461 provide a more native AMQP message represention in browse-queue

### DIFF
--- a/artemis-server/pom.xml
+++ b/artemis-server/pom.xml
@@ -103,6 +103,11 @@
          <scope>test</scope>
       </dependency>
       <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-amqp-protocol</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+      <dependency>
          <groupId>org.jctools</groupId>
          <artifactId>jctools-core</artifactId>
       </dependency>


### PR DESCRIPTION
added a message viewer for AMQP messages.
the message is used before it is converted to CORE to bypass any conversion errors and to be able to use the original message.

the message presentation has the following features:
* full view of the "amqp-value" (the regular payload)
* view "header" details in the Headers table
* view "message-annotations" details in the Properties table
* view "properties" details also in the Headers table
* ignoring "delivery-annotations", "application-annotations", "data", "amqp-sequence" and "footer" blocks for now