### PR TITLE
ARTEMIS-3986 CME when using LVQ

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/LastValueQueue.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/LastValueQueue.java
@@ -17,9 +17,9 @@
 package org.apache.activemq.artemis.core.server.impl;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.apache.activemq.artemis.api.core.QueueConfiguration;
@@ -54,7 +54,7 @@ import org.jboss.logging.Logger;
 public class LastValueQueue extends QueueImpl {
 
    private static final Logger logger = Logger.getLogger(LastValueQueue.class);
-   private final Map<SimpleString, MessageReference> map = new HashMap<>();
+   private final Map<SimpleString, MessageReference> map = new ConcurrentHashMap<>();
    private final SimpleString lastValueKey;
 
 


### PR DESCRIPTION
The map used by LastValueQueue was inadvertently changed to a non-thread-safe implementation in
4a4765c39cb73438ea2199b6e0937566d3556c10. This resulted in an occasional ConcurrentModificationException from the hashCode implementation.

This commit restores the thread-safe map implementation and adds a test which brute-forces a CME when using the non-thread-safe implementation.