### PR TITLE
ARTEMIS-3913 custom MQTT client ID rejection

### DIFF
--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/exceptions/InvalidClientIdException.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/exceptions/InvalidClientIdException.java
@@ -1,0 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.protocol.mqtt.exceptions;
+
+public class InvalidClientIdException extends RuntimeException {
+
+}

--- a/docs/user-manual/en/mqtt.md
+++ b/docs/user-manual/en/mqtt.md
@@ -100,6 +100,20 @@ UTF-8 strings and print them up to 256 characters. Payload logging is limited
 to avoid filling the logs with potentially hundreds of megabytes of unhelpful
 information.
 
+## Custom Client ID Handling
+
+The client ID used by an MQTT application is very important as it uniquely
+identifies the application. In some situations broker administrators may want
+to perform extra validation or even modify incoming client IDs to support
+specific use-cases. This is possible by implementing a custom security manager
+as demonstrated in the `security-manager` example shipped with the broker.
+
+The simplest implementation is a "wrapper" just like the `security-manager`
+example uses. In the `authenticate` method you can modify the client ID using
+`setClientId()` on the `org.apache.activemq.artemis.spi.core.protocol.RemotingConnection`
+that is passed in. If you perform some custom validation of the client ID you
+can reject the client ID by throwing a `org.apache.activemq.artemis.core.protocol.mqtt.exceptions.InvalidClientIdException`.
+
 ## Wildcard subscriptions
 
 MQTT addresses are hierarchical much like a file system, and they use a special


### PR DESCRIPTION
Sometimes users want to perform custom client ID validation, and in the
case of an invalid client ID the proper reason code should be returned
in the CONNACK packet.