### PR TITLE
ARTEMIS-4125 address can be removed inadvertently

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -1126,16 +1126,15 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
 
       private void run() {
          try {
+            Binding binding = server.getPostOffice().getBinding(bindingName);
+            if (binding == null) {
+               // the queue may have already been deleted
+               return;
+            }
             logger.debug("deleting temporary queue {}", bindingName);
-
-            try {
-               server.destroyQueue(bindingName, null, false, false, true);
-               if (observer != null) {
-                  observer.tempQueueDeleted(bindingName);
-               }
-            } catch (ActiveMQException e) {
-               // that's fine.. it can happen due to queue already been deleted
-               logger.debug(e.getMessage(), e);
+            server.destroyQueue(bindingName, null, false, false, server.getAddressInfo(binding.getAddress()).isTemporary());
+            if (observer != null) {
+               observer.tempQueueDeleted(bindingName);
             }
          } catch (Exception e) {
             ActiveMQServerLogger.LOGGER.errorRemovingTempQueue(bindingName, e);


### PR DESCRIPTION
When the last non-durable subscriber on a JMS topic disconnects the corresponding queue representing the subscription is deleted as expected. However, the queue's address will also be deleted no matter what, which is *not* expected.