### PR TITLE
ARTEMIS-3541 createQueue ignoring autoDeleteAddress flag

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -2397,15 +2397,13 @@ public class ActiveMQServerImpl implements ActiveMQServer {
             callBrokerQueuePlugins(plugin -> plugin.afterDestroyQueue(queue, address, session, checkConsumerCount, removeConsumers, autoDeleteAddress));
          }
 
-         if (queue.isTemporary()) {
-            AddressInfo addressInfo = getAddressInfo(address);
+         AddressInfo addressInfo = getAddressInfo(address);
 
-            if (autoDeleteAddress && postOffice != null && addressInfo != null && addressInfo.isAutoCreated() && !isAddressBound(address.toString()) && addressSettingsRepository.getMatch(address.toString()).getAutoDeleteAddressesDelay() == 0) {
-               try {
-                  removeAddressInfo(address, session);
-               } catch (ActiveMQDeleteAddressException e) {
-                  // Could be thrown if the address has bindings or is not deletable.
-               }
+         if (autoDeleteAddress && postOffice != null && addressInfo != null && addressInfo.isAutoCreated() && !isAddressBound(address.toString()) && addressSettingsRepository.getMatch(address.toString()).getAutoDeleteAddressesDelay() == 0) {
+            try {
+               removeAddressInfo(address, session);
+            } catch (ActiveMQDeleteAddressException e) {
+               // Could be thrown if the address has bindings or is not deletable.
             }
          }
 


### PR DESCRIPTION
Commit 481b73c8cabf9d7c88bca048b97bd587661b9c52 from ARTEMIS-3502
inadvertently broke this functionality. This commit restores the
original behavior. When autoDeleteAddress is true then the queue's
address should be automatically deleted regardless of whether or not it
is temporary (assuming it meets all the other criteria).