### PR TITLE
ARTEMIS-3702 auth failures don't adhere to MQTT spec

### DIFF
--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTProtocolManager.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTProtocolManager.java
@@ -72,6 +72,8 @@ public class MQTTProtocolManager extends AbstractProtocolManager<MqttMessage, MQ
 
    private int maximumPacketSize = MQTTUtil.DEFAULT_MAXIMUM_PACKET_SIZE;
 
+   private boolean closeMqttConnectionOnPublishAuthorizationFailure = true;
+
    private final MQTTRoutingHandler routingHandler;
 
    MQTTProtocolManager(ActiveMQServer server,
@@ -126,6 +128,14 @@ public class MQTTProtocolManager extends AbstractProtocolManager<MqttMessage, MQ
    public MQTTProtocolManager setServerKeepAlive(int serverKeepAlive) {
       this.serverKeepAlive = serverKeepAlive;
       return this;
+   }
+
+   public boolean isCloseMqttConnectionOnPublishAuthorizationFailure() {
+      return closeMqttConnectionOnPublishAuthorizationFailure;
+   }
+
+   public void setCloseMqttConnectionOnPublishAuthorizationFailure(boolean closeMqttConnectionOnPublishAuthorizationFailure) {
+      this.closeMqttConnectionOnPublishAuthorizationFailure = closeMqttConnectionOnPublishAuthorizationFailure;
    }
 
    @Override

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTSession.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTSession.java
@@ -65,7 +65,7 @@ public class MQTTSession {
 
    private CoreMessageObjectPools coreMessageObjectPools = new CoreMessageObjectPools();
 
-   private boolean five = false;
+   private MQTTVersion version = null;
 
    private boolean usingServerKeepAlive = false;
 
@@ -80,7 +80,7 @@ public class MQTTSession {
       this.connection = connection;
 
       mqttConnectionManager = new MQTTConnectionManager(this);
-      mqttPublishManager = new MQTTPublishManager(this);
+      mqttPublishManager = new MQTTPublishManager(this, protocolManager.isCloseMqttConnectionOnPublishAuthorizationFailure());
       sessionCallback = new MQTTSessionCallback(this, connection);
       subscriptionManager = new MQTTSubscriptionManager(this);
       retainMessageManager = new MQTTRetainMessageManager(this);
@@ -120,7 +120,7 @@ public class MQTTSession {
             state.setDisconnectedTime(System.currentTimeMillis());
          }
 
-         if (is5()) {
+         if (getVersion() == MQTTVersion.MQTT_5) {
             if (state.getClientSessionExpiryInterval() == 0) {
                if (state.isWill() && failure) {
                   // If the session expires the will message must be sent no matter the will delay
@@ -234,12 +234,12 @@ public class MQTTSession {
       return coreMessageObjectPools;
    }
 
-   public boolean is5() {
-      return five;
+   public void setVersion(MQTTVersion version) {
+      this.version = version;
    }
 
-   public void set5(boolean five) {
-      this.five = five;
+   public MQTTVersion getVersion() {
+      return this.version;
    }
 
    public boolean isUsingServerKeepAlive() {

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTSubscriptionManager.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTSubscriptionManager.java
@@ -309,13 +309,30 @@ public class MQTTSubscriptionManager {
                qos[i] = subscriptions.get(i).qualityOfService().value();
             } catch (ActiveMQSecurityException e) {
                // user is not authorized to create subsription
-               if (session.is5()) {
+               if (session.getVersion() == MQTTVersion.MQTT_5) {
                   qos[i] = MQTTReasonCodes.NOT_AUTHORIZED;
-               } else {
+               } else if (session.getVersion() == MQTTVersion.MQTT_3_1_1) {
                   qos[i] = MQTTReasonCodes.UNSPECIFIED_ERROR;
+               } else {
+                  /*
+                   * For MQTT 3.1 clients:
+                   *
+                   * Note that if a server implementation does not authorize a SUBSCRIBE request to be made by a client,
+                   * it has no way of informing that client. It must therefore make a positive acknowledgement with a
+                   * SUBACK, and the client will not be informed that it was not authorized to subscribe.
+                   *
+                   *
+                   * For MQTT 3.1.1 clients:
+                   *
+                   * The 3.1.1 spec doesn't directly address the situation where the server does not authorize a
+                   * SUBSCRIBE. It really just says this:
+                   *
+                   * [MQTT-3.8.4-1] When the Server receives a SUBSCRIBE Packet from a Client, the Server MUST respond
+                   *  with a SUBACK Packet.
+                   */
+                  qos[i] = subscriptions.get(i).qualityOfService().value();
                }
             }
-
          }
          return qos;
       }

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTVersion.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTVersion.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.core.protocol.mqtt;
+
+public enum MQTTVersion {
+
+   MQTT_3_1, MQTT_3_1_1, MQTT_5;
+
+   public int getVersion() {
+      switch (this) {
+         case MQTT_3_1:
+            return 3;
+         case MQTT_3_1_1:
+            return 4;
+         case MQTT_5:
+            return 5;
+         default:
+            return -1;
+      }
+   }
+
+   public static MQTTVersion getVersion(int version) {
+      switch (version) {
+         case 3:
+            return MQTT_3_1;
+         case 4:
+            return MQTT_3_1_1;
+         case 5:
+            return MQTT_5;
+         default:
+            return null;
+      }
+   }
+}

--- a/docs/user-manual/en/mqtt.md
+++ b/docs/user-manual/en/mqtt.md
@@ -263,3 +263,23 @@ However, there are currently no challenge / response mechanisms implemented so i
 a client passes the "Authentication Method" property in its `CONNECT` packet it will
 receive a `CONNACK` with a reason code of `0x8C` (i.e. bad authentication method)
 and the network connection will be closed.
+
+## Publish Authorization Failures
+
+The MQTT 3.1.1 specification is ambiguous regarding the broker's behavior when
+a `PUBLISH` packet fails due to a lack of authorization. In [section 3.3.5](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718042)
+it says:
+
+> If a Server implementation does not authorize a PUBLISH to be performed by a
+> Client; it has no way of informing that Client. It MUST either make a positive
+> acknowledgement, according to the normal QoS rules, or close the Network
+> Connection
+
+By default the broker will close the network connection. However if you'd rather
+have the broker make a positive acknowledgement then set the URL parameter
+`closeMqttConnectionOnPublishAuthorizationFailure` to `false` on the relevant
+MQTT `acceptor` in `broker.xml`, e.g.:
+
+```xml
+<acceptor name="mqtt">tcp://0.0.0:1883?protocols=MQTT;closeMqttConnectionOnPublishAuthorizationFailure=false</acceptor>
+```


### PR DESCRIPTION
The commit includes the following changes:
 - Don't drop the connection on subscribe or publish authorization
failures for 3.1 clients.
 - Don't drop the connection on subscribe authorization failures for
3.1.1 clients.
 - Add configuration parameter to control behavior on publish
authorization failures for 3.1.1 clients (either disconnect or not).