### PR TITLE
ARTEMIS-3689: tidy up console build, use consistent plugin versions etc

### DIFF
--- a/artemis-hawtio/activemq-branding/pom.xml
+++ b/artemis-hawtio/activemq-branding/pom.xml
@@ -121,7 +121,6 @@
 
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>${maven-antrun-plugin-version}</version>
                 <executions>
 
                     <execution>
@@ -165,7 +164,6 @@
 
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>${maven-resources-plugin-version}</version>
                 <executions>
                     <execution>
                         <!-- defining this maven plugin in the same phase as the
@@ -187,7 +185,6 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>${maven-bundle-plugin-version}</version>
                 <executions>
                     <execution>
                         <id>bundle-manifest</id>

--- a/artemis-hawtio/artemis-console/pom.xml
+++ b/artemis-hawtio/artemis-console/pom.xml
@@ -28,7 +28,6 @@
   <artifactId>artemis-console</artifactId>
   <name>ActiveMQ Artemis Console</name>
 
-  <!-- hawtio plugins are almost always war files -->
   <packaging>war</packaging>
 
   <properties>
@@ -46,10 +45,6 @@
       <groupId>io.hawt</groupId>
       <artifactId>hawtio-war</artifactId>
       <version>${hawtio.version}</version>
-      <!--
-        NOTE this WAR dependency type which enables this WAR to
-        inherit all the plugins and content from the core hawtio-base WAR
-      -->
       <type>war</type>
     </dependency>
 
@@ -63,7 +58,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
       <!-- License: Apache 2.0 -->
       <!-- see https://github.com/google/guava/issues/3006: checker-compat-qual could be excluded -->
       <exclusions>
@@ -106,7 +100,7 @@
                 <exclude>img/icons/**/*</exclude>
                 <exclude>img/**/*</exclude>
                 <exclude>fonts/glyphicons**</exclude>
-                <excluse>WEB-INF/lib/guava*.jar</excluse>
+                <exclude>WEB-INF/lib/guava*.jar</exclude>
               </excludes>
             </overlay>
           </overlays>
@@ -145,7 +139,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>
-        <version>2.5</version>
         <configuration>
           <filesets>
             <fileset>

--- a/artemis-hawtio/artemis-plugin/pom.xml
+++ b/artemis-hawtio/artemis-plugin/pom.xml
@@ -62,10 +62,6 @@
     <schema-outdir>${basedir}/src/main/webapp/lib</schema-outdir>
     <appjs-outfile>${webapp-outdir}/app/app.js</appjs-outfile>
 
-<!--
-    <angular.version>1.7.9</angular.version>
--->
-
   </properties>
 
   <dependencies>
@@ -119,7 +115,6 @@
 
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>${maven-antrun-plugin-version}</version>
         <executions>
 
           <execution>
@@ -160,7 +155,6 @@
 
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>${maven-resources-plugin-version}</version>
         <executions>
           <execution>
             <!-- defining this maven plugin in the same phase as the
@@ -182,7 +176,6 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>${maven-bundle-plugin-version}</version>
         <executions>
           <execution>
             <id>bundle-manifest</id>

--- a/artemis-hawtio/pom.xml
+++ b/artemis-hawtio/pom.xml
@@ -32,25 +32,9 @@
     <packaging>pom</packaging>
 
     <properties>
-
         <activemq.basedir>${project.basedir}/..</activemq.basedir>
 
-        <hawtio.version>2.14.2</hawtio.version>
-        <jline.version>3.2.0</jline.version>
-        <junit-version>4.11</junit-version>
-        <log4j-version>1.2.17</log4j-version>
-        <maven-version>3.0.4</maven-version>
-        <maven-antrun-plugin-version>1.7</maven-antrun-plugin-version>
-        <maven-bundle-plugin-version>3.0.1</maven-bundle-plugin-version>
-        <maven-plugin-version>3.3</maven-plugin-version>
-        <maven-source-plugin-version>2.1.2</maven-source-plugin-version>
-        <maven-resources-plugin-version>2.6</maven-resources-plugin-version>
         <geronimo.servlet.3.0.spec.version>1.0</geronimo.servlet.3.0.spec.version>
-
-        <!-- use slf4j-api 1.6.x to be easy compatible with older Karaf/Camel releases -->
-        <slf4j-api-version>1.6.6</slf4j-api-version>
-        <slf4j-version>1.7.21</slf4j-version>
-
     </properties>
 
     <dependencyManagement>
@@ -76,7 +60,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>${slf4j-version}</version>
+                <version>${slf4j.version}</version>
                 <scope>provided</scope>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
       <commons.codec.version>1.15</commons.codec.version>
       <fuse.mqtt.client.version>1.16</fuse.mqtt.client.version>
       <guava.version>30.1-jre</guava.version>
+      <hawtio.version>2.14.2</hawtio.version>
       <jsr305.version>3.0.2</jsr305.version>
       <jboss.logging.version>3.4.2.Final</jboss.logging.version>
       <jetty.version>9.4.44.v20210927</jetty.version>


### PR DESCRIPTION
This produces basically the same console war as before the change, with only very slight changes to e.g the manifest file entries for osgi bits (mostly change of order).