### PR TITLE
[ARTEMIS-3732]: ServerLocator disableFinalizeCheck method has been

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/client/ServerLocator.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/client/ServerLocator.java
@@ -48,6 +48,13 @@ public interface ServerLocator extends AutoCloseable {
    boolean isClosed();
 
    /**
+    * Just kept for compatibility.
+    */
+   @Deprecated
+   default void disableFinalizeCheck() {
+   }
+
+   /**
     * Creates a ClientSessionFactory using whatever load balancing policy is in force
     *
     * @return The ClientSessionFactory


### PR DESCRIPTION
removed without being deprecated first.

* Adding back empty default method for retro compatibility.

Jira: https://issues.apache.org/jira/browse/ARTEMIS-3732