### PR TITLE
ARTEMIS-3759 Add mirror controller address filter support

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/mirror/MirrorAddressFilter.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/mirror/MirrorAddressFilter.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.mirror;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.activemq.artemis.api.core.SimpleString;
+
+public class MirrorAddressFilter {
+
+   private final SimpleString[] allowList;
+
+   private final SimpleString[] denyList;
+
+   public MirrorAddressFilter(String filter) {
+      Set<SimpleString> allowList = new HashSet<>();
+      Set<SimpleString> denyList = new HashSet<>();
+
+      if (filter != null && !filter.isEmpty()) {
+         String[] parts = filter.split(",");
+         for (String part : parts) {
+            if (!"".equals(part) && !"!".equals(part)) {
+               if (part.startsWith("!")) {
+                  denyList.add(new SimpleString(part.substring(1)));
+               } else {
+                  allowList.add(new SimpleString(part));
+               }
+            }
+         }
+      }
+
+      this.allowList = allowList.toArray(new SimpleString[]{});
+      this.denyList = denyList.toArray(new SimpleString[]{});
+   }
+
+   public boolean match(SimpleString checkAddress) {
+      if (denyList.length > 0) {
+         for (SimpleString pattern : denyList) {
+            if (checkAddress.startsWith(pattern)) {
+               return false;
+            }
+         }
+      }
+
+      if (allowList.length > 0) {
+         for (SimpleString pattern : allowList) {
+            if (checkAddress.startsWith(pattern)) {
+               return true;
+            }
+         }
+         return false;
+      }
+      return true;
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/connect/mirror/MirrorAddressFilterTest.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/connect/mirror/MirrorAddressFilterTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.mirror;
+
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MirrorAddressFilterTest {
+
+   @Test
+   public void testAddressFilter() {
+      Assert.assertTrue(new MirrorAddressFilter("").match(new SimpleString("any")));
+      Assert.assertTrue(new MirrorAddressFilter("test").match(new SimpleString("test123")));
+      Assert.assertTrue(new MirrorAddressFilter("a,b").match(new SimpleString("b")));
+      Assert.assertTrue(new MirrorAddressFilter("!c").match(new SimpleString("a")));
+      Assert.assertTrue(new MirrorAddressFilter("!a,!").match(new SimpleString("b123")));
+      Assert.assertFalse(new MirrorAddressFilter("a,b,!ab").match(new SimpleString("ab")));
+      Assert.assertFalse(new MirrorAddressFilter("!a,!b").match(new SimpleString("b123")));
+      Assert.assertFalse(new MirrorAddressFilter("a,").match(new SimpleString("b")));
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPMirrorBrokerConnectionElement.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPMirrorBrokerConnectionElement.java
@@ -30,6 +30,8 @@ public class AMQPMirrorBrokerConnectionElement extends AMQPBrokerConnectionEleme
 
    SimpleString mirrorSNF;
 
+   String addressFilter;
+
    public SimpleString getMirrorSNF() {
       return mirrorSNF;
    }
@@ -86,4 +88,14 @@ public class AMQPMirrorBrokerConnectionElement extends AMQPBrokerConnectionEleme
       this.messageAcknowledgements = messageAcknowledgements;
       return this;
    }
+
+   public String getAddressFilter() {
+      return addressFilter;
+   }
+
+   public AMQPMirrorBrokerConnectionElement setAddressFilter(String addressFilter) {
+      this.addressFilter = addressFilter;
+      return this;
+   }
+
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -2094,8 +2094,10 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
                boolean queueCreation = getBooleanAttribute(e2,"queue-creation", true);
                boolean durable = getBooleanAttribute(e2, "durable", true);
                boolean queueRemoval = getBooleanAttribute(e2, "queue-removal", true);
+               String addressFilter = getAttributeValue(e2, "address-filter");
+
                AMQPMirrorBrokerConnectionElement amqpMirrorConnectionElement = new AMQPMirrorBrokerConnectionElement();
-               amqpMirrorConnectionElement.setMessageAcknowledgements(messageAcks).setQueueCreation(queueCreation).setQueueRemoval(queueRemoval).setDurable(durable);
+               amqpMirrorConnectionElement.setMessageAcknowledgements(messageAcks).setQueueCreation(queueCreation).setQueueRemoval(queueRemoval).setDurable(durable).setAddressFilter(addressFilter);
                connectionElement = amqpMirrorConnectionElement;
                connectionElement.setType(AMQPBrokerConnectionAddressType.MIRROR);
             } else {

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -2442,6 +2442,14 @@
             </xsd:documentation>
          </xsd:annotation>
       </xsd:attribute>
+      <xsd:attribute name="address-filter" type="xsd:string" use="optional">
+         <xsd:annotation>
+            <xsd:documentation>
+               This defines a filter that mirror will use to determine witch events will be forwarded toward
+               target server based on source address.
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
 
    </xsd:complexType>
 

--- a/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
@@ -442,7 +442,7 @@
             <receiver address-match="TEST-RECEIVER" />
             <peer address-match="TEST-PEER"/>
             <receiver queue-name="TEST-WITH-QUEUE-NAME"/>
-            <mirror message-acknowledgements="false" queue-creation="false" durable="false" queue-removal="false"/>
+            <mirror message-acknowledgements="false" queue-creation="false" durable="false" queue-removal="false" address-filter="TEST-QUEUE,!IGNORE-QUEUE"/>
          </amqp-connection>
          <amqp-connection uri="tcp://test2:222" name="test2">
             <mirror durable="false"/>

--- a/docs/user-manual/en/amqp-broker-connections.md
+++ b/docs/user-manual/en/amqp-broker-connections.md
@@ -103,6 +103,25 @@ The following optional arguments can be utilized:
 * `queue-removal`: Specifies whether a queue- or address-removal event is sent. The default value is `true`.
 * `message-acknowledgements`: Specifies whether message acknowledgements are sent. The default value is `true`.
 * `queue-creation`: Specifies whether a queue- or address-creation event is sent. The default value is `true`.
+* `address-filter`: An optional comma-separated list of inclusion and/or exclusion filter entries used to govern which addresses (and related queues) mirroring events will be created for on this broker-connection. That is, events will only be mirrored to the target broker for addresses that match the filter.
+  An address is matched when it begins with an inclusion entry specified in this field, unless the address is also explicitly excluded by another entry. An exclusion entry is prefixed with `!` to denote any address beginning with that value does not match.
+  If no inclusion entry is specified in the list, all addresses not explicitly excluded will match. If the address-filter attribute is not specified, then all addresses (and related queues) will match and be mirrored.
+
+  Examples:
+
+  - 'eu'
+    matches all addresses starting with 'eu'
+  - '!eu'
+    matches all address except for those starting with 'eu'
+  - 'eu.uk,eu.de'
+    matches all addresses starting with either 'eu.uk' or 'eu.de'
+  - 'eu,!eu.uk'
+    matches all addresses starting with 'eu' but not those starting with 'eu.uk'
+
+  **Note:**
+
+  - Address exclusion will always take precedence over address inclusion.
+  - Address matching on mirror elements is prefix-based and does not support wild-card matching.
 
 An example of a mirror configuration is shown below:
 ```xml


### PR DESCRIPTION
Allow replication only certain addresses with mirror controller.
The configuration is similar to cluster address configuration.