### PR TITLE
ARTEMIS-3719 DLA and expiry incorrect w/temp-queue-namespace

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/QueueControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/QueueControlImpl.java
@@ -16,9 +16,6 @@
  */
 package org.apache.activemq.artemis.core.management.impl;
 
-import org.apache.activemq.artemis.json.JsonArray;
-import org.apache.activemq.artemis.json.JsonArrayBuilder;
-import org.apache.activemq.artemis.json.JsonObjectBuilder;
 import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanOperationInfo;
 import javax.management.openmbean.CompositeData;
@@ -56,8 +53,11 @@ import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.core.transaction.ResourceManager;
 import org.apache.activemq.artemis.core.transaction.Transaction;
 import org.apache.activemq.artemis.core.transaction.TransactionOperation;
-import org.apache.activemq.artemis.selector.filter.Filterable;
+import org.apache.activemq.artemis.json.JsonArray;
+import org.apache.activemq.artemis.json.JsonArrayBuilder;
+import org.apache.activemq.artemis.json.JsonObjectBuilder;
 import org.apache.activemq.artemis.logs.AuditLogger;
+import org.apache.activemq.artemis.selector.filter.Filterable;
 import org.apache.activemq.artemis.utils.JsonLoader;
 import org.apache.activemq.artemis.utils.collections.LinkedListIterator;
 import org.jboss.logging.Logger;
@@ -545,12 +545,7 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
       clearIO();
       try {
-         AddressSettings addressSettings = addressSettingsRepository.getMatch(address);
-
-         if (addressSettings != null && addressSettings.getDeadLetterAddress() != null) {
-            return addressSettings.getDeadLetterAddress().toString();
-         }
-         return null;
+         return queue.getDeadLetterAddress() == null ? null : queue.getDeadLetterAddress().toString();
       } finally {
          blockOnIO();
       }
@@ -565,13 +560,7 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
 
       clearIO();
       try {
-         AddressSettings addressSettings = addressSettingsRepository.getMatch(address);
-
-         if (addressSettings != null && addressSettings.getExpiryAddress() != null) {
-            return addressSettings.getExpiryAddress().toString();
-         } else {
-            return null;
-         }
+         return queue.getExpiryAddress() == null ? null : queue.getExpiryAddress().toString();
       } finally {
          blockOnIO();
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/Queue.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/Queue.java
@@ -431,6 +431,8 @@ public interface Queue extends Bindable,CriticalComponent {
 
    SimpleString getExpiryAddress();
 
+   SimpleString getDeadLetterAddress();
+
    /**
     * Pauses the queue. It will receive messages but won't give them to the consumers until resumed.
     * If a queue is paused, pausing it again will only throw a warning.

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/ScheduledDeliveryHandlerTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/ScheduledDeliveryHandlerTest.java
@@ -1534,6 +1534,11 @@ public class ScheduledDeliveryHandlerTest extends Assert {
       }
 
       @Override
+      public SimpleString getDeadLetterAddress() {
+         return null;
+      }
+
+      @Override
       public void pause() {
 
       }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/FakeQueue.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/FakeQueue.java
@@ -842,6 +842,11 @@ public class FakeQueue extends CriticalComponentImpl implements Queue {
    }
 
    @Override
+   public SimpleString getDeadLetterAddress() {
+      return null;
+   }
+
+   @Override
    public void route(final Message message, final RoutingContext context) throws Exception {
       // no-op
 


### PR DESCRIPTION
When using a temporary queue with a `temporary-queue-namespace` the
`AddressSettings` lookup wasn't correct. This commit fixes that and
refactors `QueueImpl` a bit so that it holds a copy of its
`AddressSettings` rather than looking them up all the time. If any
relevant `AddressSettings` changes the
`HierarchicalRepositoryChangeListener` implementation will still
refresh the `QueueImpl` appropriately.

The `QueueControlImpl` was likewise changed to get the dead-letter
address and expiry address directly from the `QueueImpl` rather than
looking them up in the `AddressSettings` repository.

I modified some code that came from ARTEMIS-734, but I ran the test that
was associated with that Jira (i.e.
`o.a.a.a.t.i.c.d.ExpireWhileLoadBalanceTest`) and it passed so I think
that should be fine. There actually was no test included with the
original commit. One was added later so it's hard to say for sure it
exactly captures the original issue.