### PR TITLE
ARTEMIS-4005 - Fix e2e-test execution

### DIFF
--- a/tests/e2e-tests/pom.xml
+++ b/tests/e2e-tests/pom.xml
@@ -30,7 +30,7 @@
    <properties>
       <activemq.basedir>${project.basedir}/../..</activemq.basedir>
       <e2e-tests.surefire-extra-args />
-      <e2e-tests.dockerfile>Dockerfile-centos</e2e-tests.dockerfile>
+      <e2e-tests.dockerfile>Dockerfile-centos7-11</e2e-tests.dockerfile>
       <distributionDir>${activemq.basedir}/artemis-distribution/target/apache-artemis-${project.version}-bin/apache-artemis-${project.version}</distributionDir>
       <container-service-argline>-DContainerService.artemis-image.version=${project.version} -DContainerService.artemis-image.userid="1000"</container-service-argline>
    </properties>
@@ -50,6 +50,12 @@
       <dependency>
          <groupId>org.apache.activemq.tests</groupId>
          <artifactId>artemis-test-support</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-unit-test-support</artifactId>
          <version>${project.version}</version>
          <scope>test</scope>
       </dependency>


### PR DESCRIPTION
Fix the Dockerfile name reference
Add artemis-unit-test-support module as test dependency