### PR TITLE
ARTEMIS-3596 Pass class loader to ServiceLoader.load to fix OSGi issues

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/ssl/OpenSSLContextFactoryProvider.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/ssl/OpenSSLContextFactoryProvider.java
@@ -25,7 +25,7 @@ public class OpenSSLContextFactoryProvider {
    private static final OpenSSLContextFactory FACTORY;
    static {
       OpenSSLContextFactory factoryWithHighestPrio = null;
-      for (OpenSSLContextFactory factory : ServiceLoader.load(OpenSSLContextFactory.class)) {
+      for (OpenSSLContextFactory factory : ServiceLoader.load(OpenSSLContextFactory.class, OpenSSLContextFactoryProvider.class.getClassLoader())) {
          if (factoryWithHighestPrio == null || factory.getPriority() > factoryWithHighestPrio.getPriority()) {
             factoryWithHighestPrio = factory;
          }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/ssl/SSLContextFactoryProvider.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/ssl/SSLContextFactoryProvider.java
@@ -29,7 +29,7 @@ import javax.net.ssl.SSLContext;
 public class SSLContextFactoryProvider {
    private static final SSLContextFactory factory;
    static {
-      ServiceLoader<SSLContextFactory> loader = ServiceLoader.load(SSLContextFactory.class, Thread.currentThread().getContextClassLoader());
+      ServiceLoader<SSLContextFactory> loader = ServiceLoader.load(SSLContextFactory.class, SSLContextFactoryProvider.class.getClassLoader());
       final List<SSLContextFactory> factories = new ArrayList<>();
       loader.forEach(factories::add);
       if (factories.isEmpty()) {

--- a/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/bridge/impl/JMSBridgeImpl.java
+++ b/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/bridge/impl/JMSBridgeImpl.java
@@ -2050,7 +2050,7 @@ public final class JMSBridgeImpl implements JMSBridge {
       if (registry == null) {
          for (String locatorClasse : RESOURCE_RECOVERY_CLASS_NAMES) {
             try {
-               ServiceLoader<ActiveMQRegistry> sl = ServiceLoader.load(ActiveMQRegistry.class);
+               ServiceLoader<ActiveMQRegistry> sl = ServiceLoader.load(ActiveMQRegistry.class, JMSBridgeImpl.class.getClassLoader());
                if (sl.iterator().hasNext()) {
                   registry = sl.iterator().next();
                }

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/recovery/RecoveryManager.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/recovery/RecoveryManager.java
@@ -79,7 +79,7 @@ public final class RecoveryManager {
 
       for (String locatorClasse : locatorClasses) {
          try {
-            ServiceLoader<ActiveMQRegistry> sl = ServiceLoader.load(ActiveMQRegistry.class);
+            ServiceLoader<ActiveMQRegistry> sl = ServiceLoader.load(ActiveMQRegistry.class, RecoveryManager.class.getClassLoader());
             if (sl.iterator().hasNext()) {
                registry = sl.iterator().next();
             } else {


### PR DESCRIPTION
This resolves an issue i was seeing when running artemis in karaf where if the artemis-server-osgi bundle got reloaded during the resolution process I would see this error prevent artemis from starting.
org.apache.activemq.artemis.spi.core.remoting.ssl.SSLContextFactory: org.apache.activemq.artemis.core.remoting.impl.ssl.DefaultSSLContextFactory not a subtype