### PR TITLE
ARTEMIS-3783: rationalise config for alternate jakarta spec versions

### DIFF
--- a/artemis-jakarta-client-all/pom.xml
+++ b/artemis-jakarta-client-all/pom.xml
@@ -29,7 +29,7 @@
 
    <properties>
       <activemq.basedir>${project.basedir}/..</activemq.basedir>
-      <jakarta.jms-api.version>3.0.0</jakarta.jms-api.version>
+      <jakarta.jms-api.version>${jakarta.jms-api.version.alt}</jakarta.jms-api.version>
    </properties>
 
    <dependencies>

--- a/artemis-jakarta-client/pom.xml
+++ b/artemis-jakarta-client/pom.xml
@@ -29,7 +29,7 @@
 
    <properties>
       <activemq.basedir>${project.basedir}/..</activemq.basedir>
-      <jakarta.jms-api.version>3.0.0</jakarta.jms-api.version>
+      <jakarta.jms-api.version>${jakarta.jms-api.version.alt}</jakarta.jms-api.version>
    </properties>
 
    <dependencies>
@@ -64,7 +64,6 @@
       <dependency>
          <groupId>jakarta.jms</groupId>
          <artifactId>jakarta.jms-api</artifactId>
-         <version>${jakarta.jms-api.version}</version>
       </dependency>
 
       <dependency>

--- a/artemis-jakarta-ra/pom.xml
+++ b/artemis-jakarta-ra/pom.xml
@@ -29,9 +29,9 @@
 
    <properties>
       <activemq.basedir>${project.basedir}/..</activemq.basedir>
-      <jakarta.jms-api.version>3.0.0</jakarta.jms-api.version>
-      <jakarta.transaction-api.version>2.0.0</jakarta.transaction-api.version>
-      <jakarta.resource-api.version>2.0.0</jakarta.resource-api.version>
+      <jakarta.jms-api.version>${jakarta.jms-api.version.alt}</jakarta.jms-api.version>
+      <jakarta.transaction-api.version>${jakarta.transaction-api.version.alt}</jakarta.transaction-api.version>
+      <jakarta.resource-api.version>${jakarta.resource-api.version.alt}</jakarta.resource-api.version>
    </properties>
 
 
@@ -67,19 +67,16 @@
       <dependency>
          <groupId>jakarta.resource</groupId>
          <artifactId>jakarta.resource-api</artifactId>
-         <version>${jakarta.resource-api.version}</version>
          <scope>provided</scope>
       </dependency>
       <dependency>
          <groupId>jakarta.transaction</groupId>
          <artifactId>jakarta.transaction-api</artifactId>
-         <version>${jakarta.transaction-api.version}</version>
          <scope>provided</scope>
       </dependency>
       <dependency>
          <groupId>jakarta.jms</groupId>
          <artifactId>jakarta.jms-api</artifactId>
-         <version>${jakarta.jms-api.version}</version>
          <scope>provided</scope>
       </dependency>
       <dependency>

--- a/artemis-jakarta-server/pom.xml
+++ b/artemis-jakarta-server/pom.xml
@@ -29,9 +29,9 @@
 
     <properties>
         <activemq.basedir>${project.basedir}/..</activemq.basedir>
-        <jakarta.jms-api.version>3.0.0</jakarta.jms-api.version>
-        <jakarta.transaction-api.version>2.0.0</jakarta.transaction-api.version>
-        <jakarta.resource-api.version>2.0.0</jakarta.resource-api.version>
+        <jakarta.jms-api.version>${jakarta.jms-api.version.alt}</jakarta.jms-api.version>
+        <jakarta.transaction-api.version>${jakarta.transaction-api.version.alt}</jakarta.transaction-api.version>
+        <jakarta.resource-api.version>${jakarta.resource-api.version.alt}</jakarta.resource-api.version>
     </properties>
 
    <dependencies>
@@ -84,12 +84,10 @@
       <dependency>
          <groupId>jakarta.jms</groupId>
          <artifactId>jakarta.jms-api</artifactId>
-         <version>${jakarta.jms-api.version}</version>
       </dependency>
       <dependency>
          <groupId>jakarta.transaction</groupId>
          <artifactId>jakarta.transaction-api</artifactId>
-         <version>${jakarta.transaction-api.version}</version>
       </dependency>
    </dependencies>
 

--- a/artemis-jakarta-service-extensions/pom.xml
+++ b/artemis-jakarta-service-extensions/pom.xml
@@ -29,8 +29,8 @@
 
    <properties>
       <activemq.basedir>${project.basedir}/..</activemq.basedir>
-      <jakarta.jms-api.version>3.0.0</jakarta.jms-api.version>
-      <jakarta.transaction-api.version>2.0.0</jakarta.transaction-api.version>
+      <jakarta.jms-api.version>${jakarta.jms-api.version.alt}</jakarta.jms-api.version>
+      <jakarta.transaction-api.version>${jakarta.transaction-api.version.alt}</jakarta.transaction-api.version>
    </properties>
 
    <dependencies>
@@ -78,12 +78,10 @@
       <dependency>
          <groupId>jakarta.transaction</groupId>
          <artifactId>jakarta.transaction-api</artifactId>
-         <version>${jakarta.transaction-api.version}</version>
       </dependency>
       <dependency>
          <groupId>jakarta.jms</groupId>
          <artifactId>jakarta.jms-api</artifactId>
-         <version>${jakarta.jms-api.version}</version>
          <scope>provided</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -165,8 +165,11 @@
       <testcontainers.version>1.16.3</testcontainers.version>
       <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
 
-      <!-- for JakrtaEE -->
+      <!-- for JakartaEE -->
       <version.batavia>1.0.10.Final</version.batavia>
+      <jakarta.jms-api.version.alt>3.0.0</jakarta.jms-api.version.alt>
+      <jakarta.transaction-api.version.alt>2.0.0</jakarta.transaction-api.version.alt>
+      <jakarta.resource-api.version.alt>2.0.0</jakarta.resource-api.version.alt>
 
       <!-- used on tests -->
       <groovy.version>4.0.0</groovy.version>


### PR DESCRIPTION
Group the alternative versions into a related property, easily found at the root near the base version property, and perform the overrides using that. Remove superfluous version entrys from dependency uses, its already covered by the version properties and dependencyManagement.