### PR TITLE
ARTEMIS-3909 Move RoutingContext::processReferences as a static method in PostOffice

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -1592,9 +1592,15 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
 
             @Override
             public void done() {
-               context.processReferences(refs, direct);
+               processReferences(refs, direct);
             }
          });
+      }
+   }
+
+   private static void processReferences(List<MessageReference> refs, boolean direct) {
+      for (MessageReference ref : refs) {
+         ref.getQueue().addTail(ref, direct);
       }
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/RoutingContext.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/RoutingContext.java
@@ -93,8 +93,6 @@ public interface RoutingContext {
 
    RoutingType getPreviousRoutingType();
 
-   void processReferences(List<MessageReference> refs, boolean direct);
-
    boolean isReusable(Message message, int version);
 
    boolean isDuplicateDetection();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/RoutingContextImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/RoutingContextImpl.java
@@ -26,7 +26,6 @@ import java.util.concurrent.Executor;
 
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.core.server.MessageReference;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.server.RouteContextList;
 import org.apache.activemq.artemis.core.server.RoutingContext;
@@ -213,17 +212,6 @@ public class RoutingContextImpl implements RoutingContext {
       printWriter.println("..................................................");
 
       return stringWriter.toString();
-   }
-
-   @Override
-   public void processReferences(final List<MessageReference> refs, final boolean direct) {
-      internalprocessReferences(refs, direct);
-   }
-
-   private void internalprocessReferences(final List<MessageReference> refs, final boolean direct) {
-      for (MessageReference ref : refs) {
-         ref.getQueue().addTail(ref, direct);
-      }
    }
 
    @Override


### PR DESCRIPTION
We were lucky that processReferences was pretty much a static operation, hence I am moving it away from RoutingContext both for clarity and avoiding state being needed on that method.
If state was needed as part of processReferences you would had a pretty nasty bug as the IOCallback could introduce a race where a send would change the state while the IO was pending.