### PR TITLE
ARTEMIS-3140 Extra options in LDAP login module

### DIFF
--- a/docs/user-manual/en/security.md
+++ b/docs/user-manual/en/security.md
@@ -819,6 +819,9 @@ system. It is implemented by
   testing or debugging; normally, it should be set to `false`, or omitted;
   default is `false`
 
+Any additional configuration option not recognized by the LDAP login module itself 
+is passed as-is to the underlying LDAP connection logic.
+
 Add user entries under the node specified by the `userBase` option. When
 creating a new user entry in the directory, choose an object class that
 supports the `userPassword` attribute (for example, the `person` or


### PR DESCRIPTION
Adds support for extra configuration options to LDAP login module to
prepare for supporting any future/custom string configuration in LDAP
directory context creation.

Details:
* Changed LDAPLoginModule to pass any string configuration not recognized by the module itself to the InitialDirContext contruction environment.
* Changed the static LDAPLoginModule configuration key fields to an enum to be able to loop through the specified keys (e.g. to filter out the internal LDAPLoginModule configuration keys from the keys passed to InitialDirContext).
* Few fixes for issues reported by static analysis tools.
* Tested that LDAP authentication with TLS+GSSAPI works  against a recent Windows AD server with Java OpenJDK11U-jdk_x64_windows_hotspot_11.0.13_8 by setting the property com.sun.jndi.ldap.tls.cbtype (see ARTEMIS-3140) in JAAS login.conf.
* Moved LDAPLoginModuleTest to the correct package to be able to access LDAPLoginModule package privates from the test code.
* Added a test to LDAPLoginModuleTest for the task changes.
* Updated documentation to reflect the changes.
