### PR TITLE
ARTEMIS-4049 user add fails w/space in broker path

### DIFF
--- a/artemis-cli/src/test/java/org/apache/activemq/cli/test/ArtemisTest.java
+++ b/artemis-cli/src/test/java/org/apache/activemq/cli/test/ArtemisTest.java
@@ -1418,6 +1418,25 @@ public class ArtemisTest extends CliTestBase {
 
          // Checking it was acked before
          assertEquals(Integer.valueOf(100), Artemis.internalExecute("consumer", "--destination", "queue://q1", "--txt-size", "50", "--break-on-null", "--receive-timeout", "100", "--user", "admin", "--password", "admin"));
+
+         //add a simple user
+         AddUser addCmd = new AddUser();
+         addCmd.setUserCommandUser("guest");
+         addCmd.setUserCommandPassword("guest123");
+         addCmd.setRole("admin");
+         addCmd.setUser("admin");
+         addCmd.setPassword("admin");
+         addCmd.execute(new TestActionContext());
+
+         //verify use list cmd
+         TestActionContext context = new TestActionContext();
+         ListUser listCmd = new ListUser();
+         listCmd.setUser("admin");
+         listCmd.setPassword("admin");
+         listCmd.execute(context);
+         String result = context.getStdout();
+
+         assertTrue(result.contains("\"guest\"(admin)"));
       } finally {
          stopServer();
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -26,7 +26,10 @@ import javax.management.NotificationEmitter;
 import javax.management.NotificationFilter;
 import javax.management.NotificationListener;
 import javax.transaction.xa.Xid;
+import java.io.File;
+import java.lang.invoke.MethodHandles;
 import java.net.URL;
+import java.nio.file.Path;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -145,7 +148,6 @@ import org.apache.activemq.artemis.utils.SecurityFormatter;
 import org.apache.activemq.artemis.utils.collections.TypedProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.lang.invoke.MethodHandles;
 
 public class ActiveMQServerControlImpl extends AbstractControl implements ActiveMQServerControl, NotificationEmitter, org.apache.activemq.artemis.core.server.management.NotificationListener {
 
@@ -4535,8 +4537,8 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
       if (configurationUrl == null) {
          throw ActiveMQMessageBundle.BUNDLE.failedToLocateConfigURL();
       }
-      String path = configurationUrl.getPath();
-      return new PropertiesLoginModuleConfigurator(getSecurityDomain(), path.substring(0, path.lastIndexOf("/")));
+      String path = Path.of(configurationUrl.toURI()).toString();
+      return new PropertiesLoginModuleConfigurator(getSecurityDomain(), path.substring(0, path.lastIndexOf(File.separator)));
    }
 
    @Override


### PR DESCRIPTION
This problem was originally discovered on Windows, but the problem occurs on *nix as well.