### PR TITLE
ARTEMIS-3915 Add support for proxy protocol on broker acceptors

### DIFF
--- a/artemis-core-client/pom.xml
+++ b/artemis-core-client/pom.xml
@@ -128,6 +128,10 @@
       </dependency>
       <dependency>
          <groupId>io.netty</groupId>
+         <artifactId>netty-codec-haproxy</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>io.netty</groupId>
          <artifactId>netty-common</artifactId>
       </dependency>
 

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/TransportConstants.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/TransportConstants.java
@@ -29,6 +29,8 @@ public class TransportConstants {
 
    private static final Logger logger = Logger.getLogger(TransportConstants.class);
 
+   public static final String PROXY_PROTOCOL_ENABLED_PROP_NAME = "proxyProtocolEnabled";
+
    public static final String SSL_CONTEXT_PROP_NAME = "sslContext";
 
    public static final String SSL_ENABLED_PROP_NAME = "sslEnabled";
@@ -191,6 +193,8 @@ public class TransportConstants {
    public static final String AUTO_START = "autoStart";
 
    public static final boolean DEFAULT_AUTO_START = true;
+
+   public static final Boolean DEFAULT_PROXY_PROTOCOL_ENABLED = false;
 
    public static final boolean DEFAULT_SSL_ENABLED = false;
 
@@ -386,6 +390,7 @@ public class TransportConstants {
       allowableAcceptorKeys.add(TransportConstants.HTTP_RESPONSE_TIME_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.HTTP_SERVER_SCAN_PERIOD_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.HTTP_UPGRADE_ENABLED_PROP_NAME);
+      allowableAcceptorKeys.add(TransportConstants.PROXY_PROTOCOL_ENABLED_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.USE_NIO_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.USE_EPOLL_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.USE_KQUEUE_PROP_NAME);

--- a/artemis-features/src/main/resources/features.xml
+++ b/artemis-features/src/main/resources/features.xml
@@ -35,6 +35,7 @@
 		<bundle>mvn:io.netty/netty-buffer/${netty.version}</bundle>
 		<bundle>mvn:io.netty/netty-codec/${netty.version}</bundle>
 		<bundle>mvn:io.netty/netty-codec-socks/${netty.version}</bundle>
+		<bundle>mvn:io.netty/netty-codec-haproxy/${netty.version}</bundle>
 		<bundle>mvn:io.netty/netty-codec-http/${netty.version}</bundle>
 		<bundle>mvn:io.netty/netty-handler/${netty.version}</bundle>
 		<bundle>mvn:io.netty/netty-handler-proxy/${netty.version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -672,6 +672,12 @@
          </dependency>
          <dependency>
             <groupId>io.netty</groupId>
+            <artifactId>netty-codec-haproxy</artifactId>
+            <version>${netty.version}</version>
+            <!-- License: Apache 2.0 -->
+         </dependency>
+         <dependency>
+            <groupId>io.netty</groupId>
             <artifactId>netty-common</artifactId>
             <version>${netty.version}</version>
             <!-- License: Apache 2.0 -->

--- a/tests/unit-tests/pom.xml
+++ b/tests/unit-tests/pom.xml
@@ -160,6 +160,10 @@
         <artifactId>mockito-core</artifactId>
         <scope>test</scope>
       </dependency>
+       <dependency>
+           <groupId>io.netty</groupId>
+           <artifactId>netty-codec-haproxy</artifactId>
+       </dependency>
    </dependencies>
 
    <build>


### PR DESCRIPTION
Hey guys,

As discussed in a thread on the developers mailing list, I've created [ARTEMIS-3915](https://issues.apache.org/jira/browse/ARTEMIS-3915) and have started developing support for HAProxy PROXY protocol on Artemis acceptors.

I think I've modified all the right places, and the changes are fairly simple to review, I'm a bit unsure about the channel pipeline modification, but I think it makes sense for the PROXY protocol handler, if configured, to be the first in the pipeline as it represents the frontier protocol, sicne any other handler will need the packets to first be decoded from PROXY protocol into something else that they understand.

My work is mostly based on the [examples from Netty](https://github.com/netty/netty/blob/4.1/example/src/main/java/io/netty/example/haproxy/HAProxyServer.java#L59).

However I have some doubts:
1. Is there any way to run the broker locally, so I can test the workflow with an HAProxy local instance (i.e. docker)?
2. Which kind of tests should I develop for this change? I've noticed the NettyAcceptorTest.java class (and the createServer() function) which I think allows me to start a broker instance with PROXY protocol enabled configured acceptors, but I'm unsure of how to send PROXY protocol encoded messages to each of the acceptors and validate the correct operation of the broker. Below is a sketch of what I've locally added to the test class:

```java
@Test
public void testHAProxyProxyProtocolConfiguration() throws Exception {

    // Create ActiveMQ Server
    ActiveMQServer server = createServer(false, createDefaultInVMConfig());

    // Add all supported acceptors with proxy protocol option enabled
    server.getConfiguration().addAcceptorConfiguration("mqtt", "tcp://127.0.0.1:1883?proxyProtocolEnabled=true");
    server.getConfiguration().addAcceptorConfiguration("hornetq", "tcp://127.0.0.1:5445?proxyProtocolEnabled=true");
    server.getConfiguration().addAcceptorConfiguration("amqp", "tcp://127.0.0.1:5672?proxyProtocolEnabled=true");
    server.getConfiguration().addAcceptorConfiguration("stomp", "tcp://127.0.0.1:61613?proxyProtocolEnabled=true");
    server.getConfiguration().addAcceptorConfiguration("openwire", "tcp://127.0.0.1:61616?proxyProtocolEnabled=true");

    // Start the server
    server.start();

    // TODO: Send packets into each of the configured protocol acceptors
}
```
I still intend to add some documentation about the this theme, and maybe an example of a cluster deployed with an HAProxy instance which should be of great aid to new users which require a robust high availability solution, but I'd like to first close the implementation details.

@jbertram, since you were the one you led me here, could I ask for some advice? 😄 