### PR TITLE
ARTEMIS-3538 fix extra-tests formatting and examples compilation

### DIFF
--- a/examples/features/standard/xa-heuristic/src/main/java/org/apache/activemq/artemis/jms/example/DummyXid.java
+++ b/examples/features/standard/xa-heuristic/src/main/java/org/apache/activemq/artemis/jms/example/DummyXid.java
@@ -98,8 +98,6 @@ public class DummyXid implements Xid {
       return globalTransactionId;
    }
 
-----------
-
    @Override
    public int hashCode() {
       if (!hashCalculated) {

--- a/examples/features/standard/xa-receive/src/main/java/org/apache/activemq/artemis/jms/example/DummyXid.java
+++ b/examples/features/standard/xa-receive/src/main/java/org/apache/activemq/artemis/jms/example/DummyXid.java
@@ -99,8 +99,6 @@ public class DummyXid implements Xid {
       return globalTransactionId;
    }
 
-----------
-
    @Override
    public int hashCode() {
       if (!hashCalculated) {

--- a/examples/features/standard/xa-send/src/main/java/org/apache/activemq/artemis/jms/example/DummyXid.java
+++ b/examples/features/standard/xa-send/src/main/java/org/apache/activemq/artemis/jms/example/DummyXid.java
@@ -96,8 +96,6 @@ public class DummyXid implements Xid {
       return globalTransactionId;
    }
 
-----------
-
    @Override
    public int hashCode() {
       if (!hashCalculated) {

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/jms/xa/JMSXDeliveryCountTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/jms/xa/JMSXDeliveryCountTest.java
@@ -678,7 +678,6 @@ public class JMSXDeliveryCountTest extends JMSTestBase {
       }
    }
 
- 
    static class DummyXAResource implements XAResource {
 
       DummyXAResource() {


### PR DESCRIPTION
- Checkstyle verification fails on JMSXDeliveryCountTest
because of empty line with trailing spaces
```
[INFO] --- maven-checkstyle-plugin:3.1.1:check (default) @ extra-tests ---
[INFO] Starting audit...
[ERROR] /home/buildadm/workspace/upstream-test-suite/validate-install-tests/validate-install-tests-upstream/artemis-src/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/jms/xa/JMSXDeliveryCountTest.java:681: Line has trailing spaces. [RegexpSingleline]
Audit done.
[INFO] There is 1 error reported by Checkstyle 8.43 with /home/buildadm/workspace/upstream-test-suite/validate-install-tests/validate-install-tests-upstream/artemis-src/tests/extra-tests/../../etc/checkstyle.xml ruleset.
[ERROR] src/test/java/org/apache/activemq/artemis/tests/extras/jms/xa/JMSXDeliveryCountTest.java:[681] (regexp) RegexpSingleline: Line has trailing spaces.
```

- examples classes DummyXid failed to compile because of
uncommented separation comment:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project xa-heuristic: Compilation failure: Compilation failure: 
[ERROR] /home/tbueno/repos/github.com/tlbueno/activemq-artemis/examples/features/standard/xa-heuristic/src/main/java/org/apache/activemq/artemis/jms/example/DummyXid.java:[101,1] illegal start of type
[ERROR] /home/tbueno/repos/github.com/tlbueno/activemq-artemis/examples/features/standard/xa-heuristic/src/main/java/org/apache/activemq/artemis/jms/example/DummyXid.java:[101,3] ';' expected
[ERROR] /home/tbueno/repos/github.com/tlbueno/activemq-artemis/examples/features/standard/xa-heuristic/src/main/java/org/apache/activemq/artemis/jms/example/DummyXid.java:[101,5] illegal start of type
[ERROR] /home/tbueno/repos/github.com/tlbueno/activemq-artemis/examples/features/standard/xa-heuristic/src/main/java/org/apache/activemq/artemis/jms/example/DummyXid.java:[101,7] <identifier> expected
[ERROR] /home/tbueno/repos/github.com/tlbueno/activemq-artemis/examples/features/standard/xa-heuristic/src/main/java/org/apache/activemq/artemis/jms/example/DummyXid.java:[101,9] ';' expected
```