### PR TITLE
ARTEMIS-2934 - Added option to suppress SESSION-type notifications

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
@@ -647,6 +647,9 @@ public final class ActiveMQDefaultConfiguration {
    // How often (in ms) to scan for expired MQTT sessions
    private static long DEFAULT_MQTT_SESSION_SCAN_INTERVAL = 500;
 
+   // If SESSION-notifications should be suppressed or not
+   public static boolean DEFAULT_SUPPRESS_SESSION_NOTIFICATIONS = false;
+
    /**
     * If true then the ActiveMQ Artemis Server will make use of any Protocol Managers that are in available on the classpath. If false then only the core protocol will be available, unless in Embedded mode where users can inject their own Protocol Managers.
     */
@@ -1772,4 +1775,9 @@ public final class ActiveMQDefaultConfiguration {
    public static long getMqttSessionScanInterval() {
       return DEFAULT_MQTT_SESSION_SCAN_INTERVAL;
    }
+
+   public static boolean getDefaultSuppressSessionNotifications() {
+      return DEFAULT_SUPPRESS_SESSION_NOTIFICATIONS;
+   }
+
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
@@ -1393,4 +1393,12 @@ public interface Configuration {
     */
    long getMqttSessionScanInterval();
 
+   /**
+    * Returns whether suppression of session-notifications is enabled for this server. <br>
+    * Default value is {@link org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration#DEFAULT_SUPPRESS_SESSION_NOTIFICATIONS}.
+    */
+   boolean isSuppressSessionNotifications();
+
+   Configuration setSuppressSessionNotifications(boolean suppressSessionNotifications);
+
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
@@ -387,6 +387,7 @@ public class ConfigurationImpl implements Configuration, Serializable {
 
    private long mqttSessionScanInterval = ActiveMQDefaultConfiguration.getMqttSessionScanInterval();
 
+   private boolean suppressSessionNotifications = ActiveMQDefaultConfiguration.getDefaultSuppressSessionNotifications();
 
    /**
     * Parent folder for all data folders.
@@ -2687,6 +2688,17 @@ public class ConfigurationImpl implements Configuration, Serializable {
    @Override
    public Configuration setMqttSessionScanInterval(long mqttSessionScanInterval) {
       this.mqttSessionScanInterval = mqttSessionScanInterval;
+      return this;
+   }
+
+   @Override
+   public boolean isSuppressSessionNotifications() {
+      return suppressSessionNotifications;
+   }
+
+   @Override
+   public Configuration setSuppressSessionNotifications(boolean suppressSessionNotifications) {
+      this.suppressSessionNotifications = suppressSessionNotifications;
       return this;
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -323,6 +323,7 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
    private static final String ENABLE_INGRESS_TIMESTAMP = "enable-ingress-timestamp";
 
+   private static final String SUPPRESS_SESSION_NOTIFICATIONS = "suppress-session-notifications";
 
    private boolean validateAIO = false;
 
@@ -768,6 +769,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       config.setCriticalAnalyzerPolicy(CriticalAnalyzerPolicy.valueOf(getString(e, "critical-analyzer-policy", config.getCriticalAnalyzerPolicy().name(), Validators.NOT_NULL_OR_EMPTY)));
 
       config.setPageSyncTimeout(getInteger(e, "page-sync-timeout", config.getJournalBufferTimeout_NIO(), Validators.GE_ZERO));
+
+      config.setSuppressSessionNotifications(getBoolean(e, "suppress-session-notifications", config.isSuppressSessionNotifications()));
 
       parseAddressSettings(e, config);
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -474,6 +474,9 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
    }
 
    private void sendSessionNotification(final CoreNotificationType type) throws Exception {
+      if (server.getConfiguration().isSuppressSessionNotifications()) {
+         return;
+      }
       final TypedProperties props = new TypedProperties();
       if (this.getConnectionID() != null) {
          props.putSimpleStringProperty(ManagementHelper.HDR_CONNECTION_NAME, SimpleString.toSimpleString(this.getConnectionID().toString()));

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -1000,6 +1000,15 @@
             </xsd:annotation>
          </xsd:element>
 
+         <xsd:element name="suppress-session-notifications" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Whether suppression of session-notifications is enabled for this server.
+                  Can improve performance but some protocols such as MQTT need the notifications
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
          <xsd:element name="security-settings" maxOccurs="1" minOccurs="0">
             <xsd:annotation>
                <xsd:documentation>

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
@@ -136,6 +136,7 @@ public class FileConfigurationTest extends ConfigurationImplTest {
       Assert.assertEquals("somedir", conf.getBindingsDirectory());
       Assert.assertEquals(false, conf.isCreateBindingsDir());
       Assert.assertEquals(true, conf.isAmqpUseCoreSubscriptionNaming());
+      Assert.assertEquals(false, conf.isSuppressSessionNotifications());
 
       Assert.assertEquals("max concurrent io", 17, conf.getPageMaxConcurrentIO());
       Assert.assertEquals(true, conf.isReadWholePage());

--- a/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
@@ -67,6 +67,7 @@
       <critical-analyzer-check-period>333</critical-analyzer-check-period>
       <critical-analyzer-timeout>777</critical-analyzer-timeout>
       <critical-analyzer>false</critical-analyzer>
+      <suppress-session-notifications>false</suppress-session-notifications>
       <remoting-incoming-interceptors>
          <class-name>org.apache.activemq.artemis.tests.unit.core.config.impl.TestInterceptor1</class-name>
          <class-name>org.apache.activemq.artemis.tests.unit.core.config.impl.TestInterceptor2</class-name>

--- a/docs/user-manual/en/management.md
+++ b/docs/user-manual/en/management.md
@@ -723,6 +723,19 @@ configured in `broker.xml`:
 
 By default, the address is `activemq.notifications`.
 
+#### Suppressing Session Notifications
+
+Some protocols and messaging patterns can generate a lot of notifications of the types
+`SESSION_CREATED` and `SESSION_CLOSED`. In a clustered environment this will come with some 
+computational overhead. If these notifications are not otherwise used they can be disabled through:
+
+```xml
+<suppress-session-notifications>true</suppress-session-notifications>
+```
+
+Do note however that some protocols such as MQTT rely on these notifications to function properly
+across the cluster. Default value is `false`
+
 #### Receiving Notification Messages
 
 Apache ActiveMQ Artemis's Core JMS Client can be used to receive notifications:

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/NotificationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/NotificationTest.java
@@ -194,6 +194,32 @@ public class NotificationTest extends ActiveMQTestBase {
    }
 
    @Test
+   public void testSuppressSessionNotifications() throws Exception {
+      server.getConfiguration().setSuppressSessionNotifications(false);
+      ClientSessionFactory sf = createSessionFactory(locator);
+
+      NotificationTest.flush(notifConsumer);
+      ClientSession mySession = sf.createSession("myUser", "myPassword", false, true, true, locator.isPreAcknowledge(), locator.getAckBatchSize());
+
+      mySession.start();
+      ClientMessage[] notifications = NotificationTest.consumeMessages(1, notifConsumer);
+      Assert.assertEquals(SESSION_CREATED.toString(), notifications[0].getObjectProperty(ManagementHelper.HDR_NOTIFICATION_TYPE).toString());
+      mySession.close();
+      notifications = NotificationTest.consumeMessages(1, notifConsumer);
+      Assert.assertEquals(SESSION_CLOSED.toString(), notifications[0].getObjectProperty(ManagementHelper.HDR_NOTIFICATION_TYPE).toString());
+
+      NotificationTest.flush(notifConsumer);
+      server.getConfiguration().setSuppressSessionNotifications(true);
+      mySession = sf.createSession("myUser", "myPassword", false, true, true, locator.isPreAcknowledge(), locator.getAckBatchSize());
+
+      mySession.start();
+      NotificationTest.consumeMessages(0, notifConsumer);
+      mySession.close();
+      NotificationTest.consumeMessages(0, notifConsumer);
+
+   }
+
+   @Test
    public void testCONSUMER_CLOSED() throws Exception {
       ClientSessionFactory sf = createSessionFactory(locator);
       ClientSession mySession = sf.createSession("myUser", "myPassword", false, true, true, locator.isPreAcknowledge(), locator.getAckBatchSize());


### PR DESCRIPTION
Add configuration parameter to suppress these notifications as they have a massive performance impact in certain situations, such as when sessions are not cached properly. Gives the benefit of being able to manage this from the broker side and not be at the mercy of all clients behaving as expected.