### PR TITLE
[ARTEMIS-3700]: Provinding a JakartaEE 10 implementation.

### DIFF
--- a/artemis-jakarta-client/src/main/resources/jms-version.properties
+++ b/artemis-jakarta-client/src/main/resources/jms-version.properties
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-activemq.version.implementation.versionName=3.0
+activemq.version.implementation.versionName=3.1
 activemq.version.implementation.majorVersion=3
-activemq.version.implementation.minorVersion=0
+activemq.version.implementation.minorVersion=1

--- a/artemis-jakarta-ra/src/main/resources/jms-version.properties
+++ b/artemis-jakarta-ra/src/main/resources/jms-version.properties
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-activemq.version.implementation.versionName=3.0
+activemq.version.implementation.versionName=3.1
 activemq.version.implementation.majorVersion=3
-activemq.version.implementation.minorVersion=0
+activemq.version.implementation.minorVersion=1

--- a/pom.xml
+++ b/pom.xml
@@ -167,9 +167,9 @@
 
       <!-- for JakartaEE -->
       <version.batavia>1.0.10.Final</version.batavia>
-      <jakarta.jms-api.version.alt>3.0.0</jakarta.jms-api.version.alt>
-      <jakarta.transaction-api.version.alt>2.0.0</jakarta.transaction-api.version.alt>
-      <jakarta.resource-api.version.alt>2.0.0</jakarta.resource-api.version.alt>
+      <jakarta.jms-api.version.alt>3.1.0</jakarta.jms-api.version.alt>
+      <jakarta.transaction-api.version.alt>2.0.1</jakarta.transaction-api.version.alt>
+      <jakarta.resource-api.version.alt>2.1.0</jakarta.resource-api.version.alt>
 
       <!-- used on tests -->
       <groovy.version>4.0.0</groovy.version>


### PR DESCRIPTION
* Upgrading the API to Jakarta Messaging 3.1.0
* Updating the metadata to 3.1.0

Jira: https://issues.apache.org/jira/browse/ARTEMIS-3700