### PR TITLE
ARTEMIS-4065 Non Persistent Page Counters

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/PrintData.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/PrintData.java
@@ -279,7 +279,7 @@ public class PrintData extends DBOption {
             folder = pgStore.getFolder();
             out.println("####################################################################################################");
             out.println("Exploring store " + store + " folder = " + folder);
-            int pgid = (int) pgStore.getFirstPage();
+            long pgid = pgStore.getFirstPage();
 
             out.println("Number of pages ::" + pgStore.getNumberOfPages() + ", Current writing page ::" + pgStore.getCurrentWritingPage());
             for (int pg = 0; pg < pgStore.getNumberOfPages(); pg++) {

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
@@ -2003,5 +2003,8 @@ public interface ActiveMQServerControl {
 
    @Attribute(desc = "Whether the embedded web server is started")
    boolean isEmbeddedWebServerStarted();
+
+   @Attribute(desc = "Scan all paged destinations to rebuild the page counters")
+   void rebuildPageCounters() throws Exception;
 }
 

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/drivers/AbstractJDBCDriver.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/drivers/AbstractJDBCDriver.java
@@ -67,6 +67,9 @@ public abstract class AbstractJDBCDriver {
    }
 
    public void destroy() throws Exception {
+      if (logger.isTraceEnabled()) {
+         logger.trace("dropping {}", sqlProvider.getTableName(), new Exception("trace"));
+      }
       final String dropTableSql = "DROP TABLE " + sqlProvider.getTableName();
       try (Connection connection = connectionProvider.getConnection()) {
          try {

--- a/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/file/JDBCSequentialFileFactory.java
+++ b/artemis-jdbc-store/src/main/java/org/apache/activemq/artemis/jdbc/store/file/JDBCSequentialFileFactory.java
@@ -141,7 +141,9 @@ public class JDBCSequentialFileFactory implements SequentialFileFactory, ActiveM
       try {
          return dbDriver.listFiles(extension);
       } catch (SQLException e) {
-         criticalErrorListener.onIOException(e, "Error listing JDBC files.", null);
+         // We can't throw critical error here
+         // exists will call listfiles, and if the store does not exists
+         // it should simply return false
          throw e;
       }
    }

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/AbstractSequentialFile.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/AbstractSequentialFile.java
@@ -96,6 +96,9 @@ public abstract class AbstractSequentialFile implements SequentialFile {
    @Override
    public final void delete() throws IOException, InterruptedException, ActiveMQException {
       try {
+         if (logger.isTraceEnabled()) {
+            logger.trace("Deleting {}", this.getFileName(), new Exception("trace"));
+         }
          if (isOpen()) {
             close(false, false);
          }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -45,6 +45,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -4616,6 +4617,15 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
       } catch (Exception e) {
          logger.trace(e.getMessage());
          return false;
+      }
+   }
+
+   @Override
+   public void rebuildPageCounters() throws Exception {
+      // managementLock will guarantee there's only one management operation being called
+      try (AutoCloseable lock = server.managementLock()) {
+         Future<Object> task = server.getPagingManager().rebuildCounters();
+         task.get();
       }
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/PagingManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/PagingManager.java
@@ -17,6 +17,8 @@
 package org.apache.activemq.artemis.core.paging;
 
 import java.util.Map;
+import java.util.concurrent.Future;
+import java.util.function.BiConsumer;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.server.ActiveMQComponent;
@@ -141,6 +143,7 @@ public interface PagingManager extends ActiveMQComponent, HierarchicalRepository
     */
    void checkMemory(Runnable runWhenAvailable);
 
+   void counterSnapshot();
 
    /**
     * Use this when you have no refernce of an address. (anonymous AMQP Producers for example)
@@ -157,4 +160,15 @@ public interface PagingManager extends ActiveMQComponent, HierarchicalRepository
    default long getMaxMessages() {
       return 0;
    }
+
+   /**
+    * Rebuilds all page counters for destinations that are paging in the background.
+    */
+   default Future<Object> rebuildCounters() {
+      return null;
+   }
+
+   default void forEachTransaction(BiConsumer<Long, PageTransactionInfo> transactionConsumer) {
+   }
+
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/PagingStore.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/PagingStore.java
@@ -24,6 +24,7 @@ import org.apache.activemq.artemis.api.core.RefCountMessageListener;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.paging.cursor.PageCursorProvider;
 import org.apache.activemq.artemis.core.paging.impl.Page;
+import org.apache.activemq.artemis.core.persistence.StorageManager;
 import org.apache.activemq.artemis.core.replication.ReplicationManager;
 import org.apache.activemq.artemis.core.server.ActiveMQComponent;
 import org.apache.activemq.artemis.core.server.RouteContextList;
@@ -129,6 +130,9 @@ public interface PagingStore extends ActiveMQComponent, RefCountMessageListener 
 
    Page getCurrentPage();
 
+   /** it will save snapshots on the counters */
+   void counterSnapshot();
+
    /**
     * @return true if paging was started, or false if paging was already started before this call
     */
@@ -220,4 +224,8 @@ public interface PagingStore extends ActiveMQComponent, RefCountMessageListener 
    void block();
 
    void unblock();
+
+   default StorageManager getStorageManager() {
+      return null;
+   }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/ConsumedPage.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/ConsumedPage.java
@@ -17,11 +17,17 @@
 
 package org.apache.activemq.artemis.core.paging.cursor;
 
+import java.util.function.BiConsumer;
+
 // this is to expose PageSubscriptionImpl::PageCursorInfo
 public interface ConsumedPage {
 
    long getPageId();
 
    boolean isDone();
+
+   boolean isAck(int messageNumber);
+
+   void forEachAck(BiConsumer<Integer, PagePosition> ackConsumer);
 
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/PageCursorProvider.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/PageCursorProvider.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.paging.cursor;
 
+import java.util.function.Consumer;
+
 import org.apache.activemq.artemis.core.filter.Filter;
 import org.apache.activemq.artemis.core.paging.PagedMessage;
 
@@ -32,11 +34,15 @@ public interface PageCursorProvider {
     */
    PageSubscription getSubscription(long queueId);
 
+   void forEachSubscription(Consumer<PageSubscription> consumer);
+
    PageSubscription createSubscription(long queueId, Filter filter, boolean durable);
 
    void processReload() throws Exception;
 
    void stop();
+
+   void counterSnapshot();
 
    void flushExecutors();
 
@@ -55,5 +61,9 @@ public interface PageCursorProvider {
     * @param pageCursorImpl
     */
    void close(PageSubscription pageCursorImpl);
+
+   void counterRebuildStarted();
+
+   void counterRebuildDone();
 
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/PageSubscription.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/PageSubscription.java
@@ -35,6 +35,9 @@ public interface PageSubscription {
    // To be called before the server is down
    void stop();
 
+   /** Save a snapshot of the current counter value in the journal */
+   void counterSnapshot();
+
    /**
     * This is a callback to inform the PageSubscription that something was routed, so the empty flag can be cleared
     */
@@ -45,6 +48,8 @@ public interface PageSubscription {
    PageSubscriptionCounter getCounter();
 
    long getMessageCount();
+
+   boolean isCounterPending();
 
    long getPersistentSize();
 
@@ -170,4 +175,6 @@ public interface PageSubscription {
    void incrementDeliveredSize(long size);
 
    void removePendingDelivery(PagedMessage pagedMessage);
+
+   ConsumedPage locatePageInfo(long pageNr);
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/PageSubscriptionCounter.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/PageSubscriptionCounter.java
@@ -16,7 +16,6 @@
  */
 package org.apache.activemq.artemis.core.paging.cursor;
 
-import org.apache.activemq.artemis.core.paging.impl.Page;
 import org.apache.activemq.artemis.core.transaction.Transaction;
 
 public interface PageSubscriptionCounter {
@@ -36,7 +35,13 @@ public interface PageSubscriptionCounter {
 
    void loadInc(long recordInd, int add, long persistentSize);
 
-   void applyIncrementOnTX(Transaction tx, long recordID, int add, long persistentSize);
+   void applyIncrementOnTX(Transaction tx, int add, long persistentSize);
+
+   void markRebuilding();
+
+   void finishRebuild();
+
+   boolean isRebuilding();
 
    /**
     * This will process the reload
@@ -46,12 +51,12 @@ public interface PageSubscriptionCounter {
    // used when deleting the counter
    void delete() throws Exception;
 
-   void pendingCounter(Page page, int increment, long persistentSize) throws Exception;
+   void snapshot();
 
    // used when leaving page mode, so the counters are deleted in batches
    // for each queue on the address
    void delete(Transaction tx) throws Exception;
 
-   void cleanupNonTXCounters(long pageID) throws Exception;
+   PageSubscriptionCounter setSubscription(PageSubscription subscription);
 
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/BasePagingCounter.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/BasePagingCounter.java
@@ -14,13 +14,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.core.io;
+package org.apache.activemq.artemis.core.paging.cursor.impl;
 
-public interface IOCriticalErrorListener {
+import org.apache.activemq.artemis.core.paging.cursor.PageSubscriptionCounter;
 
-   default boolean isPreviouslyFailed() {
-      return false;
+public abstract class BasePagingCounter implements PageSubscriptionCounter {
+
+   private volatile  boolean rebuilding = false;
+
+   @Override
+   public void markRebuilding() {
+      rebuilding = true;
    }
 
-   void onIOException(Throwable code, String message, String file);
+   @Override
+   public void finishRebuild() {
+      rebuilding = false;
+   }
+
+   @Override
+   public boolean isRebuilding() {
+      return rebuilding;
+   }
+
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageCounterRebuildManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageCounterRebuildManager.java
@@ -1,0 +1,327 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.core.paging.cursor.impl;
+
+import io.netty.util.collection.IntObjectHashMap;
+import io.netty.util.collection.LongObjectHashMap;
+import org.apache.activemq.artemis.core.paging.PagedMessage;
+import org.apache.activemq.artemis.core.paging.PagingStore;
+import org.apache.activemq.artemis.core.paging.cursor.ConsumedPage;
+import org.apache.activemq.artemis.core.paging.cursor.PagePosition;
+import org.apache.activemq.artemis.core.paging.cursor.PageSubscription;
+import org.apache.activemq.artemis.core.paging.cursor.PageSubscriptionCounter;
+import org.apache.activemq.artemis.core.paging.impl.Page;
+import org.apache.activemq.artemis.core.persistence.StorageManager;
+import org.apache.activemq.artemis.utils.collections.LinkedList;
+import org.apache.activemq.artemis.utils.collections.LinkedListIterator;
+import org.apache.activemq.artemis.utils.collections.LongHashSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.util.function.BiConsumer;
+
+/** this class will copy current data from the Subscriptions, count messages while the server is already active
+ * performing other activity */
+public class PageCounterRebuildManager implements Runnable {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   private final PagingStore pgStore;
+   private final StorageManager sm;
+   private final LongHashSet transactions;
+   private boolean paging;
+   private long limitPageId;
+   private int limitMessageNr;
+   private LongObjectHashMap<CopiedSubscription> copiedSubscriptionMap = new LongObjectHashMap<>();
+
+
+   public PageCounterRebuildManager(PagingStore store, LongHashSet transactions) {
+      // we make a copy of the data because we are allowing data to influx. We will consolidate the values at the end
+      initialize(store);
+      this.pgStore = store;
+      this.sm = store.getStorageManager();
+      this.transactions = transactions;
+   }
+   /** this method will perform the copy from Acked recorded from the subscription into a separate data structure.
+    * So we can count data while we consolidate at the end */
+   private void initialize(PagingStore store) {
+      store.lock(-1);
+      try {
+         try {
+            paging = store.isPaging();
+            if (!paging) {
+               logger.debug("Destination {} was not paging, no need to rebuild counters");
+               store.getCursorProvider().forEachSubscription(subscription -> {
+                  subscription.getCounter().markRebuilding();
+                  subscription.getCounter().finishRebuild();
+               });
+
+               store.getCursorProvider().counterRebuildDone();
+               return;
+            }
+            store.getCursorProvider().counterRebuildStarted();
+            Page currentPage = store.getCurrentPage();
+            limitPageId = store.getCurrentWritingPage();
+            limitMessageNr = currentPage.getNumberOfMessages();
+            if (logger.isDebugEnabled()) {
+               logger.debug("PageCounterRebuild for {}, Current writing page {} and limit will be {} with lastMessage on last page={}", store.getStoreName(), store.getCurrentWritingPage(), limitPageId, limitMessageNr);
+            }
+         } catch (Exception e) {
+            logger.warn(e.getMessage(), e);
+            limitPageId = store.getCurrentWritingPage();
+         }
+         logger.trace("Copying page store ack information from address {}", store.getAddress());
+         store.getCursorProvider().forEachSubscription(subscription -> {
+            if (logger.isTraceEnabled()) {
+               logger.trace("Copying subscription ID {}", subscription.getId());
+            }
+
+            CopiedSubscription copiedSubscription = new CopiedSubscription(subscription);
+            copiedSubscription.subscriptionCounter.markRebuilding();
+            copiedSubscriptionMap.put(subscription.getId(), copiedSubscription);
+
+            subscription.forEachConsumedPage(consumedPage -> {
+               if (logger.isTraceEnabled()) {
+                  logger.trace("Copying page {}", consumedPage.getPageId());
+               }
+
+               CopiedConsumedPage copiedConsumedPage = new CopiedConsumedPage();
+               copiedSubscription.consumedPageMap.put(consumedPage.getPageId(), copiedConsumedPage);
+               if (consumedPage.isDone()) {
+                  if (logger.isTraceEnabled()) {
+                     logger.trace("Marking page {} as done on the copy", consumedPage.getPageId());
+                  }
+                  copiedConsumedPage.done = true;
+               } else {
+                  // We only copy the acks if the page is not done
+                  // as if the page is done, we just move over
+                  consumedPage.forEachAck((messageNR, pagePosition) -> {
+                     if (logger.isTraceEnabled()) {
+                        logger.trace("Marking messageNR {} as acked on pageID={} copy", messageNR, consumedPage.getPageId());
+                     }
+                     if (copiedConsumedPage.acks == null) {
+                        copiedConsumedPage.acks = new IntObjectHashMap<>();
+                     }
+                     copiedConsumedPage.acks.put(messageNR, Boolean.TRUE);
+                  });
+               }
+            });
+         });
+      } finally {
+         store.unlock();
+      }
+   }
+
+   private synchronized PageSubscriptionCounter getCounter(long queueID) {
+      CopiedSubscription copiedSubscription = copiedSubscriptionMap.get(queueID);
+      if (copiedSubscription != null) {
+         return copiedSubscription.subscriptionCounter;
+      } else {
+         return null;
+      }
+   }
+
+   private CopiedSubscription getSubscription(long queueID) {
+      return copiedSubscriptionMap.get(queueID);
+   }
+
+   private boolean isACK(long queueID, long pageNR, int messageNR) {
+      CopiedSubscription subscription = getSubscription(queueID);
+      if (subscription == null) {
+         return true;
+      }
+
+      CopiedConsumedPage consumedPage = subscription.getPage(pageNR);
+      if (consumedPage == null) {
+         return false;
+      } else {
+         return consumedPage.isAck(messageNR);
+      }
+   }
+
+   private void done() {
+      copiedSubscriptionMap.forEach((k, copiedSubscription) -> {
+         if (!copiedSubscription.empty) {
+            copiedSubscription.subscription.notEmpty();
+            try {
+               copiedSubscription.subscriptionCounter.increment(null, copiedSubscription.addUp, copiedSubscription.sizeUp);
+            } catch (Exception e) {
+               logger.warn(e.getMessage(), e);
+            }
+         }
+         if (!copiedSubscription.empty) {
+            copiedSubscription.subscription.notEmpty();
+         }
+         if (copiedSubscription.subscriptionCounter != null) {
+            copiedSubscription.subscriptionCounter.finishRebuild();
+         }
+      });
+      pgStore.getCursorProvider().counterRebuildDone();
+      pgStore.getCursorProvider().scheduleCleanup();
+   }
+
+   @Override
+   public void run() {
+      try {
+         rebuild();
+      } catch (Exception e) {
+         logger.warn(e.getMessage(), e);
+      }
+   }
+
+   public void rebuild() throws Exception {
+      if (pgStore == null) {
+         logger.debug("Page store is null during rebuildCounters");
+         return;
+      }
+
+      if (!paging) {
+         logger.debug("Ignoring call to rebuild pgStore {}", pgStore.getAddress());
+      }
+
+      logger.debug("Rebuilding counter for store {}", pgStore.getAddress());
+
+      for (long pgid = pgStore.getFirstPage(); pgid <= limitPageId; pgid++) {
+         if (logger.isDebugEnabled()) {
+            logger.debug("Rebuilding counter on messages from page {} on rebuildCounters for address {}", pgid, pgStore.getAddress());
+         }
+         Page page = pgStore.newPageObject(pgid);
+
+         if (!page.getFile().exists()) {
+            if (logger.isDebugEnabled()) {
+               logger.debug("Skipping page {} on store {}", pgid, pgStore.getAddress());
+            }
+            continue;
+         }
+         page.open(false);
+         LinkedList<PagedMessage> msgs = page.read(sm);
+         page.close(false, false);
+
+         try (LinkedListIterator<PagedMessage> iter = msgs.iterator()) {
+            while (iter.hasNext()) {
+               PagedMessage msg = iter.next();
+               if (limitPageId == pgid) {
+                  if (msg.getMessageNumber() >= limitMessageNr) {
+                     if (logger.isDebugEnabled()) {
+                        logger.debug("Rebuild counting on {} reached the last message at {}-{}", pgStore.getAddress(), limitPageId, limitMessageNr);
+                     }
+                     // this is the limit where we should count..
+                     // anything beyond this will be new data
+                     break;
+                  }
+               }
+               msg.initMessage(sm);
+               long[] routedQueues = msg.getQueueIDs();
+
+               if (logger.isTraceEnabled()) {
+                  logger.trace("reading message for rebuild cursor on address={}, pg={}, messageNR={}, routedQueues={}, message={}, queueLIst={}", pgStore.getAddress(), msg.getPageNumber(), msg.getMessageNumber(), routedQueues, msg, routedQueues);
+               }
+               for (long queueID : routedQueues) {
+                  boolean ok = !isACK(queueID, msg.getPageNumber(), msg.getMessageNumber());
+
+                  boolean txOK = msg.getTransactionID() <= 0 || transactions == null || transactions.contains(msg.getTransactionID());
+
+                  if (!txOK) {
+                     logger.debug("TX is not ok for {}", msg);
+                  }
+
+                  if (ok && txOK) { // not acked and TX is ok
+                     if (logger.isTraceEnabled()) {
+                        logger.trace("Message pageNumber={}/{} NOT acked on queue {}", msg.getPageNumber(), msg.getMessageNumber(), queueID);
+                     }
+                     CopiedSubscription copiedSubscription = copiedSubscriptionMap.get(queueID);
+                     if (copiedSubscription != null) {
+                        copiedSubscription.empty = false;
+                        copiedSubscription.addUp++;
+                        copiedSubscription.sizeUp += msg.getPersistentSize();
+                     }
+                  } else {
+                     if (logger.isTraceEnabled()) {
+                        logger.trace("Message pageNumber={}/{} IS acked on queue {}", msg.getPageNumber(), msg.getMessageNumber(), queueID);
+                     }
+                  }
+               }
+            }
+         }
+      }
+
+      logger.debug("Counter rebuilding done for address {}", pgStore.getAddress());
+
+      done();
+
+   }
+
+   private static class CopiedSubscription {
+      CopiedSubscription(PageSubscription subscription) {
+         this.subscriptionCounter = subscription.getCounter();
+         this.subscription = subscription;
+      }
+
+      private boolean empty = true;
+
+      LongObjectHashMap<CopiedConsumedPage> consumedPageMap = new LongObjectHashMap<>();
+
+      // this is not a copy! This will be the actual object listed in the PageSubscription
+      // any changes to this object will reflect in the system and management;
+      PageSubscriptionCounter subscriptionCounter;
+
+      PageSubscription subscription;
+
+      CopiedConsumedPage getPage(long pageNr) {
+         return consumedPageMap.get(pageNr);
+      }
+
+      int addUp;
+      long sizeUp;
+
+   }
+
+   private static class CopiedConsumedPage implements ConsumedPage {
+      boolean done;
+      IntObjectHashMap<Boolean> acks;
+
+      @Override
+      public long getPageId() {
+         throw new RuntimeException("method not implemented");
+      }
+
+      @Override
+      public void forEachAck(BiConsumer<Integer, PagePosition> ackConsumer) {
+         throw new RuntimeException("method not implemented");
+      }
+
+      @Override
+      public boolean isDone() {
+         return done;
+      }
+
+      @Override
+      public boolean isAck(int messageNumber) {
+         if (done) {
+            return true;
+         }
+         if (acks != null) {
+            return acks.get(messageNumber) != null;
+         }
+         return false;
+      }
+   }
+
+
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/DescribeJournal.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/DescribeJournal.java
@@ -535,7 +535,7 @@ public final class DescribeJournal {
       PageSubscriptionCounterImpl subsCounter;
       subsCounter = counters.get(queueIDForCounter);
       if (subsCounter == null) {
-         subsCounter = new PageSubscriptionCounterImpl(null, null, false, -1);
+         subsCounter = new PageSubscriptionCounterImpl(null, -1);
          counters.put(queueIDForCounter, subsCounter);
       }
       return subsCounter;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQMessageBundle.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQMessageBundle.java
@@ -524,4 +524,7 @@ public interface ActiveMQMessageBundle {
 
    @Message(id = 229244, value = "Meters already registered for {}")
    IllegalStateException metersAlreadyRegistered(String resource);
+
+   @Message(id = 229245, value = "Management controller is busy with another task. Please try again")
+   ActiveMQTimeoutException managementBusy();
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServer.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServer.java
@@ -111,6 +111,7 @@ public interface ActiveMQServer extends ServiceComponent {
       STOPPED
    }
 
+   AutoCloseable managementLock() throws Exception;
 
    void setState(SERVER_STATE state);
 
@@ -356,6 +357,14 @@ public interface ActiveMQServer extends ServiceComponent {
                                OperationContext context,
                                Map<SimpleString, RoutingType> prefixes,
                                String securityDomain) throws Exception;
+
+   /** should the server rebuild page counters upon startup.
+    *  this will be useful on testing or an embedded broker scenario */
+   boolean isRebuildCounters();
+
+   /** should the server rebuild page counters upon startup.
+    *  this will be useful on testing or an embedded broker scenario */
+   void setRebuildCounters(boolean rebuildCounters);
 
    SecurityStore getSecurityStore();
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -472,9 +472,6 @@ public interface ActiveMQServerLogger {
    @LogMessage(id = 222047, value = "Can not find queue {} while reloading ACKNOWLEDGE_CURSOR", level = LogMessage.Level.WARN)
    void journalCannotFindQueueReloadingACK(Long queueID);
 
-   @LogMessage(id = 222048, value = "PAGE_CURSOR_COUNTER_VALUE record used on a prepared statement, invalid state", level = LogMessage.Level.WARN)
-   void journalPAGEOnPrepared();
-
    @LogMessage(id = 222049, value = "InternalError: Record type {} not recognized. Maybe you are using journal files created on a different version", level = LogMessage.Level.WARN)
    void journalInvalidRecordType(Byte recordType);
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
@@ -1725,7 +1725,13 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
       if (pageSubscription != null) {
          // messageReferences will have depaged messages which we need to discount from the counter as they are
          // counted on the pageSubscription as well
-         return (long) pendingMetrics.getMessageCount() + getScheduledCount() + getDeliveringCount() + pageSubscription.getMessageCount();
+         long returnValue = (long) pendingMetrics.getMessageCount() + getScheduledCount() + getDeliveringCount() + pageSubscription.getMessageCount();
+         if (logger.isTraceEnabled()) {
+            logger.trace("Queue={}/{} returning getMessageCount returning {}. pendingMetrics.getMessageCount() = {}, getScheduledCount() = {}, pageSubscription.getMessageCount()={}, pageSubscription.getDeliveredCount()={}",
+                         name, id, returnValue, pendingMetrics.getMessageCount(), getScheduledCount(), pageSubscription.getMessageCount(),
+                         pageSubscription.getDeliveredCount());
+         }
+         return returnValue;
       } else {
          return (long) pendingMetrics.getMessageCount() + getScheduledCount() + getDeliveringCount();
       }
@@ -2279,6 +2285,9 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
    public void destroyPaging() throws Exception {
       // it could be null on embedded or certain unit tests
       if (pageSubscription != null) {
+         if (logger.isTraceEnabled()) {
+            logger.trace("Destroying paging for {}", this.name, new Exception("trace"));
+         }
          pageSubscription.destroy();
          pageSubscription.cleanupEntries(true);
       }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
@@ -295,6 +295,7 @@ public abstract class ActiveMQTestBase extends Assert {
       try {
          DriverManager.getConnection("jdbc:derby:;shutdown=true");
       } catch (Exception ignored) {
+         // it always throws an exception on shutdown
       }
    }
 
@@ -878,7 +879,7 @@ public abstract class ActiveMQTestBase extends Assert {
       return testDir;
    }
 
-   private String getEmbeddedDataBaseName() {
+   protected String getEmbeddedDataBaseName() {
       return "memory:" + getTestDir();
    }
 
@@ -2314,6 +2315,10 @@ public abstract class ActiveMQTestBase extends Assert {
    }
 
    protected int getMessageCount(final Queue queue) {
+      try {
+         Wait.waitFor(() -> queue.getPageSubscription().isCounterPending() == false);
+      } catch (Exception ignored) {
+      }
       queue.flushExecutor();
       return (int) queue.getMessageCount();
    }

--- a/tests/compatibility-tests/src/main/resources/pageCounter/checkMessages.groovy
+++ b/tests/compatibility-tests/src/main/resources/pageCounter/checkMessages.groovy
@@ -14,13 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.core.io;
 
-public interface IOCriticalErrorListener {
+package pageCounter
 
-   default boolean isPreviouslyFailed() {
-      return false;
-   }
+import org.apache.activemq.artemis.api.core.SimpleString
+import org.apache.activemq.artemis.core.server.Queue
+import org.apache.activemq.artemis.tests.compatibility.GroovyRun
 
-   void onIOException(Throwable code, String message, String file);
+int messages = Integer.parseInt(arg[0]);
+
+Queue queue = server.getJMSServerManager().getActiveMQServer().locateQueue(SimpleString.toSimpleString("queue"))
+for (int i = 0; i < 20 && queue.getMessageCount() != messages; i++) {
+    Thread.sleep(100);
+
 }
+GroovyRun.assertEquals((int)messages, (int)queue.getMessageCount());

--- a/tests/compatibility-tests/src/main/resources/pageCounter/sendMessages.groovy
+++ b/tests/compatibility-tests/src/main/resources/pageCounter/sendMessages.groovy
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pageCounter
+
+import org.apache.activemq.artemis.tests.compatibility.GroovyRun
+
+import javax.jms.*
+
+// starts an artemis server
+String serverType = arg[0];
+String protocol = arg[1];
+int messages = Integer.parseInt(arg[2]);
+
+// Can't depend directly on artemis, otherwise it wouldn't compile in hornetq
+if (protocol != null && protocol.equals("AMQP")) {
+    GroovyRun.evaluate("clients/artemisClientAMQP.groovy", "serverArg", serverType, protocol);
+} else {
+    GroovyRun.evaluate("clients/artemisClient.groovy", "serverArg", serverType);
+}
+
+Connection connection = cf.createConnection();
+Session session = connection.createSession(true, Session.SESSION_TRANSACTED);
+Queue destination = session.createQueue("queue")
+
+MessageProducer producer = session.createProducer(destination);
+producer.setDeliveryMode(DeliveryMode.PERSISTENT);
+
+for (int i = 0; i < messages; i++) {
+    TextMessage message = session.createTextMessage("Message " + i);
+    producer.send(message);
+    if (i % 100 == 0) {
+        session.commit();
+    }
+}
+
+session.commit();
+
+connection.close();

--- a/tests/compatibility-tests/src/test/java/org/apache/activemq/artemis/tests/compatibility/PagingCounterTest.java
+++ b/tests/compatibility-tests/src/test/java/org/apache/activemq/artemis/tests/compatibility/PagingCounterTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.tests.compatibility;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.activemq.artemis.tests.compatibility.base.VersionedBase;
+import org.apache.activemq.artemis.utils.FileUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.apache.activemq.artemis.tests.compatibility.GroovyRun.SNAPSHOT;
+import static org.apache.activemq.artemis.tests.compatibility.GroovyRun.TWO_TWENTYTWO_ZERO;
+
+@RunWith(Parameterized.class)
+public class PagingCounterTest extends VersionedBase {
+
+   // this will ensure that all tests in this class are run twice,
+   // once with "true" passed to the class' constructor and once with "false"
+   @Parameterized.Parameters(name = "server={0}, producer={1}, consumer={2}")
+   public static Collection getParameters() {
+      // we don't need every single version ever released..
+      // if we keep testing current one against 2.4 and 1.4.. we are sure the wire and API won't change over time
+      List<Object[]> combinations = new ArrayList<>();
+
+      /*
+      // during development sometimes is useful to comment out the combinations
+      // and add the ones you are interested.. example:
+       */
+      //      combinations.add(new Object[]{SNAPSHOT, ONE_FIVE, ONE_FIVE});
+      //      combinations.add(new Object[]{ONE_FIVE, ONE_FIVE, ONE_FIVE});
+
+      combinations.add(new Object[]{null, TWO_TWENTYTWO_ZERO, SNAPSHOT});
+      combinations.add(new Object[]{null, SNAPSHOT, TWO_TWENTYTWO_ZERO});
+      // the purpose on this one is just to validate the test itself.
+      /// if it can't run against itself it won't work at all
+      combinations.add(new Object[]{null, SNAPSHOT, SNAPSHOT});
+      return combinations;
+   }
+
+   public PagingCounterTest(String server, String sender, String receiver) throws Exception {
+      super(server, sender, receiver);
+   }
+
+   @Before
+   public void removeFolder() throws Throwable {
+      FileUtil.deleteDirectory(serverFolder.getRoot());
+      serverFolder.getRoot().mkdirs();
+   }
+
+   @After
+   public void tearDown() {
+      try {
+         stopServer(serverClassloader);
+      } catch (Throwable ignored) {
+      }
+      try {
+         stopServer(receiverClassloader);
+      } catch (Throwable ignored) {
+      }
+   }
+
+   @Test
+   public void testSendReceivePaging() throws Throwable {
+      setVariable(senderClassloader, "persistent", true);
+      startServer(serverFolder.getRoot(), senderClassloader, "pageCounter", null, true);
+      evaluate(senderClassloader, "journalcompatibility/forcepaging.groovy");
+      evaluate(senderClassloader, "pageCounter/sendMessages.groovy", server, "core", "1000");
+      evaluate(senderClassloader, "journalcompatibility/ispaging.groovy");
+      evaluate(senderClassloader, "pageCounter/checkMessages.groovy", "1000");
+      stopServer(senderClassloader);
+
+      setVariable(receiverClassloader, "persistent", true);
+      startServer(serverFolder.getRoot(), receiverClassloader, "pageCounter", null, false);
+      evaluate(receiverClassloader, "journalcompatibility/ispaging.groovy");
+      evaluate(receiverClassloader, "pageCounter/checkMessages.groovy", "1000");
+
+   }
+}
+

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/BackupSyncJournalTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/BackupSyncJournalTest.java
@@ -159,7 +159,6 @@ public class BackupSyncJournalTest extends FailoverTestBase {
       for (Pair<Long, Integer> pair : backupIds) {
          totalBackup += pair.getB();
       }
-      assertEquals("number of records must match ", total, totalBackup);
 
       // "+ 2": there two other calls that send N_MSGS.
       for (int i = 0; i < totalRounds + 3; i++) {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
@@ -1715,6 +1715,11 @@ public class ActiveMQServerControlUsingCoreTest extends ActiveMQServerControlTes
          public boolean isEmbeddedWebServerStarted() {
             return (boolean) proxy.retrieveAttributeValue("embeddedWebServerStarted");
          }
+
+         @Override
+         public void rebuildPageCounters() throws Exception {
+            proxy.invokeOperation("rebuildPageCounters");
+         }
       };
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PageCountSyncOnNonTXTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PageCountSyncOnNonTXTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.activemq.artemis.tests.integration.paging;
 
+import java.lang.invoke.MethodHandles;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -39,8 +40,12 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PageCountSyncOnNonTXTest extends SpawnedTestBase {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Rule
    public RetryRule retryRule = new RetryRule(1);
@@ -151,7 +156,7 @@ public class PageCountSyncOnNonTXTest extends SpawnedTestBase {
                }
             }
          } catch (Exception expected) {
-            expected.printStackTrace();
+            logger.info("expected exception {}", expected.toString(), expected);
          }
 
       } finally {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PageCounterRebuildTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PageCounterRebuildTest.java
@@ -1,0 +1,289 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.tests.integration.paging;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.activemq.artemis.api.core.QueueConfiguration;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.core.paging.cursor.impl.PageSubscriptionCounterImpl;
+import org.apache.activemq.artemis.core.persistence.StorageManager;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.Queue;
+import org.apache.activemq.artemis.core.server.impl.AddressInfo;
+import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.apache.activemq.artemis.tests.util.CFUtil;
+import org.apache.activemq.artemis.tests.util.Wait;
+import org.apache.activemq.artemis.utils.ReusableLatch;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PageCounterRebuildTest extends ActiveMQTestBase {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   @Test
+   public void testUnitSize() throws Exception {
+      AtomicInteger errors = new AtomicInteger(0);
+
+      StorageManager mockStorage = Mockito.mock(StorageManager.class);
+
+      PageSubscriptionCounterImpl nonPersistentPagingCounter = new PageSubscriptionCounterImpl(mockStorage, -1);
+
+      final int THREADS = 33;
+      final int ADD_VALUE = 7;
+      final int SIZE_VALUE = 17;
+      final int REPEAT = 777;
+
+      ExecutorService executorService = Executors.newFixedThreadPool(THREADS);
+      runAfter(executorService::shutdownNow);
+
+      CyclicBarrier startFlag = new CyclicBarrier(THREADS);
+
+      ReusableLatch latch = new ReusableLatch(THREADS);
+
+      for (int j = 0; j < THREADS; j++) {
+         executorService.execute(() -> {
+            try {
+               startFlag.await(10, TimeUnit.SECONDS);
+               for (int i = 0; i < REPEAT; i++) {
+                  nonPersistentPagingCounter.increment(null, ADD_VALUE, SIZE_VALUE);
+               }
+            } catch (Throwable e) {
+               logger.warn(e.getMessage(), e);
+               errors.incrementAndGet();
+            } finally {
+               latch.countDown();
+            }
+         });
+      }
+
+      Assert.assertTrue(latch.await(10, TimeUnit.SECONDS));
+
+      Assert.assertEquals(ADD_VALUE * THREADS * REPEAT, nonPersistentPagingCounter.getValue());
+      Assert.assertEquals(SIZE_VALUE * THREADS * REPEAT, nonPersistentPagingCounter.getPersistentSize());
+
+
+      latch.setCount(THREADS);
+
+      for (int j = 0; j < THREADS; j++) {
+         executorService.execute(() -> {
+            try {
+               startFlag.await(10, TimeUnit.SECONDS);
+               for (int i = 0; i < REPEAT; i++) {
+                  nonPersistentPagingCounter.increment(null, -ADD_VALUE, -SIZE_VALUE);
+               }
+            } catch (Throwable e) {
+               logger.warn(e.getMessage(), e);
+               errors.incrementAndGet();
+            } finally {
+               latch.countDown();
+            }
+         });
+      }
+
+      Assert.assertTrue(latch.await(10, TimeUnit.SECONDS));
+
+      Assert.assertEquals(0L, nonPersistentPagingCounter.getValue());
+      Assert.assertEquals(0L, nonPersistentPagingCounter.getPersistentSize());
+      Assert.assertEquals(0, errors.get());
+   }
+
+   @Test
+   public void testRebuildCounter() throws Exception {
+      ActiveMQServer server = createServer(true, true);
+      AddressSettings defaultSetting = new AddressSettings().setPageSizeBytes(100 * 1024).setMaxReadPageMessages(1);
+      server.getAddressSettingsRepository().addMatch("#", defaultSetting);
+      server.start();
+
+      String queueName = getName();
+      String nonConsumedQueueName = getName() + "_nonConsumed";
+      server.addAddressInfo(new AddressInfo(queueName).addRoutingType(RoutingType.MULTICAST));
+      server.createQueue(new QueueConfiguration(nonConsumedQueueName).setAddress(queueName).setRoutingType(RoutingType.MULTICAST));
+      server.createQueue(new QueueConfiguration(queueName).setRoutingType(RoutingType.MULTICAST));
+
+      Queue serverQueue = server.locateQueue(queueName);
+      Queue serverNonConsumedQueue = server.locateQueue(nonConsumedQueueName);
+
+      Assert.assertNotNull(serverQueue);
+      Assert.assertNotNull(serverNonConsumedQueue);
+
+      serverQueue.getPagingStore().startPaging();
+
+      final int THREADS = 4;
+      final int TX_SEND = 2000;
+      final int NON_TXT_SEND = 200;
+      final int CONSUME_MESSAGES = 200;
+      AtomicInteger errors = new AtomicInteger(0);
+
+      ExecutorService executorService = Executors.newFixedThreadPool(THREADS);
+      runAfter(executorService::shutdownNow);
+
+      CyclicBarrier startFlag = new CyclicBarrier(THREADS);
+
+      ReusableLatch latch = new ReusableLatch(THREADS);
+
+      for (int i = 0; i < THREADS; i++) {
+         final int threadNumber = i;
+         executorService.execute(() -> {
+            try {
+               startFlag.await(10, TimeUnit.SECONDS);
+               ConnectionFactory factory = CFUtil.createConnectionFactory("core", "tcp://localhost:61616");
+               try (Connection connection = factory.createConnection(); Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE); Session txSession = connection.createSession(true, Session.AUTO_ACKNOWLEDGE)) {
+
+                  logger.info("sending thread {}", threadNumber);
+
+                  javax.jms.Topic jmsQueue = session.createTopic(queueName);
+                  MessageProducer producerNonTX = session.createProducer(jmsQueue);
+                  MessageProducer producerTX = txSession.createProducer(jmsQueue);
+
+                  for (int message = 0; message < NON_TXT_SEND; message++) {
+                     TextMessage txtMessage = session.createTextMessage("hello" + message);
+                     txtMessage.setBooleanProperty("first", false);
+                     producerNonTX.send(session.createTextMessage("hello" + message));
+                  }
+                  for (int message = 0; message < TX_SEND; message++) {
+                     producerTX.send(session.createTextMessage("helloTX" + message));
+                  }
+                  txSession.commit();
+               }
+
+            } catch (Throwable e) {
+               errors.incrementAndGet();
+            } finally {
+               latch.countDown();
+            }
+         });
+      }
+
+      // this should be fast on the CIs, but if you use a slow disk, it might take a few extra seconds.
+      Assert.assertTrue(latch.await(1, TimeUnit.MINUTES));
+
+      final int numberOfMessages = TX_SEND * THREADS + NON_TXT_SEND * THREADS;
+      Wait.assertEquals(numberOfMessages, serverQueue::getMessageCount);
+
+      ConnectionFactory factory = CFUtil.createConnectionFactory("core", "tcp://localhost:61616");
+      try (Connection connection = factory.createConnection(); Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);) {
+         MessageConsumer consumer = session.createConsumer(session.createQueue(queueName + "::" + queueName));
+         connection.start();
+         for (int i = 0; i < CONSUME_MESSAGES; i++) {
+            Message message = consumer.receive(5000);
+            Assert.assertNotNull(message);
+         }
+      }
+
+      Wait.assertEquals(numberOfMessages - CONSUME_MESSAGES, serverQueue::getMessageCount);
+      Wait.assertEquals(numberOfMessages, serverNonConsumedQueue::getMessageCount);
+
+      server.stop();
+      server.start();
+
+      serverQueue = server.locateQueue(queueName);
+      serverNonConsumedQueue = server.locateQueue(nonConsumedQueueName);
+
+      Wait.assertEquals(numberOfMessages - CONSUME_MESSAGES, serverQueue::getMessageCount);
+      Wait.assertEquals(numberOfMessages, serverNonConsumedQueue::getMessageCount);
+
+      serverQueue.getPageSubscription().getCounter().markRebuilding();
+      serverNonConsumedQueue.getPageSubscription().getCounter().markRebuilding();
+
+      // if though we are rebuilding, we are still returning based on the last recorded value until processing is finished
+      Assert.assertEquals(8600, serverQueue.getMessageCount());
+      Assert.assertEquals(8800, serverNonConsumedQueue.getMessageCount());
+
+      serverQueue.getPageSubscription().getCounter().finishRebuild();
+
+      serverNonConsumedQueue.getPageSubscription().getCounter().finishRebuild();
+
+      Assert.assertEquals(0, serverQueue.getMessageCount()); // we artificially made it 0 by faking a rebuild
+      Assert.assertEquals(0, serverNonConsumedQueue.getMessageCount()); // we artificially made it 0 by faking a rebuild
+
+      server.stop();
+      server.start();
+
+      serverQueue = server.locateQueue(queueName);
+      serverNonConsumedQueue = server.locateQueue(nonConsumedQueueName);
+
+      // after a rebuild, the counter should be back to where it was
+      Wait.assertEquals(numberOfMessages - CONSUME_MESSAGES, serverQueue::getMessageCount);
+      Wait.assertEquals(numberOfMessages, serverNonConsumedQueue::getMessageCount);
+
+      server.stop();
+      server.start();
+
+      serverQueue = server.locateQueue(queueName);
+      serverNonConsumedQueue = server.locateQueue(nonConsumedQueueName);
+
+      Assert.assertNotNull(serverQueue);
+      Assert.assertNotNull(serverNonConsumedQueue);
+
+      Wait.assertEquals(numberOfMessages - CONSUME_MESSAGES, serverQueue::getMessageCount);
+      Wait.assertEquals(numberOfMessages, serverNonConsumedQueue::getMessageCount);
+
+      server.stop();
+      // restarting the server to issue a rebuild on the counters
+      server.start();
+
+      logger.info("Consuming messages");
+      factory = CFUtil.createConnectionFactory("core", "tcp://localhost:61616");
+      try (Connection connection = factory.createConnection(); Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);) {
+         MessageConsumer consumer = session.createConsumer(session.createQueue(queueName + "::" + queueName));
+         connection.start();
+         for (int i = 0; i < numberOfMessages - CONSUME_MESSAGES; i++) {
+            Message message = consumer.receive(5000);
+            Assert.assertNotNull(message);
+            if (i % 100 == 0) {
+               logger.info("Received {} messages", i);
+            }
+         }
+         Assert.assertNull(consumer.receiveNoWait());
+         consumer.close();
+
+         consumer = session.createConsumer(session.createQueue(queueName + "::" + nonConsumedQueueName));
+         connection.start();
+         for (int i = 0; i < numberOfMessages; i++) {
+            Message message = consumer.receive(5000);
+            Assert.assertNotNull(message);
+         }
+         Assert.assertNull(consumer.receiveNoWait());
+         consumer.close();
+      }
+
+      serverQueue = server.locateQueue(queueName);
+      serverNonConsumedQueue = server.locateQueue(nonConsumedQueueName);
+
+      Wait.assertEquals(0L, serverQueue::getMessageCount, 1000, 100);
+      Wait.assertEquals(0L, serverNonConsumedQueue::getMessageCount, 1000, 100);
+   }
+}

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingSendTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingSendTest.java
@@ -34,8 +34,6 @@ import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
-import org.apache.activemq.artemis.core.config.Configuration;
-import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.MessageReference;
 import org.apache.activemq.artemis.core.server.Queue;
@@ -62,7 +60,6 @@ public class PagingSendTest extends ActiveMQTestBase {
    @Before
    public void setUp() throws Exception {
       super.setUp();
-      Configuration config = new ConfigurationImpl();
       server = newActiveMQServer();
 
       server.start();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/replication/ReplicationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/replication/ReplicationTest.java
@@ -651,6 +651,7 @@ public final class ReplicationTest extends ActiveMQTestBase {
       PagingManager paging = new PagingManagerImpl(new PagingStoreFactoryNIO(storageManager, configuration.getPagingLocation(), 1000, null, executorFactory, executorFactory, false, null), addressSettingsRepository, configuration.getManagementAddress());
 
       paging.start();
+      runAfter(paging::stop);
       return paging;
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/replication/SharedNothingReplicationFlowControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/replication/SharedNothingReplicationFlowControlTest.java
@@ -150,9 +150,9 @@ public class SharedNothingReplicationFlowControlTest extends ActiveMQTestBase {
                ClientProducer producer = session.createProducer("flowcontrol");
                ClientMessage message = session.createMessage(true);
                message.writeBodyBufferBytes(body);
-               logger.info("try to send a message after replicated");
+               logger.debug("try to send a message after replicated");
                producer.send(message);
-               logger.info("send message done");
+               logger.debug("send message done");
                producer.close();
                session.close();
 
@@ -187,8 +187,8 @@ public class SharedNothingReplicationFlowControlTest extends ActiveMQTestBase {
             if (!(info.userRecordType == JournalRecordIds.ADD_MESSAGE_PROTOCOL)) {
                // ignore
             }
-            logger.info("got live message {} {}", info.id, info.userRecordType);
             liveJournalCounter.incrementAndGet();
+            logger.info("got live message {} {}, counter={}", info.id, info.userRecordType, liveJournalCounter.get());
          }
       });
 
@@ -207,8 +207,8 @@ public class SharedNothingReplicationFlowControlTest extends ActiveMQTestBase {
             if (!(info.userRecordType == JournalRecordIds.ADD_MESSAGE_PROTOCOL)) {
                // ignore
             }
-            logger.info("replicated message {}", info.id);
             replicationCounter.incrementAndGet();
+            logger.info("replicated message {}, counter={}", info.id, replicationCounter.get());
          }
       });
 

--- a/tests/performance-tests/src/test/java/org/apache/activemq/artemis/tests/performance/storage/PersistMultiThreadTest.java
+++ b/tests/performance-tests/src/test/java/org/apache/activemq/artemis/tests/performance/storage/PersistMultiThreadTest.java
@@ -246,6 +246,10 @@ public class PersistMultiThreadTest extends ActiveMQTestBase {
    class FakePagingStore implements PagingStore {
 
       @Override
+      public void counterSnapshot() {
+      }
+
+      @Override
       public void execute(Runnable runnable) {
          runnable.run();
       }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/paging/impl/PagingManagerImplTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/paging/impl/PagingManagerImplTest.java
@@ -61,6 +61,8 @@ public class PagingManagerImplTest extends ActiveMQTestBase {
 
       managerImpl.start();
 
+      runAfter(managerImpl::stop);
+
       PagingStore store = managerImpl.getPageStore(new SimpleString("simple-test"));
 
       ICoreMessage msg = createMessage(1L, new SimpleString("simple-test"), createRandomBuffer(10));

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/FakePagingManager.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/util/FakePagingManager.java
@@ -40,6 +40,11 @@ public class FakePagingManager implements PagingManager {
    }
 
    @Override
+   public void counterSnapshot() {
+
+   }
+
+   @Override
    public void addTransaction(final PageTransactionInfo pageTransaction) {
    }
 


### PR DESCRIPTION
Instead of relying on the journal to store the value of the counters, and have it eventually getting out of sync we should just use real counters from reading the pages on startup.

In a test performed, reading 700 files didn't take more than 1 minute in a modest laptop. And besides the data will be available while the rebuild is being done.