### PR TITLE
NO-JIRA Add direct jakarta.annotation-api dependency to integration-tests

### DIFF
--- a/tests/integration-tests/pom.xml
+++ b/tests/integration-tests/pom.xml
@@ -204,6 +204,10 @@
          <artifactId>jakarta.management.j2ee-api</artifactId>
       </dependency>
       <dependency>
+         <groupId>jakarta.annotation</groupId>
+         <artifactId>jakarta.annotation-api</artifactId>
+      </dependency>
+      <dependency>
          <groupId>io.netty</groupId>
          <artifactId>netty-buffer</artifactId>
       </dependency>


### PR DESCRIPTION
ResourceLoadingSslContext depends on jakarta.annotation-api