### PR TITLE
ARTEMIS-4076: add JDK 19 run to CI jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 11, 17 ]
+        java: [ 11, 17, 19 ]
 
     steps:
       - uses: actions/checkout@v3
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 11, 17 ]
+        java: [ 11, 17, 19 ]
 
     steps:
       - uses: actions/checkout@v3

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/handler/ExecutorNettyAdapter.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/handler/ExecutorNettyAdapter.java
@@ -40,7 +40,7 @@ import org.apache.activemq.artemis.utils.actors.ArtemisExecutor;
  *  TODO: This could be refactored out of the main codebase but at a high cost.
  *        We may do it some day if we find an easy way that won't clutter the code too much.
  *  */
-public class ExecutorNettyAdapter implements EventLoop {
+public class ExecutorNettyAdapter implements EventLoop, AutoCloseable {
 
    final ArtemisExecutor executor;
 
@@ -187,7 +187,7 @@ public class ExecutorNettyAdapter implements EventLoop {
 
    @Override
    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-      return false;
+      return true;
    }
 
    @Override
@@ -217,5 +217,10 @@ public class ExecutorNettyAdapter implements EventLoop {
    @Override
    public void execute(Runnable command) {
       executor.execute(command);
+   }
+
+   @Override
+   public void close() {
+     // noop
    }
 }

--- a/artemis-unit-test-support/src/main/java/org/apache/activemq/artemis/utils/ThreadLeakCheckRule.java
+++ b/artemis-unit-test-support/src/main/java/org/apache/activemq/artemis/utils/ThreadLeakCheckRule.java
@@ -235,7 +235,7 @@ public class ThreadLeakCheckRule extends TestWatcher {
    private boolean isExpectedThread(Thread thread) {
       final String threadName = thread.getName();
       final ThreadGroup group = thread.getThreadGroup();
-      final boolean isSystemThread = group != null && "system".equals(group.getName());
+      final boolean isSystemThread = group != null && ("system".equals(group.getName()) || "InnocuousThreadGroup".equals(group.getName()));
       final String javaVendor = System.getProperty("java.vendor");
 
       if (threadName.contains("SunPKCS11")) {
@@ -244,7 +244,7 @@ public class ThreadLeakCheckRule extends TestWatcher {
          return true;
       } else if (threadName.contains("Attach Listener")) {
          return true;
-      } else if ((javaVendor.contains("IBM") || isSystemThread) && threadName.equals("process reaper")) {
+      } else if ((javaVendor.contains("IBM") || isSystemThread) && threadName.startsWith("process reaper")) {
          return true;
       } else if ((javaVendor.contains("IBM") || isSystemThread) && threadName.equals("ClassCache Reaper")) {
          return true;

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/AllClassesTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/AllClassesTest.java
@@ -80,7 +80,7 @@ public class AllClassesTest {
    }
 
 
-   @Test
+   @Test(timeout = 3000)
    public void testToString() {
       Object targetInstance = null;
 


### PR DESCRIPTION
Fixes a couple of issues causing test failures or hangs, and adds a Java 19 job to the CI runs on push/PR.