### PR TITLE
ARTEMIS-3186 enable create queue more often

### DIFF
--- a/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/components/createAddress.js
+++ b/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/components/createAddress.js
@@ -57,7 +57,7 @@ var Artemis;
                      <div class="col-sm-offset-2 col-sm-10">
                          <button type="submit" class="btn btn-primary"
                                  ng-click="$ctrl.createAddress($ctrl.addressName, $ctrl.routingType)"
-                                 ng-disabled="!$ctrl.addressName">Create Address
+                                 ng-disabled="!$ctrl.addressName || !$ctrl.routingType">Create Address
                          </button>
                      </div>
                  </div>
@@ -92,7 +92,7 @@ var Artemis;
         Artemis.log.debug("loaded address controller");
         var ctrl = this;
         ctrl.addressName = "";
-        ctrl.routingType = "Anycast";
+        ctrl.routingType = null;
         ctrl.workspace = workspace;
         ctrl.message = "";
 

--- a/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/components/createQueue.js
+++ b/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/components/createQueue.js
@@ -91,7 +91,7 @@ var Artemis;
                      <div class="col-sm-offset-2 col-sm-10">
                          <button type="submit" class="btn btn-primary"
                                  ng-click="$ctrl.createQueue($ctrl.queueName, $ctrl.routingType, $ctrl.durable, $ctrl.filter, $ctrl.maxConsumers, $ctrl.purgeWhenNoConsumers)"
-                                 ng-disabled="!$ctrl.queueName">Create Queue
+                                 ng-disabled="!$ctrl.queueName || !$ctrl.routingType">Create Queue
                          </button>
                      </div>
                  </div>
@@ -160,7 +160,13 @@ var Artemis;
         var artemisJmxDomain = localStorage['artemisJmxDomain'] || "org.apache.activemq.artemis";
         ctrl.workspace = workspace;
         ctrl.maxConsumers = -1;
-        ctrl.routingType = "Anycast";
+        if (workspace.selection.folderNames.length >= 6 && workspace.selection.folderNames[5] === "anycast") {
+            ctrl.routingType = "Anycast";
+        } else if (workspace.selection.folderNames.length >= 6 && workspace.selection.folderNames[5] === "multicast") {
+            ctrl.routingType = "Multicast";
+        } else {
+            ctrl.routingType = null;
+        }
         ctrl.filter = "";
         ctrl.purgeWhenNoConsumers = false;
         ctrl.durable = true;
@@ -184,8 +190,8 @@ var Artemis;
             var mbean = Artemis.getBrokerMBean(workspace, jolokia);
             if (mbean) {
                 var selection = workspace.selection;
-                var entries = selection.entries;
-                var address = entries["address"];
+                var folderNames = selection.folderNames;
+                var address = folderNames[3];
                 if (address.charAt(0) === '"' && address.charAt(address.length -1) === '"')
                 {
                     address = address.substr(1,address.length -2);

--- a/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/components/navigation.js
+++ b/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/components/navigation.js
@@ -158,13 +158,13 @@ var Artemis;
                 if (shouldShowDeleteQueueTab()) {
                     tabs.push(new Nav.HawtioTab(TAB_CONFIG.deleteQueue.title, TAB_CONFIG.deleteQueue.route));
                 }
-                if (shouldShowSendMessageTab(workspace)) {
+                if (shouldShowSendMessageTab()) {
                     tabs.push(new Nav.HawtioTab(TAB_CONFIG.sendMessage.title, TAB_CONFIG.sendMessage.route));
                 }
-                if (shouldShowAddressSendMessageTab(workspace)) {
+                if (shouldShowAddressSendMessageTab()) {
                     tabs.push(new Nav.HawtioTab(TAB_CONFIG.addressSendMessage.title, TAB_CONFIG.addressSendMessage.route));
                 }
-                if (shouldShowBrowseMessageTab(workspace)) {
+                if (shouldShowBrowseMessageTab()) {
                     tabs.push(new Nav.HawtioTab(TAB_CONFIG.browseQueue.title, TAB_CONFIG.browseQueue.route));
                 }
                 tabs.push(new Nav.HawtioTab(TAB_CONFIG.brokerDiagram.title, TAB_CONFIG.brokerDiagram.route));
@@ -173,31 +173,53 @@ var Artemis;
         }
 
         function shouldShowCreateAddressTab() {
-            return workspace.selectionHasDomainAndLastFolderName(artemisJmxDomain, 'addresses') && ctrl.showCreateAddress;
+            if (!workspace.selectionHasDomainAndLastFolderName(artemisJmxDomain, 'addresses')) return false;
+            if (!ctrl.showCreateAddress) return false;
+            return true;
         }
 
         function shouldShowDeleteAddressTab() {
-            return workspace.hasDomainAndProperties(artemisJmxDomain, {'component': 'addresses'}) && !workspace.hasDomainAndProperties(artemisJmxDomain, {'subcomponent': 'queues'}) && !workspace.hasDomainAndProperties(artemisJmxDomain, {'subcomponent': 'diverts'}) && ctrl.showDeleteAddress;
+            if (!workspace.hasDomainAndProperties(artemisJmxDomain, {'component': 'addresses'})) return false;
+            if (workspace.hasDomainAndProperties(artemisJmxDomain, {'subcomponent': 'queues'})) return false;
+            if (workspace.hasDomainAndProperties(artemisJmxDomain, {'subcomponent': 'diverts'})) return false;
+            if (!ctrl.showDeleteAddress) return false;
+            return true;
         }
 
         function shouldShowCreateQueueTab() {
-            return workspace.hasDomainAndProperties(artemisJmxDomain, {'component': 'addresses'}) && !workspace.hasDomainAndProperties(artemisJmxDomain, {'subcomponent': 'queues'}) && !workspace.hasDomainAndProperties(artemisJmxDomain, {'subcomponent': 'diverts'}) && ctrl.showCreateQueue;
+            if (!workspace.selection) return false;
+            if (!workspace.selection.folderNames) return false;
+            if (workspace.selection.folderNames.length < 4 || workspace.selection.folderNames.length > 6) return false;
+            if (workspace.selection.folderNames[2] !== "addresses") return false;
+            if (workspace.selection.folderNames.length >= 5 && workspace.selection.folderNames[4] !== "queues") return false;
+            if (!ctrl.showCreateQueue) return false;
+            return true;
         }
 
         function shouldShowDeleteQueueTab() {
-            return workspace.hasDomainAndProperties(artemisJmxDomain, {'subcomponent': 'queues'}) && ctrl.showDeleteQueue;
+            if (!workspace.hasDomainAndProperties(artemisJmxDomain, {'subcomponent': 'queues'})) return false;
+            if (!ctrl.showDeleteQueue) return false;
+            return true;
         }
 
-        function shouldShowSendMessageTab(workspace) {
-            return workspace.hasDomainAndProperties(artemisJmxDomain, {'subcomponent': 'queues'}) && hasQueueinvokeRights(workspace, "sendMessage");
+        function shouldShowSendMessageTab() {
+            if (!workspace.hasDomainAndProperties(artemisJmxDomain, {'subcomponent': 'queues'})) return false;
+            if (!hasQueueinvokeRights(workspace, "sendMessage")) return false;
+            return true;
         }
 
-        function shouldShowAddressSendMessageTab(workspace) {
-            return workspace.hasDomainAndProperties(artemisJmxDomain, {'component': 'addresses'}) && !workspace.hasDomainAndProperties(artemisJmxDomain, {'subcomponent': 'queues'}) && hasQueueinvokeRights(workspace, "sendMessage");
+        function shouldShowAddressSendMessageTab() {
+            if (!workspace.hasDomainAndProperties(artemisJmxDomain, {'component': 'addresses'})) return false;
+            if (workspace.hasDomainAndProperties(artemisJmxDomain, {'subcomponent': 'queues'})) return false;
+            if (!hasQueueinvokeRights(workspace, "sendMessage")) return false;
+            return true;
         }
 
-        function shouldShowBrowseMessageTab(workspace) {
-            return workspace.hasDomainAndProperties(artemisJmxDomain, {'subcomponent': 'queues'}) && hasQueueinvokeRights(workspace, "browse") && hasQueueinvokeRights(workspace, "countMessages");
+        function shouldShowBrowseMessageTab() {
+            if (!workspace.hasDomainAndProperties(artemisJmxDomain, {'subcomponent': 'queues'})) return false;
+            if (!hasQueueinvokeRights(workspace, "browse")) return false;
+            if (!hasQueueinvokeRights(workspace, "countMessages")) return false;
+            return true;
         }
 
         function hasInvokeRights(jolokia, mbean, operation) {


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/ARTEMIS-3186

The PR has 5 commits. For the purpose of the review these are still separate. This can of course be collapsed as needed.
1) remove unused parameter "workspace" from 3 `shouldShow...` functions. only 3 of the 7 functions in this category still had this unused parameter. unrelated, but in the same technical area.
2) The default routing type when creating a queue is often overlooked (in my experience), and one ends up with the wrong type. Reset the default to "no selection". The "Create Queue" button is disabled until the choice is made (next to the existing condition that a name must be provided). see also point (5)
3) All 7 `shouldShow...` functions have been reformatted so that each condition is visible on a separate line. Their logic has not been changed. see point (4) for the exception.
4) Updated the "Create Queue" navigation logic so that "Create Queue" is visible on 3 levels in the "tree". 1st is the traditional address level. 2nd (new) is on the "queues" level. 3rd (new) is on the "anycast" or "multicast" level. Since the "queues"/"anycast"/"multicast" levels in the tree do not represent JMX objects, the selection logic is now based on the "selection/folderNames" property, which is always available. This has a small effect on the callback-function as well, as that now must use that same information.
5) When a queue is created while "anycast"/"multicast" is selected (so in the 3rd case), that is also the default for the routing type that is used for the queue creation.