### PR TITLE
ARTEMIS-3886 fix CLI operation retry

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/ConnectionAbstract.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/ConnectionAbstract.java
@@ -163,8 +163,7 @@ public class ConnectionAbstract extends InputAbstract {
       } catch (JMSSecurityException e) {
          // if a security exception will get the user and password through an input
          context.err.println("Connection failed::" + e.getMessage());
-         userPassword();
-         cf = new JmsConnectionFactory(user, password, brokerURL);
+         cf = new JmsConnectionFactory(inputUser(user), inputPassword(password), brokerURL);
          if (clientID != null) {
             cf.setClientID(clientID);
          }
@@ -172,9 +171,7 @@ public class ConnectionAbstract extends InputAbstract {
       } catch (JMSException e) {
          // if a connection exception will ask for the URL, user and password
          context.err.println("Connection failed::" + e.getMessage());
-         brokerURL = input("--url", "Type in the broker URL for a retry (e.g. tcp://localhost:61616)", brokerURL);
-         userPassword();
-         cf = new JmsConnectionFactory(user, password, brokerURL);
+         cf = new JmsConnectionFactory(inputUser(user), inputPassword(password), inputBrokerURL(brokerURL));
          if (clientID != null) {
             cf.setClientID(clientID);
          }
@@ -204,8 +201,7 @@ public class ConnectionAbstract extends InputAbstract {
          if (context != null) {
             context.err.println("Connection failed::" + e.getMessage());
          }
-         userPassword();
-         cf = new ActiveMQConnectionFactory(brokerURL, user, password);
+         cf = new ActiveMQConnectionFactory(brokerURL, inputUser(user), inputPassword(password));
          if (clientID != null) {
             cf.setClientID(clientID);
          }
@@ -215,9 +211,7 @@ public class ConnectionAbstract extends InputAbstract {
          if (context != null) {
             context.err.println("Connection failed::" + e.getMessage());
          }
-         brokerURL = input("--url", "Type in the broker URL for a retry (e.g. tcp://localhost:61616)", brokerURL);
-         userPassword();
-         cf = new ActiveMQConnectionFactory(brokerURL, user, password);
+         cf = new ActiveMQConnectionFactory(inputBrokerURL(brokerURL), inputUser(user), inputPassword(password));
          if (clientID != null) {
             cf.setClientID(clientID);
          }
@@ -225,13 +219,21 @@ public class ConnectionAbstract extends InputAbstract {
       }
    }
 
-   private void userPassword() {
+   private String inputBrokerURL(String defaultValue) {
+      return input("--url", "Type in the broker URL for a retry (e.g. tcp://localhost:61616)", defaultValue);
+   }
+
+   private String inputUser(String user) {
       if (user == null) {
          user = input("--user", "Type the username for a retry", null);
       }
+      return user;
+   }
+
+   private String inputPassword(String password) {
       if (password == null) {
          password = inputPassword("--password", "Type the password for a retry", null);
       }
+      return password;
    }
-
 }


### PR DESCRIPTION
Commit f8b045bd2d95ec28c70c4d64c85400b28d8baef5 broke the operation
retry as it introduced local variables named "user" and "password" which
overried the class-level variables of the same name. Therefore, when the
user re-enters the username and password on the command-line those
values won't actually be used when attempting to reconnect.