### PR TITLE
ARTEMIS-3662 remove deprecated config from default broker.xml

### DIFF
--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/broker.xml
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/broker.xml
@@ -127,8 +127,6 @@ ${cluster-security.settings}${cluster.settings}${replicated.settings}${shared-st
             <address-full-policy>${full-policy}</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -141,8 +139,6 @@ ${cluster-security.settings}${cluster.settings}${replicated.settings}${shared-st
             <address-full-policy>${full-policy}</address-full-policy>
             <auto-create-queues>${auto-create}</auto-create-queues>
             <auto-create-addresses>${auto-create}</auto-create-addresses>
-            <auto-create-jms-queues>${auto-create}</auto-create-jms-queues>
-            <auto-create-jms-topics>${auto-create}</auto-create-jms-topics>
             <auto-delete-queues>${auto-delete}</auto-delete-queues>
             <auto-delete-addresses>${auto-delete}</auto-delete-addresses>
          </address-setting>

--- a/artemis-features/src/main/resources/artemis.xml
+++ b/artemis-features/src/main/resources/artemis.xml
@@ -161,8 +161,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -175,8 +173,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/artemis-server/src/test/resources/ConfigurationTest-full-config-wrong-address.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-full-config-wrong-address.xml
@@ -175,8 +175,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -189,8 +187,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/examples/features/broker-balancer/evenly-redirect/src/main/resources/activemq/server0/broker.xml
+++ b/examples/features/broker-balancer/evenly-redirect/src/main/resources/activemq/server0/broker.xml
@@ -98,8 +98,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -112,8 +110,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/examples/features/broker-balancer/evenly-redirect/src/main/resources/activemq/server1/broker.xml
+++ b/examples/features/broker-balancer/evenly-redirect/src/main/resources/activemq/server1/broker.xml
@@ -76,8 +76,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -90,8 +88,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/examples/features/broker-balancer/evenly-redirect/src/main/resources/activemq/server2/broker.xml
+++ b/examples/features/broker-balancer/evenly-redirect/src/main/resources/activemq/server2/broker.xml
@@ -76,8 +76,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -90,8 +88,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/examples/features/broker-balancer/symmetric-redirect/src/main/resources/activemq/server0/broker.xml
+++ b/examples/features/broker-balancer/symmetric-redirect/src/main/resources/activemq/server0/broker.xml
@@ -113,8 +113,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -127,8 +125,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/examples/features/broker-balancer/symmetric-redirect/src/main/resources/activemq/server1/broker.xml
+++ b/examples/features/broker-balancer/symmetric-redirect/src/main/resources/activemq/server1/broker.xml
@@ -113,8 +113,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -127,8 +125,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/examples/features/broker-balancer/symmetric-simple/src/main/resources/activemq/server0/broker.xml
+++ b/examples/features/broker-balancer/symmetric-simple/src/main/resources/activemq/server0/broker.xml
@@ -84,8 +84,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -98,8 +96,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/examples/features/broker-balancer/symmetric-simple/src/main/resources/activemq/server1/broker.xml
+++ b/examples/features/broker-balancer/symmetric-simple/src/main/resources/activemq/server1/broker.xml
@@ -85,8 +85,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -99,8 +97,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/examples/features/broker-connection/amqp-receiving-messages/src/main/resources/activemq/server0/broker.xml
+++ b/examples/features/broker-connection/amqp-receiving-messages/src/main/resources/activemq/server0/broker.xml
@@ -85,8 +85,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -99,8 +97,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/examples/features/broker-connection/amqp-receiving-messages/src/main/resources/activemq/server1/broker.xml
+++ b/examples/features/broker-connection/amqp-receiving-messages/src/main/resources/activemq/server1/broker.xml
@@ -79,8 +79,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -93,8 +91,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/examples/features/broker-connection/amqp-sending-messages-multicast/src/main/resources/activemq/server0/broker.xml
+++ b/examples/features/broker-connection/amqp-sending-messages-multicast/src/main/resources/activemq/server0/broker.xml
@@ -85,8 +85,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -99,8 +97,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/examples/features/broker-connection/amqp-sending-messages-multicast/src/main/resources/activemq/server1/broker.xml
+++ b/examples/features/broker-connection/amqp-sending-messages-multicast/src/main/resources/activemq/server1/broker.xml
@@ -79,8 +79,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -93,8 +91,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/examples/features/broker-connection/amqp-sending-messages/src/main/resources/activemq/server0/broker.xml
+++ b/examples/features/broker-connection/amqp-sending-messages/src/main/resources/activemq/server0/broker.xml
@@ -85,8 +85,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -99,8 +97,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/examples/features/broker-connection/amqp-sending-messages/src/main/resources/activemq/server1/broker.xml
+++ b/examples/features/broker-connection/amqp-sending-messages/src/main/resources/activemq/server1/broker.xml
@@ -79,8 +79,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -93,8 +91,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/examples/features/standard/broker-msg-auth-plugin/src/main/resources/activemq/server0/broker.xml
+++ b/examples/features/standard/broker-msg-auth-plugin/src/main/resources/activemq/server0/broker.xml
@@ -165,8 +165,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -179,8 +177,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/examples/features/standard/broker-plugin/src/main/resources/activemq/server0/broker.xml
+++ b/examples/features/standard/broker-plugin/src/main/resources/activemq/server0/broker.xml
@@ -162,8 +162,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -176,8 +174,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/MaxQueueResourceTest/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/MaxQueueResourceTest/broker.xml
@@ -56,7 +56,7 @@ under the License.
       <journal-device-block-size>4096</journal-device-block-size>
 
       <journal-file-size>10M</journal-file-size>
-      
+
       <!--
        This value was determined through a calculation.
        Your system could perform 25 writes per millisecond
@@ -118,7 +118,7 @@ under the License.
 
       <critical-analyzer-policy>HALT</critical-analyzer-policy>
 
-      
+
       <page-sync-timeout>40000</page-sync-timeout>
 
 
@@ -180,8 +180,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -194,8 +192,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/audit-logging/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/audit-logging/broker.xml
@@ -148,8 +148,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -162,8 +160,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/audit-logging2/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/audit-logging2/broker.xml
@@ -148,8 +148,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -162,8 +160,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/bridgeTransfer/serverA/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/bridgeTransfer/serverA/broker.xml
@@ -110,7 +110,7 @@ under the License.
 
       <critical-analyzer-policy>HALT</critical-analyzer-policy>
 
-      
+
 
             <!-- the system will enter into page mode once you hit this limit.
            This is an estimate in bytes of how much the messages are using in memory
@@ -189,8 +189,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -203,8 +201,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/bridgeTransfer/serverB/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/bridgeTransfer/serverB/broker.xml
@@ -110,7 +110,7 @@ under the License.
 
       <critical-analyzer-policy>HALT</critical-analyzer-policy>
 
-      
+
 
             <!-- the system will enter into page mode once you hit this limit.
            This is an estimate in bytes of how much the messages are using in memory
@@ -171,8 +171,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -185,8 +183,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/brokerConnect/bridgeSecurityA/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/brokerConnect/bridgeSecurityA/broker.xml
@@ -55,7 +55,7 @@ under the License.
       <journal-device-block-size>4096</journal-device-block-size>
 
       <journal-file-size>10M</journal-file-size>
-      
+
       <!--
        This value was determined through a calculation.
        Your system could perform 25 writes per millisecond
@@ -117,7 +117,7 @@ under the License.
 
       <critical-analyzer-policy>HALT</critical-analyzer-policy>
 
-      
+
       <page-sync-timeout>40000</page-sync-timeout>
 
 
@@ -189,8 +189,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -203,8 +201,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/brokerConnect/bridgeSecurityB/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/brokerConnect/bridgeSecurityB/broker.xml
@@ -55,7 +55,7 @@ under the License.
       <journal-device-block-size>4096</journal-device-block-size>
 
       <journal-file-size>10M</journal-file-size>
-      
+
       <!--
        This value was determined through a calculation.
        Your system could perform 25 writes per millisecond
@@ -117,7 +117,7 @@ under the License.
 
       <critical-analyzer-policy>HALT</critical-analyzer-policy>
 
-      
+
       <page-sync-timeout>40000</page-sync-timeout>
 
 
@@ -181,8 +181,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -195,8 +193,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/brokerConnect/chainedMirror/serverA/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/brokerConnect/chainedMirror/serverA/broker.xml
@@ -56,7 +56,7 @@ under the License.
       <journal-device-block-size>4096</journal-device-block-size>
 
       <journal-file-size>10M</journal-file-size>
-      
+
       <!--
        This value was determined through a calculation.
        Your system could perform 25 writes per millisecond
@@ -123,7 +123,7 @@ under the License.
 
       <critical-analyzer-policy>HALT</critical-analyzer-policy>
 
-      
+
       <page-sync-timeout>40000</page-sync-timeout>
 
 
@@ -160,8 +160,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -174,8 +172,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/brokerConnect/chainedMirror/serverB/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/brokerConnect/chainedMirror/serverB/broker.xml
@@ -54,7 +54,7 @@ under the License.
       <journal-device-block-size>4096</journal-device-block-size>
 
       <journal-file-size>10M</journal-file-size>
-      
+
       <!--
        This value was determined through a calculation.
        Your system could perform 25 writes per millisecond
@@ -121,7 +121,7 @@ under the License.
 
       <critical-analyzer-policy>HALT</critical-analyzer-policy>
 
-      
+
       <page-sync-timeout>40000</page-sync-timeout>
 
 
@@ -157,8 +157,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -171,8 +169,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/brokerConnect/chainedMirror/serverRoot/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/brokerConnect/chainedMirror/serverRoot/broker.xml
@@ -54,7 +54,7 @@ under the License.
       <journal-device-block-size>4096</journal-device-block-size>
 
       <journal-file-size>10M</journal-file-size>
-      
+
       <!--
        This value was determined through a calculation.
        Your system could perform 25 writes per millisecond
@@ -115,7 +115,7 @@ under the License.
 
       <critical-analyzer-policy>HALT</critical-analyzer-policy>
 
-      
+
       <page-sync-timeout>40000</page-sync-timeout>
 
 
@@ -158,8 +158,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -172,8 +170,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/brokerConnect/mirrorSecurityA/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/brokerConnect/mirrorSecurityA/broker.xml
@@ -54,7 +54,7 @@ under the License.
       <journal-device-block-size>4096</journal-device-block-size>
 
       <journal-file-size>10M</journal-file-size>
-      
+
       <!--
        This value was determined through a calculation.
        Your system could perform 25 writes per millisecond
@@ -116,7 +116,7 @@ under the License.
 
       <critical-analyzer-policy>HALT</critical-analyzer-policy>
 
-      
+
       <page-sync-timeout>40000</page-sync-timeout>
 
 
@@ -159,8 +159,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -173,8 +171,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/brokerConnect/mirrorSecurityB/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/brokerConnect/mirrorSecurityB/broker.xml
@@ -54,7 +54,7 @@ under the License.
       <journal-device-block-size>4096</journal-device-block-size>
 
       <journal-file-size>10M</journal-file-size>
-      
+
       <!--
        This value was determined through a calculation.
        Your system could perform 25 writes per millisecond
@@ -116,7 +116,7 @@ under the License.
 
       <critical-analyzer-policy>HALT</critical-analyzer-policy>
 
-      
+
       <page-sync-timeout>40000</page-sync-timeout>
 
       <broker-connections>
@@ -158,8 +158,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -172,8 +170,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/brokerConnect/pagedA/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/brokerConnect/pagedA/broker.xml
@@ -159,8 +159,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -173,8 +171,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/brokerConnect/pagedB/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/brokerConnect/pagedB/broker.xml
@@ -159,8 +159,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -173,8 +171,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/brokerConnect/qdr/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/brokerConnect/qdr/broker.xml
@@ -54,7 +54,7 @@ under the License.
       <journal-device-block-size>4096</journal-device-block-size>
 
       <journal-file-size>10M</journal-file-size>
-      
+
       <!--
        This value was determined through a calculation.
        Your system could perform 25 writes per millisecond
@@ -115,7 +115,7 @@ under the License.
 
       <critical-analyzer-policy>HALT</critical-analyzer-policy>
 
-      
+
       <page-sync-timeout>40000</page-sync-timeout>
 
 
@@ -165,8 +165,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>false</auto-create-queues>
             <auto-create-addresses>false</auto-create-addresses>
-            <auto-create-jms-queues>false</auto-create-jms-queues>
-            <auto-create-jms-topics>false</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -179,8 +177,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>false</auto-create-queues>
             <auto-create-addresses>false</auto-create-addresses>
-            <auto-create-jms-queues>false</auto-create-jms-queues>
-            <auto-create-jms-topics>false</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/brokerConnect/replicaBackupServerA/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/brokerConnect/replicaBackupServerA/broker.xml
@@ -101,8 +101,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -117,8 +115,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/brokerConnect/replicaBackupServerB/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/brokerConnect/replicaBackupServerB/broker.xml
@@ -101,8 +101,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -117,8 +115,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/brokerConnect/replicaMainServerA/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/brokerConnect/replicaMainServerA/broker.xml
@@ -98,8 +98,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -114,8 +112,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/brokerConnect/replicaMainServerB/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/brokerConnect/replicaMainServerB/broker.xml
@@ -98,8 +98,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -114,8 +112,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/brokerConnect/serverA/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/brokerConnect/serverA/broker.xml
@@ -54,7 +54,7 @@ under the License.
       <journal-device-block-size>4096</journal-device-block-size>
 
       <journal-file-size>10M</journal-file-size>
-      
+
       <!--
        This value was determined through a calculation.
        Your system could perform 25 writes per millisecond
@@ -115,7 +115,7 @@ under the License.
 
       <critical-analyzer-policy>HALT</critical-analyzer-policy>
 
-      
+
       <page-sync-timeout>40000</page-sync-timeout>
 
 
@@ -159,8 +159,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -173,8 +171,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/brokerConnect/serverB/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/brokerConnect/serverB/broker.xml
@@ -54,7 +54,7 @@ under the License.
       <journal-device-block-size>4096</journal-device-block-size>
 
       <journal-file-size>10M</journal-file-size>
-      
+
       <!--
        This value was determined through a calculation.
        Your system could perform 25 writes per millisecond
@@ -116,7 +116,7 @@ under the License.
 
       <critical-analyzer-policy>HALT</critical-analyzer-policy>
 
-      
+
       <page-sync-timeout>40000</page-sync-timeout>
 
 
@@ -124,7 +124,7 @@ under the License.
          <acceptor name="artemis">tcp://0.0.0.0:61616?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;amqpMinLargeMessageSize=102400;protocols=CORE,AMQP,STOMP,HORNETQ,MQTT,OPENWIRE;useEpoll=true;amqpCredits=1000;amqpLowCredits=300;amqpDuplicateDetection=true</acceptor>
       </acceptors>
 
-      
+
       <broker-connections>
          <amqp-connection uri="tcp://serverA:61616" name="serverA" user="artemis" password="artemis" retry-interval="100" reconnect-attempts="-1">
             <mirror durable="true"/>
@@ -159,8 +159,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -173,8 +171,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/brokerConnect/splitMirror/serverA/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/brokerConnect/splitMirror/serverA/broker.xml
@@ -56,7 +56,7 @@ under the License.
       <journal-device-block-size>4096</journal-device-block-size>
 
       <journal-file-size>10M</journal-file-size>
-      
+
       <!--
        This value was determined through a calculation.
        Your system could perform 25 writes per millisecond
@@ -117,7 +117,7 @@ under the License.
 
       <critical-analyzer-policy>HALT</critical-analyzer-policy>
 
-      
+
       <page-sync-timeout>40000</page-sync-timeout>
 
 
@@ -154,8 +154,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -168,8 +166,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/brokerConnect/splitMirror/serverB/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/brokerConnect/splitMirror/serverB/broker.xml
@@ -54,7 +54,7 @@ under the License.
       <journal-device-block-size>4096</journal-device-block-size>
 
       <journal-file-size>10M</journal-file-size>
-      
+
       <!--
        This value was determined through a calculation.
        Your system could perform 25 writes per millisecond
@@ -116,7 +116,7 @@ under the License.
 
       <critical-analyzer-policy>HALT</critical-analyzer-policy>
 
-      
+
       <page-sync-timeout>40000</page-sync-timeout>
 
 
@@ -152,8 +152,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -166,8 +164,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/brokerConnect/splitMirror/serverRoot/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/brokerConnect/splitMirror/serverRoot/broker.xml
@@ -54,7 +54,7 @@ under the License.
       <journal-device-block-size>4096</journal-device-block-size>
 
       <journal-file-size>10M</journal-file-size>
-      
+
       <!--
        This value was determined through a calculation.
        Your system could perform 25 writes per millisecond
@@ -115,7 +115,7 @@ under the License.
 
       <critical-analyzer-policy>HALT</critical-analyzer-policy>
 
-      
+
       <page-sync-timeout>40000</page-sync-timeout>
 
 
@@ -161,8 +161,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -175,8 +173,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/dnsswitch-replicated-backup-withping/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/dnsswitch-replicated-backup-withping/broker.xml
@@ -103,8 +103,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -119,8 +117,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/dnsswitch-replicated-backup/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/dnsswitch-replicated-backup/broker.xml
@@ -99,8 +99,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -115,8 +113,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/dnsswitch-replicated-main-noretrydns/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/dnsswitch-replicated-main-noretrydns/broker.xml
@@ -97,8 +97,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -113,8 +111,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/dnsswitch-replicated-main-withping/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/dnsswitch-replicated-main-withping/broker.xml
@@ -103,8 +103,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -119,8 +117,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/dnsswitch-replicated-main/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/dnsswitch-replicated-main/broker.xml
@@ -97,8 +97,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -113,8 +111,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/dnsswitch/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/dnsswitch/broker.xml
@@ -144,8 +144,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -159,8 +157,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/dnsswitch2/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/dnsswitch2/broker.xml
@@ -144,8 +144,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -159,8 +157,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/expire/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/expire/broker.xml
@@ -148,8 +148,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -162,8 +160,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/jmx-failback1/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/jmx-failback1/broker.xml
@@ -195,8 +195,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -209,8 +207,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/jmx-failback2/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/jmx-failback2/broker.xml
@@ -194,8 +194,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -208,8 +206,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/maxConsumers/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/maxConsumers/broker.xml
@@ -148,8 +148,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -162,8 +160,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <address-setting match="myQueue">
             <dead-letter-address>DLQ</dead-letter-address>
@@ -176,8 +172,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/mmfactory/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/mmfactory/broker.xml
@@ -193,8 +193,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -209,8 +207,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/mqtt/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/mqtt/broker.xml
@@ -161,8 +161,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -176,8 +174,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/nettynative/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/nettynative/broker.xml
@@ -46,7 +46,7 @@ under the License.
 
       <large-messages-directory>./data/large-messages</large-messages-directory>
 
-      
+
       <!-- if you want to retain your journal uncomment this following configuration.
 
       This will allow your system to keep 7 days of your data, up to 10G. Tweak it accordingly to your use case and capacity.
@@ -113,7 +113,7 @@ under the License.
 
       <critical-analyzer-policy>HALT</critical-analyzer-policy>
 
-      
+
 
             <!-- the system will enter into page mode once you hit this limit.
            This is an estimate in bytes of how much the messages are using in memory
@@ -186,8 +186,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -200,8 +198,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
             <auto-delete-queues>false</auto-delete-queues>
             <auto-delete-addresses>false</auto-delete-addresses>
          </address-setting>

--- a/tests/smoke-tests/src/main/resources/servers/paging/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/paging/broker.xml
@@ -148,8 +148,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -163,8 +161,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/replicated-failback-master1/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/replicated-failback-master1/broker.xml
@@ -101,8 +101,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -117,8 +115,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/replicated-failback-master2/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/replicated-failback-master2/broker.xml
@@ -102,8 +102,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -118,8 +116,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/replicated-failback-master3/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/replicated-failback-master3/broker.xml
@@ -102,8 +102,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -118,8 +116,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/replicated-failback-slave1/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/replicated-failback-slave1/broker.xml
@@ -101,8 +101,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -117,8 +115,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/replicated-static0/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/replicated-static0/broker.xml
@@ -93,8 +93,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -109,8 +107,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/replicated-static1/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/replicated-static1/broker.xml
@@ -95,8 +95,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -111,8 +109,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/zkReplicationBackup/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/zkReplicationBackup/broker.xml
@@ -102,8 +102,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -118,8 +116,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/zkReplicationPrimary/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/zkReplicationPrimary/broker.xml
@@ -100,8 +100,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -116,8 +114,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/zkReplicationPrimaryPeerA/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/zkReplicationPrimaryPeerA/broker.xml
@@ -102,8 +102,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -118,8 +116,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/zkReplicationPrimaryPeerB/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/zkReplicationPrimaryPeerB/broker.xml
@@ -102,8 +102,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
          <!--default for catch all-->
          <address-setting match="#">
@@ -118,8 +116,6 @@ under the License.
             <address-full-policy>PAGE</address-full-policy>
             <auto-create-queues>true</auto-create-queues>
             <auto-create-addresses>true</auto-create-addresses>
-            <auto-create-jms-queues>true</auto-create-jms-queues>
-            <auto-create-jms-topics>true</auto-create-jms-topics>
          </address-setting>
       </address-settings>
 


### PR DESCRIPTION
The auto-create-jms-queues, auto-delete-jms-queues,
auto-create-jms-topics, and auto-delete-jms-topics address settings
were deprecated in ARTEMIS-881 way back in 2016. There's no need to keep
them in the default broker.xml at this point.