### PR TITLE
ARTEMIS-3542 Avoid requesting LDAP root attribute

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/jaas/LDAPLoginModule.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/jaas/LDAPLoginModule.java
@@ -579,7 +579,12 @@ public class LDAPLoginModule implements AuditLoginModule {
       context.addToEnvironment(Context.SECURITY_PRINCIPAL, dn);
       context.addToEnvironment(Context.SECURITY_CREDENTIALS, password);
       try {
-         context.getAttributes("", null);
+         String baseDn = getLDAPPropertyValue(ConfigKey.CONNECTION_URL).replaceFirst(".*/", ",");
+         String userDn = dn.replace(baseDn, "");
+         if (logger.isDebugEnabled()) {
+            logger.debug("Get user Attributes with dn " + userDn);
+         }
+         context.getAttributes(userDn, null);
          isValid = true;
          if (logger.isDebugEnabled()) {
             logger.debug("User " + dn + " successfully bound.");


### PR DESCRIPTION
Check getAttributes with dn of user entry to avoid missing permissions