### PR TITLE
NO-JIRA - fix ManifestTest

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -85,10 +85,6 @@
             <configuration>
                <skipTests>${skipUnitTests}</skipTests>
                <argLine>${activemq-surefire-argline}</argLine>
-               <excludes>
-                  <!--todo this test is dependent on the jar so needs to be run post package as an integration test-->
-                  <exclude>**/ManifestTest.java</exclude>
-               </excludes>
             </configuration>
          </plugin>
       </plugins>

--- a/tests/smoke-tests/pom.xml
+++ b/tests/smoke-tests/pom.xml
@@ -29,6 +29,7 @@
    <properties>
       <activemq.basedir>${project.basedir}/../../</activemq.basedir>
       <sts-surefire-extra-args />
+      <artemis-distribuiton-lib-dir>-Ddistribution.lib="${activemq.basedir}/artemis-distribution/target/apache-artemis-${project.version}-bin/apache-artemis-${project.version}/lib"</artemis-distribuiton-lib-dir>
    </properties>
 
    <dependencies>
@@ -1332,7 +1333,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
                <skipTests>${skipSmokeTests}</skipTests>
-               <argLine>${sts-surefire-extra-args} ${activemq-surefire-argline}</argLine>
+               <argLine>${sts-surefire-extra-args} ${activemq-surefire-argline} ${artemis-distribuiton-lib-dir}</argLine>
             </configuration>
          </plugin>
       </plugins>


### PR DESCRIPTION
This PR contains a fix to the jms jar manifest test:

As the test needs the generated jms jars to be verified I moved it from unit-tests to smoke-tests.
Updated the test to look for the correct jars as the originally specified does not exist.
Update the test to assert against Implementation-Version instead of ActiveMQ-Version in the manifest file as the ActiveMQ-Version property does not exist.