### PR TITLE
ARTEMIS-3707 remove use of TransactionManager

### DIFF
--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRAConnectionFactoryImpl.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRAConnectionFactoryImpl.java
@@ -139,7 +139,7 @@ public class ActiveMQRAConnectionFactoryImpl implements ActiveMQRAConnectionFact
          ActiveMQRALogger.LOGGER.trace("createQueueConnection()");
       }
 
-      ActiveMQRASessionFactoryImpl s = new ActiveMQRASessionFactoryImpl(mcf, cm, getResourceAdapter().getTM(), ActiveMQRAConnectionFactory.QUEUE_CONNECTION);
+      ActiveMQRASessionFactoryImpl s = new ActiveMQRASessionFactoryImpl(mcf, cm, getResourceAdapter().getTSR(), ActiveMQRAConnectionFactory.QUEUE_CONNECTION);
 
       if (ActiveMQRALogger.LOGGER.isTraceEnabled()) {
          ActiveMQRALogger.LOGGER.trace("Created queue connection: " + s);
@@ -162,7 +162,7 @@ public class ActiveMQRAConnectionFactoryImpl implements ActiveMQRAConnectionFact
          ActiveMQRALogger.LOGGER.trace("createQueueConnection(" + userName + ", ****)");
       }
 
-      ActiveMQRASessionFactoryImpl s = new ActiveMQRASessionFactoryImpl(mcf, cm, getResourceAdapter().getTM(), ActiveMQRAConnectionFactory.QUEUE_CONNECTION);
+      ActiveMQRASessionFactoryImpl s = new ActiveMQRASessionFactoryImpl(mcf, cm, getResourceAdapter().getTSR(), ActiveMQRAConnectionFactory.QUEUE_CONNECTION);
       s.setUserName(userName);
       s.setPassword(password);
 
@@ -187,7 +187,7 @@ public class ActiveMQRAConnectionFactoryImpl implements ActiveMQRAConnectionFact
          ActiveMQRALogger.LOGGER.trace("createTopicConnection()");
       }
 
-      ActiveMQRASessionFactoryImpl s = new ActiveMQRASessionFactoryImpl(mcf, cm, getResourceAdapter().getTM(), ActiveMQRAConnectionFactory.TOPIC_CONNECTION);
+      ActiveMQRASessionFactoryImpl s = new ActiveMQRASessionFactoryImpl(mcf, cm, getResourceAdapter().getTSR(), ActiveMQRAConnectionFactory.TOPIC_CONNECTION);
 
       if (ActiveMQRALogger.LOGGER.isTraceEnabled()) {
          ActiveMQRALogger.LOGGER.trace("Created topic connection: " + s);
@@ -210,7 +210,7 @@ public class ActiveMQRAConnectionFactoryImpl implements ActiveMQRAConnectionFact
          ActiveMQRALogger.LOGGER.trace("createTopicConnection(" + userName + ", ****)");
       }
 
-      ActiveMQRASessionFactoryImpl s = new ActiveMQRASessionFactoryImpl(mcf, cm, getResourceAdapter().getTM(), ActiveMQRAConnectionFactory.TOPIC_CONNECTION);
+      ActiveMQRASessionFactoryImpl s = new ActiveMQRASessionFactoryImpl(mcf, cm, getResourceAdapter().getTSR(), ActiveMQRAConnectionFactory.TOPIC_CONNECTION);
       s.setUserName(userName);
       s.setPassword(password);
       validateUser(s);
@@ -234,7 +234,7 @@ public class ActiveMQRAConnectionFactoryImpl implements ActiveMQRAConnectionFact
          ActiveMQRALogger.LOGGER.trace("createConnection()");
       }
 
-      ActiveMQRASessionFactoryImpl s = new ActiveMQRASessionFactoryImpl(mcf, cm, getResourceAdapter().getTM(), ActiveMQRAConnectionFactory.CONNECTION);
+      ActiveMQRASessionFactoryImpl s = new ActiveMQRASessionFactoryImpl(mcf, cm, getResourceAdapter().getTSR(), ActiveMQRAConnectionFactory.CONNECTION);
 
       if (ActiveMQRALogger.LOGGER.isTraceEnabled()) {
          ActiveMQRALogger.LOGGER.trace("Created connection: " + s);
@@ -257,7 +257,7 @@ public class ActiveMQRAConnectionFactoryImpl implements ActiveMQRAConnectionFact
          ActiveMQRALogger.LOGGER.trace("createConnection(" + userName + ", ****)");
       }
 
-      ActiveMQRASessionFactoryImpl s = new ActiveMQRASessionFactoryImpl(mcf, cm, getResourceAdapter().getTM(), ActiveMQRAConnectionFactory.CONNECTION);
+      ActiveMQRASessionFactoryImpl s = new ActiveMQRASessionFactoryImpl(mcf, cm, getResourceAdapter().getTSR(), ActiveMQRAConnectionFactory.CONNECTION);
       s.setUserName(userName);
       s.setPassword(password);
 
@@ -282,7 +282,7 @@ public class ActiveMQRAConnectionFactoryImpl implements ActiveMQRAConnectionFact
          ActiveMQRALogger.LOGGER.trace("createXAQueueConnection()");
       }
 
-      ActiveMQRASessionFactoryImpl s = new ActiveMQRASessionFactoryImpl(mcf, cm, getResourceAdapter().getTM(), ActiveMQRAConnectionFactory.XA_QUEUE_CONNECTION);
+      ActiveMQRASessionFactoryImpl s = new ActiveMQRASessionFactoryImpl(mcf, cm, getResourceAdapter().getTSR(), ActiveMQRAConnectionFactory.XA_QUEUE_CONNECTION);
 
       if (ActiveMQRALogger.LOGGER.isTraceEnabled()) {
          ActiveMQRALogger.LOGGER.trace("Created queue connection: " + s);
@@ -305,7 +305,7 @@ public class ActiveMQRAConnectionFactoryImpl implements ActiveMQRAConnectionFact
          ActiveMQRALogger.LOGGER.trace("createXAQueueConnection(" + userName + ", ****)");
       }
 
-      ActiveMQRASessionFactoryImpl s = new ActiveMQRASessionFactoryImpl(mcf, cm, getResourceAdapter().getTM(), ActiveMQRAConnectionFactory.XA_QUEUE_CONNECTION);
+      ActiveMQRASessionFactoryImpl s = new ActiveMQRASessionFactoryImpl(mcf, cm, getResourceAdapter().getTSR(), ActiveMQRAConnectionFactory.XA_QUEUE_CONNECTION);
       s.setUserName(userName);
       s.setPassword(password);
       validateUser(s);
@@ -329,7 +329,7 @@ public class ActiveMQRAConnectionFactoryImpl implements ActiveMQRAConnectionFact
          ActiveMQRALogger.LOGGER.trace("createXATopicConnection()");
       }
 
-      ActiveMQRASessionFactoryImpl s = new ActiveMQRASessionFactoryImpl(mcf, cm, getResourceAdapter().getTM(), ActiveMQRAConnectionFactory.XA_TOPIC_CONNECTION);
+      ActiveMQRASessionFactoryImpl s = new ActiveMQRASessionFactoryImpl(mcf, cm, getResourceAdapter().getTSR(), ActiveMQRAConnectionFactory.XA_TOPIC_CONNECTION);
 
       if (ActiveMQRALogger.LOGGER.isTraceEnabled()) {
          ActiveMQRALogger.LOGGER.trace("Created topic connection: " + s);
@@ -352,7 +352,7 @@ public class ActiveMQRAConnectionFactoryImpl implements ActiveMQRAConnectionFact
          ActiveMQRALogger.LOGGER.trace("createXATopicConnection(" + userName + ", ****)");
       }
 
-      ActiveMQRASessionFactoryImpl s = new ActiveMQRASessionFactoryImpl(mcf, cm, getResourceAdapter().getTM(), ActiveMQRAConnectionFactory.XA_TOPIC_CONNECTION);
+      ActiveMQRASessionFactoryImpl s = new ActiveMQRASessionFactoryImpl(mcf, cm, getResourceAdapter().getTSR(), ActiveMQRAConnectionFactory.XA_TOPIC_CONNECTION);
       s.setUserName(userName);
       s.setPassword(password);
       validateUser(s);
@@ -376,7 +376,7 @@ public class ActiveMQRAConnectionFactoryImpl implements ActiveMQRAConnectionFact
          ActiveMQRALogger.LOGGER.trace("createXAConnection()");
       }
 
-      ActiveMQRASessionFactoryImpl s = new ActiveMQRASessionFactoryImpl(mcf, cm, getResourceAdapter().getTM(), ActiveMQRAConnectionFactory.XA_CONNECTION);
+      ActiveMQRASessionFactoryImpl s = new ActiveMQRASessionFactoryImpl(mcf, cm, getResourceAdapter().getTSR(), ActiveMQRAConnectionFactory.XA_CONNECTION);
 
       if (ActiveMQRALogger.LOGGER.isTraceEnabled()) {
          ActiveMQRALogger.LOGGER.trace("Created connection: " + s);
@@ -399,7 +399,7 @@ public class ActiveMQRAConnectionFactoryImpl implements ActiveMQRAConnectionFact
          ActiveMQRALogger.LOGGER.trace("createXAConnection(" + userName + ", ****)");
       }
 
-      ActiveMQRASessionFactoryImpl s = new ActiveMQRASessionFactoryImpl(mcf, cm, getResourceAdapter().getTM(), ActiveMQRAConnectionFactory.XA_CONNECTION);
+      ActiveMQRASessionFactoryImpl s = new ActiveMQRASessionFactoryImpl(mcf, cm, getResourceAdapter().getTSR(), ActiveMQRAConnectionFactory.XA_CONNECTION);
       s.setUserName(userName);
       s.setPassword(password);
       validateUser(s);
@@ -424,7 +424,7 @@ public class ActiveMQRAConnectionFactoryImpl implements ActiveMQRAConnectionFact
    @Override
    public JMSContext createContext(String userName, String password, int sessionMode) {
       @SuppressWarnings("resource")
-      ActiveMQRASessionFactoryImpl conn = new ActiveMQRASessionFactoryImpl(mcf, cm, getResourceAdapter().getTM(), ActiveMQRAConnectionFactory.CONNECTION);
+      ActiveMQRASessionFactoryImpl conn = new ActiveMQRASessionFactoryImpl(mcf, cm, getResourceAdapter().getTSR(), ActiveMQRAConnectionFactory.CONNECTION);
       conn.setUserName(userName);
       conn.setPassword(password);
       try {
@@ -453,7 +453,7 @@ public class ActiveMQRAConnectionFactoryImpl implements ActiveMQRAConnectionFact
 
    @Override
    public XAJMSContext createXAContext(String userName, String password) {
-      ActiveMQRASessionFactoryImpl conn = new ActiveMQRASessionFactoryImpl(mcf, cm, getResourceAdapter().getTM(), ActiveMQRAConnectionFactory.XA_CONNECTION);
+      ActiveMQRASessionFactoryImpl conn = new ActiveMQRASessionFactoryImpl(mcf, cm, getResourceAdapter().getTSR(), ActiveMQRAConnectionFactory.XA_CONNECTION);
       conn.setUserName(userName);
       conn.setPassword(password);
       try {

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRAManagedConnection.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRAManagedConnection.java
@@ -16,6 +16,18 @@
  */
 package org.apache.activemq.artemis.ra;
 
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
+
 import javax.jms.ExceptionListener;
 import javax.jms.JMSException;
 import javax.jms.ResourceAllocationException;
@@ -32,21 +44,8 @@ import javax.resource.spi.ManagedConnectionMetaData;
 import javax.resource.spi.SecurityException;
 import javax.security.auth.Subject;
 import javax.transaction.Status;
-import javax.transaction.SystemException;
-import javax.transaction.Transaction;
-import javax.transaction.TransactionManager;
+import javax.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.xa.XAResource;
-import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.activemq.artemis.core.client.impl.ClientSessionInternal;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnection;
@@ -122,7 +121,7 @@ public final class ActiveMQRAManagedConnection implements ManagedConnection, Exc
 
    private XAResource xaResource;
 
-   private final TransactionManager tm;
+   private final TransactionSynchronizationRegistry tsr;
 
    private boolean inManagedTx;
 
@@ -145,7 +144,7 @@ public final class ActiveMQRAManagedConnection implements ManagedConnection, Exc
 
       this.mcf = mcf;
       this.cri = cri;
-      this.tm = ra.getTM();
+      this.tsr = ra.getTSR();
       this.ra = ra;
       this.userName = userName;
       this.password = password;
@@ -346,20 +345,11 @@ public final class ActiveMQRAManagedConnection implements ManagedConnection, Exc
 
    public void checkTransactionActive() throws JMSException {
       // don't bother looking at the transaction if there's an active XID
-      if (!inManagedTx && tm != null) {
-         try {
-            Transaction tx = tm.getTransaction();
-            if (tx != null) {
-               int status = tx.getStatus();
-               // Only allow states that will actually succeed
-               if (status != Status.STATUS_ACTIVE && status != Status.STATUS_PREPARING && status != Status.STATUS_PREPARED && status != Status.STATUS_COMMITTING) {
-                  throw new javax.jms.IllegalStateException("Transaction " + tx + " not active");
-               }
-            }
-         } catch (SystemException e) {
-            JMSException jmsE = new javax.jms.IllegalStateException("Unexpected exception on the Transaction ManagerTransaction");
-            jmsE.initCause(e);
-            throw jmsE;
+      if (!inManagedTx && tsr != null) {
+         int status = tsr.getTransactionStatus();
+         // Only allow states that will actually succeed
+         if (status != Status.STATUS_ACTIVE && status != Status.STATUS_PREPARING && status != Status.STATUS_PREPARED && status != Status.STATUS_COMMITTING) {
+            throw new javax.jms.IllegalStateException("Transaction " + tsr.getTransactionKey() + " not active");
          }
       }
    }

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRASessionFactoryImpl.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRASessionFactoryImpl.java
@@ -16,6 +16,10 @@
  */
 package org.apache.activemq.artemis.ra;
 
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
 import javax.jms.ConnectionConsumer;
 import javax.jms.ConnectionMetaData;
 import javax.jms.Destination;
@@ -38,12 +42,8 @@ import javax.jms.XATopicSession;
 import javax.naming.Reference;
 import javax.resource.Referenceable;
 import javax.resource.spi.ConnectionManager;
-import javax.transaction.SystemException;
-import javax.transaction.Transaction;
-import javax.transaction.TransactionManager;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Set;
+import javax.transaction.Status;
+import javax.transaction.TransactionSynchronizationRegistry;
 
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSConstants;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionForContext;
@@ -93,7 +93,7 @@ public final class ActiveMQRASessionFactoryImpl extends ActiveMQConnectionForCon
     * The managed connection factory
     */
    private final ActiveMQRAManagedConnectionFactory mcf;
-   private TransactionManager tm;
+   private final TransactionSynchronizationRegistry tsr;
 
    /**
     * The connection manager
@@ -126,11 +126,11 @@ public final class ActiveMQRASessionFactoryImpl extends ActiveMQConnectionForCon
     */
    public ActiveMQRASessionFactoryImpl(final ActiveMQRAManagedConnectionFactory mcf,
                                        final ConnectionManager cm,
-                                       final TransactionManager tm,
+                                       final TransactionSynchronizationRegistry tsr,
                                        final int type) {
       this.mcf = mcf;
 
-      this.tm = tm;
+      this.tsr = tsr;
 
       if (cm == null) {
          this.cm = new ActiveMQRAConnectionManager();
@@ -926,14 +926,8 @@ public final class ActiveMQRASessionFactoryImpl extends ActiveMQConnectionForCon
 
    private boolean inJtaTransaction() {
       boolean inJtaTx = false;
-      if (tm != null) {
-         Transaction tx = null;
-         try {
-            tx = tm.getTransaction();
-         } catch (SystemException e) {
-            //assume false
-         }
-         inJtaTx = tx != null;
+      if (tsr != null) {
+         inJtaTx = tsr.getTransactionStatus() != Status.STATUS_NO_TRANSACTION;
       }
       return inJtaTx;
    }

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
@@ -24,7 +24,7 @@ import javax.resource.spi.ResourceAdapter;
 import javax.resource.spi.ResourceAdapterInternalException;
 import javax.resource.spi.endpoint.MessageEndpointFactory;
 import javax.resource.spi.work.WorkManager;
-import javax.transaction.TransactionManager;
+import javax.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.xa.XAResource;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -57,7 +57,6 @@ import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.ra.inflow.ActiveMQActivation;
 import org.apache.activemq.artemis.ra.inflow.ActiveMQActivationSpec;
 import org.apache.activemq.artemis.ra.recovery.RecoveryManager;
-import org.apache.activemq.artemis.service.extensions.ServiceUtils;
 import org.apache.activemq.artemis.service.extensions.xa.recovery.XARecoveryConfig;
 import org.jboss.logging.Logger;
 import org.jgroups.JChannel;
@@ -110,7 +109,7 @@ public class ActiveMQResourceAdapter implements ResourceAdapter, Serializable {
 
    private ActiveMQConnectionFactory recoveryActiveMQConnectionFactory;
 
-   private TransactionManager tm;
+   private TransactionSynchronizationRegistry tsr;
 
    private String unparsedJndiParams;
 
@@ -147,8 +146,8 @@ public class ActiveMQResourceAdapter implements ResourceAdapter, Serializable {
       recoveryManager = new RecoveryManager();
    }
 
-   public TransactionManager getTM() {
-      return tm;
+   public TransactionSynchronizationRegistry getTSR() {
+      return tsr;
    }
 
    /**
@@ -238,7 +237,7 @@ public class ActiveMQResourceAdapter implements ResourceAdapter, Serializable {
          logger.trace("start(" + ctx + ")");
       }
 
-      tm = ServiceUtils.getTransactionManager();
+      tsr = ctx.getTransactionSynchronizationRegistry();
 
       recoveryManager.start(useAutoRecovery);
 

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQActivation.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQActivation.java
@@ -16,18 +16,6 @@
  */
 package org.apache.activemq.artemis.ra.inflow;
 
-import javax.jms.Destination;
-import javax.jms.Message;
-import javax.jms.MessageListener;
-import javax.jms.Queue;
-import javax.jms.Topic;
-import javax.naming.Context;
-import javax.naming.InitialContext;
-import javax.resource.ResourceException;
-import javax.resource.spi.endpoint.MessageEndpointFactory;
-import javax.resource.spi.work.Work;
-import javax.resource.spi.work.WorkManager;
-import javax.transaction.xa.XAResource;
 import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedExceptionAction;
@@ -38,12 +26,25 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.jms.Destination;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+import javax.jms.Queue;
+import javax.jms.Topic;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.resource.ResourceException;
+import javax.resource.spi.endpoint.MessageEndpointFactory;
+import javax.resource.spi.work.Work;
 import javax.resource.spi.work.WorkException;
+import javax.resource.spi.work.WorkManager;
+import javax.transaction.xa.XAResource;
+
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
 import org.apache.activemq.artemis.api.core.ActiveMQNonExistentQueueException;
 import org.apache.activemq.artemis.api.core.ActiveMQNotConnectedException;
-
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
@@ -320,7 +321,7 @@ public class ActiveMQActivation {
                cf = factory.getServerLocator().createSessionFactory();
             }
             session = setupSession(cf);
-            ActiveMQMessageHandler handler = new ActiveMQMessageHandler(factory, this, ra.getTM(), (ClientSessionInternal) session, cf, i);
+            ActiveMQMessageHandler handler = new ActiveMQMessageHandler(factory, this, ra.getTSR(), (ClientSessionInternal) session, cf, i);
             handler.setup();
             handlers.add(handler);
          } catch (Exception e) {

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQMessageHandler.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQMessageHandler.java
@@ -16,18 +16,17 @@
  */
 package org.apache.activemq.artemis.ra.inflow;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
 import javax.jms.MessageListener;
 import javax.resource.ResourceException;
 import javax.resource.spi.endpoint.MessageEndpoint;
 import javax.resource.spi.endpoint.MessageEndpointFactory;
 import javax.transaction.Status;
-import javax.transaction.SystemException;
-import javax.transaction.Transaction;
-import javax.transaction.TransactionManager;
+import javax.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.xa.XAResource;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.QueueConfiguration;
@@ -86,7 +85,7 @@ public class ActiveMQMessageHandler implements MessageHandler, FailoverEventList
 
    private final int sessionNr;
 
-   private final TransactionManager tm;
+   private final TransactionSynchronizationRegistry tsr;
 
    private ClientSessionFactory cf;
 
@@ -96,7 +95,7 @@ public class ActiveMQMessageHandler implements MessageHandler, FailoverEventList
 
    public ActiveMQMessageHandler(final ConnectionFactoryOptions options,
                                  final ActiveMQActivation activation,
-                                 final TransactionManager tm,
+                                 final TransactionSynchronizationRegistry tsr,
                                  final ClientSessionInternal session,
                                  final ClientSessionFactory cf,
                                  final int sessionNr) {
@@ -105,7 +104,7 @@ public class ActiveMQMessageHandler implements MessageHandler, FailoverEventList
       this.session = session;
       this.cf = cf;
       this.sessionNr = sessionNr;
-      this.tm = tm;
+      this.tsr = tsr;
    }
 
    public void setup() throws Exception {
@@ -302,10 +301,6 @@ public class ActiveMQMessageHandler implements MessageHandler, FailoverEventList
       boolean beforeDelivery = false;
 
       try {
-         if (activation.getActivationSpec().getTransactionTimeout() > 0 && tm != null) {
-            tm.setTransactionTimeout(activation.getActivationSpec().getTransactionTimeout());
-         }
-
          if (logger.isTraceEnabled()) {
             logger.trace("ActiveMQMessageHandler::calling beforeDelivery on message " + message);
          }
@@ -351,27 +346,16 @@ public class ActiveMQMessageHandler implements MessageHandler, FailoverEventList
          ActiveMQRALogger.LOGGER.errorDeliveringMessage(e);
          // we need to call before/afterDelivery as a pair
          int status = Status.STATUS_NO_TRANSACTION;
-         if (useXA && tm != null) {
-            try {
-               status = tm.getStatus();
-            } catch (SystemException e1) {
-               //not sure we can do much more here
-            }
+         if (useXA && tsr != null) {
+            status = tsr.getTransactionStatus();
          }
          if (beforeDelivery || status != Status.STATUS_NO_TRANSACTION) {
-            if (useXA && tm != null) {
+            if (useXA && tsr != null) {
                // This is the job for the container,
                // however if the container throws an exception because of some other errors,
                // there are situations where the container is not setting the rollback only
                // this is to avoid a scenario where afterDelivery would kick in
-               try {
-                  Transaction tx = tm.getTransaction();
-                  if (tx != null) {
-                     tx.setRollbackOnly();
-                  }
-               } catch (Exception e1) {
-                  ActiveMQRALogger.LOGGER.unableToClearTheTransaction(e1);
-               }
+               tsr.setRollbackOnly();
             }
 
             MessageEndpoint endToUse = endpoint;


### PR DESCRIPTION
To use the ResourceAdapter in other ApplicationServers, use of TransactionManager is removed. 
From the javadoc:
The TransactionManager is intended for use by the application server, the TransactionSynchronizationRegistry for use by the application server components such as persistence managers, resource adapters...