### PR TITLE
ARTEMIS-3842 removed reference to JDK8 by retiring a whole mvn profile

### DIFF
--- a/artemis-selector/pom.xml
+++ b/artemis-selector/pom.xml
@@ -49,35 +49,6 @@
       </dependency>
    </dependencies>
 
-   <profiles>
-      <profile>
-         <id>ibm-jdk8</id>
-         <activation>
-            <jdk>1.8</jdk>
-            <property>
-               <name>java.vendor</name>
-               <value>IBM Corporation</value>
-            </property>
-         </activation>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-javadoc-plugin</artifactId>
-                  <configuration>
-                     <additionalparam>-Xdoclint:none</additionalparam>
-                  </configuration>
-               </plugin>
-               <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-compiler-plugin</artifactId>
-                  <configuration combine.self="override" />
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
-
    <build>
       <resources>
          <resource>


### PR DESCRIPTION
see https://issues.apache.org/jira/browse/ARTEMIS-3842