### PR TITLE
ARTEMIS-3767 Fix replication incompatibility between pre 2.18.0 and SNAPSHOT (WIP)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
       <jakarta.resource-api.version.alt>2.1.0</jakarta.resource-api.version.alt>
 
       <!-- used on tests -->
-      <groovy.version>4.0.0</groovy.version>
+      <groovy.version>4.0.3</groovy.version>
       <vertx.version>3.9.4</vertx.version>
       <hadoop.minikdc.version>3.3.1</hadoop.minikdc.version>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -141,6 +141,7 @@
       <module>integration-tests</module>
       <module>karaf-client-integration-tests</module>
       <module>compatibility-tests</module>
+      <module>server-compatibility-tests</module>
       <module>soak-tests</module>
       <module>stress-tests</module>
       <module>performance-tests</module>

--- a/tests/server-compatibility-tests/pom.xml
+++ b/tests/server-compatibility-tests/pom.xml
@@ -1,0 +1,251 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.activemq.tests</groupId>
+        <artifactId>artemis-tests-pom</artifactId>
+        <version>2.24.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>server-compatibility-tests</artifactId>
+    <packaging>jar</packaging>
+    <name>ActiveMQ Artemis Server Compatibility Tests</name>
+
+    <properties>
+        <activemq.basedir>${project.basedir}/../..</activemq.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>${groovy.version}</version>
+            <type>pom</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.groovy</groupId>
+                    <artifactId>groovy-test-junit5</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-processor</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-annotations</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.marshalling</groupId>
+            <artifactId>jboss-marshalling-river</artifactId>
+            <version>2.0.9.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-server</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-commons</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-core-client</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>artemis-maven-plugin</artifactId>
+                <executions>
+                    <!-- The executions of dependency-scan will calculate dependencies for each specific version used here on this testsuite. -->
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>dependency-scan</goal>
+                        </goals>
+                        <id>2_17_0-check</id>
+                        <configuration>
+                            <optional>true</optional>
+                            <libListWithDeps>
+                                <arg>org.apache.activemq:artemis-server:2.17.0</arg>
+                                <arg>org.apache.activemq:artemis-commons:2.17.0</arg>
+                                <arg>org.apache.activemq:artemis-core-client:2.17.0</arg>
+                                <arg>org.apache.groovy:groovy-all:pom:${groovy.version}</arg>
+                            </libListWithDeps>
+                            <libList>
+                                <arg>org.apache.activemq.tests:server-compatibility-tests:${project.version}</arg>
+                            </libList>
+                            <variableName>ARTEMIS-2_17_0</variableName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>dependency-scan</goal>
+                        </goals>
+                        <id>2_18_0-check</id>
+                        <configuration>
+                            <optional>true</optional>
+                            <libListWithDeps>
+                                <arg>org.apache.activemq:artemis-server:2.18.0</arg>
+                                <arg>org.apache.activemq:artemis-commons:2.18.0</arg>
+                                <arg>org.apache.activemq:artemis-core-client:2.18.0</arg>
+                                <arg>org.apache.groovy:groovy-all:pom:${groovy.version}</arg>
+                            </libListWithDeps>
+                            <libList>
+                                <arg>org.apache.activemq.tests:server-compatibility-tests:${project.version}</arg>
+                            </libList>
+                            <variableName>ARTEMIS-2_18_0</variableName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>dependency-scan</goal>
+                        </goals>
+                        <id>SNAPSHOT-check</id>
+                        <configuration>
+                            <optional>true</optional>
+                            <libListWithDeps>
+                                <arg>org.apache.activemq:artemis-server:${project.version}</arg>
+                                <arg>org.apache.activemq:artemis-commons:${project.version}</arg>
+                                <arg>org.apache.activemq:artemis-core-client:${project.version}</arg>
+                                <arg>org.apache.groovy:groovy-all:pom:${groovy.version}</arg>
+                            </libListWithDeps>
+                            <libList>
+                                <arg>org.apache.activemq.tests:server-compatibility-tests:${project.version}</arg>
+                            </libList>
+                            <variableName>ARTEMIS-SNAPSHOT</variableName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemProperties>
+                        <property>
+                            <name>ARTEMIS-SNAPSHOT</name>
+                            <value>${ARTEMIS-SNAPSHOT}</value>
+                        </property>
+                        <property>
+                            <name>ARTEMIS-2_17_0</name> <!-- 2.17.0 -->
+                            <value>${ARTEMIS-2_17_0}</value>
+                        </property>
+                        <property>
+                            <name>ARTEMIS-2_18_0</name> <!-- 2.17.0 -->
+                            <value>${ARTEMIS-2_18_0}</value>
+                        </property>
+                        <property>
+                            <name>ARTEMIS-SNAPSHOT</name>
+                            <value>${ARTEMIS-SNAPSHOT}</value>
+                        </property>
+                    </systemProperties>
+                    <skipTests>${skipCompatibilityTests}</skipTests>
+                    <argLine>${modular.jdk.surefire.arg} -Djgroups.bind_addr=::1 ${activemq-surefire-argline}</argLine>
+                </configuration>
+            </plugin>
+            <!-- during testing and debugging, it may be useful to add all the classpath variables to your IDE settings and run compatibility tests manually.
+                 uncomment this next group so you will have a big line to add to your test setting -->
+            <!-- <plugin>
+               <artifactId>maven-antrun-plugin</artifactId>
+               <executions>
+                  <execution>
+                     <phase>compile</phase>
+                     <goals>
+                        <goal>run</goal>
+                     </goals>
+                     <configuration>
+                        <tasks>
+                           <echo>You can use this line to include into your tests runnings</echo>
+                           <echo>-DARTEMIS-200="${ARTEMIS-200}" -DARTEMIS-210="${ARTEMIS-210}" -DARTEMIS-263="${ARTEMIS-263}" -DARTEMIS-240="${ARTEMIS-240}" -DARTEMIS-155="${ARTEMIS-155}" -DARTEMIS-140="${ARTEMIS-140}" -DHORNETQ-235="${HORNETQ-235}" -DHORNETQ-247="${HORNETQ-247}" -DARTEMIS-270="${ARTEMIS-270}" -DARTEMIS-240="${ARTEMIS-240}" -DARTEMIS-155="${ARTEMIS-155}" -DARTEMIS-140="${ARTEMIS-140}"</echo>
+                        </tasks>
+                     </configuration>
+                  </execution>
+               </executions>
+            </plugin> -->
+            <plugin>
+                <groupId>org.apache.servicemix.tooling</groupId>
+                <artifactId>depends-maven-plugin</artifactId>
+                <version>1.2</version>
+                <executions>
+                    <execution>
+                        <id>generate-depends-file</id>
+                        <goals>
+                            <goal>generate-depends-file</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <distributionManagement>
+        <repository>
+            <id>jboss-releases-repository</id>
+            <name>JBoss Releases Repository</name>
+            <url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</url>
+        </repository>
+        <snapshotRepository>
+            <id>jboss-snapshots-repository</id>
+            <name>JBoss Snapshots Repository</name>
+            <url>https://repository.jboss.org/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+</project>

--- a/tests/server-compatibility-tests/src/main/java/logs/JBossLoggingApacheLoggerBridge.java
+++ b/tests/server-compatibility-tests/src/main/java/logs/JBossLoggingApacheLoggerBridge.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logs;
+
+import org.apache.commons.logging.Log;
+import org.jboss.logging.Logger;
+
+/**
+ * This is a necessary copy of the JBossLoggingApacheLoggerBridge on artemis-commons package.
+ * Since we define -Dorg.apache.commons.logging.Log=org.apache.activemq.artemis.logs.JBossLoggingApacheLoggerBridge
+ * We need to have the class defined.
+ * However I cannot import commons into older versions.
+ * For that reason this class was needed as a duplicate.
+ * */
+public class JBossLoggingApacheLoggerBridge implements Log {
+
+   final Logger bridgeLog;
+
+   public JBossLoggingApacheLoggerBridge(Class clazz) {
+      bridgeLog = Logger.getLogger(clazz);
+   }
+
+   public JBossLoggingApacheLoggerBridge(String name) {
+      bridgeLog = Logger.getLogger(name);
+   }
+
+   @Override
+   public void debug(Object message) {
+      bridgeLog.debug(message);
+   }
+
+   @Override
+   public void debug(Object message, Throwable t) {
+      bridgeLog.debug(message, t);
+   }
+
+   @Override
+   public void error(Object message) {
+      bridgeLog.error(message);
+   }
+
+   @Override
+   public void error(Object message, Throwable t) {
+      bridgeLog.error(message, t);
+   }
+
+   @Override
+   public void fatal(Object message) {
+      bridgeLog.fatal(message);
+   }
+
+   @Override
+   public void fatal(Object message, Throwable t) {
+      bridgeLog.fatal(message, t);
+   }
+
+   @Override
+   public void info(Object message) {
+      bridgeLog.info(message);
+   }
+
+   @Override
+   public void info(Object message, Throwable t) {
+      bridgeLog.info(message, t);
+   }
+
+   @Override
+   public boolean isDebugEnabled() {
+      return bridgeLog.isDebugEnabled();
+   }
+
+   @Override
+   public boolean isErrorEnabled() {
+      return bridgeLog.isEnabled(Logger.Level.ERROR);
+   }
+
+   @Override
+   public boolean isFatalEnabled() {
+      return bridgeLog.isEnabled(Logger.Level.FATAL);
+   }
+
+   @Override
+   public boolean isInfoEnabled() {
+      return bridgeLog.isInfoEnabled();
+   }
+
+   @Override
+   public boolean isTraceEnabled() {
+      return bridgeLog.isTraceEnabled();
+   }
+
+   @Override
+   public boolean isWarnEnabled() {
+      return bridgeLog.isEnabled(Logger.Level.WARN);
+   }
+
+   @Override
+   public void trace(Object message) {
+      bridgeLog.trace(message);
+   }
+
+   @Override
+   public void trace(Object message, Throwable t) {
+      bridgeLog.trace(message, t);
+   }
+
+   @Override
+   public void warn(Object message) {
+      bridgeLog.warn(message);
+   }
+
+   @Override
+   public void warn(Object message, Throwable t) {
+      bridgeLog.warn(message, t);
+   }
+}

--- a/tests/server-compatibility-tests/src/test/java/org/apache/activemq/artemis/tests/servercompatibility/ReplicationTest.java
+++ b/tests/server-compatibility-tests/src/test/java/org/apache/activemq/artemis/tests/servercompatibility/ReplicationTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.tests.servercompatibility;
+
+import org.apache.activemq.artemis.tests.servercompatibility.base.ScriptedCompatibilityTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.apache.activemq.artemis.tests.servercompatibility.base.VersionTags.*;
+
+@RunWith(Parameterized.class)
+public class ReplicationTest extends ScriptedCompatibilityTest {
+
+    private static final int MASTER = FIRST;
+    private static final int SLAVE = SECOND;
+
+    @Parameterized.Parameters(name = "master={0}, slave={1}")
+    public static Collection<?> getParameters() {
+        return List.of(
+
+                // ARTEMIS-3767
+                // new Object[]{ARTEMIS_2_17_0, ARTEMIS_2_18_0},
+                // new Object[]{ARTEMIS_2_18_0, ARTEMIS_2_17_0},
+
+                // Current
+                new Object[]{ARTEMIS_2_17_0, ARTEMIS_SNAPSHOT},
+                new Object[]{ARTEMIS_SNAPSHOT, ARTEMIS_2_17_0},
+
+                // These below should work OK
+                new Object[]{ARTEMIS_2_17_0, ARTEMIS_2_17_0},
+                new Object[]{ARTEMIS_2_18_0, ARTEMIS_2_18_0},
+                new Object[]{ARTEMIS_SNAPSHOT, ARTEMIS_SNAPSHOT}
+
+        );
+    }
+
+    public ReplicationTest(String master, String slave) {
+        super(master, slave);
+    }
+
+    @Test
+    public void testReplication() throws Throwable {
+        try {
+            executeScript(MASTER, "ReplicationTest/createMaster.groovy");
+            executeScript(SLAVE, "ReplicationTest/createSlave.groovy");
+            executeScript(MASTER, "ReplicationTest/testSendMessageToMaster.groovy");
+            executeScript(MASTER, "servers/stopServer.groovy");
+            executeScript(SLAVE, "ReplicationTest/testReceiveMessageFromSlave.groovy");
+            executeScript(SLAVE, "servers/stopServer.groovy");
+        } catch (Throwable t) {
+            try {
+                executeScript(MASTER, "servers/stopServer.groovy");
+            } catch (Throwable t1) {
+                t1.printStackTrace();
+            }
+            try {
+                executeScript(SLAVE, "servers/stopServer.groovy");
+            } catch (Throwable t2) {
+                t2.printStackTrace();
+            }
+            throw t;
+        }
+    }
+
+}

--- a/tests/server-compatibility-tests/src/test/java/org/apache/activemq/artemis/tests/servercompatibility/base/CompatibilityTestScript.java
+++ b/tests/server-compatibility-tests/src/test/java/org/apache/activemq/artemis/tests/servercompatibility/base/CompatibilityTestScript.java
@@ -1,0 +1,118 @@
+package org.apache.activemq.artemis.tests.servercompatibility.base;
+
+import groovy.lang.Binding;
+import groovy.lang.Closure;
+import groovy.lang.GroovyShell;
+import groovy.lang.Script;
+import groovy.transform.Memoized;
+import org.codehaus.groovy.control.CompilationFailedException;
+import org.codehaus.groovy.control.CompilerConfiguration;
+import org.codehaus.groovy.runtime.DefaultGroovyMethods;
+import org.jboss.logging.Logger;
+import org.junit.Assert;
+import org.junit.Assume;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.*;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+
+public abstract class CompatibilityTestScript extends Script implements CompatibilityTestScriptInterface {
+
+    @Memoized
+    private static Set<String> getInterfacePropertyNames() {
+        return Arrays.stream(CompatibilityTestScriptInterface.class.getDeclaredMethods())
+                .filter((m) -> m.getParameterCount() == 0)
+                .filter((m) -> m.getReturnType() != Void.class)
+                .map(Method::getName)
+                .filter((m) -> m.startsWith("get"))
+                .map((m) -> m.substring(3, 4).toLowerCase() + m.substring(4))
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public void setBinding(Binding binding) {
+        super.setBinding(binding);
+        getInterfacePropertyNames().forEach((p) -> {
+            if (!binding.hasVariable(p)) {
+                throw new AssertionError("Binding property '" + p + "' not set.");
+            }
+        });
+    }
+
+    public File getWorkingDir() {
+        return (File) getBinding().getVariable("workingDir");
+    }
+
+    public String getSide() {
+        return (String) getBinding().getVariable("side");
+    }
+
+    private Object createLocalShell() throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
+        final ClassLoader cl = getClass().getClassLoader();
+        final Class<?> confClass = cl.loadClass(CompilerConfiguration.class.getCanonicalName());
+        final Object conf = confClass.getConstructor().newInstance();
+        conf.getClass().getMethod("setScriptBaseClass", String.class).invoke(conf, getClass().getCanonicalName());
+        final Class<?> bindingClass = cl.loadClass(Binding.class.getCanonicalName());
+        final Class<?> shellClass = cl.loadClass(GroovyShell.class.getCanonicalName());
+        return shellClass.getConstructor(ClassLoader.class, bindingClass, confClass).newInstance(cl, getBinding(), conf);
+    }
+
+    @Override
+    public Object evaluate(File script) throws IOException {
+        if (!script.isAbsolute()) {
+            script = ScriptedCompatibilityTest.getScript(script.getPath());
+        }
+        try {
+            final Object shell = createLocalShell();
+            return shell.getClass().getMethod("evaluate", File.class).invoke(shell, script);
+        } catch (ClassNotFoundException | InvocationTargetException | InstantiationException | IllegalAccessException |
+                 NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Object evaluate(String expression) throws CompilationFailedException {
+        try {
+            final Object shell = createLocalShell();
+            return shell.getClass().getMethod("evaluate", String.class).invoke(shell, expression);
+        } catch (ClassNotFoundException | InvocationTargetException | InstantiationException | IllegalAccessException |
+                 NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void assertEquals(Object expected, Object given) {
+        Assert.assertEquals(expected, given);
+    }
+
+    public void assertTrue(boolean condition) {
+        Assert.assertTrue(condition);
+    }
+
+    public void assertFalse(boolean condition) {
+        Assert.assertFalse(condition);
+    }
+
+    public void assertNotNull(Object object) {
+        Assert.assertNotNull(object);
+    }
+
+    public <T> T waitForCondition(int seconds, Closure<T> condition) throws InterruptedException {
+        while (seconds > 0) {
+            T result = condition.call();
+            if (DefaultGroovyMethods.asBoolean(result)) {
+                return result;
+            }
+            Thread.sleep(1000);
+            seconds--;
+        }
+        T result = condition.call();
+        assertTrue(DefaultGroovyMethods.asBoolean(result));
+        return result;
+    }
+}

--- a/tests/server-compatibility-tests/src/test/java/org/apache/activemq/artemis/tests/servercompatibility/base/CompatibilityTestScriptInterface.java
+++ b/tests/server-compatibility-tests/src/test/java/org/apache/activemq/artemis/tests/servercompatibility/base/CompatibilityTestScriptInterface.java
@@ -1,0 +1,12 @@
+package org.apache.activemq.artemis.tests.servercompatibility.base;
+
+import java.io.File;
+
+@SuppressWarnings("unused")
+public interface CompatibilityTestScriptInterface {
+
+    File getWorkingDir();
+
+    String getSide();
+
+}

--- a/tests/server-compatibility-tests/src/test/java/org/apache/activemq/artemis/tests/servercompatibility/base/ScriptedCompatibilityTest.java
+++ b/tests/server-compatibility-tests/src/test/java/org/apache/activemq/artemis/tests/servercompatibility/base/ScriptedCompatibilityTest.java
@@ -1,0 +1,245 @@
+package org.apache.activemq.artemis.tests.servercompatibility.base;
+
+import groovy.lang.Binding;
+import groovy.lang.GroovyClassLoader;
+import groovy.lang.GroovyShell;
+import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl;
+import org.codehaus.groovy.control.CompilerConfiguration;
+import org.jboss.logging.Logger;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.*;
+import java.util.concurrent.FutureTask;
+
+public abstract class ScriptedCompatibilityTest {
+
+    private static final Logger logger = Logger.getLogger(ScriptedCompatibilityTest.class);
+    private static final Set<String> warningsPrintedFor = new HashSet<>();
+
+    protected static final int FIRST = 1;
+    protected static final int SECOND = 2;
+    protected static final int THIRD = 3;
+
+    private final Logger log = logger;
+    private final String[] sides;
+    /**
+     * Maps side index to Groovy shell to keep the sides separated.
+     */
+    private final Map<Integer, Object> shells = new HashMap<>();
+    /**
+     * Maps side name to a classloader, which we can reuse.
+     */
+    private static final Map<String, GroovyClassLoader> classLoaders = new HashMap<>();
+
+    private File workingDir;
+
+    @Rule
+    public TemporaryFolder temporaryFolder = TemporaryFolder.builder().assureDeletion().build();
+
+    @Rule
+    public TestRule watcher = new TestWatcher() {
+
+        @Override
+        protected void starting(Description description) {
+            log.info(String.format("**** start #test %s() ***", ScriptedCompatibilityTest.this.getClass().getName() + "::" + description.getMethodName()));
+        }
+
+        @Override
+        protected void finished(Description description) {
+            log.info(String.format("**** end #test %s() ***", ScriptedCompatibilityTest.this.getClass().getName() + "::" + description.getMethodName()));
+        }
+    };
+
+    protected ScriptedCompatibilityTest(String... sides) {
+        if (sides.length < 2) {
+            throw new IllegalArgumentException("sides.length < 2");
+        }
+        this.sides = sides;
+    }
+
+    protected Object executeScript(int sideIndex, String scriptPath) throws Throwable {
+        final Object shell = getShell(sideIndex);
+        final FutureTask<Object> executionTask = new FutureTask<>(() -> shell.getClass().getMethod("evaluate", File.class).invoke(shell, getScript(scriptPath)));
+        final Thread executionThread = new Thread(executionTask);
+        executionThread.setName(getSide(sideIndex) + ": " + scriptPath);
+        // If we don't replace the context class loader too then some things -- such as ServiceLoader -- don't work properly.
+        executionThread.setContextClassLoader((ClassLoader) shell.getClass().getMethod("getClassLoader").invoke(shell));
+        executionThread.start();
+        executionThread.join();
+        try {
+            return executionTask.get();
+        } catch (Exception e) {
+            tryUnpackAssertionError(e);
+        }
+        return null;
+    }
+
+    protected Object getVariable(int sideIndex, String name) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        final Object shell = getShell(sideIndex);
+        return shell.getClass().getMethod("getVariable", String.class).invoke(shell, name);
+    }
+
+    protected void setVariable(int sideIndex, String name, Object value) {
+        final Object shell = getShell(sideIndex);
+        try {
+            shell.getClass().getMethod("setVariable", String.class, Object.class).invoke(shell, name, value);
+        } catch (Exception e) {
+            Assume.assumeNoException(e);
+        }
+    }
+
+    private Object getShell(int sideIndex) {
+        return shells.computeIfAbsent(sideIndex, (i) -> {
+            final String side = getSide(i);
+            final Binding binding = new Binding(Map.of(
+                    "workingDir", getWorkingDir(),
+                    "side", side
+            ));
+            try {
+                return createShell(getShellClassLoader(side), binding);
+            } catch (Exception e) {
+                Assume.assumeNoException(e);
+            }
+            return null;
+        });
+    }
+
+    /**
+     * Creates a {@linkplain GroovyShell} object using the class taken from the given class loader. This is important
+     * because we need the shell to be compatible with the scripts we're about to run there.
+     *
+     * @param cl      The class loader.
+     * @param binding The binding to be COPIED as the new shell context.
+     * @return The shell as the instance of class which may not be available during compile time.
+     * @throws ClassNotFoundException
+     * @throws NoSuchMethodException
+     * @throws InvocationTargetException
+     * @throws InstantiationException
+     * @throws IllegalAccessException
+     */
+    public static Object createShell(ClassLoader cl, Binding binding) throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
+        final Class<?> confClass = cl.loadClass(CompilerConfiguration.class.getCanonicalName());
+        final Object conf = confClass.getConstructor().newInstance();
+        conf.getClass().getMethod("setScriptBaseClass", String.class).invoke(conf, CompatibilityTestScript.class.getCanonicalName());
+        final Class<?> bindingClass = cl.loadClass(Binding.class.getCanonicalName());
+        final Object newBinding = bindingClass.getConstructor(Map.class).newInstance(new HashMap<Object, Object>(binding.getVariables()));
+        final Class<?> shellClass = cl.loadClass(GroovyShell.class.getCanonicalName());
+        return shellClass.getConstructor(ClassLoader.class, bindingClass, confClass).newInstance(cl, newBinding, conf);
+    }
+
+    protected File getWorkingDir() {
+        if (workingDir == null) {
+            try {
+                workingDir = temporaryFolder.newFolder();
+            } catch (IOException e) {
+                Assume.assumeNoException("Failed to create test working directory under '" + temporaryFolder.getRoot().getAbsolutePath() + "'.", e);
+                return null;
+            }
+        }
+        return workingDir;
+    }
+
+    protected static GroovyClassLoader getShellClassLoader(String side) {
+        return classLoaders.computeIfAbsent(side, ScriptedCompatibilityTest::createShellClassLoader);
+    }
+
+    private String getSide(int sideIndex) {
+        if (sideIndex < 1) {
+            throw new IllegalArgumentException("sideIndex < 1");
+        }
+        if (sideIndex > sides.length) {
+            throw new IllegalArgumentException("sideIndex > " + sides.length);
+        }
+        return sides[sideIndex - 1];
+    }
+
+    protected static File getScript(String scriptPath) throws IOException {
+        final URL resource = ScriptedCompatibilityTest.class.getClassLoader().getResource(scriptPath);
+        if (resource == null) {
+            throw new IOException("Resource not found: " + scriptPath);
+        }
+        try {
+            return new File(resource.toURI());
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Creates a class loader which shall prioritize the side-related classes.
+     *
+     * @param side The side.
+     * @return The class loader.
+     */
+    private static GroovyClassLoader createShellClassLoader(String side) {
+        // Collect entries on the current classpath so that we can recompose the current class loader later.
+        final List<URL> baseClassPath = new LinkedList<>();
+        final Enumeration<URL> baseClassPathEnumeration;
+        try {
+            baseClassPathEnumeration = ScriptedCompatibilityTest.class.getClassLoader().getResources("");
+            while (baseClassPathEnumeration.hasMoreElements()) {
+                baseClassPath.add(baseClassPathEnumeration.nextElement());
+            }
+        } catch (IOException e) {
+            Assume.assumeNoException(e);
+        }
+        // We need to put the requested server version at the beginning of class loader chain so that it gets selected
+        // with higher priority. At the same time we need the other classes to be present. These will be appended to the
+        // chain.
+        final ClassLoader serverClassLoader = new URLClassLoader(getClassPath(side), ClassLoader.getPlatformClassLoader());
+        final ClassLoader baseClassLoader = new URLClassLoader(baseClassPath.toArray(new URL[0]), serverClassLoader);
+        return new GroovyClassLoader(baseClassLoader);
+    }
+
+    private static URL[] getClassPath(String side) {
+        final String classPath = System.getProperties().getProperty(side);
+        if ((classPath == null) || classPath.isBlank()) {
+            if (!warningsPrintedFor.contains(side)) {
+                warningsPrintedFor.add(side);
+                System.out.println("Add \"-D" + side + "=\'CLASSPATH\'\" into your VM settings");
+                System.out.println("You will see it in the output from mvn install at the compatibility-tests");
+                System.out.println("... look for output from dependency-scan");
+                // our dependency scan used at the pom under compatibility-tests/pom.xml will generate these, example:
+                // [INFO] dependency-scan setting: -DARTEMIS-140="/Users/someuser/....."
+                // copy that into your IDE setting and you should be able to debug it
+            }
+            Assume.assumeTrue("Cannot run these tests, no classpath found", true);
+        }
+        assert classPath != null; // Avoid warning
+        String[] classPathArray = classPath.split(File.pathSeparator);
+        List<URL> elements = new ArrayList<>(classPathArray.length);
+        for (String s : classPathArray) {
+            try {
+                elements.add(new File(s).toURI().toURL());
+            } catch (MalformedURLException e) {
+                Assume.assumeNoException("Invalid " + side + " classpath entry found.", e);
+            }
+        }
+        return elements.toArray(new URL[0]);
+    }
+
+    private static void tryUnpackAssertionError(Throwable t) throws Throwable {
+        Objects.requireNonNull(t);
+        Throwable cause = t;
+        while (cause != null) {
+            cause = cause.getCause();
+            if (cause instanceof AssertionError) {
+                throw cause;
+            }
+        }
+        throw t;
+    }
+}

--- a/tests/server-compatibility-tests/src/test/java/org/apache/activemq/artemis/tests/servercompatibility/base/VersionTags.java
+++ b/tests/server-compatibility-tests/src/test/java/org/apache/activemq/artemis/tests/servercompatibility/base/VersionTags.java
@@ -1,0 +1,9 @@
+package org.apache.activemq.artemis.tests.servercompatibility.base;
+
+public class VersionTags {
+
+    public static final String ARTEMIS_SNAPSHOT = "ARTEMIS-SNAPSHOT";
+    public static final String ARTEMIS_2_17_0 = "ARTEMIS-2_17_0";
+    public static final String ARTEMIS_2_18_0 = "ARTEMIS-2_18_0";
+
+}

--- a/tests/server-compatibility-tests/src/test/resources/ReplicationTest/createMaster.groovy
+++ b/tests/server-compatibility-tests/src/test/resources/ReplicationTest/createMaster.groovy
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ReplicationTest
+
+import org.apache.activemq.artemis.core.config.ClusterConnectionConfiguration
+import org.apache.activemq.artemis.core.config.ha.ReplicatedPolicyConfiguration
+import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl
+import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl
+
+evaluate(new File('ReplicationTest/testConfiguration.groovy'))
+
+final clusterConnectionConfiguration = new ClusterConnectionConfiguration()
+clusterConnectionConfiguration.name = 'test'
+clusterConnectionConfiguration.connectorName = 'master'
+clusterConnectionConfiguration.staticConnectors = ['slave']
+
+final haConfiguration = new ReplicatedPolicyConfiguration()
+haConfiguration.clusterName = 'test'
+haConfiguration.checkForLiveServer = true
+
+final configuration = new ConfigurationImpl()
+configuration.name = 'master'
+configuration.brokerInstance = new File(workingDir, 'master')
+configuration.addAcceptorConfiguration('artemis', "tcp://${masterBindAddress}:${masterBindPort}?protocols=CORE")
+configuration.securityEnabled = false
+configuration.persistenceEnabled = true
+configuration.addConnectorConfiguration('master', "tcp://${masterBindAddress}:${masterBindPort}")
+configuration.addConnectorConfiguration('slave', "tcp://${slaveBindAddress}:${slaveBindPort}")
+configuration.setHAPolicyConfiguration(haConfiguration)
+configuration.addClusterConfiguration(clusterConnectionConfiguration)
+
+server = new ActiveMQServerImpl(configuration)
+println "Created \"${configuration.name}\" server of version ${server.version.fullVersion}."
+
+evaluate(new File('servers/startServer.groovy'))
+

--- a/tests/server-compatibility-tests/src/test/resources/ReplicationTest/createSlave.groovy
+++ b/tests/server-compatibility-tests/src/test/resources/ReplicationTest/createSlave.groovy
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ReplicationTest
+
+import org.apache.activemq.artemis.core.config.ClusterConnectionConfiguration
+import org.apache.activemq.artemis.core.config.ha.ReplicaPolicyConfiguration
+import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl
+import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl
+
+evaluate(new File('ReplicationTest/testConfiguration.groovy'))
+
+final clusterConnectionConfiguration = new ClusterConnectionConfiguration()
+clusterConnectionConfiguration.name = 'test'
+clusterConnectionConfiguration.connectorName = 'slave'
+clusterConnectionConfiguration.staticConnectors = ['master']
+
+final haConfiguration = new ReplicaPolicyConfiguration()
+haConfiguration.clusterName = 'test'
+haConfiguration.allowFailBack = true
+
+final configuration = new ConfigurationImpl()
+configuration.name = 'slave'
+configuration.brokerInstance = new File(workingDir, 'slave')
+configuration.addAcceptorConfiguration('artemis', "tcp://${slaveBindAddress}:${slaveBindPort}?protocols=CORE")
+configuration.createJournalDir = true
+configuration.securityEnabled = false
+configuration.persistenceEnabled = true
+configuration.addConnectorConfiguration('master', "tcp://${masterBindAddress}:${masterBindPort}")
+configuration.addConnectorConfiguration('slave', "tcp://${slaveBindAddress}:${slaveBindPort}")
+configuration.setHAPolicyConfiguration(haConfiguration)
+configuration.addClusterConfiguration(clusterConnectionConfiguration)
+
+server = new ActiveMQServerImpl(configuration)
+println "Created \"${configuration.name}\" server of version ${server.version.fullVersion}."
+
+evaluate(new File('servers/startServer.groovy'))

--- a/tests/server-compatibility-tests/src/test/resources/ReplicationTest/testConfiguration.groovy
+++ b/tests/server-compatibility-tests/src/test/resources/ReplicationTest/testConfiguration.groovy
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ReplicationTest
+
+masterBindAddress = '127.0.0.1'
+masterBindPort = 61616
+slaveBindAddress = '127.0.0.1'
+slaveBindPort = 61617
+replicationTestQueueName = 'dummy'
+replicationTestString = 'hello world'

--- a/tests/server-compatibility-tests/src/test/resources/ReplicationTest/testReceiveMessageFromSlave.groovy
+++ b/tests/server-compatibility-tests/src/test/resources/ReplicationTest/testReceiveMessageFromSlave.groovy
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ReplicationTest
+
+import org.apache.activemq.artemis.api.core.client.ClientMessage
+import org.apache.activemq.artemis.core.client.impl.ServerLocatorImpl
+import org.apache.activemq.artemis.core.server.ActiveMQServer
+
+evaluate(new File('ReplicationTest/testConfiguration.groovy'))
+server = server as ActiveMQServer
+
+waitForCondition(10, server.&isActive)
+
+ServerLocatorImpl.newLocator("tcp://${slaveBindAddress}:${slaveBindPort}").withCloseable { locator ->
+    locator.createSessionFactory().withCloseable { sf ->
+        sf.createSession(true, false).withCloseable { session ->
+            session.start()
+            session.createConsumer(replicationTestQueueName as String).withCloseable { consumer ->
+                ClientMessage message = consumer.receive(5000)
+                assertNotNull(message)
+                final os = new ByteArrayOutputStream()
+                os.withCloseable {
+                    message.saveToOutputStream(it)
+                }
+                assertEquals(replicationTestString, os.toString())
+            }
+            session.commit()
+        }
+    }
+}

--- a/tests/server-compatibility-tests/src/test/resources/ReplicationTest/testSendMessageToMaster.groovy
+++ b/tests/server-compatibility-tests/src/test/resources/ReplicationTest/testSendMessageToMaster.groovy
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ReplicationTest
+
+import org.apache.activemq.artemis.api.core.QueueConfiguration
+import org.apache.activemq.artemis.api.core.client.ClientMessage
+import org.apache.activemq.artemis.core.client.impl.ServerLocatorImpl
+import org.apache.activemq.artemis.core.server.ActiveMQServer
+import org.apache.tools.ant.filters.StringInputStream
+
+import java.nio.charset.Charset
+
+evaluate(new File('ReplicationTest/testConfiguration.groovy'))
+server = server as ActiveMQServer
+
+waitForCondition(10, server.&isActive)
+
+ServerLocatorImpl.newLocator("tcp://${masterBindAddress}:${masterBindPort}").withCloseable { locator ->
+    locator.blockOnDurableSend = true
+    locator.createSessionFactory().withCloseable { sf ->
+        sf.createSession(true, true).withCloseable { session ->
+            session.start()
+            session.createQueue(new QueueConfiguration(replicationTestQueueName as String))
+            session.createProducer(replicationTestQueueName as String).withCloseable { producer ->
+                new StringInputStream(replicationTestString).withCloseable { body ->
+                    ClientMessage message = session.createMessage(true)
+                    message.bodyInputStream = body
+                    producer.send(message)
+                }
+            }
+        }
+    }
+}
+
+waitForCondition(10, server.&isReplicaSync)
+
+queue = server.locateQueue(replicationTestQueueName)
+assertEquals(1L, queue.durableMessageCount)
+browser = queue.browserIterator()
+assertTrue(browser.hasNext())
+message = browser.next()
+assertEquals(replicationTestString, message.message.toCore().readOnlyBodyBuffer.byteBuf().toString(Charset.defaultCharset()))

--- a/tests/server-compatibility-tests/src/test/resources/compatibilityScript.gdsl
+++ b/tests/server-compatibility-tests/src/test/resources/compatibilityScript.gdsl
@@ -1,0 +1,12 @@
+/**
+ * This file helps with autocompletion and syntax check in compatibility scripts based on
+ * CompatibilityTestScriptInterface in Intellij IDEA.
+ *
+ * Re-save and reactivate this script in the CompatibilityTestScriptInterface changes in order to reflect the changes in
+ * scripts if IDEA throws com.intellij.openapi.progress.ProcessCanceledException.
+ */
+
+def generalContext = context(scope: scriptScope(), pathRegexp: /.*\/*\.groovy/)
+contributor generalContext, {
+    delegatesTo(findClass('org.apache.activemq.artemis.tests.compatibility.base.CompatibilityTestScriptInterface'))
+}

--- a/tests/server-compatibility-tests/src/test/resources/servers/startServer.groovy
+++ b/tests/server-compatibility-tests/src/test/resources/servers/startServer.groovy
@@ -1,0 +1,38 @@
+package servers
+
+import org.apache.activemq.artemis.core.server.ActiveMQServer
+import org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ
+
+if (!binding.hasVariable('server')) {
+    println 'No server to start.'
+    return
+}
+
+if (!server.metaClass.getMetaMethod('start')) {
+    println 'The "server" property doesn\'t contain a "start()" method.'
+    return server
+}
+
+server.start()
+
+if (server instanceof EmbeddedActiveMQ) {
+    server = server.activeMQServer
+}
+
+if (server !instanceof ActiveMQServer) {
+    println "The \"server\" property is not a supported server. Not waiting for it to start."
+    return server
+}
+
+server = server as ActiveMQServer
+
+println "Waiting up to 10 seconds for the server \"${server.configuration.name}\" to start ..."
+
+10.times {
+    directive = server.state == ActiveMQServer.SERVER_STATE.STARTED ? 1 : 0
+    Thread.sleep(1000)
+}
+
+assertEquals(ActiveMQServer.SERVER_STATE.STARTED, server.state)
+
+println "Server \"${server.configuration.name}\" started."

--- a/tests/server-compatibility-tests/src/test/resources/servers/stopServer.groovy
+++ b/tests/server-compatibility-tests/src/test/resources/servers/stopServer.groovy
@@ -1,0 +1,36 @@
+package servers
+
+import org.apache.activemq.artemis.core.server.ActiveMQServer
+import org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ
+
+if (!binding.hasVariable('server')) {
+    println 'No server to stop.'
+    return
+}
+
+if (!server.metaClass.getMetaMethod('stop')) {
+    println 'The "server" property doesn\'t contain a "stop()" method.'
+    return server
+}
+
+server.stop()
+
+if (server instanceof EmbeddedActiveMQ) {
+    server = server.activeMQServer
+}
+
+if (server !instanceof ActiveMQServer) {
+    println "The \"server\" property is not a supported server. Not waiting for it to stop."
+    return server
+}
+
+server = server as ActiveMQServer
+if (server.state != ActiveMQServer.SERVER_STATE.STOPPED) {
+    println "Waiting up to 10 seconds for the server \"${server.configuration.name}\" to stop ..."
+    10.times {
+        directive = server.state == ActiveMQServer.SERVER_STATE.STOPPED ? 1 : 0
+        Thread.sleep(1000)
+    }
+    assertEquals(ActiveMQServer.SERVER_STATE.STOPPED, server.state)
+    println "Server \"${server.configuration.name}\" stopped."
+}


### PR DESCRIPTION
This PR attempts to solve the issue described in https://issues.apache.org/jira/browse/ARTEMIS-3767.

TL;DR replication between 2.17.0 and newer Artemis versions is broken since 2.18.0.