### PR TITLE
ARTEMIS-3870: mark -all client deps optional in distribution pom

### DIFF
--- a/artemis-distribution/pom.xml
+++ b/artemis-distribution/pom.xml
@@ -39,16 +39,6 @@
      <!-- ActiveMQ Artemis artifacts -->
       <dependency>
          <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-jms-client-all</artifactId>
-         <version>${project.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-jakarta-client-all</artifactId>
-         <version>${project.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-boot</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -127,6 +117,23 @@
          <artifactId>artemis-website</artifactId>
          <version>${project.version}</version>
       </dependency>
+
+      <!-- Must be optional to avoid passing on, as they clash
+           with each other, and contain duplicates of their deps
+           with those from the original jms client dep  -->
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-jms-client-all</artifactId>
+         <version>${project.version}</version>
+         <optional>true</optional>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-jakarta-client-all</artifactId>
+         <version>${project.version}</version>
+         <optional>true</optional>
+      </dependency>
+
       <!-- dependencies -->
        <dependency>
            <groupId>org.apache.activemq</groupId>

--- a/tests/e2e-tests/pom.xml
+++ b/tests/e2e-tests/pom.xml
@@ -48,16 +48,6 @@
          <version>${project.version}</version>
          <scope>compile</scope>
          <type>pom</type>
-         <exclusions>
-            <exclusion>
-               <groupId>org.apache.activemq</groupId>
-               <artifactId>artemis-jms-client-all</artifactId>
-            </exclusion>
-            <exclusion>
-               <groupId>org.apache.activemq</groupId>
-               <artifactId>artemis-jakarta-client-all</artifactId>
-            </exclusion>
-         </exclusions>
       </dependency>
       <dependency>
          <groupId>org.testcontainers</groupId>

--- a/tests/smoke-tests/pom.xml
+++ b/tests/smoke-tests/pom.xml
@@ -50,16 +50,6 @@
          <version>${project.version}</version>
          <scope>compile</scope>
          <type>pom</type>
-         <exclusions>
-            <exclusion>
-               <groupId>org.apache.activemq</groupId>
-               <artifactId>artemis-jms-client-all</artifactId>
-            </exclusion>
-            <exclusion>
-               <groupId>org.apache.activemq</groupId>
-               <artifactId>artemis-jakarta-client-all</artifactId>
-            </exclusion>
-         </exclusions>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>


### PR DESCRIPTION
Mark the -all client deps optional in distribution pom to avoid passing on their clashing/duplicate deps to users of it. Clean up some existing uses in the build itself hitting the issue.