### PR TITLE
ARTEMIS-3559 Exclude netty-transport-native-epoll from zookeeper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -911,6 +911,10 @@
                   <groupId>log4j</groupId>
                   <artifactId>log4j</artifactId>
                </exclusion>
+               <exclusion>
+                  <groupId>io.netty</groupId>
+                  <artifactId>netty-transport-native-epoll</artifactId>
+               </exclusion>
             </exclusions>
          </dependency>
          <dependency>


### PR DESCRIPTION
The netty-transport-native-epoll transitive dependency version of zookeeper
doesn't match the netty version defined and causes a distribution issue.