### PR TITLE
ARTEMIS-4113 Fix NPE for backup brokers with connection routers

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/routing/ConnectionRouter.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/routing/ConnectionRouter.java
@@ -128,6 +128,10 @@ public class ConnectionRouter implements ActiveMQComponent {
 
    @Override
    public void start() throws Exception {
+      if (localTarget != null) {
+         localTarget.getTarget().connect();
+      }
+
       if (cache != null) {
          cache.start();
       }
@@ -149,6 +153,10 @@ public class ConnectionRouter implements ActiveMQComponent {
 
       if (cache != null) {
          cache.stop();
+      }
+
+      if (localTarget != null) {
+         localTarget.getTarget().disconnect();
       }
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/routing/ConnectionRouterManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/routing/ConnectionRouterManager.java
@@ -18,7 +18,6 @@ package org.apache.activemq.artemis.core.server.routing;
 
 import org.apache.activemq.artemis.api.core.DiscoveryGroupConfiguration;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
-import org.apache.activemq.artemis.core.cluster.DiscoveryGroup;
 import org.apache.activemq.artemis.core.config.routing.ConnectionRouterConfiguration;
 import org.apache.activemq.artemis.core.config.routing.CacheConfiguration;
 import org.apache.activemq.artemis.core.config.routing.NamedPropertyConfiguration;
@@ -142,8 +141,7 @@ public final class ConnectionRouterManager implements ActiveMQComponent {
          DiscoveryGroupConfiguration discoveryGroupConfiguration = server.getConfiguration().
             getDiscoveryGroupConfigurations().get(config.getDiscoveryGroupName());
 
-         DiscoveryService discoveryService = new DiscoveryGroupService(new DiscoveryGroup(server.getNodeID().toString(), config.getDiscoveryGroupName(),
-            discoveryGroupConfiguration.getRefreshTimeout(), discoveryGroupConfiguration.getBroadcastEndpointFactory(), null));
+         DiscoveryService discoveryService = new DiscoveryGroupService(localTarget, discoveryGroupConfiguration);
 
          pool = new DiscoveryPool(targetFactory, scheduledExecutor, config.getCheckPeriod(), discoveryService);
       } else if (config.getStaticConnectors() != null) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/routing/pools/DiscoveryGroupService.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/routing/pools/DiscoveryGroupService.java
@@ -16,9 +16,11 @@
  */
 package org.apache.activemq.artemis.core.server.routing.pools;
 
+import org.apache.activemq.artemis.api.core.DiscoveryGroupConfiguration;
 import org.apache.activemq.artemis.core.cluster.DiscoveryEntry;
 import org.apache.activemq.artemis.core.cluster.DiscoveryGroup;
 import org.apache.activemq.artemis.core.cluster.DiscoveryListener;
+import org.apache.activemq.artemis.core.server.routing.targets.Target;
 
 import java.util.HashMap;
 import java.util.List;
@@ -26,16 +28,20 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class DiscoveryGroupService extends DiscoveryService implements DiscoveryListener {
-   private final DiscoveryGroup discoveryGroup;
+   private final Target localTarget;
+   private final DiscoveryGroupConfiguration config;
+   private DiscoveryGroup discoveryGroup;
 
    private final Map<String, Entry> entries = new ConcurrentHashMap<>();
 
-   public DiscoveryGroupService(DiscoveryGroup discoveryGroup) {
-      this.discoveryGroup = discoveryGroup;
+   public DiscoveryGroupService(Target localTarget, DiscoveryGroupConfiguration config) {
+      this.localTarget = localTarget;
+      this.config = config;
    }
 
    @Override
    public void start() throws Exception {
+      discoveryGroup = new DiscoveryGroup(localTarget.getNodeID(), config.getName(), config.getRefreshTimeout(), config.getBroadcastEndpointFactory(), null);
       discoveryGroup.registerListener(this);
 
       discoveryGroup.start();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/routing/targets/LocalTarget.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/routing/targets/LocalTarget.java
@@ -25,7 +25,7 @@ public class LocalTarget extends AbstractTarget {
    private final ManagementService managementService;
 
    public LocalTarget(TransportConfiguration connector, ActiveMQServer server) {
-      super(connector, server.getNodeID().toString());
+      super(connector, null);
 
       this.server = server;
       this.managementService = server.getManagementService();
@@ -43,7 +43,9 @@ public class LocalTarget extends AbstractTarget {
 
    @Override
    public void connect() throws Exception {
-
+      if (getNodeID() == null) {
+         setNodeID(server.getNodeID().toString());
+      }
    }
 
    @Override

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/routing/ConnectionRouterManagerTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/routing/ConnectionRouterManagerTest.java
@@ -18,7 +18,6 @@ package org.apache.activemq.artemis.core.server.routing;
 
 import java.util.Collections;
 
-import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.config.routing.ConnectionRouterConfiguration;
 import org.apache.activemq.artemis.core.config.routing.NamedPropertyConfiguration;
 import org.apache.activemq.artemis.core.config.routing.PoolConfiguration;
@@ -46,7 +45,6 @@ public class ConnectionRouterManagerTest {
    public void setUp() throws Exception {
 
       mockServer = mock(ActiveMQServer.class);
-      Mockito.when(mockServer.getNodeID()).thenReturn(SimpleString.toSimpleString("UUID"));
 
       underTest = new ConnectionRouterManager(null, mockServer, null);
       underTest.start();

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/routing/ConnectionRouterTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/routing/ConnectionRouterTest.java
@@ -19,7 +19,6 @@ package org.apache.activemq.artemis.core.server.routing;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
-import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.routing.policies.AbstractPolicy;
 import org.apache.activemq.artemis.core.server.routing.policies.Policy;
@@ -29,7 +28,6 @@ import org.apache.activemq.artemis.core.server.routing.targets.TargetResult;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -41,7 +39,6 @@ public class ConnectionRouterTest {
    @Before
    public void setUp() {
       ActiveMQServer mockServer = mock(ActiveMQServer.class);
-      Mockito.when(mockServer.getNodeID()).thenReturn(SimpleString.toSimpleString("UUID"));
       localTarget = new LocalTarget(null, mockServer);
    }
 


### PR DESCRIPTION
The nodeID on backup brokers is available only after they become live.