### PR TITLE
ARTEMIS-3957 check for Subject on RemotingConnection before auth cache

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/security/impl/SecurityStoreImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/security/impl/SecurityStoreImpl.java
@@ -102,7 +102,9 @@ public class SecurityStoreImpl implements SecurityStore, HierarchicalRepositoryC
                                        .maximumSize(authorizationCacheSize)
                                        .expireAfterWrite(invalidationInterval, TimeUnit.MILLISECONDS)
                                        .build();
-      this.securityRepository.registerListener(this);
+      if (securityRepository != null) {
+         this.securityRepository.registerListener(this);
+      }
    }
 
    // SecurityManager implementation --------------------------------
@@ -376,6 +378,11 @@ public class SecurityStoreImpl implements SecurityStore, HierarchicalRepositoryC
     * @return the authenticated Subject with all associated role principals
     */
    private Subject getSubjectForAuthorization(SecurityAuth auth, ActiveMQSecurityManager5 securityManager) {
+      Subject subject = auth.getRemotingConnection() == null ? null : auth.getRemotingConnection().getSubject();
+      if (subject != null) {
+         return subject;
+      }
+
       Pair<Boolean, Subject> cached = authenticationCache.getIfPresent(createAuthenticationCacheKey(auth.getUsername(), auth.getPassword(), auth.getRemotingConnection()));
       /*
        * We don't need to worry about the cached boolean being false as users always have to

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/spi/core/security/SecurityStoreImplTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/spi/core/security/SecurityStoreImplTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.spi.core.security;
+
+import javax.security.auth.Subject;
+
+import org.apache.activemq.artemis.core.security.SecurityAuth;
+import org.apache.activemq.artemis.core.security.impl.SecurityStoreImpl;
+import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertTrue;
+
+public class SecurityStoreImplTest {
+
+   @Test
+   public void testConnectionSubject() {
+      ActiveMQSecurityManager5 securityManager = Mockito.mock(ActiveMQSecurityManager5.class);
+      SecurityStoreImpl securityStore = new SecurityStoreImpl(null, securityManager, 0, true, null, null, null, 0, 0);
+      SecurityAuth auth = Mockito.mock(SecurityAuth.class);
+      RemotingConnection rc = Mockito.mock(RemotingConnection.class);
+      Mockito.when(auth.getRemotingConnection()).thenReturn(rc);
+      Subject subject = Mockito.mock(Subject.class);
+      Mockito.when(rc.getSubject()).thenReturn(subject);
+      assertTrue(subject == securityStore.getSessionSubject(auth));
+   }
+}


### PR DESCRIPTION
Authenticated users automatically have their Subject set on their
RemotingConnection. The SecurityStore should check for this Subject
during authorization before checking its cache or attempting
re-authentication. This will avoid unnecessary traffic to the underlying
security repository (e.g. LDAP) in cases where the cache times out or is
disabled completely.