### PR TITLE
ARTEMIS-3778 Streamline Expiration Reaping

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQScheduledComponent.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQScheduledComponent.java
@@ -36,14 +36,14 @@ import org.jboss.logging.Logger;
 public abstract class ActiveMQScheduledComponent implements ActiveMQComponent, Runnable {
 
    private static final Logger logger = Logger.getLogger(ActiveMQScheduledComponent.class);
-   private ScheduledExecutorService scheduledExecutorService;
+   protected ScheduledExecutorService scheduledExecutorService;
    private boolean startedOwnScheduler;
 
    /** initialDelay < 0 would mean no initial delay, use the period instead */
    private long initialDelay;
    private long period;
    private TimeUnit timeUnit;
-   private final Executor executor;
+   protected final Executor executor;
    private volatile boolean isStarted;
    private ScheduledFuture future;
    private final boolean onDemand;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1824,10 +1824,6 @@ public interface ActiveMQServerLogger extends BasicLogger {
    void largeMessageErrorReleasingResources(@Cause Exception e);
 
    @LogMessage(level = Logger.Level.ERROR)
-   @Message(id = 224013, value = "failed to expire messages for queue", format = Message.Format.MESSAGE_FORMAT)
-   void errorExpiringMessages(@Cause Exception e);
-
-   @LogMessage(level = Logger.Level.ERROR)
    @Message(id = 224014, value = "Failed to close session", format = Message.Format.MESSAGE_FORMAT)
    void errorClosingSession(@Cause Exception e);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingTest.java
@@ -1670,7 +1670,7 @@ public class PagingTest extends ActiveMQTestBase {
       clearDataRecreateServerDirs();
 
       Configuration config = createDefaultInVMConfig().setJournalDirectory(getJournalDir()).setJournalSyncNonTransactional(false).setJournalCompactMinFiles(0) // disable compact
-         .setMessageExpiryScanPeriod(500);
+         .setMessageExpiryScanPeriod(10);
 
       server = createServer(true, config, PagingTest.PAGE_SIZE, PagingTest.PAGE_MAX);
 


### PR DESCRIPTION
Instead of holding a thread and an iterator, we should instead keep moving to next references
without holding any threads. Just with callbacks.