### PR TITLE
ARTEMIS-3840 Core bridges with concurrency > 1 will get removed on co…

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/BridgeConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/BridgeConfiguration.java
@@ -116,11 +116,14 @@ public final class BridgeConfiguration implements Serializable {
 
    private int concurrency = ActiveMQDefaultConfiguration.getDefaultBridgeConcurrency();
 
+   private String parentName = null;
+
    public BridgeConfiguration() {
    }
 
    public BridgeConfiguration(BridgeConfiguration other) {
       name = other.name;
+      parentName = other.parentName;
       queueName = other.queueName;
       forwardingAddress = other.forwardingAddress;
       filterString = other.filterString;
@@ -265,6 +268,15 @@ public final class BridgeConfiguration implements Serializable {
     */
    public BridgeConfiguration setName(final String name) {
       this.name = name;
+      return this;
+   }
+
+   public String getParentName() {
+      return parentName;
+   }
+
+   public BridgeConfiguration setParentName(final String parentName) {
+      this.parentName = parentName;
       return this;
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ClusterManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ClusterManager.java
@@ -478,8 +478,9 @@ public class ClusterManager implements ActiveMQComponent {
       clusterLocators.add(serverLocator);
 
       for (int i = 0; i < config.getConcurrency(); i++) {
+         String parentName = config.getName();
          String name = config.getConcurrency() > 1 ? (config.getName() + "-" + i) : config.getName();
-         Bridge bridge = new BridgeImpl(serverLocator, new BridgeConfiguration(config).setName(name), nodeManager.getUUID(), queue, executorFactory.getExecutor(), scheduledExecutor, server);
+         Bridge bridge = new BridgeImpl(serverLocator, new BridgeConfiguration(config).setName(name).setParentName(parentName), nodeManager.getUUID(), queue, executorFactory.getExecutor(), scheduledExecutor, server);
          bridges.put(name, bridge);
          managementService.registerBridge(bridge);
          bridge.start();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -4420,7 +4420,8 @@ public class ActiveMQServerImpl implements ActiveMQServer {
 
          ActiveMQServerLogger.LOGGER.reloadingConfiguration("bridges");
          for (BridgeConfiguration newBridgeConfig : configuration.getBridgeConfigurations()) {
-            Bridge existingBridge = clusterManager.getBridges().get(newBridgeConfig.getName());
+            newBridgeConfig.setParentName(newBridgeConfig.getName());
+            Bridge existingBridge = clusterManager.getBridges().get(newBridgeConfig.getParentName());
             if (existingBridge != null && !existingBridge.getConfiguration().equals(newBridgeConfig)) {
                // this is an existing bridge but the config changed so stop the current bridge and deploy the new one
                destroyBridge(existingBridge.getName().toString());
@@ -4431,7 +4432,10 @@ public class ActiveMQServerImpl implements ActiveMQServer {
             }
          }
          for (final Bridge runningBridge: clusterManager.getBridges().values()) {
-            if (!configuration.getBridgeConfigurations().contains(runningBridge.getConfiguration())) {
+            List<BridgeConfiguration> newConfig = configuration.getBridgeConfigurations();
+            BridgeConfiguration running = new BridgeConfiguration(runningBridge.getConfiguration());
+            running.set("name", running.getParentName());
+            if (!configuration.getBridgeConfigurations().contains(running)) {
                // this bridge is running but it isn't in the new config which means it was removed so destroy it
                destroyBridge(runningBridge.getName().toString());
             }

--- a/tests/integration-tests/src/test/resources/reload-bridge-updated.xml
+++ b/tests/integration-tests/src/test/resources/reload-bridge-updated.xml
@@ -39,6 +39,7 @@ under the License.
          <bridge name="a">
             <queue-name>a-from</queue-name>
             <forwarding-address>a-new</forwarding-address>
+            <concurrency>2</concurrency>
             <static-connectors>
                <connector-ref>connector</connector-ref>
             </static-connectors>

--- a/tests/integration-tests/src/test/resources/reload-bridge.xml
+++ b/tests/integration-tests/src/test/resources/reload-bridge.xml
@@ -46,6 +46,7 @@ under the License.
          <bridge name="b">
             <queue-name>b-from</queue-name>
             <forwarding-address>b-to</forwarding-address>
+            <concurrency>5</concurrency>
             <static-connectors>
                <connector-ref>connector</connector-ref>
             </static-connectors>


### PR DESCRIPTION
…nfig reload

This might not be the best way to do it so I am very open to suggestions on anything to change... but this gets the job done at least from what I can tell.

Just adding "concurrency" to the reload-bridge xml-files used by: "org.apache.activemq.artemis.tests.integration.jms.RedeployTest#testRedeployBridge()" triggers the issue so the problem should be covered there.