### PR TITLE
fixed missing version numver in pom file (prevented use of mvn eclipse:eclipse

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -340,6 +340,7 @@
          <dependency>
             <groupId>org.apache.kerby</groupId>
             <artifactId>token-provider</artifactId>
+            <version>2.0.1</version>
             <scope>test</scope>
             <exclusions>
                <exclusion>


### PR DESCRIPTION
see https://issues.apache.org/jira/browse/ARTEMIS-3624