### PR TITLE
ARTEMIS-3612 update Hawtio and strip Log4j from console web app

### DIFF
--- a/artemis-hawtio/artemis-console/pom.xml
+++ b/artemis-hawtio/artemis-console/pom.xml
@@ -34,7 +34,7 @@
   <properties>
     <activemq.basedir>${project.basedir}/../..</activemq.basedir>
   </properties>
-  
+
   <dependencies>
     <dependency>
       <groupId>org.apache.geronimo.specs</groupId>
@@ -82,7 +82,10 @@
         <artifactId>maven-war-plugin</artifactId>
         <configuration>
           <useCache>true</useCache>
-          <packagingExcludes>**/lib/slf4j*.jar</packagingExcludes>
+          <packagingExcludes>
+            **/lib/slf4j*.jar,
+            **/lib/log4j*.jar
+          </packagingExcludes>
           <failOnMissingWebXml>false</failOnMissingWebXml>
           <webResources>
             <resource>

--- a/artemis-hawtio/pom.xml
+++ b/artemis-hawtio/pom.xml
@@ -35,7 +35,7 @@
 
         <activemq.basedir>${project.basedir}/..</activemq.basedir>
 
-        <hawtio.version>2.14.0</hawtio.version>
+        <hawtio.version>2.14.2</hawtio.version>
         <jline.version>3.2.0</jline.version>
         <junit-version>4.11</junit-version>
         <log4j-version>1.2.17</log4j-version>


### PR DESCRIPTION
Move to the latest release of Hawtio 2.14.x.

Also, remove the Log4j archives from the web console application. It's
not necessary to include Log4j archives because Hawtio itself uses SLF4J
and the logging implementation will be provided by the broker runtime.
We already do this for SLF4J.

While not strictly necessary, removing Log4j will ease concerns about
security issues such as the recently announced CVE-2021-44228.