### PR TITLE
ARTEMIS-4020 Standardize the naming of Logger types for consistency

### DIFF
--- a/artemis-cli/src/test/java/org/apache/activemq/cli/test/ArtemisTest.java
+++ b/artemis-cli/src/test/java/org/apache/activemq/cli/test/ArtemisTest.java
@@ -119,7 +119,7 @@ import static org.junit.Assert.fail;
  * Test to validate that the CLI doesn't throw improper exceptions when invoked.
  */
 public class ArtemisTest extends CliTestBase {
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    // some tests will set this, as some security methods will need to know the server the CLI started
    private ActiveMQServer server;
@@ -170,9 +170,9 @@ public class ArtemisTest extends CliTestBase {
       int writes = 2;
       int tries = 5;
       long totalAvg = SyncCalculation.syncTest(temporaryFolder.getRoot(), 4096, writes, tries, true, true, true, "file.tmp", 1, JournalType.NIO);
-      log.debug("TotalAvg = {}", totalAvg);
+      logger.debug("TotalAvg = {}", totalAvg);
       long nanoTime = SyncCalculation.toNanos(totalAvg, writes, false);
-      log.debug("nanoTime avg = {}", nanoTime);
+      logger.debug("nanoTime avg = {}", nanoTime);
       assertEquals(0, LibaioContext.getTotalMaxIO());
 
    }
@@ -303,7 +303,7 @@ public class ArtemisTest extends CliTestBase {
 
       byte[] contents = Files.readAllBytes(bootstrapFile.toPath());
       String cfgText = new String(contents);
-      log.debug("confg: {}", cfgText);
+      logger.debug("confg: {}", cfgText);
 
       config = parseXml(bootstrapFile);
       webElem = (Element) config.getElementsByTagName("web").item(0);
@@ -449,7 +449,7 @@ public class ArtemisTest extends CliTestBase {
          listCmd.execute(context);
 
          String result = context.getStdout();
-         log.debug("output1:\n{}", result);
+         logger.debug("output1:\n{}", result);
 
          //default only one user admin with role amq
          assertTrue(result.contains("\"admin\"(amq)"));
@@ -468,7 +468,7 @@ public class ArtemisTest extends CliTestBase {
          context = new TestActionContext();
          listCmd.execute(context);
          result = context.getStdout();
-         log.debug("output2:\n{}", result);
+         logger.debug("output2:\n{}", result);
 
          assertTrue(result.contains("\"admin\"(amq)"));
          assertTrue(result.contains("\"guest\"(admin)"));
@@ -489,7 +489,7 @@ public class ArtemisTest extends CliTestBase {
          context = new TestActionContext();
          listCmd.execute(context);
          result = context.getStdout();
-         log.debug("output3:\n{}", result);
+         logger.debug("output3:\n{}", result);
 
          assertTrue(result.contains("\"admin\"(amq)"));
          assertTrue(result.contains("\"guest\"(admin)"));
@@ -514,7 +514,7 @@ public class ArtemisTest extends CliTestBase {
          context = new TestActionContext();
          listCmd.execute(context);
          result = context.getStdout();
-         log.debug("output4:\n{}", result);
+         logger.debug("output4:\n{}", result);
 
          assertTrue(result.contains("\"admin\"(amq)"));
          assertTrue(result.contains("\"guest\"(admin)"));
@@ -531,7 +531,7 @@ public class ArtemisTest extends CliTestBase {
          context = new TestActionContext();
          listCmd.execute(context);
          result = context.getStdout();
-         log.debug("output5:\n{}", result);
+         logger.debug("output5:\n{}", result);
 
          assertTrue(result.contains("\"admin\"(amq)"));
          assertFalse(result.contains("\"guest\"(admin)"));
@@ -549,7 +549,7 @@ public class ArtemisTest extends CliTestBase {
          context = new TestActionContext();
          listCmd.execute(context);
          result = context.getStdout();
-         log.debug("output6:\n{}", result);
+         logger.debug("output6:\n{}", result);
 
          assertTrue(result.contains("\"admin\"(amq)"));
          assertFalse(result.contains("\"guest\"(admin)"));
@@ -570,7 +570,7 @@ public class ArtemisTest extends CliTestBase {
          context = new TestActionContext();
          listCmd.execute(context);
          result = context.getStdout();
-         log.debug("output7:\n{}", result);
+         logger.debug("output7:\n{}", result);
          assertTrue(result.contains("\"admin\"(amq)"));
          assertTrue(result.contains("Total: 1"));
 
@@ -585,7 +585,7 @@ public class ArtemisTest extends CliTestBase {
          context = new TestActionContext();
          listCmd.execute(context);
          result = context.getStdout();
-         log.debug("output8:\n{}", result);
+         logger.debug("output8:\n{}", result);
 
          assertTrue(result.contains("Total: 0"));
       } finally {
@@ -879,7 +879,7 @@ public class ArtemisTest extends CliTestBase {
          listCmd.execute(context);
 
          String result = context.getStdout();
-         log.debug("output1:\n{}", result);
+         logger.debug("output1:\n{}", result);
 
          //default only one user admin with role amq
          assertTrue(result.contains("\"admin\"(amq)"));
@@ -895,7 +895,7 @@ public class ArtemisTest extends CliTestBase {
          context = new TestActionContext();
          listCmd.execute(context);
          result = context.getStdout();
-         log.debug("output8:\n{}", result);
+         logger.debug("output8:\n{}", result);
 
          assertTrue(result.contains("Total: 0"));
 
@@ -928,7 +928,7 @@ public class ArtemisTest extends CliTestBase {
          context = new TestActionContext();
          listCmd.execute(context);
          result = context.getStdout();
-         log.debug("output2:\n{}", result);
+         logger.debug("output2:\n{}", result);
 
          assertTrue(result.contains("Total: 4"));
          assertTrue(result.contains("\"guest\"(admin)"));
@@ -1009,7 +1009,7 @@ public class ArtemisTest extends CliTestBase {
          listCmd.execute(context);
 
          String result = context.getStdout();
-         log.debug("output1:\n{}", result);
+         logger.debug("output1:\n{}", result);
 
          assertTrue(result.contains("Total: 1"));
          assertTrue(result.contains("\"admin\"(amq)"));
@@ -1039,7 +1039,7 @@ public class ArtemisTest extends CliTestBase {
          listCmd.execute(context);
 
          result = context.getStdout();
-         log.debug("output2:\n{}", result);
+         logger.debug("output2:\n{}", result);
 
          // make sure the admin user is still in tact (i.e. that the file wasn't corrupted via concurrent access)
          assertTrue(result.contains("\"admin\"(amq)"));
@@ -1112,7 +1112,7 @@ public class ArtemisTest extends CliTestBase {
          listCmd.execute(context);
 
          String result = context.getStdout();
-         log.debug("output1:\n{}", result);
+         logger.debug("output1:\n{}", result);
 
          assertTrue(result.contains("\"admin\"(" + roleWithSpaces + ")"));
 
@@ -1215,7 +1215,7 @@ public class ArtemisTest extends CliTestBase {
       mask.setPassword(password1);
 
       String result = (String) mask.execute(context);
-      log.debug(context.getStdout());
+      logger.debug(context.getStdout());
       assertEquals(encrypt1, result);
 
       context = new TestActionContext();
@@ -1223,7 +1223,7 @@ public class ArtemisTest extends CliTestBase {
       mask.setPassword(password1);
       mask.setHash(true);
       result = (String) mask.execute(context);
-      log.debug(context.getStdout());
+      logger.debug(context.getStdout());
       SensitiveDataCodec<String> codec = mask.getCodec();
       Assert.assertEquals(DefaultSensitiveStringCodec.class, codec.getClass());
       Assert.assertTrue(((DefaultSensitiveStringCodec)codec).verify(password1.toCharArray(), result));
@@ -1233,7 +1233,7 @@ public class ArtemisTest extends CliTestBase {
       mask.setPassword(password1);
       mask.setKey(newKey);
       result = (String) mask.execute(context);
-      log.debug(context.getStdout());
+      logger.debug(context.getStdout());
       assertEquals(encrypt2, result);
    }
 
@@ -2096,7 +2096,7 @@ public class ArtemisTest extends CliTestBase {
       TestActionContext context = new TestActionContext();
       PrintVersion printVersion = new PrintVersion();
       Version result = (Version) printVersion.execute(context);
-      log.debug(context.getStdout());
+      logger.debug(context.getStdout());
    }
 
    //read individual lines from byteStream
@@ -2167,7 +2167,7 @@ public class ArtemisTest extends CliTestBase {
          for (String r : roles) {
             String storedUsers = (String) roleConfig.getProperty(r);
 
-            log.debug("users in role: {} ; {}", r, storedUsers);
+            logger.debug("users in role: {} ; {}", r, storedUsers);
             List<String> userList = StringUtil.splitStringList(storedUsers, ",");
             assertTrue(userList.contains(user));
          }

--- a/artemis-cli/src/test/java/org/apache/activemq/cli/test/HashUtilTest.java
+++ b/artemis-cli/src/test/java/org/apache/activemq/cli/test/HashUtilTest.java
@@ -27,14 +27,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class HashUtilTest {
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Test
    public void testDefaultHashFormat() throws Exception {
       final String password = "helloworld";
       String hash = HashUtil.tryHash(new TestActionContext(), password);
       String hashStr = PasswordMaskingUtil.unwrap(hash);
-      log.debug("hashString: {}", hashStr);
+      logger.debug("hashString: {}", hashStr);
       String[] parts = hashStr.split(":");
       assertEquals(3, parts.length);
       //first part should be able to convert to an int

--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/ByteUtilTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/ByteUtilTest.java
@@ -41,7 +41,7 @@ import static org.junit.Assert.fail;
 
 public class ByteUtilTest {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Test
    public void testBytesToString() {
@@ -56,13 +56,13 @@ public class ByteUtilTest {
    public void testNonASCII() {
       assertEquals("aA", ByteUtil.toSimpleString(new byte[]{97, 0, 65, 0}));
       assertEquals(ByteUtil.NON_ASCII_STRING, ByteUtil.toSimpleString(new byte[]{0, 97, 0, 65}));
-      log.debug(ByteUtil.toSimpleString(new byte[]{0, 97, 0, 65}));
+      logger.debug(ByteUtil.toSimpleString(new byte[]{0, 97, 0, 65}));
    }
 
    @Test
    public void testMaxString() {
       byte[] byteArray = new byte[20 * 1024];
-      log.debug(ByteUtil.maxString(ByteUtil.bytesToHex(byteArray, 2), 150));
+      logger.debug(ByteUtil.maxString(ByteUtil.bytesToHex(byteArray, 2), 150));
    }
 
    void testEquals(String string1, String string2) {

--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/DefaultSensitiveStringCodecTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/DefaultSensitiveStringCodecTest.java
@@ -32,7 +32,7 @@ import static org.junit.Assert.fail;
 
 public class DefaultSensitiveStringCodecTest {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Test
    public void testDefaultAlgorithm() throws Exception {
@@ -55,7 +55,7 @@ public class DefaultSensitiveStringCodecTest {
 
       String plainText = "some_password";
       String maskedText = codec.encode(plainText);
-      log.debug("encoded value: {}", maskedText);
+      logger.debug("encoded value: {}", maskedText);
 
       if (algorithm.equals(DefaultSensitiveStringCodec.ONE_WAY)) {
          //one way can't decode
@@ -66,7 +66,7 @@ public class DefaultSensitiveStringCodecTest {
          }
       } else {
          String decoded = codec.decode(maskedText);
-         log.debug("encoded value: {}", maskedText);
+         logger.debug("encoded value: {}", maskedText);
 
          assertEquals("decoded result not match: " + decoded, decoded, plainText);
       }
@@ -110,7 +110,7 @@ public class DefaultSensitiveStringCodecTest {
 
       String plainText = "some_password";
       String maskedText = codec.encode(plainText);
-      log.debug("encoded value: {}", maskedText);
+      logger.debug("encoded value: {}", maskedText);
 
       assertTrue(codec.verify(plainText.toCharArray(), maskedText));
 

--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/actors/OrderedExecutorSanityTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/actors/OrderedExecutorSanityTest.java
@@ -33,7 +33,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class OrderedExecutorSanityTest {
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Test
    public void shouldExecuteTasksInOrder() throws InterruptedException {
@@ -179,7 +179,7 @@ public class OrderedExecutorSanityTest {
 
             long elapsed = (end - start);
 
-            log.info("execution {} in {} milliseconds", i, TimeUnit.NANOSECONDS.toMillis(elapsed));
+            logger.info("execution {} in {} milliseconds", i, TimeUnit.NANOSECONDS.toMillis(elapsed));
          }
       } finally {
          executorService.shutdown();
@@ -202,7 +202,7 @@ public class OrderedExecutorSanityTest {
          CountDownLatch latchBlock3 = new CountDownLatch(1);
          executor.execute(() -> {
             try {
-               log.info("Exec 1");
+               logger.info("Exec 1");
                latchDone1.countDown();
                latchBlock1.await(10, TimeUnit.SECONDS);
             } catch (Exception e) {
@@ -216,7 +216,7 @@ public class OrderedExecutorSanityTest {
          executor.execute(() -> {
             try {
                // Exec 2 is supposed to yield to Exec3, so Exec3 will happen first
-               log.info("Exec 2");
+               logger.info("Exec 2");
                latchDone2.countDown();
             } catch (Exception e) {
                e.printStackTrace();
@@ -226,7 +226,7 @@ public class OrderedExecutorSanityTest {
 
          executor2.execute(() -> {
             try {
-               log.info("Exec 3");
+               logger.info("Exec 3");
                latchDone3.countDown();
                latchBlock3.await(10, TimeUnit.SECONDS);
             } catch (Exception e) {

--- a/artemis-hawtio/activemq-branding/src/main/java/org/apache/activemq/hawtio/branding/PluginContextListener.java
+++ b/artemis-hawtio/activemq-branding/src/main/java/org/apache/activemq/hawtio/branding/PluginContextListener.java
@@ -30,7 +30,7 @@ import javax.servlet.ServletContextListener;
  **/
 public class PluginContextListener implements ServletContextListener {
 
-   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    HawtioPlugin plugin = null;
 
@@ -51,7 +51,7 @@ public class PluginContextListener implements ServletContextListener {
          throw createServletException(e);
       }
 
-      LOG.info("Initialized {} plugin", plugin.getName());
+      logger.info("Initialized {} plugin", plugin.getName());
    }
 
    @Override
@@ -62,7 +62,7 @@ public class PluginContextListener implements ServletContextListener {
          throw createServletException(e);
       }
 
-      LOG.info("Destroyed {} plugin", plugin.getName());
+      logger.info("Destroyed {} plugin", plugin.getName());
    }
 
    protected RuntimeException createServletException(Exception e) {

--- a/artemis-hawtio/artemis-plugin/src/main/java/org/apache/activemq/hawtio/plugin/PluginContextListener.java
+++ b/artemis-hawtio/artemis-plugin/src/main/java/org/apache/activemq/hawtio/plugin/PluginContextListener.java
@@ -30,7 +30,7 @@ import javax.servlet.ServletContextListener;
  **/
 public class PluginContextListener implements ServletContextListener {
 
-   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    HawtioPlugin plugin = null;
 
@@ -51,7 +51,7 @@ public class PluginContextListener implements ServletContextListener {
          throw createServletException(e);
       }
 
-      LOG.info("Initialized {} plugin", plugin.getName());
+      logger.info("Initialized {} plugin", plugin.getName());
    }
 
    @Override
@@ -62,7 +62,7 @@ public class PluginContextListener implements ServletContextListener {
          throw createServletException(e);
       }
 
-      LOG.info("Destroyed {} plugin", plugin.getName());
+      logger.info("Destroyed {} plugin", plugin.getName());
    }
 
    protected RuntimeException createServletException(Exception e) {

--- a/artemis-jms-client/src/test/java/org/apache/activemq/artemis/uri/ConnectionFactoryURITest.java
+++ b/artemis-jms-client/src/test/java/org/apache/activemq/artemis/uri/ConnectionFactoryURITest.java
@@ -57,7 +57,7 @@ import java.lang.invoke.MethodHandles;
 
 public class ConnectionFactoryURITest {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    ConnectionFactoryParser parser = new ConnectionFactoryParser();
 
@@ -409,7 +409,7 @@ public class ConnectionFactoryURITest {
          if (ignoreList.contains(descriptor.getName())) {
             continue;
          }
-         log.info("name::{}", descriptor.getName());
+         logger.info("name::{}", descriptor.getName());
          if (descriptor.getWriteMethod() != null && descriptor.getReadMethod() != null) {
             if (descriptor.getPropertyType() == String.class) {
                String value = RandomUtil.randomString();

--- a/artemis-junit/src/main/java/org/apache/activemq/artemis/junit/EmbeddedJMSResource.java
+++ b/artemis-junit/src/main/java/org/apache/activemq/artemis/junit/EmbeddedJMSResource.java
@@ -54,7 +54,6 @@ import org.apache.activemq.artemis.jms.server.embedded.EmbeddedJMS;
 import org.junit.rules.ExternalResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.lang.invoke.MethodHandles;
 
 /**
  * Deprecated in favor of EmbeddedActiveMQResource. Since Artemis 2.0 all JMS specific broker management classes,
@@ -79,7 +78,6 @@ import java.lang.invoke.MethodHandles;
  */
 @Deprecated
 public class EmbeddedJMSResource extends ExternalResource {
-   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    static final String SERVER_NAME = "embedded-jms-server";
 

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/client/ProtonClientConnectionManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/client/ProtonClientConnectionManager.java
@@ -41,7 +41,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class ProtonClientConnectionManager implements BaseConnectionLifeCycleListener<ProtonProtocolManager>, BufferHandler {
    private final Map<Object, ActiveMQProtonRemotingConnection> connectionMap = new ConcurrentHashMap<>();
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
    private final AMQPClientConnectionFactory connectionFactory;
    private final Optional<EventHandler> eventHandler;
    private final ClientSASLFactory clientSASLFactory;
@@ -58,17 +58,17 @@ public class ProtonClientConnectionManager implements BaseConnectionLifeCycleLis
       connectionMap.put(connection.getID(), amqpConnection);
       amqpConnection.open();
 
-      log.info("Connection {} created", amqpConnection.getRemoteAddress());
+      logger.info("Connection {} created", amqpConnection.getRemoteAddress());
    }
 
    @Override
    public void connectionDestroyed(Object connectionID) {
       RemotingConnection connection = connectionMap.remove(connectionID);
       if (connection != null) {
-         log.info("Connection {} destroyed", connection.getRemoteAddress());
+         logger.info("Connection {} destroyed", connection.getRemoteAddress());
          connection.fail(new ActiveMQRemoteDisconnectException());
       } else {
-         log.error("Connection with id {} not found in connectionDestroyed", connectionID);
+         logger.error("Connection with id {} not found in connectionDestroyed", connectionID);
       }
    }
 
@@ -76,10 +76,10 @@ public class ProtonClientConnectionManager implements BaseConnectionLifeCycleLis
    public void connectionException(Object connectionID, ActiveMQException me) {
       RemotingConnection connection = connectionMap.get(connectionID);
       if (connection != null) {
-         log.info("Connection {} exception: {}", connection.getRemoteAddress(),  me.getMessage());
+         logger.info("Connection {} exception: {}", connection.getRemoteAddress(),  me.getMessage());
          connection.fail(me);
       } else {
-         log.error("Connection with id {} not found in connectionException", connectionID);
+         logger.error("Connection with id {} not found in connectionException", connectionID);
       }
    }
 
@@ -87,10 +87,10 @@ public class ProtonClientConnectionManager implements BaseConnectionLifeCycleLis
    public void connectionReadyForWrites(Object connectionID, boolean ready) {
       RemotingConnection connection = connectionMap.get(connectionID);
       if (connection != null) {
-         log.info("Connection {} ready", connection.getRemoteAddress());
+         logger.info("Connection {} ready", connection.getRemoteAddress());
          connection.getTransportConnection().fireReady(true);
       } else {
-         log.error("Connection with id {} not found in connectionReadyForWrites()!", connectionID);
+         logger.error("Connection with id {} not found in connectionReadyForWrites()!", connectionID);
       }
    }
 
@@ -106,7 +106,7 @@ public class ProtonClientConnectionManager implements BaseConnectionLifeCycleLis
       if (connection != null) {
          connection.bufferReceived(connectionID, buffer);
       } else {
-         log.error("Connection with id {} not found in bufferReceived()!", connectionID);
+         logger.error("Connection with id {} not found in bufferReceived()!", connectionID);
       }
    }
 

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPConnectionContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPConnectionContext.java
@@ -84,7 +84,7 @@ import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.SCHEM
 
 public class AMQPConnectionContext extends ProtonInitializable implements EventHandler {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    public static final Symbol CONNECTION_OPEN_FAILED = Symbol.valueOf("amqp:connection-establishment-failed");
    public static final String AMQP_CONTAINER_ID = "amqp-container-id";
@@ -235,8 +235,8 @@ public class AMQPConnectionContext extends ProtonInitializable implements EventH
    }
 
    public void inputBuffer(ByteBuf buffer) {
-      if (log.isTraceEnabled()) {
-         ByteUtil.debugFrame(log, "Buffer Received ", buffer);
+      if (logger.isTraceEnabled()) {
+         ByteUtil.debugFrame(logger, "Buffer Received ", buffer);
       }
 
       handler.inputBuffer(buffer);
@@ -376,7 +376,7 @@ public class AMQPConnectionContext extends ProtonInitializable implements EventH
                      throw ActiveMQAMQPProtocolMessageBundle.BUNDLE.missingDesiredCapability(AMQPMirrorControllerSource.MIRROR_CAPABILITY.toString());
                   }
                } catch (ActiveMQAMQPException e) {
-                  log.warn(e.getMessage(), e);
+                  logger.warn(e.getMessage(), e);
 
                   link.setTarget(null);
                   link.setCondition(new ErrorCondition(e.getAmqpError(), e.getMessage()));
@@ -547,7 +547,7 @@ public class AMQPConnectionContext extends ProtonInitializable implements EventH
       try {
          initInternal();
       } catch (Exception e) {
-         log.error("Error init connection", e);
+         logger.error("Error init connection", e);
       }
 
       if (!validateUser(connection) || (connectionCallback.getTransportConnection().getRouter() != null
@@ -594,7 +594,7 @@ public class AMQPConnectionContext extends ProtonInitializable implements EventH
          try {
             validatedUser = protocolManager.getServer().validateUser(user, password, connectionCallback.getProtonConnectionDelegate(), protocolManager.getSecurityDomain());
          } catch (ActiveMQSecurityException e) {
-            log.warn(e.getMessage(), e);
+            logger.warn(e.getMessage(), e);
             ErrorCondition error = new ErrorCondition();
             error.setCondition(AmqpError.UNAUTHORIZED_ACCESS);
             error.setDescription(e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage());
@@ -732,7 +732,7 @@ public class AMQPConnectionContext extends ProtonInitializable implements EventH
          try {
             linkContext.close(true);
          } catch (Exception e) {
-            log.error(e.getMessage(), e);
+            logger.error(e.getMessage(), e);
          }
       }
 
@@ -776,7 +776,7 @@ public class AMQPConnectionContext extends ProtonInitializable implements EventH
       if (handler != null) {
          handler.onMessage(delivery);
       } else {
-         log.warn("Handler is null, can't delivery {}", delivery, new Exception("tracing location"));
+         logger.warn("Handler is null, can't delivery {}", delivery, new Exception("tracing location"));
       }
    }
 

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPSessionContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPSessionContext.java
@@ -46,7 +46,7 @@ import java.lang.invoke.MethodHandles;
 
 public class AMQPSessionContext extends ProtonInitializable {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
    protected final AMQPConnectionContext connection;
 
    protected final AMQPSessionCallback sessionSPI;
@@ -132,7 +132,7 @@ public class AMQPSessionContext extends ProtonInitializable {
          try {
             protonProducer.close(false);
          } catch (Exception e) {
-            log.warn(e.getMessage(), e);
+            logger.warn(e.getMessage(), e);
          }
       }
       receivers.clear();
@@ -144,7 +144,7 @@ public class AMQPSessionContext extends ProtonInitializable {
          try {
             protonConsumer.close(false);
          } catch (Exception e) {
-            log.warn(e.getMessage(), e);
+            logger.warn(e.getMessage(), e);
          }
       }
       senders.clear();
@@ -154,7 +154,7 @@ public class AMQPSessionContext extends ProtonInitializable {
             sessionSPI.close();
          }
       } catch (Exception e) {
-         log.warn(e.getMessage(), e);
+         logger.warn(e.getMessage(), e);
       }
       closed = true;
    }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerReceiverContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerReceiverContext.java
@@ -58,7 +58,7 @@ import java.lang.invoke.MethodHandles;
  */
 public class ProtonServerReceiverContext extends ProtonAbstractReceiver {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    protected SimpleString address;
    protected SimpleString lastAddress;
@@ -124,7 +124,7 @@ public class ProtonServerReceiverContext extends ProtonAbstractReceiver {
                } catch (ActiveMQAMQPNotFoundException e) {
                   throw e;
                } catch (Exception e) {
-                  log.debug(e.getMessage(), e);
+                  logger.debug(e.getMessage(), e);
                   throw new ActiveMQAMQPInternalErrorException(e.getMessage(), e);
                }
 
@@ -188,7 +188,7 @@ public class ProtonServerReceiverContext extends ProtonAbstractReceiver {
             sessionSPI.serverSend(this, tx, receiver, delivery, address, routingContext, message);
          }
       } catch (Exception e) {
-         log.warn(e.getMessage(), e);
+         logger.warn(e.getMessage(), e);
 
          deliveryFailed(delivery, receiver, e);
 
@@ -205,7 +205,7 @@ public class ProtonServerReceiverContext extends ProtonAbstractReceiver {
                ActiveMQAMQPProtocolLogger.LOGGER.incompatibleAddressFullMessagePolicy(lastAddress.toString(), String.valueOf(lastAddressPolicy), newAddress.toString(), String.valueOf(currentPolicy));
             }
 
-            log.debug("AddressFullPolicy clash between {}/{} and {}/{}", lastAddress, lastAddressPolicy, newAddress, lastAddressPolicy);
+            logger.debug("AddressFullPolicy clash between {}/{} and {}/{}", lastAddress, lastAddressPolicy, newAddress, lastAddressPolicy);
          }
          this.lastAddress = message.getAddressSimpleString();
          this.lastAddressPolicy = currentPolicy;

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java
@@ -101,7 +101,7 @@ import java.lang.invoke.MethodHandles;
  */
 public class ProtonServerSenderContext extends ProtonInitializable implements ProtonDeliveryHandler {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private static final Symbol COPY = Symbol.valueOf("copy");
    private static final Symbol TOPIC = Symbol.valueOf("topic");
@@ -298,7 +298,7 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
          try {
             sessionSPI.closeSender(brokerConsumer);
          } catch (Exception e) {
-            log.warn(e.getMessage(), e);
+            logger.warn(e.getMessage(), e);
          }
          sender.close();
          connection.flush();
@@ -320,7 +320,7 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
          try {
             internalClose(remoteLinkClose);
          } catch (Exception e) {
-            log.warn(e.getMessage(), e);
+            logger.warn(e.getMessage(), e);
          }
       });
    }
@@ -336,7 +336,7 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
 
          }
       } catch (Exception e) {
-         log.warn(e.getMessage(), e);
+         logger.warn(e.getMessage(), e);
          throw new ActiveMQAMQPInternalErrorException(e.getMessage());
       }
    }
@@ -380,7 +380,7 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
       try {
          sessionSPI.ack(null, brokerConsumer, message);
       } catch (Exception e) {
-         log.warn(e.toString(), e);
+         logger.warn(e.toString(), e);
          throw ActiveMQAMQPProtocolMessageBundle.BUNDLE.errorAcknowledgingMessage(message.toString(), e.getMessage());
       }
    }
@@ -390,7 +390,7 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
       boolean handled = true;
 
       if (remoteState == null) {
-         log.debug("Received null disposition for delivery update: {}", remoteState);
+         logger.debug("Received null disposition for delivery update: {}", remoteState);
          return true;
       }
 
@@ -459,7 +459,7 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
             }
             break;
          default:
-            log.debug("Received null or unknown disposition for delivery update: {}", remoteState);
+            logger.debug("Received null or unknown disposition for delivery update: {}", remoteState);
             handled = false;
       }
 
@@ -535,7 +535,7 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
 
       try {
          if (sender.getLocalState() == EndpointState.CLOSED) {
-            log.debug("Not delivering message {} as the sender is closed and credits were available, if you see too many of these it means clients are issuing credits and closing the connection with pending credits a lot of times", messageReference);
+            logger.debug("Not delivering message {} as the sender is closed and credits were available, if you see too many of these it means clients are issuing credits and closing the connection with pending credits a lot of times", messageReference);
             return;
          }
          AMQPMessage message = CoreAmqpConverter.checkAMQP(messageReference.getMessage(), sessionSPI.getStorageManager());
@@ -560,7 +560,7 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
             }
             return;
          }
-         log.warn(e.getMessage(), e);
+         logger.warn(e.getMessage(), e);
          brokerConsumer.errorProcessing(e, messageReference);
       }
    }
@@ -635,7 +635,7 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
                try {
                   sessionSPI.ack(null, brokerConsumer, reference.getMessage());
                } catch (Exception e) {
-                  log.debug(e.getMessage(), e);
+                  logger.debug(e.getMessage(), e);
                }
                delivery.settle();
             } else {
@@ -650,7 +650,7 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
 
             finishLargeMessage();
          } catch (Exception e) {
-            log.warn(e.getMessage(), e);
+            logger.warn(e.getMessage(), e);
             brokerConsumer.errorProcessing(e, reference);
          }
       }
@@ -678,7 +678,7 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
             replaceInitialHeader(deliveryAnnotationsToEncode, context, new NettyWritable(frameBuffer));
          } catch (IndexOutOfBoundsException indexOutOfBoundsException) {
             assert position == 0 : "this shouldn't happen unless replaceInitialHeader is updating position before modifying frameBuffer";
-            log.debug("Delivery of message failed with an overFlowException, retrying again with expandable buffer");
+            logger.debug("Delivery of message failed with an overFlowException, retrying again with expandable buffer");
 
             // on the very first packet, if the initial header was replaced with a much bigger header (re-encoding)
             // we could recover the situation with a retry using an expandable buffer.
@@ -847,7 +847,7 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
             try {
                sessionSPI.ack(null, brokerConsumer, messageReference.getMessage());
             } catch (Exception e) {
-               log.debug(e.getMessage(), e);
+               logger.debug(e.getMessage(), e);
             }
             delivery.settle();
          } else {

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/handler/ProtonHandler.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/handler/ProtonHandler.java
@@ -56,7 +56,7 @@ import java.lang.invoke.MethodHandles;
 
 public class ProtonHandler extends ProtonInitializable implements SaslListener {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private static final byte SASL = 0x03;
 
@@ -157,7 +157,7 @@ public class ProtonHandler extends ProtonInitializable implements SaslListener {
          ((TransportInternal) transport).setUseReadOnlyOutputBuffer(false);
       } catch (NoSuchMethodError nsme) {
          // using a version at runtime where the optimization isn't available, ignore
-         log.trace("Proton output buffer optimisation unavailable");
+         logger.trace("Proton output buffer optimisation unavailable");
       }
 
       transport.bind(connection);
@@ -176,7 +176,7 @@ public class ProtonHandler extends ProtonInitializable implements SaslListener {
                return rescheduleAt;
             }
          } catch (Exception e) {
-            log.warn(e.getMessage(), e);
+            logger.warn(e.getMessage(), e);
             transport.close();
             connection.setCondition(new ErrorCondition());
          } finally {
@@ -318,9 +318,9 @@ public class ProtonHandler extends ProtonInitializable implements SaslListener {
             flush();
          } else {
             if (capacity == 0) {
-               log.debug("abandoning: readableBytes={}", buffer.readableBytes());
+               logger.debug("abandoning: readableBytes={}", buffer.readableBytes());
             } else {
-               log.debug("transport closed, discarding: readableBytes={}, capacity={}", buffer.readableBytes(), transport.capacity());
+               logger.debug("transport closed, discarding: readableBytes={}, capacity={}", buffer.readableBytes(), transport.capacity());
             }
             break;
          }
@@ -393,7 +393,7 @@ public class ProtonHandler extends ProtonInitializable implements SaslListener {
    // server side SASL Listener
    @Override
    public void onSaslInit(Sasl sasl, Transport transport) {
-      log.debug("onSaslInit: {}", sasl);
+      logger.debug("onSaslInit: {}", sasl);
       dispatchRemoteMechanismChosen(sasl.getRemoteMechanisms()[0]);
 
       if (chosenMechanism != null) {
@@ -410,8 +410,8 @@ public class ProtonHandler extends ProtonInitializable implements SaslListener {
       byte[] dataSASL = new byte[sasl.pending()];
 
       int received = sasl.recv(dataSASL, 0, dataSASL.length);
-      if (log.isTraceEnabled()) {
-         log.trace("Working on sasl, length:{}", received);
+      if (logger.isTraceEnabled()) {
+         logger.trace("Working on sasl, length:{}", received);
       }
 
       byte[] response = chosenMechanism.processSASL(received != -1 ? dataSASL : null);
@@ -431,7 +431,7 @@ public class ProtonHandler extends ProtonInitializable implements SaslListener {
 
    @Override
    public void onSaslResponse(Sasl sasl, Transport transport) {
-      log.debug("onSaslResponse: {}", sasl);
+      logger.debug("onSaslResponse: {}", sasl);
       processPending(sasl);
    }
 
@@ -442,7 +442,7 @@ public class ProtonHandler extends ProtonInitializable implements SaslListener {
       dispatchMechanismsOffered(sasl.getRemoteMechanisms());
 
       if (clientSASLMechanism == null) {
-         log.info("Outbound connection failed - unknown mechanism, offered mechanisms: {}",
+         logger.info("Outbound connection failed - unknown mechanism, offered mechanisms: {}",
                    Arrays.asList(sasl.getRemoteMechanisms()));
          dispatchAuthFailed();
       } else {
@@ -465,14 +465,14 @@ public class ProtonHandler extends ProtonInitializable implements SaslListener {
 
    @Override
    public void onSaslOutcome(Sasl sasl, Transport transport) {
-      log.debug("onSaslOutcome: {}", sasl);
+      logger.debug("onSaslOutcome: {}", sasl);
       switch (sasl.getState()) {
          case PN_SASL_FAIL:
-            log.info("Outbound connection failed, authentication failure");
+            logger.info("Outbound connection failed, authentication failure");
             dispatchAuthFailed();
             break;
          case PN_SASL_PASS:
-            log.debug("Outbound connection succeeded");
+            logger.debug("Outbound connection succeeded");
 
             if (sasl.pending() != 0) {
                byte[] additionalData = new byte[sasl.pending()];
@@ -506,7 +506,7 @@ public class ProtonHandler extends ProtonInitializable implements SaslListener {
    }
 
    private void saslComplete(Sasl sasl, Sasl.SaslOutcome saslOutcome) {
-      log.debug("saslComplete: {}", sasl);
+      logger.debug("saslComplete: {}", sasl);
       sasl.done(saslOutcome);
       if (chosenMechanism != null) {
          chosenMechanism.done();
@@ -559,19 +559,19 @@ public class ProtonHandler extends ProtonInitializable implements SaslListener {
          }
          while ((ev = collector.peek()) != null) {
             for (EventHandler h : handlers) {
-               log.trace("Handling {} towards {}", ev, h);
+               logger.trace("Handling {} towards {}", ev, h);
 
                try {
                   Events.dispatch(ev, h);
                } catch (ActiveMQSecurityException e) {
-                  log.warn(e.getMessage(), e);
+                  logger.warn(e.getMessage(), e);
                   ErrorCondition error = new ErrorCondition();
                   error.setCondition(AmqpError.UNAUTHORIZED_ACCESS);
                   error.setDescription(e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage());
                   connection.setCondition(error);
                   connection.close();
                } catch (Exception e) {
-                  log.warn(e.getMessage(), e);
+                  logger.warn(e.getMessage(), e);
                   ErrorCondition error = new ErrorCondition();
                   error.setCondition(AmqpError.INTERNAL_ERROR);
                   error.setDescription("Unrecoverable error: " + (e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage()));
@@ -602,7 +602,7 @@ public class ProtonHandler extends ProtonInitializable implements SaslListener {
    }
 
    private void internalHandlerError(Exception e) {
-      log.warn(e.getMessage(), e);
+      logger.warn(e.getMessage(), e);
       ErrorCondition error = new ErrorCondition();
       error.setCondition(AmqpError.INTERNAL_ERROR);
       error.setDescription("Unrecoverable error: " + (e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage()));
@@ -645,7 +645,7 @@ public class ProtonHandler extends ProtonInitializable implements SaslListener {
             }
          }
       } catch (Throwable e) {
-         log.warn(e.getMessage(), e);
+         logger.warn(e.getMessage(), e);
       }
 
       receivedFirstPacket = true;

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/transaction/ProtonTransactionHandler.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/transaction/ProtonTransactionHandler.java
@@ -46,7 +46,7 @@ import java.lang.invoke.MethodHandles;
  */
 public class ProtonTransactionHandler implements ProtonDeliveryHandler {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private final int amqpCredit;
    private final int amqpLowMark;
@@ -174,7 +174,7 @@ public class ProtonTransactionHandler implements ProtonDeliveryHandler {
    }
 
    private void txError(Delivery delivery, Throwable e) {
-      log.warn(e.getMessage(), e);
+      logger.warn(e.getMessage(), e);
       connection.runNow(() -> {
          delivery.settle();
          if (e instanceof ActiveMQAMQPException) {

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/sasl/GSSAPIServerSASL.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/sasl/GSSAPIServerSASL.java
@@ -38,7 +38,7 @@ import java.util.HashMap;
  * delegate the the jdk GSSAPI support
  */
 public class GSSAPIServerSASL implements ServerSASL {
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    public static final String NAME = "GSSAPI";
    private String loginConfigScope;
@@ -83,7 +83,7 @@ public class GSSAPIServerSASL implements ServerSASL {
          return challenge;
 
       } catch (Exception outOfHere) {
-         log.info("Error on sasl input: {}", outOfHere.toString(), outOfHere);
+         logger.info("Error on sasl input: {}", outOfHere.toString(), outOfHere);
          result = new PrincipalSASLResult(false, null);
       }
       return null;
@@ -100,7 +100,7 @@ public class GSSAPIServerSASL implements ServerSASL {
          try {
             saslServer.dispose();
          } catch (SaslException error) {
-            log.debug("Exception on sasl dispose", error);
+            logger.debug("Exception on sasl dispose", error);
          }
       }
    }

--- a/artemis-selector/src/test/java/org/apache/activemq/artemis/selector/SelectorParserTest.java
+++ b/artemis-selector/src/test/java/org/apache/activemq/artemis/selector/SelectorParserTest.java
@@ -31,10 +31,10 @@ import java.lang.invoke.MethodHandles;
 
 public class SelectorParserTest {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    public void info(String msg) {
-      log.debug(msg);
+      logger.debug(msg);
    }
 
    @Test

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/replication/ReplicatedJournal.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/replication/ReplicatedJournal.java
@@ -49,7 +49,7 @@ import java.lang.invoke.MethodHandles;
  */
 public class ReplicatedJournal implements Journal {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private final ReplicationManager replicationManager;
 
@@ -103,8 +103,8 @@ public class ReplicatedJournal implements Journal {
                                Persister persister,
                                final Object record,
                                final boolean sync) throws Exception {
-      if (log.isTraceEnabled()) {
-         log.trace("Append record id = {} recordType = {}", id, recordType);
+      if (logger.isTraceEnabled()) {
+         logger.trace("Append record id = {} recordType = {}", id, recordType);
       }
       replicationManager.appendUpdateRecord(journalID, ADD_OPERATION_TYPE.ADD, id, recordType, persister, record);
       localJournal.appendAddRecord(id, recordType, persister, record, sync);
@@ -125,8 +125,8 @@ public class ReplicatedJournal implements Journal {
                                final Object record,
                                final boolean sync,
                                final IOCompletion completionCallback) throws Exception {
-      if (log.isTraceEnabled()) {
-         log.trace("Append record id = {} recordType = {}", id, recordType);
+      if (logger.isTraceEnabled()) {
+         logger.trace("Append record id = {} recordType = {}", id, recordType);
       }
       replicationManager.appendUpdateRecord(journalID, ADD_OPERATION_TYPE.ADD, id, recordType, persister, record);
       localJournal.appendAddRecord(id, recordType, persister, record, sync, completionCallback);
@@ -139,8 +139,8 @@ public class ReplicatedJournal implements Journal {
                        Object record,
                        boolean sync,
                        IOCompletion completionCallback) throws Exception {
-      if (log.isTraceEnabled()) {
-         log.trace("Append record id = {} recordType = {}", id, recordType);
+      if (logger.isTraceEnabled()) {
+         logger.trace("Append record id = {} recordType = {}", id, recordType);
       }
       replicationManager.appendUpdateRecord(journalID, ADD_OPERATION_TYPE.EVENT, id, recordType, persister, record);
       localJournal.appendAddEvent(id, recordType, persister, record, sync, completionCallback);
@@ -176,8 +176,8 @@ public class ReplicatedJournal implements Journal {
                                             final byte recordType,
                                             final Persister persister,
                                             final Object record) throws Exception {
-      if (log.isTraceEnabled()) {
-         log.trace("Append record txID={} recordType = {}", id, recordType);
+      if (logger.isTraceEnabled()) {
+         logger.trace("Append record txID={} recordType = {}", id, recordType);
       }
       replicationManager.appendAddRecordTransactional(journalID, ADD_OPERATION_TYPE.ADD, txID, id, recordType, persister, record);
       localJournal.appendAddRecordTransactional(txID, id, recordType, persister, record);
@@ -191,8 +191,8 @@ public class ReplicatedJournal implements Journal {
     */
    @Override
    public void appendCommitRecord(final long txID, final boolean sync) throws Exception {
-      if (log.isTraceEnabled()) {
-         log.trace("AppendCommit txID={}", txID);
+      if (logger.isTraceEnabled()) {
+         logger.trace("AppendCommit txID={}", txID);
       }
       replicationManager.appendCommitRecord(journalID, txID, sync, true);
       localJournal.appendCommitRecord(txID, sync);
@@ -200,8 +200,8 @@ public class ReplicatedJournal implements Journal {
 
    @Override
    public void appendCommitRecord(final long txID, final boolean sync, final IOCompletion callback) throws Exception {
-      if (log.isTraceEnabled()) {
-         log.trace("AppendCommit {}", txID);
+      if (logger.isTraceEnabled()) {
+         logger.trace("AppendCommit {}", txID);
       }
       replicationManager.appendCommitRecord(journalID, txID, sync, true);
       localJournal.appendCommitRecord(txID, sync, callback);
@@ -212,8 +212,8 @@ public class ReplicatedJournal implements Journal {
                                   boolean sync,
                                   IOCompletion callback,
                                   boolean lineUpContext) throws Exception {
-      if (log.isTraceEnabled()) {
-         log.trace("AppendCommit {}", txID);
+      if (logger.isTraceEnabled()) {
+         logger.trace("AppendCommit {}", txID);
       }
       replicationManager.appendCommitRecord(journalID, txID, sync, lineUpContext);
       localJournal.appendCommitRecord(txID, sync, callback, lineUpContext);
@@ -227,8 +227,8 @@ public class ReplicatedJournal implements Journal {
     */
    @Override
    public void appendDeleteRecord(final long id, final boolean sync) throws Exception {
-      if (log.isTraceEnabled()) {
-         log.trace("AppendDelete {}", id);
+      if (logger.isTraceEnabled()) {
+         logger.trace("AppendDelete {}", id);
       }
       replicationManager.appendDeleteRecord(journalID, id);
       localJournal.appendDeleteRecord(id, sync);
@@ -242,8 +242,8 @@ public class ReplicatedJournal implements Journal {
     */
    @Override
    public void tryAppendDeleteRecord(final long id, final JournalUpdateCallback updateCallback, final boolean sync) throws Exception {
-      if (log.isTraceEnabled()) {
-         log.trace("AppendDelete {}", id);
+      if (logger.isTraceEnabled()) {
+         logger.trace("AppendDelete {}", id);
       }
       replicationManager.appendDeleteRecord(journalID, id);
       localJournal.tryAppendDeleteRecord(id, updateCallback, sync);
@@ -253,8 +253,8 @@ public class ReplicatedJournal implements Journal {
    public void appendDeleteRecord(final long id,
                                   final boolean sync,
                                   final IOCompletion completionCallback) throws Exception {
-      if (log.isTraceEnabled()) {
-         log.trace("AppendDelete {}", id);
+      if (logger.isTraceEnabled()) {
+         logger.trace("AppendDelete {}", id);
       }
       replicationManager.appendDeleteRecord(journalID, id);
       localJournal.appendDeleteRecord(id, sync, completionCallback);
@@ -265,8 +265,8 @@ public class ReplicatedJournal implements Journal {
                                   final boolean sync,
                                   final JournalUpdateCallback updateCallback,
                                   final IOCompletion completionCallback) throws Exception {
-      if (log.isTraceEnabled()) {
-         log.trace("AppendDelete {}", id);
+      if (logger.isTraceEnabled()) {
+         logger.trace("AppendDelete {}", id);
       }
       replicationManager.appendDeleteRecord(journalID, id);
       localJournal.tryAppendDeleteRecord(id, sync, updateCallback, completionCallback);
@@ -294,8 +294,8 @@ public class ReplicatedJournal implements Journal {
    public void appendDeleteRecordTransactional(final long txID,
                                                final long id,
                                                final EncodingSupport record) throws Exception {
-      if (log.isTraceEnabled()) {
-         log.trace("AppendDelete txID={} id={}", txID, id);
+      if (logger.isTraceEnabled()) {
+         logger.trace("AppendDelete txID={} id={}", txID, id);
       }
       replicationManager.appendDeleteRecordTransactional(journalID, txID, id, record);
       localJournal.appendDeleteRecordTransactional(txID, id, record);
@@ -309,8 +309,8 @@ public class ReplicatedJournal implements Journal {
     */
    @Override
    public void appendDeleteRecordTransactional(final long txID, final long id) throws Exception {
-      if (log.isTraceEnabled()) {
-         log.trace("AppendDelete (noencoding) txID={} id={}", txID, id);
+      if (logger.isTraceEnabled()) {
+         logger.trace("AppendDelete (noencoding) txID={} id={}", txID, id);
       }
       replicationManager.appendDeleteRecordTransactional(journalID, txID, id);
       localJournal.appendDeleteRecordTransactional(txID, id);
@@ -339,8 +339,8 @@ public class ReplicatedJournal implements Journal {
    public void appendPrepareRecord(final long txID,
                                    final EncodingSupport transactionData,
                                    final boolean sync) throws Exception {
-      if (log.isTraceEnabled()) {
-         log.trace("AppendPrepare txID={}", txID);
+      if (logger.isTraceEnabled()) {
+         logger.trace("AppendPrepare txID={}", txID);
       }
       replicationManager.appendPrepareRecord(journalID, txID, transactionData);
       localJournal.appendPrepareRecord(txID, transactionData, sync);
@@ -351,8 +351,8 @@ public class ReplicatedJournal implements Journal {
                                    final EncodingSupport transactionData,
                                    final boolean sync,
                                    final IOCompletion callback) throws Exception {
-      if (log.isTraceEnabled()) {
-         log.trace("AppendPrepare txID={}", txID);
+      if (logger.isTraceEnabled()) {
+         logger.trace("AppendPrepare txID={}", txID);
       }
       replicationManager.appendPrepareRecord(journalID, txID, transactionData);
       localJournal.appendPrepareRecord(txID, transactionData, sync, callback);
@@ -366,8 +366,8 @@ public class ReplicatedJournal implements Journal {
     */
    @Override
    public void appendRollbackRecord(final long txID, final boolean sync) throws Exception {
-      if (log.isTraceEnabled()) {
-         log.trace("AppendRollback {}", txID);
+      if (logger.isTraceEnabled()) {
+         logger.trace("AppendRollback {}", txID);
       }
       replicationManager.appendRollbackRecord(journalID, txID);
       localJournal.appendRollbackRecord(txID, sync);
@@ -375,8 +375,8 @@ public class ReplicatedJournal implements Journal {
 
    @Override
    public void appendRollbackRecord(final long txID, final boolean sync, final IOCompletion callback) throws Exception {
-      if (log.isTraceEnabled()) {
-         log.trace("AppendRollback {}", txID);
+      if (logger.isTraceEnabled()) {
+         logger.trace("AppendRollback {}", txID);
       }
       replicationManager.appendRollbackRecord(journalID, txID);
       localJournal.appendRollbackRecord(txID, sync, callback);
@@ -423,8 +423,8 @@ public class ReplicatedJournal implements Journal {
                                   final Persister persister,
                                   final Object record,
                                   final boolean sync) throws Exception {
-      if (log.isTraceEnabled()) {
-         log.trace("AppendUpdateRecord id = {} , recordType = {}", id, recordType);
+      if (logger.isTraceEnabled()) {
+         logger.trace("AppendUpdateRecord id = {} , recordType = {}", id, recordType);
       }
       replicationManager.appendUpdateRecord(journalID, ADD_OPERATION_TYPE.UPDATE, id, recordType, persister, record);
       localJournal.appendUpdateRecord(id, recordType, persister, record, sync);
@@ -437,8 +437,8 @@ public class ReplicatedJournal implements Journal {
                                   final Object record,
                                   final JournalUpdateCallback updateCallback,
                                   final boolean sync, final boolean replaceable) throws Exception {
-      if (log.isTraceEnabled()) {
-         log.trace("AppendUpdateRecord id = {} , recordType = {}", id, recordType);
+      if (logger.isTraceEnabled()) {
+         logger.trace("AppendUpdateRecord id = {} , recordType = {}", id, recordType);
       }
       replicationManager.appendUpdateRecord(journalID, ADD_OPERATION_TYPE.UPDATE, id, recordType, persister, record);
       localJournal.tryAppendUpdateRecord(id, recordType, persister, record, updateCallback, sync, replaceable);
@@ -451,8 +451,8 @@ public class ReplicatedJournal implements Journal {
                                   final Object record,
                                   final boolean sync,
                                   final IOCompletion completionCallback) throws Exception {
-      if (log.isTraceEnabled()) {
-         log.trace("AppendUpdateRecord id = {} , recordType = {}", id, journalRecordType);
+      if (logger.isTraceEnabled()) {
+         logger.trace("AppendUpdateRecord id = {} , recordType = {}", id, journalRecordType);
       }
       replicationManager.appendUpdateRecord(journalID, ADD_OPERATION_TYPE.UPDATE, id, journalRecordType, persister, record);
       localJournal.appendUpdateRecord(id, journalRecordType, persister, record, sync, completionCallback);
@@ -467,8 +467,8 @@ public class ReplicatedJournal implements Journal {
                                   final boolean replaceableUpdate,
                                   final JournalUpdateCallback updateCallback,
                                   final IOCompletion completionCallback) throws Exception {
-      if (log.isTraceEnabled()) {
-         log.trace("AppendUpdateRecord id = {} , recordType = {}", id, journalRecordType);
+      if (logger.isTraceEnabled()) {
+         logger.trace("AppendUpdateRecord id = {} , recordType = {}", id, journalRecordType);
       }
       replicationManager.appendUpdateRecord(journalID, ADD_OPERATION_TYPE.UPDATE, id, journalRecordType, persister, record);
       localJournal.tryAppendUpdateRecord(id, journalRecordType, persister, record, sync, replaceableUpdate, updateCallback, completionCallback);
@@ -504,8 +504,8 @@ public class ReplicatedJournal implements Journal {
                                                final byte recordType,
                                                final Persister persister,
                                                final Object record) throws Exception {
-      if (log.isTraceEnabled()) {
-         log.trace("AppendUpdateRecord txid={} id = {} , recordType = {}", txID, id, recordType);
+      if (logger.isTraceEnabled()) {
+         logger.trace("AppendUpdateRecord txid={} id = {} , recordType = {}", txID, id, recordType);
       }
       replicationManager.appendAddRecordTransactional(journalID, ADD_OPERATION_TYPE.UPDATE, txID, id, recordType, persister, record);
       localJournal.appendUpdateRecordTransactional(txID, id, recordType, persister, record);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/NodeManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/NodeManager.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 import java.lang.invoke.MethodHandles;
 
 public abstract class NodeManager implements ActiveMQComponent {
-   private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @FunctionalInterface
    public interface LockListener {
@@ -171,7 +171,7 @@ public abstract class NodeManager implements ActiveMQComponent {
          try {
             lockListener.lostLock();
          } catch (Exception e) {
-            LOGGER.warn("On notify lost lock", e);
+            logger.warn("On notify lost lock", e);
             // Need to notify everyone so ignore any exception
          }
       });

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ReplicationBackupActivation.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ReplicationBackupActivation.java
@@ -54,7 +54,7 @@ import static org.apache.activemq.artemis.core.server.impl.quorum.ActivationSequ
  */
 public final class ReplicationBackupActivation extends Activation implements DistributedPrimitiveManager.UnavailableManagerListener {
 
-   private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private final ReplicationBackupPolicy policy;
    private final ActiveMQServerImpl activeMQServer;
@@ -112,7 +112,7 @@ public final class ReplicationBackupActivation extends Activation implements Dis
             return;
          }
       }
-      LOGGER.info("Unavailable quorum service detected: try restart server");
+      logger.info("Unavailable quorum service detected: try restart server");
       asyncRestartServer(activeMQServer, true);
    }
 
@@ -170,12 +170,12 @@ public final class ReplicationBackupActivation extends Activation implements Dis
             while (true) {
                distributedManager.start();
                try {
-                  liveLockWithInSyncReplica = tryActivate(activeMQServer.getNodeManager(), distributedManager, LOGGER);
+                  liveLockWithInSyncReplica = tryActivate(activeMQServer.getNodeManager(), distributedManager, logger);
                   break;
                } catch (UnavailableStateException canRecoverEx) {
                   distributedManager.stop();
                } catch (NodeManager.NodeManagerException fatalEx) {
-                  LOGGER.warn("Failed while auto-repairing activation sequence: stop server now", fatalEx);
+                  logger.warn("Failed while auto-repairing activation sequence: stop server now", fatalEx);
                   asyncRestartServer(activeMQServer, false);
                   return;
                }
@@ -208,7 +208,7 @@ public final class ReplicationBackupActivation extends Activation implements Dis
 
          final ClusterController clusterController = activeMQServer.getClusterManager().getClusterController();
 
-         LOGGER.info("Apache ActiveMQ Artemis Backup Server version {} [{}] started, awaiting connection to a live cluster member to start replication", activeMQServer.getVersion().getFullVersion(),
+         logger.info("Apache ActiveMQ Artemis Backup Server version {} [{}] started, awaiting connection to a live cluster member to start replication", activeMQServer.getVersion().getFullVersion(),
                       activeMQServer.toString());
 
          clusterController.awaitConnectionToReplicationCluster();
@@ -240,9 +240,9 @@ public final class ReplicationBackupActivation extends Activation implements Dis
             // stopBackup is going to write the NodeID and activation sequence previously set on the NodeManager,
             // because activeMQServer.resetNodeManager() has created a NodeManager with replicatedBackup == true.
             nodeManager.stopBackup();
-            ensureSequentialAccessToNodeData(activeMQServer.toString(), nodeManager, distributedManager, LOGGER);
+            ensureSequentialAccessToNodeData(activeMQServer.toString(), nodeManager, distributedManager, logger);
          } catch (Throwable fatal) {
-            LOGGER.warn(fatal.getMessage());
+            logger.warn(fatal.getMessage());
             // policy is already live one, but there's no activation yet: we can just stop
             asyncRestartServer(activeMQServer, false, false);
             throw new ActiveMQIllegalStateException("This server cannot ensure sequential access to broker data: activation is failed");
@@ -263,7 +263,7 @@ public final class ReplicationBackupActivation extends Activation implements Dis
          try {
             stillLive = liveLock.isHeldByCaller();
          } catch (UnavailableStateException e) {
-            LOGGER.warn(e.getMessage(), e);
+            logger.warn(e.getMessage(), e);
             primaryActivation.onUnavailableLockEvent();
             throw new ActiveMQIllegalStateException("This server cannot check its role as a live: activation is failed");
          }
@@ -304,7 +304,7 @@ public final class ReplicationBackupActivation extends Activation implements Dis
                }
             }
             if (expectedNodeID != null) {
-               LOGGER.info("awaiting connecting to any live node with NodeID = {}", expectedNodeID);
+               logger.info("awaiting connecting to any live node with NodeID = {}", expectedNodeID);
             }
             final ReplicationFailure failure = replicateLive(clusterController, nodeLocator, registrationFailureForwarder);
             if (failure == null) {
@@ -314,7 +314,7 @@ public final class ReplicationBackupActivation extends Activation implements Dis
             if (!activeMQServer.isStarted()) {
                return null;
             }
-            LOGGER.debug("ReplicationFailure = {}", failure);
+            logger.debug("ReplicationFailure = {}", failure);
             switch (failure) {
                case VoluntaryFailOver:
                case NonVoluntaryFailover:
@@ -330,14 +330,14 @@ public final class ReplicationBackupActivation extends Activation implements Dis
                   DistributedLock liveLockWithInSyncReplica = null;
                   if (nodeManager.getNodeActivationSequence() > 0) {
                      try {
-                        liveLockWithInSyncReplica = tryActivate(nodeManager, distributedManager, LOGGER);
+                        liveLockWithInSyncReplica = tryActivate(nodeManager, distributedManager, logger);
                      } catch (Throwable error) {
                         // no need to retry here, can just restart as backup that will handle a more resilient tryActivate
-                        LOGGER.warn("Errored while attempting failover", error);
+                        logger.warn("Errored while attempting failover", error);
                         liveLockWithInSyncReplica = null;
                      }
                   } else {
-                     LOGGER.error("Expected positive local activation sequence for NodeID = {} during fail-over, but was {}: restarting as backup",
+                     logger.error("Expected positive local activation sequence for NodeID = {} during fail-over, but was {}: restarting as backup",
                                    nodeManager.getNodeId(), nodeManager.getNodeActivationSequence());
                   }
                   assert stopping.get();
@@ -349,13 +349,13 @@ public final class ReplicationBackupActivation extends Activation implements Dis
                   asyncRestartServer(activeMQServer, true, false);
                   return null;
                case RegistrationError:
-                  LOGGER.error("Stopping broker because of critical registration error");
+                  logger.error("Stopping broker because of critical registration error");
                   asyncRestartServer(activeMQServer, false);
                   return null;
                case AlreadyReplicating:
                   // can just retry here, data should be clean and nodeLocator
                   // should remove the live node that has answered this
-                  LOGGER.info("Live broker was already replicating: retry sync with another live");
+                  logger.info("Live broker was already replicating: retry sync with another live");
                   continue;
                case ClosedObserver:
                   return null;
@@ -368,22 +368,22 @@ public final class ReplicationBackupActivation extends Activation implements Dis
                      try {
                         activeMQServer.getNodeManager().setNodeActivationSequence(NULL_NODE_ACTIVATION_SEQUENCE);
                      } catch (Throwable fatal) {
-                        LOGGER.error("Errored while resetting local activation sequence {} for NodeID = {}: stopping broker",
+                        logger.error("Errored while resetting local activation sequence {} for NodeID = {}: stopping broker",
                                       activationSequence, syncNodeId, fatal);
                         restart = false;
                      }
                   }
                   if (restart) {
-                     LOGGER.info("Replication failure while initial sync not yet completed: restart as backup");
+                     logger.info("Replication failure while initial sync not yet completed: restart as backup");
                   }
                   asyncRestartServer(activeMQServer, restart);
                   return null;
                case WrongNodeId:
-                  LOGGER.error("Stopping broker because of wrong node ID communication from live: maybe a misbehaving live?");
+                  logger.error("Stopping broker because of wrong node ID communication from live: maybe a misbehaving live?");
                   asyncRestartServer(activeMQServer, false);
                   return null;
                case WrongActivationSequence:
-                  LOGGER.error("Stopping broker because of wrong activation sequence communication from live: maybe a misbehaving live?");
+                  logger.error("Stopping broker because of wrong activation sequence communication from live: maybe a misbehaving live?");
                   asyncRestartServer(activeMQServer, false);
                   return null;
                default:
@@ -446,7 +446,7 @@ public final class ReplicationBackupActivation extends Activation implements Dis
       try {
          task.run();
       } catch (Throwable ignore) {
-         LOGGER.debug(debugErrorMessage, ignore);
+         logger.debug(debugErrorMessage, ignore);
       }
    }
 
@@ -526,7 +526,7 @@ public final class ReplicationBackupActivation extends Activation implements Dis
             return clusterController.connectToNodeInReplicatedCluster(tc);
          }
       } catch (Exception e) {
-         LOGGER.debug(e.getMessage(), e);
+         logger.debug(e.getMessage(), e);
       }
       return null;
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/metrics/MetricsManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/metrics/MetricsManager.java
@@ -42,7 +42,7 @@ import java.lang.invoke.MethodHandles;
 
 public class MetricsManager {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private final String brokerName;
 
@@ -144,7 +144,7 @@ public class MetricsManager {
          for (Gauge.Builder gaugeBuilder : newMeters) {
             Gauge gauge = gaugeBuilder.register(meterRegistry);
             meters.add(gauge);
-            log.debug("Registered meter: {}", gauge.getId());
+            logger.debug("Registered meter: {}", gauge.getId());
          }
          return meters;
       });
@@ -157,7 +157,7 @@ public class MetricsManager {
          }
          for (Meter meter : meters) {
             Meter removed = meterRegistry.remove(meter);
-            log.debug("Unregistered meter: {}", removed.getId());
+            logger.debug("Unregistered meter: {}", removed.getId());
          }
          return null;
       });

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImplTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImplTest.java
@@ -71,7 +71,7 @@ import org.junit.Test;
 
 public class ConfigurationImplTest extends ActiveMQTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    protected Configuration conf;
 
@@ -571,7 +571,7 @@ public class ConfigurationImplTest extends ActiveMQTestBase {
          tempFolder = new File(tempFolder.getAbsolutePath());
          tempFolder.mkdirs();
 
-         log.debug("TempFolder = {}", tempFolder.getAbsolutePath());
+         logger.debug("TempFolder = {}", tempFolder.getAbsolutePath());
 
          ConfigurationImpl configuration = new ConfigurationImpl();
          configuration.setJournalDirectory(tempFolder.getAbsolutePath());
@@ -589,7 +589,7 @@ public class ConfigurationImplTest extends ActiveMQTestBase {
          tempFolder = new File(tempFolder.getAbsolutePath());
          tempFolder.mkdirs();
 
-         log.debug("TempFolder = {}", tempFolder.getAbsolutePath());
+         logger.debug("TempFolder = {}", tempFolder.getAbsolutePath());
          configuration.setNodeManagerLockDirectory(tempFolder.getAbsolutePath());
          File lockLocation = configuration.getNodeManagerLockLocation();
          Assert.assertTrue(lockLocation.exists());

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/security/jaas/JAASSecurityManagerTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/security/jaas/JAASSecurityManagerTest.java
@@ -47,7 +47,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
 public class JAASSecurityManagerTest {
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Parameterized.Parameters(name = "newLoader=({0})")
    public static Collection<Object[]> data() {
@@ -78,7 +78,7 @@ public class JAASSecurityManagerTest {
    @Test
    public void testLoginClassloading() throws Exception {
       ClassLoader existingLoader = Thread.currentThread().getContextClassLoader();
-      log.debug("loader: {}", existingLoader);
+      logger.debug("loader: {}", existingLoader);
       try {
          if (usingNewLoader) {
             URLClassLoader simulatedLoader = new URLClassLoader(new URL[]{tmpDir.getRoot().toURI().toURL()}, null);

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/files/FileStoreMonitorTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/files/FileStoreMonitorTest.java
@@ -40,7 +40,7 @@ import org.junit.Test;
 
 public class FileStoreMonitorTest extends ActiveMQTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private ScheduledExecutorService scheduledExecutorService;
    private ExecutorService executorService;
@@ -81,19 +81,19 @@ public class FileStoreMonitorTest extends ActiveMQTestBase {
          @Override
          public void tick(long usableSpace, long totalSpace) {
             tick.incrementAndGet();
-            log.debug("tick:: usableSpace: {}, totalSpace:{}", usableSpace, totalSpace);
+            logger.debug("tick:: usableSpace: {}, totalSpace:{}", usableSpace, totalSpace);
          }
 
          @Override
          public void over(long usableSpace, long totalSpace) {
             over.incrementAndGet();
-            log.debug("over:: usableSpace: {}, totalSpace:{}", usableSpace, totalSpace);
+            logger.debug("over:: usableSpace: {}, totalSpace:{}", usableSpace, totalSpace);
          }
 
          @Override
          public void under(long usableSpace, long totalSpace) {
             under.incrementAndGet();
-            log.debug("under:: usableSpace: {}, totalSpace: {}", usableSpace, totalSpace);
+            logger.debug("under:: usableSpace: {}, totalSpace: {}", usableSpace, totalSpace);
          }
       };
       FileStoreMonitor storeMonitor = new FileStoreMonitor(scheduledExecutorService, executorService, 100, TimeUnit.MILLISECONDS, 0.999, null);
@@ -125,7 +125,7 @@ public class FileStoreMonitorTest extends ActiveMQTestBase {
       storeMonitor.addCallback(new FileStoreMonitor.Callback() {
          @Override
          public void tick(long usableSpace, long totalSpace) {
-            log.debug("Tick");
+            logger.debug("Tick");
             latch.countDown();
          }
 

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/ScheduledDeliveryHandlerTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/ScheduledDeliveryHandlerTest.java
@@ -68,7 +68,7 @@ import org.junit.Test;
 
 public class ScheduledDeliveryHandlerTest extends Assert {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Test
    public void testScheduleRandom() throws Exception {
@@ -285,7 +285,7 @@ public class ScheduledDeliveryHandlerTest extends Assert {
             assertTrue(ref.getScheduledDeliveryTime() >= lastTime);
          } else {
             if (ref.getScheduledDeliveryTime() < lastTime) {
-               log.debug("^^^fail at {}", ref.getScheduledDeliveryTime());
+               logger.debug("^^^fail at {}", ref.getScheduledDeliveryTime());
             }
          }
          lastTime = ref.getScheduledDeliveryTime();

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/transaction/impl/TransactionImplTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/transaction/impl/TransactionImplTest.java
@@ -74,7 +74,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class TransactionImplTest extends ActiveMQTestBase {
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Test
    public void testTimeoutAndThenCommitWithARollback() throws Exception {
@@ -102,7 +102,7 @@ public class TransactionImplTest extends ActiveMQTestBase {
 
          @Override
          public void afterCommit(Transaction tx) {
-            log.debug("commit...");
+            logger.debug("commit...");
             commit.incrementAndGet();
          }
 
@@ -113,7 +113,7 @@ public class TransactionImplTest extends ActiveMQTestBase {
 
          @Override
          public void afterRollback(Transaction tx) {
-            log.debug("rollback...");
+            logger.debug("rollback...");
             rollback.incrementAndGet();
          }
 
@@ -170,7 +170,7 @@ public class TransactionImplTest extends ActiveMQTestBase {
 
          @Override
          public void afterCommit(Transaction tx) {
-            log.debug("commit...");
+            logger.debug("commit...");
             commit.incrementAndGet();
          }
 
@@ -181,7 +181,7 @@ public class TransactionImplTest extends ActiveMQTestBase {
 
          @Override
          public void afterRollback(Transaction tx) {
-            log.debug("rollback...");
+            logger.debug("rollback...");
             rollback.incrementAndGet();
          }
 

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/uri/AcceptorParserTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/uri/AcceptorParserTest.java
@@ -32,14 +32,14 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class AcceptorParserTest {
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Test
    public void testAcceptor() throws Exception {
       List<TransportConfiguration> configs = ConfigurationUtils.parseAcceptorURI("test", "tcp://localhost:8080?tcpSendBufferSize=1048576&tcpReceiveBufferSize=1048576&protocols=openwire&banana=x");
 
       for (TransportConfiguration config : configs) {
-         log.debug("config: {}", config);
+         logger.debug("config: {}", config);
          Assert.assertTrue(config.getExtraParams().get("banana").equals("x"));
       }
    }
@@ -64,8 +64,8 @@ public class AcceptorParserTest {
       List<TransportConfiguration> configs = ConfigurationUtils.parseAcceptorURI("test", "tcp://0.0.0.0:5672?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;virtualTopicConsumerWildcards=Consumer.*.%3E%3B2");
 
       for (TransportConfiguration config : configs) {
-         log.debug("config: {}", config);
-         log.debug("{}", config.getExtraParams().get("virtualTopicConsumerWildcards"));
+         logger.debug("config: {}", config);
+         logger.debug("{}", config.getExtraParams().get("virtualTopicConsumerWildcards"));
          Assert.assertTrue(config.getExtraParams().get("virtualTopicConsumerWildcards").equals("Consumer.*.>;2"));
       }
    }

--- a/artemis-unit-test-support/src/main/java/org/apache/activemq/artemis/utils/CleanupSystemPropertiesRule.java
+++ b/artemis-unit-test-support/src/main/java/org/apache/activemq/artemis/utils/CleanupSystemPropertiesRule.java
@@ -21,17 +21,12 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import java.lang.invoke.MethodHandles;
 import org.junit.rules.ExternalResource;
 
 /**
  * This will make sure any properties changed through tests are cleaned up between tests.
  */
 public class CleanupSystemPropertiesRule extends ExternalResource {
-
-   private static Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private Properties originalProperties;
 

--- a/artemis-unit-test-support/src/main/java/org/apache/activemq/artemis/utils/ThreadLeakCheckRule.java
+++ b/artemis-unit-test-support/src/main/java/org/apache/activemq/artemis/utils/ThreadLeakCheckRule.java
@@ -38,7 +38,7 @@ import org.junit.runner.Description;
  */
 public class ThreadLeakCheckRule extends TestWatcher {
 
-   private static Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private static Set<String> knownThreads = new HashSet<>();
 
@@ -84,8 +84,8 @@ public class ThreadLeakCheckRule extends TestWatcher {
     */
    @Override
    protected void finished(Description description) {
-      if (log.isDebugEnabled()) {
-         log.debug("checking thread enabled? {}, testFailed? {}", enabled, testFailed);
+      if (logger.isDebugEnabled()) {
+         logger.debug("checking thread enabled? {}, testFailed? {}", enabled, testFailed);
       }
       try {
          if (enabled) {
@@ -139,10 +139,10 @@ public class ThreadLeakCheckRule extends TestWatcher {
    public static void forceGC() {
 
       if (failedGCCalls >= 10) {
-         log.info("ignoring forceGC call since it seems System.gc is not working anyways");
+         logger.info("ignoring forceGC call since it seems System.gc is not working anyways");
          return;
       }
-      log.info("#test forceGC");
+      logger.info("#test forceGC");
       CountDownLatch finalized = new CountDownLatch(1);
       WeakReference<DumbReference> dumbReference = new WeakReference<>(new DumbReference(finalized));
 
@@ -160,12 +160,12 @@ public class ThreadLeakCheckRule extends TestWatcher {
 
       if (dumbReference.get() != null) {
          failedGCCalls++;
-         log.info("It seems that GC is disabled at your VM");
+         logger.info("It seems that GC is disabled at your VM");
       } else {
          // a success would reset the count
          failedGCCalls = 0;
       }
-      log.info("#test forceGC Done ");
+      logger.info("#test forceGC Done ");
    }
 
    public static void forceGC(final Reference<?> ref, final long timeout) {

--- a/examples/features/perf/perf/src/main/java/org/apache/activemq/artemis/jms/example/PerfBase.java
+++ b/examples/features/perf/perf/src/main/java/org/apache/activemq/artemis/jms/example/PerfBase.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
 
 public abstract class PerfBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private static final String DEFAULT_PERF_PROPERTIES_FILE_NAME = "target/classes/perf.properties";
 
@@ -95,20 +95,20 @@ public abstract class PerfBase {
       String clientLibrary = props.getProperty("client-library", "core");
       String uri = props.getProperty("server-uri", "tcp://localhost:61616");
 
-      PerfBase.log.info("num-messages: {}", noOfMessages);
-      PerfBase.log.info("num-warmup-messages: {}", noOfWarmupMessages);
-      PerfBase.log.info("message-size: {}", messageSize);
-      PerfBase.log.info("durable: {}", durable);
-      PerfBase.log.info("transacted: {}", transacted);
-      PerfBase.log.info("batch-size: {}", batchSize);
-      PerfBase.log.info("drain-queue: {}", drainQueue);
-      PerfBase.log.info("throttle-rate: {}", throttleRate);
-      PerfBase.log.info("destination-name: {}", destinationName);
-      PerfBase.log.info("disable-message-id: {}", disableMessageID);
-      PerfBase.log.info("disable-message-timestamp: {}", disableTimestamp);
-      PerfBase.log.info("dups-ok-acknowledge: {}", dupsOK);
-      PerfBase.log.info("server-uri: {}", uri);
-      PerfBase.log.info("client-library:{}", clientLibrary);
+      PerfBase.logger.info("num-messages: {}", noOfMessages);
+      PerfBase.logger.info("num-warmup-messages: {}", noOfWarmupMessages);
+      PerfBase.logger.info("message-size: {}", messageSize);
+      PerfBase.logger.info("durable: {}", durable);
+      PerfBase.logger.info("transacted: {}", transacted);
+      PerfBase.logger.info("batch-size: {}", batchSize);
+      PerfBase.logger.info("drain-queue: {}", drainQueue);
+      PerfBase.logger.info("throttle-rate: {}", throttleRate);
+      PerfBase.logger.info("destination-name: {}", destinationName);
+      PerfBase.logger.info("disable-message-id: {}", disableMessageID);
+      PerfBase.logger.info("disable-message-timestamp: {}", disableTimestamp);
+      PerfBase.logger.info("dups-ok-acknowledge: {}", dupsOK);
+      PerfBase.logger.info("server-uri: {}", uri);
+      PerfBase.logger.info("client-library:{}", clientLibrary);
 
       PerfParams perfParams = new PerfParams();
       perfParams.setNoOfMessagesToSend(noOfMessages);
@@ -179,7 +179,7 @@ public abstract class PerfBase {
    private void displayAverage(final long numberOfMessages, final long start, final long end) {
       double duration = (1.0 * end - start) / 1000; // in seconds
       double average = 1.0 * numberOfMessages / duration;
-      PerfBase.log.info(String.format("average: %.2f msg/s (%d messages in %2.2fs)", average, numberOfMessages, duration));
+      PerfBase.logger.info(String.format("average: %.2f msg/s (%d messages in %2.2fs)", average, numberOfMessages, duration));
    }
 
    protected void runSender() {
@@ -191,9 +191,9 @@ public abstract class PerfBase {
          }
 
          start = System.currentTimeMillis();
-         PerfBase.log.info("warming up by sending {} messages", perfParams.getNoOfWarmupMessages());
+         PerfBase.logger.info("warming up by sending {} messages", perfParams.getNoOfWarmupMessages());
          sendMessages(perfParams.getNoOfWarmupMessages(), perfParams.getBatchSize(), perfParams.isDurable(), perfParams.isSessionTransacted(), false, perfParams.getThrottleRate(), perfParams.getMessageSize());
-         PerfBase.log.info("warmed up");
+         PerfBase.logger.info("warmed up");
          start = System.currentTimeMillis();
          sendMessages(perfParams.getNoOfMessagesToSend(), perfParams.getBatchSize(), perfParams.isDurable(), perfParams.isSessionTransacted(), true, perfParams.getThrottleRate(), perfParams.getMessageSize());
          long end = System.currentTimeMillis();
@@ -230,7 +230,7 @@ public abstract class PerfBase {
 
          connection.start();
 
-         PerfBase.log.info("READY!!!");
+         PerfBase.logger.info("READY!!!");
 
          CountDownLatch countDownLatch = new CountDownLatch(1);
          consumer.setMessageListener(new PerfListener(countDownLatch, perfParams));
@@ -259,7 +259,7 @@ public abstract class PerfBase {
    }
 
    private void drainQueue() throws Exception {
-      PerfBase.log.info("Draining queue");
+      PerfBase.logger.info("Draining queue");
 
       Session drainSession = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
 
@@ -283,7 +283,7 @@ public abstract class PerfBase {
 
       drainSession.close();
 
-      PerfBase.log.info("Drained {} messages", count);
+      PerfBase.logger.info("Drained {} messages", count);
    }
 
    private void sendMessages(final int numberOfMessages,
@@ -326,7 +326,7 @@ public abstract class PerfBase {
 
          if (display && i % modulo == 0) {
             double duration = (1.0 * System.currentTimeMillis() - start) / 1000;
-            PerfBase.log.info(String.format("sent %6d messages in %2.2fs", i, duration));
+            PerfBase.logger.info(String.format("sent %6d messages in %2.2fs", i, duration));
          }
 
          if (tbl != null) {
@@ -365,7 +365,7 @@ public abstract class PerfBase {
             if (warmingUp) {
                boolean committed = checkCommit();
                if (count.incrementAndGet() == perfParams.getNoOfWarmupMessages()) {
-                  PerfBase.log.info("warmed up after receiving {} msgs", count.longValue());
+                  PerfBase.logger.info("warmed up after receiving {} msgs", count.longValue());
                   if (!committed) {
                      checkCommit();
                   }
@@ -391,7 +391,7 @@ public abstract class PerfBase {
             }
             if (currentCount % modulo == 0) {
                double duration = (1.0 * System.currentTimeMillis() - start) / 1000;
-               PerfBase.log.info(String.format("received %6d messages in %2.2fs", currentCount, duration));
+               PerfBase.logger.info(String.format("received %6d messages in %2.2fs", currentCount, duration));
             }
          } catch (Exception e) {
             e.printStackTrace();

--- a/examples/features/perf/soak/src/main/java/org/apache/activemq/artemis/jms/soak/example/SoakBase.java
+++ b/examples/features/perf/soak/src/main/java/org/apache/activemq/artemis/jms/soak/example/SoakBase.java
@@ -26,7 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class SoakBase {
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private static final String DEFAULT_SOAK_PROPERTIES_FILE_NAME = "soak.properties";
 
@@ -75,19 +75,19 @@ public class SoakBase {
       boolean disableMessageID = Boolean.valueOf(props.getProperty("disable-message-id"));
       boolean disableTimestamp = Boolean.valueOf(props.getProperty("disable-message-timestamp"));
 
-      SoakBase.log.info("duration-in-minutes: {}", durationInMinutes);
-      SoakBase.log.info("num-warmup-messages: {}", noOfWarmupMessages);
-      SoakBase.log.info("message-size: {}", messageSize);
-      SoakBase.log.info("durable: {}", durable);
-      SoakBase.log.info("transacted: {}", transacted);
-      SoakBase.log.info("batch-size: {}", batchSize);
-      SoakBase.log.info("drain-queue: {}", drainQueue);
-      SoakBase.log.info("throttle-rate: {}", throttleRate);
-      SoakBase.log.info("connection-factory-lookup: {}", connectionFactoryLookup);
-      SoakBase.log.info("destination-lookup: {}", destinationLookup);
-      SoakBase.log.info("disable-message-id: {}", disableMessageID);
-      SoakBase.log.info("disable-message-timestamp: {}", disableTimestamp);
-      SoakBase.log.info("dups-ok-acknowledge: {}", dupsOK);
+      SoakBase.logger.info("duration-in-minutes: {}", durationInMinutes);
+      SoakBase.logger.info("num-warmup-messages: {}", noOfWarmupMessages);
+      SoakBase.logger.info("message-size: {}", messageSize);
+      SoakBase.logger.info("durable: {}", durable);
+      SoakBase.logger.info("transacted: {}", transacted);
+      SoakBase.logger.info("batch-size: {}", batchSize);
+      SoakBase.logger.info("drain-queue: {}", drainQueue);
+      SoakBase.logger.info("throttle-rate: {}", throttleRate);
+      SoakBase.logger.info("connection-factory-lookup: {}", connectionFactoryLookup);
+      SoakBase.logger.info("destination-lookup: {}", destinationLookup);
+      SoakBase.logger.info("disable-message-id: {}", disableMessageID);
+      SoakBase.logger.info("disable-message-timestamp: {}", disableTimestamp);
+      SoakBase.logger.info("dups-ok-acknowledge: {}", dupsOK);
 
       SoakParams soakParams = new SoakParams();
       soakParams.setDurationInMinutes(durationInMinutes);

--- a/examples/features/perf/soak/src/main/java/org/apache/activemq/artemis/jms/soak/example/SoakReceiver.java
+++ b/examples/features/perf/soak/src/main/java/org/apache/activemq/artemis/jms/soak/example/SoakReceiver.java
@@ -37,7 +37,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class SoakReceiver {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private static final String EOF = UUID.randomUUID().toString();
 
@@ -96,8 +96,8 @@ public class SoakReceiver {
 
          try {
             if (SoakReceiver.EOF.equals(msg.getStringProperty("eof"))) {
-               SoakReceiver.log.info(String.format("Received %s messages in %.2f minutes", count, 1.0 * totalDuration / SoakBase.TO_MILLIS));
-               SoakReceiver.log.info("END OF RUN");
+               SoakReceiver.logger.info(String.format("Received %s messages in %.2f minutes", count, 1.0 * totalDuration / SoakBase.TO_MILLIS));
+               SoakReceiver.logger.info("END OF RUN");
 
                return;
             }
@@ -107,7 +107,7 @@ public class SoakReceiver {
          if (count.incrementAndGet() % modulo == 0) {
             double duration = (1.0 * System.currentTimeMillis() - moduloStart) / 1000;
             moduloStart = System.currentTimeMillis();
-            SoakReceiver.log.info(String.format("received %s messages in %2.2fs (total: %.0fs)", modulo, duration, totalDuration / 1000.0));
+            SoakReceiver.logger.info(String.format("received %s messages in %2.2fs (total: %.0fs)", modulo, duration, totalDuration / 1000.0));
          }
       }
    };

--- a/examples/features/perf/soak/src/main/java/org/apache/activemq/artemis/jms/soak/example/SoakSender.java
+++ b/examples/features/perf/soak/src/main/java/org/apache/activemq/artemis/jms/soak/example/SoakSender.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
 
 public class SoakSender {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    public static void main(final String[] args) {
       try {
@@ -120,7 +120,7 @@ public class SoakSender {
             if (display && count.longValue() % modulo == 0) {
                double duration = (1.0 * System.currentTimeMillis() - moduleStart) / 1000;
                moduleStart = System.currentTimeMillis();
-               SoakSender.log.info(String.format("sent %s messages in %2.2fs (time: %.0fs)", modulo, duration, totalDuration / 1000.0));
+               SoakSender.logger.info(String.format("sent %s messages in %2.2fs (time: %.0fs)", modulo, duration, totalDuration / 1000.0));
             }
 
             if (tbl != null) {
@@ -135,8 +135,8 @@ public class SoakSender {
          }
       }
 
-      SoakSender.log.info(String.format("Sent %s messages in %s minutes", count, perfParams.getDurationInMinutes()));
-      SoakSender.log.info("END OF RUN");
+      SoakSender.logger.info(String.format("Sent %s messages in %s minutes", count, perfParams.getDurationInMinutes()));
+      SoakSender.logger.info("END OF RUN");
 
       if (connection != null) {
          connection.close();

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/AmqpAbstractResource.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/AmqpAbstractResource.java
@@ -34,7 +34,7 @@ import java.lang.invoke.MethodHandles;
  */
 public abstract class AmqpAbstractResource<E extends Endpoint> implements AmqpResource {
 
-   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    protected AsyncResult openRequest;
    protected AsyncResult closeRequest;
@@ -146,7 +146,7 @@ public abstract class AmqpAbstractResource<E extends Endpoint> implements AmqpRe
          endpoint.close();
       }
 
-      LOG.info("Resource {} was remotely closed", this);
+      logger.info("Resource {} was remotely closed", this);
 
       connection.fireClientException(error);
    }
@@ -159,7 +159,7 @@ public abstract class AmqpAbstractResource<E extends Endpoint> implements AmqpRe
          endpoint.close();
       }
 
-      LOG.info("Resource {} was locally closed", this);
+      logger.info("Resource {} was locally closed", this);
 
       connection.fireClientException(error);
    }
@@ -212,7 +212,7 @@ public abstract class AmqpAbstractResource<E extends Endpoint> implements AmqpRe
    public void processRemoteDetach(AmqpConnection connection) throws IOException {
       doDetachedInspection();
       if (isAwaitingClose()) {
-         LOG.debug("{} is now closed: ", this);
+         logger.debug("{} is now closed: ", this);
          closed();
       } else {
          remotelyClosed(connection);
@@ -223,11 +223,11 @@ public abstract class AmqpAbstractResource<E extends Endpoint> implements AmqpRe
    public void processRemoteClose(AmqpConnection connection) throws IOException {
       doClosedInspection();
       if (isAwaitingClose()) {
-         LOG.debug("{} is now closed: ", this);
+         logger.debug("{} is now closed: ", this);
          closed();
       } else if (isAwaitingOpen()) {
          // Error on Open, create exception and signal failure.
-         LOG.warn("Open of {} failed: ", this);
+         logger.warn("Open of {} failed: ", this);
          Exception openError;
          if (hasRemoteError()) {
             openError = AmqpSupport.convertToException(getEndpoint().getRemoteCondition());
@@ -281,7 +281,7 @@ public abstract class AmqpAbstractResource<E extends Endpoint> implements AmqpRe
     * to provide additional verification actions or configuration updates.
     */
    protected void doOpenCompletion() {
-      LOG.debug("{} is now open: ", this);
+      logger.debug("{} is now open: ", this);
       opened();
    }
 

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/AmqpClient.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/AmqpClient.java
@@ -34,7 +34,7 @@ import java.lang.invoke.MethodHandles;
  */
 public class AmqpClient {
 
-   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private final String username;
    private final String password;
@@ -70,7 +70,7 @@ public class AmqpClient {
 
       AmqpConnection connection = createConnection();
 
-      LOG.debug("Attempting to create new connection to peer: {}", remoteURI);
+      logger.debug("Attempting to create new connection to peer: {}", remoteURI);
       connection.connect();
 
       return connection;
@@ -88,7 +88,7 @@ public class AmqpClient {
       AmqpConnection connection = createConnection();
       connection.setNoContainerID();
 
-      LOG.debug("Attempting to create new connection to peer: {}", remoteURI);
+      logger.debug("Attempting to create new connection to peer: {}", remoteURI);
       connection.connect();
 
       return connection;
@@ -107,7 +107,7 @@ public class AmqpClient {
       AmqpConnection connection = createConnection();
       connection.setContainerId(containerId);
 
-      LOG.debug("Attempting to create new connection to peer: {}", remoteURI);
+      logger.debug("Attempting to create new connection to peer: {}", remoteURI);
       connection.connect();
 
       return connection;

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/AmqpConnection.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/AmqpConnection.java
@@ -61,7 +61,7 @@ import io.netty.util.ReferenceCountUtil;
 
 public class AmqpConnection extends AmqpAbstractResource<Connection> implements NettyTransportListener {
 
-   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private static final NoOpAsyncResult NOOP_REQUEST = new NoOpAsyncResult();
 
@@ -229,7 +229,7 @@ public class AmqpConnection extends AmqpAbstractResource<Connection> implements 
 
                   pumpToProtonTransport(request);
                } catch (Exception e) {
-                  LOG.debug("Caught exception while closing proton connection");
+                  logger.debug("Caught exception while closing proton connection");
                }
             }
          });
@@ -241,20 +241,20 @@ public class AmqpConnection extends AmqpAbstractResource<Connection> implements 
                request.sync(closeTimeout, TimeUnit.MILLISECONDS);
             }
          } catch (IOException e) {
-            LOG.warn("Error caught while closing Provider: ", e.getMessage());
+            logger.warn("Error caught while closing Provider: ", e.getMessage());
          } finally {
             if (transport != null) {
                try {
                   transport.close();
                } catch (Exception e) {
-                  LOG.debug("Cuaght exception while closing down Transport: {}", e.getMessage());
+                  logger.debug("Cuaght exception while closing down Transport: {}", e.getMessage());
                }
             }
 
             serializer.shutdownNow();
             try {
                if (!serializer.awaitTermination(10, TimeUnit.SECONDS)) {
-                  LOG.warn("Serializer didn't shutdown cleanly");
+                  logger.warn("Serializer didn't shutdown cleanly");
                }
             } catch (InterruptedException e) {
             }
@@ -549,10 +549,10 @@ public class AmqpConnection extends AmqpAbstractResource<Connection> implements 
          @Override
          public void run() {
             ByteBuffer source = incoming.nioBuffer();
-            LOG.trace("Client Received from Broker {} bytes:", source.remaining());
+            logger.trace("Client Received from Broker {} bytes:", source.remaining());
 
             if (protonTransport.isClosed()) {
-               LOG.debug("Ignoring incoming data because transport is closed");
+               logger.debug("Ignoring incoming data because transport is closed");
                return;
             }
 
@@ -579,7 +579,7 @@ public class AmqpConnection extends AmqpAbstractResource<Connection> implements 
 
    @Override
    public void onTransportClosed() {
-      LOG.debug("The transport has unexpectedly closed");
+      logger.debug("The transport has unexpectedly closed");
       failed(getOpenAbortException());
    }
 
@@ -607,13 +607,13 @@ public class AmqpConnection extends AmqpAbstractResource<Connection> implements 
                   public void run() {
                      try {
                         if (getEndpoint().getLocalState() != EndpointState.CLOSED) {
-                           LOG.debug("Client performing next idle check");
+                           logger.debug("Client performing next idle check");
                            // Using nano time since it is not related to the wall clock, which may change
                            long now = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
                            long deadline = protonTransport.tick(now);
                            pumpToProtonTransport();
                            if (protonTransport.isClosed()) {
-                              LOG.debug("Transport closed after inactivity check.");
+                              logger.debug("Transport closed after inactivity check.");
                               throw new IllegalStateException("Channel was inactive for too long");
                            } else {
                               if (deadline != 0) {
@@ -672,7 +672,7 @@ public class AmqpConnection extends AmqpAbstractResource<Connection> implements 
          Event protonEvent = null;
          while ((protonEvent = protonCollector.peek()) != null) {
             if (!protonEvent.getType().equals(Type.TRANSPORT)) {
-               LOG.trace("Client: New Proton Event: {}", protonEvent.getType());
+               logger.trace("Client: New Proton Event: {}", protonEvent.getType());
             }
 
             AmqpEventSink amqpEventSink = null;
@@ -725,7 +725,7 @@ public class AmqpConnection extends AmqpAbstractResource<Connection> implements 
             processSaslAuthentication();
          }
       } catch (Exception ex) {
-         LOG.warn("Caught Exception during update processing: {}", ex.getMessage(), ex);
+         logger.warn("Caught Exception during update processing: {}", ex.getMessage(), ex);
          fireClientException(ex);
       }
    }

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/AmqpSender.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/AmqpSender.java
@@ -56,7 +56,7 @@ import java.lang.invoke.MethodHandles;
  */
 public class AmqpSender extends AmqpAbstractResource<Sender> {
 
-   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
    private static final byte[] EMPTY_BYTE_ARRAY = new byte[] {};
 
    public static final long DEFAULT_SEND_TIMEOUT = 15000;
@@ -434,7 +434,7 @@ public class AmqpSender extends AmqpAbstractResource<Sender> {
    }
 
    private void doSend(AmqpMessage message, AsyncResult request, AmqpTransactionId txId) throws Exception {
-      LOG.trace("Producer sending message: {}", message);
+      logger.trace("Producer sending message: {}", message);
 
       Delivery delivery = null;
       if (presettle) {
@@ -492,14 +492,14 @@ public class AmqpSender extends AmqpAbstractResource<Sender> {
                break;
             }
          } else {
-            LOG.warn("{} failed to send any data from current Message.", this);
+            logger.warn("{} failed to send any data from current Message.", this);
          }
       }
    }
 
    @Override
    public void processFlowUpdates(AmqpConnection connection) throws IOException {
-      LOG.trace("Sender {} flow update, credit = {}", getEndpoint().getCredit());
+      logger.trace("Sender {} flow update, credit = {}", getEndpoint().getCredit());
 
       doCreditInspection();
    }
@@ -518,12 +518,12 @@ public class AmqpSender extends AmqpAbstractResource<Sender> {
 
          Outcome outcome = null;
          if (state instanceof TransactionalState) {
-            LOG.trace("State of delivery is Transactional, retrieving outcome: {}", state);
+            logger.trace("State of delivery is Transactional, retrieving outcome: {}", state);
             outcome = ((TransactionalState) state).getOutcome();
          } else if (state instanceof Outcome) {
             outcome = (Outcome) state;
          } else {
-            LOG.warn("Message send updated with unsupported state: {}", state);
+            logger.warn("Message send updated with unsupported state: {}", state);
             outcome = null;
          }
 
@@ -531,12 +531,12 @@ public class AmqpSender extends AmqpAbstractResource<Sender> {
          Exception deliveryError = null;
 
          if (outcome instanceof Accepted) {
-            LOG.trace("Outcome of delivery was accepted: {}", delivery);
+            logger.trace("Outcome of delivery was accepted: {}", delivery);
             if (request != null && !request.isComplete()) {
                request.onSuccess();
             }
          } else if (outcome instanceof Rejected) {
-            LOG.trace("Outcome of delivery was rejected: {}", delivery);
+            logger.trace("Outcome of delivery was rejected: {}", delivery);
             ErrorCondition remoteError = ((Rejected) outcome).getError();
             if (remoteError == null) {
                remoteError = getEndpoint().getRemoteCondition();
@@ -544,10 +544,10 @@ public class AmqpSender extends AmqpAbstractResource<Sender> {
 
             deliveryError = AmqpSupport.convertToException(remoteError);
          } else if (outcome instanceof Released) {
-            LOG.trace("Outcome of delivery was released: {}", delivery);
+            logger.trace("Outcome of delivery was released: {}", delivery);
             deliveryError = new IOException("Delivery failed: released by receiver");
          } else if (outcome instanceof Modified) {
-            LOG.trace("Outcome of delivery was modified: {}", delivery);
+            logger.trace("Outcome of delivery was modified: {}", delivery);
             deliveryError = new IOException("Delivery failed: failure at remote");
          }
 

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/AmqpTransactionContext.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/AmqpTransactionContext.java
@@ -33,7 +33,7 @@ import java.lang.invoke.MethodHandles;
  */
 public class AmqpTransactionContext {
 
-   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private final AmqpSession session;
    private final Set<AmqpReceiver> txReceivers = new LinkedHashSet<>();
@@ -69,21 +69,21 @@ public class AmqpTransactionContext {
          }
       });
 
-      LOG.info("Attempting to Begin TX:[{}]", txId);
+      logger.info("Attempting to Begin TX:[{}]", txId);
 
       session.getScheduler().execute(new Runnable() {
 
          @Override
          public void run() {
             if (coordinator == null || coordinator.isClosed()) {
-               LOG.info("Creating new Coordinator for TX:[{}]", txId);
+               logger.info("Creating new Coordinator for TX:[{}]", txId);
                coordinator = new AmqpTransactionCoordinator(session);
                coordinator.open(new AsyncResult() {
 
                   @Override
                   public void onSuccess() {
                      try {
-                        LOG.info("Attempting to declare TX:[{}]", txId);
+                        logger.info("Attempting to declare TX:[{}]", txId);
                         coordinator.declare(txId, request);
                      } catch (Exception e) {
                         request.onFailure(e);
@@ -102,7 +102,7 @@ public class AmqpTransactionContext {
                });
             } else {
                try {
-                  LOG.info("Attempting to declare TX:[{}]", txId);
+                  logger.info("Attempting to declare TX:[{}]", txId);
                   coordinator.declare(txId, request);
                } catch (Exception e) {
                   request.onFailure(e);
@@ -143,13 +143,13 @@ public class AmqpTransactionContext {
          }
       });
 
-      LOG.debug("Commit on TX[{}] initiated", transactionId);
+      logger.debug("Commit on TX[{}] initiated", transactionId);
       session.getScheduler().execute(new Runnable() {
 
          @Override
          public void run() {
             try {
-               LOG.info("Attempting to commit TX:[{}]", transactionId);
+               logger.info("Attempting to commit TX:[{}]", transactionId);
                coordinator.discharge(transactionId, request, true);
                session.pumpToProtonTransport(request);
             } catch (Exception e) {
@@ -188,13 +188,13 @@ public class AmqpTransactionContext {
          }
       });
 
-      LOG.debug("Rollback on TX[{}] initiated", transactionId);
+      logger.debug("Rollback on TX[{}] initiated", transactionId);
       session.getScheduler().execute(new Runnable() {
 
          @Override
          public void run() {
             try {
-               LOG.info("Attempting to roll back TX:[{}]", transactionId);
+               logger.info("Attempting to roll back TX:[{}]", transactionId);
                coordinator.discharge(transactionId, request, false);
                session.pumpToProtonTransport(request);
             } catch (Exception e) {

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/AmqpTransactionCoordinator.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/AmqpTransactionCoordinator.java
@@ -54,7 +54,7 @@ import java.lang.invoke.MethodHandles;
  */
 public class AmqpTransactionCoordinator extends AmqpAbstractResource<Sender> {
 
-   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private final byte[] OUTBOUND_BUFFER = new byte[64];
 
@@ -87,12 +87,12 @@ public class AmqpTransactionCoordinator extends AmqpAbstractResource<Sender> {
             }
 
             if (state instanceof Declared) {
-               LOG.debug("New TX started: {}", txId.getTxId());
+               logger.debug("New TX started: {}", txId.getTxId());
                Declared declared = (Declared) state;
                txId.setRemoteTxId(declared.getTxnId());
                pendingRequest.onSuccess();
             } else if (state instanceof Rejected) {
-               LOG.debug("Last TX request failed: {}", txId.getTxId());
+               logger.debug("Last TX request failed: {}", txId.getTxId());
                Rejected rejected = (Rejected) state;
                Exception cause = AmqpSupport.convertToException(rejected.getError());
                JMSException failureCause = null;
@@ -104,7 +104,7 @@ public class AmqpTransactionCoordinator extends AmqpAbstractResource<Sender> {
 
                pendingRequest.onFailure(failureCause);
             } else {
-               LOG.debug("Last TX request succeeded: {}", txId.getTxId());
+               logger.debug("Last TX request succeeded: {}", txId.getTxId());
                pendingRequest.onSuccess();
             }
 
@@ -203,7 +203,7 @@ public class AmqpTransactionCoordinator extends AmqpAbstractResource<Sender> {
          getEndpoint().free();
       }
 
-      LOG.debug("Transaction Coordinator link {} was remotely closed", getEndpoint());
+      logger.debug("Transaction Coordinator link {} was remotely closed", getEndpoint());
    }
 
    //----- Internal implementation ------------------------------------------//

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/sasl/SaslAuthenticator.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/sasl/SaslAuthenticator.java
@@ -31,7 +31,7 @@ import java.lang.invoke.MethodHandles;
  */
 public class SaslAuthenticator {
 
-   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private final Sasl sasl;
    private final String username;
@@ -121,7 +121,7 @@ public class SaslAuthenticator {
 
       for (String remoteMechanism : remoteMechanisms) {
          if (mechanismRestriction != null && !mechanismRestriction.equals(remoteMechanism)) {
-            LOG.debug("Skipping {} mechanism because it is not the configured mechanism restriction {}", remoteMechanism, mechanismRestriction);
+            logger.debug("Skipping {} mechanism because it is not the configured mechanism restriction {}", remoteMechanism, mechanismRestriction);
             continue;
          }
 
@@ -133,7 +133,7 @@ public class SaslAuthenticator {
          } else if (remoteMechanism.equalsIgnoreCase("CRAM-MD5")) {
             mechanism = new CramMD5Mechanism();
          } else {
-            LOG.debug("Unknown remote mechanism {}, skipping", remoteMechanism);
+            logger.debug("Unknown remote mechanism {}, skipping", remoteMechanism);
             continue;
          }
 
@@ -149,7 +149,7 @@ public class SaslAuthenticator {
          match = found.get(found.size() - 1);
       }
 
-      LOG.info("Best match for SASL auth was: {}", match);
+      logger.info("Best match for SASL auth was: {}", match);
 
       return match;
    }

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/util/IdGenerator.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/util/IdGenerator.java
@@ -31,7 +31,7 @@ import java.lang.invoke.MethodHandles;
  */
 public class IdGenerator {
 
-   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
    private static final String UNIQUE_STUB;
    private static int instanceCount;
    private static String hostName;
@@ -57,16 +57,16 @@ public class IdGenerator {
          ServerSocket ss = null;
          try {
             idGeneratorPort = Integer.parseInt(System.getProperty(PROPERTY_IDGENERATOR_PORT, "0"));
-            LOG.trace("Using port {}", idGeneratorPort);
+            logger.trace("Using port {}", idGeneratorPort);
             hostName = getLocalHostName();
             ss = new ServerSocket(idGeneratorPort);
             stub = "-" + ss.getLocalPort() + "-" + System.currentTimeMillis() + "-";
             Thread.sleep(100);
          } catch (Exception e) {
-            if (LOG.isTraceEnabled()) {
-               LOG.trace("could not generate unique stub by using DNS and binding to local port", e);
+            if (logger.isTraceEnabled()) {
+               logger.trace("could not generate unique stub by using DNS and binding to local port", e);
             } else {
-               LOG.warn("could not generate unique stub by using DNS and binding to local port: {} {}", e.getClass().getCanonicalName(), e.getMessage());
+               logger.warn("could not generate unique stub by using DNS and binding to local port: {} {}", e.getClass().getCanonicalName(), e.getMessage());
             }
 
             // Restore interrupted state so higher level code can deal with it.
@@ -78,10 +78,10 @@ public class IdGenerator {
                try {
                   ss.close();
                } catch (IOException ioe) {
-                  if (LOG.isTraceEnabled()) {
-                     LOG.trace("Closing the server socket failed", ioe);
+                  if (logger.isTraceEnabled()) {
+                     logger.trace("Closing the server socket failed", ioe);
                   } else {
-                     LOG.warn("Closing the server socket failed due to {}", ioe.getMessage());
+                     logger.warn("Closing the server socket failed due to {}", ioe.getMessage());
                   }
                }
             }
@@ -152,7 +152,7 @@ public class IdGenerator {
 
       if (changed) {
          String newHost = sb.toString();
-         LOG.info("Sanitized hostname from: {} to: {}", hostName, newHost);
+         logger.info("Sanitized hostname from: {} to: {}", hostName, newHost);
          return newHost;
       } else {
          return hostName;

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/netty/NettyTcpTransport.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/netty/NettyTcpTransport.java
@@ -57,7 +57,7 @@ import io.netty.util.concurrent.GenericFutureListener;
  */
 public class NettyTcpTransport implements NettyTransport {
 
-   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private static final int SHUTDOWN_TIMEOUT = 100;
    public static final int DEFAULT_MAX_FRAME_SIZE = 65535;
@@ -158,7 +158,7 @@ public class NettyTcpTransport implements NettyTransport {
       try {
          connectLatch.await();
       } catch (InterruptedException ex) {
-         LOG.debug("Transport connection was interrupted.");
+         logger.debug("Transport connection was interrupted.");
          Thread.interrupted();
          failureCause = IOExceptionSupport.create(ex);
       }
@@ -172,7 +172,7 @@ public class NettyTcpTransport implements NettyTransport {
          if (group != null) {
             Future<?> fut = group.shutdownGracefully(0, SHUTDOWN_TIMEOUT, TimeUnit.MILLISECONDS);
             if (!fut.awaitUninterruptibly(2 * SHUTDOWN_TIMEOUT)) {
-               LOG.trace("Channel group shutdown failed to complete in allotted time");
+               logger.trace("Channel group shutdown failed to complete in allotted time");
             }
             group = null;
          }
@@ -214,7 +214,7 @@ public class NettyTcpTransport implements NettyTransport {
             if (group != null) {
                Future<?> fut = group.shutdownGracefully(0, SHUTDOWN_TIMEOUT, TimeUnit.MILLISECONDS);
                if (!fut.awaitUninterruptibly(2 * SHUTDOWN_TIMEOUT)) {
-                  LOG.trace("Channel group shutdown failed to complete in allotted time");
+                  logger.trace("Channel group shutdown failed to complete in allotted time");
                }
             }
          }
@@ -242,7 +242,7 @@ public class NettyTcpTransport implements NettyTransport {
          return null;
       }
 
-      LOG.trace("Attempted write of: {} bytes", length);
+      logger.trace("Attempted write of: {} bytes", length);
 
       return channel.writeAndFlush(bufferTransformer.apply(output), promise);
    }
@@ -328,22 +328,22 @@ public class NettyTcpTransport implements NettyTransport {
    // ----- Event Handlers which can be overridden in subclasses -------------//
 
    protected void handleConnected(Channel channel) throws Exception {
-      LOG.trace("Channel has become active! Channel is {}", channel);
+      logger.trace("Channel has become active! Channel is {}", channel);
       connectionEstablished(channel);
    }
 
    protected void handleChannelInactive(Channel channel) throws Exception {
-      LOG.trace("Channel has gone inactive! Channel is {}", channel);
+      logger.trace("Channel has gone inactive! Channel is {}", channel);
       if (connected.compareAndSet(true, false) && !closed.get()) {
-         LOG.trace("Firing onTransportClosed listener");
+         logger.trace("Firing onTransportClosed listener");
          listener.onTransportClosed();
       }
    }
 
    protected void handleException(Channel channel, Throwable cause) throws Exception {
-      LOG.trace("Exception on channel! Channel is {}", channel);
+      logger.trace("Exception on channel! Channel is {}", channel);
       if (connected.compareAndSet(true, false) && !closed.get()) {
-         LOG.trace("Firing onTransportError listener");
+         logger.trace("Firing onTransportError listener");
          if (failureCause != null) {
             listener.onTransportError(failureCause);
          } else {
@@ -353,7 +353,7 @@ public class NettyTcpTransport implements NettyTransport {
          // Hold the first failure for later dispatch if connect succeeds.
          // This will then trigger disconnect using the first error reported.
          if (failureCause == null) {
-            LOG.trace("Holding error until connect succeeds: {}", cause.getMessage());
+            logger.trace("Holding error until connect succeeds: {}", cause.getMessage());
             failureCause = IOExceptionSupport.create(cause);
          }
 
@@ -447,10 +447,10 @@ public class NettyTcpTransport implements NettyTransport {
                @Override
                public void operationComplete(Future<Channel> future) throws Exception {
                   if (future.isSuccess()) {
-                     LOG.trace("SSL Handshake has completed: {}", channel);
+                     logger.trace("SSL Handshake has completed: {}", channel);
                      handleConnected(channel);
                   } else {
-                     LOG.trace("SSL Handshake has failed: {}", channel);
+                     logger.trace("SSL Handshake has failed: {}", channel);
                      handleException(channel, future.cause());
                   }
                }
@@ -475,7 +475,7 @@ public class NettyTcpTransport implements NettyTransport {
 
       @Override
       protected void channelRead0(ChannelHandlerContext ctx, ByteBuf buffer) throws Exception {
-         LOG.trace("New data read: {} bytes incoming: {}", buffer.readableBytes(), buffer);
+         logger.trace("New data read: {} bytes incoming: {}", buffer.readableBytes(), buffer);
          listener.onData(buffer);
       }
    }

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/netty/NettyTransportSupport.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/netty/NettyTransportSupport.java
@@ -50,7 +50,7 @@ import io.netty.handler.ssl.SslHandler;
  */
 public class NettyTransportSupport {
 
-   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    /**
     * Creates a Netty SslHandler instance for use in Transports that require an SSL encoder /
@@ -85,7 +85,7 @@ public class NettyTransportSupport {
    public static SSLContext createSslContext(NettyTransportSslOptions options) throws Exception {
       try {
          String contextProtocol = options.getContextProtocol();
-         LOG.trace("Getting SSLContext instance using protocol: {}", contextProtocol);
+         logger.trace("Getting SSLContext instance using protocol: {}", contextProtocol);
 
          SSLContext context = SSLContext.getInstance(contextProtocol);
          KeyManager[] keyMgrs = loadKeyManagers(options);
@@ -94,7 +94,7 @@ public class NettyTransportSupport {
          context.init(keyMgrs, trustManagers, new SecureRandom());
          return context;
       } catch (Exception e) {
-         LOG.error("Failed to create SSLContext: {}", e, e);
+         logger.error("Failed to create SSLContext: {}", e, e);
          throw e;
       }
    }
@@ -160,22 +160,22 @@ public class NettyTransportSupport {
 
       if (options.getEnabledProtocols() != null) {
          List<String> configuredProtocols = Arrays.asList(options.getEnabledProtocols());
-         LOG.trace("Configured protocols from transport options: {}", configuredProtocols);
+         logger.trace("Configured protocols from transport options: {}", configuredProtocols);
          enabledProtocols.addAll(configuredProtocols);
       } else {
          List<String> engineProtocols = Arrays.asList(engine.getEnabledProtocols());
-         LOG.trace("Default protocols from the SSLEngine: {}", engineProtocols);
+         logger.trace("Default protocols from the SSLEngine: {}", engineProtocols);
          enabledProtocols.addAll(engineProtocols);
       }
 
       String[] disabledProtocols = options.getDisabledProtocols();
       if (disabledProtocols != null) {
          List<String> disabled = Arrays.asList(disabledProtocols);
-         LOG.trace("Disabled protocols: {}", disabled);
+         logger.trace("Disabled protocols: {}", disabled);
          enabledProtocols.removeAll(disabled);
       }
 
-      LOG.trace("Enabled protocols: {}", enabledProtocols);
+      logger.trace("Enabled protocols: {}", enabledProtocols);
 
       return enabledProtocols.toArray(new String[0]);
    }
@@ -185,22 +185,22 @@ public class NettyTransportSupport {
 
       if (options.getEnabledCipherSuites() != null) {
          List<String> configuredCipherSuites = Arrays.asList(options.getEnabledCipherSuites());
-         LOG.trace("Configured cipher suites from transport options: {}", configuredCipherSuites);
+         logger.trace("Configured cipher suites from transport options: {}", configuredCipherSuites);
          enabledCipherSuites.addAll(configuredCipherSuites);
       } else {
          List<String> engineCipherSuites = Arrays.asList(engine.getEnabledCipherSuites());
-         LOG.trace("Default cipher suites from the SSLEngine: {}", engineCipherSuites);
+         logger.trace("Default cipher suites from the SSLEngine: {}", engineCipherSuites);
          enabledCipherSuites.addAll(engineCipherSuites);
       }
 
       String[] disabledCipherSuites = options.getDisabledCipherSuites();
       if (disabledCipherSuites != null) {
          List<String> disabled = Arrays.asList(disabledCipherSuites);
-         LOG.trace("Disabled cipher suites: {}", disabled);
+         logger.trace("Disabled cipher suites: {}", disabled);
          enabledCipherSuites.removeAll(disabled);
       }
 
-      LOG.trace("Enabled cipher suites: {}", enabledCipherSuites);
+      logger.trace("Enabled cipher suites: {}", enabledCipherSuites);
 
       return enabledCipherSuites.toArray(new String[0]);
    }
@@ -220,7 +220,7 @@ public class NettyTransportSupport {
       String storePassword = options.getTrustStorePassword();
       String storeType = options.getStoreType();
 
-      LOG.trace("Attempt to load TrustStore from location {} of type {}", storeLocation, storeType);
+      logger.trace("Attempt to load TrustStore from location {} of type {}", storeLocation, storeType);
 
       KeyStore trustStore = loadStore(storeLocation, storePassword, storeType);
       fact.init(trustStore);
@@ -240,7 +240,7 @@ public class NettyTransportSupport {
       String storeType = options.getStoreType();
       String alias = options.getKeyAlias();
 
-      LOG.trace("Attempt to load KeyStore from location {} of type {}", storeLocation, storeType);
+      logger.trace("Attempt to load KeyStore from location {} of type {}", storeLocation, storeType);
 
       KeyStore keyStore = loadStore(storeLocation, storePassword, storeType);
       fact.init(keyStore, storePassword != null ? storePassword.toCharArray() : null);

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/netty/NettyWSTransport.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/netty/NettyWSTransport.java
@@ -50,7 +50,7 @@ import io.netty.handler.codec.http.websocketx.WebSocketVersion;
  */
 public class NettyWSTransport extends NettyTcpTransport {
 
-   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    public static final String AMQP_SUB_PROTOCOL = "amqp";
 
@@ -103,7 +103,7 @@ public class NettyWSTransport extends NettyTcpTransport {
 
    @Override
    protected void handleConnected(Channel channel) throws Exception {
-      LOG.trace("Channel has become active, awaiting WebSocket handshake! Channel is {}", channel);
+      logger.trace("Channel has become active, awaiting WebSocket handshake! Channel is {}", channel);
    }
 
    // ----- Handle connection events -----------------------------------------//
@@ -127,12 +127,12 @@ public class NettyWSTransport extends NettyTcpTransport {
 
       @Override
       protected void channelRead0(ChannelHandlerContext ctx, Object message) throws Exception {
-         LOG.trace("New data read: incoming: {}", message);
+         logger.trace("New data read: incoming: {}", message);
 
          Channel ch = ctx.channel();
          if (!handshaker.isHandshakeComplete()) {
             handshaker.finishHandshake(ch, (FullHttpResponse) message);
-            LOG.trace("WebSocket Client connected! {}", ctx.channel());
+            logger.trace("WebSocket Client connected! {}", ctx.channel());
             // Now trigger super processing as we are really connected.
             NettyWSTransport.super.handleConnected(ch);
             return;
@@ -148,21 +148,21 @@ public class NettyWSTransport extends NettyTcpTransport {
          WebSocketFrame frame = (WebSocketFrame) message;
          if (frame instanceof TextWebSocketFrame) {
             TextWebSocketFrame textFrame = (TextWebSocketFrame) frame;
-            LOG.warn("WebSocket Client received message: {}", textFrame.text());
+            logger.warn("WebSocket Client received message: {}", textFrame.text());
             ctx.fireExceptionCaught(new IOException("Received invalid frame over WebSocket."));
          } else if (frame instanceof BinaryWebSocketFrame) {
             BinaryWebSocketFrame binaryFrame = (BinaryWebSocketFrame) frame;
-            LOG.trace("WebSocket Client received data: {} bytes", binaryFrame.content().readableBytes());
+            logger.trace("WebSocket Client received data: {} bytes", binaryFrame.content().readableBytes());
             listener.onData(binaryFrame.content());
          } else if (frame instanceof ContinuationWebSocketFrame) {
             ContinuationWebSocketFrame continuationFrame = (ContinuationWebSocketFrame) frame;
-            LOG.trace("WebSocket Client received data continuation: {} bytes", continuationFrame.content().readableBytes());
+            logger.trace("WebSocket Client received data continuation: {} bytes", continuationFrame.content().readableBytes());
             listener.onData(continuationFrame.content());
          } else if (frame instanceof PingWebSocketFrame) {
-            LOG.trace("WebSocket Client received ping, response with pong");
+            logger.trace("WebSocket Client received ping, response with pong");
             ch.write(new PongWebSocketFrame(frame.content()));
          } else if (frame instanceof CloseWebSocketFrame) {
-            LOG.trace("WebSocket Client received closing");
+            logger.trace("WebSocket Client received closing");
             ch.close();
          }
       }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpDurableReceiverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpDurableReceiverTest.java
@@ -48,7 +48,7 @@ import java.lang.invoke.MethodHandles;
  */
 public class AmqpDurableReceiverTest extends AmqpClientTestSupport {
 
-   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private final String SELECTOR_STRING = "color = red";
 
@@ -342,7 +342,7 @@ public class AmqpDurableReceiverTest extends AmqpClientTestSupport {
          session.lookupSubscription(getSubscriptionName());
          fail("Should throw an exception since there is not subscription");
       } catch (Exception e) {
-         LOG.debug("Error on lookup: {}", e.getMessage());
+         logger.debug("Error on lookup: {}", e.getMessage());
       }
 
       connection.close();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpInboundConnectionTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpInboundConnectionTest.java
@@ -50,7 +50,7 @@ import java.lang.invoke.MethodHandles;
  */
 public class AmqpInboundConnectionTest extends AmqpClientTestSupport {
 
-   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private static final String BROKER_NAME = "localhost";
    private static final String PRODUCT_NAME = "apache-activemq-artemis";
@@ -286,7 +286,7 @@ public class AmqpInboundConnectionTest extends AmqpClientTestSupport {
          connection2.connect();
          fail("Should not be able to connect with same container Id.");
       } catch (Exception ex) {
-         LOG.debug("Second connection with same container Id failed as expected.");
+         logger.debug("Second connection with same container Id failed as expected.");
       }
 
       connection2.getStateInspector().assertValid();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpLargeMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpLargeMessageTest.java
@@ -78,7 +78,7 @@ import java.lang.invoke.MethodHandles;
 @RunWith(Parameterized.class)
 public class AmqpLargeMessageTest extends AmqpClientTestSupport {
 
-   protected static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   protected static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private final Random rand = new Random(System.currentTimeMillis());
 
@@ -312,7 +312,7 @@ public class AmqpLargeMessageTest extends AmqpClientTestSupport {
             if (wrapped.getBody() instanceof Data) {
                // converters can change this to AmqValue
                Data data = (Data) wrapped.getBody();
-               LOG.debug("received : message: {}", data.getValue().getLength());
+               logger.debug("received : message: {}", data.getValue().getLength());
                assertEquals(payload, data.getValue().getLength());
             }
             message.accept();
@@ -366,7 +366,7 @@ public class AmqpLargeMessageTest extends AmqpClientTestSupport {
          MessageImpl wrapped = (MessageImpl) message.getWrappedMessage();
          if (wrapped.getBody() instanceof Data) {
             Data data = (Data) wrapped.getBody();
-            LOG.debug("received : message: {}", data.getValue().getLength());
+            logger.debug("received : message: {}", data.getValue().getLength());
             assertEquals(payload, data.getValue().getLength());
          }
 
@@ -469,7 +469,7 @@ public class AmqpLargeMessageTest extends AmqpClientTestSupport {
          payload[i] = (byte) rand.nextInt(256);
       }
 
-      LOG.debug("Created buffer with size : {} bytes", sizeInBytes);
+      logger.debug("Created buffer with size : {} bytes", sizeInBytes);
       return payload;
    }
 
@@ -552,7 +552,7 @@ public class AmqpLargeMessageTest extends AmqpClientTestSupport {
    }
 
    public void doTestSendLargeMessage(int expectedSize) throws Exception {
-      LOG.debug("doTestSendLargeMessage called with expectedSize {}", expectedSize);
+      logger.debug("doTestSendLargeMessage called with expectedSize {}", expectedSize);
       byte[] payload = createLargePayload(expectedSize);
       assertEquals(expectedSize, payload.length);
 
@@ -572,12 +572,12 @@ public class AmqpLargeMessageTest extends AmqpClientTestSupport {
          producer.send(message);
          long endTime = System.currentTimeMillis();
 
-         LOG.debug("Returned from send after {} ms", endTime - startTime);
+         logger.debug("Returned from send after {} ms", endTime - startTime);
          startTime = System.currentTimeMillis();
          MessageConsumer consumer = session.createConsumer(queue);
          connection.start();
 
-         LOG.debug("Calling receive");
+         logger.debug("Calling receive");
          Message received = consumer.receive();
          assertNotNull(received);
          assertTrue(received instanceof BytesMessage);
@@ -585,7 +585,7 @@ public class AmqpLargeMessageTest extends AmqpClientTestSupport {
          assertNotNull(bytesMessage);
          endTime = System.currentTimeMillis();
 
-         LOG.debug("Returned from receive after {} ms", endTime - startTime);
+         logger.debug("Returned from receive after {} ms", endTime - startTime);
          byte[] bytesReceived = new byte[expectedSize];
          assertEquals(expectedSize, bytesMessage.readBytes(bytesReceived, expectedSize));
          assertTrue(Arrays.equals(payload, bytesReceived));
@@ -729,27 +729,27 @@ public class AmqpLargeMessageTest extends AmqpClientTestSupport {
          boolean timeRemaining = true;
          while (timeRemaining) {
             if (messagesA.size() < numMsgs) {
-               LOG.debug("Attempting to receive message for receiver A");
+               logger.debug("Attempting to receive message for receiver A");
                AmqpMessage messageA = receiverA.receive(20, TimeUnit.MILLISECONDS);
                if (messageA != null) {
-                  LOG.debug("Got message for receiver A");
+                  logger.debug("Got message for receiver A");
                   messagesA.add(messageA);
                   messageA.accept();
                }
             }
 
             if (messagesB.size() < numMsgs) {
-               LOG.debug("Attempting to receive message for receiver B");
+               logger.debug("Attempting to receive message for receiver B");
                AmqpMessage messageB = receiverB.receive(20, TimeUnit.MILLISECONDS);
                if (messageB != null) {
-                  LOG.debug("Got message for receiver B");
+                  logger.debug("Got message for receiver B");
                   messagesB.add(messageB);
                   messageB.accept();
                }
             }
 
             if (messagesA.size() == numMsgs && messagesB.size() == numMsgs) {
-               LOG.debug("Received expected messages");
+               logger.debug("Received expected messages");
                break;
             }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpMaxFrameSizeTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpMaxFrameSizeTest.java
@@ -42,7 +42,7 @@ import java.lang.invoke.MethodHandles;
 
 public class AmqpMaxFrameSizeTest extends AmqpClientTestSupport {
 
-   protected static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   protected static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private boolean maxFrameSizeConfigSet = false;
    private static final int CONFIGURED_FRAME_SIZE = 4321;
@@ -182,7 +182,7 @@ public class AmqpMaxFrameSizeTest extends AmqpClientTestSupport {
 
             verifyMessage(receivedMessage, payloadSize);
 
-            LOG.trace("received : message {}", i);
+            logger.trace("received : message {}", i);
             receivedMessage.accept();
          }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpMessagePriorityTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpMessagePriorityTest.java
@@ -36,7 +36,7 @@ import java.lang.invoke.MethodHandles;
  */
 public class AmqpMessagePriorityTest extends AmqpClientTestSupport {
 
-   protected static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   protected static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Test(timeout = 60000)
    public void testMessageDefaultPriority() throws Exception {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpSessionTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpSessionTest.java
@@ -34,7 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class AmqpSessionTest extends AmqpClientTestSupport {
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Test(timeout = 60000)
    public void testCreateSession() throws Exception {
@@ -54,7 +54,7 @@ public class AmqpSessionTest extends AmqpClientTestSupport {
 
          @Override
          public void inspectClosedResource(Session session) {
-            log.debug("Session closed: {}", session.getContext());
+            logger.debug("Session closed: {}", session.getContext());
          }
 
          @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpTempDestinationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpTempDestinationTest.java
@@ -44,7 +44,7 @@ import java.lang.invoke.MethodHandles;
  */
 public class AmqpTempDestinationTest extends AmqpClientTestSupport {
 
-   protected static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   protected static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Test(timeout = 60000)
    public void testCreateDynamicSenderToTopic() throws Exception {
@@ -210,7 +210,7 @@ public class AmqpTempDestinationTest extends AmqpClientTestSupport {
 
       // Get the new address
       String address = sender.getSender().getRemoteTarget().getAddress();
-      LOG.debug("New dynamic sender address -> {}", address);
+      logger.debug("New dynamic sender address -> {}", address);
 
       // Create a message and send to a receive that is listening on the newly
       // created dynamic link address.
@@ -259,7 +259,7 @@ public class AmqpTempDestinationTest extends AmqpClientTestSupport {
 
       // Get the new address
       String address = receiver.getReceiver().getRemoteSource().getAddress();
-      LOG.debug("New dynamic receiver address -> {}", address);
+      logger.debug("New dynamic receiver address -> {}", address);
 
       // Create a message and send to a receive that is listening on the newly
       // created dynamic link address.

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSMessageConsumerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSMessageConsumerTest.java
@@ -56,7 +56,7 @@ import java.lang.invoke.MethodHandles;
 
 public class JMSMessageConsumerTest extends JMSClientTestSupport {
 
-   protected static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   protected static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Override
    protected String getConfiguredProtocols() {
@@ -651,7 +651,7 @@ public class JMSMessageConsumerTest extends JMSClientTestSupport {
                message.acknowledge();
                done.countDown();
             } catch (JMSException ex) {
-               LOG.debug("Caught exception.", ex);
+               logger.debug("Caught exception.", ex);
             }
          }
       });
@@ -731,7 +731,7 @@ public class JMSMessageConsumerTest extends JMSClientTestSupport {
                while (count > 0) {
                   try {
                      if (++n % 1000 == 0) {
-                        LOG.debug("received {} messages", n);
+                        logger.debug("received {} messages", n);
                      }
 
                      Message m = consumer.receive(5000);
@@ -783,11 +783,11 @@ public class JMSMessageConsumerTest extends JMSClientTestSupport {
       Wait.assertEquals(0, queueView::getMessageCount);
 
       long taken = (System.currentTimeMillis() - time);
-      LOG.debug("Microbenchamrk ran in {} milliseconds, sending/receiving {}", taken, numMessages);
+      logger.debug("Microbenchamrk ran in {} milliseconds, sending/receiving {}", taken, numMessages);
 
       double messagesPerSecond = ((double) numMessages / (double) taken) * 1000;
 
-      LOG.debug("{} messages per second", ((int) messagesPerSecond));
+      logger.debug("{} messages per second", ((int) messagesPerSecond));
    }
 
    @Test(timeout = 60000)

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSMessageGroupsTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSMessageGroupsTest.java
@@ -41,7 +41,7 @@ import java.lang.invoke.MethodHandles;
 
 public class JMSMessageGroupsTest extends JMSClientTestSupport {
 
-   protected static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   protected static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private static final int ITERATIONS = 10;
    private static final int MESSAGE_COUNT = 10;
@@ -279,11 +279,11 @@ public class JMSMessageGroupsTest extends JMSClientTestSupport {
       for (int i = 0; i < MESSAGE_COUNT; ++i) {
          Message message = consumer.receive(RECEIVE_TIMEOUT);
          assertNotNull(message);
-         LOG.debug("Read message #{}: type = {}", i, message.getClass().getSimpleName());
+         logger.debug("Read message #{}: type = {}", i, message.getClass().getSimpleName());
          String gid = message.getStringProperty("JMSXGroupID");
          int seq = message.getIntProperty("JMSXGroupSeq");
-         LOG.debug("Message assigned JMSXGroupID := {}", gid);
-         LOG.debug("Message assigned JMSXGroupSeq := {}", seq);
+         logger.debug("Message assigned JMSXGroupID := {}", gid);
+         logger.debug("Message assigned JMSXGroupSeq := {}", seq);
          assertEquals("Sequence order should match", sequence.incrementAndGet(), seq);
          if (additionalCheck != null) {
             additionalCheck.accept(i, message);
@@ -308,7 +308,7 @@ public class JMSMessageGroupsTest extends JMSClientTestSupport {
          buffer[count] = (byte) value;
       }
 
-      LOG.debug("Sending {} messages to destination: {}", MESSAGE_COUNT, queue);
+      logger.debug("Sending {} messages to destination: {}", MESSAGE_COUNT, queue);
       for (int i = 1; i <= MESSAGE_COUNT; i++) {
          BytesMessage message = session.createBytesMessage();
          message.setJMSDeliveryMode(DeliveryMode.PERSISTENT);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSQueueBrowserTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSQueueBrowserTest.java
@@ -41,7 +41,7 @@ import java.lang.invoke.MethodHandles;
  */
 public class JMSQueueBrowserTest extends JMSClientTestSupport {
 
-   protected static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   protected static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Test(timeout = 60000)
    public void testBrowseAllInQueueZeroPrefetch() throws Exception {
@@ -68,11 +68,11 @@ public class JMSQueueBrowserTest extends JMSClientTestSupport {
       while (count < MSG_COUNT && enumeration.hasMoreElements()) {
          Message msg = (Message) enumeration.nextElement();
          assertNotNull(msg);
-         LOG.debug("Recv: {}", msg);
+         logger.debug("Recv: {}", msg);
          count++;
       }
 
-      LOG.debug("Received all expected message, checking that hasMoreElements returns false");
+      logger.debug("Received all expected message, checking that hasMoreElements returns false");
       assertFalse(enumeration.hasMoreElements());
       assertEquals(5, count);
    }
@@ -130,7 +130,7 @@ public class JMSQueueBrowserTest extends JMSClientTestSupport {
       while (enumeration.hasMoreElements()) {
          Message m = (Message) enumeration.nextElement();
          assertTrue(m instanceof TextMessage);
-         LOG.debug("Browsed message {} from Queue {}", m, queue);
+         logger.debug("Browsed message {} from Queue {}", m, queue);
       }
 
       browser.close();
@@ -161,7 +161,7 @@ public class JMSQueueBrowserTest extends JMSClientTestSupport {
       while (enumeration.hasMoreElements()) {
          Message msg = (Message) enumeration.nextElement();
          assertNotNull(msg);
-         LOG.debug("Recv: {}", msg);
+         logger.debug("Recv: {}", msg);
          count++;
          TimeUnit.MILLISECONDS.sleep(50);
       }
@@ -189,7 +189,7 @@ public class JMSQueueBrowserTest extends JMSClientTestSupport {
       while (enumeration.hasMoreElements()) {
          Message msg = (Message) enumeration.nextElement();
          assertNotNull(msg);
-         LOG.debug("Recv: {}", msg);
+         logger.debug("Recv: {}", msg);
          count++;
       }
       assertFalse(enumeration.hasMoreElements());
@@ -216,7 +216,7 @@ public class JMSQueueBrowserTest extends JMSClientTestSupport {
       while (enumeration.hasMoreElements()) {
          Message msg = (Message) enumeration.nextElement();
          assertNotNull(msg);
-         LOG.debug("Recv: {}", msg);
+         logger.debug("Recv: {}", msg);
          count++;
       }
       assertFalse(enumeration.hasMoreElements());
@@ -251,7 +251,7 @@ public class JMSQueueBrowserTest extends JMSClientTestSupport {
       while (enumeration.hasMoreElements()) {
          Message msg = (Message) enumeration.nextElement();
          assertNotNull(msg);
-         LOG.debug("Recv: {}", msg);
+         logger.debug("Recv: {}", msg);
          count++;
       }
 
@@ -288,7 +288,7 @@ public class JMSQueueBrowserTest extends JMSClientTestSupport {
       while (enumeration.hasMoreElements()) {
          Message msg = (Message) enumeration.nextElement();
          assertNotNull(msg);
-         LOG.debug("Recv: {}", msg);
+         logger.debug("Recv: {}", msg);
          count++;
       }
       assertFalse(enumeration.hasMoreElements());

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSSaslGssapiTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSSaslGssapiTest.java
@@ -78,7 +78,7 @@ import java.lang.invoke.MethodHandles;
 
 public class JMSSaslGssapiTest extends JMSClientTestSupport {
 
-   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    static {
       String path = System.getProperty("java.security.auth.login.config");
@@ -117,15 +117,15 @@ public class JMSSaslGssapiTest extends JMSClientTestSupport {
       rewriteKrbConfFile(kdc);
 
       if (debug) {
-         LOG.debug("java.security.krb5.conf='{}'", System.getProperty("java.security.krb5.conf"));
+         logger.debug("java.security.krb5.conf='{}'", System.getProperty("java.security.krb5.conf"));
          try (BufferedReader br = new BufferedReader(new FileReader(System.getProperty("java.security.krb5.conf")))) {
-            br.lines().forEach(line -> LOG.debug(line));
+            br.lines().forEach(line -> logger.debug(line));
          }
 
          Keytab kt = Keytab.loadKeytab(userKeyTab);
          for (PrincipalName name : kt.getPrincipals()) {
             for (KeytabEntry entry : kt.getKeytabEntries(name)) {
-               LOG.info("KeyTab Entry: PrincipalName:{} ; KeyInfo:{}", entry.getPrincipal(), entry.getKey().getKeyType());
+               logger.info("KeyTab Entry: PrincipalName:{} ; KeyInfo:{}", entry.getPrincipal(), entry.getKey().getKeyType());
             }
          }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/SaslKrb5LDAPSecurityTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/SaslKrb5LDAPSecurityTest.java
@@ -120,7 +120,7 @@ import static org.apache.activemq.artemis.tests.util.ActiveMQTestBase.NETTY_ACCE
 @CreateKdcServer(transports = {@CreateTransport(protocol = "TCP", port = 0)})
 @ApplyLdifFiles("SaslKrb5LDAPSecurityTest.ldif")
 public class SaslKrb5LDAPSecurityTest extends AbstractLdapTestUnit {
-   protected static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   protected static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    public static final String QUEUE_NAME = "some_queue";
 
@@ -219,11 +219,11 @@ public class SaslKrb5LDAPSecurityTest extends AbstractLdapTestUnit {
       Method refreshMethod = classRef.getMethod("refresh", new Class[0]);
       refreshMethod.invoke(classRef, new Object[0]);
 
-      LOG.debug("krb5.conf to: {}", krb5conf.getAbsolutePath());
+      logger.debug("krb5.conf to: {}", krb5conf.getAbsolutePath());
       if (debug) {
-         LOG.debug("java.security.krb5.conf='{}'", System.getProperty("java.security.krb5.conf"));
+         logger.debug("java.security.krb5.conf='{}'", System.getProperty("java.security.krb5.conf"));
          try (BufferedReader br = new BufferedReader(new FileReader(System.getProperty("java.security.krb5.conf")))) {
-            br.lines().forEach(line -> LOG.debug(line));
+            br.lines().forEach(line -> logger.debug(line));
          }
       }
    }
@@ -237,7 +237,7 @@ public class SaslKrb5LDAPSecurityTest extends AbstractLdapTestUnit {
          String ss = LdifUtils.convertToLdif(entry);
          st += ss + "\n";
       }
-      LOG.debug(st);
+      logger.debug(st);
 
       cursor = (EntryFilteringCursor) getService().getAdminSession().search(new Dn("dc=example,dc=com"), SearchScope.SUBTREE, new PresenceNode("ObjectClass"), AliasDerefMode.DEREF_ALWAYS);
       st = "";
@@ -247,7 +247,7 @@ public class SaslKrb5LDAPSecurityTest extends AbstractLdapTestUnit {
          String ss = LdifUtils.convertToLdif(entry);
          st += ss + "\n";
       }
-      LOG.debug(st);
+      logger.debug(st);
    }
 
    private void initLogging() {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ActiveMQCrashTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ActiveMQCrashTest.java
@@ -44,7 +44,7 @@ import java.lang.invoke.MethodHandles;
  */
 public class ActiveMQCrashTest extends ActiveMQTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    public ActiveMQServer server;
 
@@ -100,11 +100,11 @@ public class ActiveMQCrashTest extends ActiveMQTestBase {
 
       @Override
       public boolean intercept(final Packet packet, final RemotingConnection connection) throws ActiveMQException {
-         log.debug("AckInterceptor.intercept {}", packet);
+         logger.debug("AckInterceptor.intercept {}", packet);
 
          if (packet.getType() == PacketImpl.SESS_SEND) {
             try {
-               log.debug("Stopping server");
+               logger.debug("Stopping server");
 
                new Thread() {
                   @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ConsumerRoundRobinTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/ConsumerRoundRobinTest.java
@@ -34,7 +34,7 @@ import java.lang.invoke.MethodHandles;
 
 public class ConsumerRoundRobinTest extends ActiveMQTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    public final SimpleString addressA = new SimpleString("addressA");
 
@@ -69,9 +69,9 @@ public class ConsumerRoundRobinTest extends ActiveMQTestBase {
       }
       int currMessage = 0;
       for (int i = 0; i < numMessage / 5; i++) {
-         log.debug("i is {}", i);
+         logger.debug("i is {}", i);
          for (int j = 0; j < 5; j++) {
-            log.debug("j is {}", j);
+            logger.debug("j is {}", j);
             ClientMessage cm = consumers[j].receive(5000);
             Assert.assertNotNull(cm);
             Assert.assertEquals(currMessage++, cm.getBodyBuffer().readInt());

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/FailureDeadlockTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/FailureDeadlockTest.java
@@ -40,7 +40,7 @@ import java.lang.invoke.MethodHandles;
 
 public class FailureDeadlockTest extends ActiveMQTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private ActiveMQServer server;
 
@@ -81,7 +81,7 @@ public class FailureDeadlockTest extends ActiveMQTestBase {
                try {
                   conn2.close();
                } catch (Exception e) {
-                  log.error("Failed to close connection2", e);
+                  logger.error("Failed to close connection2", e);
                }
             }
          };

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/FlowControlOnIgnoreLargeMessageBodyTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/FlowControlOnIgnoreLargeMessageBodyTest.java
@@ -37,7 +37,7 @@ import java.lang.invoke.MethodHandles;
 
 public class FlowControlOnIgnoreLargeMessageBodyTest extends JMSTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private Topic topic;
 
@@ -108,7 +108,7 @@ public class FlowControlOnIgnoreLargeMessageBodyTest extends JMSTestBase {
          Connection connection = null;
          Session session = null;
          MessageProducer prod;
-         log.debug("Starting producer for {} - {}", topic, getName());
+         logger.debug("Starting producer for {} - {}", topic, getName());
          try {
             connection = cf.createConnection();
             session = connection.createSession(true, Session.SESSION_TRANSACTED);
@@ -129,10 +129,10 @@ public class FlowControlOnIgnoreLargeMessageBodyTest extends JMSTestBase {
                   session.commit();
                }
                if (i % 100 == 0) {
-                  log.debug("Address {} sent {} messages", topic, i);
+                  logger.debug("Address {} sent {} messages", topic, i);
                }
             }
-            log.debug("Ending producer for {} - {} messages {}", topic, getName(), sentMessages);
+            logger.debug("Ending producer for {} - {} messages {}", topic, getName(), sentMessages);
          } catch (Exception e) {
             error = true;
             e.printStackTrace();
@@ -206,7 +206,7 @@ public class FlowControlOnIgnoreLargeMessageBodyTest extends JMSTestBase {
          Session session = null;
          stopped = false;
          requestForStop = false;
-         log.debug("Starting consumer for {} - {}", topic, getName());
+         logger.debug("Starting consumer for {} - {}", topic, getName());
          try {
             connection = cf.createConnection();
 
@@ -224,11 +224,11 @@ public class FlowControlOnIgnoreLargeMessageBodyTest extends JMSTestBase {
 
             while (counter < numberOfMessages && !requestForStop && !error) {
                if (counter == 0) {
-                  log.debug("Starting to consume for {} - {}", topic, getName());
+                  logger.debug("Starting to consume for {} - {}", topic, getName());
                }
                BytesMessage msg = (BytesMessage) subscriber.receive(receiveTimeout);
                if (msg == null) {
-                  log.debug("Cannot get message in specified timeout: {} - {}", topic, getName());
+                  logger.debug("Cannot get message in specified timeout: {} - {}", topic, getName());
                   error = true;
                } else {
                   counter++;
@@ -240,13 +240,13 @@ public class FlowControlOnIgnoreLargeMessageBodyTest extends JMSTestBase {
                   session.commit();
                }
                if (counter % 100 == 0) {
-                  log.debug("## {} {} received {}", getName(), topic, counter);
+                  logger.debug("## {} {} received {}", getName(), topic, counter);
                }
                receivedMessages = counter;
             }
             session.commit();
          } catch (Exception e) {
-            log.debug("Exception in consumer {} : {}", getName(), e.getMessage());
+            logger.debug("Exception in consumer {} : {}", getName(), e.getMessage());
             e.printStackTrace();
          } finally {
             if (session != null) {
@@ -265,7 +265,7 @@ public class FlowControlOnIgnoreLargeMessageBodyTest extends JMSTestBase {
             }
          }
          stopped = true;
-         log.debug("Stopping consumer for {} - {}, received {}", topic, getName(), getReceivedMessages());
+         logger.debug("Stopping consumer for {} - {}, received {}", topic, getName(), getReceivedMessages());
       }
 
       public int getReceivedMessages() {
@@ -319,7 +319,7 @@ public class FlowControlOnIgnoreLargeMessageBodyTest extends JMSTestBase {
             Assert.fail(errorMessage);
          }
       } catch (Exception e) {
-         log.warn(e.getMessage(), e);
+         logger.warn(e.getMessage(), e);
       }
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/IncompatibleVersionTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/IncompatibleVersionTest.java
@@ -55,7 +55,7 @@ import static org.apache.activemq.artemis.tests.util.RandomUtil.randomString;
 
 public class IncompatibleVersionTest extends SpawnedTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private static final String WORD_START = "&*STARTED&*";
 
@@ -230,7 +230,7 @@ public class IncompatibleVersionTest extends SpawnedTestBase {
 
          System.out.println(WORD_START);
 
-         log.debug("### server: {}", startedString);
+         logger.debug("### server: {}", startedString);
       }
    }
 
@@ -243,7 +243,7 @@ public class IncompatibleVersionTest extends SpawnedTestBase {
             locator = createNettyNonHALocator();
             sf = locator.createSessionFactory();
             ClientSession session = sf.createSession(false, true, true);
-            log.debug("### client: connected. server incrementingVersion = {}", session.getVersion());
+            logger.debug("### client: connected. server incrementingVersion = {}", session.getVersion());
             session.close();
          } finally {
             closeSessionFactory(sf);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/InterruptedLargeMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/InterruptedLargeMessageTest.java
@@ -76,7 +76,7 @@ import java.lang.invoke.MethodHandles;
 
 public class InterruptedLargeMessageTest extends LargeMessageTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    static final int RECEIVE_WAIT_TIME = 60000;
 
@@ -181,7 +181,7 @@ public class InterruptedLargeMessageTest extends LargeMessageTestBase {
          @Override
          public void run() {
             try {
-               log.debug("Receiving message");
+               logger.debug("Receiving message");
                ClientMessage msg = cons.receive(5000);
                if (msg == null) {
                   System.err.println("Message not received");
@@ -235,7 +235,7 @@ public class InterruptedLargeMessageTest extends LargeMessageTestBase {
          @Override
          public void run() {
             try {
-               log.debug("Receiving message");
+               logger.debug("Receiving message");
                javax.jms.Message msg = consumer.receive(5000);
                if (msg == null) {
                   System.err.println("Message not received");
@@ -243,10 +243,10 @@ public class InterruptedLargeMessageTest extends LargeMessageTestBase {
                   return;
                }
             } catch (JMSException e) {
-               log.debug("This exception was ok as it was expected", e);
+               logger.debug("This exception was ok as it was expected", e);
                expectedErrors.incrementAndGet();
             } catch (Throwable e) {
-               log.warn("Captured unexpected exception", e);
+               logger.warn("Captured unexpected exception", e);
                unexpectedErrors.incrementAndGet();
             }
          }
@@ -452,7 +452,7 @@ public class InterruptedLargeMessageTest extends LargeMessageTestBase {
       server.start();
 
       for (int start = 0; start < 2; start++) {
-         log.debug("Start {}", start);
+         logger.debug("Start {}", start);
 
          sf = createSessionFactory(locator);
 
@@ -466,7 +466,7 @@ public class InterruptedLargeMessageTest extends LargeMessageTestBase {
          ClientConsumer cons1 = session.createConsumer(ADDRESS);
          session.start();
          for (int i = 0; i < 10; i++) {
-            log.info("I = {}", i);
+            logger.info("I = {}", i);
             ClientMessage msg = cons1.receive(5000);
             Assert.assertNotNull(msg);
             Assert.assertEquals(1, msg.getIntProperty("txid").intValue());
@@ -531,7 +531,7 @@ public class InterruptedLargeMessageTest extends LargeMessageTestBase {
 
          @Override
          public void postAcknowledge(final MessageReference ref, AckReason reason) {
-            log.debug("Ignoring postACK on message {}", ref);
+            logger.debug("Ignoring postACK on message {}", ref);
          }
 
          @Override
@@ -745,7 +745,7 @@ public class InterruptedLargeMessageTest extends LargeMessageTestBase {
          if (packet instanceof SessionContinuationMessage) {
             SessionContinuationMessage msg = (SessionContinuationMessage) packet;
             if (!msg.isContinues() && intMessages) {
-               log.debug("Ignored a message");
+               logger.debug("Ignored a message");
                latch.countDown();
                return false;
             }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/LargeMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/LargeMessageTest.java
@@ -76,7 +76,7 @@ import java.lang.invoke.MethodHandles;
 
 public class LargeMessageTest extends LargeMessageTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private static final int RECEIVE_WAIT_TIME = 10000;
 
@@ -99,7 +99,7 @@ public class LargeMessageTest extends LargeMessageTestBase {
    @Test
    public void testRollbackPartiallyConsumedBuffer() throws Exception {
       for (int i = 0; i < 1; i++) {
-         log.debug("#test {}", i);
+         logger.debug("#test {}", i);
          internalTestRollbackPartiallyConsumedBuffer(false);
          tearDown();
          setUp();
@@ -670,7 +670,7 @@ public class LargeMessageTest extends LargeMessageTestBase {
       msg.acknowledge();
       Assert.assertEquals(1, msg.getDeliveryCount());
 
-      log.debug("body buffer is {}", msg.getBodyBuffer());
+      logger.debug("body buffer is {}", msg.getBodyBuffer());
 
       for (int i = 0; i < messageSize; i++) {
          Assert.assertEquals(ActiveMQTestBase.getSamplebyte(i), msg.getBodyBuffer().readByte());
@@ -1574,7 +1574,7 @@ public class LargeMessageTest extends LargeMessageTestBase {
       msg.acknowledge();
       consumer.close();
 
-      log.debug("Stopping");
+      logger.debug("Stopping");
 
       session.stop();
 
@@ -2243,12 +2243,12 @@ public class LargeMessageTest extends LargeMessageTestBase {
 
          session.start();
 
-         log.debug("Sending");
+         logger.debug("Sending");
          producer.send(clientFile);
 
          producer.close();
 
-         log.debug("Waiting");
+         logger.debug("Waiting");
 
          ClientConsumer consumer = session.createConsumer(ADDRESS);
 
@@ -2311,12 +2311,12 @@ public class LargeMessageTest extends LargeMessageTestBase {
 
          session.start();
 
-         log.debug("Sending");
+         logger.debug("Sending");
          producer.send(clientFile);
 
          producer.close();
 
-         log.debug("Waiting");
+         logger.debug("Waiting");
 
          ClientConsumer consumer = session.createConsumer(ADDRESS);
 
@@ -2455,16 +2455,16 @@ public class LargeMessageTest extends LargeMessageTestBase {
          msg.putIntProperty(new SimpleString("key"), i);
          producer.send(msg);
 
-         log.debug("Sent msg {}", i);
+         logger.debug("Sent msg {}", i);
       }
 
       session.start();
 
-      log.debug("Sending");
+      logger.debug("Sending");
 
       producer.close();
 
-      log.debug("Waiting");
+      logger.debug("Waiting");
 
       ClientConsumer consumer = session.createConsumer(ADDRESS);
 
@@ -2484,7 +2484,7 @@ public class LargeMessageTest extends LargeMessageTestBase {
       Assert.assertEquals(0, ((Queue) server.getPostOffice().getBinding(ADDRESS).getBindable()).getDeliveringCount());
       Assert.assertEquals(0, getMessageCount(((Queue) server.getPostOffice().getBinding(ADDRESS).getBindable())));
 
-      log.debug("Thread done");
+      logger.debug("Thread done");
    }
 
    @Test

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MessageConcurrencyTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MessageConcurrencyTest.java
@@ -41,7 +41,7 @@ import java.lang.invoke.MethodHandles;
 
 public class MessageConcurrencyTest extends ActiveMQTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private ActiveMQServer server;
 
@@ -219,7 +219,7 @@ public class MessageConcurrencyTest extends ActiveMQTestBase {
                producer.send(msg);
             }
          } catch (Exception e) {
-            log.error("Failed to send message", e);
+            logger.error("Failed to send message", e);
 
             failed = true;
          }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MessageGroupingTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MessageGroupingTest.java
@@ -48,7 +48,7 @@ import java.lang.invoke.MethodHandles;
 
 public class MessageGroupingTest extends ActiveMQTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private ActiveMQServer server;
 
@@ -201,7 +201,7 @@ public class MessageGroupingTest extends ActiveMQTestBase {
          Assert.assertEquals(cm.getBodyBuffer().readString(), "m" + i);
       }
 
-      log.debug("closing consumer2");
+      logger.debug("closing consumer2");
 
       consumer2.close();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MessagePriorityTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MessagePriorityTest.java
@@ -38,7 +38,7 @@ import java.lang.invoke.MethodHandles;
 
 public class MessagePriorityTest extends ActiveMQTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private ActiveMQServer server;
 
@@ -111,7 +111,7 @@ public class MessagePriorityTest extends ActiveMQTestBase {
       for (int i = 9; i >= 0; i--) {
          ClientMessage m = consumer.receive(500);
 
-         log.debug("received msg {}", m.getPriority());
+         logger.debug("received msg {}", m.getPriority());
 
          Assert.assertNotNull(m);
          Assert.assertEquals(i, m.getPriority());

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/NIOvsOIOTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/NIOvsOIOTest.java
@@ -48,7 +48,7 @@ import java.lang.invoke.MethodHandles;
 
 public class NIOvsOIOTest extends ActiveMQTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Test
    public void testNIOPerf() throws Exception {
@@ -198,7 +198,7 @@ public class NIOvsOIOTest extends ActiveMQTestBase {
             try {
                producer.send(msg);
             } catch (Exception e) {
-               log.error("Caught exception", e);
+               logger.error("Caught exception", e);
             }
          }
       }
@@ -263,7 +263,7 @@ public class NIOvsOIOTest extends ActiveMQTestBase {
          try {
             msg.acknowledge();
          } catch (Exception e) {
-            log.error("Caught exception", e);
+            logger.error("Caught exception", e);
          }
 
          count++;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SessionStopStartTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SessionStopStartTest.java
@@ -39,7 +39,7 @@ import java.lang.invoke.MethodHandles;
 
 public class SessionStopStartTest extends ActiveMQTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private ActiveMQServer server;
 
@@ -284,7 +284,7 @@ public class SessionStopStartTest extends ActiveMQTestBase {
       try {
          session.stop();
       } catch (Exception e) {
-         SessionStopStartTest.log.warn(e.getMessage(), e);
+         SessionStopStartTest.logger.warn(e.getMessage(), e);
          throw e;
       }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/TemporaryQueueTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/TemporaryQueueTest.java
@@ -60,7 +60,7 @@ import java.lang.invoke.MethodHandles;
 
 public class TemporaryQueueTest extends SingleServerTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private static final long CONNECTION_TTL = 2000;
 
@@ -372,11 +372,11 @@ public class TemporaryQueueTest extends SingleServerTestBase {
                latch.countDown();
 
                if (!message.getStringProperty("color").equals(color)) {
-                  log.warn("Unexpected color {} when we were expecting {}", message.getStringProperty("color"), color);
+                  logger.warn("Unexpected color {} when we were expecting {}", message.getStringProperty("color"), color);
                   errors.incrementAndGet();
                }
             } catch (Exception e) {
-               log.warn(e.getMessage(), e);
+               logger.warn(e.getMessage(), e);
                errors.incrementAndGet();
             }
          }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/clientcrash/ClientCrashTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/clientcrash/ClientCrashTest.java
@@ -46,7 +46,7 @@ import java.lang.invoke.MethodHandles;
  */
 public class ClientCrashTest extends ClientTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Rule
    public SpawnedVMCheck spawnedVMCheck = new SpawnedVMCheck();
@@ -148,7 +148,7 @@ public class ClientCrashTest extends ClientTestBase {
       // spawn a JVM that creates a Core client, which sends a message
       p = SpawnedVMSupport.spawnVM(CrashClient2.class.getName());
 
-      ClientCrashTest.log.debug("waiting for the client VM to crash ...");
+      ClientCrashTest.logger.debug("waiting for the client VM to crash ...");
       Assert.assertTrue(p.waitFor(1, TimeUnit.MINUTES));
 
       assertEquals(CrashClient2.OK, p.exitValue());

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/clientcrash/ClientExitTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/clientcrash/ClientExitTest.java
@@ -45,7 +45,7 @@ public class ClientExitTest extends ClientTestBase {
 
    private static final SimpleString QUEUE = new SimpleString("ClientExitTestQueue");
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private ClientSession session;
 
@@ -65,7 +65,7 @@ public class ClientExitTest extends ClientTestBase {
 
       // the client VM should exit by itself. If it doesn't, that means we have a problem
       // and the test will timeout
-      ClientExitTest.log.debug("waiting for the client VM to exit ...");
+      ClientExitTest.logger.debug("waiting for the client VM to exit ...");
       p.waitFor();
 
       assertEquals(0, p.exitValue());

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/clientcrash/CrashClient.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/clientcrash/CrashClient.java
@@ -34,7 +34,7 @@ import java.lang.invoke.MethodHandles;
  */
 public class CrashClient {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    public static int OK = 9;
    public static int NOT_OK = 1;
@@ -59,7 +59,7 @@ public class CrashClient {
          // exit without closing the session properly
          System.exit(OK);
       } catch (Throwable t) {
-         CrashClient.log.error(t.getMessage(), t);
+         CrashClient.logger.error(t.getMessage(), t);
          System.exit(NOT_OK);
       }
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/clientcrash/CrashClient2.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/clientcrash/CrashClient2.java
@@ -34,7 +34,7 @@ import java.lang.invoke.MethodHandles;
  */
 public class CrashClient2 {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
    public static final int OK = 9;
 
    public static void main(final String[] args) throws Exception {
@@ -62,7 +62,7 @@ public class CrashClient2 {
          ClientMessage msg = cons.receive(10000);
 
          if (msg == null) {
-            log.error("Didn't receive msg");
+            logger.error("Didn't receive msg");
 
             System.exit(1);
          }
@@ -70,7 +70,7 @@ public class CrashClient2 {
          // exit without closing the session properly
          System.exit(OK);
       } catch (Throwable t) {
-         log.error(t.getMessage(), t);
+         logger.error(t.getMessage(), t);
          System.exit(1);
       }
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/clientcrash/DummyInterceptor.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/clientcrash/DummyInterceptor.java
@@ -31,7 +31,7 @@ import java.lang.invoke.MethodHandles;
 
 public class DummyInterceptor implements Interceptor {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    boolean sendException = false;
 
@@ -49,7 +49,7 @@ public class DummyInterceptor implements Interceptor {
 
    @Override
    public boolean intercept(final Packet packet, final RemotingConnection conn) throws ActiveMQException {
-      log.debug("DummyFilter packet = {}", packet.getClass().getName());
+      logger.debug("DummyFilter packet = {}", packet.getClass().getName());
       syncCounter.addAndGet(1);
       if (sendException) {
          throw new ActiveMQInternalErrorException();
@@ -57,7 +57,7 @@ public class DummyInterceptor implements Interceptor {
       if (changeMessage) {
          if (packet instanceof SessionReceiveMessage) {
             SessionReceiveMessage deliver = (SessionReceiveMessage) packet;
-            log.debug("msg = {}", deliver.getMessage().getClass().getName());
+            logger.debug("msg = {}", deliver.getMessage().getClass().getName());
             deliver.getMessage().putStringProperty(new SimpleString("DummyInterceptor"), new SimpleString("was here"));
          }
       }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/clientcrash/DummyInterceptorB.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/clientcrash/DummyInterceptorB.java
@@ -28,7 +28,7 @@ import java.lang.invoke.MethodHandles;
 
 public class DummyInterceptorB implements Interceptor {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    static AtomicInteger syncCounter = new AtomicInteger(0);
 
@@ -43,7 +43,7 @@ public class DummyInterceptorB implements Interceptor {
    @Override
    public boolean intercept(final Packet packet, final RemotingConnection conn) throws ActiveMQException {
       DummyInterceptorB.syncCounter.addAndGet(1);
-      log.debug("DummyFilter packet = {}", packet);
+      logger.debug("DummyFilter packet = {}", packet);
       return true;
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/clientcrash/GracefulClient.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/clientcrash/GracefulClient.java
@@ -34,7 +34,7 @@ import java.lang.invoke.MethodHandles;
  * Code to be run in an external VM, via main()
  */
 public class GracefulClient {
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
 
    public static void main(final String[] args) throws Exception {
@@ -64,7 +64,7 @@ public class GracefulClient {
          session.close();
          System.exit(0);
       } catch (Throwable t) {
-         GracefulClient.log.error(t.getMessage(), t);
+         GracefulClient.logger.error(t.getMessage(), t);
          System.exit(1);
       }
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/bridge/BridgeReconnectTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/bridge/BridgeReconnectTest.java
@@ -86,7 +86,7 @@ public class BridgeReconnectTest extends BridgeTestBase {
    @Parameterized.Parameter(0)
    public boolean persistCache;
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private static final int NUM_MESSAGES = 100;
 
@@ -238,7 +238,7 @@ public class BridgeReconnectTest extends BridgeTestBase {
 
       startServers();
 
-      BridgeReconnectTest.log.debug("** failing connection");
+      BridgeReconnectTest.logger.debug("** failing connection");
       // Now we will simulate a failure of the bridge connection between server0 and server1
       server0.fail(true);
 
@@ -507,7 +507,7 @@ public class BridgeReconnectTest extends BridgeTestBase {
                // Simulate CPU load until bridge delivery after failure
                deliveryAfterFailureLatch.await();
             } catch (InterruptedException e) {
-               log.debug("Interrupted", e);
+               logger.debug("Interrupted", e);
             }
          }
 
@@ -519,9 +519,9 @@ public class BridgeReconnectTest extends BridgeTestBase {
                   // before routing messages delivered by bridge before failure
                   routingBarrier.await();
                } catch (InterruptedException e) {
-                  log.debug("Interrupted", e);
+                  logger.debug("Interrupted", e);
                } catch (BrokenBarrierException e) {
-                  log.debug("Interrupted", e);
+                  logger.debug("Interrupted", e);
                }
             }
          }
@@ -611,16 +611,16 @@ public class BridgeReconnectTest extends BridgeTestBase {
 
       ClientProducer prod0 = session0.createProducer(testAddress);
 
-      BridgeReconnectTest.log.debug("stopping server1");
+      BridgeReconnectTest.logger.debug("stopping server1");
       server1.stop();
 
       if (sleep) {
          Thread.sleep(2 * clientFailureCheckPeriod);
       }
 
-      BridgeReconnectTest.log.debug("restarting server1");
+      BridgeReconnectTest.logger.debug("restarting server1");
       server1.start();
-      BridgeReconnectTest.log.debug("server 1 restarted");
+      BridgeReconnectTest.logger.debug("server 1 restarted");
 
       ClientSessionFactory csf1 = locator.createSessionFactory(server1tc);
       session1 = csf1.createSession(false, true, true);
@@ -640,7 +640,7 @@ public class BridgeReconnectTest extends BridgeTestBase {
          prod0.send(message);
       }
 
-      BridgeReconnectTest.log.debug("sent messages");
+      BridgeReconnectTest.logger.debug("sent messages");
 
       for (int i = 0; i < numMessages; i++) {
          ClientMessage r1 = cons1.receive(30000);
@@ -648,7 +648,7 @@ public class BridgeReconnectTest extends BridgeTestBase {
          assertEquals("property value matches", i, r1.getObjectProperty(propKey));
       }
 
-      BridgeReconnectTest.log.debug("got messages");
+      BridgeReconnectTest.logger.debug("got messages");
       closeServers();
       assertNoMoreConnections();
    }
@@ -751,7 +751,7 @@ public class BridgeReconnectTest extends BridgeTestBase {
          fail("Message " + outOfOrder + " was received out of order, it was supposed to be " + supposed);
       }
 
-      log.debug("=========== second failure, sending message");
+      logger.debug("=========== second failure, sending message");
 
       // Fail again - should reconnect
       forwardingConnection = ((BridgeImpl) bridge).getForwardingConnection();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/bridge/BridgeTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/bridge/BridgeTest.java
@@ -95,7 +95,7 @@ import java.lang.invoke.MethodHandles;
 @RunWith(value = Parameterized.class)
 public class BridgeTest extends ActiveMQTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private ActiveMQServer server0;
    private ActiveMQServer server1;
@@ -1497,7 +1497,7 @@ public class BridgeTest extends ActiveMQTestBase {
             msgCount.incrementAndGet();
 
             if (i % 500 == 0)
-               log.debug("received {}", i);
+               logger.debug("received {}", i);
          }
 
          boolean failed = false;
@@ -1815,7 +1815,7 @@ public class BridgeTest extends ActiveMQTestBase {
 
          File outputFile = new File(getTemporaryDir(), "huge_message_received.dat");
 
-         log.debug("-----message save to: {}", outputFile.getAbsolutePath());
+         logger.debug("-----message save to: {}", outputFile.getAbsolutePath());
          FileOutputStream fileOutputStream = new FileOutputStream(outputFile);
 
          BufferedOutputStream bufferedOutput = new BufferedOutputStream(fileOutputStream);
@@ -1860,7 +1860,7 @@ public class BridgeTest extends ActiveMQTestBase {
 
       createFile(fileInput, largeMessageSize);
 
-      log.debug("File created at: {}", fileInput.getAbsolutePath());
+      logger.debug("File created at: {}", fileInput.getAbsolutePath());
 
       ClientMessage message = session.createMessage(Message.BYTES_TYPE, true);
 
@@ -1874,13 +1874,13 @@ public class BridgeTest extends ActiveMQTestBase {
 
    private static void createFile(final File file, final long fileSize) throws IOException {
       if (file.exists()) {
-         log.warn("---file already there {}", file.length());
+         logger.warn("---file already there {}", file.length());
          return;
       }
       FileOutputStream fileOut = new FileOutputStream(file);
       BufferedOutputStream buffOut = new BufferedOutputStream(fileOut);
       byte[] outBuffer = new byte[1024 * 1024];
-      log.debug(" --- creating file, size: {}", fileSize);
+      logger.debug(" --- creating file, size: {}", fileSize);
       for (long i = 0; i < fileSize; i += outBuffer.length) {
          buffOut.write(outBuffer);
       }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/AutoDeleteDistributedTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/AutoDeleteDistributedTest.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
 import java.lang.invoke.MethodHandles;
 
 public class AutoDeleteDistributedTest extends ClusterTestBase {
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Override
    @Before
@@ -111,7 +111,7 @@ public class AutoDeleteDistributedTest extends ClusterTestBase {
          client2JmsConsumer.setMessageListener(new MessageListener() {
             @Override
             public void onMessage(final javax.jms.Message m) {
-               log.debug("Message received. {}", m);
+               logger.debug("Message received. {}", m);
                onMessageReceived.countDown();
             }
          });
@@ -126,7 +126,7 @@ public class AutoDeleteDistributedTest extends ClusterTestBase {
             jmsProducer.setAsync(new javax.jms.CompletionListener() {
                @Override
                public void onCompletion(final javax.jms.Message m) {
-                  log.debug("Message sent. {}", m);
+                  logger.debug("Message sent. {}", m);
                   onMessageSent.countDown();
                }
 
@@ -142,11 +142,11 @@ public class AutoDeleteDistributedTest extends ClusterTestBase {
                jmsProducer.send(client1JmsContext.createQueue("queues.myQueue"), jmsMsg);
             }
 
-            log.debug("Waiting for message to be sent...");
+            logger.debug("Waiting for message to be sent...");
             onMessageSent.await(5, TimeUnit.SECONDS);
          }
 
-         log.debug("Waiting for message to be received...");
+         logger.debug("Waiting for message to be received...");
          Assert.assertTrue(onMessageReceived.await(5, TimeUnit.SECONDS));
 
          client2JmsConsumer.close();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/ClusterTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/ClusterTestBase.java
@@ -102,7 +102,7 @@ import java.lang.invoke.MethodHandles;
 
 public abstract class ClusterTestBase extends ActiveMQTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private static final int[] PORTS = {TransportConstants.DEFAULT_PORT, TransportConstants.DEFAULT_PORT + 1, TransportConstants.DEFAULT_PORT + 2, TransportConstants.DEFAULT_PORT + 3, TransportConstants.DEFAULT_PORT + 4, TransportConstants.DEFAULT_PORT + 5, TransportConstants.DEFAULT_PORT + 6, TransportConstants.DEFAULT_PORT + 7, TransportConstants.DEFAULT_PORT + 8, TransportConstants.DEFAULT_PORT + 9,};
 
@@ -150,7 +150,7 @@ public abstract class ClusterTestBase extends ActiveMQTestBase {
       try {
          pluggableQuorumConfiguration = new DistributedPrimitiveManagerConfiguration(FileBasedPrimitiveManager.class.getName(), Collections.singletonMap("locks-folder", temporaryFolder.newFolder("manager").toString()));
       } catch (IOException ioException) {
-         log.error(ioException.getMessage(), ioException);
+         logger.error(ioException.getMessage(), ioException);
          return null;
       }
       return pluggableQuorumConfiguration;
@@ -281,8 +281,8 @@ public abstract class ClusterTestBase extends ActiveMQTestBase {
    protected void waitForFailoverTopology(final int bNode, final int... nodes) throws Exception {
       ActiveMQServer server = servers[bNode];
 
-      if (log.isDebugEnabled()) {
-         log.debug("waiting for {} on the topology for server = {}",  Arrays.toString(nodes), server);
+      if (logger.isDebugEnabled()) {
+         logger.debug("waiting for {} on the topology for server = {}",  Arrays.toString(nodes), server);
       }
 
       long start = System.currentTimeMillis();
@@ -327,7 +327,7 @@ public abstract class ClusterTestBase extends ActiveMQTestBase {
                topology +
                ")";
 
-            log.error(msg);
+            logger.error(msg);
 
             logTopologyDiagram();
 
@@ -337,7 +337,7 @@ public abstract class ClusterTestBase extends ActiveMQTestBase {
    }
 
    private void logTopologyDiagram() {
-      if (!log.isDebugEnabled()) {
+      if (!logger.isDebugEnabled()) {
          return;
       }
 
@@ -387,9 +387,9 @@ public abstract class ClusterTestBase extends ActiveMQTestBase {
             }
          }
          topologyDiagram.append("\n");
-         log.debug(topologyDiagram.toString());
+         logger.debug(topologyDiagram.toString());
       } catch (Throwable e) {
-         log.warn(String.format("error printing the topology::%s", e.getMessage()), e);
+         logger.warn(String.format("error printing the topology::%s", e.getMessage()), e);
       }
    }
 
@@ -432,7 +432,7 @@ public abstract class ClusterTestBase extends ActiveMQTestBase {
       if (!servers[node].waitForActivation(waitTimeout, TimeUnit.MILLISECONDS)) {
          String msg = "Timed out waiting for server starting = " + node;
 
-         log.error(msg);
+         logger.error(msg);
 
          throw new IllegalStateException(msg);
       }
@@ -443,8 +443,8 @@ public abstract class ClusterTestBase extends ActiveMQTestBase {
                                   final int expectedBindingCount,
                                   final int expectedConsumerCount,
                                   final boolean local) throws Exception {
-      if (log.isDebugEnabled()) {
-         log.debug("waiting for bindings on node {} address {} expectedBindingCount {} consumerCount {} local {}",
+      if (logger.isDebugEnabled()) {
+         logger.debug("waiting for bindings on node {} address {} expectedBindingCount {} consumerCount {} local {}",
                    node, address, expectedBindingCount, expectedConsumerCount, local);
       }
 
@@ -463,14 +463,14 @@ public abstract class ClusterTestBase extends ActiveMQTestBase {
       PostOffice po = server.getPostOffice();
       Bindings bindings = po.getBindingsForAddress(new SimpleString(address));
 
-      log.debug("=======================================================================");
-      log.debug("Binding information for address = {} on node {}", address, node);
+      logger.debug("=======================================================================");
+      logger.debug("Binding information for address = {} on node {}", address, node);
 
       for (Binding binding : bindings.getBindings()) {
          if (binding.isConnected() && (binding instanceof LocalQueueBinding && local || binding instanceof RemoteQueueBinding && !local)) {
             QueueBinding qBinding = (QueueBinding) binding;
 
-            log.debug("Binding = {}, queue={}", qBinding, qBinding.getQueue());
+            logger.debug("Binding = {}, queue={}", qBinding, qBinding.getQueue());
          }
       }
 
@@ -577,7 +577,7 @@ public abstract class ClusterTestBase extends ActiveMQTestBase {
          filterString = ClusterTestBase.FILTER_PROP.toString() + "='" + filterVal + "'";
       }
 
-      log.debug("Creating {} , address {} on {}", queueName, address, servers[node]);
+      logger.debug("Creating {} , address {} on {}", queueName, address, servers[node]);
 
       session.createQueue(new QueueConfiguration(queueName).setAddress(address).setRoutingType(routingType).setFilterString(filterString).setDurable(durable));
 
@@ -916,7 +916,7 @@ public abstract class ClusterTestBase extends ActiveMQTestBase {
             ClientMessage message = holder.consumer.receive(2000);
 
             if (message == null) {
-               log.debug("*** dumping consumers:");
+               logger.debug("*** dumping consumers:");
 
                dumpConsumers();
 
@@ -1000,7 +1000,7 @@ public abstract class ClusterTestBase extends ActiveMQTestBase {
             ClientMessage message = holder.consumer.receive(WAIT_TIMEOUT);
 
             if (message == null) {
-               log.debug("*** dumping consumers:");
+               logger.debug("*** dumping consumers:");
 
                dumpConsumers();
 
@@ -1026,7 +1026,7 @@ public abstract class ClusterTestBase extends ActiveMQTestBase {
                      message.getObjectProperty(ClusterTestBase.COUNT_PROP);
                }
                outOfOrder = true;
-               log.debug("Message j={} was received out of order = {}", j, message.getObjectProperty(ClusterTestBase.COUNT_PROP));
+               logger.debug("Message j={} was received out of order = {}", j, message.getObjectProperty(ClusterTestBase.COUNT_PROP));
             }
          }
       }
@@ -1037,7 +1037,7 @@ public abstract class ClusterTestBase extends ActiveMQTestBase {
    private void dumpConsumers() throws Exception {
       for (int i = 0; i < consumers.length; i++) {
          if (consumers[i] != null && !consumers[i].consumer.isClosed()) {
-            log.debug("Dumping consumer {}", i);
+            logger.debug("Dumping consumer {}", i);
 
             checkReceive(i);
          }
@@ -1090,9 +1090,9 @@ public abstract class ClusterTestBase extends ActiveMQTestBase {
             message = holder.consumer.receive(500);
 
             if (message != null) {
-               log.debug("check receive Consumer {} received message {}", consumerID, message.getObjectProperty(ClusterTestBase.COUNT_PROP));
+               logger.debug("check receive Consumer {} received message {}", consumerID, message.getObjectProperty(ClusterTestBase.COUNT_PROP));
             } else {
-               log.debug("check receive Consumer {} null message", consumerID);
+               logger.debug("check receive Consumer {} null message", consumerID);
             }
          }
          while (message != null);
@@ -1262,7 +1262,7 @@ public abstract class ClusterTestBase extends ActiveMQTestBase {
 
                checkMessageBody(message);
 
-               // log.debug("consumer {} received message {}", consumerIDs[i], count);
+               // logger.debug("consumer {} received message {}", consumerIDs[i], count);
 
                Assert.assertFalse(counts.contains(count));
 
@@ -1992,7 +1992,7 @@ public abstract class ClusterTestBase extends ActiveMQTestBase {
 
    protected void startServers(final int... nodes) throws Exception {
       for (int node : nodes) {
-         log.debug("#test start node {}", node);
+         logger.debug("#test start node {}", node);
          final long currentTime = System.currentTimeMillis();
          boolean waitForSelf = currentTime - timeStarts[node] < TIMEOUT_START_SERVER;
          boolean waitForPrevious = node > 0 && currentTime - timeStarts[node - 1] < TIMEOUT_START_SERVER;
@@ -2000,10 +2000,10 @@ public abstract class ClusterTestBase extends ActiveMQTestBase {
             Thread.sleep(TIMEOUT_START_SERVER);
          }
          timeStarts[node] = System.currentTimeMillis();
-         log.debug("starting server {}", servers[node]);
+         logger.debug("starting server {}", servers[node]);
          servers[node].start();
 
-         log.debug("started server {}", servers[node]);
+         logger.debug("started server {}", servers[node]);
          waitForServerToStart(servers[node]);
 
          if (servers[node].getStorageManager() != null && isForceUniqueStorageManagerIds()) {
@@ -2028,8 +2028,8 @@ public abstract class ClusterTestBase extends ActiveMQTestBase {
    }
 
    protected void stopServers(final int... nodes) throws Exception {
-      if (log.isDebugEnabled()) {
-         log.debug("Stopping nodes {}", Arrays.toString(nodes));
+      if (logger.isDebugEnabled()) {
+         logger.debug("Stopping nodes {}", Arrays.toString(nodes));
       }
 
       Exception exception = null;
@@ -2043,9 +2043,9 @@ public abstract class ClusterTestBase extends ActiveMQTestBase {
 
                timeStarts[node] = System.currentTimeMillis();
 
-               log.debug("stopping server {}", node);
+               logger.debug("stopping server {}", node);
                servers[node].stop();
-               log.debug("server {} stopped", node);
+               logger.debug("server {} stopped", node);
             } catch (Exception e) {
                exception = e;
             }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/ClusteredGroupingTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/ClusteredGroupingTest.java
@@ -58,7 +58,7 @@ import java.lang.invoke.MethodHandles;
 
 public class ClusteredGroupingTest extends ClusterTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Rule
    public RetryRule retryRule = new RetryRule(2);
@@ -599,12 +599,12 @@ public class ClusteredGroupingTest extends ClusterTestBase {
             groups.add(group);
          }
          producer.send(message);
-         log.trace("Sent message to server 1 with dupID: {}", dupID);
+         logger.trace("Sent message to server 1 with dupID: {}", dupID);
       }
 
       session.commit();
       totalMessageProduced.addAndGet(500);
-      log.trace("Sent block of 500 messages to server 1. Total sent: {}", totalMessageProduced.get());
+      logger.trace("Sent block of 500 messages to server 1. Total sent: {}", totalMessageProduced.get());
       session.close();
 
       // need thread pool to service both consumers and producers plus a thread to cycle nodes
@@ -626,7 +626,7 @@ public class ClusteredGroupingTest extends ClusterTestBase {
                String group = groupx;
 
                String basicID = UUID.randomUUID().toString();
-               log.debug("Starting producer thread...");
+               logger.debug("Starting producer thread...");
                ClientSessionFactory factory;
                ClientSession session = null;
                ClientProducer producer = null;
@@ -644,12 +644,12 @@ public class ClusteredGroupingTest extends ClusterTestBase {
                   } else {
                      factory = sf0;
                   }
-                  log.debug("Creating producer session factory to node {}", targetServer);
+                  logger.debug("Creating producer session factory to node {}", targetServer);
                   session = addClientSession(factory.createSession(false, true, true));
                   producer = addClientProducer(session.createProducer(ADDRESS));
                } catch (Exception e) {
                   errors.incrementAndGet();
-                  log.warn("Producer thread couldn't establish connection", e);
+                  logger.warn("Producer thread couldn't establish connection", e);
                   return;
                }
 
@@ -665,11 +665,11 @@ public class ClusteredGroupingTest extends ClusterTestBase {
                      totalMessageProduced.incrementAndGet();
                      messageCount++;
                   } catch (ActiveMQException e) {
-                     log.warn("Producer thread threw exception while sending messages to {}: {}", targetServer, e.getMessage());
+                     logger.warn("Producer thread threw exception while sending messages to {}: {}", targetServer, e.getMessage());
                      // in case of a failure we change the group to make possible errors more likely
                      group = group + "afterFail";
                   } catch (Exception e) {
-                     log.warn("Producer thread threw unexpected exception while sending messages to {}: {}", targetServer, e.getMessage());
+                     logger.warn("Producer thread threw unexpected exception while sending messages to {}: {}", targetServer, e.getMessage());
                      group = group + "afterFail";
                      break;
                   }
@@ -711,13 +711,13 @@ public class ClusteredGroupingTest extends ClusterTestBase {
             @Override
             public void run() {
                try {
-                  log.debug("Waiting to start consumer thread...");
+                  logger.debug("Waiting to start consumer thread...");
                   okToConsume.await(20, TimeUnit.SECONDS);
                } catch (InterruptedException e) {
                   e.printStackTrace();
                   return;
                }
-               log.debug("Starting consumer thread...");
+               logger.debug("Starting consumer thread...");
                ClientSessionFactory factory;
                ClientSession session = null;
                ClientConsumer consumer = null;
@@ -734,14 +734,14 @@ public class ClusteredGroupingTest extends ClusterTestBase {
                      } else {
                         factory = sf0;
                      }
-                     log.debug("Creating consumer session factory to node {}", targetServer);
+                     logger.debug("Creating consumer session factory to node {}", targetServer);
                      session = addClientSession(factory.createSession(false, false, true));
                      consumer = addClientConsumer(session.createConsumer(QUEUE));
                      session.start();
                      consumerCounter.incrementAndGet();
                   }
                } catch (Exception e) {
-                  log.debug("Consumer thread couldn't establish connection", e);
+                  logger.debug("Consumer thread couldn't establish connection", e);
                   errors.incrementAndGet();
                   return;
                }
@@ -754,13 +754,13 @@ public class ClusteredGroupingTest extends ClusterTestBase {
                         return;
                      }
                      m.acknowledge();
-                     log.trace("Consumed message {} from server {}. Total consumed: {}", m.getStringProperty(Message.HDR_DUPLICATE_DETECTION_ID), targetServer, totalMessagesConsumed.incrementAndGet());
+                     logger.trace("Consumed message {} from server {}. Total consumed: {}", m.getStringProperty(Message.HDR_DUPLICATE_DETECTION_ID), targetServer, totalMessagesConsumed.incrementAndGet());
                   } catch (ActiveMQException e) {
                      errors.incrementAndGet();
-                     log.warn("Consumer thread threw exception while receiving messages from server {}.: {}", targetServer, e.getMessage());
+                     logger.warn("Consumer thread threw exception while receiving messages from server {}.: {}", targetServer, e.getMessage());
                   } catch (Exception e) {
                      errors.incrementAndGet();
-                     log.warn("Consumer thread threw unexpected exception while receiving messages from server {}.: {}", targetServer, e.getMessage());
+                     logger.warn("Consumer thread threw unexpected exception while receiving messages from server {}.: {}", targetServer, e.getMessage());
                      return;
                   }
                }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/MessageRedistributionTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/MessageRedistributionTest.java
@@ -58,7 +58,7 @@ import java.lang.invoke.MethodHandles;
 
 public class MessageRedistributionTest extends ClusterTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Override
    @Before
@@ -91,7 +91,7 @@ public class MessageRedistributionTest extends ClusterTestBase {
    public void testRedistributionWithMessageGroups() throws Exception {
       setupCluster(MessageLoadBalancingType.ON_DEMAND);
 
-      log.debug("Doing test");
+      logger.debug("Doing test");
 
       getServer(0).getConfiguration().setGroupingHandlerConfiguration(new GroupingHandlerConfiguration().setName(new SimpleString("handler")).setType(GroupingHandlerConfiguration.TYPE.LOCAL).setAddress(new SimpleString("queues")));
       getServer(1).getConfiguration().setGroupingHandlerConfiguration(new GroupingHandlerConfiguration().setName(new SimpleString("handler")).setType(GroupingHandlerConfiguration.TYPE.REMOTE).setAddress(new SimpleString("queues")));
@@ -170,7 +170,7 @@ public class MessageRedistributionTest extends ClusterTestBase {
          message.acknowledge();
          Assert.assertNotNull(message.getSimpleStringProperty(Message.HDR_GROUP_ID));
       }
-      log.debug("Test done");
+      logger.debug("Test done");
    }
 
    //https://issues.jboss.org/browse/HORNETQ-1057
@@ -178,7 +178,7 @@ public class MessageRedistributionTest extends ClusterTestBase {
    public void testRedistributionStopsWhenConsumerAdded() throws Exception {
       setupCluster(MessageLoadBalancingType.ON_DEMAND);
 
-      log.debug("Doing test");
+      logger.debug("Doing test");
 
       startServers(0, 1, 2);
 
@@ -208,14 +208,14 @@ public class MessageRedistributionTest extends ClusterTestBase {
       Bindable bindable = servers[0].getPostOffice().getBinding(new SimpleString("queue0")).getBindable();
       String debug = ((QueueImpl) bindable).debug();
       Assert.assertFalse(debug.contains(Redistributor.class.getName()));
-      log.debug("Test done");
+      logger.debug("Test done");
    }
 
    @Test
    public void testRedistributionWhenConsumerIsClosed() throws Exception {
       setupCluster(MessageLoadBalancingType.ON_DEMAND);
 
-      log.debug("Doing test");
+      logger.debug("Doing test");
 
       startServers(0, 1, 2);
 
@@ -249,7 +249,7 @@ public class MessageRedistributionTest extends ClusterTestBase {
 
       verifyReceiveRoundRobinInSomeOrderWithCounts(false, ids1, 0, 2);
 
-      log.debug("Test done");
+      logger.debug("Test done");
    }
 
    @Test
@@ -331,7 +331,7 @@ public class MessageRedistributionTest extends ClusterTestBase {
       Assert.assertNull(consumer1.receiveImmediate());
       Assert.assertNull(consumer2.receiveImmediate());
 
-      log.debug("Test done");
+      logger.debug("Test done");
    }
 
    @Test

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/OnewayTwoNodeClusterTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/OnewayTwoNodeClusterTest.java
@@ -27,7 +27,7 @@ import java.lang.invoke.MethodHandles;
 
 public class OnewayTwoNodeClusterTest extends ClusterTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Override
    @Before
@@ -145,19 +145,19 @@ public class OnewayTwoNodeClusterTest extends ClusterTestBase {
 
       long start = System.currentTimeMillis();
 
-      OnewayTwoNodeClusterTest.log.debug("stopping server 1");
+      OnewayTwoNodeClusterTest.logger.debug("stopping server 1");
 
       stopServers(1);
 
       waitForTopology(servers[0], 1);
 
-      OnewayTwoNodeClusterTest.log.debug("restarting server 1({})", servers[1].getIdentity());
+      OnewayTwoNodeClusterTest.logger.debug("restarting server 1({})", servers[1].getIdentity());
 
       startServers(1);
 
       waitForTopology(servers[0], 2);
 
-      log.debug("Server 1 id={}", servers[1].getNodeID());
+      logger.debug("Server 1 id={}", servers[1].getNodeID());
 
       long end = System.currentTimeMillis();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/SimpleSymmetricClusterTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/SimpleSymmetricClusterTest.java
@@ -37,7 +37,7 @@ import java.lang.invoke.MethodHandles;
 
 public class SimpleSymmetricClusterTest extends ClusterTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
 
 
@@ -71,19 +71,19 @@ public class SimpleSymmetricClusterTest extends ClusterTestBase {
 
       startServers(0, 1, 2, 3, 4, 5);
 
-      log.debug("");
+      logger.debug("");
       for (int i = 0; i <= 5; i++) {
-         log.debug(servers[i].describe());
-         log.debug(debugBindings(servers[i], servers[i].getConfiguration().getManagementNotificationAddress().toString()));
+         logger.debug(servers[i].describe());
+         logger.debug(debugBindings(servers[i], servers[i].getConfiguration().getManagementNotificationAddress().toString()));
       }
-      log.debug("");
+      logger.debug("");
 
-      log.debug("");
+      logger.debug("");
       for (int i = 0; i <= 5; i++) {
-         log.debug(servers[i].describe());
-         log.debug(debugBindings(servers[i], servers[i].getConfiguration().getManagementNotificationAddress().toString()));
+         logger.debug(servers[i].describe());
+         logger.debug(debugBindings(servers[i], servers[i].getConfiguration().getManagementNotificationAddress().toString()));
       }
-      log.debug("");
+      logger.debug("");
 
       stopServers(0, 1, 2, 3, 4, 5);
 
@@ -284,7 +284,7 @@ public class SimpleSymmetricClusterTest extends ClusterTestBase {
    public void _testLoop() throws Throwable {
       for (int i = 0; i < 10; i++) {
          loopNumber = i;
-         log.debug("#test {}", i);
+         logger.debug("#test {}", i);
          testSimple();
          tearDown();
          setUp();
@@ -315,7 +315,7 @@ public class SimpleSymmetricClusterTest extends ClusterTestBase {
          waitForTopology(servers[i], 5);
       }
 
-      log.debug("All the servers have been started already!");
+      logger.debug("All the servers have been started already!");
 
       for (int i = 0; i <= 4; i++) {
          setupSessionFactory(i, isNetty());

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/SymmetricClusterTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/SymmetricClusterTest.java
@@ -35,7 +35,7 @@ import java.lang.invoke.MethodHandles;
  */
 public class SymmetricClusterTest extends ClusterTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Override
    @Before
@@ -275,14 +275,14 @@ public class SymmetricClusterTest extends ClusterTestBase {
 
    @Test
    public void testRoundRobinMultipleQueues() throws Exception {
-      log.debug("starting");
+      logger.debug("starting");
       setupCluster();
 
-      log.debug("setup cluster");
+      logger.debug("setup cluster");
 
       startServers();
 
-      log.debug("started servers");
+      logger.debug("started servers");
 
       setupSessionFactory(0, isNetty());
       setupSessionFactory(1, isNetty());
@@ -290,7 +290,7 @@ public class SymmetricClusterTest extends ClusterTestBase {
       setupSessionFactory(3, isNetty());
       setupSessionFactory(4, isNetty());
 
-      log.debug("Set up session factories");
+      logger.debug("Set up session factories");
 
       createQueue(0, "queues.testaddress", "queue0", null, false);
       createQueue(1, "queues.testaddress", "queue0", null, false);
@@ -310,7 +310,7 @@ public class SymmetricClusterTest extends ClusterTestBase {
       createQueue(3, "queues.testaddress", "queue2", null, false);
       createQueue(4, "queues.testaddress", "queue2", null, false);
 
-      log.debug("created queues");
+      logger.debug("created queues");
 
       addConsumer(0, 0, "queue0", null);
       addConsumer(1, 1, "queue0", null);
@@ -330,7 +330,7 @@ public class SymmetricClusterTest extends ClusterTestBase {
       addConsumer(13, 3, "queue2", null);
       addConsumer(14, 4, "queue2", null);
 
-      log.debug("added consumers");
+      logger.debug("added consumers");
 
       waitForBindings(0, "queues.testaddress", 3, 3, true);
       waitForBindings(1, "queues.testaddress", 3, 3, true);
@@ -344,23 +344,23 @@ public class SymmetricClusterTest extends ClusterTestBase {
       waitForBindings(3, "queues.testaddress", 12, 12, false);
       waitForBindings(4, "queues.testaddress", 12, 12, false);
 
-      log.debug("waited for bindings");
+      logger.debug("waited for bindings");
 
       send(0, "queues.testaddress", 10, false, null);
 
-      log.debug("sent messages");
+      logger.debug("sent messages");
 
       verifyReceiveRoundRobinInSomeOrder(10, 0, 1, 2, 3, 4);
 
-      log.debug("verified 1");
+      logger.debug("verified 1");
 
       verifyReceiveRoundRobinInSomeOrder(10, 5, 6, 7, 8, 9);
 
-      log.debug("verified 2");
+      logger.debug("verified 2");
 
       verifyReceiveRoundRobinInSomeOrder(10, 10, 11, 12, 13, 14);
 
-      log.debug("verified 3");
+      logger.debug("verified 3");
    }
 
    @Test

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/AsynchronousFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/AsynchronousFailoverTest.java
@@ -54,7 +54,7 @@ import java.lang.invoke.MethodHandles;
  */
 public class AsynchronousFailoverTest extends FailoverTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private volatile CountDownSessionFailureListener listener;
 
@@ -70,7 +70,7 @@ public class AsynchronousFailoverTest extends FailoverTestBase {
             try {
                doTestNonTransactional(this);
             } catch (Throwable e) {
-               log.error("Test failed", e);
+               logger.error("Test failed", e);
                addException(e);
             }
          }
@@ -93,7 +93,7 @@ public class AsynchronousFailoverTest extends FailoverTestBase {
                   running = false;
                }
             } catch (Throwable e) {
-               log.error("Test failed", e);
+               logger.error("Test failed", e);
                addException(e);
             }
          }
@@ -124,9 +124,9 @@ public class AsynchronousFailoverTest extends FailoverTestBase {
 
       void checkForExceptions() throws Throwable {
          if (errors.size() > 0) {
-            log.warn("Exceptions on test:");
+            logger.warn("Exceptions on test:");
             for (Throwable e : errors) {
-               log.warn(e.getMessage(), e);
+               logger.warn(e.getMessage(), e);
             }
             // throwing the first error that happened on the Runnable
             throw errors.get(0);
@@ -141,7 +141,7 @@ public class AsynchronousFailoverTest extends FailoverTestBase {
 
       try {
          for (int i = 0; i < numIts; i++) {
-            log.debug("Iteration {}", i);
+            logger.debug("Iteration {}", i);
             //set block timeout to 10 sec to reduce test time.
             ServerLocator locator = getServerLocator().setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setReconnectAttempts(30).setRetryInterval(100).setConfirmationWindowSize(10 * 1024 * 1024).setCallTimeout(10000).setCallFailoverTimeout(10000);
 
@@ -162,15 +162,15 @@ public class AsynchronousFailoverTest extends FailoverTestBase {
 
                long randomDelay = (long) (2000 * Math.random());
 
-               log.debug("Sleeping {}", randomDelay);
+               logger.debug("Sleeping {}", randomDelay);
 
                Thread.sleep(randomDelay);
 
-               log.debug("Failing asynchronously");
+               logger.debug("Failing asynchronously");
 
                // Simulate failure on connection
                synchronized (lockFail) {
-                  log.debug("#test crashing test");
+                  logger.debug("#test crashing test");
                   crash(createSession);
                }
 
@@ -183,7 +183,7 @@ public class AsynchronousFailoverTest extends FailoverTestBase {
 
                runnable.setFailed();
 
-               log.debug("Fail complete");
+               logger.debug("Fail complete");
 
                t.join(TimeUnit.SECONDS.toMillis(120));
                if (t.isAlive()) {
@@ -221,7 +221,7 @@ public class AsynchronousFailoverTest extends FailoverTestBase {
 
    private void doTestNonTransactional(final TestRunner runner) throws Exception {
       while (!runner.isFailed()) {
-         log.debug("looping");
+         logger.debug("looping");
 
          ClientSession session = sf.createSession(true, true, 0);
 
@@ -249,7 +249,7 @@ public class AsynchronousFailoverTest extends FailoverTestBase {
 
                   retry = false;
                } catch (ActiveMQUnBlockedException ube) {
-                  log.debug("exception when sending message with counter {}", i);
+                  logger.debug("exception when sending message with counter {}", i);
 
                   ube.printStackTrace();
 
@@ -271,7 +271,7 @@ public class AsynchronousFailoverTest extends FailoverTestBase {
 
                retry = false;
             } catch (ActiveMQUnBlockedException ube) {
-               log.debug("exception when creating consumer");
+               logger.debug("exception when creating consumer");
 
                retry = true;
 
@@ -302,7 +302,7 @@ public class AsynchronousFailoverTest extends FailoverTestBase {
                   Assert.fail("got another counter gap at " + count + ": " + counts);
                } else {
                   if (lastCount != -1) {
-                     log.debug("got first counter gap at {}", count);
+                     logger.debug("got first counter gap at {}", count);
                      counterGap = true;
                   }
                }
@@ -328,7 +328,7 @@ public class AsynchronousFailoverTest extends FailoverTestBase {
 
          executionId++;
 
-         log.debug("#test doTestTransactional starting now. Execution {}", executionId);
+         logger.debug("#test doTestTransactional starting now. Execution {}", executionId);
 
          try {
 
@@ -375,12 +375,12 @@ public class AsynchronousFailoverTest extends FailoverTestBase {
 
                      addPayload(message);
 
-                     log.debug("Sending message {}", message);
+                     logger.debug("Sending message {}", message);
 
                      producer.send(message);
                   }
 
-                  log.debug("Sending commit");
+                  logger.debug("Sending commit");
                   session.commit();
 
                   retry = false;
@@ -388,19 +388,19 @@ public class AsynchronousFailoverTest extends FailoverTestBase {
                   logAndSystemOut("#test duplicate id rejected on sending");
                   break;
                } catch (ActiveMQTransactionRolledBackException trbe) {
-                  log.debug("#test transaction rollback retrying on sending");
+                  logger.debug("#test transaction rollback retrying on sending");
                   // OK
                   retry = true;
                } catch (ActiveMQUnBlockedException ube) {
-                  log.debug("#test transaction rollback retrying on sending");
+                  logger.debug("#test transaction rollback retrying on sending");
                   // OK
                   retry = true;
                } catch (ActiveMQTransactionOutcomeUnknownException toue) {
-                  log.debug("#test transaction rollback retrying on sending");
+                  logger.debug("#test transaction rollback retrying on sending");
                   // OK
                   retry = true;
                } catch (ActiveMQObjectClosedException closedException) {
-                  log.debug("#test producer closed, retrying on sending...");
+                  logger.debug("#test producer closed, retrying on sending...");
                   Thread.sleep(2000);
                   // OK
                   retry = true;
@@ -410,7 +410,7 @@ public class AsynchronousFailoverTest extends FailoverTestBase {
                   Thread.sleep(2000);
                   retry = true;
                } catch (ActiveMQException e) {
-                  log.debug("#test Exception {}", e.getMessage(), e);
+                  logger.debug("#test Exception {}", e.getMessage(), e);
                   throw e;
                }
             }
@@ -446,19 +446,19 @@ public class AsynchronousFailoverTest extends FailoverTestBase {
                   session.start();
 
                   for (int i = 0; i < numMessages; i++) {
-                     log.debug("Consumer receiving message {}", i);
+                     logger.debug("Consumer receiving message {}", i);
 
                      ClientMessage message = consumer.receive(60000);
                      if (message == null) {
                         break;
                      }
 
-                     log.debug("Received message {}", message);
+                     logger.debug("Received message {}", message);
 
                      int count = message.getIntProperty("counter");
 
                      if (count != i) {
-                        log.warn("count was received out of order, {}!={}", count, i);
+                        logger.warn("count was received out of order, {}!={}", count, i);
                      }
 
                      msgs.add(count);
@@ -466,7 +466,7 @@ public class AsynchronousFailoverTest extends FailoverTestBase {
                      message.acknowledge();
                   }
 
-                  log.debug("#test commit");
+                  logger.debug("#test commit");
                   try {
                      session.commit();
                   } catch (ActiveMQTransactionRolledBackException trbe) {
@@ -476,7 +476,7 @@ public class AsynchronousFailoverTest extends FailoverTestBase {
                   } catch (ActiveMQException e) {
                      // This could eventually happen
                      // We will get rid of this when we implement 2 phase commit on failover
-                     log.warn("exception during commit, continue {}", e.getMessage(), e);
+                     logger.warn("exception during commit, continue {}", e.getMessage(), e);
                      continue;
                   }
 
@@ -487,9 +487,9 @@ public class AsynchronousFailoverTest extends FailoverTestBase {
                         assertTrue("msgs.size is expected to be " + numMessages + " but it was " + msgs.size(), msgs.size() == numMessages);
                      }
                   } catch (Throwable e) {
-                     if (log.isDebugEnabled()) {
+                     if (logger.isDebugEnabled()) {
                         String dumpMessage = "Thread dump, messagesReceived = " + msgs.size();
-                        log.debug(threadDump(dumpMessage));
+                        logger.debug(threadDump(dumpMessage));
                      }
                      logAndSystemOut(e.getMessage() + " messages received");
                      for (Integer msg : msgs) {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/ClusterWithBackupFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/ClusterWithBackupFailoverTest.java
@@ -60,8 +60,8 @@ public  abstract class ClusterWithBackupFailoverTest extends ClusterWithBackupFa
       send(2, QUEUES_TESTADDRESS, 10, false, null);
       verifyReceiveRoundRobinInSomeOrder(true, 10, 0, 1, 2);
       Thread.sleep(1000);
-      log.debug("######### Topology on client = {} locator = {}", locators[0].getTopology().describe(), locators[0]);
-      log.debug("######### Crashing it........., sfs[0] = {}", sfs[0]);
+      logger.debug("######### Topology on client = {} locator = {}", locators[0].getTopology().describe(), locators[0]);
+      logger.debug("######### Crashing it........., sfs[0] = {}", sfs[0]);
       failNode(0);
 
       waitForFailoverTopology(4, 3, 1, 2);
@@ -79,7 +79,7 @@ public  abstract class ClusterWithBackupFailoverTest extends ClusterWithBackupFa
       // activated backup nodes
       waitForBindings(3, QUEUES_TESTADDRESS, 2, 2, false);
 
-      ClusterWithBackupFailoverTestBase.log.debug("** now sending");
+      ClusterWithBackupFailoverTestBase.logger.debug("** now sending");
 
       send(0, QUEUES_TESTADDRESS, 10, false, null);
       verifyReceiveRoundRobinInSomeOrder(true, 10, 0, 1, 2);
@@ -269,7 +269,7 @@ public  abstract class ClusterWithBackupFailoverTest extends ClusterWithBackupFa
       // activated backup nodes
       waitForBindings(3, QUEUES_TESTADDRESS, 2, 2, false);
 
-      ClusterWithBackupFailoverTestBase.log.debug("** now sending");
+      ClusterWithBackupFailoverTestBase.logger.debug("** now sending");
 
       send(0, QUEUES_TESTADDRESS, 10, false, null);
       verifyReceiveRoundRobinInSomeOrder(true, 10, 0, 1, 2);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/ClusterWithBackupFailoverTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/ClusterWithBackupFailoverTestBase.java
@@ -34,7 +34,7 @@ public abstract class ClusterWithBackupFailoverTestBase extends ClusterTestBase 
    protected static final String QUEUE_NAME = "queue0";
    protected static final String QUEUES_TESTADDRESS = "queues.testaddress";
 
-   protected static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   protected static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    protected abstract void setupCluster(MessageLoadBalancingType messageLoadBalancingType) throws Exception;
 
@@ -75,7 +75,7 @@ public abstract class ClusterWithBackupFailoverTestBase extends ClusterTestBase 
     * @throws Exception
     */
    protected void failNode(final int node, final int originalLiveNode) throws Exception {
-      log.debug("*** failing node {}", node);
+      logger.debug("*** failing node {}", node);
 
       ActiveMQServer server = getServer(node);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailBackAutoTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailBackAutoTest.java
@@ -45,7 +45,7 @@ import java.lang.invoke.MethodHandles;
 
 public class FailBackAutoTest extends FailoverTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private static final int NUM_MESSAGES = 100;
    private ServerLocatorInternal locator;
@@ -74,9 +74,9 @@ public class FailBackAutoTest extends FailoverTestBase {
 
       assertTrue(latch.await(5, TimeUnit.SECONDS));
 
-      log.debug("backup (nowLive) topology = {}", backupServer.getServer().getClusterManager().getDefaultConnection(null).getTopology().describe());
+      logger.debug("backup (nowLive) topology = {}", backupServer.getServer().getClusterManager().getDefaultConnection(null).getTopology().describe());
 
-      log.debug("Server Crash!!!");
+      logger.debug("Server Crash!!!");
 
       ClientProducer producer = session.createProducer(ADDRESS);
 
@@ -96,12 +96,12 @@ public class FailBackAutoTest extends FailoverTestBase {
 
       session.addFailureListener(listener);
 
-      log.debug("******* starting live server back");
+      logger.debug("******* starting live server back");
       liveServer.start();
 
       Thread.sleep(1000);
 
-      log.debug("After failback: {}", locator.getTopology().describe());
+      logger.debug("After failback: {}", locator.getTopology().describe());
 
       assertTrue(latch2.await(5, TimeUnit.SECONDS));
 
@@ -148,7 +148,7 @@ public class FailBackAutoTest extends FailoverTestBase {
 
       session.addFailureListener(listener);
 
-      log.debug("Crashing live server...");
+      logger.debug("Crashing live server...");
 
       liveServer.crash(session);
 
@@ -165,7 +165,7 @@ public class FailBackAutoTest extends FailoverTestBase {
       listener = new CountDownSessionFailureListener(session);
 
       session.addFailureListener(listener);
-      log.debug("restarting live node now");
+      logger.debug("restarting live node now");
       liveServer.start();
 
       assertTrue("expected a session failure 1", listener.getLatch().await(5, TimeUnit.SECONDS));
@@ -184,7 +184,7 @@ public class FailBackAutoTest extends FailoverTestBase {
 
       waitForBackup(sf, 10);
 
-      log.debug("Crashing live server again...");
+      logger.debug("Crashing live server again...");
 
       liveServer.crash();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailoverOnFlowControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/FailoverOnFlowControlTest.java
@@ -41,7 +41,7 @@ import java.lang.invoke.MethodHandles;
 
 public class FailoverOnFlowControlTest extends FailoverTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
    @Test
    public void testOverflowSend() throws Exception {
       ServerLocator locator = getServerLocator().setBlockOnNonDurableSend(true).setBlockOnDurableSend(true).setReconnectAttempts(300).setProducerWindowSize(1000).setRetryInterval(100);
@@ -51,14 +51,14 @@ public class FailoverOnFlowControlTest extends FailoverTestBase {
 
          @Override
          public boolean intercept(Packet packet, RemotingConnection connection) throws ActiveMQException {
-            log.debug("Intercept...{}", packet.getClass().getName());
+            logger.debug("Intercept...{}", packet.getClass().getName());
 
             if (packet instanceof SessionProducerCreditsMessage) {
                SessionProducerCreditsMessage credit = (SessionProducerCreditsMessage) packet;
 
-               log.debug("Credits: {}", credit.getCredits());
+               logger.debug("Credits: {}", credit.getCredits());
                if (count.incrementAndGet() == 2) {
-                  log.debug("### crashing server");
+                  logger.debug("### crashing server");
                   try {
                      InVMConnection.setFlushEnabled(false);
                      crash(false, sessionList.get(0));

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/quorum/PluggableQuorumNettyNoGroupNameReplicatedFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/quorum/PluggableQuorumNettyNoGroupNameReplicatedFailoverTest.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
 import java.lang.invoke.MethodHandles;
 
 public class PluggableQuorumNettyNoGroupNameReplicatedFailoverTest extends FailoverTest {
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    protected void beforeWaitForRemoteBackupSynchronization() {
    }
@@ -222,7 +222,7 @@ public class PluggableQuorumNettyNoGroupNameReplicatedFailoverTest extends Failo
 
    @Override
    protected void decrementActivationSequenceForForceRestartOf(TestableServer testableServer) throws Exception {
-      doDecrementActivationSequenceForForceRestartOf(log, nodeManager, managerConfiguration);
+      doDecrementActivationSequenceForForceRestartOf(logger, nodeManager, managerConfiguration);
    }
 
    public static void doDecrementActivationSequenceForForceRestartOf(Logger log, NodeManager nodeManager, DistributedPrimitiveManagerConfiguration distributedPrimitiveManagerConfiguration) throws Exception {
@@ -237,7 +237,7 @@ public class PluggableQuorumNettyNoGroupNameReplicatedFailoverTest extends Failo
          if (!mutableLong.compareAndSet(localActivation + 1, localActivation)) {
             throw new Exception("Failed to decrement coordinated activation sequence to:" + localActivation + ", not +1 : " + mutableLong.get());
          }
-         log.warn("Intentionally decrementing coordinated activation sequence for test, may result is lost data");
+         logger.warn("Intentionally decrementing coordinated activation sequence for test, may result is lost data");
 
       } finally {
          fileBasedPrimitiveManager.stop();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/quorum/PluggableQuorumReplicatedLargeMessageFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/quorum/PluggableQuorumReplicatedLargeMessageFailoverTest.java
@@ -28,7 +28,7 @@ import static org.apache.activemq.artemis.tests.integration.cluster.failover.quo
 
 public class PluggableQuorumReplicatedLargeMessageFailoverTest extends LargeMessageFailoverTest {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
    @Override
    protected void createConfigs() throws Exception {
       createPluggableReplicatedConfigs();
@@ -65,6 +65,6 @@ public class PluggableQuorumReplicatedLargeMessageFailoverTest extends LargeMess
 
    @Override
    protected void decrementActivationSequenceForForceRestartOf(TestableServer liveServer) throws Exception {
-      doDecrementActivationSequenceForForceRestartOf(log, nodeManager, managerConfiguration);
+      doDecrementActivationSequenceForForceRestartOf(logger, nodeManager, managerConfiguration);
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/MultiThreadRandomReattachTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/MultiThreadRandomReattachTestBase.java
@@ -47,7 +47,7 @@ import java.lang.invoke.MethodHandles;
 
 public abstract class MultiThreadRandomReattachTestBase extends MultiThreadReattachSupportTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
 
    private static final int RECEIVE_TIMEOUT = 30000;
@@ -358,7 +358,7 @@ public abstract class MultiThreadRandomReattachTestBase extends MultiThreadReatt
 
       long end = System.currentTimeMillis();
 
-      log.debug("duration {}", (end - start));
+      logger.debug("duration {}", (end - start));
    }
 
    protected void doTestB(final ClientSessionFactory sf, final int threadNum) throws Exception {
@@ -438,7 +438,7 @@ public abstract class MultiThreadRandomReattachTestBase extends MultiThreadReatt
 
       long end = System.currentTimeMillis();
 
-      log.debug("duration {}", (end - start));
+      logger.debug("duration {}", (end - start));
 
    }
 
@@ -539,7 +539,7 @@ public abstract class MultiThreadRandomReattachTestBase extends MultiThreadReatt
 
       long end = System.currentTimeMillis();
 
-      log.debug("duration {}", (end - start));
+      logger.debug("duration {}", (end - start));
    }
 
    protected void doTestD(final ClientSessionFactory sf, final int threadNum) throws Exception {
@@ -664,7 +664,7 @@ public abstract class MultiThreadRandomReattachTestBase extends MultiThreadReatt
 
       long end = System.currentTimeMillis();
 
-      log.debug("duration {}", (end - start));
+      logger.debug("duration {}", (end - start));
    }
 
    // Now with synchronous receive()
@@ -723,7 +723,7 @@ public abstract class MultiThreadRandomReattachTestBase extends MultiThreadReatt
 
       long end = System.currentTimeMillis();
 
-      log.debug("duration {}", (end - start));
+      logger.debug("duration {}", (end - start));
    }
 
    protected void doTestF(final ClientSessionFactory sf, final int threadNum) throws Exception {
@@ -782,7 +782,7 @@ public abstract class MultiThreadRandomReattachTestBase extends MultiThreadReatt
 
       long end = System.currentTimeMillis();
 
-      log.debug("duration {}", (end - start));
+      logger.debug("duration {}", (end - start));
    }
 
    protected void doTestG(final ClientSessionFactory sf, final int threadNum) throws Exception {
@@ -855,7 +855,7 @@ public abstract class MultiThreadRandomReattachTestBase extends MultiThreadReatt
 
       long end = System.currentTimeMillis();
 
-      log.debug("duration {}", (end - start));
+      logger.debug("duration {}", (end - start));
    }
 
    protected void doTestH(final ClientSessionFactory sf, final int threadNum) throws Exception {
@@ -930,7 +930,7 @@ public abstract class MultiThreadRandomReattachTestBase extends MultiThreadReatt
 
       long end = System.currentTimeMillis();
 
-      log.debug("duration {}", (end - start));
+      logger.debug("duration {}", (end - start));
    }
 
    protected void doTestI(final ClientSessionFactory sf, final int threadNum) throws Exception {
@@ -1230,7 +1230,7 @@ public abstract class MultiThreadRandomReattachTestBase extends MultiThreadReatt
          try {
             message.acknowledge();
          } catch (ActiveMQException me) {
-            log.error("Failed to process", me);
+            logger.error("Failed to process", me);
          }
 
          if (done) {
@@ -1247,14 +1247,14 @@ public abstract class MultiThreadRandomReattachTestBase extends MultiThreadReatt
 
          if (tn == threadNum && cnt != c.intValue()) {
             failure = "Invalid count, expected " + threadNum + ":" + c + " got " + cnt;
-            log.error(failure);
+            logger.error(failure);
 
             latch.countDown();
          }
 
          if (!checkSize(message)) {
             failure = "Invalid size on message";
-            log.error(failure);
+            logger.error(failure);
             latch.countDown();
          }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/MultiThreadReattachSupportTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/MultiThreadReattachSupportTestBase.java
@@ -41,7 +41,7 @@ import java.lang.invoke.MethodHandles;
 
 public abstract class MultiThreadReattachSupportTestBase extends ActiveMQTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
    @Rule
    public RetryRule retryRule = new RetryRule(2);
 
@@ -78,7 +78,7 @@ public abstract class MultiThreadReattachSupportTestBase extends ActiveMQTestBas
                                                  final boolean failOnCreateConnection,
                                                  final long failDelay) throws Exception {
       for (int its = 0; its < numIts; its++) {
-         log.debug("Beginning iteration {}", its);
+         logger.debug("Beginning iteration {}", its);
 
          start();
 
@@ -111,7 +111,7 @@ public abstract class MultiThreadReattachSupportTestBase extends ActiveMQTestBas
                } catch (Throwable t) {
                   throwable = t;
 
-                  log.error("Failed to run test", t);
+                  logger.error("Failed to run test", t);
 
                   // Case a failure happened here, it should print the Thread dump
                   // Sending it to System.out, as it would show on the Tests report
@@ -187,7 +187,7 @@ public abstract class MultiThreadReattachSupportTestBase extends ActiveMQTestBas
 
       public void checkFail() {
          if (throwable != null) {
-            log.error("Test failed: {}", failReason, throwable);
+            logger.error("Test failed: {}", failReason, throwable);
          }
          if (failReason != null) {
             Assert.fail(failReason);
@@ -213,7 +213,7 @@ public abstract class MultiThreadReattachSupportTestBase extends ActiveMQTestBas
 
       @Override
       public synchronized void run() {
-         log.debug("** Failing connection");
+         logger.debug("** Failing connection");
 
          RemotingConnectionImpl conn = (RemotingConnectionImpl) ((ClientSessionInternal) session).getConnection();
 
@@ -224,7 +224,7 @@ public abstract class MultiThreadReattachSupportTestBase extends ActiveMQTestBas
             conn.fail(new ActiveMQNotConnectedException("blah"));
          }
 
-         log.debug("** Fail complete");
+         logger.debug("** Fail complete");
 
          cancel();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/RandomReattachTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/reattach/RandomReattachTest.java
@@ -57,7 +57,7 @@ public class RandomReattachTest extends ActiveMQTestBase {
    @Rule
    public RetryRule retryRule = new RetryRule(2);
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
 
    private static final int RECEIVE_TIMEOUT = 10000;
@@ -205,7 +205,7 @@ public class RandomReattachTest extends ActiveMQTestBase {
       final int numIts = getNumIterations();
 
       for (int its = 0; its < numIts; its++) {
-         log.debug("####{} iteration #{}", getName(), its);
+         logger.debug("####{} iteration #{}", getName(), its);
          start();
          ServerLocator locator = createInVMNonHALocator().setReconnectAttempts(15).setConfirmationWindowSize(1024 * 1024);
 
@@ -281,7 +281,7 @@ public class RandomReattachTest extends ActiveMQTestBase {
             try {
                message.acknowledge();
             } catch (ActiveMQException me) {
-               RandomReattachTest.log.error("Failed to process", me);
+               RandomReattachTest.logger.error("Failed to process", me);
             }
 
             if (count == numMessages) {
@@ -323,7 +323,7 @@ public class RandomReattachTest extends ActiveMQTestBase {
 
       long end = System.currentTimeMillis();
 
-      log.debug("duration {}", (end - start));
+      logger.debug("duration {}", (end - start));
    }
 
    protected void doTestB(final ClientSessionFactory sf) throws Exception {
@@ -422,7 +422,7 @@ public class RandomReattachTest extends ActiveMQTestBase {
 
       long end = System.currentTimeMillis();
 
-      log.debug("duration {}", (end - start));
+      logger.debug("duration {}", (end - start));
 
    }
 
@@ -563,7 +563,7 @@ public class RandomReattachTest extends ActiveMQTestBase {
 
       long end = System.currentTimeMillis();
 
-      log.debug("duration {}", (end - start));
+      logger.debug("duration {}", (end - start));
    }
 
    protected void doTestD(final ClientSessionFactory sf) throws Exception {
@@ -698,7 +698,7 @@ public class RandomReattachTest extends ActiveMQTestBase {
 
       long end = System.currentTimeMillis();
 
-      log.debug("duration {}", (end - start));
+      logger.debug("duration {}", (end - start));
    }
 
    // Now with synchronous receive()
@@ -776,7 +776,7 @@ public class RandomReattachTest extends ActiveMQTestBase {
 
       long end = System.currentTimeMillis();
 
-      log.debug("duration {}", (end - start));
+      logger.debug("duration {}", (end - start));
    }
 
    protected void doTestF(final ClientSessionFactory sf) throws Exception {
@@ -860,7 +860,7 @@ public class RandomReattachTest extends ActiveMQTestBase {
 
       long end = System.currentTimeMillis();
 
-      log.debug("duration {}", (end - start));
+      logger.debug("duration {}", (end - start));
    }
 
    protected void doTestG(final ClientSessionFactory sf) throws Exception {
@@ -972,7 +972,7 @@ public class RandomReattachTest extends ActiveMQTestBase {
 
       long end = System.currentTimeMillis();
 
-      log.debug("duration {}", (end - start));
+      logger.debug("duration {}", (end - start));
    }
 
    protected void doTestH(final ClientSessionFactory sf) throws Exception {
@@ -1088,7 +1088,7 @@ public class RandomReattachTest extends ActiveMQTestBase {
 
       long end = System.currentTimeMillis();
 
-      log.debug("duration {}", (end - start));
+      logger.debug("duration {}", (end - start));
    }
 
    protected void doTestI(final ClientSessionFactory sf) throws Exception {
@@ -1271,11 +1271,11 @@ public class RandomReattachTest extends ActiveMQTestBase {
 
       @Override
       public synchronized void run() {
-         log.debug("** Failing connection");
+         logger.debug("** Failing connection");
 
          session.getConnection().fail(new ActiveMQNotConnectedException("oops"));
 
-         log.debug("** Fail complete");
+         logger.debug("** Fail complete");
 
          cancel();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/restart/ClusterRestartTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/restart/ClusterRestartTest.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 
 public class ClusterRestartTest extends ClusterTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Test
    public void testRestartWithQueuesCreateInDiffOrder() throws Exception {
@@ -42,8 +42,8 @@ public class ClusterRestartTest extends ClusterTestBase {
 
       startServers(0, 1);
 
-      log.debug("server 0 = {}", getServer(0).getNodeID());
-      log.debug("server 1 = {}", getServer(1).getNodeID());
+      logger.debug("server 0 = {}", getServer(0).getNodeID());
+      logger.debug("server 1 = {}", getServer(1).getNodeID());
 
       setupSessionFactory(0, isNetty(), 15);
       setupSessionFactory(1, isNetty());
@@ -91,7 +91,7 @@ public class ClusterRestartTest extends ClusterTestBase {
       sendInRange(1, "queues.testaddress", 10, 20, false, null);
 
       verifyReceiveAllInRange(0, 20, 0);
-      log.debug("*****************************************************************************");
+      logger.debug("*****************************************************************************");
    }
 
    @Test
@@ -105,8 +105,8 @@ public class ClusterRestartTest extends ClusterTestBase {
 
       startServers(0, 1);
 
-      log.debug("server 0 = {}", getServer(0).getNodeID());
-      log.debug("server 1 = {}", getServer(1).getNodeID());
+      logger.debug("server 0 = {}", getServer(0).getNodeID());
+      logger.debug("server 1 = {}", getServer(1).getNodeID());
       setupSessionFactory(0, isNetty(), 15);
       setupSessionFactory(1, isNetty());
 
@@ -134,11 +134,11 @@ public class ClusterRestartTest extends ClusterTestBase {
 
       sendInRange(1, "queues.testaddress", 0, 10, true, null);
 
-      log.debug("stopping******************************************************");
+      logger.debug("stopping******************************************************");
       stopServers(0);
 
       sendInRange(1, "queues.testaddress", 10, 20, true, null);
-      log.debug("stopped******************************************************");
+      logger.debug("stopped******************************************************");
       startServers(0);
 
       waitForBindings(0, "queues.testaddress", 1, 0, true);
@@ -151,14 +151,14 @@ public class ClusterRestartTest extends ClusterTestBase {
       addConsumer(1, 0, "queue10", null);
 
       verifyReceiveRoundRobin(0, 20, 0, 1);
-      log.debug("*****************************************************************************");
+      logger.debug("*****************************************************************************");
    }
 
    private void printBindings(final int num) throws Exception {
       for (int i = 0; i < num; i++) {
          Collection<Binding> bindings0 = getServer(i).getPostOffice().getBindingsForAddress(new SimpleString("queues.testaddress")).getBindings();
          for (Binding binding : bindings0) {
-            log.debug("{} on node {} at {}", binding, i, binding.getID());
+            logger.debug("{} on node {} at {}", binding, i, binding.getID());
          }
       }
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/interceptors/Outgoing.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/interceptors/Outgoing.java
@@ -29,11 +29,11 @@ import java.lang.invoke.MethodHandles;
 
 public class Outgoing implements Interceptor {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Override
    public boolean intercept(final Packet packet, final RemotingConnection connection) throws ActiveMQException {
-      log.debug("Outgoin:Packet : {}", packet);
+      logger.debug("Outgoin:Packet : {}", packet);
       if (packet.getType() == PacketImpl.SESS_SEND) {
          SessionSendMessage p = (SessionSendMessage) packet;
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/FloodServerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/FloodServerTest.java
@@ -41,7 +41,7 @@ import java.lang.invoke.MethodHandles;
  */
 public class FloodServerTest extends ActiveMQTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private ActiveMQServer server;
 
@@ -171,7 +171,7 @@ public class FloodServerTest extends ActiveMQTestBase {
                Message msg = consumer.receive();
 
                if (msg == null) {
-                  FloodServerTest.log.error("message is null");
+                  FloodServerTest.logger.error("message is null");
                   break;
                }
             }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/ConnectionTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/ConnectionTest.java
@@ -49,7 +49,7 @@ import java.lang.invoke.MethodHandles;
 
 public class ConnectionTest extends JMSTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private Connection conn2;
 
@@ -288,7 +288,7 @@ public class ConnectionTest extends JMSTestBase {
                         // ignore
                         break;
                      } catch (Throwable t) {
-                        log.warn(t.getMessage(), t);
+                        logger.warn(t.getMessage(), t);
                         error.set(true);
                         break;
                      }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/NewQueueRequestorTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/NewQueueRequestorTest.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
 
 public class NewQueueRequestorTest extends JMSTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Test
    public void testQueueRequestor() throws Exception {
@@ -90,7 +90,7 @@ public class NewQueueRequestorTest extends JMSTestBase {
             Message m2 = sess.createTextMessage("This is the response");
             sender.send(queue, m2);
          } catch (JMSException e) {
-            log.error(e.getMessage(), e);
+            logger.error(e.getMessage(), e);
          }
       }
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/journal/ValidateTransactionHealthTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/journal/ValidateTransactionHealthTest.java
@@ -44,7 +44,7 @@ import java.lang.invoke.MethodHandles;
  */
 public class ValidateTransactionHealthTest extends SpawnedTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private static final int OK = 10;
 
@@ -138,7 +138,7 @@ public class ValidateTransactionHealthTest extends SpawnedTestBase {
                              final int numberOfThreads) throws Exception {
       try {
          if (type.equals("aio") && !LibaioContext.isLoaded()) {
-            log.warn("AIO not found, test being ignored on this platform");
+            logger.warn("AIO not found, test being ignored on this platform");
             return;
          }
 
@@ -215,7 +215,7 @@ public class ValidateTransactionHealthTest extends SpawnedTestBase {
       @Override
       public void addRecord(final RecordInfo info) {
          if (info.id == lastID) {
-            log.debug("id = {} last id = {}", info.id, lastID);
+            logger.debug("id = {} last id = {}", info.id, lastID);
          }
 
          ByteBuffer buffer = ByteBuffer.wrap(info.data);
@@ -399,7 +399,7 @@ public class ValidateTransactionHealthTest extends SpawnedTestBase {
                   journal.appendAddRecordTransactional(transactionId, id, (byte) 99, buffer.array());
 
                   if (++transactionCounter == transactionSize) {
-                     log.debug("Commit transaction {}", transactionId);
+                     logger.debug("Commit transaction {}", transactionId);
                      journal.appendCommitRecord(transactionId, true);
                      transactionCounter = 0;
                      transactionId = nextID.incrementAndGet();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/largemessage/LargeMessageTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/largemessage/LargeMessageTestBase.java
@@ -60,7 +60,7 @@ import java.lang.invoke.MethodHandles;
 public abstract class LargeMessageTestBase extends ActiveMQTestBase {
 
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    protected final SimpleString ADDRESS = new SimpleString("SimpleAddress");
 
@@ -285,9 +285,9 @@ public abstract class LargeMessageTestBase extends ActiveMQTestBase {
                               public void write(final byte[] b) throws IOException {
                                  if (b[0] == ActiveMQTestBase.getSamplebyte(bytesRead.get())) {
                                     bytesRead.addAndGet(b.length);
-                                    LargeMessageTestBase.log.debug("Read position {} on consumer", bytesRead.get());
+                                    LargeMessageTestBase.logger.debug("Read position {} on consumer", bytesRead.get());
                                  } else {
-                                    LargeMessageTestBase.log.warn("Received invalid packet at position {}", bytesRead.get());
+                                    LargeMessageTestBase.logger.warn("Received invalid packet at position {}", bytesRead.get());
                                  }
                               }
 
@@ -296,7 +296,7 @@ public abstract class LargeMessageTestBase extends ActiveMQTestBase {
                                  if (b == ActiveMQTestBase.getSamplebyte(bytesRead.get())) {
                                     bytesRead.incrementAndGet();
                                  } else {
-                                    LargeMessageTestBase.log.warn("byte not as expected!");
+                                    LargeMessageTestBase.logger.warn("byte not as expected!");
                                  }
                               }
                            });
@@ -308,7 +308,7 @@ public abstract class LargeMessageTestBase extends ActiveMQTestBase {
                            buffer.resetReaderIndex();
                            for (long b = 0; b < numberOfBytes; b++) {
                               if (b % (1024L * 1024L) == 0) {
-                                 LargeMessageTestBase.log.debug("Read {} bytes", b);
+                                 LargeMessageTestBase.logger.debug("Read {} bytes", b);
                               }
 
                               Assert.assertEquals(ActiveMQTestBase.getSamplebyte(b), buffer.readByte());
@@ -322,7 +322,7 @@ public abstract class LargeMessageTestBase extends ActiveMQTestBase {
                         }
                      } catch (Throwable e) {
                         e.printStackTrace();
-                        LargeMessageTestBase.log.warn("Got an error", e);
+                        LargeMessageTestBase.logger.warn("Got an error", e);
                         errors.incrementAndGet();
                      } finally {
                         latchDone.countDown();
@@ -373,7 +373,7 @@ public abstract class LargeMessageTestBase extends ActiveMQTestBase {
                               if (b[0] == ActiveMQTestBase.getSamplebyte(bytesRead.get())) {
                                  bytesRead.addAndGet(b.length);
                               } else {
-                                 LargeMessageTestBase.log.warn("Received invalid packet at position {}", bytesRead.get());
+                                 LargeMessageTestBase.logger.warn("Received invalid packet at position {}", bytesRead.get());
                               }
                            }
                         }
@@ -381,12 +381,12 @@ public abstract class LargeMessageTestBase extends ActiveMQTestBase {
                         @Override
                         public void write(final int b) throws IOException {
                            if (bytesRead.get() % (1024L * 1024L) == 0) {
-                              LargeMessageTestBase.log.debug("Read {} bytes", bytesRead.get());
+                              LargeMessageTestBase.logger.debug("Read {} bytes", bytesRead.get());
                            }
                            if (b == (byte) 'a') {
                               bytesRead.incrementAndGet();
                            } else {
-                              LargeMessageTestBase.log.warn("byte not as expected!");
+                              LargeMessageTestBase.logger.warn("byte not as expected!");
                            }
                         }
                      });
@@ -398,7 +398,7 @@ public abstract class LargeMessageTestBase extends ActiveMQTestBase {
 
                      for (long b = 0; b < numberOfBytes; b++) {
                         if (b % (1024L * 1024L) == 0L) {
-                           LargeMessageTestBase.log.debug("Read {} bytes", b);
+                           LargeMessageTestBase.logger.debug("Read {} bytes", b);
                         }
                         Assert.assertEquals(ActiveMQTestBase.getSamplebyte(b), buffer.readByte());
                      }
@@ -465,17 +465,17 @@ public abstract class LargeMessageTestBase extends ActiveMQTestBase {
                              final long delayDelivery,
                              final ClientSession session,
                              final ClientProducer producer) throws Exception {
-      LargeMessageTestBase.log.debug("NumberOfBytes = {}", numberOfBytes);
+      LargeMessageTestBase.logger.debug("NumberOfBytes = {}", numberOfBytes);
       for (int i = 0; i < numberOfMessages; i++) {
          ClientMessage message = session.createMessage(true);
 
          // If the test is using more than 1M, we will only use the Streaming, as it require too much memory from the
          // test
          if (numberOfBytes > 1024 * 1024 || i % 2 == 0) {
-            LargeMessageTestBase.log.debug("Sending message (stream){}", i);
+            LargeMessageTestBase.logger.debug("Sending message (stream){}", i);
             message.setBodyInputStream(ActiveMQTestBase.createFakeLargeStream(numberOfBytes));
          } else {
-            LargeMessageTestBase.log.debug("Sending message (array){}", i);
+            LargeMessageTestBase.logger.debug("Sending message (array){}", i);
             byte[] bytes = new byte[(int) numberOfBytes];
             for (int j = 0; j < bytes.length; j++) {
                bytes[j] = ActiveMQTestBase.getSamplebyte(j);
@@ -571,7 +571,7 @@ public abstract class LargeMessageTestBase extends ActiveMQTestBase {
          @Override
          public void write(final int b) throws IOException {
             if (count++ % 1024 * 1024 == 0) {
-               LargeMessageTestBase.log.debug("OutputStream received {} bytes", count);
+               LargeMessageTestBase.logger.debug("OutputStream received {} bytes", count);
             }
             if (closed) {
                throw new IOException("Stream was closed");

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
@@ -120,7 +120,7 @@ import java.lang.invoke.MethodHandles;
 @RunWith(Parameterized.class)
 public class ActiveMQServerControlTest extends ManagementTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Rule
    public RetryRule retryRule = new RetryRule(0);
@@ -2611,7 +2611,7 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       addClientSession(factories.get(1).createSession());
 
       String jsonString = serverControl.listConnectionsAsJSON();
-      log.debug(jsonString);
+      logger.debug(jsonString);
       Assert.assertNotNull(jsonString);
       JsonArray array = JsonUtil.readJsonArray(jsonString);
       Assert.assertEquals(usingCore() ? 3 : 2, array.size());
@@ -2674,7 +2674,7 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       addClientConsumer(session.createConsumer(queueName, SimpleString.toSimpleString(filter), true));
 
       String jsonString = serverControl.listConsumersAsJSON(factory.getConnection().getID().toString());
-      log.debug(jsonString);
+      logger.debug(jsonString);
       Assert.assertNotNull(jsonString);
       JsonArray array = JsonUtil.readJsonArray(jsonString);
       Assert.assertEquals(2, array.size());
@@ -2737,7 +2737,7 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       addClientConsumer(session2.createConsumer(queueName));
 
       String jsonString = serverControl.listAllConsumersAsJSON();
-      log.debug(jsonString);
+      logger.debug(jsonString);
       Assert.assertNotNull(jsonString);
       JsonArray array = JsonUtil.readJsonArray(jsonString);
       Assert.assertEquals(usingCore() ? 3 : 2, array.size());
@@ -2810,7 +2810,7 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       session2.createConsumer(queueName);
 
       String jsonString = serverControl.listSessionsAsJSON(factory.getConnection().getID().toString());
-      log.debug(jsonString);
+      logger.debug(jsonString);
       Assert.assertNotNull(jsonString);
       JsonArray array = JsonUtil.readJsonArray(jsonString);
       Assert.assertEquals(2, array.size());
@@ -2874,7 +2874,7 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       session2.createConsumer(queueName);
 
       String jsonString = serverControl.listAllSessionsAsJSON();
-      log.debug(jsonString);
+      logger.debug(jsonString);
       Assert.assertNotNull(jsonString);
       JsonArray array = JsonUtil.readJsonArray(jsonString);
       Assert.assertEquals(2 + (usingCore() ? 1 : 0), array.size());
@@ -2915,7 +2915,7 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       con.setClientID(clientID);
 
       String jsonString = serverControl.listAllSessionsAsJSON();
-      log.debug(jsonString);
+      logger.debug(jsonString);
       Assert.assertNotNull(jsonString);
       JsonArray array = JsonUtil.readJsonArray(jsonString);
       Assert.assertEquals(1 + (usingCore() ? 1 : 0), array.size());

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ManagementHelperTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ManagementHelperTest.java
@@ -32,7 +32,7 @@ import java.lang.invoke.MethodHandles;
 
 public class ManagementHelperTest extends Assert {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Test
    public void testArrayOfStringParameter() throws Exception {
@@ -47,7 +47,7 @@ public class ManagementHelperTest extends Assert {
       Assert.assertEquals(2, parameters.length);
       Assert.assertEquals(param, parameters[0]);
       Object parameter_2 = parameters[1];
-      log.debug("type {}", parameter_2);
+      logger.debug("type {}", parameter_2);
       Assert.assertTrue(parameter_2 instanceof Object[]);
       Object[] retrievedParams = (Object[]) parameter_2;
       Assert.assertEquals(params.length, retrievedParams.length);
@@ -181,15 +181,15 @@ public class ManagementHelperTest extends Assert {
       String key1 = RandomUtil.randomString();
       String[] val1 = new String[]{"a", "b", "c"};
 
-      if (log.isDebugEnabled()) {
-         log.debug("val1 type is {}", Arrays.toString(val1));
+      if (logger.isDebugEnabled()) {
+         logger.debug("val1 type is {}", Arrays.toString(val1));
       }
 
       String key2 = RandomUtil.randomString();
       Long[] val2 = new Long[]{1L, 2L, 3L, 4L, 5L};
 
-      if (log.isDebugEnabled()) {
-         log.debug("val2 type is {}", Arrays.toString(val2));
+      if (logger.isDebugEnabled()) {
+         logger.debug("val2 type is {}", Arrays.toString(val2));
       }
 
       map.put(key1, val1);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MQTTFQQNTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MQTTFQQNTest.java
@@ -23,13 +23,8 @@ import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.postoffice.Binding;
 import org.apache.activemq.artemis.core.server.QueueQueryResult;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import java.lang.invoke.MethodHandles;
 
 public class MQTTFQQNTest extends MQTTTestSupport {
-
-   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Test
    public void testMQTTSubNames() throws Exception {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MQTTQueueCleanTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MQTTQueueCleanTest.java
@@ -33,7 +33,7 @@ import java.util.Set;
 
 public class MQTTQueueCleanTest extends MQTTTestSupport {
 
-   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Test
    public void testQueueClean() throws Exception {
@@ -113,7 +113,7 @@ public class MQTTQueueCleanTest extends MQTTTestSupport {
                clientProvider.subscribe(address, AT_LEAST_ONCE);
             }
          } catch (Throwable e) {
-            LOG.error(e.getMessage(), e);
+            logger.error(e.getMessage(), e);
          } finally {
             for (MQTTClientProvider clientProvider : clientProviders) {
                clientProvider.disconnect();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MQTTSessionExpiryIntervalTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MQTTSessionExpiryIntervalTest.java
@@ -28,7 +28,7 @@ import java.lang.invoke.MethodHandles;
 
 public class MQTTSessionExpiryIntervalTest extends MQTTTestSupport {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Test(timeout = 60 * 1000)
    public void testCustomSessionExpiryInterval() throws Exception {
@@ -50,6 +50,6 @@ public class MQTTSessionExpiryIntervalTest extends MQTTTestSupport {
    protected void addMQTTConnector() throws Exception {
       server.getConfiguration().addAcceptorConfiguration("MQTT", "tcp://localhost:" + port + "?protocols=MQTT;anycastPrefix=anycast:;multicastPrefix=multicast:;defaultMqttSessionExpiryInterval=3");
 
-      log.debug("Added MQTT connector to broker");
+      logger.debug("Added MQTT connector to broker");
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MQTTTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MQTTTest.java
@@ -79,7 +79,7 @@ import static org.apache.activemq.artemis.utils.collections.IterableStream.itera
  */
 public class MQTTTest extends MQTTTestSupport {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private static final String AMQP_URI = "tcp://localhost:61616";
 
@@ -669,7 +669,7 @@ public class MQTTTest extends MQTTTestSupport {
 
       final String[] clientIds = {null, "foo", "durable"};
       for (String clientId : clientIds) {
-         log.debug("Testing now with Client ID: {}", clientId);
+         logger.debug("Testing now with Client ID: {}", clientId);
 
          mqtt.setClientId(clientId);
          mqtt.setCleanSession(!"durable".equals(clientId));
@@ -738,7 +738,7 @@ public class MQTTTest extends MQTTTestSupport {
 
       final String[] clientIds = {null, "foo", "durable"};
       for (String clientId : clientIds) {
-         log.debug("Testing now with Client ID: {}", clientId);
+         logger.debug("Testing now with Client ID: {}", clientId);
 
          mqtt.setClientId(clientId);
          mqtt.setCleanSession(!"durable".equals(clientId));
@@ -791,7 +791,7 @@ public class MQTTTest extends MQTTTestSupport {
          msg.ack();
          assertNull(connection.receive(100, TimeUnit.MILLISECONDS));
 
-         log.debug("Test now unsubscribing from: {} for the last time", TOPICA);
+         logger.debug("Test now unsubscribing from: {} for the last time", TOPICA);
          connection.unsubscribe(new String[]{TOPICA});
          connection.disconnect();
       }
@@ -808,7 +808,7 @@ public class MQTTTest extends MQTTTestSupport {
       mqtt.setTracer(new Tracer() {
          @Override
          public void onReceive(MQTTFrame frame) {
-            log.debug("Client received:\n{}", frame);
+            logger.debug("Client received:\n{}", frame);
             if (frame.messageType() == PUBLISH.TYPE) {
                PUBLISH publish = new PUBLISH();
                try {
@@ -822,7 +822,7 @@ public class MQTTTest extends MQTTTestSupport {
 
          @Override
          public void onSend(MQTTFrame frame) {
-            log.debug("Client sent:\n{}", frame);
+            logger.debug("Client sent:\n{}", frame);
          }
       });
 
@@ -894,7 +894,7 @@ public class MQTTTest extends MQTTTestSupport {
       mqtt.setTracer(new Tracer() {
          @Override
          public void onReceive(MQTTFrame frame) {
-            log.debug("Client received:\n{}", frame);
+            logger.debug("Client received:\n{}", frame);
             if (frame.messageType() == PUBLISH.TYPE) {
                PUBLISH publish = new PUBLISH();
                try {
@@ -908,7 +908,7 @@ public class MQTTTest extends MQTTTestSupport {
 
          @Override
          public void onSend(MQTTFrame frame) {
-            log.debug("Client sent:\n{}", frame);
+            logger.debug("Client sent:\n{}", frame);
          }
       });
 
@@ -951,12 +951,12 @@ public class MQTTTest extends MQTTTestSupport {
       mqtt.setTracer(new Tracer() {
          @Override
          public void onReceive(MQTTFrame frame) {
-            log.debug("Client received:\n{}", frame);
+            logger.debug("Client received:\n{}", frame);
             if (frame.messageType() == PUBLISH.TYPE) {
                PUBLISH publish = new PUBLISH();
                try {
                   publish.decode(frame);
-                  log.debug("PUBLISH {}", publish);
+                  logger.debug("PUBLISH {}", publish);
                } catch (ProtocolException e) {
                   fail("Error decoding publish " + e.getMessage());
                }
@@ -969,7 +969,7 @@ public class MQTTTest extends MQTTTestSupport {
 
          @Override
          public void onSend(MQTTFrame frame) {
-            log.debug("Client sent:\n{}", frame);
+            logger.debug("Client sent:\n{}", frame);
          }
       });
 
@@ -1031,12 +1031,12 @@ public class MQTTTest extends MQTTTestSupport {
          mqtts[i].setTracer(new Tracer() {
             @Override
             public void onReceive(MQTTFrame frame) {
-               log.debug("Client received:\n{}", frame);
+               logger.debug("Client received:\n{}", frame);
                if (frame.messageType() == PUBLISH.TYPE) {
                   PUBLISH publish = new PUBLISH();
                   try {
                      publish.decode(frame);
-                     log.debug("PUBLISH {}", publish);
+                     logger.debug("PUBLISH {}", publish);
                   } catch (ProtocolException e) {
                      fail("Error decoding publish " + e.getMessage());
                   }
@@ -1049,7 +1049,7 @@ public class MQTTTest extends MQTTTestSupport {
 
             @Override
             public void onSend(MQTTFrame frame) {
-               log.debug("Client sent:\n{}", frame);
+               logger.debug("Client sent:\n{}", frame);
             }
          });
       }
@@ -1449,7 +1449,7 @@ public class MQTTTest extends MQTTTestSupport {
 
       for (int i = 1; i <= 10; ++i) {
 
-         log.debug("Creating MQTT Connection {}", i);
+         logger.debug("Creating MQTT Connection {}", i);
 
          MQTT mqtt = createMQTTConnection(clientId, false);
          mqtt.setKeepAlive((short) 2);
@@ -1546,7 +1546,7 @@ public class MQTTTest extends MQTTTestSupport {
          received++;
          payload = message.getPayload();
          String messageContent = new String(payload);
-         log.debug("Received message from topic: {} Message content: {}", message.getTopic(), messageContent);
+         logger.debug("Received message from topic: {} Message content: {}", message.getTopic(), messageContent);
          message.ack();
       }
 
@@ -1692,7 +1692,7 @@ public class MQTTTest extends MQTTTestSupport {
       for (int i = 0; i < 5; ++i) {
          Message message = connectionSub.receive(5, TimeUnit.SECONDS);
          assertNotNull("Missing message " + i, message);
-         log.debug("Message is {}", new String(message.getPayload()));
+         logger.debug("Message is {}", new String(message.getPayload()));
          received++;
          message.ack();
       }
@@ -1741,7 +1741,7 @@ public class MQTTTest extends MQTTTestSupport {
    //         @Override
    //         public void onReceive(MQTTFrame frame) {
    //            if (frame.messageType() == PUBLISH.TYPE) {
-   //               log.debug("Received message with retain={}", frame.retain());
+   //               logger.debug("Received message with retain={}", frame.retain());
    //               if (frame.retain()) {
    //                  retain[0]++;
    //               } else {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MQTTTestSupport.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MQTTTestSupport.java
@@ -74,7 +74,7 @@ import static java.util.Collections.singletonList;
 
 public class MQTTTestSupport extends ActiveMQTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
    protected ActiveMQServer server;
 
    static {
@@ -236,7 +236,7 @@ public class MQTTTestSupport extends ActiveMQTestBase {
       TransportConfiguration transportConfiguration = new TransportConfiguration(NETTY_ACCEPTOR_FACTORY, params);
       server.getConfiguration().getAcceptorConfigurations().add(transportConfiguration);
 
-      log.debug("Added CORE connector to broker");
+      logger.debug("Added CORE connector to broker");
    }
 
    protected void addMQTTConnector() throws Exception {
@@ -246,7 +246,7 @@ public class MQTTTestSupport extends ActiveMQTestBase {
 
       server.getConfiguration().addAcceptorConfiguration("MQTT", "tcp://localhost:" + port + "?protocols=MQTT;anycastPrefix=anycast:;multicastPrefix=multicast:");
 
-      log.debug("Added MQTT connector to broker");
+      logger.debug("Added MQTT connector to broker");
    }
 
    public void stopBroker() throws Exception {
@@ -408,18 +408,18 @@ public class MQTTTestSupport extends ActiveMQTestBase {
       return new Tracer() {
          @Override
          public void onReceive(MQTTFrame frame) {
-            log.debug("Client Received:\n{}", frame);
+            logger.debug("Client Received:\n{}", frame);
          }
 
          @Override
          public void onSend(MQTTFrame frame) {
-            log.debug("Client Sent:\n{}", frame);
+            logger.debug("Client Sent:\n{}", frame);
          }
 
          @Override
          public void debug(String message, Object... args) {
-            if (log.isDebugEnabled()) {
-               log.debug(String.format(message, args));
+            if (logger.isDebugEnabled()) {
+               logger.debug(String.format(message, args));
             }
          }
       };

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/PahoMQTTTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/PahoMQTTTest.java
@@ -43,7 +43,7 @@ import java.lang.invoke.MethodHandles;
 @RunWith(Parameterized.class)
 public class PahoMQTTTest extends MQTTTestSupport {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Parameterized.Parameters(name = "protocol={0}")
    public static Collection<Object[]> getParams() {
@@ -60,7 +60,7 @@ public class PahoMQTTTest extends MQTTTestSupport {
    public void testLotsOfClients() throws Exception {
 
       final int CLIENTS = Integer.getInteger("PahoMQTTTest.CLIENTS", 100);
-      log.debug("Using: {} clients: ", CLIENTS);
+      logger.debug("Using: {} clients: ", CLIENTS);
 
       final AtomicInteger receiveCounter = new AtomicInteger();
       MqttClient client = createPahoClient("consumer");
@@ -116,7 +116,7 @@ public class PahoMQTTTest extends MQTTTestSupport {
       assertNull("Async error: " + asyncError.get(), asyncError.get());
       sendBarrier.countDown();
 
-      log.debug("All clients connected... waiting to receive sent messages...");
+      logger.debug("All clients connected... waiting to receive sent messages...");
 
       // We should eventually get all the messages.
       within(30, TimeUnit.SECONDS, new Task() {
@@ -126,7 +126,7 @@ public class PahoMQTTTest extends MQTTTestSupport {
          }
       });
 
-      log.debug("All messages received.");
+      logger.debug("All messages received.");
 
       disconnectDoneLatch.await();
       assertNull("Async error: " + asyncError.get(), asyncError.get());

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/MQTT5Test.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/MQTT5Test.java
@@ -46,16 +46,11 @@ import org.eclipse.paho.mqttv5.common.packet.MqttProperties;
 import org.eclipse.paho.mqttv5.common.packet.UserProperty;
 import org.junit.Assume;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import java.lang.invoke.MethodHandles;
 
 /*
  * General tests for things not covered directly in the specification.
  */
 public class MQTT5Test extends MQTT5TestSupport {
-
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    public MQTT5Test(String protocol) {
       super(protocol);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/MQTT5TestSupport.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/MQTT5TestSupport.java
@@ -111,7 +111,7 @@ public class MQTT5TestSupport extends ActiveMQTestBase {
       return new MqttAsyncClient(protocol + "://localhost:" + (isUseSsl() ? getSslPort() : getPort()), clientId, new MemoryPersistence());
    }
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
    protected static final long DEFAULT_TIMEOUT = 300000;
    protected ActiveMQServer server;
 
@@ -255,7 +255,7 @@ public class MQTT5TestSupport extends ActiveMQTestBase {
       TransportConfiguration transportConfiguration = new TransportConfiguration(NETTY_ACCEPTOR_FACTORY, params);
       server.getConfiguration().getAcceptorConfigurations().add(transportConfiguration);
 
-      log.debug("Added CORE connector to broker");
+      logger.debug("Added CORE connector to broker");
    }
 
    protected void addMQTTConnector() throws Exception {
@@ -266,7 +266,7 @@ public class MQTT5TestSupport extends ActiveMQTestBase {
       server.getConfiguration().addAcceptorConfiguration(MQTT_PROTOCOL_NAME, "tcp://localhost:" + (isUseSsl() ? sslPort : port) + "?protocols=MQTT;anycastPrefix=anycast:;multicastPrefix=multicast:" + (isUseSsl() ? "&sslEnabled=true&keyStorePath=server-keystore.p12&keyStorePassword=securepass" : "") + (isMutualSsl() ? "&needClientAuth=true&trustStorePath=client-ca-truststore.p12&trustStorePassword=securepass" : ""));
       server.getConfiguration().setConnectionTtlCheckInterval(100);
 
-      log.debug("Added MQTT connector to broker");
+      logger.debug("Added MQTT connector to broker");
    }
 
    public void stopBroker() throws Exception {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/ConnectTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/ConnectTests.java
@@ -103,7 +103,7 @@ import java.lang.invoke.MethodHandles;
  */
 public class ConnectTests extends MQTT5TestSupport {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    public ConnectTests(String protocol) {
       super(protocol);
@@ -437,7 +437,7 @@ public class ConnectTests extends MQTT5TestSupport {
       MQTTInterceptor incomingInterceptor = (packet, connection) -> {
          if (packet.fixedHeader().messageType() == MqttMessageType.PINGREQ) {
             try {
-               log.info("Caught PING so sleeping...");
+               logger.info("Caught PING so sleeping...");
                Thread.sleep(3000);
             } catch (InterruptedException e) {
                // ignore

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/PublishTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/PublishTests.java
@@ -78,7 +78,7 @@ import java.lang.invoke.MethodHandles;
 
 public class PublishTests extends MQTT5TestSupport {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    public PublishTests(String protocol) {
       super(protocol);
@@ -1282,7 +1282,7 @@ public class PublishTests extends MQTT5TestSupport {
       @Override
       public void messageArrived(String topic, MqttMessage message) throws Exception {
          int sentAs = Integer.valueOf(new String(message.getPayload(), StandardCharsets.UTF_8));
-         log.info("QoS of publish: {}; QoS of subscription: {}; QoS of receive: {}", sentAs, qosOfSubscription, message.getQos());
+         logger.info("QoS of publish: {}; QoS of subscription: {}; QoS of receive: {}", sentAs, qosOfSubscription, message.getQos());
          if (sentAs == 0) {
             assertTrue(message.getQos() == 0);
          } else if (sentAs == 1) {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingTest.java
@@ -132,7 +132,7 @@ import java.lang.invoke.MethodHandles;
 @RunWith(Parameterized.class)
 public class PagingTest extends ActiveMQTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Rule
    public RetryRule retryMethod = new RetryRule(1);
@@ -894,8 +894,8 @@ public class PagingTest extends ActiveMQTestBase {
       sf = createSessionFactory(locator);
       session = sf.createSession(false, true, true);
 
-      log.info("*******************************************************************************************************************************");
-      log.info("Creating consumer");
+      logger.info("*******************************************************************************************************************************");
+      logger.info("Creating consumer");
 
       consumer = session.createConsumer(ADDRESS);
       session.start();
@@ -1067,7 +1067,7 @@ public class PagingTest extends ActiveMQTestBase {
       for (int i = 0; i < 10; i++) {
          ClientMessage msgRec = consumer.receive(1000);
          Assert.assertNotNull(msgRec);
-         log.debug("received i={} page={}", msgRec.getIntProperty("i"), msgRec.getIntProperty("page"));
+         logger.debug("received i={} page={}", msgRec.getIntProperty("i"), msgRec.getIntProperty("page"));
          msgRec.acknowledge();
       }
       session.commit();
@@ -1123,7 +1123,7 @@ public class PagingTest extends ActiveMQTestBase {
             ClientMessage msgRec = browser.receive(1000);
             Assert.assertNotNull(msgRec);
 
-            log.debug("received i={} page={}", msgRec.getIntProperty("i"), msgRec.getIntProperty("page"));
+            logger.debug("received i={} page={}", msgRec.getIntProperty("i"), msgRec.getIntProperty("page"));
 
             int pageProperty = msgRec.getIntProperty("page");
             Assert.assertTrue(pageProperty != 5 && pageProperty != 3);
@@ -1211,7 +1211,7 @@ public class PagingTest extends ActiveMQTestBase {
          for (int i = 0; i < numberOfMessages; i++) {
             ClientMessage msgRec = consumer.receive(1000);
             Assert.assertNotNull(msgRec);
-            log.debug("msgRec, i={}, page={}", msgRec.getIntProperty("i"), msgRec.getIntProperty("page"));
+            logger.debug("msgRec, i={}, page={}", msgRec.getIntProperty("i"), msgRec.getIntProperty("page"));
             msgRec.acknowledge();
          }
          session.commit();
@@ -2198,7 +2198,7 @@ public class PagingTest extends ActiveMQTestBase {
 
       if (!deletedQueueReferences.isEmpty()) {
          for (Long value : deletedQueueReferences) {
-            log.warn("Deleted Queue still has a reference:{}", value);
+            logger.warn("Deleted Queue still has a reference:{}", value);
          }
 
          fail("Deleted queue still have references");
@@ -2562,18 +2562,18 @@ public class PagingTest extends ActiveMQTestBase {
       sessionConsumer.start();
       ClientConsumer consumer = sessionConsumer.createConsumer(PagingTest.ADDRESS);
       for (int msgCount = 0; msgCount < numberOfMessages; msgCount++) {
-         log.debug("Received {}", msgCount);
+         logger.debug("Received {}", msgCount);
          msgReceived++;
          ClientMessage msg = consumer.receiveImmediate();
          if (msg == null) {
-            log.debug("It's null. leaving now");
+            logger.debug("It's null. leaving now");
             sessionConsumer.commit();
             fail("Didn't receive a message");
          }
          msg.acknowledge();
 
          if (msgCount % 5 == 0) {
-            log.debug("commit");
+            logger.debug("commit");
             sessionConsumer.commit();
          }
       }
@@ -2740,18 +2740,18 @@ public class PagingTest extends ActiveMQTestBase {
       sessionConsumer.start();
       ClientConsumer consumer = sessionConsumer.createConsumer(PagingTest.ADDRESS);
       for (int msgCount = 0; msgCount < numberOfMessages; msgCount++) {
-         log.debug("Received {}", msgCount);
+         logger.debug("Received {}", msgCount);
          msgReceived++;
          ClientMessage msg = consumer.receive(5000);
          if (msg == null) {
-            log.debug("It's null. leaving now");
+            logger.debug("It's null. leaving now");
             sessionConsumer.commit();
             fail("Didn't receive a message");
          }
          msg.acknowledge();
 
          if (msgCount % 5 == 0) {
-            log.debug("commit");
+            logger.debug("commit");
             sessionConsumer.commit();
          }
       }
@@ -2822,18 +2822,18 @@ public class PagingTest extends ActiveMQTestBase {
       sessionConsumer.start();
       consumer = sessionConsumer.createConsumer(PagingTest.ADDRESS);
       for (int msgCount = 0; msgCount < numberOfMessages; msgCount++) {
-         log.debug("Received {}", msgCount);
+         logger.debug("Received {}", msgCount);
          msgReceived++;
          ClientMessage msg = consumer.receive(5000);
          if (msg == null) {
-            log.debug("It's null. leaving now");
+            logger.debug("It's null. leaving now");
             sessionConsumer.commit();
             fail("Didn't receive a message");
          }
          msg.acknowledge();
 
          if (msgCount % 5 == 0) {
-            log.debug("commit");
+            logger.debug("commit");
             sessionConsumer.commit();
          }
       }
@@ -2946,7 +2946,7 @@ public class PagingTest extends ActiveMQTestBase {
       // a dumb user, or anything that will remove the data
       deleteDirectory(new File(getPageDir()));
 
-      log.trace("Server restart");
+      logger.trace("Server restart");
 
       server.start();
 
@@ -3366,7 +3366,7 @@ public class PagingTest extends ActiveMQTestBase {
                   Thread.sleep(10);
                }
             } catch (InterruptedException e) {
-               log.debug("Thread interrupted");
+               logger.debug("Thread interrupted");
             }
          }
       }
@@ -3396,7 +3396,7 @@ public class PagingTest extends ActiveMQTestBase {
 
             for (int i = 0; i < numberOfMessages; i++) {
                if (i % 500 == 0) {
-                  log.debug("Sent {} messages", i);
+                  logger.debug("Sent {} messages", i);
                   session.commit();
                }
                message = session.createMessage(true);
@@ -3474,7 +3474,7 @@ public class PagingTest extends ActiveMQTestBase {
 
                         if (i % 100 == 0) {
                            if (i % 5000 == 0) {
-                              log.debug("{} consumed {} messages", addressToSubscribe, i);
+                              logger.debug("{} consumed {} messages", addressToSubscribe, i);
                            }
                            session.commit();
                         }
@@ -3482,9 +3482,9 @@ public class PagingTest extends ActiveMQTestBase {
                         try {
                            assertBodiesEqual(body, message2.getBodyBuffer());
                         } catch (AssertionError e) {
-                           if (log.isDebugEnabled()) {
-                              log.debug("Expected buffer:{}", ActiveMQTestBase.dumpBytesHex(body, 40));
-                              log.debug("Arriving buffer:{}", ActiveMQTestBase.dumpBytesHex(message2.getBodyBuffer().toByteBuffer().array(), 40));
+                           if (logger.isDebugEnabled()) {
+                              logger.debug("Expected buffer:{}", ActiveMQTestBase.dumpBytesHex(body, 40));
+                              logger.debug("Arriving buffer:{}", ActiveMQTestBase.dumpBytesHex(message2.getBodyBuffer().toByteBuffer().array(), 40));
                            }
                            throw e;
                         }
@@ -3644,9 +3644,9 @@ public class PagingTest extends ActiveMQTestBase {
                   try {
                      assertBodiesEqual(body, message2.getBodyBuffer());
                   } catch (AssertionError e) {
-                     if (log.isDebugEnabled()) {
-                        log.debug("Expected buffer: {}", ActiveMQTestBase.dumpBytesHex(body, 40));
-                        log.debug("Arriving buffer: {}", ActiveMQTestBase.dumpBytesHex(message2.getBodyBuffer().toByteBuffer().array(), 40));
+                     if (logger.isDebugEnabled()) {
+                        logger.debug("Expected buffer: {}", ActiveMQTestBase.dumpBytesHex(body, 40));
+                        logger.debug("Arriving buffer: {}", ActiveMQTestBase.dumpBytesHex(message2.getBodyBuffer().toByteBuffer().array(), 40));
                      }
                      throw e;
                   }
@@ -3772,9 +3772,9 @@ public class PagingTest extends ActiveMQTestBase {
          try {
             assertBodiesEqual(body, message2.getBodyBuffer());
          } catch (AssertionError e) {
-            if (log.isDebugEnabled()) {
-               log.debug("Expected buffer:{}", ActiveMQTestBase.dumpBytesHex(body, 40));
-               log.debug("Arriving buffer:{}", ActiveMQTestBase.dumpBytesHex(message2.getBodyBuffer().toByteBuffer().array(), 40));
+            if (logger.isDebugEnabled()) {
+               logger.debug("Expected buffer:{}", ActiveMQTestBase.dumpBytesHex(body, 40));
+               logger.debug("Arriving buffer:{}", ActiveMQTestBase.dumpBytesHex(message2.getBodyBuffer().toByteBuffer().array(), 40));
             }
             throw e;
          }
@@ -4252,7 +4252,7 @@ public class PagingTest extends ActiveMQTestBase {
 
                sessionProducer.commit();
 
-               log.debug("Producer gone");
+               logger.debug("Producer gone");
 
             } catch (Throwable e) {
                e.printStackTrace(); // >> junit report
@@ -4284,8 +4284,8 @@ public class PagingTest extends ActiveMQTestBase {
          ClientMessage msg = consumer.receive(5000);
          assertNotNull(msg);
          if (i != msg.getIntProperty("count").intValue()) {
-            log.debug("Received {} with property = {}", i,  msg.getIntProperty("count"));
-            log.debug("###### different");
+            logger.debug("Received {} with property = {}", i,  msg.getIntProperty("count"));
+            logger.debug("###### different");
          }
          // assertEquals(i, msg.getIntProperty("count").intValue());
          msg.acknowledge();
@@ -4391,9 +4391,9 @@ public class PagingTest extends ActiveMQTestBase {
          try {
             assertBodiesEqual(body, message2.getBodyBuffer());
          } catch (AssertionError e) {
-            if (log.isDebugEnabled()) {
-               log.debug("Expected buffer: {}", ActiveMQTestBase.dumpBytesHex(body, 40));
-               log.debug("Arriving buffer: {}", ActiveMQTestBase.dumpBytesHex(message2.getBodyBuffer().toByteBuffer().array(), 40));
+            if (logger.isDebugEnabled()) {
+               logger.debug("Expected buffer: {}", ActiveMQTestBase.dumpBytesHex(body, 40));
+               logger.debug("Arriving buffer: {}", ActiveMQTestBase.dumpBytesHex(message2.getBodyBuffer().toByteBuffer().array(), 40));
             }
             throw e;
          }
@@ -4639,7 +4639,7 @@ public class PagingTest extends ActiveMQTestBase {
       server.stop();
       mainCleanup.set(false);
 
-      log.trace("Server restart");
+      logger.trace("Server restart");
 
       server.start();
 
@@ -5026,7 +5026,7 @@ public class PagingTest extends ActiveMQTestBase {
             count++;
 
             if (count % 1000 == 0) {
-               log.debug("received {}", count);
+               logger.debug("received {}", count);
             }
 
             try {
@@ -5966,7 +5966,7 @@ public class PagingTest extends ActiveMQTestBase {
          ClientProducer producer = session.createProducer(PagingTest.ADDRESS);
 
          for (int i = 0; i < 100; i++) {
-            log.debug("send message #{}", i);
+            logger.debug("send message #{}", i);
             ClientMessage message = session.createMessage(true);
 
             message.putStringProperty("id", "str" + i);
@@ -6005,7 +6005,7 @@ public class PagingTest extends ActiveMQTestBase {
          }
 
          for (int i = 2; i < 100; i++) {
-            log.debug("Received message {}", i);
+            logger.debug("Received message {}", i);
             ClientMessage message = cons.receive(5000);
             assertNotNull("Message " + i + " wasn't received", message);
             message.acknowledge();
@@ -6021,15 +6021,15 @@ public class PagingTest extends ActiveMQTestBase {
 
             try {
                if (!message.waitOutputStreamCompletion(10000)) {
-                  if (log.isDebugEnabled()) {
-                     log.debug(threadDump("dump"));
+                  if (logger.isDebugEnabled()) {
+                     logger.debug(threadDump("dump"));
                   }
                   fail("Couldn't finish large message receiving");
                }
             } catch (Throwable e) {
-               if (log.isDebugEnabled()) {
-                  log.debug("output bytes = {}", bytesOutput);
-                  log.debug(threadDump("dump"));
+               if (logger.isDebugEnabled()) {
+                  logger.debug("output bytes = {}", bytesOutput);
+                  logger.debug(threadDump("dump"));
                }
                fail("Couldn't finish large message receiving for id=" + message.getStringProperty("id") + " with messageID=" + message.getMessageID());
             }
@@ -6067,7 +6067,7 @@ public class PagingTest extends ActiveMQTestBase {
          cons = session.createConsumer(ADDRESS);
 
          for (int i = 2; i < 100; i++) {
-            log.debug("Received message {}", i);
+            logger.debug("Received message {}", i);
             ClientMessage message = cons.receive(5000);
             assertNotNull(message);
 
@@ -6176,7 +6176,7 @@ public class PagingTest extends ActiveMQTestBase {
 
          for (int i = 0; i < 500; i++) {
             if (i % 100 == 0)
-               log.debug("send message #{}", i);
+               logger.debug("send message #{}", i);
             message = session.createMessage(true);
 
             message.putStringProperty("id", "str" + i);
@@ -6230,7 +6230,7 @@ public class PagingTest extends ActiveMQTestBase {
          ClientConsumer cons = session.createConsumer("DLA");
 
          for (int i = 0; i < 500; i++) {
-            log.debug("Received message {}",  i);
+            logger.debug("Received message {}",  i);
             message = cons.receive(10000);
             assertNotNull(message);
             message.acknowledge();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/metrics/AbstractPersistentStatTestSupport.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/metrics/AbstractPersistentStatTestSupport.java
@@ -49,7 +49,7 @@ import java.lang.invoke.MethodHandles;
  */
 public abstract class AbstractPersistentStatTestSupport extends JMSTestBase {
 
-   protected static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   protected static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    protected static int defaultMessageSize = 1000;
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/metrics/JournalPendingMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/metrics/JournalPendingMessageTest.java
@@ -51,7 +51,7 @@ import java.lang.invoke.MethodHandles;
 
 
 public class JournalPendingMessageTest extends AbstractPersistentStatTestSupport {
-   protected static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   protected static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    // protected URI brokerConnectURI;
    protected String defaultQueueName = "test.queue";

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/plugin/AmqpPluginTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/plugin/AmqpPluginTest.java
@@ -73,7 +73,7 @@ import java.lang.invoke.MethodHandles;
  */
 public class AmqpPluginTest extends AmqpClientTestSupport {
 
-   protected static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   protected static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private final Map<String, AtomicInteger> methodCalls = new ConcurrentHashMap<>();
    private final MethodCalledVerifier verifier = new MethodCalledVerifier(methodCalls);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/scheduling/MultipliedDelayedMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/scheduling/MultipliedDelayedMessageTest.java
@@ -36,7 +36,7 @@ import java.lang.invoke.MethodHandles;
 
 public class MultipliedDelayedMessageTest extends ActiveMQTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private ActiveMQServer server;
 
@@ -103,11 +103,11 @@ public class MultipliedDelayedMessageTest extends ActiveMQTestBase {
          session.rollback();
 
          long expectedDelay = calculateExpectedDelay(DELAY, MAX_DELAY, MULTIPLIER, i);
-         log.debug("\nExpected delay: {}", expectedDelay);
+         logger.debug("\nExpected delay: {}", expectedDelay);
          tm = consumer.receive(expectedDelay + 500);
          long stop = System.currentTimeMillis();
          Assert.assertNotNull(tm);
-         log.debug("Actual delay: {}", (stop - start));
+         logger.debug("Actual delay: {}", (stop - start));
          Assert.assertTrue(stop - start >= expectedDelay);
       }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/AddressQueueDeleteDelayTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/AddressQueueDeleteDelayTest.java
@@ -40,7 +40,7 @@ import java.lang.invoke.MethodHandles;
 
 public class AddressQueueDeleteDelayTest extends ActiveMQTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    public static final int DURATION_MILLIS = 30_000;
    public static final int NEGATIVE_DURATION_MILLIS = 1_000;
@@ -87,14 +87,14 @@ public class AddressQueueDeleteDelayTest extends ActiveMQTestBase {
 
 
       long elapsedTime = System.currentTimeMillis() - start;
-      log.debug("Elapsed time to delete queue: {}", elapsedTime);
+      logger.debug("Elapsed time to delete queue: {}", elapsedTime);
       assertTrue(elapsedTime >= (deleteQueuesDelay));
 
       start = info.getBindingRemovedTimestamp();
 
       assertTrue(Wait.waitFor(() -> server.getAddressInfo(address) == null, DURATION_MILLIS, SLEEP_MILLIS));
       elapsedTime = System.currentTimeMillis() - start;
-      log.debug("Elapsed time to delete address: {}", elapsedTime);
+      logger.debug("Elapsed time to delete address: {}", elapsedTime);
       assertTrue("ellapsedTime=" + elapsedTime + " while delay is " + deleteAddressesDelay, elapsedTime >= (deleteAddressesDelay));
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/ScaleDown3NodeTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/ScaleDown3NodeTest.java
@@ -44,7 +44,7 @@ import java.lang.invoke.MethodHandles;
 
 public class ScaleDown3NodeTest extends ClusterTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Override
    @Before
@@ -76,11 +76,11 @@ public class ScaleDown3NodeTest extends ClusterTestBase {
       setupSessionFactory(0, isNetty(), false, servers[0].getConfiguration().getClusterUser(), servers[0].getConfiguration().getClusterPassword());
       setupSessionFactory(1, isNetty(), false, servers[1].getConfiguration().getClusterUser(), servers[1].getConfiguration().getClusterPassword());
       setupSessionFactory(2, isNetty(), false, servers[2].getConfiguration().getClusterUser(), servers[2].getConfiguration().getClusterPassword());
-      log.debug("===============================");
-      log.debug("Node 0: {}", servers[0].getClusterManager().getNodeId());
-      log.debug("Node 1: {}", servers[1].getClusterManager().getNodeId());
-      log.debug("Node 2: {}", servers[2].getClusterManager().getNodeId());
-      log.debug("===============================");
+      logger.debug("===============================");
+      logger.debug("Node 0: {}", servers[0].getClusterManager().getNodeId());
+      logger.debug("Node 1: {}", servers[1].getClusterManager().getNodeId());
+      logger.debug("Node 2: {}", servers[2].getClusterManager().getNodeId());
+      logger.debug("===============================");
 
       servers[0].setIdentity("Node0");
       servers[1].setIdentity("Node1");
@@ -171,7 +171,7 @@ public class ScaleDown3NodeTest extends ClusterTestBase {
       Assert.assertEquals(TEST_SIZE, getMessageCount(snfQueue));
 
       // trigger scaleDown from node 0 to node 1
-      log.debug("============ Stopping {}", servers[0].getNodeID());
+      logger.debug("============ Stopping {}", servers[0].getNodeID());
       removeConsumer(0);
       servers[0].stop();
 
@@ -196,7 +196,7 @@ public class ScaleDown3NodeTest extends ClusterTestBase {
                Assert.assertEquals(ActiveMQTestBase.getSamplebyte(j), clientMessage.getBodyBuffer().readByte());
             }
          }
-         log.debug("Received: {}", clientMessage);
+         logger.debug("Received: {}", clientMessage);
          clientMessage.acknowledge();
       }
 
@@ -263,7 +263,7 @@ public class ScaleDown3NodeTest extends ClusterTestBase {
       Wait.assertEquals(TEST_SIZE * 2, snfQueue::getMessageCount);
 
       // trigger scaleDown from node 0 to node 1
-      log.debug("============ Stopping {}", servers[0].getNodeID());
+      logger.debug("============ Stopping {}", servers[0].getNodeID());
       removeConsumer(0);
       removeConsumer(1);
       servers[0].stop();
@@ -284,12 +284,12 @@ public class ScaleDown3NodeTest extends ClusterTestBase {
       for (int i = 0; i < TEST_SIZE; i++) {
          ClientMessage clientMessage = consumers[0].getConsumer().receive(1000);
          Assert.assertNotNull(clientMessage);
-         log.debug("Received: {}", clientMessage);
+         logger.debug("Received: {}", clientMessage);
          clientMessage.acknowledge();
 
          clientMessage = consumers[1].getConsumer().receive(1000);
          Assert.assertNotNull(clientMessage);
-         log.debug("Received: {}", clientMessage);
+         logger.debug("Received: {}", clientMessage);
          clientMessage.acknowledge();
       }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/StompTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/StompTest.java
@@ -84,7 +84,7 @@ import static org.apache.activemq.artemis.utils.collections.IterableStream.itera
 @RunWith(Parameterized.class)
 public class StompTest extends StompTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    protected StompClientConnection conn;
 
@@ -107,7 +107,7 @@ public class StompTest extends StompTestBase {
    public void tearDown() throws Exception {
       try {
          boolean connected = conn != null && conn.isConnected();
-         log.debug("Connection 1.0 connected: {}", connected);
+         logger.debug("Connection 1.0 connected: {}", connected);
          if (connected) {
             try {
                conn.disconnect();
@@ -834,11 +834,11 @@ public class StompTest extends StompTestBase {
       subscribe(conn, null, Stomp.Headers.Subscribe.AckModeValues.AUTO);
 
       String text = "A" + "\u00ea" + "\u00f1" + "\u00fc" + "C";
-      log.debug(text);
+      logger.debug(text);
       sendJmsMessage(text);
 
       ClientStompFrame frame = conn.receiveFrame(10000);
-      log.debug("{}", frame);
+      logger.debug("{}", frame);
       Assert.assertEquals(Stomp.Responses.MESSAGE, frame.getCommand());
       Assert.assertEquals(getQueuePrefix() + getQueueName(), frame.getHeader(Stomp.Headers.Message.DESTINATION));
       Assert.assertEquals(text, frame.getBody());
@@ -993,7 +993,7 @@ public class StompTest extends StompTestBase {
       ClientStompFrame frame = conn.receiveFrame(10000);
       Assert.assertEquals(Stomp.Responses.MESSAGE, frame.getCommand());
 
-      log.debug("Reconnecting!");
+      logger.debug("Reconnecting!");
 
       if (sendDisconnect) {
          conn.disconnect();
@@ -1049,7 +1049,7 @@ public class StompTest extends StompTestBase {
       sendJmsMessage("second message");
 
       frame = conn.receiveFrame(100);
-      log.debug("Received frame: {}", frame);
+      logger.debug("Received frame: {}", frame);
       Assert.assertNull("No message should have been received since subscription was removed", frame);
    }
 
@@ -1072,7 +1072,7 @@ public class StompTest extends StompTestBase {
       sendJmsMessage("second message");
 
       frame = conn.receiveFrame(100);
-      log.debug("Received frame: {}", frame);
+      logger.debug("Received frame: {}", frame);
       Assert.assertNull("No message should have been received since subscription was removed", frame);
 
    }
@@ -1159,7 +1159,7 @@ public class StompTest extends StompTestBase {
          if (length - baselineQueueCount == 1) {
             return true;
          } else {
-            log.debug("Queue count: {}", (length - baselineQueueCount));
+            logger.debug("Queue count: {}", (length - baselineQueueCount));
             return false;
          }
       });
@@ -1176,7 +1176,7 @@ public class StompTest extends StompTestBase {
       sendJmsMessage(getName(), topic);
 
       frame = conn.receiveFrame(100);
-      log.debug("Received frame: {}", frame);
+      logger.debug("Received frame: {}", frame);
       Assert.assertNull("No message should have been received since subscription was removed", frame);
 
       assertEquals("Subscription queue should be deleted", 0, server.getActiveMQServerControl().getQueueNames().length - baselineQueueCount);
@@ -1211,7 +1211,7 @@ public class StompTest extends StompTestBase {
       sendJmsMessage(getName(), queue);
 
       frame = conn.receiveFrame(100);
-      log.debug("Received frame: {}", frame);
+      logger.debug("Received frame: {}", frame);
       Assert.assertNull("No message should have been received since subscription was removed", frame);
 
       assertEquals("Subscription queue should not be deleted", baselineQueueCount, server.getActiveMQServerControl().getQueueNames().length);
@@ -1246,7 +1246,7 @@ public class StompTest extends StompTestBase {
       sendJmsMessage(getName(), ActiveMQJMSClient.createQueue(nonExistentQueue));
 
       frame = conn.receiveFrame(100);
-      log.debug("Received frame: {}", frame);
+      logger.debug("Received frame: {}", frame);
       Assert.assertNull("No message should have been received since subscription was removed", frame);
 
       conn.disconnect();
@@ -1410,7 +1410,7 @@ public class StompTest extends StompTestBase {
       send(conn, getTopicPrefix() + getTopicName(), null, "Hello World");
 
       ClientStompFrame frame = conn.receiveFrame(100);
-      log.debug("Received frame: {}", frame);
+      logger.debug("Received frame: {}", frame);
       Assert.assertNull("No message should have been received since subscription was removed", frame);
 
       // send message on another JMS connection => it should be received
@@ -1445,7 +1445,7 @@ public class StompTest extends StompTestBase {
 
       // ...and nothing else
       ClientStompFrame frame = conn.receiveFrame(100);
-      log.debug("Received frame: {}", frame);
+      logger.debug("Received frame: {}", frame);
       Assert.assertNull(frame);
 
       conn.disconnect();
@@ -1514,7 +1514,7 @@ public class StompTest extends StompTestBase {
       sendJmsMessage(getName(), topic);
 
       ClientStompFrame frame = conn.receiveFrame(NEGATIVE_TIME_OUT);
-      log.debug("Received frame: {}", frame);
+      logger.debug("Received frame: {}", frame);
       Assert.assertNull("No message should have been received since subscription was removed", frame);
 
       conn.disconnect();
@@ -1856,7 +1856,7 @@ public class StompTest extends StompTestBase {
 
       frame = conn.receiveFrame(10000);
 
-      log.debug("Received: {}", frame);
+      logger.debug("Received: {}", frame);
 
       Assert.assertEquals(Boolean.TRUE.toString(), frame.getHeader(ManagementHelper.HDR_OPERATION_SUCCEEDED.toString()));
       // the address will be returned in the message body in a JSON array
@@ -1879,7 +1879,7 @@ public class StompTest extends StompTestBase {
 
       frame = conn.receiveFrame(10000);
 
-      log.debug("Received: {}", frame);
+      logger.debug("Received: {}", frame);
 
       Assert.assertEquals(Boolean.TRUE.toString(), frame.getHeader(ManagementHelper.HDR_OPERATION_SUCCEEDED.toString()));
       // there is no such messages => 0 returned in a JSON array

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/StompTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/StompTestBase.java
@@ -67,7 +67,7 @@ import java.lang.invoke.MethodHandles;
 @RunWith(Parameterized.class)
 public abstract class StompTestBase extends ActiveMQTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Parameterized.Parameter
    public String scheme;
@@ -639,7 +639,7 @@ public abstract class StompTestBase extends ActiveMQTestBase {
          assertEquals(uuid, frame.getHeader(Stomp.Headers.Response.RECEIPT_ID));
       }
 
-      log.debug("Received: {}", frame);
+      logger.debug("Received: {}", frame);
 
       return frame;
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/util/StompClientConnectionV10.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/util/StompClientConnectionV10.java
@@ -26,7 +26,7 @@ import java.lang.invoke.MethodHandles;
 
 public class StompClientConnectionV10 extends AbstractStompClientConnection {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    public StompClientConnectionV10(String host, int port) throws IOException {
       super("1.0", host, port);
@@ -64,7 +64,7 @@ public class StompClientConnectionV10 extends AbstractStompClientConnection {
       if (response.getCommand().equals(Stomp.Responses.CONNECTED)) {
          connected = true;
       } else {
-         log.warn("Connection failed with: {}", response);
+         logger.warn("Connection failed with: {}", response);
          connected = false;
       }
       return response;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/v12/StompV12Test.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/v12/StompV12Test.java
@@ -62,7 +62,7 @@ import java.lang.invoke.MethodHandles;
 @RunWith(Parameterized.class)
 public class StompV12Test extends StompTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    public static final String CLIENT_ID = "myclientid";
 
@@ -91,7 +91,7 @@ public class StompV12Test extends StompTestBase {
    public void tearDown() throws Exception {
       try {
          boolean connected = conn != null && conn.isConnected();
-         log.debug("Connection 1.2 : {}", connected);
+         logger.debug("Connection 1.2 : {}", connected);
          if (connected) {
             conn.disconnect();
          }
@@ -266,7 +266,7 @@ public class StompV12Test extends StompTestBase {
 
       conn.disconnect();
 
-      log.debug("Got error frame {}", reply);
+      logger.debug("Got error frame {}", reply);
 
    }
 
@@ -287,7 +287,7 @@ public class StompV12Test extends StompTestBase {
 
       ClientStompFrame frame = newConn.receiveFrame();
 
-      log.debug("received {}", frame);
+      logger.debug("received {}", frame);
 
       Assert.assertEquals(Stomp.Responses.MESSAGE, frame.getCommand());
 
@@ -302,7 +302,7 @@ public class StompV12Test extends StompTestBase {
 
       frame = newConn.receiveFrame();
 
-      log.debug("received {}", frame);
+      logger.debug("received {}", frame);
 
       //unsub
       unsubscribe(newConn, "a-sub");
@@ -323,7 +323,7 @@ public class StompV12Test extends StompTestBase {
 
       ClientStompFrame frame = newConn.receiveFrame();
 
-      log.debug("received {}", frame);
+      logger.debug("received {}", frame);
 
       Assert.assertEquals(Stomp.Responses.MESSAGE, frame.getCommand());
 
@@ -421,7 +421,7 @@ public class StompV12Test extends StompTestBase {
       Assert.assertEquals(Stomp.Responses.MESSAGE, frame.getCommand());
       Assert.assertEquals(body, frame.getBody());
 
-      log.debug("received: {}", frame);
+      logger.debug("received: {}", frame);
       Assert.assertEquals("value1", frame.getHeader("foo"));
 
       //unsub
@@ -479,7 +479,7 @@ public class StompV12Test extends StompTestBase {
       Assert.assertEquals(Stomp.Responses.MESSAGE, frame.getCommand());
       Assert.assertEquals(body, frame.getBody());
 
-      log.debug("received: {}", frame);
+      logger.debug("received: {}", frame);
       Assert.assertEquals(null, frame.getHeader("header1"));
       Assert.assertEquals("value1 ", frame.getHeader(" header1"));
       Assert.assertEquals("value2   ", frame.getHeader("  header2"));
@@ -512,7 +512,7 @@ public class StompV12Test extends StompTestBase {
                                    .addHeader(hKey, hVal)
                                    .setBody(body);
 
-      log.debug("key: |{}| val: |{}|", hKey, hVal);
+      logger.debug("key: |{}| val: |{}|", hKey, hVal);
 
       conn.sendFrame(frame);
 
@@ -524,7 +524,7 @@ public class StompV12Test extends StompTestBase {
 
       frame = newConn.receiveFrame();
 
-      log.debug("received {}", frame);
+      logger.debug("received {}", frame);
 
       Assert.assertEquals(Stomp.Responses.MESSAGE, frame.getCommand());
 
@@ -556,7 +556,7 @@ public class StompV12Test extends StompTestBase {
       String hVal = "is\\ttab";
       frame.addHeader(hKey, hVal);
 
-      log.debug("key: |{}| val: |{}|", hKey, hVal);
+      logger.debug("key: |{}| val: |{}|", hKey, hVal);
 
       frame.setBody(body);
 
@@ -564,7 +564,7 @@ public class StompV12Test extends StompTestBase {
 
       ClientStompFrame error = conn.receiveFrame();
 
-      log.debug("received {}", error);
+      logger.debug("received {}", error);
 
       String desc = "Should have received an ERROR for undefined escape sequence";
       Assert.assertNotNull(desc, error);
@@ -707,7 +707,7 @@ public class StompV12Test extends StompTestBase {
       //now check the frame size
       int size = conn.getServerPingNumber();
 
-      log.debug("ping received: {}", size);
+      logger.debug("ping received: {}", size);
 
       Assert.assertTrue("size: " + size, size > 5);
 
@@ -936,7 +936,7 @@ public class StompV12Test extends StompTestBase {
 
       ClientStompFrame error = conn.receiveFrame();
 
-      log.debug("Receiver error: {}", error);
+      logger.debug("Receiver error: {}", error);
 
       waitDisconnect(conn);
       Assert.assertFalse("Should be disconnected in STOMP 1.2 after ERROR", conn.isConnected());
@@ -1020,7 +1020,7 @@ public class StompV12Test extends StompTestBase {
 
       ClientStompFrame error = conn.receiveFrame();
 
-      log.debug("Receiver error: {}", error);
+      logger.debug("Receiver error: {}", error);
 
       waitDisconnect(conn);
       Assert.assertFalse("Should be disconnected in STOMP 1.2 after ERROR", conn.isConnected());
@@ -1051,7 +1051,7 @@ public class StompV12Test extends StompTestBase {
 
       ClientStompFrame error = conn.sendFrame(ackFrame);
 
-      log.debug("Receiver error: {}", error);
+      logger.debug("Receiver error: {}", error);
 
       Assert.assertEquals(Stomp.Responses.ERROR, error.getCommand());
 
@@ -1086,7 +1086,7 @@ public class StompV12Test extends StompTestBase {
 
       ClientStompFrame error = conn.sendFrame(ackFrame);
 
-      log.debug("Receiver error: {}", error);
+      logger.debug("Receiver error: {}", error);
 
       Assert.assertEquals(Stomp.Responses.ERROR, error.getCommand());
 
@@ -1254,7 +1254,7 @@ public class StompV12Test extends StompTestBase {
          frame = conn.receiveFrame();
          Assert.assertNotNull(frame);
 
-         log.debug("{} == received: {}", i, frame);
+         logger.debug("{} == received: {}", i, frame);
          //ack on even numbers
          if (i % 2 == 0) {
             ack(conn, frame);
@@ -1272,7 +1272,7 @@ public class StompV12Test extends StompTestBase {
       for (int i = 0; i < num / 2; i++) {
          message = (TextMessage) consumer.receive(1000);
          Assert.assertNotNull(message);
-         log.debug("Legal: {}", message.getText());
+         logger.debug("Legal: {}", message.getText());
       }
 
       message = (TextMessage) consumer.receiveNoWait();
@@ -1296,13 +1296,13 @@ public class StompV12Test extends StompTestBase {
       // receive message from socket
       ClientStompFrame frame = conn.receiveFrame(1000);
 
-      log.debug("received frame : {}", frame);
+      logger.debug("received frame : {}", frame);
       Assert.assertEquals("Hello World", frame.getBody());
       Assert.assertEquals("sub1", frame.getHeader(Stomp.Headers.Message.SUBSCRIPTION));
 
       frame = newConn.receiveFrame(1000);
 
-      log.debug("received 2 frame : {}", frame);
+      logger.debug("received 2 frame : {}", frame);
       Assert.assertEquals("Hello World", frame.getBody());
       Assert.assertEquals("sub2", frame.getHeader(Stomp.Headers.Message.SUBSCRIPTION));
 
@@ -1355,11 +1355,11 @@ public class StompV12Test extends StompTestBase {
       subscribe(conn, getName(), Stomp.Headers.Subscribe.AckModeValues.AUTO);
 
       String text = "A" + "\u00ea" + "\u00f1" + "\u00fc" + "C";
-      log.debug(text);
+      logger.debug(text);
       sendJmsMessage(text);
 
       ClientStompFrame frame = conn.receiveFrame();
-      log.debug("{}", frame);
+      logger.debug("{}", frame);
       Assert.assertTrue(frame.getCommand().equals(Stomp.Responses.MESSAGE));
       Assert.assertNotNull(frame.getHeader(Stomp.Headers.Subscribe.DESTINATION));
       Assert.assertTrue(frame.getBody().equals(text));
@@ -1705,7 +1705,7 @@ public class StompV12Test extends StompTestBase {
             TextMessage m = (TextMessage) arg0;
             latch.countDown();
             try {
-               log.debug("___> latch now: {} m: {}", latch.getCount(), m.getText());
+               logger.debug("___> latch now: {} m: {}", latch.getCount(), m.getText());
             } catch (JMSException e) {
                Assert.fail("here failed");
                e.printStackTrace();
@@ -1996,7 +1996,7 @@ public class StompV12Test extends StompTestBase {
 
       Assert.assertEquals(Stomp.Responses.MESSAGE, frame.getCommand());
 
-      log.debug("Message: {}", frame);
+      logger.debug("Message: {}", frame);
 
       Assert.assertEquals("5", frame.getHeader(Stomp.Headers.CONTENT_LENGTH));
 
@@ -2276,7 +2276,7 @@ public class StompV12Test extends StompTestBase {
 
       Assert.assertEquals(Stomp.Responses.MESSAGE, frame.getCommand());
 
-      log.debug("Reconnecting!");
+      logger.debug("Reconnecting!");
 
       if (sendDisconnect) {
          conn.disconnect();
@@ -2352,7 +2352,7 @@ public class StompV12Test extends StompTestBase {
 
       ClientStompFrame frame = conn.receiveFrame();
 
-      log.debug("Received: {}", frame);
+      logger.debug("Received: {}", frame);
 
       Assert.assertEquals(Stomp.Responses.MESSAGE, frame.getCommand());
       Assert.assertEquals("ID:MYMACHINE-50616-635482262727823605-1:1:1:1", frame.getHeader(Stomp.Headers.Message.SUBSCRIPTION));

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/xa/BasicXaRecoveryTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/xa/BasicXaRecoveryTest.java
@@ -57,7 +57,7 @@ import java.lang.invoke.MethodHandles;
 @RunWith(Parameterized.class)
 public class BasicXaRecoveryTest extends ActiveMQTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private final Map<String, AddressSettings> addressSettings = new HashMap<>();
 
@@ -285,7 +285,7 @@ public class BasicXaRecoveryTest extends ActiveMQTestBase {
       clientSession.end(xid, XAResource.TMSUCCESS);
       clientSession.prepare(xid);
 
-      log.debug("*** stopping and restarting");
+      logger.debug("*** stopping and restarting");
 
       if (restartServer) {
          stopAndRestartServer();
@@ -522,7 +522,7 @@ public class BasicXaRecoveryTest extends ActiveMQTestBase {
       clientSession.end(xid, XAResource.TMSUCCESS);
       clientSession.prepare(xid);
 
-      log.debug("shutting down server");
+      logger.debug("shutting down server");
 
       if (stopServer) {
          stopAndRestartServer();
@@ -530,7 +530,7 @@ public class BasicXaRecoveryTest extends ActiveMQTestBase {
          recreateClients();
       }
 
-      log.debug("restarted");
+      logger.debug("restarted");
 
       Xid[] xids = clientSession.recover(XAResource.TMSTARTRSCAN);
 
@@ -947,7 +947,7 @@ public class BasicXaRecoveryTest extends ActiveMQTestBase {
       clientSession.end(xid, XAResource.TMSUCCESS);
       clientSession.prepare(xid);
 
-      log.debug("stopping and restarting");
+      logger.debug("stopping and restarting");
 
       if (stopServer) {
          stopAndRestartServer();
@@ -955,7 +955,7 @@ public class BasicXaRecoveryTest extends ActiveMQTestBase {
          recreateClients();
       }
 
-      log.debug("Restarted");
+      logger.debug("Restarted");
 
       Xid[] xids = clientSession.recover(XAResource.TMSTARTRSCAN);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/xa/BasicXaTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/xa/BasicXaTest.java
@@ -60,7 +60,7 @@ import java.lang.invoke.MethodHandles;
 @RunWith(Parameterized.class)
 public class BasicXaTest extends ActiveMQTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private final Map<String, AddressSettings> addressSettings = new HashMap<>();
 
@@ -311,7 +311,7 @@ public class BasicXaTest extends ActiveMQTestBase {
 
       clientSession = sessionFactory.createSession(true, false, false);
 
-      log.debug("committing");
+      logger.debug("committing");
 
       clientSession.commit(xid, false);
       clientSession.start();
@@ -675,7 +675,7 @@ public class BasicXaTest extends ActiveMQTestBase {
 
       String[] preparedTransactions = messagingService.getActiveMQServerControl().listPreparedTransactions();
       Assert.assertEquals(1, preparedTransactions.length);
-      log.debug(preparedTransactions[0]);
+      logger.debug(preparedTransactions[0]);
       Assert.assertTrue(messagingService.getActiveMQServerControl().commitPreparedTransaction(XidImpl.toBase64String(xid)));
       Assert.assertEquals(1, messagingService.getActiveMQServerControl().listHeuristicCommittedTransactions().length);
 
@@ -693,7 +693,7 @@ public class BasicXaTest extends ActiveMQTestBase {
 
       String[] preparedTransactions = messagingService.getActiveMQServerControl().listPreparedTransactions();
       Assert.assertEquals(1, preparedTransactions.length);
-      log.debug(preparedTransactions[0]);
+      logger.debug(preparedTransactions[0]);
 
       Assert.assertTrue(messagingService.getActiveMQServerControl().rollbackPreparedTransaction(XidImpl.toBase64String(xid)));
       Assert.assertEquals(1, messagingService.getActiveMQServerControl().listHeuristicRolledBackTransactions().length);
@@ -1024,7 +1024,7 @@ public class BasicXaTest extends ActiveMQTestBase {
          try {
             message.acknowledge();
          } catch (ActiveMQException e) {
-            BasicXaTest.log.error("Failed to process message", e);
+            BasicXaTest.logger.error("Failed to process message", e);
          }
          try {
             session.end(xid, XAResource.TMSUCCESS);

--- a/tests/performance-tests/src/test/java/org/apache/activemq/artemis/tests/performance/journal/JournalImplTestUnit.java
+++ b/tests/performance-tests/src/test/java/org/apache/activemq/artemis/tests/performance/journal/JournalImplTestUnit.java
@@ -34,7 +34,7 @@ import java.lang.invoke.MethodHandles;
 
 public abstract class JournalImplTestUnit extends JournalImplTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Override
    @After
@@ -118,7 +118,7 @@ public abstract class JournalImplTestUnit extends JournalImplTestBase {
       update(updates);
       delete(deletes);
 
-      JournalImplTestUnit.log.debug("Debug journal:{}", debugJournal());
+      JournalImplTestUnit.logger.debug("Debug journal:{}", debugJournal());
       stopJournal(false);
       createJournal();
       startJournal();
@@ -147,7 +147,7 @@ public abstract class JournalImplTestUnit extends JournalImplTestBase {
          }
 
          if (count % 100 == 0) {
-            JournalImplTestUnit.log.debug("Done: {}", count);
+            JournalImplTestUnit.logger.debug("Done: {}", count);
          }
       }
 
@@ -155,9 +155,9 @@ public abstract class JournalImplTestUnit extends JournalImplTestBase {
 
       double rate = 1000 * (double) NUMBER_OF_RECORDS / (end - start);
 
-      JournalImplTestUnit.log.info("Rate of {} adds/removes per sec", rate);
+      JournalImplTestUnit.logger.info("Rate of {} adds/removes per sec", rate);
 
-      JournalImplTestUnit.log.debug("Reclaim status = {}", debugJournal());
+      JournalImplTestUnit.logger.debug("Reclaim status = {}", debugJournal());
 
       stopJournal();
       createJournal();
@@ -213,13 +213,13 @@ public abstract class JournalImplTestUnit extends JournalImplTestBase {
          long end = System.currentTimeMillis();
 
          for (double rate : rates) {
-            JournalImplTestUnit.log.info("Transaction Rate = {} records/sec", rate);
+            JournalImplTestUnit.logger.info("Transaction Rate = {} records/sec", rate);
 
          }
 
          double rate = 1000 * (double) numMessages / (end - start);
 
-         JournalImplTestUnit.log.info("Rate {} records/sec", rate);
+         JournalImplTestUnit.logger.info("Rate {} records/sec", rate);
       } finally {
          journal.stop();
       }
@@ -235,7 +235,7 @@ public abstract class JournalImplTestUnit extends JournalImplTestBase {
          numFiles = 2;
       }
 
-      JournalImplTestUnit.log.debug("num Files={}", numFiles);
+      JournalImplTestUnit.logger.debug("num Files={}", numFiles);
 
       Journal journal = new JournalImpl(10 * 1024 * 1024, numFiles, numFiles, 0, 0, getFileFactory(), "activemq-data", "amq", 5000);
 
@@ -243,7 +243,7 @@ public abstract class JournalImplTestUnit extends JournalImplTestBase {
 
       journal.load(new ArrayList<RecordInfo>(), null, null);
 
-      JournalImplTestUnit.log.debug("Adding data");
+      JournalImplTestUnit.logger.debug("Adding data");
       SimpleEncoding data = new SimpleEncoding(700, (byte) 'j');
 
       long start = System.currentTimeMillis();
@@ -256,7 +256,7 @@ public abstract class JournalImplTestUnit extends JournalImplTestBase {
 
       double rate = 1000 * (double) numMessages / (end - start);
 
-      JournalImplTestUnit.log.info("Rate {} records/sec", rate);
+      JournalImplTestUnit.logger.info("Rate {} records/sec", rate);
 
       journal.stop();
 

--- a/tests/performance-tests/src/test/java/org/apache/activemq/artemis/tests/performance/journal/RealJournalImplAIOTest.java
+++ b/tests/performance-tests/src/test/java/org/apache/activemq/artemis/tests/performance/journal/RealJournalImplAIOTest.java
@@ -28,7 +28,7 @@ import java.lang.invoke.MethodHandles;
 
 public class RealJournalImplAIOTest extends JournalImplTestUnit {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @BeforeClass
    public static void hasAIO() {
@@ -45,7 +45,7 @@ public class RealJournalImplAIOTest extends JournalImplTestUnit {
    protected SequentialFileFactory getFileFactory() throws Exception {
       File file = new File(getTestDir());
 
-      RealJournalImplAIOTest.log.debug("deleting directory {}", file);
+      RealJournalImplAIOTest.logger.debug("deleting directory {}", file);
 
       deleteDirectory(file);
 

--- a/tests/performance-tests/src/test/java/org/apache/activemq/artemis/tests/performance/journal/RealJournalImplNIOTest.java
+++ b/tests/performance-tests/src/test/java/org/apache/activemq/artemis/tests/performance/journal/RealJournalImplNIOTest.java
@@ -26,13 +26,13 @@ import java.lang.invoke.MethodHandles;
 
 public class RealJournalImplNIOTest extends JournalImplTestUnit {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Override
    protected SequentialFileFactory getFileFactory() throws Exception {
       File file = new File(getTestDir());
 
-      RealJournalImplNIOTest.log.debug("deleting directory {}", getTestDir());
+      RealJournalImplNIOTest.logger.debug("deleting directory {}", getTestDir());
 
       deleteDirectory(file);
 

--- a/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/crossprotocol/MultiThreadConvertTest.java
+++ b/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/crossprotocol/MultiThreadConvertTest.java
@@ -51,7 +51,7 @@ public class MultiThreadConvertTest extends SmokeTestBase {
 
    private static final String SERVER_NAME_0 = "standard";
 
-   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Before
    public void before() throws Exception {
@@ -130,7 +130,7 @@ public class MultiThreadConvertTest extends SmokeTestBase {
                   }
 
                } catch (Throwable t) {
-                  LOG.error("Error during message consumption: ", t);
+                  logger.error("Error during message consumption: ", t);
                   error.set(true);
                } finally {
                   try {

--- a/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/replicationflow/SoakPagingTest.java
+++ b/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/replicationflow/SoakPagingTest.java
@@ -70,7 +70,7 @@ import java.lang.invoke.MethodHandles;
 @RunWith(Parameterized.class)
 public class SoakPagingTest extends SmokeTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    public static final int LAG_CONSUMER_TIME = 1000;
    public static final int TIME_RUNNING = 4000;
@@ -182,23 +182,23 @@ public class SoakPagingTest extends SmokeTestBase {
             t.start();
          }
 
-         log.debug("Awaiting producers...");
+         logger.debug("Awaiting producers...");
          if (!producersLatch.await(30000, TimeUnit.MILLISECONDS)) {
             System.err.println("Awaiting producers timeout");
             System.exit(0);
          }
 
-         log.debug("Awaiting consumers...");
+         logger.debug("Awaiting consumers...");
          if (!consumersLatch.await(30000, TimeUnit.MILLISECONDS)) {
             System.err.println("Awaiting consumers timeout");
             System.exit(0);
          }
 
-         log.debug("Awaiting timeout...");
+         logger.debug("Awaiting timeout...");
          Thread.sleep(time);
 
          int exitStatus = consumed.get() > 0 ? 1 : 0;
-         log.debug("Exiting with the status: {}", exitStatus);
+         logger.debug("Exiting with the status: {}", exitStatus);
          System.exit(exitStatus);
       } catch (Throwable t) {
          System.err.println("Exiting with the status 0. Reason: " + t);
@@ -231,7 +231,7 @@ public class SoakPagingTest extends SmokeTestBase {
          System.out.println("*******************************************************************************************************************************");
          ExecuteUtil.runCommand(true, 1, TimeUnit.MINUTES, "jstack", "" + server0.pid());
       } catch (Throwable e) {
-         log.warn("Error executing jstack on Server 0", e);
+         logger.warn("Error executing jstack on Server 0", e);
       }
       try {
          System.out.println("*******************************************************************************************************************************");
@@ -239,7 +239,7 @@ public class SoakPagingTest extends SmokeTestBase {
          System.out.println("*******************************************************************************************************************************");
          ExecuteUtil.runCommand(true, 1, TimeUnit.MINUTES, "jstack", "" + server1.pid());
       } catch (Throwable e) {
-         log.warn("Error executing jstack on Server 1", e);
+         logger.warn("Error executing jstack on Server 1", e);
       }
    }
 
@@ -255,7 +255,7 @@ public class SoakPagingTest extends SmokeTestBase {
          latch.countDown();
 
          connection.start();
-         log.debug("Producer{} started", index);
+         logger.debug("Producer{} started", index);
 
          final Session session;
 
@@ -289,7 +289,7 @@ public class SoakPagingTest extends SmokeTestBase {
             produced.incrementAndGet();
             i++;
             if (i % 100 == 0) {
-               log.debug("Producer{} published {} messages", index, i);
+               logger.debug("Producer{} published {} messages", index, i);
                if (transaction) {
                   session.commit();
                }
@@ -334,17 +334,17 @@ public class SoakPagingTest extends SmokeTestBase {
 
          latch.countDown();
          connection.start();
-         log.debug("Consumer{} started", index);
+         logger.debug("Consumer{} started", index);
 
          int i = 0;
          while (true) {
             Message m = messageConsumer.receive(1000);
             consumed.incrementAndGet();
             if (m == null)
-               log.debug("Consumer{} received null", index);
+               logger.debug("Consumer{} received null", index);
             i++;
             if (i % 100 == 0) {
-               log.debug("Consumer{} received {} messages", index, i);
+               logger.debug("Consumer{} received {} messages", index, i);
                if (transaction) {
                   session.commit();
                }

--- a/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/client/ClientAbstract.java
+++ b/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/client/ClientAbstract.java
@@ -38,7 +38,7 @@ import java.lang.invoke.MethodHandles;
  */
 public abstract class ClientAbstract extends Thread {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    protected ClientSession session;
 
@@ -104,7 +104,7 @@ public abstract class ClientAbstract extends Thread {
 
             break;
          } catch (Exception e) {
-            ClientAbstract.log.warn("Can't connect to server, retrying");
+            ClientAbstract.logger.warn("Can't connect to server, retrying");
             disconnect();
             try {
                Thread.sleep(1000);

--- a/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/paging/MultipleConsumersPageStressTest.java
+++ b/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/paging/MultipleConsumersPageStressTest.java
@@ -43,7 +43,7 @@ import java.lang.invoke.MethodHandles;
 
 public class MultipleConsumersPageStressTest extends ActiveMQTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
 
    private static final int TIME_TO_RUN = 60 * 1000;
@@ -317,7 +317,7 @@ public class MultipleConsumersPageStressTest extends ActiveMQTestBase {
                for (int i = 0; i < numberOfMessages; i++) {
                   ClientMessage msg = consumer.receive(10000);
                   if (msg == null) {
-                     log.warn("msg {} was null, currentBatchSize={}, current msg being read={}", count, numberOfMessages, i);
+                     logger.warn("msg {} was null, currentBatchSize={}, current msg being read={}", count, numberOfMessages, i);
                   }
                   Assert.assertNotNull("msg " + count +
                                           " was null, currentBatchSize=" +

--- a/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/remote/PingStressTest.java
+++ b/tests/stress-tests/src/test/java/org/apache/activemq/artemis/tests/stress/remote/PingStressTest.java
@@ -38,7 +38,7 @@ import java.lang.invoke.MethodHandles;
 
 public class PingStressTest extends ActiveMQTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private static final long PING_INTERVAL = 500;
 
@@ -75,9 +75,9 @@ public class PingStressTest extends ActiveMQTestBase {
       Interceptor noPongInterceptor = new Interceptor() {
          @Override
          public boolean intercept(final Packet packet, final RemotingConnection conn) throws ActiveMQException {
-            PingStressTest.log.info("In interceptor, packet is {}", packet.getType());
+            PingStressTest.logger.info("In interceptor, packet is {}", packet.getType());
             if (packet.getType() == PacketImpl.PING) {
-               PingStressTest.log.info("Ignoring Ping packet.. it will be dropped");
+               PingStressTest.logger.info("Ignoring Ping packet.. it will be dropped");
                return false;
             } else {
                return true;

--- a/tests/timing-tests/src/test/java/org/apache/activemq/artemis/tests/timing/core/journal/impl/JournalImplTestUnit.java
+++ b/tests/timing-tests/src/test/java/org/apache/activemq/artemis/tests/timing/core/journal/impl/JournalImplTestUnit.java
@@ -31,7 +31,7 @@ import java.lang.invoke.MethodHandles;
 
 public abstract class JournalImplTestUnit extends JournalImplTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Override
    @After
@@ -143,7 +143,7 @@ public abstract class JournalImplTestUnit extends JournalImplTestBase {
          }
 
          if (count % 100 == 0) {
-            JournalImplTestUnit.log.debug("Done: {}", count);
+            JournalImplTestUnit.logger.debug("Done: {}", count);
          }
       }
 
@@ -151,9 +151,9 @@ public abstract class JournalImplTestUnit extends JournalImplTestBase {
 
       double rate = 1000 * (double) NUMBER_OF_RECORDS / (end - start);
 
-      log.debug("Rate of {} adds/removes per sec", rate);
+      logger.debug("Rate of {} adds/removes per sec", rate);
 
-      log.debug("Reclaim status = {}", debugJournal());
+      logger.debug("Reclaim status = {}", debugJournal());
 
       stopJournal();
       createJournal();

--- a/tests/timing-tests/src/test/java/org/apache/activemq/artemis/tests/timing/core/server/impl/QueueConcurrentTest.java
+++ b/tests/timing-tests/src/test/java/org/apache/activemq/artemis/tests/timing/core/server/impl/QueueConcurrentTest.java
@@ -43,7 +43,7 @@ import java.lang.invoke.MethodHandles;
  */
 public class QueueConcurrentTest extends ActiveMQTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private FakeQueueFactory queueFactory = new FakeQueueFactory();
 
@@ -101,9 +101,9 @@ public class QueueConcurrentTest extends ActiveMQTestBase {
 
       assertRefListsIdenticalRefs(sender.getReferences(), consumer.getReferences());
 
-      log.info("num refs: {}", sender.getReferences().size());
+      logger.info("num refs: {}", sender.getReferences().size());
 
-      log.info("num toggles: {}", toggler.getNumToggles());
+      logger.info("num toggles: {}", toggler.getNumToggles());
 
    }
 

--- a/tests/timing-tests/src/test/java/org/apache/activemq/artemis/tests/timing/jms/bridge/impl/JMSBridgeImplTest.java
+++ b/tests/timing-tests/src/test/java/org/apache/activemq/artemis/tests/timing/jms/bridge/impl/JMSBridgeImplTest.java
@@ -75,7 +75,7 @@ import java.lang.invoke.MethodHandles;
 
 public class JMSBridgeImplTest extends ActiveMQTestBase {
 
-   private static Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
 
    private static final String SOURCE = RandomUtil.randomString();
@@ -432,7 +432,7 @@ public class JMSBridgeImplTest extends ActiveMQTestBase {
       for (int i = 0; i < numMessages - 1; i++) {
          TextMessage msg = sourceSess.createTextMessage();
          producer.send(msg);
-         log.info("sent message {}", i);
+         logger.info("sent message {}", i);
       }
 
       Thread.sleep(1000);
@@ -500,7 +500,7 @@ public class JMSBridgeImplTest extends ActiveMQTestBase {
       for (int i = 0; i < numMessages; i++) {
          TextMessage msg = sourceSess.createTextMessage();
          producer.send(msg);
-         log.info("sent message {}", i);
+         logger.info("sent message {}", i);
       }
 
       sourceConn.close();

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/AllClassesTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/AllClassesTest.java
@@ -39,7 +39,7 @@ import java.util.List;
 
 @RunWith(value = Parameterized.class)
 public class AllClassesTest {
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Parameterized.Parameters(name = "classInfo={0}")
    public static Collection getParameters() {
@@ -58,7 +58,7 @@ public class AllClassesTest {
                      parameters.add(loadedClass);
                   }
                } catch (Throwable loadThrowable) {
-                  log.debug("cannot load {} : {}", classInfo.getName(), loadThrowable);
+                  logger.debug("cannot load {} : {}", classInfo.getName(), loadThrowable);
                }
             }
          }
@@ -67,7 +67,7 @@ public class AllClassesTest {
 
          return parameters;
       } catch (Exception e) {
-         log.warn("Exception on loading all classes: {}", e.toString());
+         logger.warn("Exception on loading all classes: {}", e.toString());
       }
 
       return parameters;
@@ -87,20 +87,20 @@ public class AllClassesTest {
       try {
          targetInstance = newInstance(targetClass);
       } catch (Throwable t) {
-         log.debug("Error creating a new instance of {}: {}", targetClass.getName(), t);
+         logger.debug("Error creating a new instance of {}: {}", targetClass.getName(), t);
       }
 
       Assume.assumeTrue("Cannot create " + targetClass.getName(), targetInstance != null);
 
       try {
          String targetOutput = targetInstance.toString();
-         log.debug("targetOutput: {}", targetOutput);
+         logger.debug("targetOutput: {}", targetOutput);
       } finally {
          if (targetInstance instanceof AutoCloseable) {
             try {
                ((AutoCloseable)targetInstance).close();
             } catch (Throwable t) {
-               log.debug("Error closing the instance of {}: {}", targetClass.getName(), t);
+               logger.debug("Error closing the instance of {}: {}", targetClass.getName(), t);
             }
          }
       }
@@ -142,8 +142,8 @@ public class AllClassesTest {
          try {
             return targetConstructor.newInstance(initArgs.toArray());
          } catch (Throwable t) {
-            if (log.isDebugEnabled()) {
-               log.debug("Cannot construct {}: {}", targetClass.getName(), t);
+            if (logger.isDebugEnabled()) {
+               logger.debug("Cannot construct {}: {}", targetClass.getName(), t);
             }
          }
       }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/asyncio/MultiThreadAsynchronousFileTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/asyncio/MultiThreadAsynchronousFileTest.java
@@ -47,7 +47,7 @@ import java.lang.invoke.MethodHandles;
  */
 public class MultiThreadAsynchronousFileTest extends AIOTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @BeforeClass
    public static void hasAIO() {
@@ -93,7 +93,7 @@ public class MultiThreadAsynchronousFileTest extends AIOTestBase {
    }
 
    private void executeTest(final boolean sync) throws Throwable {
-      log.debug(sync ? "Sync test:" : "Async test");
+      logger.debug(sync ? "Sync test:" : "Async test");
 
       AIOSequentialFileFactory factory = new AIOSequentialFileFactory(getTestDirfile(), 100);
       factory.start();
@@ -102,11 +102,11 @@ public class MultiThreadAsynchronousFileTest extends AIOTestBase {
       AIOSequentialFile file = (AIOSequentialFile) factory.createSequentialFile(fileName);
       file.open();
       try {
-         log.debug("Preallocating file");
+         logger.debug("Preallocating file");
 
          file.fill(MultiThreadAsynchronousFileTest.NUMBER_OF_THREADS *
                       MultiThreadAsynchronousFileTest.SIZE * MultiThreadAsynchronousFileTest.NUMBER_OF_LINES);
-         log.debug("Done Preallocating file");
+         logger.debug("Done Preallocating file");
 
          CountDownLatch latchStart = new CountDownLatch(MultiThreadAsynchronousFileTest.NUMBER_OF_THREADS + 1);
 
@@ -134,7 +134,7 @@ public class MultiThreadAsynchronousFileTest extends AIOTestBase {
          long numRecords = NUMBER_OF_THREADS * NUMBER_OF_LINES;
          long rate = numRecords * 1000 / duration;
 
-         log.info("{} result: Records/Second = {} total time = {} total number of records = {}", (sync ? "Sync" : "Async"), rate, duration, numRecords);
+         logger.info("{} result: Records/Second = {} total time = {} total number of records = {}", (sync ? "Sync" : "Async"), rate, duration, numRecords);
       } finally {
          file.close();
          factory.stop();

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/AlignedJournalImplTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/AlignedJournalImplTest.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
 import java.lang.invoke.MethodHandles;
 
 public class AlignedJournalImplTest extends ActiveMQTestBase {
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
 
    private static final LoaderCallback dummyLoader = new LoaderCallback() {
@@ -261,9 +261,9 @@ public class AlignedJournalImplTest extends ActiveMQTestBase {
 
       Assert.assertEquals(2, factory.listFiles("tt").size());
 
-      log.debug("Initial:--> {}", journalImpl.debug());
+      logger.debug("Initial:--> {}", journalImpl.debug());
 
-      log.debug("_______________________________");
+      logger.debug("_______________________________");
 
       for (int i = 0; i < 50; i++) {
          journalImpl.appendAddRecord(i, (byte) 1, new SimpleEncoding(1, (byte) 'x'), false);
@@ -305,9 +305,9 @@ public class AlignedJournalImplTest extends ActiveMQTestBase {
 
       Assert.assertEquals(2, factory.listFiles("tt").size());
 
-      log.debug("Initial:--> {}", journalImpl.debug());
+      logger.debug("Initial:--> {}", journalImpl.debug());
 
-      log.debug("_______________________________");
+      logger.debug("_______________________________");
 
       for (int i = 0; i < 50; i++) {
          journalImpl.appendAddRecord(i, (byte) 1, new SimpleEncoding(1, (byte) 'x'), false);
@@ -339,15 +339,15 @@ public class AlignedJournalImplTest extends ActiveMQTestBase {
 
       journalImpl.checkReclaimStatus();
 
-      log.debug(journalImpl.debug());
+      logger.debug(journalImpl.debug());
 
       journalImpl.debugWait();
 
-      log.debug("Final:--> {}", journalImpl.debug());
+      logger.debug("Final:--> {}", journalImpl.debug());
 
-      log.debug("_______________________________");
+      logger.debug("_______________________________");
 
-      log.debug("Files bufferSize: {}", factory.listFiles("tt").size());
+      logger.debug("Files bufferSize: {}", factory.listFiles("tt").size());
 
       Assert.assertEquals(2, factory.listFiles("tt").size());
 
@@ -375,7 +375,7 @@ public class AlignedJournalImplTest extends ActiveMQTestBase {
          // forgotten (interrupted by a reload).
          Assert.fail("Supposed to throw exception");
       } catch (Exception e) {
-         log.warn(e.getMessage(), e);
+         logger.warn(e.getMessage(), e);
       }
 
       setupAndLoadJournal(JOURNAL_SIZE, 100);
@@ -423,7 +423,7 @@ public class AlignedJournalImplTest extends ActiveMQTestBase {
          // forgotten (interrupted by a reload).
          Assert.fail("Supposed to throw exception");
       } catch (Exception e) {
-         log.debug("Got an expected exception:", e);
+         logger.debug("Got an expected exception:", e);
       }
 
       setupAndLoadJournal(JOURNAL_SIZE, 100);
@@ -530,7 +530,7 @@ public class AlignedJournalImplTest extends ActiveMQTestBase {
 
       journalImpl.debugWait();
 
-      log.debug("Files = {}", factory.listFiles("tt"));
+      logger.debug("Files = {}", factory.listFiles("tt"));
 
       SequentialFile file = factory.createSequentialFile("tt-1.tt");
 
@@ -1327,7 +1327,7 @@ public class AlignedJournalImplTest extends ActiveMQTestBase {
          public void failedTransaction(final long transactionID,
                                        final List<RecordInfo> records,
                                        final List<RecordInfo> recordsToDelete) {
-            log.debug("records.length = {}", records.size());
+            logger.debug("records.length = {}", records.size());
             incompleteTransactions.add(transactionID);
          }
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/JournalImplTestBase.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/JournalImplTestBase.java
@@ -67,7 +67,7 @@ public abstract class JournalImplTestBase extends ActiveMQTestBase {
       }
    }
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    protected List<RecordInfo> records = new LinkedList<>();
 
@@ -255,7 +255,7 @@ public abstract class JournalImplTestBase extends ActiveMQTestBase {
     * @throws Exception
     */
    protected void exportImportJournal() throws Exception {
-      log.debug("Exporting to {}/output.log", getTestDir());
+      logger.debug("Exporting to {}/output.log", getTestDir());
 
       EncodeJournal.exportJournal(getTestDir(), this.filePrefix, this.fileExtension, this.minFiles, this.fileSize, getTestDir() + "/output.log");
 
@@ -268,12 +268,12 @@ public abstract class JournalImplTestBase extends ActiveMQTestBase {
          }
       };
 
-      log.debug("file = {}", dir);
+      logger.debug("file = {}", dir);
 
       File[] files = dir.listFiles(fnf);
 
       for (File file : files) {
-         log.debug("Deleting {}", file);
+         logger.debug("Deleting {}", file);
          file.delete();
       }
 
@@ -679,7 +679,7 @@ public abstract class JournalImplTestBase extends ActiveMQTestBase {
          expectedSet.removeAll(actualSet);
 
          for (RecordInfo info : expectedSet) {
-            log.warn("The following record is missing:: {}", info);
+            logger.warn("The following record is missing:: {}", info);
          }
 
          Assert.assertEquals("There are duplicates on the actual list", actualSet.size(), actualSet.size());
@@ -695,29 +695,29 @@ public abstract class JournalImplTestBase extends ActiveMQTestBase {
          HashSet<RecordInfo> hashExpected = new HashSet<>();
          hashExpected.addAll(expected);
 
-         log.debug("#Summary **********************************************************************************************************************");
+         logger.debug("#Summary **********************************************************************************************************************");
          for (RecordInfo r : hashActual) {
             if (!hashExpected.contains(r)) {
-               log.debug("Record {} was supposed to be removed and it exists", r);
+               logger.debug("Record {} was supposed to be removed and it exists", r);
             }
          }
 
          for (RecordInfo r : hashExpected) {
             if (!hashActual.contains(r)) {
-               log.debug("Record {} was not found on actual list", r);
+               logger.debug("Record {} was not found on actual list", r);
             }
          }
 
-         log.debug("#expected **********************************************************************************************************************");
+         logger.debug("#expected **********************************************************************************************************************");
          for (RecordInfo recordInfo : expected) {
-            log.debug("Record::{}", recordInfo);
+            logger.debug("Record::{}", recordInfo);
          }
-         log.debug("#actual ************************************************************************************************************************");
+         logger.debug("#actual ************************************************************************************************************************");
          for (RecordInfo recordInfo : actual) {
-            log.debug("Record::{}", recordInfo);
+            logger.debug("Record::{}", recordInfo);
          }
 
-         log.debug("#records ***********************************************************************************************************************");
+         logger.debug("#records ***********************************************************************************************************************");
 
          try {
             describeJournal(journal.getFileFactory(), (JournalImpl) journal, journal.getFileFactory().getDirectory(), System.out);

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/JournalImplTestUnit.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/JournalImplTestUnit.java
@@ -41,7 +41,7 @@ import org.junit.Test;
 
 public abstract class JournalImplTestUnit extends JournalImplTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Override
    @After
@@ -735,7 +735,7 @@ public abstract class JournalImplTestUnit extends JournalImplTestBase {
 
       int addRecordsPerFile = calculateRecordsPerFile(10 * 1024, journal.getAlignment(), JournalImpl.SIZE_ADD_RECORD + 1 + recordLength);
 
-      log.debug("{}", (JournalImpl.SIZE_ADD_RECORD + 1 + recordLength));
+      logger.debug("{}", (JournalImpl.SIZE_ADD_RECORD + 1 + recordLength));
 
       // Fills exactly 10 files
       int initialNumberOfAddRecords = addRecordsPerFile * 10;
@@ -1084,8 +1084,8 @@ public abstract class JournalImplTestUnit extends JournalImplTestBase {
 
       journal.debugWait();
 
-      if (log.isDebugEnabled()) {
-         log.debug("journal tmp : {}", journal.debug());
+      if (logger.isDebugEnabled()) {
+         logger.debug("journal tmp : {}", journal.debug());
       }
 
       journal.processBackup();
@@ -1104,8 +1104,8 @@ public abstract class JournalImplTestUnit extends JournalImplTestBase {
 
       journal.debugWait();
 
-      if (log.isDebugEnabled()) {
-         log.debug("journal tmp2 : {}", journal.debug());
+      if (logger.isDebugEnabled()) {
+         logger.debug("journal tmp2 : {}", journal.debug());
       }
 
       journal.processBackup();
@@ -1114,8 +1114,8 @@ public abstract class JournalImplTestUnit extends JournalImplTestBase {
       Assert.assertEquals(4, files3.size());
       Assert.assertEquals(1, journal.getOpenedFilesCount());
 
-      log.debug("data files count {}", journal.getDataFilesCount());
-      log.debug("free files count {}", journal.getFreeFilesCount());
+      logger.debug("data files count {}", journal.getDataFilesCount());
+      logger.debug("free files count {}", journal.getFreeFilesCount());
 
       Assert.assertEquals(2, journal.getDataFilesCount());
       Assert.assertEquals(0, journal.getFreeFilesCount());
@@ -1165,8 +1165,8 @@ public abstract class JournalImplTestUnit extends JournalImplTestBase {
 
       journal.checkReclaimStatus();
 
-      if (log.isDebugEnabled()) {
-         log.debug("journal: {}", journal.debug());
+      if (logger.isDebugEnabled()) {
+         logger.debug("journal: {}", journal.debug());
       }
       stopJournal(false);
       createJournal();
@@ -2025,8 +2025,8 @@ public abstract class JournalImplTestUnit extends JournalImplTestBase {
 
       addWithSize(1024 - JournalImpl.SIZE_ADD_RECORD, 6);
 
-      if (log.isDebugEnabled()) {
-         log.debug("Debug journal on testPrepareReclaim ->\n{}", debugJournal());
+      if (logger.isDebugEnabled()) {
+         logger.debug("Debug journal on testPrepareReclaim ->\n{}", debugJournal());
       }
 
       Assert.assertEquals(1, journal.getOpenedFilesCount());
@@ -3067,8 +3067,8 @@ public abstract class JournalImplTestUnit extends JournalImplTestBase {
       addTx(4, 31);
       commit(3);
 
-      if (log.isDebugEnabled()) {
-         log.debug("Debug on Journal before stopJournal - \n{}", debugJournal());
+      if (logger.isDebugEnabled()) {
+         logger.debug("Debug on Journal before stopJournal - \n{}", debugJournal());
       }
 
       stopJournal();
@@ -3110,18 +3110,18 @@ public abstract class JournalImplTestUnit extends JournalImplTestBase {
        * Enable System.outs again if test fails and needs to be debugged
        */
 
-      //      log.debug("Before stop ****************************");
-      //      log.debug(journal.debug());
-      //      log.debug("*****************************************");
+      //      logger.debug("Before stop ****************************");
+      //      logger.debug(journal.debug());
+      //      logger.debug("*****************************************");
 
       stopJournal();
       createJournal();
       startJournal();
       loadAndCheck();
 
-      //      log.debug("After start ****************************");
-      //      log.debug(journal.debug());
-      //      log.debug("*****************************************");
+      //      logger.debug("After start ****************************");
+      //      logger.debug(journal.debug());
+      //      logger.debug("*****************************************");
 
       journal.forceMoveNextFile();
 
@@ -3129,40 +3129,40 @@ public abstract class JournalImplTestUnit extends JournalImplTestBase {
          delete(i);
       }
 
-      //      log.debug("After delete ****************************");
-      //      log.debug(journal.debug());
-      //      log.debug("*****************************************");
+      //      logger.debug("After delete ****************************");
+      //      logger.debug(journal.debug());
+      //      logger.debug("*****************************************");
 
       for (int i = 100; i < 200; i++) {
          updateTx(transactionID, i);
       }
 
-      //      log.debug("After updatetx ****************************");
-      //      log.debug(journal.debug());
-      //      log.debug("*****************************************");
+      //      logger.debug("After updatetx ****************************");
+      //      logger.debug(journal.debug());
+      //      logger.debug("*****************************************");
 
       journal.forceMoveNextFile();
 
       commit(transactionID++);
 
-      //      log.debug("After commit ****************************");
-      //      log.debug(journal.debug());
-      //      log.debug("*****************************************");
+      //      logger.debug("After commit ****************************");
+      //      logger.debug(journal.debug());
+      //      logger.debug("*****************************************");
 
       for (int i = 100; i < 200; i++) {
          updateTx(transactionID, i);
          deleteTx(transactionID, i);
       }
 
-      //      log.debug("After delete ****************************");
-      //      log.debug(journal.debug());
-      //      log.debug("*****************************************");
+      //      logger.debug("After delete ****************************");
+      //      logger.debug(journal.debug());
+      //      logger.debug("*****************************************");
 
       commit(transactionID++);
 
-      //      log.debug("Before reclaim/after commit ****************************");
-      //      log.debug(journal.debug());
-      //      log.debug("*****************************************");
+      //      logger.debug("Before reclaim/after commit ****************************");
+      //      logger.debug(journal.debug());
+      //      logger.debug("*****************************************");
 
       journal.processBackup();
       stopJournal();
@@ -3170,9 +3170,9 @@ public abstract class JournalImplTestUnit extends JournalImplTestBase {
       startJournal();
       loadAndCheck();
 
-      //      log.debug("After reclaim ****************************");
-      //      log.debug(journal.debug());
-      //      log.debug("*****************************************");
+      //      logger.debug("After reclaim ****************************");
+      //      logger.debug(journal.debug());
+      //      logger.debug("*****************************************");
 
       journal.forceMoveNextFile();
       checkAndReclaimFiles();

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/TimedBufferTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/TimedBufferTest.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
 import java.lang.invoke.MethodHandles;
 
 public class TimedBufferTest extends ActiveMQTestBase {
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
 
    private static final int ONE_SECOND_IN_NANOS = 1000000000; // in nanoseconds
@@ -164,7 +164,7 @@ public class TimedBufferTest extends ActiveMQTestBase {
       IOCallback callback = new IOCallback() {
          @Override
          public void done() {
-            log.debug("done");
+            logger.debug("done");
             latchFlushed.countDown();
          }
 
@@ -385,7 +385,7 @@ public class TimedBufferTest extends ActiveMQTestBase {
          assert observer.flushesDone() == 2;
          //it is much more than what is expected!!if it will fail it means that the timed IOPS = 1/(timeout + blockingDeviceFlushTime)!!!!!!
          //while it has to be IOPS = 1/timeout
-         log.debug("elapsed time: {} with timeout: {}", elapsedTime, timeout);
+         logger.debug("elapsed time: {} with timeout: {}", elapsedTime, timeout);
          final long maxExpected = timeout + deviceTime;
          Assert.assertTrue("elapsed = " + elapsedTime + " max expected = " + maxExpected, elapsedTime <= maxExpected);
       } finally {
@@ -426,7 +426,7 @@ public class TimedBufferTest extends ActiveMQTestBase {
          assert observer.flushesDone() == 2;
          //it is much more than what is expected!!if it will fail it means that the timed IOPS = 1/(timeout + blockingDeviceFlushTime)!!!!!!
          //while it has to be IOPS = 1/timeout
-         log.debug("elapsed time: {} with timeout: {}", elapsedTime, timeout);
+         logger.debug("elapsed time: {} with timeout: {}", elapsedTime, timeout);
          final long maxExpected = timeout + deviceTime;
          Assert.assertTrue("elapsed = " + elapsedTime + " max expected = " + maxExpected, elapsedTime <= maxExpected);
       } finally {

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/message/impl/MessageImplTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/message/impl/MessageImplTest.java
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
 import java.lang.invoke.MethodHandles;
 
 public class MessageImplTest extends ActiveMQTestBase {
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Test
    public void getSetAttributes() {
@@ -242,7 +242,7 @@ public class MessageImplTest extends ActiveMQTestBase {
    public void testMessageCopyIssue() throws Exception {
       for (long i = 0; i < 300; i++) {
          if (i % 10 == 0)
-            log.debug("#test {}", i);
+            logger.debug("#test {}", i);
          internalMessageCopy();
       }
    }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/paging/impl/PagingStoreImplTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/paging/impl/PagingStoreImplTest.java
@@ -91,7 +91,7 @@ import java.lang.invoke.MethodHandles;
 import static org.apache.activemq.artemis.logs.AssertionLoggerHandler.findText;
 
 public class PagingStoreImplTest extends ActiveMQTestBase {
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    static {
       MessagePersister.registerPersister(CoreMessagePersister.getInstance());
@@ -280,8 +280,8 @@ public class PagingStoreImplTest extends ActiveMQTestBase {
       storeImpl.start();
 
       for (int repeat = 0; repeat < 5; repeat++) {
-         log.debug("###############################################################################################################################");
-         log.debug("#repeat {}", repeat);
+         logger.debug("###############################################################################################################################");
+         logger.debug("#repeat {}", repeat);
 
          storeImpl.startPaging();
          Assert.assertEquals(1, storeImpl.getNumberOfPages());
@@ -323,7 +323,7 @@ public class PagingStoreImplTest extends ActiveMQTestBase {
          }
          iterator.close();
 
-         if (log.isDebugEnabled()) {
+         if (logger.isDebugEnabled()) {
             debugPage(storeImpl, subscription, storeImpl.getFirstPage(), storeImpl.getCurrentWritingPage());
          }
 
@@ -341,7 +341,7 @@ public class PagingStoreImplTest extends ActiveMQTestBase {
 
             Assert.assertTrue(subscription.contains(reference));
 
-            log.debug("#received message {}, {}", messagesRead, reference);
+            logger.debug("#received message {}, {}", messagesRead, reference);
             messagesRead++;
             int pageOnMsg = reference.getMessage().getIntProperty("page");
             Assert.assertTrue("received " + reference, pageOnMsg <= 2 || pageOnMsg >= 10);
@@ -368,7 +368,7 @@ public class PagingStoreImplTest extends ActiveMQTestBase {
       for (long pgID = startPage; pgID <= endPage; pgID++) {
          Page page = storeImpl.newPageObject(pgID);
          page.open(false);
-         log.debug("# Page {}", pgID);
+         logger.debug("# Page {}", pgID);
          page.getMessages().forEach(p -> {
             String acked;
             try {
@@ -377,7 +377,7 @@ public class PagingStoreImplTest extends ActiveMQTestBase {
                e.printStackTrace();
                acked = "";
             }
-            log.debug("{}{}", acked, p);
+            logger.debug("{}{}", acked, p);
          });
          page.close(false);
       }
@@ -400,7 +400,7 @@ public class PagingStoreImplTest extends ActiveMQTestBase {
 
       for (int repeat = 0; repeat < 5; repeat++) {
 
-         log.debug("#repeat {}", repeat);
+         logger.debug("#repeat {}", repeat);
 
          storeImpl.startPaging();
 
@@ -579,7 +579,7 @@ public class PagingStoreImplTest extends ActiveMQTestBase {
       for (int pageNr = 0; pageNr < 2; pageNr++) {
          Page page = store.depage();
 
-         log.debug("numberOfPages = {}", store.getNumberOfPages());
+         logger.debug("numberOfPages = {}", store.getNumberOfPages());
 
          page.open(true);
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/WildcardAddressManagerUnitTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/WildcardAddressManagerUnitTest.java
@@ -51,7 +51,7 @@ import java.lang.invoke.MethodHandles;
  * This test is replicating the behaviour from https://issues.jboss.org/browse/HORNETQ-988.
  */
 public class WildcardAddressManagerUnitTest extends ActiveMQTestBase {
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Test
    public void testUnitOnWildCardFailingScenario() throws Exception {
@@ -486,7 +486,7 @@ public class WildcardAddressManagerUnitTest extends ActiveMQTestBase {
 
       @Override
       public void route(Message message, RoutingContext context) throws Exception {
-         log.debug("routing message: {}", message);
+         logger.debug("routing message: {}", message);
       }
 
       @Override

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/impl/QueueImplTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/impl/QueueImplTest.java
@@ -65,7 +65,7 @@ import org.slf4j.LoggerFactory;
 import java.lang.invoke.MethodHandles;
 
 public class QueueImplTest extends ActiveMQTestBase {
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    // The tests ----------------------------------------------------------------
 
@@ -235,7 +235,7 @@ public class QueueImplTest extends ActiveMQTestBase {
       float rate = (float) getRate.invoke(queue, null);
 
       Assert.assertTrue(rate <= 10.0f);
-      log.debug("Rate: {}", rate);
+      logger.debug("Rate: {}", rate);
    }
 
    @Test

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/util/RandomUtilDistributionTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/util/RandomUtilDistributionTest.java
@@ -33,7 +33,7 @@ import java.lang.invoke.MethodHandles;
  * This test will start many parallel VMs, to make sure each VM would generate a good distribution of random numbers
  */
 public class RandomUtilDistributionTest {
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Rule
    public SpawnedVMCheck check = new SpawnedVMCheck();
@@ -71,7 +71,7 @@ public class RandomUtilDistributionTest {
       // Be careful removing it (make sure you know what you're doing in case you do so)
       int minimumExpected = (int) ((iterations * numberOfStarts) * 0.80);
 
-      log.debug("values = {}, minimum expected = {}", value, minimumExpected);
+      logger.debug("values = {}, minimum expected = {}", value, minimumExpected);
       Assert.assertTrue("The Random distribution is pretty bad. Many tries have returned duplicated randoms. Number of different values=" + value + ", minimum expected = " + minimumExpected, value >= minimumExpected);
    }
 
@@ -92,7 +92,7 @@ public class RandomUtilDistributionTest {
             valueSet.add(process[i].exitValue());
          }
 
-         log.debug("Generated {} randoms out of {} tries", valueSet.size(), numberOfTries);
+         logger.debug("Generated {} randoms out of {} tries", valueSet.size(), numberOfTries);
 
          return valueSet.size();
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/ra/ActiveMQResourceAdapterConfigTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/ra/ActiveMQResourceAdapterConfigTest.java
@@ -42,7 +42,7 @@ import org.xml.sax.InputSource;
  * add a description for each new property added and try and put it in the config some where appropriate.
  */
 public class ActiveMQResourceAdapterConfigTest extends ActiveMQTestBase {
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private static String config = "" +
       "<config-property>\n" +
@@ -478,7 +478,7 @@ public class ActiveMQResourceAdapterConfigTest extends ActiveMQTestBase {
             newConfig.append("         \"         <config-property-value></config-property-value>\" + \n");
             newConfig.append("         \"      </config-property>\" + \n");
          }
-         log.debug(newConfig.toString());
+         logger.debug(newConfig.toString());
          fail("methods not shown please see previous and add");
       }
    }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/InVMContext.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/InVMContext.java
@@ -42,7 +42,7 @@ import java.lang.invoke.MethodHandles;
 
 public class InVMContext implements Context, Serializable {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
 
    private static final long serialVersionUID = 385743957345L;
@@ -288,7 +288,7 @@ public class InVMContext implements Context, Serializable {
    }
 
    private void internalBind(String name, final Object obj, final boolean rebind) throws NamingException {
-      log.debug("Binding {} obj {} rebind {}", name, obj, rebind);
+      logger.debug("Binding {} obj {} rebind {}", name, obj, rebind);
       name = trimSlashes(name);
       int i = name.lastIndexOf("/");
       InVMContext c = this;

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/InVMNamingContext.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/InVMNamingContext.java
@@ -42,7 +42,7 @@ import java.lang.invoke.MethodHandles;
 
 public class InVMNamingContext implements Context, Serializable {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private static final long serialVersionUID = 385743957345L;
 
@@ -288,7 +288,7 @@ public class InVMNamingContext implements Context, Serializable {
    }
 
    private void internalBind(String name, final Object obj, final boolean rebind) throws NamingException {
-      log.debug("Binding {} obj {} rebind {}", name, obj, rebind);
+      logger.debug("Binding {} obj {} rebind {}", name, obj, rebind);
       name = trimSlashes(name);
       int i = name.lastIndexOf("/");
       InVMNamingContext c = this;

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/MemorySizeTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/MemorySizeTest.java
@@ -26,18 +26,18 @@ import org.slf4j.LoggerFactory;
 import java.lang.invoke.MethodHandles;
 
 public class MemorySizeTest extends Assert {
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Test
    public void testObjectSizes() throws Exception {
-      log.info("Server message size is {}", MemorySize.calculateSize(new MemorySize.ObjectFactory() {
+      logger.info("Server message size is {}", MemorySize.calculateSize(new MemorySize.ObjectFactory() {
          @Override
          public Object createObject() {
             return new CoreMessage(1, 1000);
          }
       }));
 
-      log.info("Message reference size is {}", MemorySize.calculateSize(new MemorySize.ObjectFactory() {
+      logger.info("Message reference size is {}", MemorySize.calculateSize(new MemorySize.ObjectFactory() {
          @Override
          public Object createObject() {
             return new MessageReferenceImpl();

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/ReusableLatchTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/ReusableLatchTest.java
@@ -28,7 +28,7 @@ import java.lang.invoke.MethodHandles;
 
 public class ReusableLatchTest extends ActiveMQTestBase {
 
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Test
    public void testLatchWithParameterizedDown() throws Exception {
@@ -86,10 +86,10 @@ public class ReusableLatchTest extends ActiveMQTestBase {
          public void run() {
             try {
                if (!latch.await(5000)) {
-                  log.error("Latch timed out");
+                  logger.error("Latch timed out");
                }
             } catch (Exception e) {
-               log.error(e.getMessage(), e);
+               logger.error(e.getMessage(), e);
             }
             waiting = false;
          }
@@ -117,7 +117,7 @@ public class ReusableLatchTest extends ActiveMQTestBase {
                   latch.countUp();
                }
             } catch (Exception e) {
-               log.error(e.getMessage(), e);
+               logger.error(e.getMessage(), e);
             }
          }
       }
@@ -170,7 +170,7 @@ public class ReusableLatchTest extends ActiveMQTestBase {
                   latch.countDown();
                }
             } catch (Exception e) {
-               log.error(e.getMessage(), e);
+               logger.error(e.getMessage(), e);
             }
          }
       }
@@ -234,10 +234,10 @@ public class ReusableLatchTest extends ActiveMQTestBase {
             readyLatch.countDown();
             try {
                if (!latch.await(1000)) {
-                  log.error("Latch timed out!", new Exception("trace"));
+                  logger.error("Latch timed out!", new Exception("trace"));
                }
             } catch (Exception e) {
-               log.error(e.getMessage(), e);
+               logger.error(e.getMessage(), e);
                this.e = e;
             }
             waiting = false;


### PR DESCRIPTION
Attempt to standardize all Logger declaration to a singular variable name which makes the code more consistent and make finding usages of loggers in the code a bit easier.