### PR TITLE
ARTEMIS-3461: add some tests and resolve various issues spotted

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/JsonUtil.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/JsonUtil.java
@@ -326,7 +326,7 @@ public final class JsonUtil {
    }
 
    public static String truncateString(final String str, final int valueSizeLimit) {
-      if (str.length() > valueSizeLimit) {
+      if (valueSizeLimit >= 0 && str.length() > valueSizeLimit) {
          return new StringBuilder(valueSizeLimit + 32).append(str.substring(0, valueSizeLimit)).append(", + ").append(str.length() - valueSizeLimit).append(" more").toString();
       } else {
          return str;

--- a/artemis-core-client/src/test/java/org/apache/activemq/artemis/api/core/JsonUtilTest.java
+++ b/artemis-core-client/src/test/java/org/apache/activemq/artemis/api/core/JsonUtilTest.java
@@ -69,7 +69,8 @@ public class JsonUtilTest {
       Assert.assertEquals(6, jsonObject.getJsonArray("byteArray").size());
    }
 
-   @Test public void testAddByteArrayToJsonArray() {
+   @Test
+   public void testAddByteArrayToJsonArray() {
       JsonArrayBuilder jsonArrayBuilder = JsonLoader.createArrayBuilder();
       byte[] bytes = {0x0a, 0x1b, 0x2c, 0x3d, 0x4e, 0x5f};
 
@@ -78,5 +79,45 @@ public class JsonUtilTest {
       JsonArray jsonArray = jsonArrayBuilder.build();
 
       Assert.assertEquals(1, jsonArray.size());
+   }
+
+   @Test
+   public void testTruncateUsingStringWithValueSizeLimit() {
+      String prefix = "12345";
+      int valueSizeLimit = prefix.length();
+      String remaining = "remaining";
+
+      String truncated = (String) JsonUtil.truncate(prefix + remaining, valueSizeLimit);
+
+      String expected = prefix + ", + " + String.valueOf(remaining.length()) + " more";
+      Assert.assertEquals(expected, truncated);
+   }
+
+   @Test
+   public void testTruncateUsingStringWithoutValueSizeLimit() {
+      String input = "testTruncateUsingStringWithoutValueSizeLimit";
+      String notTruncated = (String) JsonUtil.truncate(input, -1);
+
+      Assert.assertEquals(input, notTruncated);
+   }
+
+   @Test
+   public void testTruncateStringWithValueSizeLimit() {
+      String prefix = "12345";
+      int valueSizeLimit = prefix.length();
+      String remaining = "remaining";
+
+      String truncated = JsonUtil.truncateString(prefix + remaining, valueSizeLimit);
+
+      String expected = prefix + ", + " + String.valueOf(remaining.length()) + " more";
+      Assert.assertEquals(expected, truncated);
+   }
+
+   @Test
+   public void testTruncateStringWithoutValueSizeLimit() {
+      String input = "testTruncateStringWithoutValueSizeLimit";
+      String notTruncated = JsonUtil.truncateString(input, -1);
+
+      Assert.assertEquals(input, notTruncated);
    }
 }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
@@ -881,7 +881,7 @@ public abstract class AMQPMessage extends RefCountMessage implements org.apache.
             map.put(propertiesPrefix + "contentEncoding", properties.getContentEncoding().toString());
          }
          if (properties.getGroupId() != null) {
-            map.put(propertiesPrefix + "groupID", properties.getGroupId());
+            map.put(propertiesPrefix + "groupId", properties.getGroupId());
          }
          if (properties.getGroupSequence() != null) {
             map.put(propertiesPrefix + "groupSequence", properties.getGroupSequence().intValue());
@@ -916,9 +916,9 @@ public abstract class AMQPMessage extends RefCountMessage implements org.apache.
                map.put(prefix + "x-opt-delivery-time", deliveryTime);
             } else if ("x-opt-delivery-delay".equals(key) && entry.getValue() != null) {
                long delay = ((Number) entry.getValue()).longValue();
-               map.put("x-opt-delivery-delay", delay);
+               map.put(prefix + "x-opt-delivery-delay", delay);
             } else if (AMQPMessageSupport.X_OPT_INGRESS_TIME.equals(key) && entry.getValue() != null) {
-               map.put("X_OPT_INGRESS_TIME", ((Number) entry.getValue()).longValue());
+               map.put(prefix + AMQPMessageSupport.X_OPT_INGRESS_TIME, ((Number) entry.getValue()).longValue());
             } else {
                try {
                   map.put(prefix + key, entry.getValue());
@@ -1878,30 +1878,25 @@ public abstract class AMQPMessage extends RefCountMessage implements org.apache.
          }
 
          final Symbol contentType = properties != null ? properties.getContentType() : null;
-         final String contentTypeString = contentType != null ? contentType.toString() : null;
 
          if (m.getBody() instanceof Data && contentType != null) {
-
-            if (contentType.equals(AMQPMessageSupport.SERIALIZED_JAVA_OBJECT_CONTENT_TYPE)) {
+            if (AMQPMessageSupport.SERIALIZED_JAVA_OBJECT_CONTENT_TYPE.equals(contentType)) {
                type = OBJECT_TYPE;
-            } else if (contentType.equals(AMQPMessageSupport.OCTET_STREAM_CONTENT_TYPE)) {
+            } else if (AMQPMessageSupport.OCTET_STREAM_CONTENT_TYPE_SYMBOL.equals(contentType)) {
                type = BYTES_TYPE;
             } else {
-               Charset charset = getCharsetForTextualContent(contentTypeString);
+               Charset charset = getCharsetForTextualContent(contentType.toString());
                if (StandardCharsets.UTF_8.equals(charset)) {
                   type = TEXT_TYPE;
                }
             }
-         } else if (m.getBody() instanceof AmqpSequence) {
-            type = STREAM_TYPE;
          } else if (m.getBody() instanceof AmqpValue) {
             Object value = ((AmqpValue) m.getBody()).getValue();
 
             if (value instanceof String) {
                type = TEXT_TYPE;
             } else if (value instanceof Binary) {
-
-               if (contentType.equals(AMQPMessageSupport.SERIALIZED_JAVA_OBJECT_CONTENT_TYPE)) {
+               if (AMQPMessageSupport.SERIALIZED_JAVA_OBJECT_CONTENT_TYPE.equals(contentType)) {
                   type = OBJECT_TYPE;
                } else {
                   type = BYTES_TYPE;
@@ -1911,7 +1906,10 @@ public abstract class AMQPMessage extends RefCountMessage implements org.apache.
             } else if (value instanceof Map) {
                type = MAP_TYPE;
             }
+         } else if (m.getBody() instanceof AmqpSequence) {
+            type = STREAM_TYPE;
          }
+
          return type;
       }
    }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/converter/AMQPMessageSupport.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/converter/AMQPMessageSupport.java
@@ -66,6 +66,8 @@ public final class AMQPMessageSupport {
    public static SimpleString HDR_ORIGINAL_ADDRESS_ANNOTATION = SimpleString.toSimpleString("x-opt-ORIG-ADDRESS");
 
    public static final String JMS_REPLY_TO_TYPE_MSG_ANNOTATION_SYMBOL_NAME = "x-opt-jms-reply-to";
+   public static final String X_OPT_DELIVERY_TIME = "x-opt-delivery-time";
+   public static final String X_OPT_DELIVERY_DELAY = "x-opt-delivery-delay";
 
    // Message Properties used to map AMQP to JMS and back
    /**
@@ -85,12 +87,12 @@ public final class AMQPMessageSupport {
    /**
     * Attribute used to mark the Application defined delivery time assigned to the message
     */
-   public static final Symbol SCHEDULED_DELIVERY_TIME = Symbol.getSymbol("x-opt-delivery-time");
+   public static final Symbol SCHEDULED_DELIVERY_TIME = Symbol.getSymbol(X_OPT_DELIVERY_TIME);
 
    /**
     * Attribute used to mark the Application defined delivery time assigned to the message
     */
-   public static final Symbol SCHEDULED_DELIVERY_DELAY = Symbol.getSymbol("x-opt-delivery-delay");
+   public static final Symbol SCHEDULED_DELIVERY_DELAY = Symbol.getSymbol(X_OPT_DELIVERY_DELAY);
 
    /**
     * Attribute used to mark the Application defined delivery time assigned to the message
@@ -204,10 +206,12 @@ public final class AMQPMessageSupport {
    public static final byte TEMP_QUEUE_TYPE = 0x02;
    public static final byte TEMP_TOPIC_TYPE = 0x03;
 
+   public static final String OCTET_STREAM_CONTENT_TYPE = "application/octet-stream";
+
    /**
     * Content type used to mark Data sections as containing arbitrary bytes.
     */
-   public static final String OCTET_STREAM_CONTENT_TYPE = "application/octet-stream";
+   public static final Symbol OCTET_STREAM_CONTENT_TYPE_SYMBOL = Symbol.valueOf(OCTET_STREAM_CONTENT_TYPE);
 
    /**
     * Lookup and return the correct Proton Symbol instance based on the given key.


### PR DESCRIPTION
ARTEMIS-3461: add some tests and resolve various issues spotted with the prior changes

- Avoid blowing up on string bodies of any size if the valueSizeLimit bits are configured to disable limit.
- Dont NPE if amqp-value + binary body is sent without a content-type, as it always should be.
- Include expected prefix when adding delivery delay and ingress time annotations.
- Use the actual name for ingress time annotation, as with all other annotations.
- Use correct object type when testing equality with content-type value.
- Use consistent case for 'groupId' in different properties.