### PR TITLE
Correctly compare Boolean object and fix NPE introduced in bf875c

### DIFF
--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
@@ -745,7 +745,7 @@ public class ActiveMQSession implements QueueSession, TopicSession {
 
          QueueQuery subResponse = session.queueQuery(queueName);
 
-         if ((!subResponse.isExists() || !Objects.equals(subResponse.getAddress(), dest.getSimpleAddress()) || !Objects.equals(subResponse.getFilterString(), coreFilterString)) && !subResponse.isConfigurationManaged()) {
+         if ((!subResponse.isExists() || !Objects.equals(subResponse.getAddress(), dest.getSimpleAddress()) || !Objects.equals(subResponse.getFilterString(), coreFilterString)) && !Boolean.TRUE.equals(subResponse.isConfigurationManaged())) {
             try {
                createSharedQueue(dest, RoutingType.MULTICAST, queueName, coreFilterString, durability == ConsumerDurability.DURABLE, response);
             } catch (ActiveMQQueueExistsException ignored) {


### PR DESCRIPTION
We have an [issue](https://github.com/quarkiverse/quarkus-artemis/issues/17) in quarkus-artemis extension. To summarize the issue, the user hits an NPE due to our upgrade from 2.17.0 to 2.19.0 of Artemis JMS client. I did a `git bisect` and the NPE is introduced in bf875c3a376726083ea97313380c89ed1c02d526 where a `!subResponse.isConfigurationManaged()` is introduced. The `isConfiguredManaged` returns a `Boolean` which can be `null` and is the case in this issue. In an if statement the `Boolean` is unboxed via `booleanValue()` which throws the `NPE`. More correctly would be the following commit.

This only fixes the incident, but there are more naked `!isConfigurationManaged` and `isConfigurationManaged` and there are also more `Boolean` methods in the same interfaces. In [QueueConfiguration](https://github.com/apache/activemq-artemis/blob/main/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/QueueConfiguration.java#L535) this is solved by making sure the `Boolean` is never `null`. I lack the knowledge to separate the cases where it can be hit or not and also not sure about the approach to fix this (e.g. why not change it to primitive).