### PR TITLE
ARTEMIS-3819 do not trip on empty values in web-console

### DIFF
--- a/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/components/browse.js
+++ b/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/components/browse.js
@@ -328,6 +328,7 @@ var Artemis;
                 itemField: 'validatedUser',
                 header: 'Validated User',
                 templateFn: function(value) {
+                    if (!value) return undefined;
                     return value._AMQ_VALIDATED_USER;
                 }
             }
@@ -339,6 +340,7 @@ var Artemis;
                 itemField: 'StringProperties',
                 header: 'Original Queue',
                 templateFn: function(value) {
+                    if (!value) return undefined;
                     return (value['_AMQ_ORIG_QUEUE'] ? value['_AMQ_ORIG_QUEUE'] : value['extraProperties._AMQ_ORIG_QUEUE']);
                 }
             };


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/ARTEMIS-3819

fields 'validateduser' and 'original queue' may not have a value.
this PR just makes sure that the JS code does not care