### PR TITLE
ARTEMIS-3707 fixing tests

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ra/ActiveMQRATestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ra/ActiveMQRATestBase.java
@@ -173,6 +173,12 @@ public abstract class ActiveMQRATestBase extends JMSTestBase {
    }
 
    public class MyBootstrapContext implements BootstrapContext {
+      TransactionSynchronizationRegistry tsr = null;
+
+      public MyBootstrapContext setTransactionSynchronizationRegistry(TransactionSynchronizationRegistry tsr) {
+         this.tsr = tsr;
+         return this;
+      }
 
       WorkManager workManager = new DummyWorkManager();
 
@@ -188,7 +194,7 @@ public abstract class ActiveMQRATestBase extends JMSTestBase {
 
       @Override
       public TransactionSynchronizationRegistry getTransactionSynchronizationRegistry() {
-         return null;
+         return tsr;
       }
 
       @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ra/DummyTransactionSynchronizationRegistry.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ra/DummyTransactionSynchronizationRegistry.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.ra;
+
+import javax.transaction.Status;
+import javax.transaction.Synchronization;
+import javax.transaction.TransactionSynchronizationRegistry;
+
+public class DummyTransactionSynchronizationRegistry implements TransactionSynchronizationRegistry {
+   private int status = Status.STATUS_NO_TRANSACTION;
+   private boolean rollbackOnly = false;
+
+   public DummyTransactionSynchronizationRegistry setStatus(int status) {
+      this.status = status;
+      return this;
+   }
+
+   @Override
+   public Object getTransactionKey() {
+      return null;
+   }
+
+   @Override
+   public void putResource(Object key, Object value) {
+
+   }
+
+   @Override
+   public Object getResource(Object key) {
+      return null;
+   }
+
+   @Override
+   public void registerInterposedSynchronization(Synchronization sync) {
+
+   }
+
+   @Override
+   public int getTransactionStatus() {
+      return status;
+   }
+
+   @Override
+   public void setRollbackOnly() {
+      rollbackOnly = true;
+   }
+
+   @Override
+   public boolean getRollbackOnly() {
+      return rollbackOnly;
+   }
+}

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ra/IgnoreJTATest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ra/IgnoreJTATest.java
@@ -37,6 +37,7 @@ import javax.jms.Queue;
 import javax.jms.QueueConnection;
 import javax.jms.Session;
 import javax.jms.TextMessage;
+import javax.transaction.Status;
 
 public class IgnoreJTATest extends ActiveMQRATestBase {
 
@@ -90,13 +91,12 @@ public class IgnoreJTATest extends ActiveMQRATestBase {
    }
 
    private void testSendAndReceive(Boolean ignoreJTA) throws Exception {
-      setDummyTX();
       setupDLQ(10);
       resourceAdapter = newResourceAdapter();
       if (ignoreJTA != null) {
          resourceAdapter.setIgnoreJTA(ignoreJTA);
       }
-      MyBootstrapContext ctx = new MyBootstrapContext();
+      MyBootstrapContext ctx = new MyBootstrapContext().setTransactionSynchronizationRegistry(new DummyTransactionSynchronizationRegistry().setStatus(Status.STATUS_ACTIVE));
       resourceAdapter.start(ctx);
       ActiveMQRAManagedConnectionFactory mcf = new ActiveMQRAManagedConnectionFactory();
       mcf.setResourceAdapter(resourceAdapter);


### PR DESCRIPTION
A handful of tests started to fail after the original fix was committed. This commit fixes those failures mainly by using a mock `TransactionSynchronizationRegistry`.

I changed `o.a.a.a.r.ActiveMQRAManagedConnection#checkTransactionActive` slightly because `getTransactionStatus` will never return `null` unlike `getTransaction` would. The semantics should still be the same, though.