### PR TITLE
ARTEMIS-4129 Add max-saved-replicated-journals-size parameter to primary and replicated policy configuration

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/ConfigurationUtils.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/ConfigurationUtils.java
@@ -77,7 +77,7 @@ public final class ConfigurationUtils {
          }
          case REPLICATED: {
             ReplicatedPolicyConfiguration pc = (ReplicatedPolicyConfiguration) conf;
-            return new ReplicatedPolicy(pc.isCheckForLiveServer(), pc.getGroupName(), pc.getClusterName(), pc.getInitialReplicationSyncTimeout(), server.getNetworkHealthCheck(), pc.getVoteOnReplicationFailure(), pc.getQuorumSize(), pc.getVoteRetries(), pc.getVoteRetryWait(), pc.getQuorumVoteWait(), pc.getRetryReplicationWait());
+            return new ReplicatedPolicy(pc.isCheckForLiveServer(), pc.getGroupName(), pc.getClusterName(), pc.getMaxSavedReplicatedJournalsSize(), pc.getInitialReplicationSyncTimeout(), server.getNetworkHealthCheck(), pc.getVoteOnReplicationFailure(), pc.getQuorumSize(), pc.getVoteRetries(), pc.getVoteRetryWait(), pc.getQuorumVoteWait(), pc.getRetryReplicationWait());
          }
          case REPLICA: {
             ReplicaPolicyConfiguration pc = (ReplicaPolicyConfiguration) conf;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/ha/ReplicatedPolicyConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/ha/ReplicatedPolicyConfiguration.java
@@ -27,6 +27,8 @@ public class ReplicatedPolicyConfiguration implements HAPolicyConfiguration {
 
    private String clusterName = null;
 
+   private int maxSavedReplicatedJournalsSize = ActiveMQDefaultConfiguration.getDefaultMaxSavedReplicatedJournalsSize();
+
    private long initialReplicationSyncTimeout = ActiveMQDefaultConfiguration.getDefaultInitialReplicationSyncTimeout();
 
    private boolean voteOnReplicationFailure = ActiveMQDefaultConfiguration.getDefaultVoteOnReplicationFailure();
@@ -74,6 +76,15 @@ public class ReplicatedPolicyConfiguration implements HAPolicyConfiguration {
 
    public ReplicatedPolicyConfiguration setClusterName(String clusterName) {
       this.clusterName = clusterName;
+      return this;
+   }
+
+   public int getMaxSavedReplicatedJournalsSize() {
+      return maxSavedReplicatedJournalsSize;
+   }
+
+   public ReplicatedPolicyConfiguration setMaxSavedReplicatedJournalsSize(int maxSavedReplicatedJournalsSize) {
+      this.maxSavedReplicatedJournalsSize = maxSavedReplicatedJournalsSize;
       return this;
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/ha/ReplicationPrimaryPolicyConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/ha/ReplicationPrimaryPolicyConfiguration.java
@@ -33,6 +33,8 @@ public class ReplicationPrimaryPolicyConfiguration implements HAPolicyConfigurat
 
    private String coordinationId = null;
 
+   private int maxSavedReplicatedJournalsSize = ActiveMQDefaultConfiguration.getDefaultMaxSavedReplicatedJournalsSize();
+
    public static ReplicationPrimaryPolicyConfiguration withDefault() {
       return new ReplicationPrimaryPolicyConfiguration();
    }
@@ -110,5 +112,14 @@ public class ReplicationPrimaryPolicyConfiguration implements HAPolicyConfigurat
       if (this.coordinationId != null) {
          this.coordinationId = this.coordinationId.replace('-', '.');
       }
+   }
+
+   public int getMaxSavedReplicatedJournalsSize() {
+      return maxSavedReplicatedJournalsSize;
+   }
+
+   public ReplicationPrimaryPolicyConfiguration setMaxSavedReplicatedJournalsSize(int maxSavedReplicatedJournalsSize) {
+      this.maxSavedReplicatedJournalsSize = maxSavedReplicatedJournalsSize;
+      return this;
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -1718,6 +1718,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
       configuration.setClusterName(getString(policyNode, "cluster-name", configuration.getClusterName(), Validators.NO_CHECK));
 
+      configuration.setMaxSavedReplicatedJournalsSize(getInteger(policyNode, "max-saved-replicated-journals-size", configuration.getMaxSavedReplicatedJournalsSize(), Validators.MINUS_ONE_OR_GE_ZERO));
+
       configuration.setInitialReplicationSyncTimeout(getLong(policyNode, "initial-replication-sync-timeout", configuration.getInitialReplicationSyncTimeout(), Validators.GT_ZERO));
 
       configuration.setVoteOnReplicationFailure(getBoolean(policyNode, "vote-on-replication-failure", configuration.getVoteOnReplicationFailure()));
@@ -1780,6 +1782,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       configuration.setDistributedManagerConfiguration(createDistributedPrimitiveManagerConfiguration(policyNode, config));
 
       configuration.setCoordinationId(getString(policyNode, "coordination-id", configuration.getCoordinationId(), Validators.NOT_NULL_OR_EMPTY));
+
+      configuration.setMaxSavedReplicatedJournalsSize(getInteger(policyNode, "max-saved-replicated-journals-size", configuration.getMaxSavedReplicatedJournalsSize(), Validators.MINUS_ONE_OR_GE_ZERO));
 
       return configuration;
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ha/ReplicatedPolicy.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ha/ReplicatedPolicy.java
@@ -33,6 +33,8 @@ public class ReplicatedPolicy implements HAPolicy<LiveActivation> {
 
    private String clusterName;
 
+   private int maxSavedReplicatedJournalsSize = ActiveMQDefaultConfiguration.getDefaultMaxSavedReplicatedJournalsSize();
+
    private long initialReplicationSyncTimeout = ActiveMQDefaultConfiguration.getDefaultInitialReplicationSyncTimeout();
 
    /*
@@ -75,6 +77,7 @@ public class ReplicatedPolicy implements HAPolicy<LiveActivation> {
    public ReplicatedPolicy(boolean checkForLiveServer,
                            String groupName,
                            String clusterName,
+                           int maxSavedReplicatedJournalsSize,
                            long initialReplicationSyncTimeout,
                            NetworkHealthCheck networkHealthCheck,
                            boolean voteOnReplicationFailure,
@@ -86,6 +89,7 @@ public class ReplicatedPolicy implements HAPolicy<LiveActivation> {
       this.checkForLiveServer = checkForLiveServer;
       this.groupName = groupName;
       this.clusterName = clusterName;
+      this.maxSavedReplicatedJournalsSize = maxSavedReplicatedJournalsSize;
       this.initialReplicationSyncTimeout = initialReplicationSyncTimeout;
       this.networkHealthCheck = networkHealthCheck;
       this.voteOnReplicationFailure = voteOnReplicationFailure;
@@ -165,6 +169,7 @@ public class ReplicatedPolicy implements HAPolicy<LiveActivation> {
          replicaPolicy.setVoteRetries(voteRetries);
          replicaPolicy.setVoteRetryWait(voteRetryWait);
          replicaPolicy.setretryReplicationWait(retryReplicationWait);
+         replicaPolicy.setMaxSavedReplicatedJournalsSize(maxSavedReplicatedJournalsSize);
          if (clusterName != null && clusterName.length() > 0) {
             replicaPolicy.setClusterName(clusterName);
          }
@@ -250,5 +255,9 @@ public class ReplicatedPolicy implements HAPolicy<LiveActivation> {
 
    public long getRetryReplicationWait() {
       return retryReplicationWait;
+   }
+
+   public int getMaxSavedReplicatedJournalsSize() {
+      return maxSavedReplicatedJournalsSize;
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ha/ReplicationBackupPolicy.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ha/ReplicationBackupPolicy.java
@@ -79,12 +79,14 @@ public class ReplicationBackupPolicy implements HAPolicy<ReplicationBackupActiva
     * It creates a companion backup policy for a natural-born primary: it would cause the broker to try failback.
     */
    static ReplicationBackupPolicy failback(long retryReplicationWait,
+                                           int maxSavedReplicatedJournalsSize,
                                            String clusterName,
                                            String groupName,
                                            ReplicationPrimaryPolicy livePolicy,
                                            DistributedPrimitiveManagerConfiguration distributedManagerConfiguration) {
       return new ReplicationBackupPolicy(ReplicationBackupPolicyConfiguration.withDefault()
                                             .setRetryReplicationWait(retryReplicationWait)
+                                            .setMaxSavedReplicatedJournalsSize(maxSavedReplicatedJournalsSize)
                                             .setClusterName(clusterName)
                                             .setGroupName(groupName)
                                             .setDistributedManagerConfiguration(distributedManagerConfiguration),

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ha/ReplicationPrimaryPolicy.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ha/ReplicationPrimaryPolicy.java
@@ -56,7 +56,7 @@ public class ReplicationPrimaryPolicy implements HAPolicy<ReplicationPrimaryActi
       initialReplicationSyncTimeout = config.getInitialReplicationSyncTimeout();
       distributedManagerConfiguration = config.getDistributedManagerConfiguration();
       this.allowAutoFailBack = false;
-      backupPolicy = ReplicationBackupPolicy.failback(config.getRetryReplicationWait(), config.getClusterName(),
+      backupPolicy = ReplicationBackupPolicy.failback(config.getRetryReplicationWait(), config.getMaxSavedReplicatedJournalsSize(), config.getClusterName(),
                                                       config.getGroupName(), this,
                                                       config.getDistributedManagerConfiguration());
    }

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -3252,6 +3252,15 @@
                </xsd:documentation>
             </xsd:annotation>
          </xsd:element>
+         <xsd:element name="max-saved-replicated-journals-size" type="xsd:int" default="2" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  This option specifies how many replication backup directories will be kept when server starts as replica.
+                  Every time when server starts as replica all former data moves to 'oldreplica.{id}' directory, where id is growing backup index,
+                  this parameter sets the maximum number of such directories kept on disk.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
          <xsd:element name="check-for-live-server" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
             <xsd:annotation>
                <xsd:documentation>
@@ -3340,9 +3349,9 @@
          <xsd:element name="max-saved-replicated-journals-size" type="xsd:int" default="2" maxOccurs="1" minOccurs="0">
             <xsd:annotation>
                <xsd:documentation>
-                  This specifies how many times a replicated backup server can restart after moving its files on start.
-                  Once there are this number of backup journal files the server will stop permanently after if fails
-                  back.
+                  This option specifies how many replication backup directories will be kept when server starts as replica.
+                  Every time when server starts as replica all former data moves to 'oldreplica.{id}' directory, where id is growing backup index,
+                  this parameter sets the maximum number of such directories kept on disk.
                </xsd:documentation>
             </xsd:annotation>
          </xsd:element>
@@ -3486,6 +3495,15 @@
                </xsd:documentation>
             </xsd:annotation>
          </xsd:element>
+         <xsd:element name="max-saved-replicated-journals-size" type="xsd:int" default="2" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  This option specifies how many replication backup directories will be kept when server starts as replica.
+                  Every time when server starts as replica all former data moves to 'oldreplica.{id}' directory, where id is growing backup index,
+                  this parameter sets the maximum number of such directories kept on disk.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
       </xsd:all>
       <xsd:attributeGroup ref="xml:specialAttrs"/>
    </xsd:complexType>
@@ -3518,9 +3536,9 @@
          <xsd:element name="max-saved-replicated-journals-size" type="xsd:int" default="2" maxOccurs="1" minOccurs="0">
             <xsd:annotation>
                <xsd:documentation>
-                  This specifies how many times a replicated backup server can restart after moving its files on start.
-                  Once there are this number of backup journal files the server will stop permanently after if fails
-                  back.
+                  This option specifies how many replication backup directories will be kept when server starts as replica.
+                  Every time when server starts as replica all former data moves to 'oldreplica.{id}' directory, where id is growing backup index,
+                  this parameter sets the maximum number of such directories kept on disk.
                </xsd:documentation>
             </xsd:annotation>
          </xsd:element>
@@ -3576,9 +3594,9 @@
          <xsd:element name="max-saved-replicated-journals-size" type="xsd:int" default="2" maxOccurs="1" minOccurs="0">
             <xsd:annotation>
                <xsd:documentation>
-                  This specifies how many times a replicated backup server can restart after moving its files on start.
-                  Once there are this number of backup journal files the server will stop permanently after if fails
-                  back.
+                  This option specifies how many replication backup directories will be kept when server starts as replica.
+                  Every time when server starts as replica all former data moves to 'oldreplica.{id}' directory, where id is growing backup index,
+                  this parameter sets the maximum number of such directories kept on disk.
                </xsd:documentation>
             </xsd:annotation>
          </xsd:element>

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/HAPolicyConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/HAPolicyConfigurationTest.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.FileDeploymentManager;
 import org.apache.activemq.artemis.core.config.HAPolicyConfiguration;
@@ -317,7 +316,7 @@ public class HAPolicyConfigurationTest extends ActiveMQTestBase {
          assertEquals(policy.getGroupName(), failbackPolicy.getGroupName());
          assertEquals(policy.getBackupGroupName(), failbackPolicy.getBackupGroupName());
          assertEquals(policy.getClusterName(), failbackPolicy.getClusterName());
-         assertEquals(failbackPolicy.getMaxSavedReplicatedJournalsSize(), ActiveMQDefaultConfiguration.getDefaultMaxSavedReplicatedJournalsSize());
+         assertEquals(73, failbackPolicy.getMaxSavedReplicatedJournalsSize());
          assertTrue(failbackPolicy.isTryFailback());
          assertTrue(failbackPolicy.isBackup());
          assertFalse(failbackPolicy.isSharedStore());
@@ -413,6 +412,7 @@ public class HAPolicyConfigurationTest extends ActiveMQTestBase {
          assertEquals(replicatedPolicy.getClusterName(), "abcdefg");
          assertEquals(replicatedPolicy.getInitialReplicationSyncTimeout(), 9876);
          assertEquals(replicatedPolicy.getRetryReplicationWait(), 12345);
+         assertEquals(replicatedPolicy.getMaxSavedReplicatedJournalsSize(), 73);
       } finally {
          server.stop();
       }

--- a/artemis-server/src/test/resources/primary-hapolicy-config.xml
+++ b/artemis-server/src/test/resources/primary-hapolicy-config.xml
@@ -27,6 +27,7 @@
                <cluster-name>abcdefg</cluster-name>
                <initial-replication-sync-timeout>9876</initial-replication-sync-timeout>
                <retry-replication-wait>12345</retry-replication-wait>
+               <max-saved-replicated-journals-size>73</max-saved-replicated-journals-size>
                <manager>
                   <class-name>
                      org.apache.activemq.artemis.core.config.impl.HAPolicyConfigurationTest$FakeDistributedPrimitiveManager

--- a/artemis-server/src/test/resources/replicated-hapolicy-config.xml
+++ b/artemis-server/src/test/resources/replicated-hapolicy-config.xml
@@ -28,6 +28,7 @@
                <cluster-name>abcdefg</cluster-name>
                <initial-replication-sync-timeout>9876</initial-replication-sync-timeout>
                <retry-replication-wait>12345</retry-replication-wait>
+               <max-saved-replicated-journals-size>73</max-saved-replicated-journals-size>
             </master>
          </replication>
       </ha-policy>

--- a/docs/user-manual/en/configuration-index.md
+++ b/docs/user-manual/en/configuration-index.md
@@ -191,7 +191,7 @@ log-delegate-factory-class-name | **deprecated** the name of the factory class t
 [management-address](management.md#configuring-management)| the name of the management address to send management messages to. | `activemq.management`
 [management-notification-address](management.md#configuring-the-management-notification-address) | the name of the address that consumers bind to receive management notifications. | `activemq.notifications`
 [mask-password](masking-passwords.md) | This option controls whether passwords in server configuration need be masked. If set to "true" the passwords are masked. | `false`
-[max-saved-replicated-journals-size](ha.md#data-replication) | This specifies how many times a replicated backup server can restart after moving its files on start. Once there are this number of backup journal files the server will stop permanently after if fails back. -1 Means no Limit; 0 don't keep a copy at all. | 2
+[max-saved-replicated-journals-size](ha.md#data-replication) | This specifies how many replication backup directories will be kept when server starts as replica. -1 Means no Limit; 0 don't keep a copy at all. | 2
 [max-disk-usage](paging.md#max-disk-usage) | The max percentage of data we should use from disks. The broker will block while the disk is full. Disable by setting -1. | 90
 [memory-measure-interval](perf-tuning.md) | frequency to sample JVM memory in ms (or -1 to disable memory sampling). | -1
 [memory-warning-threshold](perf-tuning.md)| Percentage of available memory which will trigger a warning log. | 25

--- a/docs/user-manual/en/ha.md
+++ b/docs/user-manual/en/ha.md
@@ -350,9 +350,10 @@ group-name
 
 - `max-saved-replicated-journals-size`
 
-This specifies how many times a replicated backup server can restart
-after moving its files on start. Once there are this number of backup
-journal files the server will stop permanently after if fails back.
+This option specifies how many replication backup directories will be kept 
+when server starts as replica. Every time when server starts as replica all 
+former data moves to 'oldreplica.{id}' directory, where id is growing backup index,
+this parameter sets the maximum number of such directories kept on disk.
 
 - `allow-failback`
 


### PR DESCRIPTION
Allow override default max-saved-replicated-journals-size value when the server is configured as primary or replicated.