### PR TITLE
ARTEMIS-3697 Skipping testInabilityToCreateDirectoryDuringPaging for db

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingTest.java
@@ -2041,14 +2041,12 @@ public class PagingTest extends ActiveMQTestBase {
 
    @Test
    public void testInabilityToCreateDirectoryDuringPaging() throws Exception {
+      // this test only applies to file-based stores
+      Assume.assumeTrue(storeType == StoreConfiguration.StoreType.FILE);
 
       AssertionLoggerHandler.startCapture();
 
       try {
-
-         // this test only applies to file-based stores
-         Assume.assumeTrue(storeType == StoreConfiguration.StoreType.FILE);
-
          clearDataRecreateServerDirs();
 
          Configuration config = createDefaultInVMConfig().setJournalSyncNonTransactional(false).setPagingDirectory("/" + UUID.randomUUID().toString());


### PR DESCRIPTION
Execute org.apache.activemq.artemis.tests.integration.paging.PagingTest.testInabilityToCreateDirectoryDuringPaging[storeType=DATABASE, mapped=false] to reproduce this issue.