### PR TITLE
NO-JIRA fix duplicate text in security.md doc

### DIFF
--- a/docs/user-manual/en/security.md
+++ b/docs/user-manual/en/security.md
@@ -893,34 +893,9 @@ In the preceding example, the JAAS realm is configured to use a single
 `org.apache.activemq.artemis.spi.core.security.jaas.TextFileCertificateLoginModule`
 login module. The options supported by this login module are as follows:
 
--   `debug` - boolean flag; if true, enable debugging; this is used only for testing or debugging; normally,
-    it should be set to `false`, or omitted; default is `false`
-
--   `org.apache.activemq.jaas.textfiledn.user` - specifies the location of the user properties file (relative to the
-     directory containing the login configuration file).
-
--   `org.apache.activemq.jaas.textfiledn.role` - specifies the location of the role properties file (relative to the
-    directory containing the login configuration file).
-
--   `reload` - boolean flag; whether or not to reload the properties files when a modification occurs; default is `false`
-
-In the context of the certificate login module, the `users.properties` file consists of a list of properties of the form,
-`UserName=StringifiedSubjectDN` or `UserName=/SubjectDNRegExp/`. For example, to define the users, `system`, `user` and
-`guest` as well as a `hosts` user matching several DNs, you could create a file like the following:
-
-    system=CN=system,O=Progress,C=US
-    user=CN=humble user,O=Progress,C=US
-    guest=CN=anon,O=Progress,C=DE
-    hosts=/CN=host\\d+\\.acme\\.com,O=Acme,C=UK/
-
-Note that the backslash character has to be escaped because it has a special treatment in properties files.
-
-Each username is mapped to a subject DN, encoded as a string (where the string encoding is specified by RFC 2253). For
-example, the system username is mapped to the `CN=system,O=Progress,C=US` subject DN. When performing authentication,
-the plug-in extracts the subject DN from the received certificate, converts it to the standard string format, and
-compares it with the subject DNs in the `users.properties` file by testing for string equality. Consequently, you must
-be careful to ensure that the subject DNs appearing in the `users.properties` file are an exact match for the subject
-DNs extracted from the user certificates.
+- `debug` - boolean flag; if true, enable debugging; this is used only for
+  testing or debugging; normally, it should be set to `false`, or omitted;
+  default is `false`
 
 - `org.apache.activemq.jaas.textfiledn.user` - specifies the location of the
   user properties file (relative to the directory containing the login
@@ -934,15 +909,20 @@ DNs extracted from the user certificates.
   modification occurs; default is `false`
 
 In the context of the certificate login module, the `users.properties` file
-consists of a list of properties of the form, `UserName=StringifiedSubjectDN`.
-For example, to define the users, system, user, and guest, you could create a
-file like the following:
+consists of a list of properties of the form, `UserName=StringifiedSubjectDN`
+or `UserName=/SubjectDNRegExp/`. For example, to define the users, `system`,
+`user` and `guest` as well as a `hosts` user matching several DNs, you could
+create a file like the following:
 
 ```properties
 system=CN=system,O=Progress,C=US
 user=CN=humble user,O=Progress,C=US
 guest=CN=anon,O=Progress,C=DE
+hosts=/CN=host\\d+\\.acme\\.com,O=Acme,C=UK/
 ```
+
+Note that the backslash character has to be escaped because it has a special
+treatment in properties files.
 
 Each username is mapped to a subject DN, encoded as a string (where the string
 encoding is specified by RFC 2253). For example, the system username is mapped


### PR DESCRIPTION
This PR is to remove a duplicate documentation text in the CertificateLoginModule section of the the security.md doc
