### PR TITLE
ARTEMIS-3963 Fix setting security roles via properties on OpenJ9 JDK 11

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
@@ -31,6 +31,7 @@ import java.io.StringWriter;
 import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.net.URI;
 import java.net.URL;
 import java.security.AccessController;
@@ -2967,9 +2968,9 @@ public class ConfigurationImpl implements Configuration, Serializable {
          }
 
          // we don't know the type, infer from add method add(X x) or add(String key, X x)
-         final Method[] methods = hostingBean.getClass().getMethods();
+         final Method[] methods = hostingBean.getClass().getDeclaredMethods();
          for (Method candidate : methods) {
-            if (candidate.getName().equals(addPropertyName) &&
+            if (Modifier.isPublic(candidate.getModifiers()) && candidate.getName().equals(addPropertyName) &&
                (candidate.getParameterCount() == 1 ||
                   (candidate.getParameterCount() == 2
                      // has a String key


### PR DESCRIPTION
RoleSet.class.getMethods() returns the same methods on both OpenJDK 11 and
OpenJ9 JDK 11 but the order is different. OpenJDK 11 returns
`public void org.apache.activemq.artemis.core.config.impl.RoleSet.add` before
`public boolean java.util.HashSet.add` while OpenJ9 JDK 11 returns
`public boolean java.util.HashSet.add` before
`public void org.apache.activemq.artemis.core.config.impl.RoleSet.add`