### PR TITLE
ARTEMIS-649 deprecate the HTML based JMX reports

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
@@ -1139,6 +1139,7 @@ public interface ActiveMQServerControl {
     * List all the prepared transaction, sorted by date,
     * oldest first, with details, in HTML format
     */
+   @Deprecated
    @Operation(desc = "List all the prepared transaction, sorted by date, oldest first, with details, in HTML format")
    String listPreparedTransactionDetailsAsHTML() throws Exception;
 

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/QueueControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/QueueControl.java
@@ -632,6 +632,7 @@ public interface QueueControl {
    /**
     * Lists the message counter history for this queue as a HTML table.
     */
+   @Deprecated
    @Operation(desc = "List the message counters history HTML", impact = MBeanOperationInfo.INFO)
    String listMessageCounterHistoryAsHTML() throws Exception;
 

--- a/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/JMSServerManager.java
+++ b/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/JMSServerManager.java
@@ -337,6 +337,7 @@ public interface JMSServerManager extends ActiveMQComponent {
 
    String listPreparedTransactionDetailsAsJSON() throws Exception;
 
+   @Deprecated
    String listPreparedTransactionDetailsAsHTML() throws Exception;
 
    ActiveMQServer getActiveMQServer();

--- a/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/impl/JMSServerManagerImpl.java
+++ b/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/impl/JMSServerManagerImpl.java
@@ -1324,6 +1324,7 @@ public class JMSServerManagerImpl extends CleaningActivateCallback implements JM
       return server.getActiveMQServerControl().listPreparedTransactionDetailsAsJSON((xid, tx, creation) -> new JMSTransactionDetail(xid, tx, creation));
    }
 
+   @Deprecated
    @Override
    public String listPreparedTransactionDetailsAsHTML() throws Exception {
       return server.getActiveMQServerControl().listPreparedTransactionDetailsAsHTML((xid, tx, creation) -> new JMSTransactionDetail(xid, tx, creation));

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -1986,11 +1986,13 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
       }
    }
 
+   @Deprecated
    @Override
    public String listPreparedTransactionDetailsAsHTML() throws Exception {
       return listPreparedTransactionDetailsAsHTML((xid, tx, creation) -> new CoreTransactionDetail(xid, tx, creation));
    }
 
+   @Deprecated
    public String listPreparedTransactionDetailsAsHTML(TransactionDetailFactory factory) throws Exception {
       if (AuditLogger.isBaseLoggingEnabled()) {
          AuditLogger.listPreparedTransactionDetailsAsHTML(this.server, factory);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/QueueControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/QueueControlImpl.java
@@ -1423,6 +1423,7 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
       }
    }
 
+   @Deprecated
    @Override
    public String listMessageCounterAsHTML() {
       if (AuditLogger.isBaseLoggingEnabled()) {
@@ -1453,6 +1454,7 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
       }
    }
 
+   @Deprecated
    @Override
    public String listMessageCounterHistoryAsHTML() {
       if (AuditLogger.isBaseLoggingEnabled()) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/messagecounter/impl/MessageCounterHelper.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/messagecounter/impl/MessageCounterHelper.java
@@ -48,6 +48,7 @@ public class MessageCounterHelper {
       return DayCounterInfo.toJSON(infos);
    }
 
+   @Deprecated
    public static String listMessageCounterAsHTML(final MessageCounter[] counters) {
       if (counters == null) {
          return null;
@@ -88,6 +89,7 @@ public class MessageCounterHelper {
       return ret.toString();
    }
 
+   @Deprecated
    public static String listMessageCounterHistoryAsHTML(final MessageCounter[] counters) {
       if (counters == null) {
          return null;


### PR DESCRIPTION
The HTML output methods are hold-overs from way back when the code-base
started off as JBoss Messaging 2 and the broker mainly ran in JBoss AS 4
and 5 which leveraged an HTML-based JMX console where these methods
would be executed and spit out nicely formatted data. That stuff has all
long since been retired so this commit deprecates the HTML-based
management methods so they can be removed completely in a future release.
JSON is a better structured output format for this and most of the
deprecated methods have JSON alternatives.