### PR TITLE
ARTEMIS-3958 sending LWT may recurse infinitely if disk full

### DIFF
--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTProtocolManager.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTProtocolManager.java
@@ -195,7 +195,7 @@ public class MQTTProtocolManager extends AbstractProtocolManager<MqttMessage, MQ
          if (!state.isAttached() && sessionExpiryInterval > 0 && state.getDisconnectedTime() + (sessionExpiryInterval * 1000) < System.currentTimeMillis()) {
             toRemove.add(entry.getKey());
          }
-         if (state.isWill() && !state.isAttached() && state.isFailed() && !state.isWillSent() && state.getWillDelayInterval() > 0 && state.getDisconnectedTime() + (state.getWillDelayInterval() * 1000) < System.currentTimeMillis()) {
+         if (state.isWill() && !state.isAttached() && state.isFailed() && state.getWillDelayInterval() > 0 && state.getDisconnectedTime() + (state.getWillDelayInterval() * 1000) < System.currentTimeMillis()) {
             state.getSession().sendWillMessage();
          }
       }
@@ -203,7 +203,7 @@ public class MQTTProtocolManager extends AbstractProtocolManager<MqttMessage, MQ
       for (String key : toRemove) {
          logger.debugf("Removing state for session: %s", key);
          MQTTSessionState state = removeSessionState(key);
-         if (state != null && state.isWill() && !state.isAttached() && state.isFailed() && !state.isWillSent()) {
+         if (state != null && state.isWill() && !state.isAttached() && state.isFailed()) {
             state.getSession().sendWillMessage();
          }
       }

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTSessionState.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTSessionState.java
@@ -78,7 +78,7 @@ public class MQTTSessionState {
 
    private List<? extends MqttProperties.MqttProperty> willUserProperties;
 
-   private boolean willSent = false;
+   private WillStatus willStatus = WillStatus.NOT_SENT;
 
    private boolean failed = false;
 
@@ -113,7 +113,7 @@ public class MQTTSessionState {
          willMessage.clear();
          willMessage = null;
       }
-      willSent = false;
+      willStatus = WillStatus.NOT_SENT;
       failed = false;
       willDelayInterval = 0;
       willRetain = false;
@@ -282,12 +282,12 @@ public class MQTTSessionState {
       return willUserProperties;
    }
 
-   public boolean isWillSent() {
-      return willSent;
+   public WillStatus getWillStatus() {
+      return willStatus;
    }
 
-   public void setWillSent(boolean willSent) {
-      this.willSent = willSent;
+   public void setWillStatus(WillStatus willStatus) {
+      this.willStatus = willStatus;
    }
 
    public boolean isFailed() {
@@ -447,5 +447,35 @@ public class MQTTSessionState {
    @Override
    public String toString() {
       return "MQTTSessionState[" + "session=" + session + ", clientId='" + clientId + "', subscriptions=" + subscriptions + ", messageRefStore=" + messageRefStore + ", addressMessageMap=" + addressMessageMap + ", pubRec=" + pubRec + ", attached=" + attached + ", outboundStore=" + outboundStore + ", disconnectedTime=" + disconnectedTime + ", sessionExpiryInterval=" + clientSessionExpiryInterval + ", isWill=" + isWill + ", willMessage=" + willMessage + ", willTopic='" + willTopic + "', willQoSLevel=" + willQoSLevel + ", willRetain=" + willRetain + ", willDelayInterval=" + willDelayInterval + ", failed=" + failed + ", maxPacketSize=" + clientMaxPacketSize + ']';
+   }
+
+   public enum WillStatus {
+      NOT_SENT, SENT, SENDING;
+
+      public byte getStatus() {
+         switch (this) {
+            case NOT_SENT:
+               return 0;
+            case SENT:
+               return 1;
+            case SENDING:
+               return 2;
+            default:
+               return -1;
+         }
+      }
+
+      public static WillStatus getStatus(byte status) {
+         switch (status) {
+            case 0:
+               return NOT_SENT;
+            case 1:
+               return SENT;
+            case 2:
+               return SENDING;
+            default:
+               return null;
+         }
+      }
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingManagerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingManagerImpl.java
@@ -251,6 +251,13 @@ public final class PagingManagerImpl implements PagingManager {
       }
    }
 
+   /*
+    * For tests only!
+    */
+   protected void setDiskFull(boolean diskFull) {
+      this.diskFull = diskFull;
+   }
+
    @Override
    public boolean isDiskFull() {
       return diskFull;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/core/paging/impl/PagingManagerImplAccessor.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/core/paging/impl/PagingManagerImplAccessor.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.paging.impl;
+
+public class PagingManagerImplAccessor {
+   public static void setDiskFull(PagingManagerImpl pagingManager, boolean diskFull) {
+      pagingManager.setDiskFull(diskFull);
+   }
+}


### PR DESCRIPTION
Due to the changes in 682f505e32f9b6472665212acd6f58c32c7bf98d we now
send "Last Will & Testament" MQTT messages via ServerSession. This means
sending will fail if the disk is full. For MQTT this triggers a
connection failure which in turns triggers sending an LWT message. This
process will recurse infinitely until it results in a
java.lang.StackOverflowError.

This commit fixes that by tracking whether or not sending a LWT message
is already in progress.