### PR TITLE
ARTEMIS-3624: rework dep mangement entry for minikdc dep

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,7 @@
       <!-- used on tests -->
       <groovy.version>2.5.10</groovy.version>
       <vertx.version>3.9.4</vertx.version>
+      <hadoop.minikdc.version>3.3.1</hadoop.minikdc.version>
 
       <owasp.version>6.1.0</owasp.version>
       <spring.version>5.1.7.RELEASE</spring.version>
@@ -338,10 +339,15 @@
          </dependency>
 
          <dependency>
-            <groupId>org.apache.kerby</groupId>
-            <artifactId>token-provider</artifactId>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-minikdc</artifactId>
+            <version>${hadoop.minikdc.version}</version>
             <scope>test</scope>
             <exclusions>
+               <exclusion>
+                  <groupId>org.slf4j</groupId>
+                  <artifactId>slf4j-log4j12</artifactId>
+               </exclusion>
                <exclusion>
                   <groupId>com.nimbusds</groupId>
                   <artifactId>nimbus-jose-jwt</artifactId>

--- a/tests/integration-tests/pom.xml
+++ b/tests/integration-tests/pom.xml
@@ -386,13 +386,6 @@
       <dependency>
          <groupId>org.apache.hadoop</groupId>
          <artifactId>hadoop-minikdc</artifactId>
-         <version>3.3.0</version>
-         <exclusions>
-            <exclusion>
-               <groupId>org.slf4j</groupId>
-               <artifactId>slf4j-log4j12</artifactId>
-            </exclusion>
-         </exclusions>
          <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Alternative to #3905, reworks the minikdc dep handling more generally, managing that deps version and applying the previous exclusion via the base dep rather than at the importing transitive dep as in the prior non-version-related management.