### PR TITLE
NO-JIRA releaseBufferMemory just in case

### DIFF
--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/nio/NIOSequentialFileFactory.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/nio/NIOSequentialFileFactory.java
@@ -134,7 +134,9 @@ public class NIOSequentialFileFactory extends AbstractSequentialFileFactory {
 
    @Override
    public void releaseDirectBuffer(ByteBuffer buffer) {
-      PlatformDependent.freeDirectBuffer(buffer);
+      if (buffer.isDirect()) {
+         PlatformDependent.freeDirectBuffer(buffer);
+      }
    }
 
    @Override
@@ -155,6 +157,8 @@ public class NIOSequentialFileFactory extends AbstractSequentialFileFactory {
    public void releaseBuffer(ByteBuffer buffer) {
       if (this.bufferPooling) {
          bytesPool.release(buffer);
+      } else {
+         releaseDirectBuffer(buffer);
       }
    }
 


### PR DESCRIPTION
This is just to make releaseBuffer to have the same semantic when no pool is used.

This has no effect on how the broker behaves as we always have it pooled.