### PR TITLE
ARTEMIS-3623 preserve type of numeric extraProperties

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
@@ -872,7 +872,12 @@ public abstract class AMQPMessage extends RefCountMessage implements org.apache.
       TypedProperties extraProperties = getExtraProperties();
       if (extraProperties != null) {
          extraProperties.forEach((s, o) -> {
-            map.put(extraPropertiesPrefix + s.toString(), JsonUtil.truncate(o.toString(), valueSizeLimit));
+            if (o instanceof Number) {
+               // keep fields like _AMQ_ACTUAL_EXPIRY in their original type
+               map.put(extraPropertiesPrefix + s.toString(), o);
+            } else {
+               map.put(extraPropertiesPrefix + s.toString(), JsonUtil.truncate(o.toString(), valueSizeLimit));
+            }
          });
       }
 

--- a/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessageTest.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessageTest.java
@@ -2522,6 +2522,22 @@ public class AMQPMessageTest {
       assertEquals(org.apache.activemq.artemis.api.core.Message.TEXT_TYPE, cd.get(CompositeDataConstants.TYPE));
    }
 
+   @Test
+   public void testToPropertyMap() throws Exception {
+      Message protonMessage = Message.Factory.create();
+      AMQPStandardMessage decoded = encodeAndDecodeMessage(protonMessage);
+      TypedProperties props = decoded.createExtraProperties();
+      props.putSimpleStringProperty(new SimpleString("firstString"), new SimpleString("firstValue"));
+      props.putLongProperty(new SimpleString("secondLong"), 1234567);
+
+      // same as toPropertyMap(false,5)
+      Map<String, Object> map = decoded.toPropertyMap(-1);
+
+      assertEquals(2, map.size());
+      assertEquals(map.get("firstString"), "firstValue");
+      assertEquals(map.get("secondLong"), 1234567L);
+   }
+
    //----- Test Support ------------------------------------------------------//
 
    private MessageImpl createProtonMessage() {


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/ARTEMIS-3623

@clebertsuconic this is a modification on 'your' code. did I overlook a reason why the extraProperties must always be strings?