### PR TITLE
ARTEMIS-3888 make web console detection more robust

### DIFF
--- a/artemis-web/src/test/java/org/apache/activemq/cli/test/WebServerComponentTest.java
+++ b/artemis-web/src/test/java/org/apache/activemq/cli/test/WebServerComponentTest.java
@@ -59,6 +59,7 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.CharsetUtil;
+import org.apache.activemq.artemis.api.core.Pair;
 import org.apache.activemq.artemis.cli.factory.xml.XmlBrokerFactoryHandler;
 import org.apache.activemq.artemis.component.WebServerComponent;
 import org.apache.activemq.artemis.component.WebServerComponentTestAccessor;
@@ -419,7 +420,7 @@ public class WebServerComponentTest extends Assert {
       testedComponents.add(webServerComponent);
       webServerComponent.configure(webServerDTO, "./target", "./target");
       WebAppContext ctxt = WebServerComponentTestAccessor.createWebAppContext(webServerComponent, url, warName, Paths.get(".").resolve("target").toAbsolutePath(), null);
-      webServerComponent.getWebContexts().add(ctxt);
+      webServerComponent.getWebContextData().add(new Pair(ctxt, null));
 
       WebInfConfiguration cfg = new WebInfConfiguration();
       List<File> garbage = new ArrayList<>();

--- a/docs/user-manual/en/management-console.md
+++ b/docs/user-manual/en/management-console.md
@@ -85,3 +85,22 @@ To create a new queue click on the address you want to bind the queue to and cli
 Once you have created a queue you should be able to **Send** a message to it or **Browse** it or view the  **Attributes** or **Charts**. Simply click on the queue in th ejmx tree and click on the appropriate tab.
 
 You can also see a graphical view of all brokers, addresses, queues and their consumers using the **Diagram** tab. 
+
+### Status Logging
+
+When the broker starts it will detect the presence of the web console and log
+status information, e.g.:
+
+```
+INFO  [org.apache.activemq.artemis] AMQ241002: Artemis Jolokia REST API available at http://localhost:8161/console/jolokia
+INFO  [org.apache.activemq.artemis] AMQ241004: Artemis Console available at http://localhost:8161/console
+```
+
+The web console is detected by inspecting the value of the `<display-name>` tag
+in the war file's `WEB-INF/web.xml` descriptor. By default it looks for
+`hawtio`. However, if this value is changed for any reason the broker can look
+for this new value by setting the following system property
+
+```
+-Dorg.apache.activemq.artemis.webConsoleDisplayName=newValue
+```


### PR DESCRIPTION
Currently the broker detects the presence of the web console by looking
for the name of a file (i.e. console.war). This is fragile because if
the file is renamed for any reason then the broker won't print the
status of the web console when it starts.

This commit improves web console detection by inspecting the
<display-name> tag in the war file's WEB-INF/web.xml. By default it
looks for "hawtio", but this can be customized using the system property
"org.apache.activemq.artemis.webConsoleDisplayName".