### PR TITLE
[ARTEMIS-3607]: Supporting JsonValues in JsonUtil.addToArray and

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/JsonUtil.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/JsonUtil.java
@@ -173,6 +173,8 @@ public final class JsonUtil {
             addToArray(parameter, objectArrayBuilder);
          }
          jsonObjectBuilder.add(key, objectArrayBuilder);
+      } else if (param instanceof JsonValue) {
+         jsonObjectBuilder.add(key, (JsonValue)param);
       } else {
          jsonObjectBuilder.add(key, param.toString());
       }
@@ -218,6 +220,8 @@ public final class JsonUtil {
             addToArray(parameter, objectArrayBuilder);
          }
          jsonArrayBuilder.add(objectArrayBuilder);
+      } else if (param instanceof JsonValue) {
+         jsonArrayBuilder.add((JsonValue)param);
       } else {
          jsonArrayBuilder.add(param.toString());
       }


### PR DESCRIPTION
JsonUtil.addToObject

* When the added Object is of type JsonValue, don't call the toString
  method on it.

Issue: https://issues.apache.org/jira/browse/ARTEMIS-3607