### PR TITLE
How about add more Forked VM when run all tests in build

### DIFF
--- a/tests/extra-tests/pom.xml
+++ b/tests/extra-tests/pom.xml
@@ -283,7 +283,7 @@
                <!-- make sure maven puts the byteman jar in the classpath rather than in a manifest jar -->
                <useManifestOnlyJar>false</useManifestOnlyJar>
                <!-- when upgrading this plugin from 2.4 to 2.18.1 <forkMode>once</forkMode> was replaced with these: -->
-               <forkCount>1</forkCount>
+               <forkCount>1.5C</forkCount>
                <reuseForks>true</reuseForks>
                <!--
                <debugForkedProcess>true</debugForkedProcess>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
