### PR TITLE
ARTEMIS-3780 - OpenWire, UTF8Buffer to String before setting properti…

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireMessageConverter.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireMessageConverter.java
@@ -447,7 +447,11 @@ public final class OpenWireMessageConverter {
       if (!props.isEmpty()) {
          props.forEach((key, value) -> {
             try {
-               coreMessage.putObjectProperty(key, value);
+               if (value instanceof UTF8Buffer) {
+                  coreMessage.putObjectProperty(key, value.toString());
+               } else {
+                  coreMessage.putObjectProperty(key, value);
+               }
             } catch (ActiveMQPropertyConversionException e) {
                coreMessage.putStringProperty(key, value.toString());
             }


### PR DESCRIPTION
…es to avoid exception

Converting to String beforehand to avoid exception.
Shows some performance increase when running a producer/consumer pair sending and receiving 100k messages 5 times, alternating between setting 8 custom headers or not.

Before:
8 user properties: 
Average: 64.236
Each run: 68.30, 60.74, 62.86, 65.39, 63.89

0 user properties: 
Average: 54.862
Each run: 53.55, 52.55, 56.24, 61.14, 50.83

After:
8 user properties: 
Average: 52.944
Each run: 49.48, 57.12, 53.84, 51.66, 52.62

0 user properties: 
Average: 52.1
Each run: 50.45, 52.28, 50.23, 51.69, 55.85

*Values in seconds