### PR TITLE
ARTEMIS-3845 Update hawtio

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
       <commons.codec.version>1.15</commons.codec.version>
       <fuse.mqtt.client.version>1.16</fuse.mqtt.client.version>
       <guava.version>30.1-jre</guava.version>
-      <hawtio.version>2.14.2</hawtio.version>
+      <hawtio.version>2.15.0</hawtio.version>
       <jsr305.version>3.0.2</jsr305.version>
       <jboss.logging.version>3.5.0.Final</jboss.logging.version>
       <jetty.version>9.4.45.v20220203</jetty.version>


### PR DESCRIPTION
Update hawtio to 2.15.0 - drops support for Java8 and updates dependencies