### PR TITLE
ARTEMIS-3692 support temporary queue namespace w/security-settings

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/logs/AuditLogger.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/logs/AuditLogger.java
@@ -2933,4 +2933,12 @@ public interface AuditLogger extends BasicLogger {
    @LogMessage(level = Logger.Level.INFO)
    @Message(id = 601758, value = "User {0} is calling schedulePageCleanup on address: {1}", format = Message.Format.MESSAGE_FORMAT)
    void schedulePageCleanup(String user, Object address);
+
+   static void destroyAddress(Object source, Subject user, String remoteAddress, Object... args) {
+      BASE_LOGGER.destroyAddress(getCaller(user, remoteAddress), source, arrayToString(args));
+   }
+
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 601759, value = "User {0} is deleting a address on target resource: {1} {2}", format = Message.Format.MESSAGE_FORMAT)
+   void destroyAddress(String user, Object source, Object... args);
 }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/logger/ActiveMQAMQPProtocolMessageBundle.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/logger/ActiveMQAMQPProtocolMessageBundle.java
@@ -108,5 +108,7 @@ public interface ActiveMQAMQPProtocolMessageBundle {
    @Message(id = 119024, value = "link is missing a desired capability declaration {0}", format = Message.Format.MESSAGE_FORMAT)
    ActiveMQAMQPIllegalStateException missingDesiredCapability(String capability);
 
+   @Message(id = 119025, value = "not authorized to delete temporary destination, {0}", format = Message.Format.MESSAGE_FORMAT)
+   ActiveMQAMQPSecurityException securityErrorDeletingTempDestination(String message);
 
 }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPConnectionContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPConnectionContext.java
@@ -44,6 +44,7 @@ import org.apache.activemq.artemis.protocol.amqp.broker.AMQPSessionCallback;
 import org.apache.activemq.artemis.protocol.amqp.broker.ProtonProtocolManager;
 import org.apache.activemq.artemis.protocol.amqp.connect.mirror.AMQPMirrorControllerSource;
 import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPException;
+import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPSecurityException;
 import org.apache.activemq.artemis.protocol.amqp.logger.ActiveMQAMQPProtocolLogger;
 import org.apache.activemq.artemis.protocol.amqp.logger.ActiveMQAMQPProtocolMessageBundle;
 import org.apache.activemq.artemis.protocol.amqp.proton.handler.EventHandler;
@@ -729,6 +730,8 @@ public class AMQPConnectionContext extends ProtonInitializable implements EventH
       if (linkContext != null) {
          try {
             linkContext.close(true);
+         } catch (ActiveMQAMQPSecurityException e) {
+            throw e;
          } catch (Exception e) {
             log.error(e.getMessage(), e);
          }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/handler/ProtonHandler.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/handler/ProtonHandler.java
@@ -31,6 +31,7 @@ import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.EventLoop;
 import org.apache.activemq.artemis.api.core.ActiveMQSecurityException;
 import org.apache.activemq.artemis.logs.AuditLogger;
+import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPSecurityException;
 import org.apache.activemq.artemis.protocol.amqp.proton.AMQPConnectionContext;
 import org.apache.activemq.artemis.protocol.amqp.proton.ProtonInitializable;
 import org.apache.activemq.artemis.protocol.amqp.sasl.ClientSASL;
@@ -562,7 +563,7 @@ public class ProtonHandler extends ProtonInitializable implements SaslListener {
                }
                try {
                   Events.dispatch(ev, h);
-               } catch (ActiveMQSecurityException e) {
+               } catch (ActiveMQAMQPSecurityException | ActiveMQSecurityException e) {
                   log.warn(e.getMessage(), e);
                   ErrorCondition error = new ErrorCondition();
                   error.setCondition(AmqpError.UNAUTHORIZED_ACCESS);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/security/SecurityStore.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/security/SecurityStore.java
@@ -30,6 +30,8 @@ public interface SecurityStore {
 
    void check(SimpleString address, SimpleString queue, CheckType checkType, SecurityAuth session) throws Exception;
 
+   void check(SimpleString address, SimpleString queue, CheckType checkType, SecurityAuth session, boolean temp) throws Exception;
+
    boolean isSecurityEnabled();
 
    void setSecurityEnabled(boolean securityEnabled);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1949,8 +1949,8 @@ public interface ActiveMQServerLogger extends BasicLogger {
    void errorDeletingLargeMessageFile(@Cause Throwable e);
 
    @LogMessage(level = Logger.Level.ERROR)
-   @Message(id = 224048, value = "Failed to remove temporary queue {0}", format = Message.Format.MESSAGE_FORMAT)
-   void errorRemovingTempQueue(@Cause Exception e, SimpleString bindingName);
+   @Message(id = 224048, value = "Failed to remove temporary resource {0}", format = Message.Format.MESSAGE_FORMAT)
+   void errorRemovingTempResource(@Cause Exception e, SimpleString bindingName);
 
    @LogMessage(level = Logger.Level.ERROR)
    @Message(id = 224049, value = "Cannot find consumer with id {0}", format = Message.Format.MESSAGE_FORMAT)

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ServerSession.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ServerSession.java
@@ -305,6 +305,8 @@ public interface ServerSession extends SecurityAuth {
 
    void deleteQueue(SimpleString name) throws Exception;
 
+   void deleteAddress(SimpleString name) throws Exception;
+
    ServerConsumer createConsumer(long consumerID,
                                  SimpleString queueName,
                                  SimpleString filterString,

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/TempResourceObserver.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/TempResourceObserver.java
@@ -18,7 +18,7 @@ package org.apache.activemq.artemis.core.server;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
 
-public interface TempQueueObserver {
+public interface TempResourceObserver {
 
    void tempQueueDeleted(SimpleString bindingName);
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -2400,7 +2400,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
 
          if (session != null) {
             // make sure the user has privileges to delete this queue
-            securityStore.check(address, queueName, queue.isDurable() ? CheckType.DELETE_DURABLE_QUEUE : CheckType.DELETE_NON_DURABLE_QUEUE, session);
+            securityStore.check(address, queueName, queue.isDurable() ? CheckType.DELETE_DURABLE_QUEUE : CheckType.DELETE_NON_DURABLE_QUEUE, session, queue.isTemporary());
          }
 
          // This check is only valid if checkConsumerCount == true
@@ -3135,7 +3135,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
          ActiveMQServerLogger.LOGGER.clusterSecurityRisk();
       }
 
-      securityStore = new SecurityStoreImpl(securityRepository, securityManager, configuration.getSecurityInvalidationInterval(), configuration.isSecurityEnabled(), configuration.getClusterUser(), configuration.getClusterPassword(), managementService, configuration.getAuthenticationCacheSize(), configuration.getAuthorizationCacheSize());
+      securityStore = new SecurityStoreImpl(securityRepository, securityManager, configuration.getSecurityInvalidationInterval(), configuration.isSecurityEnabled(), configuration.getClusterUser(), configuration.getClusterPassword(), managementService, configuration.getAuthenticationCacheSize(), configuration.getAuthorizationCacheSize(), configuration.getTemporaryQueueNamespace() + configuration.getWildcardConfiguration().getDelimiterString());
 
       queueFactory = new QueueFactoryImpl(executorFactory, scheduledPool, addressSettingsRepository, storageManager, this);
 
@@ -3706,12 +3706,12 @@ public class ActiveMQServerImpl implements ActiveMQServer {
 
    @Override
    public void removeAddressInfo(final SimpleString address, final SecurityAuth auth, boolean force) throws Exception {
+      AddressInfo addressInfo = getAddressInfo(address);
       if (auth != null) {
-         securityStore.check(address, CheckType.DELETE_ADDRESS, auth);
+         securityStore.check(address, null, CheckType.DELETE_ADDRESS, auth, addressInfo.isTemporary());
       }
 
       try {
-         AddressInfo addressInfo = getAddressInfo(address);
          if (postOffice.removeAddressInfo(address, force) == null) {
             throw ActiveMQMessageBundle.BUNDLE.addressDoesNotExist(address);
          }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/TransientQueueManagerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/TransientQueueManagerImpl.java
@@ -47,7 +47,7 @@ public class TransientQueueManagerImpl extends ReferenceCounterUtil implements T
             ActiveMQServerLogger.LOGGER.errorOnDeletingQueue(queueName.toString(), e);
          }
       } catch (Exception e) {
-         ActiveMQServerLogger.LOGGER.errorRemovingTempQueue(e, queueName);
+         ActiveMQServerLogger.LOGGER.errorRemovingTempResource(e, queueName);
       }
    }
 

--- a/docs/user-manual/en/security.md
+++ b/docs/user-manual/en/security.md
@@ -179,6 +179,29 @@ FQQN) in the `match` of the `security-setting`, e.g.:
 **Note:** Wildcard matching doesn't work in conjuction with FQQN. The explicit
 goal of using FQQN here is to be *exact*.
 
+### Temporary Queues
+
+The `temporary-queue-namespace` value can be used with a `security-setting`
+match just as it can with an [`address-setting`](address-model.md#temporary-queues).
+For example:
+
+```xml
+<temporary-queue-namespace>temp</temporary-queue-namespace>
+
+<security-settings>
+   <security-setting match="temp.#">
+      <permission type="createAddress" roles="myRole"/>
+      <permission type="createNonDurableQueue" roles="myRole"/>
+      <permission type="deleteAddress" roles="myRole"/>
+      <permission type="deleteNonDurableQueue" roles="myRole"/>
+   </security-setting>
+</security-settings>
+```
+
+Using this configuration any user in `myRole` can create and delete all the
+resources necessary to deal with temporary JMS queues or topics, but users
+without that role will not be able to create or delete those resources.
+
 ## Security Setting Plugin
 
 Aside from configuring sets of permissions via XML these permissions can

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSClientTestSupport.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSClientTestSupport.java
@@ -209,6 +209,10 @@ public abstract class JMSClientTestSupport extends AmqpClientTestSupport {
       return createCoreConnection(getBrokerCoreJMSConnectionString(), null, null, null, start);
    }
 
+   protected Connection createCoreConnection(String username, String password) throws JMSException {
+      return createCoreConnection(getBrokerCoreJMSConnectionString(), username, password, null, true);
+   }
+
    private Connection createCoreConnection(String connectionString, String username, String password, String clientId, boolean start) throws JMSException {
       ActiveMQJMSConnectionFactory factory = new ActiveMQJMSConnectionFactory(connectionString);
 
@@ -262,7 +266,11 @@ public abstract class JMSClientTestSupport extends AmqpClientTestSupport {
    }
 
    protected Connection createOpenWireConnection(boolean start) throws JMSException {
-      return createOpenWireConnection(getBrokerOpenWireJMSConnectionString(), null, null, null, false);
+      return createOpenWireConnection(getBrokerOpenWireJMSConnectionString(), null, null, null, start);
+   }
+
+   protected Connection createOpenWireConnection(String username, String password) throws JMSException {
+      return createOpenWireConnection(getBrokerOpenWireJMSConnectionString(), username, password, null, true);
    }
 
    private Connection createOpenWireConnection(String connectionString, String username, String password, String clientId, boolean start) throws JMSException {
@@ -290,5 +298,9 @@ public abstract class JMSClientTestSupport extends AmqpClientTestSupport {
 
    interface ConnectionSupplier {
       Connection createConnection() throws JMSException;
+   }
+
+   interface SecureConnectionSupplier {
+      Connection createConnection(String username, String Password) throws JMSException;
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/multiprotocol/TemporaryDestinationWithSecurityTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/multiprotocol/TemporaryDestinationWithSecurityTest.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.jms.multiprotocol;
+
+import javax.jms.Connection;
+import javax.jms.JMSSecurityException;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.TemporaryQueue;
+import javax.jms.TemporaryTopic;
+import javax.jms.TextMessage;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.activemq.artemis.core.security.Role;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.Queue;
+import org.apache.activemq.artemis.core.settings.HierarchicalRepository;
+import org.apache.activemq.artemis.spi.core.security.ActiveMQJAASSecurityManager;
+import org.apache.activemq.artemis.tests.util.RandomUtil;
+import org.apache.activemq.artemis.tests.util.Wait;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(value = Parameterized.class)
+public class TemporaryDestinationWithSecurityTest extends MultiProtocolJMSClientTestSupport {
+
+   private SecureConnectionSupplier connectionSupplier;
+   private final String TEMP_QUEUE_NAMESPACE = RandomUtil.randomString();
+   private String createOnlyUser = "createonly";
+   private String createOnlyPass = "createonly";
+
+   @Parameterized.Parameters(name = "connectionSupplier={0}")
+   public static Collection getParameters() {
+      return Arrays.asList(new Object[][]{
+         {"AMQP"},
+         {"CORE"},
+         {"OPENWIRE"}
+      });
+   }
+
+   public TemporaryDestinationWithSecurityTest(String connectionSupplier) {
+      switch (connectionSupplier) {
+         case "AMQP":
+            this.connectionSupplier = (username, password) -> createConnection(username, password);
+            break;
+         case "CORE":
+            this.connectionSupplier = (username, password) -> createCoreConnection(username, password);
+            break;
+         case "OPENWIRE":
+            this.connectionSupplier = (username, password) -> createOpenWireConnection(username, password);
+            break;
+      }
+   }
+
+   @Override
+   protected boolean isSecurityEnabled() {
+      return true;
+   }
+
+   @Override
+   protected void enableSecurity(ActiveMQServer server, String... securityMatches) {
+      super.enableSecurity(server, TEMP_QUEUE_NAMESPACE + ".#");
+
+      // add a new user/role who can create but not delete
+      ActiveMQJAASSecurityManager securityManager = (ActiveMQJAASSecurityManager) server.getSecurityManager();
+      securityManager.getConfiguration().addUser(createOnlyUser, createOnlyPass);
+      securityManager.getConfiguration().addRole(createOnlyUser, "createonly");
+      HierarchicalRepository<Set<Role>> securityRepository = server.getSecurityRepository();
+      Set<Role> value = securityRepository.getMatch(TEMP_QUEUE_NAMESPACE + ".#");
+      value.add(new Role("createonly", false, false, true, false, true, false, false, false, true, false));
+   }
+   @Override
+   protected void configureAMQPAcceptorParameters(Map<String, Object> params) {
+      params.put("supportAdvisory", "false");
+   }
+
+   @Override
+   protected void addConfiguration(ActiveMQServer server) {
+      super.addConfiguration(server);
+      server.getConfiguration().setTemporaryQueueNamespace(TEMP_QUEUE_NAMESPACE);
+   }
+
+   @Test(timeout = 60000)
+   public void testCreateTemporaryQueue() throws Throwable {
+      Connection connection = connectionSupplier.createConnection(fullUser, fullPass);
+
+      Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+      TemporaryQueue queue = session.createTemporaryQueue();
+      MessageProducer producer = session.createProducer(queue);
+
+      TextMessage message = session.createTextMessage();
+      message.setText("Message temporary");
+      producer.send(message);
+
+      MessageConsumer consumer = session.createConsumer(queue);
+      connection.start();
+
+      message = (TextMessage) consumer.receive(5000);
+
+      assertNotNull(message);
+   }
+
+   @Test(timeout = 60000)
+   public void testCreateTemporaryQueueNegative() throws Throwable {
+      Connection connection = connectionSupplier.createConnection(noprivUser, noprivPass);
+
+      Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+      try {
+         session.createTemporaryQueue();
+         fail();
+      } catch (JMSSecurityException e) {
+         // expected
+      }
+   }
+
+   @Test(timeout = 30000)
+   public void testDeleteTemporaryQueue() throws Exception {
+      Connection connection = connectionSupplier.createConnection(fullUser, fullPass);
+
+      Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+      final javax.jms.TemporaryQueue queue = session.createTemporaryQueue();
+      assertNotNull(queue);
+
+      Queue queueView = getProxyToQueue(queue.getQueueName());
+      assertNotNull(queueView);
+
+      queue.delete();
+
+      Wait.assertTrue("Temp Queue should be deleted.", () -> getProxyToQueue(queue.getQueueName()) == null, 3000, 10);
+   }
+
+   @Test(timeout = 30000)
+   public void testDeleteTemporaryQueueNegative() throws Exception {
+      Connection connection = connectionSupplier.createConnection(createOnlyUser, createOnlyPass);
+
+      Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+      final javax.jms.TemporaryQueue queue = session.createTemporaryQueue();
+      assertNotNull(queue);
+
+      Queue queueView = getProxyToQueue(queue.getQueueName());
+      assertNotNull(queueView);
+
+      try {
+         queue.delete();
+         fail();
+      } catch (JMSSecurityException e) {
+         // expected
+      }
+
+      connection.close();
+
+      Wait.assertTrue(() -> getProxyToAddress(queue.getQueueName()) == null, 3000, 10);
+   }
+
+   @Test(timeout = 60000)
+   public void testCreateTemporaryTopic() throws Throwable {
+      Connection connection = connectionSupplier.createConnection(fullUser, fullPass);
+
+      Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+      TemporaryTopic topic = session.createTemporaryTopic();
+
+      MessageConsumer consumer = session.createConsumer(topic);
+      MessageProducer producer = session.createProducer(topic);
+
+      TextMessage message = session.createTextMessage();
+      message.setText("Message temporary");
+      producer.send(message);
+
+      connection.start();
+      message = (TextMessage) consumer.receive(5000);
+      assertNotNull(message);
+   }
+
+   @Test(timeout = 60000)
+   public void testCreateTemporaryTopicNegative() throws Throwable {
+      Connection connection = connectionSupplier.createConnection(noprivUser, noprivPass);
+
+      Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+      try {
+         session.createTemporaryTopic();
+         fail();
+      } catch (JMSSecurityException e) {
+         // expected
+      }
+   }
+
+   @Test(timeout = 30000)
+   public void testDeleteTemporaryTopic() throws Exception {
+      Connection connection = connectionSupplier.createConnection(fullUser, fullPass);
+
+      Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+      final javax.jms.TemporaryTopic topic = session.createTemporaryTopic();
+      assertNotNull(topic);
+
+      Wait.assertTrue(() -> getProxyToAddress(topic.getTopicName()) != null, 3000, 10);
+
+      topic.delete();
+
+      Wait.assertTrue("Temp Queue should be deleted.", () -> getProxyToQueue(topic.getTopicName()) == null, 3000, 10);
+   }
+
+   @Test(timeout = 30000)
+   public void testDeleteTemporaryTopicNegative() throws Exception {
+      Connection connection = connectionSupplier.createConnection(createOnlyUser, createOnlyPass);
+
+      Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+      final javax.jms.TemporaryTopic topic = session.createTemporaryTopic();
+      assertNotNull(topic);
+
+      Wait.assertTrue(() -> getProxyToAddress(topic.getTopicName()) != null, 3000, 10);
+
+      try {
+         topic.delete();
+         fail();
+      } catch (JMSSecurityException e) {
+         // expected
+      }
+
+      connection.close();
+
+      Wait.assertTrue(() -> getProxyToAddress(topic.getTopicName()) == null, 3000, 10);
+   }
+}


### PR DESCRIPTION
This commit includes a handful of changes in order to support using the
temporary-queue-namespace with security-settings:

 - Passing a new temp flag to the SecurityStore implementation.
 - Add plumbing for address-specific operations (e.g. for JMS temporary
topic use-cases).