### PR TITLE
ARTEMIS-3770 refactor MQTT handling of client ID

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/protocol/AbstractRemotingConnection.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/protocol/AbstractRemotingConnection.java
@@ -161,20 +161,16 @@ public abstract class AbstractRemotingConnection implements RemotingConnection {
 
    @Override
    public List<CloseListener> removeCloseListeners() {
-      List<CloseListener> ret = new ArrayList<>(closeListeners);
-
+      List<CloseListener> deletedCloseListeners = new ArrayList<>(closeListeners);
       closeListeners.clear();
-
-      return ret;
+      return deletedCloseListeners;
    }
 
    @Override
    public List<FailureListener> removeFailureListeners() {
-      List<FailureListener> ret = getFailureListeners();
-
+      List<FailureListener> deletedFailureListeners = getFailureListeners();
       failureListeners.clear();
-
-      return ret;
+      return deletedFailureListeners;
    }
 
    @Override

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTConnection.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTConnection.java
@@ -19,151 +19,41 @@ package org.apache.activemq.artemis.core.protocol.mqtt;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.core.remoting.CloseListener;
 import org.apache.activemq.artemis.core.remoting.FailureListener;
-import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
+import org.apache.activemq.artemis.spi.core.protocol.AbstractRemotingConnection;
 import org.apache.activemq.artemis.spi.core.remoting.Connection;
-import org.apache.activemq.artemis.spi.core.remoting.ReadyListener;
 
-import javax.security.auth.Subject;
-
-public class MQTTConnection implements RemotingConnection {
-
-   private final Connection transportConnection;
-
-   private final long creationTime;
-
-   private AtomicBoolean dataReceived;
+public class MQTTConnection extends AbstractRemotingConnection {
 
    private boolean destroyed;
 
    private boolean connected;
 
-   private String clientID;
-
-   private final List<FailureListener> failureListeners = new CopyOnWriteArrayList<>();
-
-   private final List<CloseListener> closeListeners = new CopyOnWriteArrayList<>();
-
-   private Subject subject;
-
    private int receiveMaximum = -1;
 
    private String protocolVersion;
 
+   private boolean clientIdAssignedByBroker = false;
+
    public MQTTConnection(Connection transportConnection) throws Exception {
-      this.transportConnection = transportConnection;
-      this.creationTime = System.currentTimeMillis();
-      this.dataReceived = new AtomicBoolean();
+      super(transportConnection, null);
       this.destroyed = false;
       transportConnection.setProtocolConnection(this);
    }
 
-
-   @Override
-   public void scheduledFlush() {
-      flush();
-   }
-
-   @Override
-   public boolean isWritable(ReadyListener callback) {
-      return transportConnection.isWritable(callback) && transportConnection.isOpen();
-   }
-
-   @Override
-   public Object getID() {
-      return transportConnection.getID();
-   }
-
-   @Override
-   public long getCreationTime() {
-      return creationTime;
-   }
-
-   @Override
-   public String getRemoteAddress() {
-      return transportConnection.getRemoteAddress();
-   }
-
-   @Override
-   public void addFailureListener(FailureListener listener) {
-      failureListeners.add(listener);
-   }
-
-   @Override
-   public boolean removeFailureListener(FailureListener listener) {
-      return failureListeners.remove(listener);
-   }
-
-   @Override
-   public void addCloseListener(CloseListener listener) {
-      closeListeners.add(listener);
-   }
-
-   @Override
-   public boolean removeCloseListener(CloseListener listener) {
-      return closeListeners.remove(listener);
-   }
-
-   @Override
-   public List<CloseListener> removeCloseListeners() {
-      List<CloseListener> deletedCloseListeners = copyCloseListeners();
-      closeListeners.clear();
-      return deletedCloseListeners;
-   }
-
-   @Override
-   public void setCloseListeners(List<CloseListener> listeners) {
-      closeListeners.clear();
-      closeListeners.addAll(listeners);
-   }
-
-   @Override
-   public List<FailureListener> getFailureListeners() {
-      return failureListeners;
-   }
-
-   @Override
-   public List<FailureListener> removeFailureListeners() {
-      List<FailureListener> deletedFailureListeners = copyFailureListeners();
-      failureListeners.clear();
-      return deletedFailureListeners;
-   }
-
-   @Override
-   public void setFailureListeners(List<FailureListener> listeners) {
-      failureListeners.clear();
-      failureListeners.addAll(listeners);
-   }
-
-   @Override
-   public ActiveMQBuffer createTransportBuffer(int size) {
-      return transportConnection.createTransportBuffer(size);
-   }
-
    @Override
    public void fail(ActiveMQException me) {
-      List<FailureListener> copy = copyFailureListeners();
+      List<FailureListener> copy = new ArrayList<>(failureListeners);
       for (FailureListener listener : copy) {
          listener.connectionFailed(me, false);
       }
       transportConnection.close();
-   }
-
-   private List<FailureListener> copyFailureListeners() {
-      return new ArrayList<>(failureListeners);
-   }
-
-   private List<CloseListener> copyCloseListeners() {
-      return new ArrayList<>(closeListeners);
    }
 
    @Override
@@ -199,11 +89,6 @@ public class MQTTConnection implements RemotingConnection {
    }
 
    @Override
-   public Connection getTransportConnection() {
-      return transportConnection;
-   }
-
-   @Override
    public boolean isClient() {
       return false;
    }
@@ -224,12 +109,7 @@ public class MQTTConnection implements RemotingConnection {
    }
 
    protected void dataReceived() {
-      dataReceived.set(true);
-   }
-
-   @Override
-   public boolean checkDataReceived() {
-      return dataReceived.compareAndSet(true, false);
+      dataReceived = true;
    }
 
    @Override
@@ -255,28 +135,8 @@ public class MQTTConnection implements RemotingConnection {
    }
 
    @Override
-   public boolean isSupportReconnect() {
-      return false;
-   }
-
-   @Override
    public boolean isSupportsFlowControl() {
       return false;
-   }
-
-   @Override
-   public void setAuditSubject(Subject subject) {
-      this.subject = subject;
-   }
-
-   @Override
-   public Subject getAuditSubject() {
-      return subject;
-   }
-
-   @Override
-   public Subject getSubject() {
-      return null;
    }
 
    /**
@@ -287,26 +147,6 @@ public class MQTTConnection implements RemotingConnection {
    @Override
    public String getProtocolName() {
       return MQTTProtocolManagerFactory.MQTT_PROTOCOL_NAME + (protocolVersion != null ? protocolVersion : "");
-   }
-
-   /**
-    * Sets the client ID associated with this connection
-    *
-    * @param cID
-    */
-   @Override
-   public void setClientID(String cID) {
-      this.clientID = cID;
-   }
-
-   /**
-    * Returns the Client ID associated with this connection
-    *
-    * @return
-    */
-   @Override
-   public String getClientID() {
-      return clientID;
    }
 
    @Override
@@ -324,5 +164,13 @@ public class MQTTConnection implements RemotingConnection {
 
    public void setProtocolVersion(String protocolVersion) {
       this.protocolVersion = protocolVersion;
+   }
+
+   public void setClientIdAssignedByBroker(boolean clientIdAssignedByBroker) {
+      this.clientIdAssignedByBroker = clientIdAssignedByBroker;
+   }
+
+   public boolean isClientIdAssignedByBroker() {
+      return clientIdAssignedByBroker;
    }
 }

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTProtocolManager.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTProtocolManager.java
@@ -202,7 +202,7 @@ public class MQTTProtocolManager extends AbstractProtocolManager<MqttMessage, MQ
 
       for (String key : toRemove) {
          logger.debugf("Removing state for session: %s", key);
-         MQTTSessionState state = sessionStates.remove(key);
+         MQTTSessionState state = removeSessionState(key);
          if (state != null && state.isWill() && !state.isAttached() && state.isFailed() && !state.isWillSent()) {
             state.getSession().sendWillMessage();
          }

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTRoutingContext.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTRoutingContext.java
@@ -31,7 +31,7 @@ public class MQTTRoutingContext extends RoutingContext {
 
 
    public MQTTRoutingContext(MQTTConnection mqttConnection, MQTTSession mqttSession, MqttConnectMessage connect) {
-      super(mqttConnection, connect.payload().clientIdentifier(), connect.payload().userName());
+      super(mqttConnection, mqttConnection.getClientID(), connect.payload().userName());
       this.mqttSession = mqttSession;
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MQTTSecurityManagerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MQTTSecurityManagerTest.java
@@ -1,0 +1,152 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.mqtt;
+
+import javax.security.auth.Subject;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.activemq.artemis.core.protocol.mqtt.MQTTProtocolManager;
+import org.apache.activemq.artemis.core.protocol.mqtt.MQTTSessionState;
+import org.apache.activemq.artemis.core.remoting.impl.AbstractAcceptor;
+import org.apache.activemq.artemis.core.security.CheckType;
+import org.apache.activemq.artemis.core.security.Role;
+import org.apache.activemq.artemis.spi.core.protocol.ProtocolManager;
+import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
+import org.apache.activemq.artemis.spi.core.remoting.Acceptor;
+import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager5;
+import org.apache.activemq.artemis.tests.util.RandomUtil;
+import org.apache.activemq.artemis.tests.util.Wait;
+import org.fusesource.mqtt.client.BlockingConnection;
+import org.fusesource.mqtt.client.MQTT;
+import org.junit.Test;
+
+public class MQTTSecurityManagerTest extends MQTTTestSupport {
+
+   private String clientID = "new-" + RandomUtil.randomString();
+
+   @Override
+   public boolean isSecurityEnabled() {
+      return true;
+   }
+
+   @Override
+   public void configureBroker() throws Exception {
+      super.configureBroker();
+      server.setSecurityManager(new ActiveMQSecurityManager5() {
+         @Override
+         public Subject authenticate(String user,
+                                     String password,
+                                     RemotingConnection remotingConnection,
+                                     String securityDomain) {
+            remotingConnection.setClientID(clientID);
+            System.out.println("Setting: " + clientID);
+            return new Subject();
+         }
+
+         @Override
+         public boolean authorize(Subject subject, Set<Role> roles, CheckType checkType, String address) {
+            return true;
+         }
+
+         @Override
+         public boolean validateUser(String user, String password) {
+            return true;
+         }
+
+         @Override
+         public boolean validateUserAndRole(String user, String password, Set<Role> roles, CheckType checkType) {
+            return true;
+         }
+      });
+      server.getConfiguration().setAuthenticationCacheSize(0);
+      server.getConfiguration().setAuthorizationCacheSize(0);
+   }
+
+   @Test(timeout = 30000)
+   public void testSecurityManagerModifyClientID() throws Exception {
+      BlockingConnection connection = null;
+      try {
+         MQTT mqtt = createMQTTConnection(RandomUtil.randomString(), true);
+         mqtt.setUserName(fullUser);
+         mqtt.setPassword(fullPass);
+         mqtt.setConnectAttemptsMax(1);
+         connection = mqtt.blockingConnection();
+         connection.connect();
+         BlockingConnection finalConnection = connection;
+         assertTrue("Should be connected", Wait.waitFor(() -> finalConnection.isConnected(), 5000, 100));
+         Map<String, MQTTSessionState> sessionStates = null;
+         Acceptor acceptor = server.getRemotingService().getAcceptor("MQTT");
+         if (acceptor instanceof AbstractAcceptor) {
+            ProtocolManager protocolManager = ((AbstractAcceptor) acceptor).getProtocolMap().get("MQTT");
+            if (protocolManager instanceof MQTTProtocolManager) {
+               sessionStates = ((MQTTProtocolManager) protocolManager).getSessionStates();
+            }
+         }
+         assertEquals(1, sessionStates.size());
+         assertTrue(sessionStates.keySet().contains(clientID));
+         for (MQTTSessionState state : sessionStates.values()) {
+            assertEquals(clientID, state.getClientId());
+         }
+      } finally {
+         if (connection != null && connection.isConnected()) connection.disconnect();
+      }
+   }
+
+   @Test(timeout = 30000)
+   public void testSecurityManagerModifyClientIDAndStealConnection() throws Exception {
+      BlockingConnection connection1 = null;
+      BlockingConnection connection2 = null;
+      final String CLIENT_ID = "old-" + RandomUtil.randomString();
+      try {
+         MQTT mqtt = createMQTTConnection(CLIENT_ID, true);
+         mqtt.setUserName(fullUser);
+         mqtt.setPassword(fullPass);
+         mqtt.setConnectAttemptsMax(1);
+         connection1 = mqtt.blockingConnection();
+         connection1.connect();
+         final BlockingConnection finalConnection = connection1;
+         assertTrue("Should be connected", Wait.waitFor(() -> finalConnection.isConnected(), 5000, 100));
+         Map<String, MQTTSessionState> sessionStates = null;
+         Acceptor acceptor = server.getRemotingService().getAcceptor("MQTT");
+         if (acceptor instanceof AbstractAcceptor) {
+            ProtocolManager protocolManager = ((AbstractAcceptor) acceptor).getProtocolMap().get("MQTT");
+            if (protocolManager instanceof MQTTProtocolManager) {
+               sessionStates = ((MQTTProtocolManager) protocolManager).getSessionStates();
+            }
+         }
+         assertEquals(1, sessionStates.size());
+         assertTrue(sessionStates.keySet().contains(clientID));
+         for (MQTTSessionState state : sessionStates.values()) {
+            assertEquals(clientID, state.getClientId());
+         }
+
+         connection2 = mqtt.blockingConnection();
+         connection2.connect();
+         final BlockingConnection finalConnection2 = connection2;
+         assertTrue("Should be connected", Wait.waitFor(() -> finalConnection2.isConnected(), 5000, 100));
+         Wait.assertFalse(() -> finalConnection.isConnected(), 5000, 100);
+         assertEquals(1, sessionStates.size());
+         assertTrue(sessionStates.keySet().contains(clientID));
+         for (MQTTSessionState state : sessionStates.values()) {
+            assertEquals(clientID, state.getClientId());
+         }
+      } finally {
+         if (connection1 != null && connection1.isConnected()) connection1.disconnect();
+      }
+   }
+}


### PR DESCRIPTION
It would be useful for security manager implementations to be able to
alter the client ID of MQTT connections.

This commit supports this functionality by moving the code which handles
the client ID *ahead* of the authentication code. There it sets the
client ID on the connection and thereafter any component (e.g. security
managers) which needs to inspect or modify it can do so on the
connection.

This commit also refactors the MQTT connection class to extend the
abstract connection class. This greatly simplifies the MQTT connection
class and will make it easier to maintain in the future.