### PR TITLE
Update ActiveMQSession.java

### DIFF
--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
@@ -338,7 +338,13 @@ public class ActiveMQSession implements QueueSession, TopicSession {
       }
 
       try {
-         session.rollback(true);
+         /*
+         When calling Session.recover(), unacknowledged messages must be returned to the queue, that is, ClientSession.rollback (false). 
+         If you call ClientSession.rollback (true), the ActiveMQServerMessagePlugin.messageAcknowledged () is called. Which is illogical 
+         and misleading.
+         However, this introduces the problem that deliveryCount does not increase on rereads. ut this needs to be fixed elsewhere.
+         */
+         session.rollback (false);
       } catch (ActiveMQException e) {
          throw JMSExceptionHelper.convertFromActiveMQException(e);
       }

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
@@ -66,6 +66,7 @@ import org.apache.activemq.artemis.api.core.client.ClientSession.AddressQuery;
 import org.apache.activemq.artemis.api.core.client.ClientSession.QueueQuery;
 import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
+import org.apache.activemq.artemis.api.jms.ActiveMQJMSConstants;
 import org.apache.activemq.artemis.jms.client.compatible1X.ActiveMQBytesCompatibleMessage;
 import org.apache.activemq.artemis.jms.client.compatible1X.ActiveMQCompatibleMessage;
 import org.apache.activemq.artemis.jms.client.compatible1X.ActiveMQMapCompatibleMessage;

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
@@ -339,8 +339,8 @@ public class ActiveMQSession implements QueueSession, TopicSession {
       }
 
       try {
-         //When calling Session.recover(), unacknowledged messages must be returned to the queue, that is, ClientSession.rollback (false). 
-         //If you call ClientSession.rollback (true), the ActiveMQServerMessagePlugin.messageAcknowledged () is called. Which is illogical 
+         //When calling Session.recover(), unacknowledged messages must be returned to the queue, that is, ClientSession.rollback (false).
+         //If you call ClientSession.rollback (true), the ActiveMQServerMessagePlugin.messageAcknowledged () is called. Which is illogical
          //and misleading.
          session.rollback(ackMode != ActiveMQJMSConstants.INDIVIDUAL_ACKNOWLEDGE);
       } catch (ActiveMQException e) {

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
@@ -339,9 +339,6 @@ public class ActiveMQSession implements QueueSession, TopicSession {
       }
 
       try {
-         //When calling Session.recover(), unacknowledged messages must be returned to the queue, that is, ClientSession.rollback (false).
-         //If you call ClientSession.rollback (true), the ActiveMQServerMessagePlugin.messageAcknowledged () is called. Which is illogical
-         //and misleading.
          session.rollback(ackMode != ActiveMQJMSConstants.INDIVIDUAL_ACKNOWLEDGE);
       } catch (ActiveMQException e) {
          throw JMSExceptionHelper.convertFromActiveMQException(e);

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
@@ -339,7 +339,7 @@ public class ActiveMQSession implements QueueSession, TopicSession {
       }
 
       try {
-         session.rollback(ackMode != ActiveMQJMSConstants.INDIVIDUAL_ACKNOWLEDGE);
+         session.rollback(ackMode != ActiveMQJMSConstants.INDIVIDUAL_ACKNOWLEDGE);//ARTEMIS-4111 bugfix
       } catch (ActiveMQException e) {
          throw JMSExceptionHelper.convertFromActiveMQException(e);
       }

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
@@ -342,9 +342,8 @@ public class ActiveMQSession implements QueueSession, TopicSession {
          When calling Session.recover(), unacknowledged messages must be returned to the queue, that is, ClientSession.rollback (false). 
          If you call ClientSession.rollback (true), the ActiveMQServerMessagePlugin.messageAcknowledged () is called. Which is illogical 
          and misleading.
-         However, this introduces the problem that deliveryCount does not increase on rereads. ut this needs to be fixed elsewhere.
          */
-         session.rollback (false);
+         session.rollback (ackMode != ActiveMQJMSConstants.INDIVIDUAL_ACKNOWLEDGE);
       } catch (ActiveMQException e) {
          throw JMSExceptionHelper.convertFromActiveMQException(e);
       }

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
@@ -342,7 +342,7 @@ public class ActiveMQSession implements QueueSession, TopicSession {
          //When calling Session.recover(), unacknowledged messages must be returned to the queue, that is, ClientSession.rollback (false). 
          //If you call ClientSession.rollback (true), the ActiveMQServerMessagePlugin.messageAcknowledged () is called. Which is illogical 
          //and misleading.
-         session.rollback (ackMode != ActiveMQJMSConstants.INDIVIDUAL_ACKNOWLEDGE);
+         session.rollback(ackMode != ActiveMQJMSConstants.INDIVIDUAL_ACKNOWLEDGE);
       } catch (ActiveMQException e) {
          throw JMSExceptionHelper.convertFromActiveMQException(e);
       }

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
@@ -65,8 +65,8 @@ import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSession.AddressQuery;
 import org.apache.activemq.artemis.api.core.client.ClientSession.QueueQuery;
 import org.apache.activemq.artemis.api.core.RoutingType;
-import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSConstants;
+import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
 import org.apache.activemq.artemis.jms.client.compatible1X.ActiveMQBytesCompatibleMessage;
 import org.apache.activemq.artemis.jms.client.compatible1X.ActiveMQCompatibleMessage;
 import org.apache.activemq.artemis.jms.client.compatible1X.ActiveMQMapCompatibleMessage;
@@ -339,11 +339,9 @@ public class ActiveMQSession implements QueueSession, TopicSession {
       }
 
       try {
-         /*
-         When calling Session.recover(), unacknowledged messages must be returned to the queue, that is, ClientSession.rollback (false). 
-         If you call ClientSession.rollback (true), the ActiveMQServerMessagePlugin.messageAcknowledged () is called. Which is illogical 
-         and misleading.
-         */
+         //When calling Session.recover(), unacknowledged messages must be returned to the queue, that is, ClientSession.rollback (false). 
+         //If you call ClientSession.rollback (true), the ActiveMQServerMessagePlugin.messageAcknowledged () is called. Which is illogical 
+         //and misleading.
          session.rollback (ackMode != ActiveMQJMSConstants.INDIVIDUAL_ACKNOWLEDGE);
       } catch (ActiveMQException e) {
          throw JMSExceptionHelper.convertFromActiveMQException(e);


### PR DESCRIPTION
         When calling Session.recover(), unacknowledged messages must be returned to the queue, that is, ClientSession.rollback (false). If you call ClientSession.rollback (true), the ActiveMQServerMessagePlugin.messageAcknowledged () is called. Which is illogical and misleading. However, this introduces the problem that deliveryCount does not increase on rereads. ut this needs to be fixed elsewhere.