### PR TITLE
ARTEMIS-3922 Reducing contention on Throwable#getOurStackTrace

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/DBOption.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/DBOption.java
@@ -221,7 +221,7 @@ public class DBOption extends OptionalLocking {
 
    protected void initializeJournal(Configuration configuration) throws Exception {
       this.config = configuration;
-      executor = Executors.newFixedThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory());
+      executor = Executors.newFixedThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName()));
       executorFactory = new OrderedExecutorFactory(executor);
 
       scheduledExecutorService = new ScheduledThreadPoolExecutor(configuration.getScheduledThreadPoolMaxSize(), new ThreadFactory() {

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/ActiveMQThreadFactory.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/ActiveMQThreadFactory.java
@@ -127,8 +127,19 @@ public final class ActiveMQThreadFactory implements ThreadFactory {
       return t;
    }
 
+
+   /**
+    * @return ActiveMQThreadFactory
+    * @deprecated Expensive due to StackTrace lookup with called synchronized java.lang.Throwable#getOurStackTrace.
+    *    Use {@link #defaultThreadFactory(String)} instead.
+    */
+   @Deprecated
    public static ActiveMQThreadFactory defaultThreadFactory() {
       String callerClassName = Thread.currentThread().getStackTrace()[2].getClassName();
+      return defaultThreadFactory(callerClassName);
+   }
+
+   public static ActiveMQThreadFactory defaultThreadFactory(String callerClassName) {
       return new ActiveMQThreadFactory(callerClassName, false, null);
    }
 

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/UUIDGenerator.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/UUIDGenerator.java
@@ -137,7 +137,7 @@ public final class UUIDGenerator {
    public static byte[] getHardwareAddress() {
       try {
          // check if we have enough security permissions to create and shutdown an executor
-         ExecutorService executor = Executors.newFixedThreadPool(1, ActiveMQThreadFactory.defaultThreadFactory());
+         ExecutorService executor = Executors.newFixedThreadPool(1, ActiveMQThreadFactory.defaultThreadFactory(UUIDGenerator.class.getName()));
          executor.shutdownNow();
       } catch (Throwable t) {
          // not enough security permission
@@ -261,7 +261,7 @@ public final class UUIDGenerator {
    }
 
    private static byte[] findFirstMatchingHardwareAddress(List<NetworkInterface> ifaces) {
-      ExecutorService executor = Executors.newFixedThreadPool(ifaces.size(), ActiveMQThreadFactory.defaultThreadFactory());
+      ExecutorService executor = Executors.newFixedThreadPool(ifaces.size(), ActiveMQThreadFactory.defaultThreadFactory(UUIDGenerator.class.getName()));
       Collection<Callable<byte[]>> tasks = new ArrayList<>(ifaces.size());
 
       for (final NetworkInterface networkInterface : ifaces) {

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
@@ -114,7 +114,7 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
 
    private final FailoverEventListener failoverListener = new FailoverEventListenerImpl(this);
 
-   private final ExecutorService failoverListenerExecutor = Executors.newFixedThreadPool(1, ActiveMQThreadFactory.defaultThreadFactory());
+   private final ExecutorService failoverListenerExecutor = Executors.newFixedThreadPool(1, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName()));
 
    private final Version thisVersion;
 

--- a/artemis-rest/src/main/java/org/apache/activemq/artemis/rest/MessageServiceManager.java
+++ b/artemis-rest/src/main/java/org/apache/activemq/artemis/rest/MessageServiceManager.java
@@ -130,7 +130,7 @@ public class MessageServiceManager {
          }
       }
       if (threadPool == null)
-         threadPool = Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory());
+         threadPool = Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName()));
       timeoutTaskInterval = configuration.getTimeoutTaskInterval();
       timeoutTask = new TimeoutTask(timeoutTaskInterval);
       threadPool.execute(timeoutTask);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMConnector.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMConnector.java
@@ -123,9 +123,9 @@ public class InVMConnector extends AbstractConnector {
    private static synchronized ExecutorService getInVMExecutor() {
       if (threadPoolExecutor == null) {
          if (ActiveMQClient.getGlobalThreadPoolSize() <= -1) {
-            threadPoolExecutor = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60L, TimeUnit.SECONDS, new SynchronousQueue<Runnable>(), ActiveMQThreadFactory.defaultThreadFactory());
+            threadPoolExecutor = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60L, TimeUnit.SECONDS, new SynchronousQueue<Runnable>(), ActiveMQThreadFactory.defaultThreadFactory(InVMConnector.class.getName()));
          } else {
-            threadPoolExecutor = new ActiveMQThreadPoolExecutor(0, ActiveMQClient.getGlobalThreadPoolSize(), 60L, TimeUnit.SECONDS, ActiveMQThreadFactory.defaultThreadFactory());
+            threadPoolExecutor = new ActiveMQThreadPoolExecutor(0, ActiveMQClient.getGlobalThreadPoolSize(), 60L, TimeUnit.SECONDS, ActiveMQThreadFactory.defaultThreadFactory(InVMConnector.class.getName()));
          }
       }
       return threadPoolExecutor;


### PR DESCRIPTION
By allowing to pass caller's classname directly to org.apache.activemq.artemis.utils.ActiveMQThreadFactory#defaultThreadFactory instead of calculating it from stack.