### PR TITLE
Changed artemis group/user id to 1001

### DIFF
--- a/artemis-docker/Dockerfile-adoptopenjdk-11
+++ b/artemis-docker/Dockerfile-adoptopenjdk-11
@@ -29,7 +29,7 @@ ENV ANONYMOUS_LOGIN false
 ENV EXTRA_ARGS --http-host 0.0.0.0 --relax-jolokia
 
 # add user and group for artemis
-RUN groupadd -g 1000 -r artemis && useradd -r -u 1000 -g artemis artemis \
+RUN groupadd -g 1001 -r artemis && useradd -r -u 1001 -g artemis artemis \
  && apt-get -qq -o=Dpkg::Use-Pty=0 update && \
     apt-get -qq -o=Dpkg::Use-Pty=0 install -y libaio1 && \
     rm -rf /var/lib/apt/lists/*

--- a/artemis-docker/Dockerfile-debian
+++ b/artemis-docker/Dockerfile-debian
@@ -29,7 +29,7 @@ ENV ANONYMOUS_LOGIN false
 ENV EXTRA_ARGS --http-host 0.0.0.0 --relax-jolokia
 
 # add user and group for artemis
-RUN groupadd -g 1000 -r artemis && useradd -r -u 1000 -g artemis artemis \
+RUN groupadd -g 1001 -r artemis && useradd -r -u 1001 -g artemis artemis \
  && apt-get -qq -o=Dpkg::Use-Pty=0 update && \
     apt-get -qq -o=Dpkg::Use-Pty=0 install -y libaio1 && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Changed group and user ids to 1001 to allow artemis user to be the owner of /var/lib/artemis-instance and /opt/activemq-artemis. Otherwise the owner will be root (1000). This was already being done in Dockerfile-centos file.