### PR TITLE
ARTEMIS-3873 AMQP Broker Conn Encrypted Attrs

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -2070,7 +2070,13 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       int retryInterval = getAttributeInteger(e, "retry-interval", 5000, Validators.GT_ZERO);
       int reconnectAttempts = getAttributeInteger(e, "reconnect-attempts", -1, Validators.MINUS_ONE_OR_GT_ZERO);
       String user = getAttributeValue(e, "user");
+      if (user != null && PasswordMaskingUtil.isEncMasked(user)) {
+         user = PasswordMaskingUtil.resolveMask(mainConfig.isMaskPassword(), user, mainConfig.getPasswordCodec());
+      }
       String password = getAttributeValue(e, "password");
+      if (password != null && PasswordMaskingUtil.isEncMasked(password)) {
+         password = PasswordMaskingUtil.resolveMask(mainConfig.isMaskPassword(), password, mainConfig.getPasswordCodec());
+      }
       boolean autoStart = getBooleanAttribute(e, "auto-start", true);
 
       getInteger(e, "local-bind-port", -1, Validators.MINUS_ONE_OR_GT_ZERO);

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -2117,6 +2117,7 @@
       <xsd:sequence maxOccurs="unbounded">
         <xsd:element name="amqp-connection" type="amqp-connectionUriType"/>
       </xsd:sequence>
+      <xsd:attributeGroup ref="xml:specialAttrs"/>
    </xsd:complexType>
 
    <xsd:complexType name="connectionRouterType">

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationBrokerConnectionEncryptedTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationBrokerConnectionEncryptedTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.config.impl;
+
+import java.util.List;
+
+import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.config.FileDeploymentManager;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBrokerConnectConfiguration;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FileConfigurationBrokerConnectionEncryptedTest extends ConfigurationImplTest {
+
+   protected String getConfigurationName() {
+      return "ConfigurationTest-broker-connection-encrypted-config.xml";
+   }
+
+   @Override
+   @Test
+   public void testDefaults() {
+      // empty
+   }
+
+   @Test
+   public void testAMQPBrokerConfigEncryptedUserAndPassword() {
+
+      List<AMQPBrokerConnectConfiguration> brokerConnections = conf.getAMQPConnection();
+      Assert.assertNotNull("brokerConnections is null", brokerConnections);
+      Assert.assertFalse("brokerConnections is empty", brokerConnections.isEmpty());
+
+      boolean encTest = false;
+      boolean plainTest = false;
+      boolean emptyTest = false;
+
+      for (AMQPBrokerConnectConfiguration brokerConnection : brokerConnections) {
+         // Check each expected configuration is present
+         encTest = encTest || "enc-test".equals(brokerConnection.getName());
+         plainTest = plainTest || "plain-test".equals(brokerConnection.getName());
+         emptyTest = emptyTest || "empty-test".equals(brokerConnection.getName());
+
+         if ("empty-test".equals(brokerConnection.getName())) {
+
+            // Empty configuration should have null user and password
+            Assert.assertNull(brokerConnection.getUser());
+            Assert.assertNull(brokerConnection.getPassword());
+
+         } else {
+
+            // Both the encrypted and plain user and password use the same expected value
+            Assert.assertEquals("testuser", brokerConnection.getUser());
+            Assert.assertEquals("testpassword", brokerConnection.getPassword());
+
+         }
+      }
+
+      Assert.assertTrue("enc-test configuration is not present", encTest);
+      Assert.assertTrue("plain-test configuration is not present", plainTest);
+      Assert.assertTrue("empty-test configuration is not present", emptyTest);
+
+   }
+
+   @Override
+   protected Configuration createConfiguration() throws Exception {
+      FileConfiguration fc = new FileConfiguration();
+      FileDeploymentManager deploymentManager = new FileDeploymentManager(getConfigurationName());
+      deploymentManager.addDeployable(fc);
+      deploymentManager.readConfiguration();
+      return fc;
+   }
+
+}

--- a/artemis-server/src/test/resources/ConfigurationTest-broker-connection-encrypted-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-broker-connection-encrypted-config.xml
@@ -1,0 +1,37 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<configuration xmlns="urn:activemq" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:activemq ../../../../activemq-server/src/main/resources/schema/artemis-server.xsd">
+   <core xmlns="urn:activemq:core">
+
+      <broker-connections>
+         <!-- user="testuser" password="testpassword" -->
+         <amqp-connection uri="tcp://test1:111" name="enc-test" user="ENC(-5da23e449f1b4b24dd05b6572705eea3)" password="ENC(-4c07e66dc377c18d95220e791dd51e82)">
+            <mirror />
+         </amqp-connection>
+
+         <!-- user="testuser" password="testpassword" -->
+         <amqp-connection uri="tcp://test2:111" name="plain-test" user="testuser" password="testpassword">
+            <mirror />
+         </amqp-connection>
+
+         <amqp-connection uri="tcp://test2:111" name="empty-test">
+            <mirror />
+         </amqp-connection>
+      </broker-connections>
+
+   </core>
+</configuration>


### PR DESCRIPTION
Adds support for ENC(...) attribute values for user and password on
amqp-connection.