### PR TITLE
ARTEMIS-1964 fix and deprecate getNumberOfMessages() on AddressControl

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/AddressControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/AddressControl.java
@@ -73,26 +73,27 @@ public interface AddressControl {
    /**
     * Returns the sum of messages on queue(s), including messages in delivery.
     */
-   @Attribute(desc = "the sum of messages on queue(s), including messages in delivery")
-   long getNumberOfMessages() throws Exception;
+   @Deprecated
+   @Attribute(desc = "the sum of messages on queue(s), including messages in delivery; DEPRECATED: use getMessageCount() instead")
+   long getNumberOfMessages();
 
    /**
     * Returns the names of the remote queue(s) bound to this address.
     */
    @Attribute(desc = "names of the remote queue(s) bound to this address")
-   String[] getRemoteQueueNames() throws Exception;
+   String[] getRemoteQueueNames();
 
    /**
     * Returns the names of the local queue(s) bound to this address.
     */
    @Attribute(desc = "names of the local queue(s) bound to this address")
-   String[] getQueueNames() throws Exception;
+   String[] getQueueNames();
 
    /**
     * Returns the names of both the local and remote queue(s) bound to this address.
     */
    @Attribute(desc = "names of both the local & remote queue(s) bound to this address")
-   String[] getAllQueueNames() throws Exception;
+   String[] getAllQueueNames();
 
    /**
     * Returns the number of pages used by this address.

--- a/tests/integration-tests/pom.xml
+++ b/tests/integration-tests/pom.xml
@@ -455,6 +455,12 @@
          <scope>test</scope>
       </dependency>
 
+      <dependency>
+         <groupId>org.mockito</groupId>
+         <artifactId>mockito-core</artifactId>
+         <scope>test</scope>
+      </dependency>
+
    </dependencies>
 
    <build>

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/AddressControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/AddressControlTest.java
@@ -22,14 +22,10 @@ import javax.jms.MessageConsumer;
 import javax.jms.MessageProducer;
 import javax.jms.Session;
 import javax.jms.TextMessage;
-
-import org.apache.activemq.artemis.core.server.Queue;
-import org.apache.activemq.artemis.json.JsonArray;
-import org.apache.activemq.artemis.json.JsonString;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
-import java.util.EnumSet;
 import java.util.Date;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -51,15 +47,19 @@ import org.apache.activemq.artemis.api.core.management.AddressControl;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
 import org.apache.activemq.artemis.api.core.management.RoleInfo;
 import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.postoffice.BindingType;
 import org.apache.activemq.artemis.core.security.CheckType;
 import org.apache.activemq.artemis.core.security.Role;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.server.cluster.RemoteQueueBinding;
 import org.apache.activemq.artemis.core.server.cluster.impl.MessageLoadBalancingType;
 import org.apache.activemq.artemis.core.server.cluster.impl.RemoteQueueBindingImpl;
 import org.apache.activemq.artemis.core.server.impl.AddressInfo;
 import org.apache.activemq.artemis.core.server.impl.QueueImpl;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
+import org.apache.activemq.artemis.json.JsonArray;
+import org.apache.activemq.artemis.json.JsonString;
 import org.apache.activemq.artemis.tests.util.CFUtil;
 import org.apache.activemq.artemis.tests.util.Wait;
 import org.apache.activemq.artemis.utils.Base64;
@@ -67,6 +67,7 @@ import org.apache.activemq.artemis.utils.RandomUtil;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import static org.apache.activemq.artemis.tests.util.RandomUtil.randomString;
 
@@ -449,6 +450,36 @@ public class AddressControlTest extends ManagementTestBase {
       session.createQueue(new QueueConfiguration(address.concat('2')).setAddress(address).setRoutingType(RoutingType.ANYCAST));
       producer.send(session.createMessage(false));
       assertTrue(Wait.waitFor(() -> addressControl.getMessageCount() == 2, 2000, 100));
+   }
+
+   @Test
+   public void testNumberOfMessages() throws Exception {
+      SimpleString address = RandomUtil.randomSimpleString();
+      session.createAddress(address, RoutingType.ANYCAST, false);
+
+      AddressControl addressControl = createManagementControl(address);
+      assertEquals(0, addressControl.getNumberOfMessages());
+
+      ClientProducer producer = session.createProducer(address.toString());
+      producer.send(session.createMessage(false));
+      assertEquals(0, addressControl.getNumberOfMessages());
+
+      session.createQueue(new QueueConfiguration(address).setRoutingType(RoutingType.ANYCAST));
+      producer.send(session.createMessage(false));
+      Wait.assertTrue(() -> addressControl.getNumberOfMessages() == 1, 2000, 100);
+
+      RemoteQueueBinding binding = Mockito.mock(RemoteQueueBinding.class);
+      Mockito.when(binding.getAddress()).thenReturn(address);
+      Queue queue = Mockito.mock(Queue.class);
+      Mockito.when(queue.getMessageCount()).thenReturn((long) 999);
+      Mockito.when(binding.getQueue()).thenReturn(queue);
+      Mockito.when(binding.getUniqueName()).thenReturn(RandomUtil.randomSimpleString());
+      Mockito.when(binding.getRoutingName()).thenReturn(RandomUtil.randomSimpleString());
+      Mockito.when(binding.getClusterName()).thenReturn(RandomUtil.randomSimpleString());
+      Mockito.when(binding.getType()).thenReturn(BindingType.REMOTE_QUEUE);
+      server.getPostOffice().addBinding(binding);
+
+      assertEquals(1, addressControl.getNumberOfMessages());
    }
 
    @Test

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/AddressControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/AddressControlUsingCoreTest.java
@@ -62,22 +62,22 @@ public class AddressControlUsingCoreTest extends AddressControlTest {
          }
 
          @Override
-         public long getNumberOfMessages() throws Exception {
+         public long getNumberOfMessages() {
             return (long) proxy.retrieveAttributeValue("numberOfMessages");
          }
 
          @Override
-         public String[] getRemoteQueueNames() throws Exception {
+         public String[] getRemoteQueueNames() {
             return (String[]) proxy.retrieveAttributeValue("remoteQueueNames", String.class);
          }
 
          @Override
-         public String[] getAllQueueNames() throws Exception {
+         public String[] getAllQueueNames() {
             return (String[]) proxy.retrieveAttributeValue("allQueueNames", String.class);
          }
 
          @Override
-         public String[] getQueueNames() throws Exception {
+         public String[] getQueueNames() {
             return (String[]) proxy.retrieveAttributeValue("queueNames", String.class);
          }
 


### PR DESCRIPTION
AddressControl has 2 methods to get same metric. Both
getNumberOfMessages() and getMessageCount() return the same metric
albeit in different ways.

Also, getNumberOfMessages() inspects both "local" and "remote" queue
bindings which is wrong.

This commit fixes these issues via the following changes:

 - Deprecate getNumberOfMessages().
 - Change getNumberOfMessages() to invoke getMessageCount().
 - Add a test to ensure getNumberOfMessages() does not count remote
queue bindings.
 - Simplify getMessageCount(DurabilityType).