### PR TITLE
ARTEMIS-3593: Be defensive when reading data from `ActiveMQBuffer` and allocating memory.

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/utils/XidPayloadException.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/utils/XidPayloadException.java
@@ -23,7 +23,7 @@ package org.apache.activemq.artemis.utils;
  */
 public class XidPayloadException extends RuntimeException {
 
-    public XidPayloadException(String message) {
-        super(message, null, true, false);
-    }
+   public XidPayloadException(String message) {
+      super(message, null, true, false);
+   }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/utils/XidPayloadException.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/utils/XidPayloadException.java
@@ -1,0 +1,12 @@
+package org.apache.activemq.artemis.utils;
+
+/**
+ * Special type of exception with stacktrace removed which is thrown when binary payload representing
+ * [{@link javax.transaction.xa.Xid}] is invalid.
+ */
+public class XidPayloadException extends RuntimeException {
+
+    public XidPayloadException(String message) {
+        super(message, null, true, false);
+    }
+}

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/utils/XidPayloadException.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/utils/XidPayloadException.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.activemq.artemis.utils;
 
 /**

--- a/artemis-core-client/src/test/java/org/apache/activemq/artemis/util/XidCodecSupportTest.java
+++ b/artemis-core-client/src/test/java/org/apache/activemq/artemis/util/XidCodecSupportTest.java
@@ -29,6 +29,7 @@ import javax.transaction.xa.Xid;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.fail;
 
 public class XidCodecSupportTest {
 
@@ -47,14 +48,18 @@ public class XidCodecSupportTest {
       assertThat(readXid, equalTo(VALID_XID));
    }
 
-   @Test(expected = XidPayloadException.class)
+   @Test
    public void testNegativeLength() {
       final ActiveMQBuffer buffer = ActiveMQBuffers.dynamicBuffer(0);
       XidCodecSupport.encodeXid(VALID_XID, buffer);
       // Alter branchQualifierLength to be negative
       buffer.setByte(4, (byte) 0xFF);
-
-      XidCodecSupport.decodeXid(buffer);
+      try {
+         XidCodecSupport.decodeXid(buffer);
+         fail("Should have thrown");
+      } catch (XidPayloadException ex) {
+         assertThat(ex.getStackTrace().length, equalTo(0));
+      }
    }
 
    @Test(expected = XidPayloadException.class)

--- a/artemis-core-client/src/test/java/org/apache/activemq/artemis/util/XidCodecSupportTest.java
+++ b/artemis-core-client/src/test/java/org/apache/activemq/artemis/util/XidCodecSupportTest.java
@@ -32,38 +32,38 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class XidCodecSupportTest {
 
-    private static final Xid VALID_XID =
-            new XidImpl("xa1".getBytes(), 1, UUIDGenerator.getInstance().generateStringUUID().getBytes());
+   private static final Xid VALID_XID =
+         new XidImpl("xa1".getBytes(), 1, UUIDGenerator.getInstance().generateStringUUID().getBytes());
 
-    @Test
-    public void testEncodeDecode() {
-        final ActiveMQBuffer buffer = ActiveMQBuffers.dynamicBuffer(0);
-        XidCodecSupport.encodeXid(VALID_XID, buffer);
+   @Test
+   public void testEncodeDecode() {
+      final ActiveMQBuffer buffer = ActiveMQBuffers.dynamicBuffer(0);
+      XidCodecSupport.encodeXid(VALID_XID, buffer);
 
-        assertThat(buffer.readableBytes(), equalTo(51)); // formatId(4) + branchQualLength(4) + branchQual(3) +
-        // globalTxIdLength(4) + globalTx(36)
+      assertThat(buffer.readableBytes(), equalTo(51)); // formatId(4) + branchQualLength(4) + branchQual(3) +
+      // globalTxIdLength(4) + globalTx(36)
 
-        final Xid readXid = XidCodecSupport.decodeXid(buffer);
-        assertThat(readXid, equalTo(VALID_XID));
-    }
+      final Xid readXid = XidCodecSupport.decodeXid(buffer);
+      assertThat(readXid, equalTo(VALID_XID));
+   }
 
-    @Test(expected = XidPayloadException.class)
-    public void testNegativeLength() {
-        final ActiveMQBuffer buffer = ActiveMQBuffers.dynamicBuffer(0);
-        XidCodecSupport.encodeXid(VALID_XID, buffer);
-        // Alter branchQualifierLength to be negative
-        buffer.setByte(4, (byte) 0xFF);
+   @Test(expected = XidPayloadException.class)
+   public void testNegativeLength() {
+      final ActiveMQBuffer buffer = ActiveMQBuffers.dynamicBuffer(0);
+      XidCodecSupport.encodeXid(VALID_XID, buffer);
+      // Alter branchQualifierLength to be negative
+      buffer.setByte(4, (byte) 0xFF);
 
-        XidCodecSupport.decodeXid(buffer);
-    }
+      XidCodecSupport.decodeXid(buffer);
+   }
 
-    @Test(expected = XidPayloadException.class)
-    public void testOverflowLength() {
-        final ActiveMQBuffer buffer = ActiveMQBuffers.dynamicBuffer(0);
-        XidCodecSupport.encodeXid(VALID_XID, buffer);
-        // Alter globalTxIdLength to be too big
-        buffer.setByte(11, (byte) 0x0C);
+   @Test(expected = XidPayloadException.class)
+   public void testOverflowLength() {
+      final ActiveMQBuffer buffer = ActiveMQBuffers.dynamicBuffer(0);
+      XidCodecSupport.encodeXid(VALID_XID, buffer);
+      // Alter globalTxIdLength to be too big
+      buffer.setByte(11, (byte) 0x0C);
 
-        XidCodecSupport.decodeXid(buffer);
-    }
+      XidCodecSupport.decodeXid(buffer);
+   }
 }

--- a/artemis-core-client/src/test/java/org/apache/activemq/artemis/util/XidCodecSupportTest.java
+++ b/artemis-core-client/src/test/java/org/apache/activemq/artemis/util/XidCodecSupportTest.java
@@ -1,0 +1,52 @@
+package org.apache.activemq.artemis.util;
+
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
+import org.apache.activemq.artemis.core.transaction.impl.XidImpl;
+import org.apache.activemq.artemis.utils.UUIDGenerator;
+import org.apache.activemq.artemis.utils.XidCodecSupport;
+import org.apache.activemq.artemis.utils.XidPayloadException;
+import org.junit.Test;
+
+import javax.transaction.xa.Xid;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class XidCodecSupportTest {
+
+    private static final Xid VALID_XID =
+            new XidImpl("xa1".getBytes(), 1, UUIDGenerator.getInstance().generateStringUUID().getBytes());
+
+    @Test
+    public void testEncodeDecode() {
+        final ActiveMQBuffer buffer = ActiveMQBuffers.dynamicBuffer(0);
+        XidCodecSupport.encodeXid(VALID_XID, buffer);
+
+        assertThat(buffer.readableBytes(), equalTo(51)); // formatId(4) + branchQualLength(4) + branchQual(3) +
+        // globalTxIdLength(4) + globalTx(36)
+
+        final Xid readXid = XidCodecSupport.decodeXid(buffer);
+        assertThat(readXid, equalTo(VALID_XID));
+    }
+
+    @Test(expected = XidPayloadException.class)
+    public void testNegativeLength() {
+        final ActiveMQBuffer buffer = ActiveMQBuffers.dynamicBuffer(0);
+        XidCodecSupport.encodeXid(VALID_XID, buffer);
+        // Alter branchQualifierLength to be negative
+        buffer.setByte(4, (byte) 0xFF);
+
+        XidCodecSupport.decodeXid(buffer);
+    }
+
+    @Test(expected = XidPayloadException.class)
+    public void testOverflowLength() {
+        final ActiveMQBuffer buffer = ActiveMQBuffers.dynamicBuffer(0);
+        XidCodecSupport.encodeXid(VALID_XID, buffer);
+        // Alter globalTxIdLength to be too big
+        buffer.setByte(11, (byte) 0x0C);
+
+        XidCodecSupport.decodeXid(buffer);
+    }
+}

--- a/artemis-core-client/src/test/java/org/apache/activemq/artemis/util/XidCodecSupportTest.java
+++ b/artemis-core-client/src/test/java/org/apache/activemq/artemis/util/XidCodecSupportTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.activemq.artemis.util;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;


### PR DESCRIPTION
Or else, an adversary may handcraft the packet causing OOM situation for a running a JVM.