### PR TITLE
ARTEMIS-3914: client-classpath docs tweaks

### DIFF
--- a/artemis-website/pom.xml
+++ b/artemis-website/pom.xml
@@ -292,6 +292,7 @@ File | observation | package
                               </copy>
                               <copy todir="${scratch-dir-user-manual}" overwrite="true">
                                  <fileset file="${src-dir-user-manual}/book.json" />
+                                 <fileset file="${src-dir-user-manual}/client-classpath.md" />
                                  <filterset>
                                     <filter token="PROJECT_VERSION_FILTER_TOKEN" value="${project.version}" />
                                  </filterset>

--- a/docs/user-manual/en/client-classpath.md
+++ b/docs/user-manual/en/client-classpath.md
@@ -1,23 +1,10 @@
 # The Client Classpath
 
-Apache ActiveMQ Artemis requires just a single jar on the *client classpath*.
+## Maven dependencies
 
-> **Warning**
->
-> The client jar mentioned here can be found in the `lib/client` directory of
-> the Apache ActiveMQ Artemis distribution.  Be sure you only use the jar from
-> the correct version of the release, you *must not* mix and match versions of
-> jars from different Apache ActiveMQ Artemis versions. Mixing and matching
-> different jar versions may cause subtle errors and failures to occur.
+The recommended way to define a client dependency for your java application is through a Maven dependency declaration.
 
-
-## Maven Packages
-
-The best way to define a client dependency to your java application is through a maven dependency declaration.
-
-There are two packages you can choose from, org.apache.activemq:artemis-jms-client or org.apache.activemq:artemis-jakarta-client for both JMS and Jakarta APIs.
-
-Say you define artemis-version as '{{ config.version }}':
+There are two dependencies you can choose from, `org.apache.activemq:artemis-jms-client` for JMS 2.0 or `org.apache.activemq:artemis-jakarta-client` for Jakarta Messaging 3.x.
 
 For JMS:
 ```xml
@@ -25,7 +12,7 @@ For JMS:
 <dependency>
    <groupId>org.apache.activemq</groupId>
    <artifactId>artemis-jms-client</artifactId>
-   <version>${artemis-version}</version>
+   <version>@PROJECT_VERSION_FILTER_TOKEN@</version>
 </dependency>
 ...
 ```
@@ -36,33 +23,32 @@ For Jakarta:
 <dependency>
    <groupId>org.apache.activemq</groupId>
    <artifactId>artemis-jakarta-client</artifactId>
-   <version>${artemis-version}</version>
+   <version>@PROJECT_VERSION_FILTER_TOKEN@</version>
 </dependency>
 ...
 ```
 
-## All clients
+## Individual client dependencies
 
-Even though it is highly recommend using maven, in case this is not a possibility the all inclusive jars could be used. 
+If you dont wish to use a build tool such as Maven which manages the dependencies for you, you may also choose to add the specific dependency jars to your classpath, which are all included under ./lib on the main distribution.
 
-These jars will be available under ./lib/client on the main distribution:
+For more information of the clients individual dependencies, see:
+- [JMS client dependencies](client-classpath-jms.md )
+- [Jakarta client dependencies](client-classpath-jakarta.md)
 
-- artemis-jakarta-client-all-{{ config.version }}.jar
-- artemis-jms-client-all-{{ config.version }}.jar
+## Repackaged '-all' clients
+
+Even though it is highly recommend using maven, in cases this isnt a possibility and neither is using the individual dependencies detailed above, the all-inclusive repackaged jar could be used.
+
+These jars are available under `./lib/client` on the main distribution (or also as linked at Maven Central):
+- [artemis-jms-client-all-{{ config.version }}.jar](https://repo.maven.apache.org/maven2/org/apache/activemq/artemis-jms-client-all/{{ config.version }}/)
+- [artemis-jakarta-client-all-{{ config.version }}.jar](https://repo.maven.apache.org/maven2/org/apache/activemq/artemis-jakarta-client-all/{{ config.version }}/)
 
 Whether you are using JMS or just the Core API simply add the
-`artemis-jms-client-all.jar` from the `lib/client` directory to your client
-classpath. 
+`artemis-jms-client-all` jar from the `lib/client` directory to your client
+classpath. For Jakarta Messaging add the `artemis-jakarta-client-all` jar instead.
+
+**Warning:**These repackaged jars include all the [client's dependencies](client-classpath-jms.md). Be careful with mixing other components jars in your application as they may clash with each other.
 
 
-**Warning:**These jars will include all the [client's dependencies](client-classpath-jms.md). Be careful with mixing other jars in your application as they may clash with other.
 
-
-## Individual dependencies
-
-You may also choose to use the jars individually as they are all included under ./lib on the main distribution.
-
-For more information:
-
-- [client jms dependencies](client-classpath-jms.md )
-- [client jakarta dependencies](client-classpath-jakarta.md)


### PR DESCRIPTION
Reorder and clarify some bits after previous updates (on #4162), and use version placeholder substitution to provide the specific version in the example client dependency declarations rather than just undefined placeholder prop.