### PR TITLE
[ARTEMIS-3799]: Ping command is wrong on Windows.

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/core/server/NetworkHealthCheck.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/core/server/NetworkHealthCheck.java
@@ -52,7 +52,7 @@ public class NetworkHealthCheck extends ActiveMQScheduledComponent {
 
    public static final String IPV6_DEFAULT_COMMAND = "ping6 -c 1 %2$s";
 
-   public static final String IPV4_DEFAULT_COMMAND = Env.isMacOs() ? "ping -c 1 -t %d %s" : "ping -c 1 -w %d %s";
+   public static final String IPV4_DEFAULT_COMMAND = Env.isMacOs() ? "ping -c 1 -t %d %s" : Env.isLinuxOs() ? "ping -c 1 -w %d %s" : "ping -n 1 -w %d %s";
 
    private String ipv4Command = IPV4_DEFAULT_COMMAND;
 


### PR DESCRIPTION
* Changing the default ping command for Windows.

Jira: https://issues.apache.org/jira/browse/ARTEMIS-3799