### PR TITLE
ARTEMIS-4122 support timed refresh for LegacyLDAPSecuritySettingPlugin

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1557,4 +1557,6 @@ public interface ActiveMQServerLogger {
    @LogMessage(id = 224118, value = "The SQL Database is returning a current time too far from this system current time. Adjust clock on the SQL Database server. DatabaseTime={}, CurrentTime={}, allowed variance={}", level = LogMessage.Level.WARN)
    void dbReturnedTimeOffClock(long dbTime, long systemTime, long variance);
 
+   @LogMessage(id = 224119, value = "Unable to refresh security settings: {}", level = LogMessage.Level.WARN)
+   void unableToRefreshSecuritySettings(String exceptionMessage);
 }

--- a/docs/user-manual/en/security.md
+++ b/docs/user-manual/en/security.md
@@ -298,6 +298,19 @@ and Security Layer (SASL) authentication is currently not supported.
   receive updates made in the LDAP server and update the broker's authorization
   configuration in real-time. The default value is `true`.
 
+  Some LDAP servers (e.g. OpenLDAP) don't support the "persistent search"
+  feature which allows the "listener" functionality to work. For these servers
+  set the `refreshInterval` to a value greater than `0`.
+
+- `refreshInterval`. How long to wait (in seconds) before refreshing the
+  security settings from the LDAP server. This can be used for LDAP servers
+  which don't support the "persistent search" feature needed for use with
+  `enableListener` (e.g. OpenLDAP). Default is `0` (i.e. no refresh).
+
+  Keep in mind that this can be a potentially expensive operation based on how
+  often the refresh is configured and how large the data set is so take care
+  in how `refreshInterval` is configured.
+
 - `mapAdminToManage`. Whether or not to map the legacy `admin` permission to the
   `manage` permission. See details of the mapping semantics below. The default
    value is `false`.

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/security/LegacyLDAPSecuritySettingPluginRefreshTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/security/LegacyLDAPSecuritySettingPluginRefreshTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.security;
+
+import java.util.Map;
+
+import org.apache.activemq.artemis.core.server.impl.LegacyLDAPSecuritySettingPlugin;
+
+public class LegacyLDAPSecuritySettingPluginRefreshTest extends LegacyLDAPSecuritySettingPluginListenerTest {
+
+   @Override
+   protected Map<String, String> getSecuritSettingPluginConfigMap() {
+      Map<String, String> map = super.getSecuritSettingPluginConfigMap();
+      map.put(LegacyLDAPSecuritySettingPlugin.ENABLE_LISTENER, "false");
+      map.put(LegacyLDAPSecuritySettingPlugin.REFRESH_INTERVAL, "1");
+      return map;
+   }
+}


### PR DESCRIPTION
Some LDAP servers (e.g. OpenLDAP) do not support the "persistent search" feature and therefore the existing "listener" feature does not actually fetch updates. This commit implements a "pull" feature controlled by a configurable interval equivalent to what is implemented in the cached LDAP authorization module from ActiveMQ "Classic."