### PR TITLE
ARTEMIS-3925 LVQ pruning nulls

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/LastValueQueue.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/LastValueQueue.java
@@ -224,6 +224,9 @@ public class LastValueQueue extends QueueImpl {
          if (current == ref) {
             currentLastValue = true;
          }
+      } else {
+         // if the ref has no last value
+         return true;
       }
       return currentLastValue;
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/LVQTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/LVQTest.java
@@ -141,6 +141,28 @@ public class LVQTest extends ActiveMQTestBase {
    }
 
    @Test
+   public void testMultipleMessagesWithoutLastValue() throws Exception {
+      ClientProducer producer = clientSession.createProducer(address);
+      ClientMessage m1 = createTextMessage(clientSession, "message1");
+      ClientMessage m2 = createTextMessage(clientSession, "message2");
+      producer.send(m1);
+      producer.send(m2);
+
+      Wait.assertEquals(2L, () -> server.locateQueue(qName1).getMessageCount(), 2000, 100);
+
+      ClientConsumer consumer = clientSession.createConsumer(qName1);
+      clientSession.start();
+      ClientMessage m = consumer.receive(1000);
+      Assert.assertNotNull(m);
+      m.acknowledge();
+      Assert.assertEquals("message1", m.getBodyBuffer().readString());
+      m = consumer.receive(1000);
+      Assert.assertNotNull(m);
+      m.acknowledge();
+      Assert.assertEquals("message2", m.getBodyBuffer().readString());
+   }
+
+   @Test
    public void testMultipleRollback() throws Exception {
       AddressSettings qs = new AddressSettings();
       qs.setDefaultLastValueQueue(true);


### PR DESCRIPTION
Messages without a last-value property sent to an LVQ are being pruned
rather than just passing through. Only messages with a non-null
last-value property should be subject to pruning.