### PR TITLE
ARTEMIS-3794 System Property Encryption Support

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnector.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnector.java
@@ -123,6 +123,7 @@ import org.apache.activemq.artemis.spi.core.remoting.ssl.SSLContextFactoryProvid
 import org.apache.activemq.artemis.utils.ConfigurationHelper;
 import org.apache.activemq.artemis.utils.FutureLatch;
 import org.apache.activemq.artemis.utils.IPV6Util;
+import org.apache.activemq.artemis.utils.PasswordMaskingUtil;
 import org.jboss.logging.Logger;
 
 import static org.apache.activemq.artemis.utils.Base64.encodeBytes;
@@ -175,7 +176,6 @@ public class NettyConnector extends AbstractConnector {
       config.put(TransportConstants.PORT_PROP_NAME, TransportConstants.DEFAULT_PORT);
       DEFAULT_CONFIG = Collections.unmodifiableMap(config);
    }
-
 
    private final boolean serverConnection;
 
@@ -320,6 +320,7 @@ public class NettyConnector extends AbstractConnector {
                          final ClientProtocolManager protocolManager) {
       this(configuration, handler, listener, closeExecutor, threadPool, scheduledThreadPool, protocolManager, false);
    }
+
    public NettyConnector(final Map<String, Object> configuration,
                          final BufferHandler handler,
                          final BaseConnectionLifeCycleListener<?> listener,
@@ -370,7 +371,7 @@ public class NettyConnector extends AbstractConnector {
          proxyVersion = SocksVersion.valueOf((byte) socksVersionNumber);
 
          proxyUsername = ConfigurationHelper.getStringProperty(TransportConstants.PROXY_USERNAME_PROP_NAME, TransportConstants.DEFAULT_PROXY_USERNAME, configuration);
-         proxyPassword = ConfigurationHelper.getStringProperty(TransportConstants.PROXY_PASSWORD_PROP_NAME, TransportConstants.DEFAULT_PROXY_PASSWORD, configuration);
+         proxyPassword = ConfigurationHelper.getPasswordProperty(TransportConstants.PROXY_PASSWORD_PROP_NAME, TransportConstants.DEFAULT_PROXY_PASSWORD, configuration, ActiveMQDefaultConfiguration.getPropMaskPassword(), ActiveMQDefaultConfiguration.getPropPasswordCodec());
 
          proxyRemoteDNS = ConfigurationHelper.getBooleanProperty(TransportConstants.PROXY_REMOTE_DNS_PROP_NAME, TransportConstants.DEFAULT_PROXY_REMOTE_DNS, configuration);
       }
@@ -583,19 +584,19 @@ public class NettyConnector extends AbstractConnector {
             realTrustStoreType = trustStoreType;
             realTrustStorePassword = trustStorePassword;
          } else {
-            realKeyStorePath = Stream.of(System.getProperty(ACTIVEMQ_KEYSTORE_PATH_PROP_NAME), System.getProperty(JAVAX_KEYSTORE_PATH_PROP_NAME), keyStorePath).map(v -> useDefaultSslContext ? keyStorePath : v).filter(Objects::nonNull).findFirst().orElse(null);
-            realKeyStorePassword = Stream.of(System.getProperty(ACTIVEMQ_KEYSTORE_PASSWORD_PROP_NAME), System.getProperty(JAVAX_KEYSTORE_PASSWORD_PROP_NAME), keyStorePassword).map(v -> useDefaultSslContext ? keyStorePassword : v).filter(Objects::nonNull).findFirst().orElse(null);
+            realKeyStorePath = processSslProperty(keyStorePath, ACTIVEMQ_KEYSTORE_PATH_PROP_NAME, JAVAX_KEYSTORE_PATH_PROP_NAME);
+            realKeyStorePassword = processSslProperty(keyStorePassword, true, ACTIVEMQ_KEYSTORE_PASSWORD_PROP_NAME, JAVAX_KEYSTORE_PASSWORD_PROP_NAME);
 
-            Pair<String, String> keyStoreCompat = SSLSupport.getValidProviderAndType(Stream.of(System.getProperty(ACTIVEMQ_KEYSTORE_PROVIDER_PROP_NAME), System.getProperty(JAVAX_KEYSTORE_PROVIDER_PROP_NAME), keyStoreProvider).map(v -> useDefaultSslContext ? keyStoreProvider : v).filter(Objects::nonNull).findFirst().orElse(null),
-                                                                                     Stream.of(System.getProperty(ACTIVEMQ_KEYSTORE_TYPE_PROP_NAME), System.getProperty(JAVAX_KEYSTORE_TYPE_PROP_NAME), keyStoreType).map(v -> useDefaultSslContext ? keyStoreType : v).filter(Objects::nonNull).findFirst().orElse(null));
+            Pair<String, String> keyStoreCompat = SSLSupport.getValidProviderAndType(processSslProperty(keyStoreProvider, ACTIVEMQ_KEYSTORE_PROVIDER_PROP_NAME, JAVAX_KEYSTORE_PROVIDER_PROP_NAME),
+                                                                                     processSslProperty(keyStoreType, ACTIVEMQ_KEYSTORE_TYPE_PROP_NAME, JAVAX_KEYSTORE_TYPE_PROP_NAME));
             realKeyStoreProvider = keyStoreCompat.getA();
             realKeyStoreType = keyStoreCompat.getB();
 
-            realTrustStorePath = Stream.of(System.getProperty(ACTIVEMQ_TRUSTSTORE_PATH_PROP_NAME), System.getProperty(JAVAX_TRUSTSTORE_PATH_PROP_NAME), trustStorePath).map(v -> useDefaultSslContext ? trustStorePath : v).filter(Objects::nonNull).findFirst().orElse(null);
-            realTrustStorePassword = Stream.of(System.getProperty(ACTIVEMQ_TRUSTSTORE_PASSWORD_PROP_NAME), System.getProperty(JAVAX_TRUSTSTORE_PASSWORD_PROP_NAME), trustStorePassword).map(v -> useDefaultSslContext ? trustStorePassword : v).filter(Objects::nonNull).findFirst().orElse(null);
+            realTrustStorePath = processSslProperty(trustStorePath, ACTIVEMQ_TRUSTSTORE_PATH_PROP_NAME, JAVAX_TRUSTSTORE_PATH_PROP_NAME);
+            realTrustStorePassword = processSslProperty(trustStorePassword, true, ACTIVEMQ_TRUSTSTORE_PASSWORD_PROP_NAME, JAVAX_TRUSTSTORE_PASSWORD_PROP_NAME);
 
-            Pair<String, String> trustStoreCompat = SSLSupport.getValidProviderAndType(Stream.of(System.getProperty(ACTIVEMQ_TRUSTSTORE_PROVIDER_PROP_NAME), System.getProperty(JAVAX_TRUSTSTORE_PROVIDER_PROP_NAME), trustStoreProvider).map(v -> useDefaultSslContext ? trustStoreProvider : v).filter(Objects::nonNull).findFirst().orElse(null),
-                                                                                       Stream.of(System.getProperty(ACTIVEMQ_TRUSTSTORE_TYPE_PROP_NAME), System.getProperty(JAVAX_TRUSTSTORE_TYPE_PROP_NAME), trustStoreType).map(v -> useDefaultSslContext ? trustStoreType : v).filter(Objects::nonNull).findFirst().orElse(null));
+            Pair<String, String> trustStoreCompat = SSLSupport.getValidProviderAndType(processSslProperty(trustStoreProvider, ACTIVEMQ_TRUSTSTORE_PROVIDER_PROP_NAME, JAVAX_TRUSTSTORE_PROVIDER_PROP_NAME),
+                                                                                       processSslProperty(trustStoreType, ACTIVEMQ_TRUSTSTORE_TYPE_PROP_NAME, JAVAX_TRUSTSTORE_TYPE_PROP_NAME));
             realTrustStoreProvider = trustStoreCompat.getA();
             realTrustStoreType = trustStoreCompat.getB();
          }
@@ -741,6 +742,36 @@ public class NettyConnector extends AbstractConnector {
          batchFlusherFuture = scheduledThreadPool.scheduleWithFixedDelay(flusher, batchDelay, batchDelay, TimeUnit.MILLISECONDS);
       }
       ActiveMQClientLogger.LOGGER.startedNettyConnector(connectorType, TransportConstants.NETTY_VERSION, host, port);
+   }
+
+   private String processSslProperty(String contextDefault, boolean passwordField, String... systemProperties) {
+      // If useDefaultSslContext == true, just return the contextDefault. If not, look through the systemProperties to find the first non-null value.
+      // Failing that, use contextDefault anyway even though useDefaultSslContext == false
+      String rawValue = (useDefaultSslContext) ? contextDefault : Stream.of(systemProperties).map(System::getProperty).filter(Objects::nonNull).findFirst().orElse(contextDefault);
+
+      if (!passwordField || rawValue == null)
+         return rawValue;
+
+      try {
+         // Use the same logic as the ConfigurationHelper#getPasswordProperty(...) method to resolve the default password mask and codec properties
+         Object useMaskObject = configuration.get(ActiveMQDefaultConfiguration.getPropMaskPassword());
+         Boolean useMask;
+         if (useMaskObject instanceof String) {
+            useMask = Boolean.parseBoolean((String)useMaskObject);
+         } else {
+            useMask = (Boolean) useMaskObject;
+         }
+
+         String classImpl = (String) configuration.get(ActiveMQDefaultConfiguration.getPropPasswordCodec());
+
+         return PasswordMaskingUtil.resolveMask(useMask, rawValue, classImpl);
+      } catch (Exception e) {
+         throw ActiveMQClientMessageBundle.BUNDLE.errordecodingPassword(e);
+      }
+   }
+
+   private String processSslProperty(String contextDefault, String... systemProperties) {
+      return processSslProperty(contextDefault, false, systemProperties);
    }
 
    private SSLEngine loadJdkSslEngine(final SSLContextConfig sslContextConfig) throws Exception {
@@ -1350,4 +1381,3 @@ public class NettyConnector extends AbstractConnector {
       }
    }
 }
-

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/netty/NettyConnectorTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/netty/NettyConnectorTest.java
@@ -38,6 +38,8 @@ import org.apache.activemq.artemis.spi.core.remoting.ClientProtocolManager;
 import org.apache.activemq.artemis.spi.core.remoting.Connection;
 import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.ActiveMQThreadFactory;
+import org.apache.activemq.artemis.utils.DefaultSensitiveStringCodec;
+import org.apache.activemq.artemis.utils.PasswordMaskingUtil;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -166,6 +168,70 @@ public class NettyConnectorTest extends ActiveMQTestBase {
       Connection c = connector.createConnection();
       assertNotNull(c);
       c.close();
+      connector.close();
+      Assert.assertFalse(connector.isStarted());
+
+   }
+
+   /**
+    * that encrypted java system properties are read
+    */
+   @Test
+   public void testEncryptedJavaSystemProperty() throws Exception {
+      BufferHandler handler = new BufferHandler() {
+         @Override
+         public void bufferReceived(final Object connectionID, final ActiveMQBuffer buffer) {
+         }
+      };
+
+      DefaultSensitiveStringCodec codec = new DefaultSensitiveStringCodec();
+
+      System.setProperty(NettyConnector.JAVAX_KEYSTORE_PATH_PROP_NAME, "client-keystore.jks");
+      System.setProperty(NettyConnector.JAVAX_KEYSTORE_PASSWORD_PROP_NAME, PasswordMaskingUtil.wrap(codec.encode("securepass")));
+      System.setProperty(NettyConnector.JAVAX_TRUSTSTORE_PATH_PROP_NAME, "server-ca-truststore.jks");
+      System.setProperty(NettyConnector.JAVAX_TRUSTSTORE_PASSWORD_PROP_NAME, PasswordMaskingUtil.wrap(codec.encode("securepass")));
+
+      Map<String, Object> params = new HashMap<>();
+      params.put(TransportConstants.SSL_ENABLED_PROP_NAME, true);
+
+      NettyConnector connector = new NettyConnector(params, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory()), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory()));
+
+      connector.start();
+      Assert.assertTrue(connector.isStarted());
+      Connection c = connector.createConnection();
+      assertNotNull(c);
+      c.close();
+      connector.close();
+      Assert.assertFalse(connector.isStarted());
+
+   }
+
+   /**
+    * that bad value encrypted java system properties are read but fail
+    */
+   @Test
+   public void testEncryptedJavaSystemPropertyFail() throws Exception {
+      BufferHandler handler = new BufferHandler() {
+         @Override
+         public void bufferReceived(final Object connectionID, final ActiveMQBuffer buffer) {
+         }
+      };
+
+      DefaultSensitiveStringCodec codec = new DefaultSensitiveStringCodec();
+
+      System.setProperty(NettyConnector.JAVAX_KEYSTORE_PATH_PROP_NAME, "client-keystore.jks");
+      System.setProperty(NettyConnector.JAVAX_KEYSTORE_PASSWORD_PROP_NAME, PasswordMaskingUtil.wrap(codec.encode("bad password")));
+      System.setProperty(NettyConnector.JAVAX_TRUSTSTORE_PATH_PROP_NAME, "server-ca-truststore.jks");
+      System.setProperty(NettyConnector.JAVAX_TRUSTSTORE_PASSWORD_PROP_NAME, PasswordMaskingUtil.wrap(codec.encode("bad password")));
+
+      Map<String, Object> params = new HashMap<>();
+      params.put(TransportConstants.SSL_ENABLED_PROP_NAME, true);
+
+      NettyConnector connector = new NettyConnector(params, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory()), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory()));
+
+      connector.start();
+      Assert.assertTrue(connector.isStarted());
+      Assert.assertNull(connector.createConnection());
       connector.close();
       Assert.assertFalse(connector.isStarted());
 
@@ -310,7 +376,7 @@ public class NettyConnectorTest extends ActiveMQTestBase {
    }
 
    @Test
-   public void tesActiveMQSystemProperties() throws Exception {
+   public void testActiveMQSystemProperties() throws Exception {
       BufferHandler handler = new BufferHandler() {
          @Override
          public void bufferReceived(final Object connectionID, final ActiveMQBuffer buffer) {
@@ -330,6 +396,59 @@ public class NettyConnectorTest extends ActiveMQTestBase {
       Assert.assertTrue(connector.isStarted());
       Connection c = connector.createConnection();
       assertNotNull(c);
+      connector.close();
+      Assert.assertFalse(connector.isStarted());
+   }
+
+   @Test
+   public void testEncryptedActiveMQSystemProperties() throws Exception {
+      BufferHandler handler = new BufferHandler() {
+         @Override
+         public void bufferReceived(final Object connectionID, final ActiveMQBuffer buffer) {
+         }
+      };
+      Map<String, Object> params = new HashMap<>();
+      params.put(TransportConstants.SSL_ENABLED_PROP_NAME, true);
+
+      NettyConnector connector = new NettyConnector(params, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory()), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory()));
+
+      DefaultSensitiveStringCodec codec = new DefaultSensitiveStringCodec();
+
+      System.setProperty(NettyConnector.ACTIVEMQ_KEYSTORE_PATH_PROP_NAME, "client-keystore.jks");
+      System.setProperty(NettyConnector.ACTIVEMQ_KEYSTORE_PASSWORD_PROP_NAME, PasswordMaskingUtil.wrap(codec.encode("securepass")));
+      System.setProperty(NettyConnector.ACTIVEMQ_TRUSTSTORE_PATH_PROP_NAME, "server-ca-truststore.jks");
+      System.setProperty(NettyConnector.ACTIVEMQ_TRUSTSTORE_PASSWORD_PROP_NAME, PasswordMaskingUtil.wrap(codec.encode("securepass")));
+
+      connector.start();
+      Assert.assertTrue(connector.isStarted());
+      Connection c = connector.createConnection();
+      assertNotNull(c);
+      connector.close();
+      Assert.assertFalse(connector.isStarted());
+   }
+
+   @Test
+   public void testEncryptedActiveMQSystemPropertiesFail() throws Exception {
+      BufferHandler handler = new BufferHandler() {
+         @Override
+         public void bufferReceived(final Object connectionID, final ActiveMQBuffer buffer) {
+         }
+      };
+      Map<String, Object> params = new HashMap<>();
+      params.put(TransportConstants.SSL_ENABLED_PROP_NAME, true);
+
+      NettyConnector connector = new NettyConnector(params, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory()), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory()));
+
+      DefaultSensitiveStringCodec codec = new DefaultSensitiveStringCodec();
+
+      System.setProperty(NettyConnector.ACTIVEMQ_KEYSTORE_PATH_PROP_NAME, "client-keystore.jks");
+      System.setProperty(NettyConnector.ACTIVEMQ_KEYSTORE_PASSWORD_PROP_NAME, PasswordMaskingUtil.wrap(codec.encode("bad password")));
+      System.setProperty(NettyConnector.ACTIVEMQ_TRUSTSTORE_PATH_PROP_NAME, "server-ca-truststore.jks");
+      System.setProperty(NettyConnector.ACTIVEMQ_TRUSTSTORE_PASSWORD_PROP_NAME, PasswordMaskingUtil.wrap(codec.encode("bad password")));
+
+      connector.start();
+      Assert.assertTrue(connector.isStarted());
+      Assert.assertNull(connector.createConnection());
       connector.close();
       Assert.assertFalse(connector.isStarted());
    }


### PR DESCRIPTION
Adds support for standard Java TLS and ActiveMQ Artemis-specific override
encrypted system property values for the key store and trust store
passwords. Includes proxyPassword encrypted value support as well.