### PR TITLE
ARTEMIS-3808 support start/stop embedded web server via mngmnt

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/ActiveMQExceptionType.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/ActiveMQExceptionType.java
@@ -273,6 +273,12 @@ public enum ActiveMQExceptionType {
       public ActiveMQException createException(String msg) {
          return new ActiveMQRoutingException(msg);
       }
+   },
+   TIMEOUT_EXCEPTION(223) {
+      @Override
+      public ActiveMQException createException(String msg) {
+         return new ActiveMQTimeoutException(msg);
+      }
    };
    private static final Map<Integer, ActiveMQExceptionType> TYPE_MAP;
 

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/ActiveMQTimeoutException.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/ActiveMQTimeoutException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.api.core;
+
+/**
+ * An operation timed out.
+ */
+public final class ActiveMQTimeoutException extends ActiveMQException {
+
+   private static final long serialVersionUID = 0;
+
+   public ActiveMQTimeoutException(String message) {
+      super(ActiveMQExceptionType.TIMEOUT_EXCEPTION, message);
+   }
+
+   public ActiveMQTimeoutException() {
+      super(ActiveMQExceptionType.TIMEOUT_EXCEPTION);
+   }
+}

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/marker/WebServerComponentMarker.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/marker/WebServerComponentMarker.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.activemq.artemis.marker;
+
+/*
+ * This is just a "marker interface" so that the broker can find the org.apache.activemq.artemis.component.WebServerComponent
+ * for management operations (e.g. start & stop).
+ */
+public interface WebServerComponentMarker {
+}

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
@@ -652,6 +652,8 @@ public final class ActiveMQDefaultConfiguration {
    // If SESSION-notifications should be suppressed or not
    public static boolean DEFAULT_SUPPRESS_SESSION_NOTIFICATIONS = false;
 
+   public static final long DEFAULT_EMBEDDED_WEB_SERVER_RESTART_TIMEOUT = 5000;
+
    /**
     * If true then the ActiveMQ Artemis Server will make use of any Protocol Managers that are in available on the classpath. If false then only the core protocol will be available, unless in Embedded mode where users can inject their own Protocol Managers.
     */
@@ -1784,6 +1786,10 @@ public final class ActiveMQDefaultConfiguration {
 
    public static boolean getDefaultSuppressSessionNotifications() {
       return DEFAULT_SUPPRESS_SESSION_NOTIFICATIONS;
+   }
+
+   public static long getDefaultEmbeddedWebServerRestartTimeout() {
+      return DEFAULT_EMBEDDED_WEB_SERVER_RESTART_TIMEOUT;
    }
 
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
@@ -19,6 +19,7 @@ package org.apache.activemq.artemis.api.core.management;
 import javax.management.MBeanOperationInfo;
 import java.util.Map;
 
+import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.ActiveMQAddressDoesNotExistException;
 
 /**
@@ -1971,5 +1972,20 @@ public interface ActiveMQServerControl {
                @Parameter(name = "address", desc = "Name of the address to replay") String address,
                @Parameter(name = "target", desc = "Where the replay data should be sent") String target,
                @Parameter(name = "filter", desc = "Filter to apply on message selection. Null means everything matching the address") String filter) throws Exception;
+
+   @Operation(desc = "stop the embedded web server", impact = MBeanOperationInfo.ACTION)
+   void stopEmbeddedWebServer() throws Exception;
+
+   @Operation(desc = "start the embedded web server", impact = MBeanOperationInfo.ACTION)
+   void startEmbeddedWebServer() throws Exception;
+
+   @Operation(desc = "restart the embedded web server; wait the default " + ActiveMQDefaultConfiguration.DEFAULT_EMBEDDED_WEB_SERVER_RESTART_TIMEOUT + " milliseconds to ensure restart completes successfully", impact = MBeanOperationInfo.ACTION)
+   void restartEmbeddedWebServer() throws Exception;
+
+   @Operation(desc = "restart the embedded web server; wait specified time (in milliseconds) to ensure restart completes successfully", impact = MBeanOperationInfo.ACTION)
+   void restartEmbeddedWebServer(@Parameter(name = "timeout", desc = "how long to wait (in milliseconds) to ensure restart completes successfully") long timeout) throws Exception;
+
+   @Attribute(desc = "Whether the embedded web server is started")
+   boolean isEmbeddedWebServerStarted();
 }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQMessageBundle.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQMessageBundle.java
@@ -44,6 +44,7 @@ import org.apache.activemq.artemis.api.core.ActiveMQRemoteDisconnectException;
 import org.apache.activemq.artemis.api.core.ActiveMQReplicationTimeooutException;
 import org.apache.activemq.artemis.api.core.ActiveMQSecurityException;
 import org.apache.activemq.artemis.api.core.ActiveMQSessionCreationException;
+import org.apache.activemq.artemis.api.core.ActiveMQTimeoutException;
 import org.apache.activemq.artemis.api.core.ActiveMQUnexpectedRoutingTypeForAddress;
 import org.apache.activemq.artemis.api.core.DiscoveryGroupConfiguration;
 import org.apache.activemq.artemis.api.core.RoutingType;
@@ -522,4 +523,13 @@ public interface ActiveMQMessageBundle {
 
    @Message(id = 229240, value = "Connection router {0} rejected the connection", format = Message.Format.MESSAGE_FORMAT)
    ActiveMQRemoteDisconnectException connectionRejected(String connectionRouter);
+
+   @Message(id = 229241, value = "Embedded web server not found")
+   ActiveMQIllegalStateException embeddedWebServerNotFound();
+
+   @Message(id = 229242, value = "Embedded web server not restarted in {0} milliseconds", format = Message.Format.MESSAGE_FORMAT)
+   ActiveMQTimeoutException embeddedWebServerRestartTimeout(long timeout);
+
+   @Message(id = 229243, value = "Embedded web server restart failed", format = Message.Format.MESSAGE_FORMAT)
+   ActiveMQException embeddedWebServerRestartFailed(@Cause Exception e);
 }

--- a/artemis-web/src/main/java/org/apache/activemq/artemis/ActiveMQWebLogger.java
+++ b/artemis-web/src/main/java/org/apache/activemq/artemis/ActiveMQWebLogger.java
@@ -44,20 +44,32 @@ public interface ActiveMQWebLogger extends BasicLogger {
    ActiveMQWebLogger LOGGER = Logger.getMessageLogger(ActiveMQWebLogger.class, ActiveMQWebLogger.class.getPackage().getName());
 
    @LogMessage(level = Logger.Level.INFO)
-   @Message(id = 241001, value = "HTTP Server started at {0}", format = Message.Format.MESSAGE_FORMAT)
+   @Message(id = 241001, value = "Embedded web server started at {0}", format = Message.Format.MESSAGE_FORMAT)
    void webserverStarted(String bind);
 
    @LogMessage(level = Logger.Level.INFO)
    @Message(id = 241002, value = "Artemis Jolokia REST API available at {0}", format = Message.Format.MESSAGE_FORMAT)
    void jolokiaAvailable(String bind);
 
-   @LogMessage(level = Logger.Level.WARN)
-   @Message(id = 244003, value = "Temporary file not deleted on shutdown: {0}", format = Message.Format.MESSAGE_FORMAT)
-   void tmpFileNotDeleted(File tmpdir);
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 241003, value = "Starting embedded web server", format = Message.Format.MESSAGE_FORMAT)
+   void startingEmbeddedWebServer();
 
    @LogMessage(level = Logger.Level.INFO)
    @Message(id = 241004, value = "Artemis Console available at {0}", format = Message.Format.MESSAGE_FORMAT)
    void consoleAvailable(String bind);
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 241005, value = "Stopping embedded web server", format = Message.Format.MESSAGE_FORMAT)
+   void stoppingEmbeddedWebServer();
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 241006, value = "Stopped embedded web server", format = Message.Format.MESSAGE_FORMAT)
+   void stoppedEmbeddedWebServer();
+
+   @LogMessage(level = Logger.Level.WARN)
+   @Message(id = 244003, value = "Temporary file not deleted on shutdown: {0}", format = Message.Format.MESSAGE_FORMAT)
+   void tmpFileNotDeleted(File tmpdir);
 
    @LogMessage(level = Logger.Level.WARN)
    @Message(id = 244005, value = "Web customizer {0} not loaded: {1}", format = Message.Format.MESSAGE_FORMAT)

--- a/artemis-web/src/main/java/org/apache/activemq/artemis/component/WebServerComponent.java
+++ b/artemis-web/src/main/java/org/apache/activemq/artemis/component/WebServerComponent.java
@@ -33,6 +33,7 @@ import org.apache.activemq.artemis.dto.AppDTO;
 import org.apache.activemq.artemis.dto.BindingDTO;
 import org.apache.activemq.artemis.dto.ComponentDTO;
 import org.apache.activemq.artemis.dto.WebServerDTO;
+import org.apache.activemq.artemis.marker.WebServerComponentMarker;
 import org.eclipse.jetty.security.DefaultAuthenticatorFactory;
 import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.CustomRequestLog;
@@ -53,115 +54,81 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.jboss.logging.Logger;
 
-public class WebServerComponent implements ExternalComponent {
+public class WebServerComponent implements ExternalComponent, WebServerComponentMarker {
 
    private static final Logger logger = Logger.getLogger(WebServerComponent.class);
+   public static final String DIR_ALLOWED = "org.eclipse.jetty.servlet.Default.dirAllowed";
 
    private Server server;
    private HandlerList handlers;
    private WebServerDTO webServerConfig;
    private final List<String> consoleUrls = new ArrayList<>();
    private final List<String> jolokiaUrls = new ArrayList<>();
-   private List<WebAppContext> webContexts;
+   private final List<WebAppContext> webContexts = new ArrayList<>();;
    private ServerConnector[] connectors;
    private Path artemisHomePath;
    private Path temporaryWarDir;
+   private String artemisInstance;
+   private String artemisHome;
 
    @Override
    public void configure(ComponentDTO config, String artemisInstance, String artemisHome) throws Exception {
-      webServerConfig = (WebServerDTO) config;
-      server = new Server();
-
-      HttpConfiguration httpConfiguration = new HttpConfiguration();
-
-      if (webServerConfig.customizer != null) {
-         try {
-            httpConfiguration.addCustomizer((HttpConfiguration.Customizer) Class.forName(webServerConfig.customizer).getConstructor().newInstance());
-         } catch (Throwable t) {
-            ActiveMQWebLogger.LOGGER.customizerNotLoaded(webServerConfig.customizer, t);
-         }
-      }
-
-      List<BindingDTO> bindings = webServerConfig.getBindings();
-      connectors = new ServerConnector[bindings.size()];
-      String[] virtualHosts = new String[bindings.size()];
-
-      for (int i = 0; i < bindings.size(); i++) {
-         BindingDTO binding = bindings.get(i);
-         URI uri = new URI(binding.uri);
-         String scheme = uri.getScheme();
-         ServerConnector connector;
-
-         if ("https".equals(scheme)) {
-            SslContextFactory.Server sslFactory = new SslContextFactory.Server();
-            sslFactory.setKeyStorePath(binding.keyStorePath == null ? artemisInstance + "/etc/keystore.jks" : binding.keyStorePath);
-            sslFactory.setKeyStorePassword(binding.getKeyStorePassword() == null ? "password" : binding.getKeyStorePassword());
-
-            if (binding.getIncludedTLSProtocols() != null) {
-               sslFactory.setIncludeProtocols(binding.getIncludedTLSProtocols());
-            }
-            if (binding.getExcludedTLSProtocols() != null) {
-               sslFactory.setExcludeProtocols(binding.getExcludedTLSProtocols());
-            }
-            if (binding.getIncludedCipherSuites() != null) {
-               sslFactory.setIncludeCipherSuites(binding.getIncludedCipherSuites());
-            }
-            if (binding.getExcludedCipherSuites() != null) {
-               sslFactory.setExcludeCipherSuites(binding.getExcludedCipherSuites());
-            }
-            if (binding.clientAuth != null) {
-               sslFactory.setNeedClientAuth(binding.clientAuth);
-               if (binding.clientAuth) {
-                  sslFactory.setTrustStorePath(binding.trustStorePath);
-                  sslFactory.setTrustStorePassword(binding.getTrustStorePassword());
-               }
-            }
-
-            SslConnectionFactory sslConnectionFactory = new SslConnectionFactory(sslFactory, "HTTP/1.1");
-
-            httpConfiguration.addCustomizer(new SecureRequestCustomizer());
-            httpConfiguration.setSendServerVersion(false);
-            HttpConnectionFactory httpFactory = new HttpConnectionFactory(httpConfiguration);
-
-            connector = new ServerConnector(server, sslConnectionFactory, httpFactory);
-
-         } else {
-            httpConfiguration.setSendServerVersion(false);
-            ConnectionFactory connectionFactory = new HttpConnectionFactory(httpConfiguration);
-            connector = new ServerConnector(server, connectionFactory);
-         }
-         connector.setPort(uri.getPort());
-         connector.setHost(uri.getHost());
-         connector.setName("Connector-" + i);
-
-         connectors[i] = connector;
-         virtualHosts[i] = "@Connector-" + i;
-      }
-
-      server.setConnectors(connectors);
-
-      handlers = new HandlerList();
-
-      this.artemisHomePath = Paths.get(artemisHome != null ? artemisHome : ".");
-      Path homeWarDir = artemisHomePath.resolve(webServerConfig.path).toAbsolutePath();
-      Path instanceWarDir = Paths.get(artemisInstance != null ? artemisInstance : ".").resolve(webServerConfig.path).toAbsolutePath();
+      this.webServerConfig = (WebServerDTO) config;
+      this.artemisInstance = artemisInstance;
+      this.artemisHome = artemisHome;
 
       temporaryWarDir = Paths.get(artemisInstance != null ? artemisInstance : ".").resolve("tmp").resolve("webapps").toAbsolutePath();
       if (!Files.exists(temporaryWarDir)) {
          Files.createDirectories(temporaryWarDir);
       }
+   }
+
+   @Override
+   public synchronized void start() throws Exception {
+      if (isStarted()) {
+         return;
+      }
+      ActiveMQWebLogger.LOGGER.startingEmbeddedWebServer();
+
+      server = new Server();
+      handlers = new HandlerList();
+
+      HttpConfiguration httpConfiguration = new HttpConfiguration();
+
+      if (this.webServerConfig.customizer != null) {
+         try {
+            httpConfiguration.addCustomizer((HttpConfiguration.Customizer) Class.forName(this.webServerConfig.customizer).getConstructor().newInstance());
+         } catch (Throwable t) {
+            ActiveMQWebLogger.LOGGER.customizerNotLoaded(this.webServerConfig.customizer, t);
+         }
+      }
+
+      List<BindingDTO> bindings = this.webServerConfig.getBindings();
+      connectors = new ServerConnector[bindings.size()];
+      String[] virtualHosts = new String[bindings.size()];
+
+      this.artemisHomePath = Paths.get(artemisHome != null ? artemisHome : ".");
+      Path homeWarDir = artemisHomePath.resolve(this.webServerConfig.path).toAbsolutePath();
+      Path instanceWarDir = Paths.get(artemisInstance != null ? artemisInstance : ".").resolve(this.webServerConfig.path).toAbsolutePath();
 
       for (int i = 0; i < bindings.size(); i++) {
          BindingDTO binding = bindings.get(i);
+         URI uri = new URI(binding.uri);
+         String scheme = uri.getScheme();
+         ServerConnector connector = createServerConnector(httpConfiguration, i, binding, uri, scheme);
+
+         connectors[i] = connector;
+         virtualHosts[i] = "@Connector-" + i;
+
          if (binding.apps != null && binding.apps.size() > 0) {
-            webContexts = new ArrayList<>();
             for (AppDTO app : binding.apps) {
                Path dirToUse = homeWarDir;
-               if (new File(instanceWarDir.toFile().toString() + File.separator + app.war).exists()) {
+               if (new File(instanceWarDir.toFile() + File.separator + app.war).exists()) {
                   dirToUse = instanceWarDir;
                }
-               WebAppContext webContext = deployWar(app.url, app.war, dirToUse, virtualHosts[i]);
-               webContext.setInitParameter("org.eclipse.jetty.servlet.Default.dirAllowed", "false");
+               WebAppContext webContext = createWebAppContext(app.url, app.war, dirToUse, virtualHosts[i]);
+               handlers.addHandler(webContext);
+               webContext.setInitParameter(DIR_ALLOWED, "false");
                webContexts.add(webContext);
                if (app.war.startsWith("console")) {
                   consoleUrls.add(binding.uri + "/" + app.url);
@@ -170,6 +137,8 @@ public class WebServerComponent implements ExternalComponent {
             }
          }
       }
+
+      server.setConnectors(connectors);
 
       ResourceHandler homeResourceHandler = new ResourceHandler();
       homeResourceHandler.setResourceBase(homeWarDir.toString());
@@ -181,7 +150,7 @@ public class WebServerComponent implements ExternalComponent {
       homeContext.setResourceBase(homeWarDir.toString());
       homeContext.setHandler(homeResourceHandler);
       homeContext.setVirtualHosts(virtualHosts);
-      homeContext.setInitParameter("org.eclipse.jetty.servlet.Default.dirAllowed", "false");
+      homeContext.setInitParameter(DIR_ALLOWED, "false");
 
       ResourceHandler instanceResourceHandler = new ResourceHandler();
       instanceResourceHandler.setResourceBase(instanceWarDir.toString());
@@ -193,12 +162,12 @@ public class WebServerComponent implements ExternalComponent {
       instanceContext.setResourceBase(instanceWarDir.toString());
       instanceContext.setHandler(instanceResourceHandler);
       instanceContext.setVirtualHosts(virtualHosts);
-      homeContext.setInitParameter("org.eclipse.jetty.servlet.Default.dirAllowed", "false");
+      homeContext.setInitParameter(DIR_ALLOWED, "false");
 
       DefaultHandler defaultHandler = new DefaultHandler();
       defaultHandler.setServeIcon(false);
 
-      if (webServerConfig.requestLog != null) {
+      if (this.webServerConfig.requestLog != null) {
          handlers.addHandler(getLogHandler());
       }
       handlers.addHandler(homeContext);
@@ -206,6 +175,68 @@ public class WebServerComponent implements ExternalComponent {
       handlers.addHandler(defaultHandler); // this should be last
 
       server.setHandler(handlers);
+
+      cleanupTmp();
+      server.start();
+
+      ActiveMQWebLogger.LOGGER.webserverStarted(bindings
+                                                   .stream()
+                                                   .map(binding -> binding.uri)
+                                                   .collect(Collectors.joining(", ")));
+
+      ActiveMQWebLogger.LOGGER.jolokiaAvailable(String.join(", ", jolokiaUrls));
+      ActiveMQWebLogger.LOGGER.consoleAvailable(String.join(", ", consoleUrls));
+   }
+
+   private ServerConnector createServerConnector(HttpConfiguration httpConfiguration,
+                                              int i,
+                                              BindingDTO binding,
+                                              URI uri,
+                                              String scheme) throws Exception {
+      ServerConnector connector;
+
+      if ("https".equals(scheme)) {
+         SslContextFactory.Server sslFactory = new SslContextFactory.Server();
+         sslFactory.setKeyStorePath(binding.keyStorePath == null ? artemisInstance + "/etc/keystore.jks" : binding.keyStorePath);
+         sslFactory.setKeyStorePassword(binding.getKeyStorePassword() == null ? "password" : binding.getKeyStorePassword());
+
+         if (binding.getIncludedTLSProtocols() != null) {
+            sslFactory.setIncludeProtocols(binding.getIncludedTLSProtocols());
+         }
+         if (binding.getExcludedTLSProtocols() != null) {
+            sslFactory.setExcludeProtocols(binding.getExcludedTLSProtocols());
+         }
+         if (binding.getIncludedCipherSuites() != null) {
+            sslFactory.setIncludeCipherSuites(binding.getIncludedCipherSuites());
+         }
+         if (binding.getExcludedCipherSuites() != null) {
+            sslFactory.setExcludeCipherSuites(binding.getExcludedCipherSuites());
+         }
+         if (binding.clientAuth != null) {
+            sslFactory.setNeedClientAuth(binding.clientAuth);
+            if (binding.clientAuth) {
+               sslFactory.setTrustStorePath(binding.trustStorePath);
+               sslFactory.setTrustStorePassword(binding.getTrustStorePassword());
+            }
+         }
+
+         SslConnectionFactory sslConnectionFactory = new SslConnectionFactory(sslFactory, "HTTP/1.1");
+
+         httpConfiguration.addCustomizer(new SecureRequestCustomizer());
+         httpConfiguration.setSendServerVersion(false);
+         HttpConnectionFactory httpFactory = new HttpConnectionFactory(httpConfiguration);
+
+         connector = new ServerConnector(server, sslConnectionFactory, httpFactory);
+
+      } else {
+         httpConfiguration.setSendServerVersion(false);
+         ConnectionFactory connectionFactory = new HttpConnectionFactory(httpConfiguration);
+         connector = new ServerConnector(server, connectionFactory);
+      }
+      connector.setPort(uri.getPort());
+      connector.setHost(uri.getHost());
+      connector.setName("Connector-" + i);
+      return connector;
    }
 
    private RequestLogHandler getLogHandler() {
@@ -249,33 +280,6 @@ public class WebServerComponent implements ExternalComponent {
       return requestLogHandler;
    }
 
-   @Override
-   public void start() throws Exception {
-      if (isStarted()) {
-         return;
-      }
-      cleanupTmp();
-      server.start();
-
-      String bindings = webServerConfig.getBindings()
-            .stream()
-            .map(binding -> binding.uri)
-            .collect(Collectors.joining(", "));
-      ActiveMQWebLogger.LOGGER.webserverStarted(bindings);
-
-      ActiveMQWebLogger.LOGGER.jolokiaAvailable(String.join(", ", jolokiaUrls));
-      ActiveMQWebLogger.LOGGER.consoleAvailable(String.join(", ", consoleUrls));
-   }
-
-   public void internalStop() throws Exception {
-      server.stop();
-      if (webContexts != null) {
-         cleanupWebTemporaryFiles(webContexts);
-
-         webContexts.clear();
-      }
-   }
-
    private File getLibFolder() {
       Path lib = artemisHomePath.resolve("lib");
       File libFolder = new File(lib.toUri());
@@ -283,7 +287,7 @@ public class WebServerComponent implements ExternalComponent {
    }
 
    private void cleanupTmp() {
-      if (webContexts == null || webContexts.size() == 0) {
+      if (webContexts.size() == 0) {
          //there is no webapp to be deployed (as in some tests)
          return;
       }
@@ -332,7 +336,7 @@ public class WebServerComponent implements ExternalComponent {
       return -1;
    }
 
-   private WebAppContext deployWar(String url, String warFile, Path warDirectory, String virtualHost) {
+   protected WebAppContext createWebAppContext(String url, String warFile, Path warDirectory, String virtualHost) {
       WebAppContext webapp = new WebAppContext();
       if (url.startsWith("/")) {
          webapp.setContextPath(url);
@@ -353,7 +357,6 @@ public class WebServerComponent implements ExternalComponent {
 
       webapp.setVirtualHosts(new String[]{virtualHost});
 
-      handlers.addHandler(webapp);
       return webapp;
    }
 
@@ -363,9 +366,17 @@ public class WebServerComponent implements ExternalComponent {
    }
 
    @Override
-   public void stop(boolean isShutdown) throws Exception {
-      if (isShutdown) {
-         internalStop();
+   public synchronized void stop(boolean isShutdown) throws Exception {
+      if (isShutdown && isStarted()) {
+         ActiveMQWebLogger.LOGGER.stoppingEmbeddedWebServer();
+         server.stop();
+         server = null;
+         cleanupWebTemporaryFiles(webContexts);
+         webContexts.clear();
+         jolokiaUrls.clear();
+         consoleUrls.clear();
+         handlers = null;
+         ActiveMQWebLogger.LOGGER.stoppedEmbeddedWebServer();
       }
    }
 

--- a/artemis-web/src/main/java/org/apache/activemq/artemis/component/WebServerComponentTestAccessor.java
+++ b/artemis-web/src/main/java/org/apache/activemq/artemis/component/WebServerComponentTestAccessor.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.component;
+
+import java.nio.file.Path;
+
+import org.eclipse.jetty.webapp.WebAppContext;
+
+public class WebServerComponentTestAccessor {
+
+   public static WebAppContext createWebAppContext(WebServerComponent webServerComponent, String url, String warFile, Path warDirectory, String virtualHost) {
+      return webServerComponent.createWebAppContext(url, warFile, warDirectory, virtualHost);
+   }
+}

--- a/docs/user-manual/en/versions.md
+++ b/docs/user-manual/en/versions.md
@@ -8,6 +8,12 @@ This chapter provides the following information for each release:
   - **Note:** Follow the general upgrade procedure outlined in the [Upgrading the Broker](upgrading.md) 
     chapter in addition to any version-specific upgrade instructions outlined here.
 
+## 2.23.0
+[Full release notes](TBD).
+
+Highlights:
+- New [management operations](web-server.md#management) for the embedded web server.
+
 ## 2.21.0
 [Full release notes](https://issues.apache.org/jira/secure/ReleaseNote.jspa?version=12351083&projectId=12315920).
 

--- a/docs/user-manual/en/web-server.md
+++ b/docs/user-manual/en/web-server.md
@@ -123,3 +123,10 @@ Set the `customizer` attribute via the `web` element to enable the [`ForwardedRe
    </binding>
 </web>
 ```
+
+## Management
+
+The embedded web server can be stopped, started, or restarted via any available
+management interface via the `stopEmbeddedWebServer`, `starteEmbeddedWebServer`,
+and `restartEmbeddedWebServer` operations on the `ActiveMQServerControl` 
+respectively.

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
@@ -1661,6 +1661,31 @@ public class ActiveMQServerControlUsingCoreTest extends ActiveMQServerControlTes
                             String filter) throws Exception {
             proxy.invokeOperation("replay", startScan, endScan, address, target, filter);
          }
+
+         @Override
+         public void stopEmbeddedWebServer() throws Exception {
+            proxy.invokeOperation("stopEmbeddedWebServer");
+         }
+
+         @Override
+         public void startEmbeddedWebServer() throws Exception {
+            proxy.invokeOperation("startEmbeddedWebServer");
+         }
+
+         @Override
+         public void restartEmbeddedWebServer() throws Exception {
+            proxy.invokeOperation("restartEmbeddedWebServer");
+         }
+
+         @Override
+         public void restartEmbeddedWebServer(long timeout) throws Exception {
+            proxy.invokeOperation("restartEmbeddedWebServer", timeout);
+         }
+
+         @Override
+         public boolean isEmbeddedWebServerStarted() {
+            return (boolean) proxy.retrieveAttributeValue("embeddedWebServerStarted");
+         }
       };
    }
 


### PR DESCRIPTION
It would be useful to be able to cycle the embedded web server if, for
example, one needed to renew the SSL certificates. To support this
functionality I made a handful of changes, e.g.:

 - Refactoring `WebServerComponent` so that all the necessary
   configuration would happen in the `start()` method.
 - Refactoring `WebServerComponentTest` to re-use code.