### PR TITLE
2.23.x

### DIFF
--- a/artemis-boot/pom.xml
+++ b/artemis-boot/pom.xml
@@ -22,7 +22,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
       <relativePath>..</relativePath>
    </parent>
 

--- a/artemis-boot/pom.xml
+++ b/artemis-boot/pom.xml
@@ -22,7 +22,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
       <relativePath>..</relativePath>
    </parent>
 

--- a/artemis-cdi-client/pom.xml
+++ b/artemis-cdi-client/pom.xml
@@ -22,7 +22,7 @@
    <parent>
       <artifactId>artemis-pom</artifactId>
       <groupId>org.apache.activemq</groupId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
       <relativePath>..</relativePath>
    </parent>
    <modelVersion>4.0.0</modelVersion>

--- a/artemis-cdi-client/pom.xml
+++ b/artemis-cdi-client/pom.xml
@@ -22,7 +22,7 @@
    <parent>
       <artifactId>artemis-pom</artifactId>
       <groupId>org.apache.activemq</groupId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
       <relativePath>..</relativePath>
    </parent>
    <modelVersion>4.0.0</modelVersion>

--- a/artemis-cli/pom.xml
+++ b/artemis-cli/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-cli</artifactId>

--- a/artemis-cli/pom.xml
+++ b/artemis-cli/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-cli</artifactId>

--- a/artemis-commons/pom.xml
+++ b/artemis-commons/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-commons</artifactId>

--- a/artemis-commons/pom.xml
+++ b/artemis-commons/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-commons</artifactId>

--- a/artemis-core-client-all/pom.xml
+++ b/artemis-core-client-all/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-core-client-all</artifactId>

--- a/artemis-core-client-all/pom.xml
+++ b/artemis-core-client-all/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-core-client-all</artifactId>

--- a/artemis-core-client-osgi/pom.xml
+++ b/artemis-core-client-osgi/pom.xml
@@ -14,7 +14,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-core-client-osgi</artifactId>

--- a/artemis-core-client-osgi/pom.xml
+++ b/artemis-core-client-osgi/pom.xml
@@ -14,7 +14,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-core-client-osgi</artifactId>

--- a/artemis-core-client/pom.xml
+++ b/artemis-core-client/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-core-client</artifactId>

--- a/artemis-core-client/pom.xml
+++ b/artemis-core-client/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-core-client</artifactId>

--- a/artemis-distribution/pom.xml
+++ b/artemis-distribution/pom.xml
@@ -22,7 +22,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>apache-artemis</artifactId>

--- a/artemis-distribution/pom.xml
+++ b/artemis-distribution/pom.xml
@@ -22,7 +22,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>apache-artemis</artifactId>

--- a/artemis-dto/pom.xml
+++ b/artemis-dto/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-dto</artifactId>

--- a/artemis-dto/pom.xml
+++ b/artemis-dto/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-dto</artifactId>

--- a/artemis-features/pom.xml
+++ b/artemis-features/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>org.apache.activemq</groupId>
 		<artifactId>artemis-pom</artifactId>
-		<version>2.23.1</version>
+		<version>2.23.2-SNAPSHOT</version>
 	</parent>
 	<artifactId>artemis-features</artifactId>
 	<packaging>pom</packaging>

--- a/artemis-features/pom.xml
+++ b/artemis-features/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>org.apache.activemq</groupId>
 		<artifactId>artemis-pom</artifactId>
-		<version>2.24.0-SNAPSHOT</version>
+		<version>2.23.1</version>
 	</parent>
 	<artifactId>artemis-features</artifactId>
 	<packaging>pom</packaging>

--- a/artemis-hawtio/activemq-branding/pom.xml
+++ b/artemis-hawtio/activemq-branding/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.activemq</groupId>
         <artifactId>artemis-hawtio-pom</artifactId>
-        <version>2.24.0-SNAPSHOT</version>
+        <version>2.23.1</version>
     </parent>
     
     <artifactId>activemq-branding</artifactId>

--- a/artemis-hawtio/activemq-branding/pom.xml
+++ b/artemis-hawtio/activemq-branding/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.activemq</groupId>
         <artifactId>artemis-hawtio-pom</artifactId>
-        <version>2.23.1</version>
+        <version>2.23.2-SNAPSHOT</version>
     </parent>
     
     <artifactId>activemq-branding</artifactId>

--- a/artemis-hawtio/artemis-console/pom.xml
+++ b/artemis-hawtio/artemis-console/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>artemis-hawtio-pom</artifactId>
-    <version>2.23.1</version>
+    <version>2.23.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>artemis-console</artifactId>

--- a/artemis-hawtio/artemis-console/pom.xml
+++ b/artemis-hawtio/artemis-console/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>artemis-hawtio-pom</artifactId>
-    <version>2.24.0-SNAPSHOT</version>
+    <version>2.23.1</version>
   </parent>
 
   <artifactId>artemis-console</artifactId>

--- a/artemis-hawtio/artemis-plugin/pom.xml
+++ b/artemis-hawtio/artemis-plugin/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>artemis-hawtio-pom</artifactId>
-    <version>2.24.0-SNAPSHOT</version>
+    <version>2.23.1</version>
   </parent>
 
   <artifactId>artemis-plugin</artifactId>

--- a/artemis-hawtio/artemis-plugin/pom.xml
+++ b/artemis-hawtio/artemis-plugin/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>artemis-hawtio-pom</artifactId>
-    <version>2.23.1</version>
+    <version>2.23.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>artemis-plugin</artifactId>

--- a/artemis-hawtio/pom.xml
+++ b/artemis-hawtio/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.activemq</groupId>
         <artifactId>artemis-pom</artifactId>
-        <version>2.24.0-SNAPSHOT</version>
+        <version>2.23.1</version>
     </parent>
 
     <artifactId>artemis-hawtio-pom</artifactId>

--- a/artemis-hawtio/pom.xml
+++ b/artemis-hawtio/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.activemq</groupId>
         <artifactId>artemis-pom</artifactId>
-        <version>2.23.1</version>
+        <version>2.23.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>artemis-hawtio-pom</artifactId>

--- a/artemis-jakarta-client-all/pom.xml
+++ b/artemis-jakarta-client-all/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-jakarta-client-all</artifactId>

--- a/artemis-jakarta-client-all/pom.xml
+++ b/artemis-jakarta-client-all/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-jakarta-client-all</artifactId>

--- a/artemis-jakarta-client/pom.xml
+++ b/artemis-jakarta-client/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-jakarta-client</artifactId>

--- a/artemis-jakarta-client/pom.xml
+++ b/artemis-jakarta-client/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-jakarta-client</artifactId>

--- a/artemis-jakarta-ra/pom.xml
+++ b/artemis-jakarta-ra/pom.xml
@@ -21,7 +21,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-jakarta-ra</artifactId>

--- a/artemis-jakarta-ra/pom.xml
+++ b/artemis-jakarta-ra/pom.xml
@@ -21,7 +21,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-jakarta-ra</artifactId>

--- a/artemis-jakarta-server/pom.xml
+++ b/artemis-jakarta-server/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.activemq</groupId>
         <artifactId>artemis-pom</artifactId>
-        <version>2.23.1</version>
+        <version>2.23.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>artemis-jakarta-server</artifactId>

--- a/artemis-jakarta-server/pom.xml
+++ b/artemis-jakarta-server/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.activemq</groupId>
         <artifactId>artemis-pom</artifactId>
-        <version>2.24.0-SNAPSHOT</version>
+        <version>2.23.1</version>
     </parent>
 
     <artifactId>artemis-jakarta-server</artifactId>

--- a/artemis-jakarta-service-extensions/pom.xml
+++ b/artemis-jakarta-service-extensions/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-jakarta-service-extensions</artifactId>

--- a/artemis-jakarta-service-extensions/pom.xml
+++ b/artemis-jakarta-service-extensions/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-jakarta-service-extensions</artifactId>

--- a/artemis-jdbc-store/pom.xml
+++ b/artemis-jdbc-store/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-jdbc-store</artifactId>

--- a/artemis-jdbc-store/pom.xml
+++ b/artemis-jdbc-store/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-jdbc-store</artifactId>

--- a/artemis-jms-client-all/pom.xml
+++ b/artemis-jms-client-all/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-jms-client-all</artifactId>

--- a/artemis-jms-client-all/pom.xml
+++ b/artemis-jms-client-all/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-jms-client-all</artifactId>

--- a/artemis-jms-client-osgi/pom.xml
+++ b/artemis-jms-client-osgi/pom.xml
@@ -14,7 +14,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-jms-client-osgi</artifactId>

--- a/artemis-jms-client-osgi/pom.xml
+++ b/artemis-jms-client-osgi/pom.xml
@@ -14,7 +14,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-jms-client-osgi</artifactId>

--- a/artemis-jms-client/pom.xml
+++ b/artemis-jms-client/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-jms-client</artifactId>

--- a/artemis-jms-client/pom.xml
+++ b/artemis-jms-client/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-jms-client</artifactId>

--- a/artemis-jms-server/pom.xml
+++ b/artemis-jms-server/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-jms-server</artifactId>

--- a/artemis-jms-server/pom.xml
+++ b/artemis-jms-server/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-jms-server</artifactId>

--- a/artemis-journal/pom.xml
+++ b/artemis-journal/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-journal</artifactId>

--- a/artemis-journal/pom.xml
+++ b/artemis-journal/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-journal</artifactId>

--- a/artemis-junit/pom.xml
+++ b/artemis-junit/pom.xml
@@ -21,7 +21,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-junit</artifactId>

--- a/artemis-junit/pom.xml
+++ b/artemis-junit/pom.xml
@@ -21,7 +21,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-junit</artifactId>

--- a/artemis-maven-plugin/pom.xml
+++ b/artemis-maven-plugin/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-maven-plugin</artifactId>

--- a/artemis-maven-plugin/pom.xml
+++ b/artemis-maven-plugin/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-maven-plugin</artifactId>

--- a/artemis-protocols/artemis-amqp-protocol/pom.xml
+++ b/artemis-protocols/artemis-amqp-protocol/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <artifactId>artemis-protocols</artifactId>
       <groupId>org.apache.activemq</groupId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-amqp-protocol</artifactId>

--- a/artemis-protocols/artemis-amqp-protocol/pom.xml
+++ b/artemis-protocols/artemis-amqp-protocol/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <artifactId>artemis-protocols</artifactId>
       <groupId>org.apache.activemq</groupId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-amqp-protocol</artifactId>

--- a/artemis-protocols/artemis-hornetq-protocol/pom.xml
+++ b/artemis-protocols/artemis-hornetq-protocol/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <artifactId>artemis-protocols</artifactId>
       <groupId>org.apache.activemq</groupId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-hornetq-protocol</artifactId>

--- a/artemis-protocols/artemis-hornetq-protocol/pom.xml
+++ b/artemis-protocols/artemis-hornetq-protocol/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <artifactId>artemis-protocols</artifactId>
       <groupId>org.apache.activemq</groupId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-hornetq-protocol</artifactId>

--- a/artemis-protocols/artemis-hqclient-protocol/pom.xml
+++ b/artemis-protocols/artemis-hqclient-protocol/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <artifactId>artemis-protocols</artifactId>
       <groupId>org.apache.activemq</groupId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-hqclient-protocol</artifactId>

--- a/artemis-protocols/artemis-hqclient-protocol/pom.xml
+++ b/artemis-protocols/artemis-hqclient-protocol/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <artifactId>artemis-protocols</artifactId>
       <groupId>org.apache.activemq</groupId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-hqclient-protocol</artifactId>

--- a/artemis-protocols/artemis-mqtt-protocol/pom.xml
+++ b/artemis-protocols/artemis-mqtt-protocol/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <artifactId>artemis-protocols</artifactId>
       <groupId>org.apache.activemq</groupId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-mqtt-protocol</artifactId>

--- a/artemis-protocols/artemis-mqtt-protocol/pom.xml
+++ b/artemis-protocols/artemis-mqtt-protocol/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <artifactId>artemis-protocols</artifactId>
       <groupId>org.apache.activemq</groupId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-mqtt-protocol</artifactId>

--- a/artemis-protocols/artemis-openwire-protocol/pom.xml
+++ b/artemis-protocols/artemis-openwire-protocol/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <artifactId>artemis-protocols</artifactId>
       <groupId>org.apache.activemq</groupId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-openwire-protocol</artifactId>

--- a/artemis-protocols/artemis-openwire-protocol/pom.xml
+++ b/artemis-protocols/artemis-openwire-protocol/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <artifactId>artemis-protocols</artifactId>
       <groupId>org.apache.activemq</groupId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-openwire-protocol</artifactId>

--- a/artemis-protocols/artemis-stomp-protocol/pom.xml
+++ b/artemis-protocols/artemis-stomp-protocol/pom.xml
@@ -18,7 +18,7 @@
    <parent>
       <artifactId>artemis-protocols</artifactId>
       <groupId>org.apache.activemq</groupId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
 

--- a/artemis-protocols/artemis-stomp-protocol/pom.xml
+++ b/artemis-protocols/artemis-stomp-protocol/pom.xml
@@ -18,7 +18,7 @@
    <parent>
       <artifactId>artemis-protocols</artifactId>
       <groupId>org.apache.activemq</groupId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
 

--- a/artemis-protocols/pom.xml
+++ b/artemis-protocols/pom.xml
@@ -19,7 +19,7 @@
    <parent>
       <artifactId>artemis-pom</artifactId>
       <groupId>org.apache.activemq</groupId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
 

--- a/artemis-protocols/pom.xml
+++ b/artemis-protocols/pom.xml
@@ -19,7 +19,7 @@
    <parent>
       <artifactId>artemis-pom</artifactId>
       <groupId>org.apache.activemq</groupId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
 

--- a/artemis-quorum-api/pom.xml
+++ b/artemis-quorum-api/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-quorum-api</artifactId>

--- a/artemis-quorum-api/pom.xml
+++ b/artemis-quorum-api/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-quorum-api</artifactId>

--- a/artemis-quorum-ri/pom.xml
+++ b/artemis-quorum-ri/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-quorum-ri</artifactId>

--- a/artemis-quorum-ri/pom.xml
+++ b/artemis-quorum-ri/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-quorum-ri</artifactId>

--- a/artemis-ra/pom.xml
+++ b/artemis-ra/pom.xml
@@ -21,7 +21,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-ra</artifactId>

--- a/artemis-ra/pom.xml
+++ b/artemis-ra/pom.xml
@@ -21,7 +21,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-ra</artifactId>

--- a/artemis-rest/pom.xml
+++ b/artemis-rest/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <groupId>org.apache.activemq.rest</groupId>

--- a/artemis-rest/pom.xml
+++ b/artemis-rest/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <groupId>org.apache.activemq.rest</groupId>

--- a/artemis-selector/pom.xml
+++ b/artemis-selector/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-selector</artifactId>

--- a/artemis-selector/pom.xml
+++ b/artemis-selector/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-selector</artifactId>

--- a/artemis-server-osgi/pom.xml
+++ b/artemis-server-osgi/pom.xml
@@ -14,7 +14,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-server-osgi</artifactId>

--- a/artemis-server-osgi/pom.xml
+++ b/artemis-server-osgi/pom.xml
@@ -14,7 +14,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-server-osgi</artifactId>

--- a/artemis-server/pom.xml
+++ b/artemis-server/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-server</artifactId>

--- a/artemis-server/pom.xml
+++ b/artemis-server/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-server</artifactId>

--- a/artemis-service-extensions/pom.xml
+++ b/artemis-service-extensions/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-service-extensions</artifactId>

--- a/artemis-service-extensions/pom.xml
+++ b/artemis-service-extensions/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-service-extensions</artifactId>

--- a/artemis-web/pom.xml
+++ b/artemis-web/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-web</artifactId>

--- a/artemis-web/pom.xml
+++ b/artemis-web/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-web</artifactId>

--- a/artemis-website/pom.xml
+++ b/artemis-website/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-website</artifactId>

--- a/artemis-website/pom.xml
+++ b/artemis-website/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-website</artifactId>

--- a/docs/user-manual/en/versions.md
+++ b/docs/user-manual/en/versions.md
@@ -8,6 +8,12 @@ This chapter provides the following information for each release:
   - **Note:** Follow the general upgrade procedure outlined in the [Upgrading the Broker](upgrading.md) 
     chapter in addition to any version-specific upgrade instructions outlined here.
 
+## 2.23.1
+[Full release notes](https://issues.apache.org/jira/secure/ReleaseNote.jspa?version=12351846&projectId=12315920)
+
+Highlights:
+- [ARTEMIS-3856](https://issues.apache.org/jira/browse/ARTEMIS-3856) - Failed to change channel state to ReadyForWriting : java.util.ConcurrentModificationException
+
 ## 2.23.0
 [Full release notes](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315920&version=12351677).
 

--- a/examples/features/broker-connection/amqp-receiving-messages/pom.xml
+++ b/examples/features/broker-connection/amqp-receiving-messages/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker-connection</groupId>
       <artifactId>broker-connections</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>amqp-receiving-messages</artifactId>

--- a/examples/features/broker-connection/amqp-receiving-messages/pom.xml
+++ b/examples/features/broker-connection/amqp-receiving-messages/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker-connection</groupId>
       <artifactId>broker-connections</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>amqp-receiving-messages</artifactId>

--- a/examples/features/broker-connection/amqp-sending-messages-multicast/pom.xml
+++ b/examples/features/broker-connection/amqp-sending-messages-multicast/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker-connection</groupId>
       <artifactId>broker-connections</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>amqp-sending-messages-multicast</artifactId>

--- a/examples/features/broker-connection/amqp-sending-messages-multicast/pom.xml
+++ b/examples/features/broker-connection/amqp-sending-messages-multicast/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker-connection</groupId>
       <artifactId>broker-connections</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>amqp-sending-messages-multicast</artifactId>

--- a/examples/features/broker-connection/amqp-sending-messages/pom.xml
+++ b/examples/features/broker-connection/amqp-sending-messages/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker-connection</groupId>
       <artifactId>broker-connections</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>amqp-sending-messages</artifactId>

--- a/examples/features/broker-connection/amqp-sending-messages/pom.xml
+++ b/examples/features/broker-connection/amqp-sending-messages/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker-connection</groupId>
       <artifactId>broker-connections</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>amqp-sending-messages</artifactId>

--- a/examples/features/broker-connection/amqp-sending-overssl/pom.xml
+++ b/examples/features/broker-connection/amqp-sending-overssl/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker-connection</groupId>
       <artifactId>broker-connections</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>amqp-ssl-enabled</artifactId>

--- a/examples/features/broker-connection/amqp-sending-overssl/pom.xml
+++ b/examples/features/broker-connection/amqp-sending-overssl/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker-connection</groupId>
       <artifactId>broker-connections</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>amqp-ssl-enabled</artifactId>

--- a/examples/features/broker-connection/disaster-recovery/pom.xml
+++ b/examples/features/broker-connection/disaster-recovery/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker-connection</groupId>
       <artifactId>broker-connections</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>disaster-recovery</artifactId>

--- a/examples/features/broker-connection/disaster-recovery/pom.xml
+++ b/examples/features/broker-connection/disaster-recovery/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker-connection</groupId>
       <artifactId>broker-connections</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>disaster-recovery</artifactId>

--- a/examples/features/broker-connection/pom.xml
+++ b/examples/features/broker-connection/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-features</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.broker-connection</groupId>

--- a/examples/features/broker-connection/pom.xml
+++ b/examples/features/broker-connection/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-features</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.broker-connection</groupId>

--- a/examples/features/clustered/client-side-load-balancing/pom.xml
+++ b/examples/features/clustered/client-side-load-balancing/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>client-side-load-balancing</artifactId>

--- a/examples/features/clustered/client-side-load-balancing/pom.xml
+++ b/examples/features/clustered/client-side-load-balancing/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>client-side-load-balancing</artifactId>

--- a/examples/features/clustered/clustered-durable-subscription/pom.xml
+++ b/examples/features/clustered/clustered-durable-subscription/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>clustered-durable-subscription</artifactId>

--- a/examples/features/clustered/clustered-durable-subscription/pom.xml
+++ b/examples/features/clustered/clustered-durable-subscription/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>clustered-durable-subscription</artifactId>

--- a/examples/features/clustered/clustered-grouping/pom.xml
+++ b/examples/features/clustered/clustered-grouping/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>clustered-grouping</artifactId>

--- a/examples/features/clustered/clustered-grouping/pom.xml
+++ b/examples/features/clustered/clustered-grouping/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>clustered-grouping</artifactId>

--- a/examples/features/clustered/clustered-jgroups/pom.xml
+++ b/examples/features/clustered/clustered-jgroups/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>clustered-jgroups</artifactId>

--- a/examples/features/clustered/clustered-jgroups/pom.xml
+++ b/examples/features/clustered/clustered-jgroups/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>clustered-jgroups</artifactId>

--- a/examples/features/clustered/clustered-queue/pom.xml
+++ b/examples/features/clustered/clustered-queue/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>clustered-queue</artifactId>

--- a/examples/features/clustered/clustered-queue/pom.xml
+++ b/examples/features/clustered/clustered-queue/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>clustered-queue</artifactId>

--- a/examples/features/clustered/clustered-static-discovery-uri/pom.xml
+++ b/examples/features/clustered/clustered-static-discovery-uri/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>clustered-static-discovery-uri</artifactId>

--- a/examples/features/clustered/clustered-static-discovery-uri/pom.xml
+++ b/examples/features/clustered/clustered-static-discovery-uri/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>clustered-static-discovery-uri</artifactId>

--- a/examples/features/clustered/clustered-static-discovery/pom.xml
+++ b/examples/features/clustered/clustered-static-discovery/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>clustered-static-discovery</artifactId>

--- a/examples/features/clustered/clustered-static-discovery/pom.xml
+++ b/examples/features/clustered/clustered-static-discovery/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>clustered-static-discovery</artifactId>

--- a/examples/features/clustered/clustered-static-oneway/pom.xml
+++ b/examples/features/clustered/clustered-static-oneway/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>clustered-static-oneway</artifactId>

--- a/examples/features/clustered/clustered-static-oneway/pom.xml
+++ b/examples/features/clustered/clustered-static-oneway/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>clustered-static-oneway</artifactId>

--- a/examples/features/clustered/clustered-topic-uri/pom.xml
+++ b/examples/features/clustered/clustered-topic-uri/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>clustered-topic-uri</artifactId>

--- a/examples/features/clustered/clustered-topic-uri/pom.xml
+++ b/examples/features/clustered/clustered-topic-uri/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>clustered-topic-uri</artifactId>

--- a/examples/features/clustered/clustered-topic/pom.xml
+++ b/examples/features/clustered/clustered-topic/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>clustered-topic</artifactId>

--- a/examples/features/clustered/clustered-topic/pom.xml
+++ b/examples/features/clustered/clustered-topic/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>clustered-topic</artifactId>

--- a/examples/features/clustered/pom.xml
+++ b/examples/features/clustered/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-features</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.clustered</groupId>

--- a/examples/features/clustered/pom.xml
+++ b/examples/features/clustered/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-features</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.clustered</groupId>

--- a/examples/features/clustered/queue-message-redistribution/pom.xml
+++ b/examples/features/clustered/queue-message-redistribution/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>queue-message-redistribution</artifactId>

--- a/examples/features/clustered/queue-message-redistribution/pom.xml
+++ b/examples/features/clustered/queue-message-redistribution/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>queue-message-redistribution</artifactId>

--- a/examples/features/clustered/shared-storage-static-cluster/pom.xml
+++ b/examples/features/clustered/shared-storage-static-cluster/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>shared-storage-static-cluster</artifactId>

--- a/examples/features/clustered/shared-storage-static-cluster/pom.xml
+++ b/examples/features/clustered/shared-storage-static-cluster/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>shared-storage-static-cluster</artifactId>

--- a/examples/features/clustered/symmetric-cluster/pom.xml
+++ b/examples/features/clustered/symmetric-cluster/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>symmetric-cluster</artifactId>

--- a/examples/features/clustered/symmetric-cluster/pom.xml
+++ b/examples/features/clustered/symmetric-cluster/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>symmetric-cluster</artifactId>

--- a/examples/features/connection-router/evenly-redirect/pom.xml
+++ b/examples/features/connection-router/evenly-redirect/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples</groupId>
       <artifactId>connection-router</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>evenly-redirect</artifactId>

--- a/examples/features/connection-router/evenly-redirect/pom.xml
+++ b/examples/features/connection-router/evenly-redirect/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples</groupId>
       <artifactId>connection-router</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>evenly-redirect</artifactId>

--- a/examples/features/connection-router/pom.xml
+++ b/examples/features/connection-router/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-features</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <groupId>org.apache.activemq.examples</groupId>

--- a/examples/features/connection-router/pom.xml
+++ b/examples/features/connection-router/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-features</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <groupId>org.apache.activemq.examples</groupId>

--- a/examples/features/connection-router/symmetric-redirect/pom.xml
+++ b/examples/features/connection-router/symmetric-redirect/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples</groupId>
       <artifactId>connection-router</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>symmetric-redirect</artifactId>

--- a/examples/features/connection-router/symmetric-redirect/pom.xml
+++ b/examples/features/connection-router/symmetric-redirect/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples</groupId>
       <artifactId>connection-router</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>symmetric-redirect</artifactId>

--- a/examples/features/connection-router/symmetric-simple/pom.xml
+++ b/examples/features/connection-router/symmetric-simple/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples</groupId>
       <artifactId>connection-router</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>symmetric-simple</artifactId>

--- a/examples/features/connection-router/symmetric-simple/pom.xml
+++ b/examples/features/connection-router/symmetric-simple/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples</groupId>
       <artifactId>connection-router</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>symmetric-simple</artifactId>

--- a/examples/features/federation/federated-address-divert/pom.xml
+++ b/examples/features/federation/federated-address-divert/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.federation</groupId>
       <artifactId>broker-federation</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>federated-address-divert</artifactId>

--- a/examples/features/federation/federated-address-divert/pom.xml
+++ b/examples/features/federation/federated-address-divert/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.federation</groupId>
       <artifactId>broker-federation</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>federated-address-divert</artifactId>

--- a/examples/features/federation/federated-address-downstream-upstream/pom.xml
+++ b/examples/features/federation/federated-address-downstream-upstream/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.federation</groupId>
       <artifactId>broker-federation</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>federated-address-downstream-upstream</artifactId>

--- a/examples/features/federation/federated-address-downstream-upstream/pom.xml
+++ b/examples/features/federation/federated-address-downstream-upstream/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.federation</groupId>
       <artifactId>broker-federation</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>federated-address-downstream-upstream</artifactId>

--- a/examples/features/federation/federated-address-downstream/pom.xml
+++ b/examples/features/federation/federated-address-downstream/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.federation</groupId>
       <artifactId>broker-federation</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>federated-address-downstream</artifactId>

--- a/examples/features/federation/federated-address-downstream/pom.xml
+++ b/examples/features/federation/federated-address-downstream/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.federation</groupId>
       <artifactId>broker-federation</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>federated-address-downstream</artifactId>

--- a/examples/features/federation/federated-address/pom.xml
+++ b/examples/features/federation/federated-address/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.federation</groupId>
       <artifactId>broker-federation</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>federated-address</artifactId>

--- a/examples/features/federation/federated-address/pom.xml
+++ b/examples/features/federation/federated-address/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.federation</groupId>
       <artifactId>broker-federation</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>federated-address</artifactId>

--- a/examples/features/federation/federated-queue-downstream-upstream/pom.xml
+++ b/examples/features/federation/federated-queue-downstream-upstream/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.federation</groupId>
       <artifactId>broker-federation</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>federated-queue-downstream-upstream</artifactId>

--- a/examples/features/federation/federated-queue-downstream-upstream/pom.xml
+++ b/examples/features/federation/federated-queue-downstream-upstream/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.federation</groupId>
       <artifactId>broker-federation</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>federated-queue-downstream-upstream</artifactId>

--- a/examples/features/federation/federated-queue-downstream/pom.xml
+++ b/examples/features/federation/federated-queue-downstream/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.federation</groupId>
       <artifactId>broker-federation</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>federated-queue-downstream</artifactId>

--- a/examples/features/federation/federated-queue-downstream/pom.xml
+++ b/examples/features/federation/federated-queue-downstream/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.federation</groupId>
       <artifactId>broker-federation</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>federated-queue-downstream</artifactId>

--- a/examples/features/federation/federated-queue/pom.xml
+++ b/examples/features/federation/federated-queue/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.federation</groupId>
       <artifactId>broker-federation</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>federated-queue</artifactId>

--- a/examples/features/federation/federated-queue/pom.xml
+++ b/examples/features/federation/federated-queue/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.federation</groupId>
       <artifactId>broker-federation</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>federated-queue</artifactId>

--- a/examples/features/federation/pom.xml
+++ b/examples/features/federation/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-features</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.federation</groupId>

--- a/examples/features/federation/pom.xml
+++ b/examples/features/federation/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-features</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.federation</groupId>

--- a/examples/features/ha/application-layer-failover/pom.xml
+++ b/examples/features/ha/application-layer-failover/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>application-layer-failover</artifactId>

--- a/examples/features/ha/application-layer-failover/pom.xml
+++ b/examples/features/ha/application-layer-failover/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>application-layer-failover</artifactId>

--- a/examples/features/ha/client-side-failoverlistener/pom.xml
+++ b/examples/features/ha/client-side-failoverlistener/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>client-side-failoverlistener</artifactId>

--- a/examples/features/ha/client-side-failoverlistener/pom.xml
+++ b/examples/features/ha/client-side-failoverlistener/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>client-side-failoverlistener</artifactId>

--- a/examples/features/ha/colocated-failover-scale-down/pom.xml
+++ b/examples/features/ha/colocated-failover-scale-down/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>colocated-failover-scale-down</artifactId>

--- a/examples/features/ha/colocated-failover-scale-down/pom.xml
+++ b/examples/features/ha/colocated-failover-scale-down/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>colocated-failover-scale-down</artifactId>

--- a/examples/features/ha/colocated-failover/pom.xml
+++ b/examples/features/ha/colocated-failover/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>colocated-failover</artifactId>

--- a/examples/features/ha/colocated-failover/pom.xml
+++ b/examples/features/ha/colocated-failover/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>colocated-failover</artifactId>

--- a/examples/features/ha/ha-policy-autobackup/pom.xml
+++ b/examples/features/ha/ha-policy-autobackup/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>ha-policy-autobackup</artifactId>

--- a/examples/features/ha/ha-policy-autobackup/pom.xml
+++ b/examples/features/ha/ha-policy-autobackup/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>ha-policy-autobackup</artifactId>

--- a/examples/features/ha/multiple-failover-failback/pom.xml
+++ b/examples/features/ha/multiple-failover-failback/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>multiple-failover-failback</artifactId>

--- a/examples/features/ha/multiple-failover-failback/pom.xml
+++ b/examples/features/ha/multiple-failover-failback/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>multiple-failover-failback</artifactId>

--- a/examples/features/ha/multiple-failover/pom.xml
+++ b/examples/features/ha/multiple-failover/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>multiple-failover</artifactId>

--- a/examples/features/ha/multiple-failover/pom.xml
+++ b/examples/features/ha/multiple-failover/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>multiple-failover</artifactId>

--- a/examples/features/ha/non-transaction-failover/pom.xml
+++ b/examples/features/ha/non-transaction-failover/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>non-transaction-failover</artifactId>

--- a/examples/features/ha/non-transaction-failover/pom.xml
+++ b/examples/features/ha/non-transaction-failover/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>non-transaction-failover</artifactId>

--- a/examples/features/ha/pom.xml
+++ b/examples/features/ha/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-features</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.failover</groupId>

--- a/examples/features/ha/pom.xml
+++ b/examples/features/ha/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-features</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.failover</groupId>

--- a/examples/features/ha/replicated-failback-static/pom.xml
+++ b/examples/features/ha/replicated-failback-static/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>replicated-failback-static</artifactId>

--- a/examples/features/ha/replicated-failback-static/pom.xml
+++ b/examples/features/ha/replicated-failback-static/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>replicated-failback-static</artifactId>

--- a/examples/features/ha/replicated-failback/pom.xml
+++ b/examples/features/ha/replicated-failback/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>replicated-failback</artifactId>

--- a/examples/features/ha/replicated-failback/pom.xml
+++ b/examples/features/ha/replicated-failback/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>replicated-failback</artifactId>

--- a/examples/features/ha/replicated-multiple-failover/pom.xml
+++ b/examples/features/ha/replicated-multiple-failover/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>replicated-multiple-failover</artifactId>

--- a/examples/features/ha/replicated-multiple-failover/pom.xml
+++ b/examples/features/ha/replicated-multiple-failover/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>replicated-multiple-failover</artifactId>

--- a/examples/features/ha/replicated-transaction-failover/pom.xml
+++ b/examples/features/ha/replicated-transaction-failover/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>replicated-transaction-failover</artifactId>

--- a/examples/features/ha/replicated-transaction-failover/pom.xml
+++ b/examples/features/ha/replicated-transaction-failover/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>replicated-transaction-failover</artifactId>

--- a/examples/features/ha/scale-down/pom.xml
+++ b/examples/features/ha/scale-down/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>scale-down</artifactId>

--- a/examples/features/ha/scale-down/pom.xml
+++ b/examples/features/ha/scale-down/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>scale-down</artifactId>

--- a/examples/features/ha/stop-server-failover/pom.xml
+++ b/examples/features/ha/stop-server-failover/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>stop-server-failover</artifactId>

--- a/examples/features/ha/stop-server-failover/pom.xml
+++ b/examples/features/ha/stop-server-failover/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>stop-server-failover</artifactId>

--- a/examples/features/ha/transaction-failover/pom.xml
+++ b/examples/features/ha/transaction-failover/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>transaction-failover</artifactId>

--- a/examples/features/ha/transaction-failover/pom.xml
+++ b/examples/features/ha/transaction-failover/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>transaction-failover</artifactId>

--- a/examples/features/ha/zookeeper-single-pair-failback/pom.xml
+++ b/examples/features/ha/zookeeper-single-pair-failback/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>zookeeper-single-pair-failback</artifactId>

--- a/examples/features/ha/zookeeper-single-pair-failback/pom.xml
+++ b/examples/features/ha/zookeeper-single-pair-failback/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>zookeeper-single-pair-failback</artifactId>

--- a/examples/features/perf/perf/pom.xml
+++ b/examples/features/perf/perf/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.soak</groupId>
       <artifactId>perf-root</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>openwire-perf</artifactId>

--- a/examples/features/perf/perf/pom.xml
+++ b/examples/features/perf/perf/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.soak</groupId>
       <artifactId>perf-root</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>openwire-perf</artifactId>

--- a/examples/features/perf/pom.xml
+++ b/examples/features/perf/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-features</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.soak</groupId>

--- a/examples/features/perf/pom.xml
+++ b/examples/features/perf/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-features</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.soak</groupId>

--- a/examples/features/perf/soak/pom.xml
+++ b/examples/features/perf/soak/pom.xml
@@ -28,7 +28,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.soak</groupId>
       <artifactId>perf-root</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <dependencies>

--- a/examples/features/perf/soak/pom.xml
+++ b/examples/features/perf/soak/pom.xml
@@ -28,7 +28,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.soak</groupId>
       <artifactId>perf-root</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <dependencies>

--- a/examples/features/pom.xml
+++ b/examples/features/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples</groupId>
       <artifactId>artemis-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.clustered</groupId>

--- a/examples/features/pom.xml
+++ b/examples/features/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples</groupId>
       <artifactId>artemis-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.clustered</groupId>

--- a/examples/features/standard/auto-closeable/pom.xml
+++ b/examples/features/standard/auto-closeable/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>auto-closeable</artifactId>

--- a/examples/features/standard/auto-closeable/pom.xml
+++ b/examples/features/standard/auto-closeable/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>auto-closeable</artifactId>

--- a/examples/features/standard/broker-msg-auth-plugin/pom.xml
+++ b/examples/features/standard/broker-msg-auth-plugin/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
     <artifactId>broker-msg-auth-plugin</artifactId>

--- a/examples/features/standard/broker-msg-auth-plugin/pom.xml
+++ b/examples/features/standard/broker-msg-auth-plugin/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
     <artifactId>broker-msg-auth-plugin</artifactId>

--- a/examples/features/standard/broker-plugin/pom.xml
+++ b/examples/features/standard/broker-plugin/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>broker-plugin</artifactId>

--- a/examples/features/standard/broker-plugin/pom.xml
+++ b/examples/features/standard/broker-plugin/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>broker-plugin</artifactId>

--- a/examples/features/standard/browser/pom.xml
+++ b/examples/features/standard/browser/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>browser</artifactId>

--- a/examples/features/standard/browser/pom.xml
+++ b/examples/features/standard/browser/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>browser</artifactId>

--- a/examples/features/standard/camel/camel-broker/pom.xml
+++ b/examples/features/standard/camel/camel-broker/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker.camel</groupId>
       <artifactId>camel</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>camel-broker</artifactId>

--- a/examples/features/standard/camel/camel-broker/pom.xml
+++ b/examples/features/standard/camel/camel-broker/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker.camel</groupId>
       <artifactId>camel</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>camel-broker</artifactId>

--- a/examples/features/standard/camel/camel-war/pom.xml
+++ b/examples/features/standard/camel/camel-war/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker.camel</groupId>
       <artifactId>camel</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>camel-war</artifactId>

--- a/examples/features/standard/camel/camel-war/pom.xml
+++ b/examples/features/standard/camel/camel-war/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker.camel</groupId>
       <artifactId>camel</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>camel-war</artifactId>

--- a/examples/features/standard/camel/pom.xml
+++ b/examples/features/standard/camel/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.broker.camel</groupId>

--- a/examples/features/standard/camel/pom.xml
+++ b/examples/features/standard/camel/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.broker.camel</groupId>

--- a/examples/features/standard/cdi/pom.xml
+++ b/examples/features/standard/cdi/pom.xml
@@ -24,7 +24,7 @@
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>cdi</artifactId>

--- a/examples/features/standard/cdi/pom.xml
+++ b/examples/features/standard/cdi/pom.xml
@@ -24,7 +24,7 @@
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>cdi</artifactId>

--- a/examples/features/standard/client-kickoff/pom.xml
+++ b/examples/features/standard/client-kickoff/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>client-kickoff</artifactId>

--- a/examples/features/standard/client-kickoff/pom.xml
+++ b/examples/features/standard/client-kickoff/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>client-kickoff</artifactId>

--- a/examples/features/standard/completion-listener/pom.xml
+++ b/examples/features/standard/completion-listener/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>completion-listener</artifactId>

--- a/examples/features/standard/completion-listener/pom.xml
+++ b/examples/features/standard/completion-listener/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>completion-listener</artifactId>

--- a/examples/features/standard/consumer-rate-limit/pom.xml
+++ b/examples/features/standard/consumer-rate-limit/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>consumer-rate-limit</artifactId>

--- a/examples/features/standard/consumer-rate-limit/pom.xml
+++ b/examples/features/standard/consumer-rate-limit/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>consumer-rate-limit</artifactId>

--- a/examples/features/standard/context/pom.xml
+++ b/examples/features/standard/context/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>context</artifactId>

--- a/examples/features/standard/context/pom.xml
+++ b/examples/features/standard/context/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>context</artifactId>

--- a/examples/features/standard/core-bridge/pom.xml
+++ b/examples/features/standard/core-bridge/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>core-bridge</artifactId>

--- a/examples/features/standard/core-bridge/pom.xml
+++ b/examples/features/standard/core-bridge/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>core-bridge</artifactId>

--- a/examples/features/standard/database/pom.xml
+++ b/examples/features/standard/database/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>database</artifactId>

--- a/examples/features/standard/database/pom.xml
+++ b/examples/features/standard/database/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>database</artifactId>

--- a/examples/features/standard/dead-letter/pom.xml
+++ b/examples/features/standard/dead-letter/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>dead-letter</artifactId>

--- a/examples/features/standard/dead-letter/pom.xml
+++ b/examples/features/standard/dead-letter/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>dead-letter</artifactId>

--- a/examples/features/standard/delayed-redelivery/pom.xml
+++ b/examples/features/standard/delayed-redelivery/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>delayed-redelivery</artifactId>

--- a/examples/features/standard/delayed-redelivery/pom.xml
+++ b/examples/features/standard/delayed-redelivery/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>delayed-redelivery</artifactId>

--- a/examples/features/standard/divert/pom.xml
+++ b/examples/features/standard/divert/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
    <artifactId>divert</artifactId>
    <packaging>jar</packaging>

--- a/examples/features/standard/divert/pom.xml
+++ b/examples/features/standard/divert/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
    <artifactId>divert</artifactId>
    <packaging>jar</packaging>

--- a/examples/features/standard/durable-subscription/pom.xml
+++ b/examples/features/standard/durable-subscription/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>durable-subscription</artifactId>

--- a/examples/features/standard/durable-subscription/pom.xml
+++ b/examples/features/standard/durable-subscription/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>durable-subscription</artifactId>

--- a/examples/features/standard/embedded-simple/pom.xml
+++ b/examples/features/standard/embedded-simple/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>embedded-simple</artifactId>

--- a/examples/features/standard/embedded-simple/pom.xml
+++ b/examples/features/standard/embedded-simple/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>embedded-simple</artifactId>

--- a/examples/features/standard/embedded/pom.xml
+++ b/examples/features/standard/embedded/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>embedded</artifactId>

--- a/examples/features/standard/embedded/pom.xml
+++ b/examples/features/standard/embedded/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>embedded</artifactId>

--- a/examples/features/standard/exclusive-queue/pom.xml
+++ b/examples/features/standard/exclusive-queue/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>exclusive-queue</artifactId>

--- a/examples/features/standard/exclusive-queue/pom.xml
+++ b/examples/features/standard/exclusive-queue/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>exclusive-queue</artifactId>

--- a/examples/features/standard/expiry/pom.xml
+++ b/examples/features/standard/expiry/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>expiry</artifactId>

--- a/examples/features/standard/expiry/pom.xml
+++ b/examples/features/standard/expiry/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>expiry</artifactId>

--- a/examples/features/standard/http-transport/pom.xml
+++ b/examples/features/standard/http-transport/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>http-transport</artifactId>

--- a/examples/features/standard/http-transport/pom.xml
+++ b/examples/features/standard/http-transport/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>http-transport</artifactId>

--- a/examples/features/standard/instantiate-connection-factory/pom.xml
+++ b/examples/features/standard/instantiate-connection-factory/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>instantiate-connection-factory</artifactId>

--- a/examples/features/standard/instantiate-connection-factory/pom.xml
+++ b/examples/features/standard/instantiate-connection-factory/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>instantiate-connection-factory</artifactId>

--- a/examples/features/standard/interceptor-amqp/pom.xml
+++ b/examples/features/standard/interceptor-amqp/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>interceptor-amqp</artifactId>

--- a/examples/features/standard/interceptor-amqp/pom.xml
+++ b/examples/features/standard/interceptor-amqp/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>interceptor-amqp</artifactId>

--- a/examples/features/standard/interceptor-client/pom.xml
+++ b/examples/features/standard/interceptor-client/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>interceptor-client</artifactId>

--- a/examples/features/standard/interceptor-client/pom.xml
+++ b/examples/features/standard/interceptor-client/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>interceptor-client</artifactId>

--- a/examples/features/standard/interceptor-mqtt/pom.xml
+++ b/examples/features/standard/interceptor-mqtt/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>interceptor-mqtt</artifactId>

--- a/examples/features/standard/interceptor-mqtt/pom.xml
+++ b/examples/features/standard/interceptor-mqtt/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>interceptor-mqtt</artifactId>

--- a/examples/features/standard/interceptor/pom.xml
+++ b/examples/features/standard/interceptor/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>interceptor</artifactId>

--- a/examples/features/standard/interceptor/pom.xml
+++ b/examples/features/standard/interceptor/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>interceptor</artifactId>

--- a/examples/features/standard/jms-bridge/pom.xml
+++ b/examples/features/standard/jms-bridge/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>jms-bridge</artifactId>

--- a/examples/features/standard/jms-bridge/pom.xml
+++ b/examples/features/standard/jms-bridge/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>jms-bridge</artifactId>

--- a/examples/features/standard/jmx-ssl/pom.xml
+++ b/examples/features/standard/jmx-ssl/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>jmx-ssl</artifactId>

--- a/examples/features/standard/jmx-ssl/pom.xml
+++ b/examples/features/standard/jmx-ssl/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>jmx-ssl</artifactId>

--- a/examples/features/standard/jmx/pom.xml
+++ b/examples/features/standard/jmx/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>jmx</artifactId>

--- a/examples/features/standard/jmx/pom.xml
+++ b/examples/features/standard/jmx/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>jmx</artifactId>

--- a/examples/features/standard/large-message/pom.xml
+++ b/examples/features/standard/large-message/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>large-message</artifactId>

--- a/examples/features/standard/large-message/pom.xml
+++ b/examples/features/standard/large-message/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>large-message</artifactId>

--- a/examples/features/standard/last-value-queue/pom.xml
+++ b/examples/features/standard/last-value-queue/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>last-value-queue</artifactId>

--- a/examples/features/standard/last-value-queue/pom.xml
+++ b/examples/features/standard/last-value-queue/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>last-value-queue</artifactId>

--- a/examples/features/standard/management-notifications/pom.xml
+++ b/examples/features/standard/management-notifications/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>management-notifications</artifactId>

--- a/examples/features/standard/management-notifications/pom.xml
+++ b/examples/features/standard/management-notifications/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>management-notifications</artifactId>

--- a/examples/features/standard/management/pom.xml
+++ b/examples/features/standard/management/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>management</artifactId>

--- a/examples/features/standard/management/pom.xml
+++ b/examples/features/standard/management/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>management</artifactId>

--- a/examples/features/standard/message-counters/pom.xml
+++ b/examples/features/standard/message-counters/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>message-counters</artifactId>

--- a/examples/features/standard/message-counters/pom.xml
+++ b/examples/features/standard/message-counters/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>message-counters</artifactId>

--- a/examples/features/standard/message-group/pom.xml
+++ b/examples/features/standard/message-group/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>message-group</artifactId>

--- a/examples/features/standard/message-group/pom.xml
+++ b/examples/features/standard/message-group/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>message-group</artifactId>

--- a/examples/features/standard/message-group2/pom.xml
+++ b/examples/features/standard/message-group2/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>message-group2</artifactId>

--- a/examples/features/standard/message-group2/pom.xml
+++ b/examples/features/standard/message-group2/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>message-group2</artifactId>

--- a/examples/features/standard/message-priority/pom.xml
+++ b/examples/features/standard/message-priority/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>message-priority</artifactId>

--- a/examples/features/standard/message-priority/pom.xml
+++ b/examples/features/standard/message-priority/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>message-priority</artifactId>

--- a/examples/features/standard/netty-openssl/pom.xml
+++ b/examples/features/standard/netty-openssl/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>netty-openssl</artifactId>

--- a/examples/features/standard/netty-openssl/pom.xml
+++ b/examples/features/standard/netty-openssl/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>netty-openssl</artifactId>

--- a/examples/features/standard/no-consumer-buffering/pom.xml
+++ b/examples/features/standard/no-consumer-buffering/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>no-consumer-buffering</artifactId>

--- a/examples/features/standard/no-consumer-buffering/pom.xml
+++ b/examples/features/standard/no-consumer-buffering/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>no-consumer-buffering</artifactId>

--- a/examples/features/standard/opentracing/pom.xml
+++ b/examples/features/standard/opentracing/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>opentracing</artifactId>

--- a/examples/features/standard/opentracing/pom.xml
+++ b/examples/features/standard/opentracing/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>opentracing</artifactId>

--- a/examples/features/standard/paging/pom.xml
+++ b/examples/features/standard/paging/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>paging</artifactId>

--- a/examples/features/standard/paging/pom.xml
+++ b/examples/features/standard/paging/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>paging</artifactId>

--- a/examples/features/standard/pom.xml
+++ b/examples/features/standard/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-features</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.broker</groupId>

--- a/examples/features/standard/pom.xml
+++ b/examples/features/standard/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-features</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.broker</groupId>

--- a/examples/features/standard/pre-acknowledge/pom.xml
+++ b/examples/features/standard/pre-acknowledge/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>pre-acknowledge</artifactId>

--- a/examples/features/standard/pre-acknowledge/pom.xml
+++ b/examples/features/standard/pre-acknowledge/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>pre-acknowledge</artifactId>

--- a/examples/features/standard/producer-rate-limit/pom.xml
+++ b/examples/features/standard/producer-rate-limit/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>producer-rate-limit</artifactId>

--- a/examples/features/standard/producer-rate-limit/pom.xml
+++ b/examples/features/standard/producer-rate-limit/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>producer-rate-limit</artifactId>

--- a/examples/features/standard/queue-jakarta/pom.xml
+++ b/examples/features/standard/queue-jakarta/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>queue-jakarta</artifactId>

--- a/examples/features/standard/queue-jakarta/pom.xml
+++ b/examples/features/standard/queue-jakarta/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>queue-jakarta</artifactId>

--- a/examples/features/standard/queue-requestor/pom.xml
+++ b/examples/features/standard/queue-requestor/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>queue-requestor</artifactId>

--- a/examples/features/standard/queue-requestor/pom.xml
+++ b/examples/features/standard/queue-requestor/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>queue-requestor</artifactId>

--- a/examples/features/standard/queue-selector/pom.xml
+++ b/examples/features/standard/queue-selector/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>queue-selector</artifactId>

--- a/examples/features/standard/queue-selector/pom.xml
+++ b/examples/features/standard/queue-selector/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>queue-selector</artifactId>

--- a/examples/features/standard/queue/pom.xml
+++ b/examples/features/standard/queue/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>queue</artifactId>

--- a/examples/features/standard/queue/pom.xml
+++ b/examples/features/standard/queue/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>queue</artifactId>

--- a/examples/features/standard/reattach-node/pom.xml
+++ b/examples/features/standard/reattach-node/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>reattach-node</artifactId>

--- a/examples/features/standard/reattach-node/pom.xml
+++ b/examples/features/standard/reattach-node/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>reattach-node</artifactId>

--- a/examples/features/standard/request-reply/pom.xml
+++ b/examples/features/standard/request-reply/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>request-reply</artifactId>

--- a/examples/features/standard/request-reply/pom.xml
+++ b/examples/features/standard/request-reply/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>request-reply</artifactId>

--- a/examples/features/standard/rest/dup-send/pom.xml
+++ b/examples/features/standard/rest/dup-send/pom.xml
@@ -23,7 +23,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.rest</groupId>
       <artifactId>artemis-rests-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
    <artifactId>dup-send</artifactId>
    <packaging>war</packaging>

--- a/examples/features/standard/rest/dup-send/pom.xml
+++ b/examples/features/standard/rest/dup-send/pom.xml
@@ -23,7 +23,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.rest</groupId>
       <artifactId>artemis-rests-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
    <artifactId>dup-send</artifactId>
    <packaging>war</packaging>

--- a/examples/features/standard/rest/javascript-chat/pom.xml
+++ b/examples/features/standard/rest/javascript-chat/pom.xml
@@ -23,7 +23,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.rest</groupId>
       <artifactId>artemis-rests-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
    <artifactId>javascript-chat</artifactId>
    <packaging>war</packaging>

--- a/examples/features/standard/rest/javascript-chat/pom.xml
+++ b/examples/features/standard/rest/javascript-chat/pom.xml
@@ -23,7 +23,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.rest</groupId>
       <artifactId>artemis-rests-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
    <artifactId>javascript-chat</artifactId>
    <packaging>war</packaging>

--- a/examples/features/standard/rest/jms-to-rest/pom.xml
+++ b/examples/features/standard/rest/jms-to-rest/pom.xml
@@ -23,7 +23,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.rest</groupId>
       <artifactId>artemis-rests-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
    <artifactId>mixed-jms-rest</artifactId>
    <packaging>war</packaging>

--- a/examples/features/standard/rest/jms-to-rest/pom.xml
+++ b/examples/features/standard/rest/jms-to-rest/pom.xml
@@ -23,7 +23,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.rest</groupId>
       <artifactId>artemis-rests-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
    <artifactId>mixed-jms-rest</artifactId>
    <packaging>war</packaging>

--- a/examples/features/standard/rest/pom.xml
+++ b/examples/features/standard/rest/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.rest</groupId>

--- a/examples/features/standard/rest/pom.xml
+++ b/examples/features/standard/rest/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.rest</groupId>

--- a/examples/features/standard/rest/push/pom.xml
+++ b/examples/features/standard/rest/push/pom.xml
@@ -23,7 +23,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.rest</groupId>
       <artifactId>artemis-rests-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
    <artifactId>push</artifactId>
    <packaging>war</packaging>

--- a/examples/features/standard/rest/push/pom.xml
+++ b/examples/features/standard/rest/push/pom.xml
@@ -23,7 +23,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.rest</groupId>
       <artifactId>artemis-rests-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
    <artifactId>push</artifactId>
    <packaging>war</packaging>

--- a/examples/features/standard/scheduled-message/pom.xml
+++ b/examples/features/standard/scheduled-message/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>scheduled-message</artifactId>

--- a/examples/features/standard/scheduled-message/pom.xml
+++ b/examples/features/standard/scheduled-message/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>scheduled-message</artifactId>

--- a/examples/features/standard/security-keycloak/pom.xml
+++ b/examples/features/standard/security-keycloak/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>security-keycloak</artifactId>

--- a/examples/features/standard/security-keycloak/pom.xml
+++ b/examples/features/standard/security-keycloak/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>security-keycloak</artifactId>

--- a/examples/features/standard/security-ldap/pom.xml
+++ b/examples/features/standard/security-ldap/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>security-ldap</artifactId>

--- a/examples/features/standard/security-ldap/pom.xml
+++ b/examples/features/standard/security-ldap/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>security-ldap</artifactId>

--- a/examples/features/standard/security-manager/pom.xml
+++ b/examples/features/standard/security-manager/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>security-manager</artifactId>

--- a/examples/features/standard/security-manager/pom.xml
+++ b/examples/features/standard/security-manager/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>security-manager</artifactId>

--- a/examples/features/standard/security/pom.xml
+++ b/examples/features/standard/security/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>security</artifactId>

--- a/examples/features/standard/security/pom.xml
+++ b/examples/features/standard/security/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>security</artifactId>

--- a/examples/features/standard/send-acknowledgements/pom.xml
+++ b/examples/features/standard/send-acknowledgements/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>send-acknowledgements</artifactId>

--- a/examples/features/standard/send-acknowledgements/pom.xml
+++ b/examples/features/standard/send-acknowledgements/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>send-acknowledgements</artifactId>

--- a/examples/features/standard/shared-consumer/pom.xml
+++ b/examples/features/standard/shared-consumer/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>shared-consumer</artifactId>

--- a/examples/features/standard/shared-consumer/pom.xml
+++ b/examples/features/standard/shared-consumer/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>shared-consumer</artifactId>

--- a/examples/features/standard/slow-consumer/pom.xml
+++ b/examples/features/standard/slow-consumer/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>slow-consumer</artifactId>

--- a/examples/features/standard/slow-consumer/pom.xml
+++ b/examples/features/standard/slow-consumer/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>slow-consumer</artifactId>

--- a/examples/features/standard/spring-boot-integration/pom.xml
+++ b/examples/features/standard/spring-boot-integration/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>org.apache.activemq.examples.broker</groupId>
 		<artifactId>jms-examples</artifactId>
-		<version>2.23.1</version>
+		<version>2.23.2-SNAPSHOT</version>
 	</parent>
 	<artifactId>spring-boot-integration</artifactId>
 	<name>ActiveMQ Artemis JMS Spring Boot Integration Example</name>

--- a/examples/features/standard/spring-boot-integration/pom.xml
+++ b/examples/features/standard/spring-boot-integration/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>org.apache.activemq.examples.broker</groupId>
 		<artifactId>jms-examples</artifactId>
-		<version>2.24.0-SNAPSHOT</version>
+		<version>2.23.1</version>
 	</parent>
 	<artifactId>spring-boot-integration</artifactId>
 	<name>ActiveMQ Artemis JMS Spring Boot Integration Example</name>

--- a/examples/features/standard/spring-integration/pom.xml
+++ b/examples/features/standard/spring-integration/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>spring-integration</artifactId>

--- a/examples/features/standard/spring-integration/pom.xml
+++ b/examples/features/standard/spring-integration/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>spring-integration</artifactId>

--- a/examples/features/standard/ssl-enabled-crl-mqtt/pom.xml
+++ b/examples/features/standard/ssl-enabled-crl-mqtt/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.activemq.examples.broker</groupId>
         <artifactId>jms-examples</artifactId>
-        <version>2.23.1</version>
+        <version>2.23.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>ssl-enabled-crl-mqtt</artifactId>

--- a/examples/features/standard/ssl-enabled-crl-mqtt/pom.xml
+++ b/examples/features/standard/ssl-enabled-crl-mqtt/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.activemq.examples.broker</groupId>
         <artifactId>jms-examples</artifactId>
-        <version>2.24.0-SNAPSHOT</version>
+        <version>2.23.1</version>
     </parent>
 
     <artifactId>ssl-enabled-crl-mqtt</artifactId>

--- a/examples/features/standard/ssl-enabled-dual-authentication/pom.xml
+++ b/examples/features/standard/ssl-enabled-dual-authentication/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>ssl-enabled-dual-authentication</artifactId>

--- a/examples/features/standard/ssl-enabled-dual-authentication/pom.xml
+++ b/examples/features/standard/ssl-enabled-dual-authentication/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>ssl-enabled-dual-authentication</artifactId>

--- a/examples/features/standard/ssl-enabled/pom.xml
+++ b/examples/features/standard/ssl-enabled/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>ssl-enabled</artifactId>

--- a/examples/features/standard/ssl-enabled/pom.xml
+++ b/examples/features/standard/ssl-enabled/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>ssl-enabled</artifactId>

--- a/examples/features/standard/static-selector/pom.xml
+++ b/examples/features/standard/static-selector/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>static-selector</artifactId>

--- a/examples/features/standard/static-selector/pom.xml
+++ b/examples/features/standard/static-selector/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>static-selector</artifactId>

--- a/examples/features/standard/temp-queue/pom.xml
+++ b/examples/features/standard/temp-queue/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>temp-queue</artifactId>

--- a/examples/features/standard/temp-queue/pom.xml
+++ b/examples/features/standard/temp-queue/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>temp-queue</artifactId>

--- a/examples/features/standard/topic-hierarchies/pom.xml
+++ b/examples/features/standard/topic-hierarchies/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>topic-hierarchies</artifactId>

--- a/examples/features/standard/topic-hierarchies/pom.xml
+++ b/examples/features/standard/topic-hierarchies/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>topic-hierarchies</artifactId>

--- a/examples/features/standard/topic-selector1/pom.xml
+++ b/examples/features/standard/topic-selector1/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>topic-selector1</artifactId>

--- a/examples/features/standard/topic-selector1/pom.xml
+++ b/examples/features/standard/topic-selector1/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>topic-selector1</artifactId>

--- a/examples/features/standard/topic-selector2/pom.xml
+++ b/examples/features/standard/topic-selector2/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>topic-selector2</artifactId>

--- a/examples/features/standard/topic-selector2/pom.xml
+++ b/examples/features/standard/topic-selector2/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>topic-selector2</artifactId>

--- a/examples/features/standard/topic/pom.xml
+++ b/examples/features/standard/topic/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>topic</artifactId>

--- a/examples/features/standard/topic/pom.xml
+++ b/examples/features/standard/topic/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>topic</artifactId>

--- a/examples/features/standard/transactional/pom.xml
+++ b/examples/features/standard/transactional/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>transactional</artifactId>

--- a/examples/features/standard/transactional/pom.xml
+++ b/examples/features/standard/transactional/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>transactional</artifactId>

--- a/examples/features/standard/xa-heuristic/pom.xml
+++ b/examples/features/standard/xa-heuristic/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>xa-heuristic</artifactId>

--- a/examples/features/standard/xa-heuristic/pom.xml
+++ b/examples/features/standard/xa-heuristic/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>xa-heuristic</artifactId>

--- a/examples/features/standard/xa-receive/pom.xml
+++ b/examples/features/standard/xa-receive/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>xa-receive</artifactId>

--- a/examples/features/standard/xa-receive/pom.xml
+++ b/examples/features/standard/xa-receive/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>xa-receive</artifactId>

--- a/examples/features/standard/xa-send/pom.xml
+++ b/examples/features/standard/xa-send/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>xa-send</artifactId>

--- a/examples/features/standard/xa-send/pom.xml
+++ b/examples/features/standard/xa-send/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>xa-send</artifactId>

--- a/examples/features/sub-modules/artemis-jakarta-ra-rar/pom.xml
+++ b/examples/features/sub-modules/artemis-jakarta-ra-rar/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.modules</groupId>
       <artifactId>broker-modules</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-jakarta-rar</artifactId>

--- a/examples/features/sub-modules/artemis-jakarta-ra-rar/pom.xml
+++ b/examples/features/sub-modules/artemis-jakarta-ra-rar/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.modules</groupId>
       <artifactId>broker-modules</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-jakarta-rar</artifactId>

--- a/examples/features/sub-modules/artemis-ra-rar/pom.xml
+++ b/examples/features/sub-modules/artemis-ra-rar/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.modules</groupId>
       <artifactId>broker-modules</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-rar</artifactId>

--- a/examples/features/sub-modules/artemis-ra-rar/pom.xml
+++ b/examples/features/sub-modules/artemis-ra-rar/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.modules</groupId>
       <artifactId>broker-modules</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-rar</artifactId>

--- a/examples/features/sub-modules/inter-broker-bridge/artemis-jms-bridge/pom.xml
+++ b/examples/features/sub-modules/inter-broker-bridge/artemis-jms-bridge/pom.xml
@@ -25,7 +25,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.modules</groupId>
       <artifactId>inter-broker-bridge-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-jms-bridge</artifactId>

--- a/examples/features/sub-modules/inter-broker-bridge/artemis-jms-bridge/pom.xml
+++ b/examples/features/sub-modules/inter-broker-bridge/artemis-jms-bridge/pom.xml
@@ -25,7 +25,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.modules</groupId>
       <artifactId>inter-broker-bridge-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-jms-bridge</artifactId>

--- a/examples/features/sub-modules/inter-broker-bridge/pom.xml
+++ b/examples/features/sub-modules/inter-broker-bridge/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.modules</groupId>
       <artifactId>broker-modules</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.modules</groupId>

--- a/examples/features/sub-modules/inter-broker-bridge/pom.xml
+++ b/examples/features/sub-modules/inter-broker-bridge/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.modules</groupId>
       <artifactId>broker-modules</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.modules</groupId>

--- a/examples/features/sub-modules/pom.xml
+++ b/examples/features/sub-modules/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-features</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.modules</groupId>

--- a/examples/features/sub-modules/pom.xml
+++ b/examples/features/sub-modules/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.clustered</groupId>
       <artifactId>broker-features</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.modules</groupId>

--- a/examples/features/sub-modules/tomcat/pom.xml
+++ b/examples/features/sub-modules/tomcat/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.activemq.examples.modules</groupId>
         <artifactId>broker-modules</artifactId>
-        <version>2.23.1</version>
+        <version>2.23.2-SNAPSHOT</version>
     </parent>
 
 

--- a/examples/features/sub-modules/tomcat/pom.xml
+++ b/examples/features/sub-modules/tomcat/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.activemq.examples.modules</groupId>
         <artifactId>broker-modules</artifactId>
-        <version>2.24.0-SNAPSHOT</version>
+        <version>2.23.1</version>
     </parent>
 
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <groupId>org.apache.activemq.examples</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <groupId>org.apache.activemq.examples</groupId>

--- a/examples/protocols/amqp/pom.xml
+++ b/examples/protocols/amqp/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.protocols</groupId>
       <artifactId>protocols</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.amqp</groupId>

--- a/examples/protocols/amqp/pom.xml
+++ b/examples/protocols/amqp/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.protocols</groupId>
       <artifactId>protocols</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.amqp</groupId>

--- a/examples/protocols/amqp/proton-clustered-cpp/pom.xml
+++ b/examples/protocols/amqp/proton-clustered-cpp/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.amqp</groupId>
       <artifactId>amqp</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>proton-clustered-cpp</artifactId>

--- a/examples/protocols/amqp/proton-clustered-cpp/pom.xml
+++ b/examples/protocols/amqp/proton-clustered-cpp/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.amqp</groupId>
       <artifactId>amqp</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>proton-clustered-cpp</artifactId>

--- a/examples/protocols/amqp/proton-cpp/pom.xml
+++ b/examples/protocols/amqp/proton-cpp/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.amqp</groupId>
       <artifactId>amqp</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>protoncpp</artifactId>

--- a/examples/protocols/amqp/proton-cpp/pom.xml
+++ b/examples/protocols/amqp/proton-cpp/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.amqp</groupId>
       <artifactId>amqp</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>protoncpp</artifactId>

--- a/examples/protocols/amqp/proton-ruby/pom.xml
+++ b/examples/protocols/amqp/proton-ruby/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.amqp</groupId>
       <artifactId>amqp</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>proton-ruby</artifactId>

--- a/examples/protocols/amqp/proton-ruby/pom.xml
+++ b/examples/protocols/amqp/proton-ruby/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.amqp</groupId>
       <artifactId>amqp</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>proton-ruby</artifactId>

--- a/examples/protocols/amqp/queue/pom.xml
+++ b/examples/protocols/amqp/queue/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.amqp</groupId>
       <artifactId>amqp</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>queue</artifactId>

--- a/examples/protocols/amqp/queue/pom.xml
+++ b/examples/protocols/amqp/queue/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.amqp</groupId>
       <artifactId>amqp</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>queue</artifactId>

--- a/examples/protocols/amqp/sasl-scram/pom.xml
+++ b/examples/protocols/amqp/sasl-scram/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.activemq.examples.amqp</groupId>
         <artifactId>amqp</artifactId>
-        <version>2.23.1</version>
+        <version>2.23.2-SNAPSHOT</version>
     </parent>
     <properties>
         <activemq.basedir>${project.basedir}/../../../..</activemq.basedir>

--- a/examples/protocols/amqp/sasl-scram/pom.xml
+++ b/examples/protocols/amqp/sasl-scram/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.activemq.examples.amqp</groupId>
         <artifactId>amqp</artifactId>
-        <version>2.24.0-SNAPSHOT</version>
+        <version>2.23.1</version>
     </parent>
     <properties>
         <activemq.basedir>${project.basedir}/../../../..</activemq.basedir>

--- a/examples/protocols/mqtt/clustered-queue-mqtt/pom.xml
+++ b/examples/protocols/mqtt/clustered-queue-mqtt/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.mqtt</groupId>
       <artifactId>mqtt-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>clustered-queue-mqtt</artifactId>

--- a/examples/protocols/mqtt/clustered-queue-mqtt/pom.xml
+++ b/examples/protocols/mqtt/clustered-queue-mqtt/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.mqtt</groupId>
       <artifactId>mqtt-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>clustered-queue-mqtt</artifactId>

--- a/examples/protocols/mqtt/pom.xml
+++ b/examples/protocols/mqtt/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.protocols</groupId>
       <artifactId>protocols</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.mqtt</groupId>

--- a/examples/protocols/mqtt/pom.xml
+++ b/examples/protocols/mqtt/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.protocols</groupId>
       <artifactId>protocols</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.mqtt</groupId>

--- a/examples/protocols/mqtt/publish-subscribe/pom.xml
+++ b/examples/protocols/mqtt/publish-subscribe/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.mqtt</groupId>
       <artifactId>mqtt-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>publish-subscribe</artifactId>

--- a/examples/protocols/mqtt/publish-subscribe/pom.xml
+++ b/examples/protocols/mqtt/publish-subscribe/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.mqtt</groupId>
       <artifactId>mqtt-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>publish-subscribe</artifactId>

--- a/examples/protocols/openwire/chat/pom.xml
+++ b/examples/protocols/openwire/chat/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.openwire</groupId>
       <artifactId>openwire-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>chat-example</artifactId>

--- a/examples/protocols/openwire/chat/pom.xml
+++ b/examples/protocols/openwire/chat/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.openwire</groupId>
       <artifactId>openwire-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>chat-example</artifactId>

--- a/examples/protocols/openwire/message-listener/pom.xml
+++ b/examples/protocols/openwire/message-listener/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.openwire</groupId>
       <artifactId>openwire-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>message-listener</artifactId>

--- a/examples/protocols/openwire/message-listener/pom.xml
+++ b/examples/protocols/openwire/message-listener/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.openwire</groupId>
       <artifactId>openwire-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>message-listener</artifactId>

--- a/examples/protocols/openwire/message-recovery/pom.xml
+++ b/examples/protocols/openwire/message-recovery/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.openwire</groupId>
       <artifactId>openwire-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>message-recovery</artifactId>

--- a/examples/protocols/openwire/message-recovery/pom.xml
+++ b/examples/protocols/openwire/message-recovery/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.openwire</groupId>
       <artifactId>openwire-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>message-recovery</artifactId>

--- a/examples/protocols/openwire/pom.xml
+++ b/examples/protocols/openwire/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.protocols</groupId>
       <artifactId>protocols</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.openwire</groupId>

--- a/examples/protocols/openwire/pom.xml
+++ b/examples/protocols/openwire/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.protocols</groupId>
       <artifactId>protocols</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.openwire</groupId>

--- a/examples/protocols/openwire/queue/pom.xml
+++ b/examples/protocols/openwire/queue/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.openwire</groupId>
       <artifactId>openwire-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>queue-openwire</artifactId>

--- a/examples/protocols/openwire/queue/pom.xml
+++ b/examples/protocols/openwire/queue/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.openwire</groupId>
       <artifactId>openwire-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>queue-openwire</artifactId>

--- a/examples/protocols/openwire/virtual-topic-mapping/pom.xml
+++ b/examples/protocols/openwire/virtual-topic-mapping/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.openwire</groupId>
       <artifactId>openwire-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>virtual-topic-mapping</artifactId>

--- a/examples/protocols/openwire/virtual-topic-mapping/pom.xml
+++ b/examples/protocols/openwire/virtual-topic-mapping/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.openwire</groupId>
       <artifactId>openwire-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>virtual-topic-mapping</artifactId>

--- a/examples/protocols/pom.xml
+++ b/examples/protocols/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples</groupId>
       <artifactId>artemis-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.protocols</groupId>

--- a/examples/protocols/pom.xml
+++ b/examples/protocols/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples</groupId>
       <artifactId>artemis-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.protocols</groupId>

--- a/examples/protocols/stomp/pom.xml
+++ b/examples/protocols/stomp/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.protocols</groupId>
       <artifactId>protocols</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.stomp</groupId>

--- a/examples/protocols/stomp/pom.xml
+++ b/examples/protocols/stomp/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.protocols</groupId>
       <artifactId>protocols</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <groupId>org.apache.activemq.examples.stomp</groupId>

--- a/examples/protocols/stomp/stomp-dual-authentication/pom.xml
+++ b/examples/protocols/stomp/stomp-dual-authentication/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.stomp</groupId>
       <artifactId>stomp-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>stomp-dual-authentication</artifactId>

--- a/examples/protocols/stomp/stomp-dual-authentication/pom.xml
+++ b/examples/protocols/stomp/stomp-dual-authentication/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.stomp</groupId>
       <artifactId>stomp-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>stomp-dual-authentication</artifactId>

--- a/examples/protocols/stomp/stomp-embedded-interceptor/pom.xml
+++ b/examples/protocols/stomp/stomp-embedded-interceptor/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.stomp</groupId>
       <artifactId>stomp-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>stomp-embedded-interceptor</artifactId>

--- a/examples/protocols/stomp/stomp-embedded-interceptor/pom.xml
+++ b/examples/protocols/stomp/stomp-embedded-interceptor/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.stomp</groupId>
       <artifactId>stomp-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>stomp-embedded-interceptor</artifactId>

--- a/examples/protocols/stomp/stomp-jms/pom.xml
+++ b/examples/protocols/stomp/stomp-jms/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.stomp</groupId>
       <artifactId>stomp-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>stomp-jms</artifactId>

--- a/examples/protocols/stomp/stomp-jms/pom.xml
+++ b/examples/protocols/stomp/stomp-jms/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.stomp</groupId>
       <artifactId>stomp-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>stomp-jms</artifactId>

--- a/examples/protocols/stomp/stomp-websockets/pom.xml
+++ b/examples/protocols/stomp/stomp-websockets/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.stomp</groupId>
       <artifactId>stomp-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>stomp-websockets</artifactId>

--- a/examples/protocols/stomp/stomp-websockets/pom.xml
+++ b/examples/protocols/stomp/stomp-websockets/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.stomp</groupId>
       <artifactId>stomp-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>stomp-websockets</artifactId>

--- a/examples/protocols/stomp/stomp/pom.xml
+++ b/examples/protocols/stomp/stomp/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.stomp</groupId>
       <artifactId>stomp-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>stomp</artifactId>

--- a/examples/protocols/stomp/stomp/pom.xml
+++ b/examples/protocols/stomp/stomp/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.stomp</groupId>
       <artifactId>stomp-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>stomp</artifactId>

--- a/examples/protocols/stomp/stomp1.1/pom.xml
+++ b/examples/protocols/stomp/stomp1.1/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.stomp</groupId>
       <artifactId>stomp-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>stomp1.1</artifactId>

--- a/examples/protocols/stomp/stomp1.1/pom.xml
+++ b/examples/protocols/stomp/stomp1.1/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.stomp</groupId>
       <artifactId>stomp-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>stomp1.1</artifactId>

--- a/examples/protocols/stomp/stomp1.2/pom.xml
+++ b/examples/protocols/stomp/stomp1.2/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.stomp</groupId>
       <artifactId>stomp-examples</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>stomp1.2</artifactId>

--- a/examples/protocols/stomp/stomp1.2/pom.xml
+++ b/examples/protocols/stomp/stomp1.2/pom.xml
@@ -24,7 +24,7 @@ under the License.
    <parent>
       <groupId>org.apache.activemq.examples.stomp</groupId>
       <artifactId>stomp-examples</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>stomp1.2</artifactId>

--- a/integration/activemq-spring-integration/pom.xml
+++ b/integration/activemq-spring-integration/pom.xml
@@ -21,7 +21,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
       <relativePath>../../pom.xml</relativePath>
    </parent>
 

--- a/integration/activemq-spring-integration/pom.xml
+++ b/integration/activemq-spring-integration/pom.xml
@@ -21,7 +21,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
       <relativePath>../../pom.xml</relativePath>
    </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
    <groupId>org.apache.activemq</groupId>
    <artifactId>artemis-pom</artifactId>
    <packaging>pom</packaging>
-   <version>2.23.1</version>
+   <version>2.23.2-SNAPSHOT</version>
 
    <parent>
       <groupId>org.apache</groupId>
@@ -253,7 +253,7 @@
       <connection>scm:git:https://gitbox.apache.org/repos/asf/activemq-artemis.git</connection>
       <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/activemq-artemis.git</developerConnection>
       <url>https://github.com/apache/activemq-artemis</url>
-      <tag>2.23.1</tag>
+      <tag>2.19.0</tag>
    </scm>
 
    <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
    <groupId>org.apache.activemq</groupId>
    <artifactId>artemis-pom</artifactId>
    <packaging>pom</packaging>
-   <version>2.24.0-SNAPSHOT</version>
+   <version>2.23.1</version>
 
    <parent>
       <groupId>org.apache</groupId>
@@ -253,7 +253,7 @@
       <connection>scm:git:https://gitbox.apache.org/repos/asf/activemq-artemis.git</connection>
       <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/activemq-artemis.git</developerConnection>
       <url>https://github.com/apache/activemq-artemis</url>
-      <tag>2.19.0</tag>
+      <tag>2.23.1</tag>
    </scm>
 
    <distributionManagement>

--- a/tests/activemq5-unit-tests/pom.xml
+++ b/tests/activemq5-unit-tests/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>activemq5-unit-tests</artifactId>

--- a/tests/activemq5-unit-tests/pom.xml
+++ b/tests/activemq5-unit-tests/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>activemq5-unit-tests</artifactId>

--- a/tests/artemis-test-support/pom.xml
+++ b/tests/artemis-test-support/pom.xml
@@ -19,7 +19,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-test-support</artifactId>

--- a/tests/artemis-test-support/pom.xml
+++ b/tests/artemis-test-support/pom.xml
@@ -19,7 +19,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>artemis-test-support</artifactId>

--- a/tests/compatibility-tests/pom.xml
+++ b/tests/compatibility-tests/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>compatibility-tests</artifactId>
@@ -160,7 +160,7 @@
       <dependency>
          <groupId>org.apache.activemq.rest</groupId>
          <artifactId>artemis-rest</artifactId>
-         <version>2.24.0-SNAPSHOT</version>
+         <version>2.23.1</version>
       </dependency>
       <dependency>
          <groupId>org.apache.groovy</groupId>

--- a/tests/compatibility-tests/pom.xml
+++ b/tests/compatibility-tests/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>compatibility-tests</artifactId>
@@ -160,7 +160,7 @@
       <dependency>
          <groupId>org.apache.activemq.rest</groupId>
          <artifactId>artemis-rest</artifactId>
-         <version>2.23.1</version>
+         <version>2.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
          <groupId>org.apache.groovy</groupId>

--- a/tests/e2e-tests/pom.xml
+++ b/tests/e2e-tests/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>e2e-tests</artifactId>

--- a/tests/e2e-tests/pom.xml
+++ b/tests/e2e-tests/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>e2e-tests</artifactId>

--- a/tests/extra-tests/pom.xml
+++ b/tests/extra-tests/pom.xml
@@ -24,7 +24,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>extra-tests</artifactId>

--- a/tests/extra-tests/pom.xml
+++ b/tests/extra-tests/pom.xml
@@ -24,7 +24,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>extra-tests</artifactId>

--- a/tests/integration-tests/pom.xml
+++ b/tests/integration-tests/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>integration-tests</artifactId>

--- a/tests/integration-tests/pom.xml
+++ b/tests/integration-tests/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>integration-tests</artifactId>

--- a/tests/jms-tests/pom.xml
+++ b/tests/jms-tests/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>jms-tests</artifactId>

--- a/tests/jms-tests/pom.xml
+++ b/tests/jms-tests/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>jms-tests</artifactId>

--- a/tests/joram-tests/pom.xml
+++ b/tests/joram-tests/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>joram-tests</artifactId>

--- a/tests/joram-tests/pom.xml
+++ b/tests/joram-tests/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>joram-tests</artifactId>

--- a/tests/karaf-client-integration-tests/pom.xml
+++ b/tests/karaf-client-integration-tests/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>karaf-client-integration-tests</artifactId>

--- a/tests/karaf-client-integration-tests/pom.xml
+++ b/tests/karaf-client-integration-tests/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>karaf-client-integration-tests</artifactId>

--- a/tests/performance-jmh/pom.xml
+++ b/tests/performance-jmh/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.activemq.tests</groupId>
         <artifactId>artemis-tests-pom</artifactId>
-        <version>2.23.1</version>
+        <version>2.23.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/performance-jmh/pom.xml
+++ b/tests/performance-jmh/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.activemq.tests</groupId>
         <artifactId>artemis-tests-pom</artifactId>
-        <version>2.24.0-SNAPSHOT</version>
+        <version>2.23.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/performance-tests/pom.xml
+++ b/tests/performance-tests/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>performance-tests</artifactId>

--- a/tests/performance-tests/pom.xml
+++ b/tests/performance-tests/pom.xml
@@ -20,7 +20,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>performance-tests</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -18,7 +18,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <name>ActiveMQ Artemis Tests POM</name>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -18,7 +18,7 @@
    <parent>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <name>ActiveMQ Artemis Tests POM</name>

--- a/tests/smoke-tests/pom.xml
+++ b/tests/smoke-tests/pom.xml
@@ -19,7 +19,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>smoke-tests</artifactId>

--- a/tests/smoke-tests/pom.xml
+++ b/tests/smoke-tests/pom.xml
@@ -19,7 +19,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>smoke-tests</artifactId>

--- a/tests/soak-tests/pom.xml
+++ b/tests/soak-tests/pom.xml
@@ -21,7 +21,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>soak-tests</artifactId>

--- a/tests/soak-tests/pom.xml
+++ b/tests/soak-tests/pom.xml
@@ -21,7 +21,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>soak-tests</artifactId>

--- a/tests/stress-tests/pom.xml
+++ b/tests/stress-tests/pom.xml
@@ -21,7 +21,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>stress-tests</artifactId>

--- a/tests/stress-tests/pom.xml
+++ b/tests/stress-tests/pom.xml
@@ -21,7 +21,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>stress-tests</artifactId>

--- a/tests/timing-tests/pom.xml
+++ b/tests/timing-tests/pom.xml
@@ -21,7 +21,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>timing-tests</artifactId>

--- a/tests/timing-tests/pom.xml
+++ b/tests/timing-tests/pom.xml
@@ -21,7 +21,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>timing-tests</artifactId>

--- a/tests/unit-tests/pom.xml
+++ b/tests/unit-tests/pom.xml
@@ -19,7 +19,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.24.0-SNAPSHOT</version>
+      <version>2.23.1</version>
    </parent>
 
    <artifactId>unit-tests</artifactId>

--- a/tests/unit-tests/pom.xml
+++ b/tests/unit-tests/pom.xml
@@ -19,7 +19,7 @@
    <parent>
       <groupId>org.apache.activemq.tests</groupId>
       <artifactId>artemis-tests-pom</artifactId>
-      <version>2.23.1</version>
+      <version>2.23.2-SNAPSHOT</version>
    </parent>
 
    <artifactId>unit-tests</artifactId>


### PR DESCRIPTION
in activemq plugin do client validate and it can not send MQTTReasonCodes.CLIENT_IDENTIFIER_NOT_VALID to mqtt client