### PR TITLE
ARTEMIS-3877: move site javadoc generation into release profile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,9 +90,14 @@ jobs:
       - name: Javadoc Check (JDK11 / -Prelease)
         if: matrix.java == '11'
         run: |
-          mvn -s .github/maven-settings.xml javadoc:javadoc -Prelease
+          mvn -s .github/maven-settings.xml javadoc:javadoc -Prelease -DskipWebsiteDocGeneration=true -DskipWebsiteJavadocGeneration=true
 
       - name: Javadoc Check (JDK >11)
         if: matrix.java != '11'
         run: |
           mvn -s .github/maven-settings.xml javadoc:javadoc
+
+      - name: Website Content Check (JDK11 only / -Prelease)
+        if: matrix.java == '11'
+        run: |
+          mvn -s .github/maven-settings.xml clean install -DskipTests -Prelease -am -pl "artemis-website"

--- a/artemis-website/pom.xml
+++ b/artemis-website/pom.xml
@@ -25,59 +25,7 @@
 
    <artifactId>artemis-website</artifactId>
    <packaging>jar</packaging>
-   <name>ActiveMQ Artemis Web</name>
-
-   <dependencies>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-core-client</artifactId>
-         <version>${project.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-jms-client</artifactId>
-         <version>${project.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-server</artifactId>
-         <version>${project.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-jms-server</artifactId>
-         <version>${project.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-journal</artifactId>
-         <version>${project.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-selector</artifactId>
-         <version>${project.version}</version>
-      </dependency>
-
-      <!-- stuff needed to resolve various classes during javadoc processing -->
-      <dependency>
-         <groupId>org.jboss.logging</groupId>
-         <artifactId>jboss-logging-processor</artifactId>
-         <scope>provided</scope>
-         <optional>true</optional>
-      </dependency>
-      <dependency>
-         <groupId>xalan</groupId>
-         <artifactId>xalan</artifactId>
-         <optional>true</optional>
-         <scope>provided</scope>
-      </dependency>
-      <dependency>
-         <groupId>com.google.code.findbugs</groupId>
-         <artifactId>jsr305</artifactId>
-        <scope>provided</scope>
-      </dependency>
-   </dependencies>
+   <name>ActiveMQ Artemis Website</name>
 
    <properties>
       <activemq.basedir>${project.basedir}/..</activemq.basedir>
@@ -88,58 +36,142 @@
       <webapp-outdir-hacking-guide>${basedir}/target/classes/hacking-guide</webapp-outdir-hacking-guide>
       <webapp-outdir-migration-guide>${basedir}/target/classes/migration-guide</webapp-outdir-migration-guide>
 
+      <placeholderJavadocDir>${basedir}/src/placeholder/javadoc</placeholderJavadocDir>
+      <skipPlaceholderJavadocGeneration>false</skipPlaceholderJavadocGeneration>
+
       <frontend-maven-plugin-version>1.12.1</frontend-maven-plugin-version>
       <nodeVersion>v16.14.0</nodeVersion>
       <npmVersion>8.3.1</npmVersion>
       <skipWebsiteDocGeneration>false</skipWebsiteDocGeneration>
+      <skipWebsiteJavadocGeneration>false</skipWebsiteJavadocGeneration>
    </properties>
 
    <build>
       <plugins>
-
+         <!-- A placeholder content for the assembly. This is disabled when using the
+              release profile and thus activating the real (/slow) javadoc generation -->
          <plugin>
             <artifactId>maven-javadoc-plugin</artifactId>
             <executions>
                <execution>
-                  <id>javadoc-jar</id>
+                  <id>fallback-javadoc-jar</id>
                   <phase>package</phase>
                   <goals>
                      <goal>jar</goal>
                   </goals>
                   <configuration>
-                     <source>8</source>
-                     <useStandardDocletOptions>true</useStandardDocletOptions>
+                     <doctitle>ActiveMQ Artemis ${project.version} API Placeholder</doctitle>
                      <minmemory>128m</minmemory>
                      <maxmemory>512m</maxmemory>
-                     <quiet>false</quiet>
-                     <!-- switch on dependency-driven aggregation -->
-                     <includeDependencySources>true</includeDependencySources>
-
-                     <dependencySourceIncludes>
-                        <!-- include ONLY dependencies I control -->
-                        <dependencySourceInclude>org.apache.activemq:artemis-core-client</dependencySourceInclude>
-                        <dependencySourceInclude>org.apache.activemq:artemis-jms-client</dependencySourceInclude>
-                        <dependencySourceInclude>org.apache.activemq:artemis-server</dependencySourceInclude>
-                        <dependencySourceInclude>org.apache.activemq:artemis-jms-server</dependencySourceInclude>
-                        <dependencySourceInclude>org.apache.activemq:artemis-journal</dependencySourceInclude>
-                        <dependencySourceInclude>org.apache.activemq:artemis-selector</dependencySourceInclude>
-                     </dependencySourceIncludes>
-                     <quiet>false</quiet>
-                     <aggregate>true</aggregate>
-                     <excludePackageNames>org.apache.activemq.artemis.core:org.apache.activemq.artemis.utils
-                     </excludePackageNames>
+                     <skip>${skipPlaceholderJavadocGeneration}</skip>
+                     <javadocDirectory>${placeholderJavadocDir}</javadocDirectory>
+                     <noindex>true</noindex>
+                     <nohelp>true</nohelp>
+                     <notimestamp>true</notimestamp>
+                     <notree>true</notree>
+                     <use>false</use>
+                     <overview>${placeholderJavadocDir}/overview.html</overview>
                   </configuration>
                </execution>
             </executions>
          </plugin>
       </plugins>
    </build>
-
    <profiles>
       <profile>
          <id>release</id>
+         <properties>
+            <skipPlaceholderJavadocGeneration>true</skipPlaceholderJavadocGeneration>
+         </properties>
+
+         <dependencies>
+            <dependency>
+               <groupId>org.apache.activemq</groupId>
+               <artifactId>artemis-core-client</artifactId>
+               <version>${project.version}</version>
+            </dependency>
+            <dependency>
+               <groupId>org.apache.activemq</groupId>
+               <artifactId>artemis-jms-client</artifactId>
+               <version>${project.version}</version>
+            </dependency>
+            <dependency>
+               <groupId>org.apache.activemq</groupId>
+               <artifactId>artemis-server</artifactId>
+               <version>${project.version}</version>
+            </dependency>
+            <dependency>
+               <groupId>org.apache.activemq</groupId>
+               <artifactId>artemis-jms-server</artifactId>
+               <version>${project.version}</version>
+            </dependency>
+            <dependency>
+               <groupId>org.apache.activemq</groupId>
+               <artifactId>artemis-journal</artifactId>
+               <version>${project.version}</version>
+            </dependency>
+            <dependency>
+               <groupId>org.apache.activemq</groupId>
+               <artifactId>artemis-selector</artifactId>
+               <version>${project.version}</version>
+            </dependency>
+
+            <!-- stuff needed to resolve various classes during javadoc processing -->
+            <dependency>
+               <groupId>org.jboss.logging</groupId>
+               <artifactId>jboss-logging-processor</artifactId>
+               <scope>provided</scope>
+               <optional>true</optional>
+            </dependency>
+            <dependency>
+               <groupId>xalan</groupId>
+               <artifactId>xalan</artifactId>
+               <optional>true</optional>
+               <scope>provided</scope>
+            </dependency>
+            <dependency>
+               <groupId>com.google.code.findbugs</groupId>
+               <artifactId>jsr305</artifactId>
+              <scope>provided</scope>
+            </dependency>
+         </dependencies>
+
          <build>
             <plugins>
+               <plugin>
+                  <artifactId>maven-javadoc-plugin</artifactId>
+                  <executions>
+                     <execution>
+                        <id>javadoc-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                           <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                           <doctitle>ActiveMQ Artemis ${project.version} API</doctitle>
+                           <source>8</source>
+                           <minmemory>128m</minmemory>
+                           <maxmemory>512m</maxmemory>
+                           <skip>${skipWebsiteJavadocGeneration}</skip>
+                           <!-- switch on dependency-driven aggregation -->
+                           <includeDependencySources>true</includeDependencySources>
+
+                           <dependencySourceIncludes>
+                              <!-- include ONLY dependencies I control -->
+                              <dependencySourceInclude>org.apache.activemq:artemis-core-client</dependencySourceInclude>
+                              <dependencySourceInclude>org.apache.activemq:artemis-jms-client</dependencySourceInclude>
+                              <dependencySourceInclude>org.apache.activemq:artemis-server</dependencySourceInclude>
+                              <dependencySourceInclude>org.apache.activemq:artemis-jms-server</dependencySourceInclude>
+                              <dependencySourceInclude>org.apache.activemq:artemis-journal</dependencySourceInclude>
+                              <dependencySourceInclude>org.apache.activemq:artemis-selector</dependencySourceInclude>
+                           </dependencySourceIncludes>
+                           <aggregate>true</aggregate>
+                           <excludePackageNames>org.apache.activemq.artemis.core:org.apache.activemq.artemis.utils
+                           </excludePackageNames>
+                        </configuration>
+                     </execution>
+                  </executions>
+               </plugin>
                <plugin>
                   <groupId>com.github.eirslett</groupId>
                   <artifactId>frontend-maven-plugin</artifactId>

--- a/artemis-website/src/main/resources/examples/index.html
+++ b/artemis-website/src/main/resources/examples/index.html
@@ -38,7 +38,7 @@
 <div id="content">
     <div class="wrapper">
         <div class="logo">
-            <img src="../images/artemis-logo.png" alt="Artemis Logo"/>
+            <img src="../images/activemq-logo.png" alt="ActiveMQ Logo"/>
         </div>
         <div class="message">
 

--- a/artemis-website/src/main/resources/hacking-guide/index.html
+++ b/artemis-website/src/main/resources/hacking-guide/index.html
@@ -19,15 +19,17 @@ under the License.
 <html>
 <head>
     <meta http-equiv="refresh"
-          content="3;url=https://activemq.apache.org/artemis/docs/latest/hacking-guide/index.html"/>
+          content="5;url=https://activemq.apache.org/components/artemis/documentation/hacking-guide"/>
 </head>
-<h1>User Manual</h1>
+<body>
+<h1>Hacking Guide</h1>
 
-<p>If you are seeing this message, it is because the Hacking Guide was not built during the Apache ActiveMQ Artemis
-    build. To
-    build Apache ActiveMQ Artemis with the Hacking Guide you must use the maven release profile:
-    <code>mvn clean install -Prelease</code>.</p>
-<p>You can view the current documentation directly on <a
-        href="https://activemq.apache.org/artemis/docs/latest/hacking-guide/index.html">https://activemq.apache.org/artemis</a>.</p>
-
+<p>If you are seeing this message, it is because the Hacking Guide was not built during the Apache ActiveMQ Artemis build.
+   To build Apache ActiveMQ Artemis with the Hacking Guide you must use the maven release profile:
+   <code>mvn clean install -Prelease</code>.
+</p>
+<p>This page will atempt to refresh to the current Hacking Guide on the <a href="https://activemq.apache.org/components/artemis/">website</a> at
+  <a href="https://activemq.apache.org/components/artemis/documentation/hacking-guide">https://activemq.apache.org/components/artemis/documentation/hacking-guide</a>.
+</p>
+</body>
 </html>

--- a/artemis-website/src/main/resources/index.html
+++ b/artemis-website/src/main/resources/index.html
@@ -57,7 +57,7 @@
             <li><a target="_blank" href="hacking-guide/index.html">Hacking Guide</a></li>
             <li><a target="_blank" href="migration-guide/index.html">Migration Guide</a></li>
             <li><a href="examples/index.html">Examples</a></li>
-            <li><a href="http://activemq.apache.org/artemis/">Apache ActiveMQ Artemis Website</a></li>
+            <li><a href="https://activemq.apache.org/components/artemis/">Apache ActiveMQ Artemis Website</a></li>
         </ul>
         <div></div>
     </div>

--- a/artemis-website/src/placeholder/javadoc/overview.html
+++ b/artemis-website/src/placeholder/javadoc/overview.html
@@ -17,19 +17,13 @@ specific language governing permissions and limitations
 under the License.
 -->
 <html>
-<head>
-    <meta http-equiv="refresh"
-          content="5;url=https://activemq.apache.org/components/artemis/documentation/latest"/>
-</head>
 <body>
-<h1>User Manual</h1>
-
-<p>If you are seeing this message, it is because the User Manual was not built during the Apache ActiveMQ Artemis build.
-   To build Apache ActiveMQ Artemis with the User Manual you must use the maven release profile:
+<p>If you are seeing this message, it is because the API docs were not built during the Apache ActiveMQ Artemis build.
+   To build Apache ActiveMQ Artemis with the API docs you must use the maven release profile:
    <code>mvn clean install -Prelease</code>.
 </p>
-<p>This page will atempt to refresh to the current release User Manual on the <a href="https://activemq.apache.org/components/artemis/">website</a> at
-   <a href="https://activemq.apache.org/components/artemis/documentation/latest">https://activemq.apache.org/components/artemis/documentation/latest</a>.
+<p>The API documentation for the latest release can be found on the <a href="https://activemq.apache.org/components/artemis/">website</a> at
+   <a href="https://activemq.apache.org/components/artemis/documentation/javadocs/javadoc-latest/">https://activemq.apache.org/components/artemis/documentation/javadocs/javadoc-latest/</a>.
 </p>
 </body>
 </html>

--- a/artemis-website/src/placeholder/javadoc/placeholder/Placeholder.java
+++ b/artemis-website/src/placeholder/javadoc/placeholder/Placeholder.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package placeholder;
+
+/**
+ * Empty class for placeholder Javadoc generation.
+ */
+public class Placeholder {
+}

--- a/artemis-website/src/placeholder/javadoc/placeholder/package-info.java
+++ b/artemis-website/src/placeholder/javadoc/placeholder/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+* Build with the release profile to generate the API docs, or see the <a href="https://activemq.apache.org/components/artemis/">website</a> for the
+* <a href="https://activemq.apache.org/components/artemis/documentation/javadocs/javadoc-latest/">latest release API docs</a>.
+*/
+package placeholder;


### PR DESCRIPTION
Move site javadoc generation into release profile, knock ~1min off a regular build, add simple placeholder (as all the other module content has) to satisfy rest of build. Fix some issues in other related placeholder content. Tweak the CI job to more obviously/specifically check the release profile build for these bits.