### PR TITLE
ARTEMIS-3764 wrong CONNACK return code for MQTT5

### DIFF
--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTConnectionManager.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTConnectionManager.java
@@ -58,7 +58,6 @@ public class MQTTConnectionManager {
    }
 
    void connect(MqttConnectMessage connect, String validatedUser) throws Exception {
-      session.setVersion(MQTTVersion.getVersion(connect.variableHeader().version()));
       if (session.getVersion() == MQTTVersion.MQTT_5) {
          session.getConnection().setProtocolVersion(Byte.toString(MqttVersion.MQTT_5.protocolLevel()));
          String authenticationMethod = MQTTUtil.getProperty(String.class, connect.variableHeader().properties(), AUTHENTICATION_METHOD);


### PR DESCRIPTION
This bug is causing tests in o.a.a.a.t.i.m.s.c.ConnectTestsWithSecurity
to fail.

This commit fixes the problem by setting the session's version earlier
in the logic handling the CONNECT packet so that the proper CONNACK
return code can be supplied to the remote client in case of
authentication failure.