### PR TITLE
ARTEMIS-3733 - Destination cache size too small for OpenWire clients

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireProtocolManager.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireProtocolManager.java
@@ -136,6 +136,8 @@ public class OpenWireProtocolManager  extends AbstractProtocolManager<Command, O
    //to management service
    private boolean suppressInternalManagementObjects = true;
 
+   private int openWireDestinationCacheSize = 16;
+
    private final OpenWireFormat wireFormat;
 
    private final Map<SimpleString, RoutingType> prefixes = new HashMap<>();
@@ -716,6 +718,14 @@ public class OpenWireProtocolManager  extends AbstractProtocolManager<Command, O
 
    public void setSuppressInternalManagementObjects(boolean suppressInternalManagementObjects) {
       this.suppressInternalManagementObjects = suppressInternalManagementObjects;
+   }
+
+   public int getOpenWireDestinationCacheSize() {
+      return this.openWireDestinationCacheSize;
+   }
+
+   public void setOpenWireDestinationCacheSize(int openWireDestinationCacheSize) {
+      this.openWireDestinationCacheSize = openWireDestinationCacheSize;
    }
 
    public void setVirtualTopicConsumerWildcards(String virtualTopicConsumerWildcards) {

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQSession.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQSession.java
@@ -200,8 +200,8 @@ public class AMQSession implements SessionCallback {
       //lazy allocation of the cache
       if (existingQueuesCache == null) {
          //16 means 64 bytes with 32 bit references or 128 bytes with 64 bit references -> 1 or 2 cache lines with common archs
-         existingQueuesCache = new String[16];
-         assert (Integer.bitCount(existingQueuesCache.length) == 1) : "existingQueuesCache.length must be power of 2";
+         existingQueuesCache = new String[protocolManager.getOpenWireDestinationCacheSize()];
+         assert (Integer.bitCount(existingQueuesCache.length) == 1) : "openWireDestinationCacheSize must be a power of 2";
          this.existingQueuesCache = existingQueuesCache;
       }
       final int hashCode = physicalName.hashCode();

--- a/docs/user-manual/en/openwire.md
+++ b/docs/user-manual/en/openwire.md
@@ -81,6 +81,18 @@ The two parameters are configured on an OpenWire `acceptor`, e.g.:
 <acceptor name="artemis">tcp://localhost:61616?protocols=OPENWIRE;supportAdvisory=true;suppressInternalManagementObjects=false</acceptor>
 ```
 
+## OpenWire Destination Cache
+For improved performance of the broker we keep a cache of recently used destinations, so that when new messages are dispatched to them,
+we do not have to do a lookup every time. By default, this cache holds up to `16` destinations. If additional destinations are added 
+they will overwrite older records.
+If you are dealing with a large amount of queues you might want to increase this value, which is done via configuration option:
+`openWireDestinationCacheSize` set on the OpenWire `acceptor` like this:
+```xml
+<acceptor name="artemis">tcp://localhost:61616?protocols=OPENWIRE;openWireDestinationCacheSize=64</acceptor>
+```
+
+This cache has to be set to a power of 2, i.e.: `2`, `16`, `128` and so on.
+
 ## Virtual Topic Consumer Destination Translation
 
 For existing OpenWire consumers of virtual topic destinations it is possible to


### PR DESCRIPTION
For my use-case I see overall CPU-util go down by about 25% when increasing this value to more closely match my actual number of destinations used by OpenWire clients (>1000 destinations).