### PR TITLE
ARTEMIS-3676 ignore NoRouteToHostException

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnector.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnector.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.net.ConnectException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.NoRouteToHostException;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -951,7 +952,7 @@ public class NettyConnector extends AbstractConnector {
       } else {
          Throwable t = future.cause();
 
-         if (t != null && !(t instanceof ConnectException)) {
+         if (t != null && !(t instanceof ConnectException) && !(t instanceof NoRouteToHostException)) {
             ActiveMQClientLogger.LOGGER.errorCreatingNettyConnection(future.cause());
          }
 


### PR DESCRIPTION
This kind of exception can be common in cloud environments and should be
ignored for logging just like ConnectException.