### PR TITLE
ARTEMIS-3178 Page Limitting (max messages and max bytes)

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/settings/impl/PageFullMessagePolicy.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/settings/impl/PageFullMessagePolicy.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.settings.impl;
+
+public enum PageFullMessagePolicy {
+   DROP, FAIL
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/Validators.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/Validators.java
@@ -26,6 +26,7 @@ import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.core.server.cluster.impl.MessageLoadBalancingType;
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.DeletionPolicy;
+import org.apache.activemq.artemis.core.settings.impl.PageFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.SlowConsumerPolicy;
 import org.apache.activemq.artemis.core.settings.impl.SlowConsumerThresholdMeasurementUnit;
 
@@ -190,6 +191,18 @@ public final class Validators {
             !val.equals(AddressFullMessagePolicy.DROP.toString()) &&
             !val.equals(AddressFullMessagePolicy.BLOCK.toString()) &&
             !val.equals(AddressFullMessagePolicy.FAIL.toString())) {
+            throw ActiveMQMessageBundle.BUNDLE.invalidAddressFullPolicyType(val);
+         }
+      }
+   };
+
+   public static final Validator PAGE_FULL_MESSAGE_POLICY_TYPE = new Validator() {
+      @Override
+      public void validate(final String name, final Object value) {
+         String val = (String) value;
+         if (val == null ||
+            !val.equals(PageFullMessagePolicy.DROP.toString()) &&
+            !val.equals(PageFullMessagePolicy.FAIL.toString())) {
             throw ActiveMQMessageBundle.BUNDLE.invalidAddressFullPolicyType(val);
          }
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -98,6 +98,7 @@ import org.apache.activemq.artemis.core.server.plugin.ActiveMQServerPlugin;
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.core.settings.impl.DeletionPolicy;
+import org.apache.activemq.artemis.core.settings.impl.PageFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.ResourceLimitSettings;
 import org.apache.activemq.artemis.core.settings.impl.SlowConsumerPolicy;
 import org.apache.activemq.artemis.core.settings.impl.SlowConsumerThresholdMeasurementUnit;
@@ -218,6 +219,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
    private static final String ADDRESS_FULL_MESSAGE_POLICY_NODE_NAME = "address-full-policy";
 
+   private static final String PAGE_FULL_MESSAGE_POLICY_NODE_NAME = "page-full-policy";
+
    private static final String MAX_READ_PAGE_BYTES_NODE_NAME = "max-read-page-bytes";
 
    private static final String MAX_READ_PAGE_MESSAGES_NODE_NAME = "max-read-page-messages";
@@ -225,6 +228,10 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
    private static final String PAGE_SIZE_BYTES_NODE_NAME = "page-size-bytes";
 
    private static final String PAGE_MAX_CACHE_SIZE_NODE_NAME = "page-max-cache-size";
+
+   private static final String PAGE_LIMIT_BYTES_NODE_NAME = "page-limit-bytes";
+
+   private static final String PAGE_LIMIT_MESSAGES_NODE_NAME = "page-limit-messages";
 
    private static final String MESSAGE_COUNTER_HISTORY_DAY_LIMIT_NODE_NAME = "message-counter-history-day-limit";
 
@@ -1281,6 +1288,14 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
                ActiveMQServerLogger.LOGGER.pageMaxSizeUsed();
             }
             addressSettings.setPageCacheMaxSize(XMLUtil.parseInt(child));
+         } else if (PAGE_LIMIT_BYTES_NODE_NAME.equalsIgnoreCase(name)) {
+            long pageLimitBytes = ByteUtil.convertTextBytes(getTrimmedTextContent(child));
+            Validators.MINUS_ONE_OR_POSITIVE_INT.validate(PAGE_LIMIT_BYTES_NODE_NAME, pageLimitBytes);
+            addressSettings.setPageLimitBytes(pageLimitBytes);
+         } else if (PAGE_LIMIT_MESSAGES_NODE_NAME.equalsIgnoreCase(name)) {
+            long pageLimitMessages = ByteUtil.convertTextBytes(getTrimmedTextContent(child));
+            Validators.MINUS_ONE_OR_POSITIVE_INT.validate(PAGE_LIMIT_MESSAGES_NODE_NAME, pageLimitMessages);
+            addressSettings.setPageLimitMessages(pageLimitMessages);
          } else if (MESSAGE_COUNTER_HISTORY_DAY_LIMIT_NODE_NAME.equalsIgnoreCase(name)) {
             addressSettings.setMessageCounterHistoryDayLimit(XMLUtil.parseInt(child));
          } else if (ADDRESS_FULL_MESSAGE_POLICY_NODE_NAME.equalsIgnoreCase(name)) {
@@ -1288,6 +1303,11 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
             Validators.ADDRESS_FULL_MESSAGE_POLICY_TYPE.validate(ADDRESS_FULL_MESSAGE_POLICY_NODE_NAME, value);
             AddressFullMessagePolicy policy = Enum.valueOf(AddressFullMessagePolicy.class, value);
             addressSettings.setAddressFullMessagePolicy(policy);
+         } else if (PAGE_FULL_MESSAGE_POLICY_NODE_NAME.equalsIgnoreCase(name)) {
+            String value = getTrimmedTextContent(child);
+            Validators.PAGE_FULL_MESSAGE_POLICY_TYPE.validate(PAGE_FULL_MESSAGE_POLICY_NODE_NAME, value);
+            PageFullMessagePolicy policy = Enum.valueOf(PageFullMessagePolicy.class, value);
+            addressSettings.setPageFullMessagePolicy(policy);
          } else if (LVQ_NODE_NAME.equalsIgnoreCase(name) || DEFAULT_LVQ_NODE_NAME.equalsIgnoreCase(name)) {
             addressSettings.setDefaultLastValueQueue(XMLUtil.parseBoolean(child));
          } else if (DEFAULT_LVQ_KEY_NODE_NAME.equalsIgnoreCase(name)) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/PagingStore.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/PagingStore.java
@@ -23,6 +23,7 @@ import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.RefCountMessageListener;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.paging.cursor.PageCursorProvider;
+import org.apache.activemq.artemis.core.paging.cursor.PageSubscription;
 import org.apache.activemq.artemis.core.paging.impl.Page;
 import org.apache.activemq.artemis.core.persistence.StorageManager;
 import org.apache.activemq.artemis.core.replication.ReplicationManager;
@@ -30,6 +31,7 @@ import org.apache.activemq.artemis.core.server.ActiveMQComponent;
 import org.apache.activemq.artemis.core.server.RouteContextList;
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
+import org.apache.activemq.artemis.core.settings.impl.PageFullMessagePolicy;
 import org.apache.activemq.artemis.core.transaction.Transaction;
 import org.apache.activemq.artemis.utils.actors.ArtemisExecutor;
 
@@ -59,6 +61,19 @@ public interface PagingStore extends ActiveMQComponent, RefCountMessageListener 
    File getFolder();
 
    AddressFullMessagePolicy getAddressFullMessagePolicy();
+
+   PageFullMessagePolicy getPageFullMessagePolicy();
+
+   Long getPageLimitMessages();
+
+   Long getPageLimitBytes();
+
+   /** Callback to be used by a counter when the Page is full for that counter */
+   void pageFull(PageSubscription subscription);
+
+   boolean isPageFull();
+
+   void checkPageLimit(long numberOfMessages);
 
    long getFirstPage();
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/PageCursorProvider.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/PageCursorProvider.java
@@ -16,6 +16,7 @@
  */
 package org.apache.activemq.artemis.core.paging.cursor;
 
+import java.util.concurrent.Future;
 import java.util.function.Consumer;
 
 import org.apache.activemq.artemis.core.filter.Filter;
@@ -46,7 +47,7 @@ public interface PageCursorProvider {
 
    void flushExecutors();
 
-   void scheduleCleanup();
+   Future<Boolean> scheduleCleanup();
 
    void disableCleanup();
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQMessageBundle.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQMessageBundle.java
@@ -527,4 +527,7 @@ public interface ActiveMQMessageBundle {
 
    @Message(id = 229245, value = "Management controller is busy with another task. Please try again")
    ActiveMQTimeoutException managementBusy();
+
+   @Message(id = 229246, value = "Invalid page full message policy type {}")
+   IllegalArgumentException invalidPageFullPolicyType(String val);
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1563,4 +1563,23 @@ public interface ActiveMQServerLogger {
 
    @LogMessage(id = 224119, value = "Unable to refresh security settings: {}", level = LogMessage.Level.WARN)
    void unableToRefreshSecuritySettings(String exceptionMessage);
+
+   @LogMessage(id = 224120, value = "Queue {} on Address {} has more messages than configured page limit. PageLimitMesages={} while currentValue={}", level = LogMessage.Level.WARN)
+   void pageFull(SimpleString queue, SimpleString address, Object pageLImitMessage, Object currentValue);
+
+   @LogMessage(id = 224121, value = "Queue {} on Address {} is out of page limit now. We will issue a cleanup to check other queues.", level = LogMessage.Level.WARN)
+   void pageFree(SimpleString queue, SimpleString address);
+
+   @LogMessage(id = 224122, value = "Address {} number of messages is under page limit again, and it should be allowed to page again.", level = LogMessage.Level.INFO)
+   void pageFree(SimpleString address);
+
+   @LogMessage(id = 224123, value = "Address {} has more pages than allowed. System currently has {} pages, while the estimated max number of pages is {}, based on the limitPageBytes ({}) / page-size ({})", level = LogMessage.Level.WARN)
+   void pageFullMaxBytes(SimpleString address, long pages, long maxPages, long limitBytes, long bytes);
+
+   @LogMessage(id = 224124, value = "Address {} has a pageFullPolicy set as {} but there are not page-limit-bytes or page-limit-messages set. Page full configuration being ignored on this address.", level = LogMessage.Level.WARN)
+   void noPageLimitsSet(Object address, Object policy);
+
+   @LogMessage(id = 224125, value = "Address {} has page-limit-bytes={}, page-limit-messages={} and no page-full-policy set. Page full configuration being ignored on this address", level = LogMessage.Level.WARN)
+   void noPagefullPolicySet(Object address, Object limitBytes, Object limitMessages);
+
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
@@ -147,6 +147,12 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
    private Integer maxReadPageMessages = null;
 
+   private Long pageLimitBytes = null;
+
+   private Long pageLimitMessages = null;
+
+   private PageFullMessagePolicy pageFullMessagePolicy = null;
+
    private Long maxSizeMessages = null;
 
    private Integer pageSizeBytes = null;
@@ -289,6 +295,9 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       this.maxSizeMessages = other.maxSizeMessages;
       this.maxReadPageMessages = other.maxReadPageMessages;
       this.maxReadPageBytes = other.maxReadPageBytes;
+      this.pageLimitBytes = other.pageLimitBytes;
+      this.pageLimitMessages = other.pageLimitMessages;
+      this.pageFullMessagePolicy = other.pageFullMessagePolicy;
       this.pageSizeBytes = other.pageSizeBytes;
       this.pageMaxCache = other.pageMaxCache;
       this.dropMessagesWhenFull = other.dropMessagesWhenFull;
@@ -641,6 +650,33 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
    public AddressSettings setMaxReadPageMessages(final int maxReadPageMessages) {
       this.maxReadPageMessages = maxReadPageMessages;
+      return this;
+   }
+
+   public Long getPageLimitBytes() {
+      return pageLimitBytes;
+   }
+
+   public AddressSettings setPageLimitBytes(Long pageLimitBytes) {
+      this.pageLimitBytes = pageLimitBytes;
+      return this;
+   }
+
+   public Long getPageLimitMessages() {
+      return pageLimitMessages;
+   }
+
+   public AddressSettings setPageLimitMessages(Long pageLimitMessages) {
+      this.pageLimitMessages = pageLimitMessages;
+      return this;
+   }
+
+   public PageFullMessagePolicy getPageFullMessagePolicy() {
+      return this.pageFullMessagePolicy;
+   }
+
+   public AddressSettings setPageFullMessagePolicy(PageFullMessagePolicy policy) {
+      this.pageFullMessagePolicy = policy;
       return this;
    }
 
@@ -1223,6 +1259,15 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       if (enableIngressTimestamp == null) {
          enableIngressTimestamp = merged.enableIngressTimestamp;
       }
+      if (pageFullMessagePolicy == null) {
+         pageFullMessagePolicy = merged.pageFullMessagePolicy;
+      }
+      if (pageLimitBytes == null) {
+         pageLimitBytes = merged.pageLimitBytes;
+      }
+      if (pageLimitMessages == null) {
+         pageLimitMessages = merged.pageLimitMessages;
+      }
    }
 
    @Override
@@ -1472,6 +1517,24 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       if (buffer.readableBytes() > 0) {
          maxReadPageMessages = BufferHelper.readNullableInteger(buffer);
       }
+
+      if (buffer.readableBytes() > 0) {
+         pageLimitBytes = BufferHelper.readNullableLong(buffer);
+      }
+
+      if (buffer.readableBytes() > 0) {
+         pageLimitMessages = BufferHelper.readNullableLong(buffer);
+      }
+
+      if (buffer.readableBytes() > 0) {
+         policyStr = buffer.readNullableSimpleString();
+
+         if (policyStr != null) {
+            pageFullMessagePolicy = PageFullMessagePolicy.valueOf(policyStr.toString());
+         } else {
+            pageFullMessagePolicy = null;
+         }
+      }
    }
 
    @Override
@@ -1542,7 +1605,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
          BufferHelper.sizeOfNullableBoolean(enableIngressTimestamp) +
          BufferHelper.sizeOfNullableLong(maxSizeMessages) +
          BufferHelper.sizeOfNullableInteger(maxReadPageMessages) +
-         BufferHelper.sizeOfNullableInteger(maxReadPageBytes);
+         BufferHelper.sizeOfNullableInteger(maxReadPageBytes) +
+         BufferHelper.sizeOfNullableLong(pageLimitBytes) +
+         BufferHelper.sizeOfNullableLong(pageLimitMessages) +
+         BufferHelper.sizeOfNullableSimpleString(pageFullMessagePolicy != null ? pageFullMessagePolicy.toString() : null);
    }
 
    @Override
@@ -1682,6 +1748,13 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       BufferHelper.writeNullableInteger(buffer, maxReadPageBytes);
 
       BufferHelper.writeNullableInteger(buffer, maxReadPageMessages);
+
+      BufferHelper.writeNullableLong(buffer, pageLimitBytes);
+
+      BufferHelper.writeNullableLong(buffer, pageLimitMessages);
+
+      buffer.writeNullableSimpleString(pageFullMessagePolicy != null ? new SimpleString(pageFullMessagePolicy.toString()) : null);
+
    }
 
    /* (non-Javadoc)
@@ -1758,6 +1831,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       result = prime * result + ((slowConsumerThresholdMeasurementUnit == null) ? 0 : slowConsumerThresholdMeasurementUnit.hashCode());
       result = prime * result + ((enableIngressTimestamp == null) ? 0 : enableIngressTimestamp.hashCode());
       result = prime * result + ((maxSizeMessages == null) ? 0 : maxSizeMessages.hashCode());
+      result = prime * result + ((pageLimitBytes == null) ? 0 : pageLimitBytes.hashCode());
+      result = prime * result + ((pageLimitMessages == null) ? 0 : pageLimitMessages.hashCode());
+      result = prime * result + ((pageFullMessagePolicy == null) ? 0 : pageFullMessagePolicy.hashCode());
+
       return result;
    }
 
@@ -2130,6 +2207,31 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       } else if (!maxSizeMessages.equals(other.maxSizeMessages))
          return false;
 
+      if (pageLimitBytes == null) {
+         if (other.pageLimitBytes != null) {
+            return false;
+         }
+      } else if (!pageLimitBytes.equals(other.pageLimitBytes)) {
+         return false;
+      }
+
+      if (pageLimitMessages == null) {
+         if (other.pageLimitMessages != null) {
+            return false;
+         }
+      } else if (!pageLimitMessages.equals(other.pageLimitMessages)) {
+         return false;
+      }
+
+      if (pageFullMessagePolicy == null) {
+         if (other.pageFullMessagePolicy != null) {
+            return false;
+         }
+      } else if (!pageFullMessagePolicy.equals(other.pageFullMessagePolicy)) {
+         return false;
+      }
+
+
       return true;
    }
 
@@ -2267,6 +2369,12 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
          enableMetrics +
          ", enableIngressTime=" +
          enableIngressTimestamp +
+         ", pageLimitBytes=" +
+         pageLimitBytes +
+         ", pageLimitMessages=" +
+         pageLimitMessages +
+         ", pageFullMessagePolicy=" +
+         pageFullMessagePolicy +
          "]";
    }
 }

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -3757,8 +3757,25 @@
             </xsd:annotation>
          </xsd:element>
 
+         <xsd:element name="page-limit-bytes" type="xsd:string" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  After the address enters into page mode, this attribute will configure how many pages can be written into page before activating the page-full-policy.
+                  Supports byte notation like "K", "Mb", "MiB", "GB", etc.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="page-limit-messages" type="xsd:long" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  After the address enters into page mode, this attribute will configure how many messages can be written into page before activating the page-full-policy.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
          <xsd:element name="max-size-bytes-reject-threshold" type="xsd:long" default="-1" maxOccurs="1"
-                        minOccurs="0">
+                      minOccurs="0">
             <xsd:annotation>
                <xsd:documentation>
                   used with the address full BLOCK policy, the maximum size (in bytes) an address can reach before
@@ -3815,6 +3832,20 @@
                   <xsd:enumeration value="FAIL"/>
                   <xsd:enumeration value="PAGE"/>
                   <xsd:enumeration value="BLOCK"/>
+               </xsd:restriction>
+            </xsd:simpleType>
+         </xsd:element>
+
+         <xsd:element name="page-full-policy" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  After entering page mode, a second limit will be set by page-limit-bytes and/or page-limit-messages. The page-full-policy will configure what to do when that limit is reached.
+               </xsd:documentation>
+            </xsd:annotation>
+            <xsd:simpleType>
+               <xsd:restriction base="xsd:string">
+                  <xsd:enumeration value="DROP"/>
+                  <xsd:enumeration value="FAIL"/>
                </xsd:restriction>
             </xsd:simpleType>
          </xsd:element>
@@ -4315,7 +4346,7 @@
          <xsd:attributeGroup ref="xml:specialAttrs"/>
       </xsd:complexType>
    </xsd:element>
-   
+
    <xsd:complexType name="connector-serviceType">
       <xsd:sequence>
          <xsd:element maxOccurs="1" minOccurs="1" name="factory-class" type="xsd:string">

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationParserTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationParserTest.java
@@ -393,6 +393,25 @@ public class FileConfigurationParserTest extends ActiveMQTestBase {
       AddressSettings settings = configuration.getAddressSettings().get("foo");
       Assert.assertEquals(1024, settings.getMaxReadPageBytes());
       Assert.assertEquals(33, settings.getMaxReadPageMessages());
+      Assert.assertNull(settings.getPageLimitBytes());
+      Assert.assertNull(settings.getPageLimitMessages());
+      Assert.assertNull(settings.getPageFullMessagePolicy());
+   }
+
+   @Test
+   public void testParsePageLimitSettings() throws Exception {
+      String configStr = "<configuration><address-settings>" + "\n" + "<address-setting match=\"foo\">" + "\n" + "<max-read-page-bytes>1k</max-read-page-bytes><page-limit-bytes>2k</page-limit-bytes><page-limit-messages>337</page-limit-messages><page-full-policy>FAIL</page-full-policy><max-read-page-messages>33</max-read-page-messages>.\n" + "</address-setting>" + "\n" + "</address-settings></configuration>" + "\n";
+
+      FileConfigurationParser parser = new FileConfigurationParser();
+      ByteArrayInputStream input = new ByteArrayInputStream(configStr.getBytes(StandardCharsets.UTF_8));
+
+      Configuration configuration = parser.parseMainConfig(input);
+      AddressSettings settings = configuration.getAddressSettings().get("foo");
+      Assert.assertEquals(1024, settings.getMaxReadPageBytes());
+      Assert.assertEquals(33, settings.getMaxReadPageMessages());
+      Assert.assertEquals(2048L, settings.getPageLimitBytes().longValue());
+      Assert.assertEquals(337L, settings.getPageLimitMessages().longValue());
+      Assert.assertEquals("FAIL", settings.getPageFullMessagePolicy().toString());
    }
 
    @Test

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
@@ -134,6 +134,7 @@ import org.apache.activemq.artemis.core.server.impl.ReplicationBackupActivation;
 import org.apache.activemq.artemis.core.server.impl.SharedNothingBackupActivation;
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
+import org.apache.activemq.artemis.core.settings.impl.PageFullMessagePolicy;
 import org.apache.activemq.artemis.core.transaction.impl.XidImpl;
 import org.apache.activemq.artemis.jdbc.store.drivers.JDBCUtils;
 import org.apache.activemq.artemis.jdbc.store.sql.SQLProvider;
@@ -1505,12 +1506,28 @@ public abstract class ActiveMQTestBase extends Assert {
       return createServer(realFiles, configuration, pageSize, maxAddressSize, null, null, settings);
    }
 
+
+
+   protected final ActiveMQServer createServer(final boolean realFiles,
+                                               final Configuration configuration,
+                                               final int pageSize,
+                                               final long maxAddressSize,
+                                               final Integer maxReadPageMessages,
+                                               final Integer maxReadPageBytes,
+                                               final Map<String, AddressSettings> settings) {
+      return  createServer(realFiles, configuration, pageSize, maxAddressSize, maxReadPageMessages, maxReadPageBytes, null, null, null, settings);
+
+   }
+
    protected final ActiveMQServer createServer(final boolean realFiles,
                                          final Configuration configuration,
                                          final int pageSize,
                                          final long maxAddressSize,
                                          final Integer maxReadPageMessages,
                                          final Integer maxReadPageBytes,
+                                         final Long pageLimitBytes,
+                                         final Long pageLimitMessages,
+                                         final String pageLimitPolicy,
                                          final Map<String, AddressSettings> settings) {
       ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(configuration, realFiles));
 
@@ -1522,6 +1539,15 @@ public abstract class ActiveMQTestBase extends Assert {
             if (maxReadPageMessages != null) {
                setting.getValue().setMaxReadPageMessages(maxReadPageMessages.intValue());
             }
+            if (pageLimitBytes != null) {
+               setting.getValue().setPageLimitBytes(pageLimitBytes);
+            }
+            if (pageLimitMessages != null) {
+               setting.getValue().setPageLimitMessages(pageLimitMessages);
+            }
+            if (pageLimitPolicy != null) {
+               setting.getValue().setPageFullMessagePolicy(PageFullMessagePolicy.valueOf(pageLimitPolicy));
+            }
             server.getAddressSettingsRepository().addMatch(setting.getKey(), setting.getValue());
          }
       }
@@ -1532,6 +1558,15 @@ public abstract class ActiveMQTestBase extends Assert {
       }
       if (maxReadPageMessages != null) {
          defaultSetting.setMaxReadPageMessages(maxReadPageMessages.intValue());
+      }
+      if (pageLimitBytes != null) {
+         defaultSetting.setPageLimitBytes(pageLimitBytes);
+      }
+      if (pageLimitMessages != null) {
+         defaultSetting.setPageLimitMessages(pageLimitMessages);
+      }
+      if (pageLimitPolicy != null) {
+         defaultSetting.setPageFullMessagePolicy(PageFullMessagePolicy.valueOf(pageLimitPolicy));
       }
 
       server.getAddressSettingsRepository().addMatch("#", defaultSetting);

--- a/docs/user-manual/en/paging.md
+++ b/docs/user-manual/en/paging.md
@@ -74,6 +74,9 @@ Configuration is done at the address settings in `broker.xml`.
       <max-size-messages>1000</max-size-messages>
       <page-size-bytes>10485760</page-size-bytes>
       <address-full-policy>PAGE</address-full-policy>
+      <page-limit-bytes>10G</page-limit-bytes>
+      <page-limit-messages>1000000</page-limit-messages>
+      <page-full-policy>FAIL</page-full-policy>
    </address-setting>
 </address-settings>
 ```
@@ -98,6 +101,9 @@ Property Name|Description|Default
 `address-full-policy`|This must be set to `PAGE` for paging to enable. If the value is `PAGE` then further messages will be paged to disk. If the value is `DROP` then further messages will be silently dropped. If the value is `FAIL` then the messages will be dropped and the client message producers will receive an exception. If the value is `BLOCK` then client message producers will block when they try and send further messages.|`PAGE`
 `max-read-page-messages` | how many message can be read from paging into the Queue whenever more messages are needed. The system wtill stop reading if `max-read-page-bytes hits the limit first. | -1
 `max-read-page-bytes` | how much memory the messages read from paging can take on the Queue whenever more messages are needed. The system will stop reading if `max-read-page-messages` hits the limit first. | 2 * page-size-bytes
+`page-limit-bytes` | After entering page mode, how much data would the system allow incoming. Notice this will be internally converted as number of pages. | 
+`page-limit-messages` | After entering page mode, how many messages would the system allow incoming on paging. | 
+`page-full-policy` | Valid results are DROP or FAIL. This tells what to do if the system is reaching `page-limit-bytes` or `page-limit-messages` after paging | 
 
 ### max-size-bytes and max-size-messages simultaneous usage
 
@@ -204,6 +210,14 @@ should be `3333333`.
 The system should keep at least one paged file in memory caching ahead reading messages. 
 Also every active subscription could keep one paged file in memory. 
 So, if your system has too many queues it is recommended to minimize the page-size.
+
+## Page Limits and Page Full Policy
+
+Since version `2.28.0` is possible to configure limits on how much data is paged. This is to avoid a single destination using the entire disk in case their consumers are gone.
+
+You can configure either `page-limit-bytes` or `page-limit-messages`, along with `page-full-policy` on the address settings limiting how much data will be recorded in paging.
+
+If you configure `page-full-policy` as DROP, messages will be simplify dropped while the clients will not get any exceptions, while if you configured FAIL the producers will receive a JMS Exception for the error condition.
 
 ## Example
 

--- a/examples/features/standard/paging/src/main/java/org/apache/activemq/artemis/jms/example/PagingExample.java
+++ b/examples/features/standard/paging/src/main/java/org/apache/activemq/artemis/jms/example/PagingExample.java
@@ -20,6 +20,7 @@ import javax.jms.BytesMessage;
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
 import javax.jms.DeliveryMode;
+import javax.jms.JMSException;
 import javax.jms.MessageConsumer;
 import javax.jms.MessageProducer;
 import javax.jms.Queue;
@@ -32,91 +33,56 @@ import javax.naming.InitialContext;
 public class PagingExample {
 
    public static void main(final String[] args) throws Exception {
-      Connection connection = null;
+      // simple routing showing how paging should work
+      simplePaging();
+      // simple routing showing what happens when paging enters into page-full
+      pageFullLimit();
+   }
 
+
+   public static void pageFullLimit() throws Exception {
       InitialContext initialContext = null;
       try {
-         // Step 1. Create an initial context to perform the JNDI lookup.
+         // Create an initial context to perform the JNDI lookup.
          initialContext = new InitialContext();
 
-         // Step 2. Perform a lookup on the Connection Factory
+         // Perform a lookup on the Connection Factory
          ConnectionFactory cf = (ConnectionFactory) initialContext.lookup("ConnectionFactory");
 
-         // Step 3. We look-up the JMS queue object from JNDI. pagingQueue is configured to hold a very limited number
-         // of bytes in memory
-         Queue pageQueue = (Queue) initialContext.lookup("queue/pagingQueue");
+         // Create a JMS Connection
+         try (Connection connection = cf.createConnection()) {
 
-         // Step 4. Lookup for a JMS Queue
-         Queue queue = (Queue) initialContext.lookup("queue/exampleQueue");
+            // Create a JMS Session
+            Session session = connection.createSession(true, Session.SESSION_TRANSACTED);
 
-         // Step 5. Create a JMS Connection
-         connection = cf.createConnection();
+            // lookup the queue
+            Queue queue = session.createQueue("pagingQueueLimited");
 
-         // Step 6. Create a JMS Session
-         Session session = connection.createSession(false, Session.CLIENT_ACKNOWLEDGE);
+            // Create a JMS Message Producer for pageQueueAddress
+            MessageProducer pageMessageProducer = session.createProducer(queue);
 
-         // Step 7. Create a JMS Message Producer for pageQueueAddress
-         MessageProducer pageMessageProducer = session.createProducer(pageQueue);
+            // We don't need persistent messages in order to use paging. (This step is optional)
+            pageMessageProducer.setDeliveryMode(DeliveryMode.PERSISTENT);
 
-         // Step 8. We don't need persistent messages in order to use paging. (This step is optional)
-         pageMessageProducer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+            // Create a Binary Bytes Message with 10K arbitrary bytes
+            BytesMessage message = session.createBytesMessage();
+            message.writeBytes(new byte[10 * 1024]);
 
-         // Step 9. Create a Binary Bytes Message with 10K arbitrary bytes
-         BytesMessage message = session.createBytesMessage();
-         message.writeBytes(new byte[10 * 1024]);
+            try {
+               // Send messages to the queue until the address is full
+               for (int i = 0; i < 2000; i++) {
+                  pageMessageProducer.send(message);
+                  if (i > 0 && i % 100 == 0) {
+                     // batch commit on the sends
+                     session.commit();
+                  }
+               }
 
-         // Step 10. Send only 20 messages to the Queue. This will be already enough for pagingQueue. Look at
-         // ./paging/config/activemq-queues.xml for the config.
-         for (int i = 0; i < 20; i++) {
-            pageMessageProducer.send(message);
-         }
-
-         // Step 11. Create a JMS Message Producer
-         MessageProducer messageProducer = session.createProducer(queue);
-
-         // Step 12. We don't need persistent messages in order to use paging. (This step is optional)
-         messageProducer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
-
-         // Step 13. Send the message for about 1K, which should be over the memory limit imposed by the server
-         for (int i = 0; i < 1000; i++) {
-            messageProducer.send(message);
-         }
-
-         // Step 14. if you pause this example here, you will see several files under ./build/data/paging
-         // Thread.sleep(30000); // if you want to just our of curiosity, you can sleep here and inspect the created
-         // files just for
-
-         // Step 15. Create a JMS Message Consumer
-         MessageConsumer messageConsumer = session.createConsumer(queue);
-
-         // Step 16. Start the JMS Connection. This step will activate the subscribers to receive messages.
-         connection.start();
-
-         // Step 17. Receive the messages. It's important to ACK for messages as ActiveMQ Artemis will not read messages from
-         // paging
-         // until messages are ACKed
-
-         for (int i = 0; i < 1000; i++) {
-            message = (BytesMessage) messageConsumer.receive(3000);
-
-            if (i % 100 == 0) {
-               System.out.println("Received " + i + " messages");
-               message.acknowledge();
+               throw new RuntimeException("Example was supposed to get a page full exception. Check your example configuration or report a bug");
+            } catch (JMSException e) {
+               System.out.println("The producer has thrown an expected exception " + e);
             }
-         }
-
-         message.acknowledge();
-
-         // Step 18. Receive the messages from the Queue names pageQueue. Create the proper consumer for that
-         messageConsumer.close();
-         messageConsumer = session.createConsumer(pageQueue);
-
-         for (int i = 0; i < 20; i++) {
-            message = (BytesMessage) messageConsumer.receive(1000);
-
-            System.out.println("Received message " + i + " from pageQueue");
-
-            message.acknowledge();
+            session.commit();
          }
       } finally {
          // And finally, always remember to close your JMS connections after use, in a finally block. Closing a JMS
@@ -126,9 +92,106 @@ public class PagingExample {
             initialContext.close();
          }
 
-         if (connection != null) {
-            connection.close();
+      }
+   }
+
+
+   public static void simplePaging() throws Exception {
+
+      InitialContext initialContext = null;
+      try {
+         // Create an initial context to perform the JNDI lookup.
+         initialContext = new InitialContext();
+
+         // Perform a lookup on the Connection Factory
+         ConnectionFactory cf = (ConnectionFactory) initialContext.lookup("ConnectionFactory");
+
+         // We look-up the JMS queue object from JNDI. pagingQueue is configured to hold a very limited number
+         // of bytes in memory
+         Queue pageQueue = (Queue) initialContext.lookup("queue/pagingQueue");
+
+         // Lookup for a JMS Queue
+         Queue queue = (Queue) initialContext.lookup("queue/exampleQueue");
+
+         // Create a JMS Connection
+         try (Connection connection = cf.createConnection()) {
+
+            // Create a JMS Session
+            Session session = connection.createSession(false, Session.CLIENT_ACKNOWLEDGE);
+
+            // Create a JMS Message Producer for pageQueueAddress
+            MessageProducer pageMessageProducer = session.createProducer(pageQueue);
+
+            // We don't need persistent messages in order to use paging. (This step is optional)
+            pageMessageProducer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+
+            // Create a Binary Bytes Message with 10K arbitrary bytes
+            BytesMessage message = session.createBytesMessage();
+            message.writeBytes(new byte[10 * 1024]);
+
+            // Send only 20 messages to the Queue. This will be already enough for pagingQueue. Look at
+            // ./paging/config/activemq-queues.xml for the config.
+            for (int i = 0; i < 20; i++) {
+               pageMessageProducer.send(message);
+            }
+
+            // Create a JMS Message Producer
+            MessageProducer messageProducer = session.createProducer(queue);
+
+            // We don't need persistent messages in order to use paging. (This step is optional)
+            messageProducer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+
+            // Send the message for about 1K, which should be over the memory limit imposed by the server
+            for (int i = 0; i < 1000; i++) {
+               messageProducer.send(message);
+            }
+
+            // if you pause this example here, you will see several files under ./build/data/paging
+            // Thread.sleep(30000); // if you want to just our of curiosity, you can sleep here and inspect the created
+            // files just for
+
+            // Create a JMS Message Consumer
+            MessageConsumer messageConsumer = session.createConsumer(queue);
+
+            // Start the JMS Connection. This step will activate the subscribers to receive messages.
+            connection.start();
+
+            // Receive the messages. It's important to ACK for messages as ActiveMQ Artemis will not read messages from
+            // paging
+            // until messages are ACKed
+
+            for (int i = 0; i < 1000; i++) {
+               message = (BytesMessage) messageConsumer.receive(3000);
+
+               if (i % 100 == 0) {
+                  System.out.println("Received " + i + " messages");
+                  message.acknowledge();
+               }
+            }
+
+            message.acknowledge();
+
+            // Receive the messages from the Queue names pageQueue. Create the proper consumer for that
+            messageConsumer.close();
+            messageConsumer = session.createConsumer(pageQueue);
+
+            for (int i = 0; i < 20; i++) {
+               message = (BytesMessage) messageConsumer.receive(1000);
+
+               System.out.println("Received message " + i + " from pageQueue");
+
+               message.acknowledge();
+            }
          }
+
+      } finally {
+         // And finally, always remember to close your JMS connections after use, in a finally block. Closing a JMS
+         // connection will automatically close all of its sessions, consumers, producer and browser objects
+
+         if (initialContext != null) {
+            initialContext.close();
+         }
+
       }
    }
 }

--- a/examples/features/standard/paging/src/main/resources/activemq/server0/broker.xml
+++ b/examples/features/standard/paging/src/main/resources/activemq/server0/broker.xml
@@ -52,6 +52,16 @@ under the License.
             <permission roles="guest" type="send"/>
          </security-setting>
 
+         <!--security for example pagingQueueLimited-->
+         <security-setting match="pagingQueueLimited">
+            <permission roles="guest" type="createDurableQueue"/>
+            <permission roles="guest" type="deleteDurableQueue"/>
+            <permission roles="guest" type="createNonDurableQueue"/>
+            <permission roles="guest" type="deleteNonDurableQueue"/>
+            <permission roles="guest" type="consume"/>
+            <permission roles="guest" type="send"/>
+         </security-setting>
+
          <security-setting match="pagingQueue">
             <permission roles="guest" type="createDurableQueue"/>
             <permission roles="guest" type="deleteDurableQueue"/>
@@ -68,6 +78,17 @@ under the License.
             <page-size-bytes>20000</page-size-bytes>
          </address-setting>
 
+         <address-setting match="pagingQueueLimited">
+            <!-- what to do after max-size-messages is reached. We start paging at 100 messages -->
+            <address-full-policy>PAGE</address-full-policy>
+            <!-- how soon we should enter into paging -->
+            <max-size-messages>100</max-size-messages>
+            <!-- how many messages we should accept into paging before failing. We start failing after we recorded 1000 messages on paging. -->
+            <page-limit-messages>1000</page-limit-messages>
+            <!-- what to do after page-limit is used -->
+            <page-full-policy>FAIL</page-full-policy>
+         </address-setting>
+
          <address-setting match="exampleQueue">
             <max-size-bytes>10Mb</max-size-bytes>
             <page-size-bytes>1Mb</page-size-bytes>
@@ -82,6 +103,11 @@ under the License.
          <address name="pagingQueue">
             <anycast>
                <queue name="pagingQueue"/>
+            </anycast>
+         </address>
+         <address name="pagingQueueLimited">
+            <anycast>
+               <queue name="pagingQueueLimited"/>
             </anycast>
          </address>
          <address name="exampleQueue">

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingLimitTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingLimitTest.java
@@ -1,0 +1,416 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.paging;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSException;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.activemq.artemis.api.core.QueueConfiguration;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.impl.AddressInfo;
+import org.apache.activemq.artemis.logs.AssertionLoggerHandler;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.apache.activemq.artemis.tests.util.CFUtil;
+import org.apache.activemq.artemis.tests.util.Wait;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PagingLimitTest extends ActiveMQTestBase {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   ActiveMQServer server;
+
+   @Test
+   public void testPageLimitMessageCoreFail() throws Exception {
+      testPageLimitMessage("CORE", false);
+   }
+
+   @Test
+   public void testPageLimitAMQPFail() throws Exception {
+      testPageLimitMessage("AMQP", false);
+   }
+
+   @Test
+   public void testPageLimitMessagesOpenWireFail() throws Exception {
+      testPageLimitMessage("OPENWIRE", false);
+   }
+
+   @Test
+   public void testPageLimitMessageCoreDrop() throws Exception {
+      testPageLimitMessage("CORE", false);
+   }
+
+   @Test
+   public void testPageLimitAMQPDrop() throws Exception {
+      testPageLimitMessage("AMQP", false);
+   }
+
+   @Test
+   public void testPageLimitMessagesOpenWireDrop() throws Exception {
+      testPageLimitMessage("OPENWIRE", false);
+   }
+
+   public void testPageLimitMessage(String protocol, boolean drop) throws Exception {
+
+      String queueNameTX = getName() + "_TX";
+      String queueNameNonTX = getName() + "_NONTX";
+
+      Configuration config = createDefaultConfig(true);
+      config.setJournalSyncTransactional(false).setJournalSyncTransactional(false);
+
+      final int PAGE_MAX = 20 * 1024;
+
+      final int PAGE_SIZE = 10 * 1024;
+
+      server = createServer(true, config, PAGE_SIZE, PAGE_MAX, -1, -1, null, 300L, drop ? "DROP" : "FAIL", null);
+      server.start();
+
+      server.addAddressInfo(new AddressInfo(queueNameTX).addRoutingType(RoutingType.ANYCAST));
+      server.createQueue(new QueueConfiguration(queueNameTX).setRoutingType(RoutingType.ANYCAST));
+      server.addAddressInfo(new AddressInfo(queueNameNonTX).addRoutingType(RoutingType.ANYCAST));
+      server.createQueue(new QueueConfiguration(queueNameNonTX).setRoutingType(RoutingType.ANYCAST));
+
+      Wait.assertTrue(() -> server.locateQueue(queueNameNonTX) != null);
+      Wait.assertTrue(() -> server.locateQueue(queueNameTX) != null);
+
+      testPageLimitMessageFailInternal(queueNameTX, protocol, true, drop);
+      testPageLimitMessageFailInternal(queueNameNonTX, protocol, false, drop);
+
+   }
+
+   private void testPageLimitMessageFailInternal(String queueName,
+                                                 String protocol,
+                                                 boolean transacted,
+                                                 boolean drop) throws Exception {
+      AssertionLoggerHandler.startCapture();
+      runAfter(AssertionLoggerHandler::stopCapture);
+      org.apache.activemq.artemis.core.server.Queue serverQueue = server.locateQueue(queueName);
+      Assert.assertNotNull(serverQueue);
+
+      ConnectionFactory factory = CFUtil.createConnectionFactory(protocol, "tcp://localhost:61616");
+      try (Connection connection = factory.createConnection()) {
+         Session session = connection.createSession(transacted, transacted ? Session.SESSION_TRANSACTED : Session.AUTO_ACKNOWLEDGE);
+         Queue queue = session.createQueue(queueName);
+         MessageProducer producer = session.createProducer(queue);
+         connection.start();
+
+         for (int i = 0; i < 100; i++) {
+            TextMessage message = session.createTextMessage("initial " + i);
+            message.setIntProperty("i", i);
+            producer.send(message);
+         }
+         if (transacted) {
+            session.commit();
+            Assert.assertTrue(serverQueue.getPagingStore().isPaging());
+         }
+
+         for (int i = 0; i < 300; i++) {
+            if (i == 200) {
+               // the initial sent has to be consumed on transaction as we need a sync on the consumer for AMQP
+               try (MessageConsumer consumer = session.createConsumer(queue)) {
+                  for (int initI = 0; initI < 100; initI++) {
+                     TextMessage recMessage = (TextMessage) consumer.receive(1000);
+                     Assert.assertEquals("initial " + initI, recMessage.getText());
+                  }
+               }
+               if (transacted) {
+                  session.commit();
+               }
+               Wait.assertEquals(200L, serverQueue::getMessageCount);
+            }
+
+            try {
+               TextMessage message = session.createTextMessage("hello world " + i);
+               message.setIntProperty("i", i);
+               producer.send(message);
+               if (i % 100 == 0) {
+                  logger.info("sent " + i);
+               }
+               if (transacted) {
+                  if (i % 100 == 0 && i > 0) {
+                     session.commit();
+                  }
+               }
+            } catch (Exception e) {
+               logger.warn(e.getMessage(), e);
+               Assert.fail("Exception happened at " + i);
+            }
+         }
+         if (transacted) {
+            session.commit();
+         }
+
+         try {
+            producer.send(session.createTextMessage("should not complete"));
+            if (transacted) {
+               session.commit();
+            }
+            if (!drop) {
+               Assert.fail("an Exception was expected");
+            }
+            Assert.assertTrue(AssertionLoggerHandler.findText("AMQ224120"));
+         } catch (JMSException e) {
+            logger.debug("Expected exception, ok!", e);
+         }
+
+
+         Assert.assertTrue(serverQueue.getPagingStore().isPaging());
+
+         MessageConsumer consumer = session.createConsumer(queue);
+         for (int i = 0; i < 150; i++) { // we will consume half of the messages
+            TextMessage message = (TextMessage) consumer.receive(5000);
+            Assert.assertNotNull(message);
+            Assert.assertEquals("hello world " + i, message.getText());
+            Assert.assertEquals(i, message.getIntProperty("i"));
+            if (transacted) {
+               if (i % 100 == 0 && i > 0) {
+                  session.commit();
+               }
+            }
+         }
+         if (transacted) {
+            session.commit();
+         }
+         Future<Boolean> cleanupDone = serverQueue.getPagingStore().getCursorProvider().scheduleCleanup();
+
+         Assert.assertTrue(cleanupDone.get(30, TimeUnit.SECONDS));
+
+
+
+         for (int i = 300; i < 450; i++) {
+            try {
+               TextMessage message = session.createTextMessage("hello world " + i);
+               message.setIntProperty("i", i);
+               producer.send(message);
+               if (i % 100 == 0) {
+                  logger.info("sent " + i);
+               }
+               if (transacted) {
+                  if (i % 10 == 0 && i > 0) {
+                     session.commit();
+                  }
+               }
+            } catch (Exception e) {
+               logger.warn(e.getMessage(), e);
+               Assert.fail("Exception happened at " + i);
+            }
+         }
+         if (transacted) {
+            session.commit();
+         }
+         AssertionLoggerHandler.clear();
+         Assert.assertFalse(AssertionLoggerHandler.findText("AMQ224120"));
+
+
+         try {
+            producer.send(session.createTextMessage("should not complete"));
+            if (transacted) {
+               session.commit();
+            }
+            if (!drop) {
+               Assert.fail("an Exception was expected");
+            } else {
+               Assert.assertFalse(AssertionLoggerHandler.findText("AMQ224120"));
+            }
+         } catch (JMSException e) {
+            logger.debug("Expected exception, ok!", e);
+         }
+
+         for (int i = 150; i < 450; i++) { // we will consume half of the messages
+            TextMessage message = (TextMessage) consumer.receive(5000);
+            Assert.assertNotNull(message);
+            Assert.assertEquals("hello world " + i, message.getText());
+            Assert.assertEquals(i, message.getIntProperty("i"));
+            if (transacted) {
+               if (i % 100 == 0 && i > 0) {
+                  session.commit();
+               }
+            }
+         }
+
+         Assert.assertNull(consumer.receiveNoWait());
+      }
+
+   }
+
+
+   @Test
+   public void testPageLimitBytesAMQP() throws Exception {
+      testPageLimitBytes("AMQP");
+   }
+
+   @Test
+   public void testPageLimitBytesCore() throws Exception {
+      testPageLimitBytes("CORE");
+   }
+
+   @Test
+   public void testPageLimitBytesOpenWire() throws Exception {
+      testPageLimitBytes("OPENWIRE");
+   }
+
+   public void testPageLimitBytes(String protocol) throws Exception {
+
+      String queueNameTX = getName() + "_TX";
+      String queueNameNonTX = getName() + "_NONTX";
+
+      Configuration config = createDefaultConfig(true);
+      config.setJournalSyncTransactional(false).setJournalSyncTransactional(false);
+
+      final int PAGE_MAX = 20 * 1024;
+
+      final int PAGE_SIZE = 10 * 1024;
+
+      server = createServer(true, config, PAGE_SIZE, PAGE_MAX, -1, -1, (long)(PAGE_MAX * 10), null, "FAIL", null);
+      server.start();
+
+      server.addAddressInfo(new AddressInfo(queueNameTX).addRoutingType(RoutingType.ANYCAST));
+      server.createQueue(new QueueConfiguration(queueNameTX).setRoutingType(RoutingType.ANYCAST));
+      server.addAddressInfo(new AddressInfo(queueNameNonTX).addRoutingType(RoutingType.ANYCAST));
+      server.createQueue(new QueueConfiguration(queueNameNonTX).setRoutingType(RoutingType.ANYCAST));
+
+      Wait.assertTrue(() -> server.locateQueue(queueNameNonTX) != null);
+      Wait.assertTrue(() -> server.locateQueue(queueNameTX) != null);
+
+      testPageLimitBytesFailInternal(queueNameTX, protocol, true);
+      testPageLimitBytesFailInternal(queueNameNonTX, protocol, false);
+
+   }
+
+
+
+   private void testPageLimitBytesFailInternal(String queueName,
+                                                 String protocol,
+                                                 boolean transacted) throws Exception {
+      org.apache.activemq.artemis.core.server.Queue serverQueue = server.locateQueue(queueName);
+      Assert.assertNotNull(serverQueue);
+
+      ConnectionFactory factory = CFUtil.createConnectionFactory(protocol, "tcp://localhost:61616");
+      try (Connection connection = factory.createConnection()) {
+         Session session = connection.createSession(transacted, transacted ? Session.SESSION_TRANSACTED : Session.AUTO_ACKNOWLEDGE);
+         Queue queue = session.createQueue(queueName);
+         MessageProducer producer = session.createProducer(queue);
+         connection.start();
+
+         int successfullSends = 0;
+         boolean failed = false;
+
+         for (int i = 0; i < 1000; i++) {
+            try {
+               TextMessage message = session.createTextMessage("hello world " + i);
+               message.setIntProperty("i", i);
+               producer.send(message);
+               if (transacted) {
+                  session.commit();
+               }
+            } catch (Exception e) {
+               logger.debug(e.getMessage(), e);
+               failed = true;
+               break;
+            }
+            successfullSends++;
+         }
+
+         Wait.assertEquals(successfullSends, serverQueue::getMessageCount);
+         Assert.assertTrue(failed);
+
+         int reads = successfullSends / 2;
+
+         connection.start();
+         try (MessageConsumer consumer = session.createConsumer(queue)) {
+            for (int i = 0; i < reads; i++) { // we will consume half of the messages
+               TextMessage message = (TextMessage) consumer.receive(5000);
+               Assert.assertNotNull(message);
+               Assert.assertEquals("hello world " + i, message.getText());
+               Assert.assertEquals(i, message.getIntProperty("i"));
+               if (transacted) {
+                  if (i % 100 == 0 && i > 0) {
+                     session.commit();
+                  }
+               }
+            }
+            if (transacted) {
+               session.commit();
+            }
+         }
+
+         failed = false;
+
+         int originalSuccess = successfullSends;
+
+         Future<Boolean> result = serverQueue.getPagingStore().getCursorProvider().scheduleCleanup();
+         Assert.assertTrue(result.get(10, TimeUnit.SECONDS));
+
+         for (int i = successfullSends; i < 1000; i++) {
+            try {
+               TextMessage message = session.createTextMessage("hello world " + i);
+               message.setIntProperty("i", i);
+               producer.send(message);
+               if (transacted) {
+                  session.commit();
+               }
+            } catch (Exception e) {
+               logger.debug(e.getMessage(), e);
+               failed = true;
+               break;
+            }
+            successfullSends++;
+         }
+
+         Assert.assertTrue(failed);
+         Assert.assertTrue(successfullSends > originalSuccess);
+
+         try (MessageConsumer consumer = session.createConsumer(queue)) {
+            for (int i = reads; i < successfullSends; i++) {
+               TextMessage message = (TextMessage) consumer.receive(5000);
+               Assert.assertNotNull(message);
+               Assert.assertEquals("hello world " + i, message.getText());
+               Assert.assertEquals(i, message.getIntProperty("i"));
+               if (transacted) {
+                  if (i % 100 == 0 && i > 0) {
+                     session.commit();
+                  }
+               }
+            }
+            if (transacted) {
+               session.commit();
+            }
+            Assert.assertNull(consumer.receiveNoWait());
+         }
+
+
+      }
+
+   }
+
+
+
+}

--- a/tests/performance-tests/src/test/java/org/apache/activemq/artemis/tests/performance/storage/PersistMultiThreadTest.java
+++ b/tests/performance-tests/src/test/java/org/apache/activemq/artemis/tests/performance/storage/PersistMultiThreadTest.java
@@ -30,6 +30,7 @@ import org.apache.activemq.artemis.core.message.impl.CoreMessage;
 import org.apache.activemq.artemis.core.paging.PagingManager;
 import org.apache.activemq.artemis.core.paging.PagingStore;
 import org.apache.activemq.artemis.core.paging.cursor.PageCursorProvider;
+import org.apache.activemq.artemis.core.paging.cursor.PageSubscription;
 import org.apache.activemq.artemis.core.paging.impl.Page;
 import org.apache.activemq.artemis.core.persistence.OperationContext;
 import org.apache.activemq.artemis.core.persistence.StorageManager;
@@ -39,6 +40,7 @@ import org.apache.activemq.artemis.core.server.JournalType;
 import org.apache.activemq.artemis.core.server.RouteContextList;
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
+import org.apache.activemq.artemis.core.settings.impl.PageFullMessagePolicy;
 import org.apache.activemq.artemis.core.transaction.Transaction;
 import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.actors.ArtemisExecutor;
@@ -244,6 +246,36 @@ public class PersistMultiThreadTest extends ActiveMQTestBase {
    }
 
    class FakePagingStore implements PagingStore {
+
+      @Override
+      public PageFullMessagePolicy getPageFullMessagePolicy() {
+         return null;
+      }
+
+      @Override
+      public Long getPageLimitMessages() {
+         return null;
+      }
+
+      @Override
+      public Long getPageLimitBytes() {
+         return null;
+      }
+
+      @Override
+      public void pageFull(PageSubscription subscription) {
+
+      }
+
+      @Override
+      public boolean isPageFull() {
+         return false;
+      }
+
+      @Override
+      public void checkPageLimit(long numberOfMessages) {
+
+      }
 
       @Override
       public void counterSnapshot() {


### PR DESCRIPTION
I am adding three attributes to Address-settings:

* page-limit-bytes: Number of bytes. We will convert this metric into max number of pages internally by dividing max-bytes / page-size. It will allow a max based on an estimate.
* page-limit-messages: Number of messages
* page-full-message-policy: fail or drop

We will now allow paging, until these max values and then fail or drop messages.

Once these values are retracted, the address will remain full until a period where cleanup is kicked in by paging. So these values may have a certain delay on being applied, but they should always be cleared once cleanup happened.
