### PR TITLE
ARTEMIS-3990 Ensure that readable buffer string read consumes the bytes

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/util/NettyReadable.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/util/NettyReadable.java
@@ -145,7 +145,7 @@ public class NettyReadable implements ReadableBuffer {
 
    @Override
    public String readUTF8() {
-      return buffer.toString(Charset_UTF8);
+      return buffer.readCharSequence(buffer.readableBytes(), Charset_UTF8).toString();
    }
 
    @Override
@@ -192,7 +192,7 @@ public class NettyReadable implements ReadableBuffer {
 
    @Override
    public String readString(CharsetDecoder decoder) throws CharacterCodingException {
-      return buffer.toString(decoder.charset());
+      return buffer.readCharSequence(buffer.readableBytes(), decoder.charset()).toString();
    }
 
    @Override

--- a/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/util/NettyReadableTest.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/util/NettyReadableTest.java
@@ -438,7 +438,9 @@ public class NettyReadableTest {
 
       NettyReadable buffer = new NettyReadable(byteBuffer);
 
+      assertEquals(asUtf8bytes.length, buffer.remaining());
       assertEquals(testString, buffer.readUTF8());
+      assertEquals(0, buffer.remaining());
    }
 
    @Test
@@ -449,6 +451,8 @@ public class NettyReadableTest {
 
       NettyReadable buffer = new NettyReadable(byteBuffer);
 
+      assertEquals(asUtf8bytes.length, buffer.remaining());
       assertEquals(testString, buffer.readString(StandardCharsets.UTF_8.newDecoder()));
+      assertEquals(0, buffer.remaining());
    }
 }


### PR DESCRIPTION
Ensures that when reading a string the readable buffer consumes the bytes by advancing the read index as defined in the interface API docs.