### PR TITLE
ARTEMIS-3806 Upgrade jboss-logging dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
       <guava.version>30.1-jre</guava.version>
       <hawtio.version>2.14.2</hawtio.version>
       <jsr305.version>3.0.2</jsr305.version>
-      <jboss.logging.version>3.4.3.Final</jboss.logging.version>
+      <jboss.logging.version>3.5.0.Final</jboss.logging.version>
       <jetty.version>9.4.45.v20220203</jetty.version>
       <tomcat.servlet-api.version>8.5.78</tomcat.servlet-api.version>
       <jgroups.version>5.2.0.Final</jgroups.version>
@@ -397,7 +397,7 @@
          <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-processor</artifactId>
-            <version>2.2.0.Final</version>
+            <version>2.2.1.Final</version>
             <optional>true</optional>
             <scope>provided</scope>
             <!-- License: LGPL-->
@@ -405,7 +405,7 @@
          <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-annotations</artifactId>
-            <version>2.2.0.Final</version>
+            <version>2.2.1.Final</version>
             <scope>provided</scope>
             <optional>true</optional>
             <!-- License: Apache 2.0-->


### PR DESCRIPTION
Upgrade jboss-logging 3.4.3.Final dependency due to false-positive vulnerability reports

Minor upgrade for jboss-logging from 3.4.3 to 3.5.0
Patch upgrade for jboss-logging-annotations from 2.2.0.Final to 2.2.1.Final
Patch upgrade for jboss-logging-processor from 2.2.0.Final to 2.2.1.Final