### PR TITLE
NO-JIRA Fix required java version in Using server docs

### DIFF
--- a/docs/user-manual/en/using-server.md
+++ b/docs/user-manual/en/using-server.md
@@ -402,7 +402,7 @@ script, but with the `stop` argument.  Example:
 /var/lib/mybroker/bin/artemis stop
 ```
 
-Please note that Apache ActiveMQ Artemis requires a Java 8 or later.
+Please note that Apache ActiveMQ Artemis requires a Java 11 or later.
 
 By default the `etc/bootstrap.xml` configuration is used. The configuration can
 be changed e.g. by running `./artemis run -- xml:path/to/bootstrap.xml` or


### PR DESCRIPTION
From artemis 2.20 java 11 is required. Fixed a note on Using server page.