### PR TITLE
ARTEMIS-3695: use specific jetty deps instead of uber jar

### DIFF
--- a/artemis-distribution/src/main/assembly/dep.xml
+++ b/artemis-distribution/src/main/assembly/dep.xml
@@ -32,25 +32,11 @@
         </includes>
         <useProjectArtifact>false</useProjectArtifact>
       </dependencySet>
-      <dependencySet>
-         <directoryMode>0755</directoryMode>
-         <fileMode>0644</fileMode>
-         <includes>
-            <include>org.eclipse.jetty.aggregate:jetty-all:jar:uber</include>
-         </includes>
-         <outputDirectory>lib</outputDirectory>
-         <unpack>false</unpack>
-         <useProjectArtifact>false</useProjectArtifact>
-      </dependencySet>
 
       <dependencySet>
          <directoryMode>0755</directoryMode>
          <fileMode>0644</fileMode>
          <excludes>
-            <!-- Handled above for now to avoid it bringing in duplicative transitive deps -->
-            <!-- Should not be using this according to the jetty folks: https://www.eclipse.org//lists/jetty-users/msg06029.html -->
-            <exclude>org.eclipse.jetty.aggregate:jetty-all:jar:uber</exclude>
-
             <!-- Handled above -->
             <exclude>org.apache.activemq:artemis-boot</exclude>
 

--- a/artemis-hawtio/activemq-branding/pom.xml
+++ b/artemis-hawtio/activemq-branding/pom.xml
@@ -82,8 +82,8 @@
 
         <!-- servlet API is provided by the container -->
         <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-servlet_3.0_spec</artifactId>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/artemis-hawtio/artemis-console/pom.xml
+++ b/artemis-hawtio/artemis-console/pom.xml
@@ -36,8 +36,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.geronimo.specs</groupId>
-      <artifactId>geronimo-servlet_3.0_spec</artifactId>
+      <groupId>org.apache.tomcat</groupId>
+      <artifactId>tomcat-servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
 

--- a/artemis-hawtio/artemis-plugin/pom.xml
+++ b/artemis-hawtio/artemis-plugin/pom.xml
@@ -76,8 +76,8 @@
 
     <!-- servlet API is provided by the container -->
     <dependency>
-      <groupId>org.apache.geronimo.specs</groupId>
-      <artifactId>geronimo-servlet_3.0_spec</artifactId>
+      <groupId>org.apache.tomcat</groupId>
+      <artifactId>tomcat-servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
 

--- a/artemis-hawtio/pom.xml
+++ b/artemis-hawtio/pom.xml
@@ -33,8 +33,6 @@
 
     <properties>
         <activemq.basedir>${project.basedir}/..</activemq.basedir>
-
-        <geronimo.servlet.3.0.spec.version>1.0</geronimo.servlet.3.0.spec.version>
     </properties>
 
     <dependencyManagement>
@@ -46,14 +44,6 @@
                 <groupId>io.hawt</groupId>
                 <artifactId>hawtio-plugin-mbean</artifactId>
                 <version>${hawtio.version}</version>
-            </dependency>
-
-            <!-- servlet API is provided by the container -->
-            <dependency>
-                <groupId>org.apache.geronimo.specs</groupId>
-                <artifactId>geronimo-servlet_3.0_spec</artifactId>
-                <version>${geronimo.servlet.3.0.spec.version}</version>
-                <scope>provided</scope>
             </dependency>
 
             <!-- logging -->

--- a/artemis-rest/pom.xml
+++ b/artemis-rest/pom.xml
@@ -57,10 +57,12 @@
          <artifactId>jboss-logmanager</artifactId>
       </dependency>
       <dependency>
-         <groupId>org.eclipse.jetty.aggregate</groupId>
-         <artifactId>jetty-all</artifactId>
-         <type>jar</type>
-         <classifier>uber</classifier>
+         <groupId>org.apache.tomcat</groupId>
+         <artifactId>tomcat-servlet-api</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.eclipse.jetty</groupId>
+         <artifactId>jetty-server</artifactId>
       </dependency>
       <dependency>
          <groupId>org.jboss.resteasy</groupId>
@@ -94,6 +96,12 @@
          <groupId>org.jboss.resteasy</groupId>
          <artifactId>tjws</artifactId>
          <scope>provided</scope>
+         <exclusions>
+            <exclusion>
+               <groupId>javax.servlet</groupId>
+               <artifactId>servlet-api</artifactId>
+            </exclusion>
+         </exclusions>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>

--- a/artemis-web/pom.xml
+++ b/artemis-web/pom.xml
@@ -102,10 +102,20 @@
          <artifactId>netty-handler</artifactId>
       </dependency>
       <dependency>
-         <groupId>org.eclipse.jetty.aggregate</groupId>
-         <artifactId>jetty-all</artifactId>
-         <type>jar</type>
-         <classifier>uber</classifier>
+         <groupId>org.apache.tomcat</groupId>
+         <artifactId>tomcat-servlet-api</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.eclipse.jetty</groupId>
+         <artifactId>jetty-server</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.eclipse.jetty</groupId>
+         <artifactId>jetty-servlet</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.eclipse.jetty</groupId>
+         <artifactId>jetty-webapp</artifactId>
       </dependency>
       <dependency>
          <groupId>junit</groupId>

--- a/examples/features/sub-modules/tomcat/pom.xml
+++ b/examples/features/sub-modules/tomcat/pom.xml
@@ -35,8 +35,6 @@ under the License.
         <activemq.basedir>${project.basedir}/../../../..</activemq.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <projectBaseUri>${project.baseUri}</projectBaseUri>
-
-        <geronimo.servlet.3.0.spec.version>1.0</geronimo.servlet.3.0.spec.version>
     </properties>
 
     <dependencies>
@@ -58,7 +56,6 @@ under the License.
             <version>${spring.version}</version>
         </dependency>
         
-        
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>artemis-jms-client</artifactId>
@@ -66,9 +63,8 @@ under the License.
         </dependency>
 
         <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-servlet_3.0_spec</artifactId>
-            <version>${geronimo.servlet.3.0.spec.version}</version>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,7 @@
       <jsr305.version>3.0.2</jsr305.version>
       <jboss.logging.version>3.4.2.Final</jboss.logging.version>
       <jetty.version>9.4.44.v20210927</jetty.version>
+      <tomcat.servlet-api.version>8.5.76</tomcat.servlet-api.version>
       <jgroups.version>5.2.0.Final</jgroups.version>
       <errorprone.version>2.10.0</errorprone.version>
       <maven.enforcer.plugin.version>3.0.0-M3</maven.enforcer.plugin.version>
@@ -750,13 +751,30 @@
 
          <!-- ## Jetty web Dependencies ##-->
          <dependency>
-            <groupId>org.eclipse.jetty.aggregate</groupId>
-            <artifactId>jetty-all</artifactId>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
             <version>${jetty.version}</version>
-            <type>jar</type>
-            <classifier>uber</classifier>
+            <exclusions>
+               <exclusion>
+                  <groupId>javax.servlet</groupId>
+                  <artifactId>javax.servlet-api</artifactId>
+               </exclusion>
+            </exclusions>
             <!-- License: (Joint): Apache 2.0 & EPL 1.0 -->
-        </dependency>
+         </dependency>
+         <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-bom</artifactId>
+            <version>${jetty.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+            <!-- License: (Joint): Apache 2.0 & EPL 1.0 -->
+         </dependency>
+         <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-servlet-api</artifactId>
+            <version>${tomcat.servlet-api.version}</version>
+         </dependency>
          <!-- ## End Jetty Wed Dependencies ## -->
 
          <!-- for URL reflection. Using Populate on URI Factory at activemq-commons -->

--- a/tests/integration-tests/pom.xml
+++ b/tests/integration-tests/pom.xml
@@ -362,10 +362,12 @@
 
       <!-- rest test -->
       <dependency>
-         <groupId>org.eclipse.jetty.aggregate</groupId>
-         <artifactId>jetty-all</artifactId>
-         <type>jar</type>
-         <classifier>uber</classifier>
+         <groupId>org.apache.tomcat</groupId>
+         <artifactId>tomcat-servlet-api</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.eclipse.jetty</groupId>
+         <artifactId>jetty-server</artifactId>
       </dependency>
       <dependency>
          <groupId>org.jboss.resteasy</groupId>


### PR DESCRIPTION
Use specific jetty deps instead of uber jar, rationalise the servlet api deps.

Partially reverts https://github.com/apache/activemq-artemis/commit/c5f94f340d721600c4b67dc003eace023b046211 as it was useful after all.

This passes all the tests, and the console seems to work fine. It doesnt seem that any of the many more things jetty-all brought in [1] are actually needed, but maybe someone more familiar with these bits would know more.

[1] https://repo1.maven.org/maven2/org/eclipse/jetty/aggregate/jetty-all/9.4.44.v20210927/jetty-all-9.4.44.v20210927.pom