### PR TITLE
ARTEMIS-4079 CLI retry doesn't work sometimes

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/ConnectionAbstract.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/ConnectionAbstract.java
@@ -225,15 +225,15 @@ public class ConnectionAbstract extends InputAbstract {
 
    private String inputUser(String user) {
       if (user == null) {
-         user = input("--user", "Type the username for a retry", null);
+         this.user = input("--user", "Type the username for a retry", null);
       }
-      return user;
+      return this.user;
    }
 
    private String inputPassword(String password) {
       if (password == null) {
-         password = inputPassword("--password", "Type the password for a retry", null);
+         this.password = inputPassword("--password", "Type the password for a retry", null);
       }
-      return password;
+      return this.password;
    }
 }

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/queue/StatQueue.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/queue/StatQueue.java
@@ -86,6 +86,8 @@ public class StatQueue extends AbstractAction {
    @Option(name = "--maxColumnSize", description = "max width of data column. Set to -1 for no limit. Default is 25.")
    private int maxColumnSize = DEFAULT_MAX_COLUMN_SIZE;
 
+   private int statCount = 0;
+
    //easier for testing
    public StatQueue setQueueName(String queueName) {
       this.queueName = queueName;
@@ -146,7 +148,7 @@ public class StatQueue extends AbstractAction {
          getActionContext().out.println("maxRows='" + maxRows + "'");
       }
       printStats(getActionContext(), filter);
-      return null;
+      return statCount;
    }
 
    private void printStats(final ActionContext context, final String filter) throws Exception {
@@ -199,6 +201,7 @@ public class StatQueue extends AbstractAction {
 
       for (int i = 0; i < array.size(); i++) {
          printQueueStats(array.getJsonObject(i), columnSizes);
+         statCount++;
       }
 
       if (count > maxRows) {

--- a/artemis-cli/src/test/java/org/apache/activemq/cli/test/ArtemisTest.java
+++ b/artemis-cli/src/test/java/org/apache/activemq/cli/test/ArtemisTest.java
@@ -1270,7 +1270,7 @@ public class ArtemisTest extends CliTestBase {
    }
 
    @Test
-   public void testOperationRetry() throws Exception {
+   public void testProducerRetry() throws Exception {
       File instanceFolder = temporaryFolder.newFolder("server");
       setupAuth(instanceFolder);
       Run.setEmbedded(true);
@@ -1295,6 +1295,37 @@ public class ArtemisTest extends CliTestBase {
          in = new ByteArrayInputStream("tcp://localhost:61616\nadmin\n".getBytes());
          context = new ActionContext(in, System.out, System.err);
          assertEquals(Integer.valueOf(100), Artemis.internalExecute(null, null, new String[] {"producer", "--destination", "queue://q1", "--message-count", "100", "--password", "admin", "--url", "tcp://badhost:11111"}, context));
+      } finally {
+         stopServer();
+      }
+   }
+
+   @Test
+   public void testQueueStatRetry() throws Exception {
+      File instanceFolder = temporaryFolder.newFolder("server");
+      setupAuth(instanceFolder);
+      Run.setEmbedded(true);
+      Artemis.main("create", instanceFolder.getAbsolutePath(), "--verbose", "--force", "--silent", "--no-web", "--queues", "q1", "--no-autotune", "--require-login", "--default-port", "61616");
+      System.setProperty("artemis.instance", instanceFolder.getAbsolutePath());
+
+      try {
+         Artemis.internalExecute("run");
+         InputStream in = new ByteArrayInputStream("admin\n".getBytes());
+         ActionContext context = new ActionContext(in, System.out, System.err);
+
+         /*
+          * This operation should fail the first time and then prompt the user to re-enter the username which
+          * it will read from the InputStream in the ActionContext. It can't read the password since it's using
+          * System.console.readPassword() for that.
+          */
+         assertTrue((int) Artemis.internalExecute(null, null, new String[] {"queue", "stat", "--password", "admin"}, context) > 0);
+
+         /*
+          * This is the same as above except it will prompt the user to re-enter both the URL and the username.
+          */
+         in = new ByteArrayInputStream("tcp://localhost:61616\nadmin\n".getBytes());
+         context = new ActionContext(in, System.out, System.err);
+         assertTrue((int) Artemis.internalExecute(null, null, new String[] {"queue", "stat", "--password", "admin", "--url", "tcp://badhost:11111"}, context) > 0);
       } finally {
          stopServer();
       }


### PR DESCRIPTION
CLI commands which only use a JMS connection (e.g. producer and consumer) will retry successfully when omitting or specifying the incorrect user and/or password. However, commands which use the core API directly will not.