### PR TITLE
ARTEMIS-3881 Upgrade jetty to v10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
       <hawtio.version>2.15.0</hawtio.version>
       <jsr305.version>3.0.2</jsr305.version>
       <jboss.logging.version>3.5.0.Final</jboss.logging.version>
-      <jetty.version>9.4.45.v20220203</jetty.version>
+      <jetty.version>10.0.11</jetty.version>
       <tomcat.servlet-api.version>8.5.78</tomcat.servlet-api.version>
       <jgroups.version>5.2.0.Final</jgroups.version>
       <errorprone.version>2.10.0</errorprone.version>


### PR DESCRIPTION
Changes in jetty v10:

Minimum java requirement has been bumped to Java 11, some code refactoring and support for websocket over http/2.
https://www.eclipse.org/lists/jetty-announce/msg00149.html

 
Built and tested locally, everything seems to work.