### PR TITLE
ARTEMIS-4151 tighten default MBean access

### DIFF
--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/management.xml
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/management.xml
@@ -22,11 +22,19 @@
          <entry domain="hawtio"/>
       </allowlist>
       <default-access>
+         <!--
+         The "default-access" settings apply to every MBean not explicitly configured
+         in the "allowlist" or "role-access" sections
+         -->
+
+         <!-- allow read-only access by default -->
          <access method="list*" roles="${role}"/>
          <access method="get*" roles="${role}"/>
          <access method="is*" roles="${role}"/>
-         <access method="set*" roles="${role}"/>
-         <access method="*" roles="${role}"/>
+
+         <!-- don't allow write or other operations by default -->
+         <!--access method="set*" roles="${role}"/-->
+         <!--access method="*" roles="${role}"/-->
       </default-access>
       <role-access>
          <match domain="org.apache.activemq.artemis">
@@ -34,19 +42,21 @@
             <access method="get*" roles="${role}"/>
             <access method="is*" roles="${role}"/>
             <access method="set*" roles="${role}"/>
-            <!-- Note count and browse are need to access the browse tab in the console-->
+            <!-- Note count and browse are need to access the browse tab in the console -->
             <access method="browse*" roles="${role}"/>
             <access method="count*" roles="${role}"/>
             <access method="*" roles="${role}"/>
          </match>
-         <!--example of how to configure a specific object-->
-         <!--<match domain="org.apache.activemq.artemis" key="subcomponent=queues">
+         <!--example of how to configure a specific object -->
+         <!--
+         <match domain="org.apache.activemq.artemis" key="subcomponent=queues">
             <access method="list*" roles="view,update,amq"/>
             <access method="get*" roles="view,update,amq"/>
             <access method="is*" roles="view,update,amq"/>
             <access method="set*" roles="update,amq"/>
             <access method="*" roles="amq"/>
-         </match>-->
+         </match>
+         -->
       </role-access>
    </authorisation>
 </management-context>

--- a/docs/user-manual/en/versions.md
+++ b/docs/user-manual/en/versions.md
@@ -8,6 +8,21 @@ This chapter provides the following information for each release:
   - **Note:** Follow the general upgrade procedure outlined in the [Upgrading the Broker](upgrading.md) 
     chapter in addition to any version-specific upgrade instructions outlined here.
 
+## 2.29.0
+[Full release notes](...)
+
+Highlights:
+- ...
+
+#### Upgrading from older versions
+* Due to [ARTEMIS-4151](https://issues.apache.org/jira/browse/ARTEMIS-4151) the default access for MBeans not defined in
+  the `role-access` or `allowlist` of `management.xml` is now _read only_. This is a precautionary measure to ensure no
+  unanticipated MBean deployed with the broker poses a risk. However, this will also impact JVM-specific and platform
+  MBeans as well (e.g. which allow manual garbage collection, "flight recording," etc.). Write access and general
+  operational access to these MBeans will now have to be manually enabled in `management.xml` either by changing the
+  `default-access` (not recommended) or specifically configuring a `role-access` for the particular MBean in question.
+  Note: this applies to all MBean access including directly via JMX and via the Jolokia JMX-HTTP bridge.
+
 ## 2.28.0
 [Full release notes](https://issues.apache.org/jira/secure/ReleaseNote.jspa?version=12352523&projectId=12315920)
 

--- a/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/upgradeTest/CompareUpgradeTest.java
+++ b/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/upgradeTest/CompareUpgradeTest.java
@@ -55,7 +55,7 @@ public class CompareUpgradeTest {
       String windowsExpectedETC = basedir + "/target/classes/servers/windowsUpgradeETCExpected";
 
       compareDirectories(windowsExpectedBin, windowsBin);
-      compareDirectories(windowsExpectedETC, windowsETC, "broker.xml", "artemis-users.properties");
+      compareDirectories(windowsExpectedETC, windowsETC, "broker.xml", "artemis-users.properties", "management.xml");
 
       String referenceBin = basedir + "/target/reference-for-backup-check/servers/windowsUpgrade/bin";
       String referenceEtc = basedir + "/target/reference-for-backup-check/servers/windowsUpgradeETC";
@@ -75,7 +75,7 @@ public class CompareUpgradeTest {
       String linuxExpectedETC = basedir + "/target/classes/servers/linuxUpgradeETCExpected";
 
       compareDirectories(linuxExpectedBin, linuxBin);
-      compareDirectories(linuxExpectedETC, linuxETC, "broker.xml", "artemis-users.properties");
+      compareDirectories(linuxExpectedETC, linuxETC, "broker.xml", "artemis-users.properties", "management.xml");
 
       String referenceBin = basedir + "/target/reference-for-backup-check/servers/linuxUpgrade/bin";
       String referenceEtc = basedir + "/target/reference-for-backup-check/servers/linuxUpgradeETC";


### PR DESCRIPTION
This is a preventative measure to limit what users can do with any MBean other than those in the hawtio or org.apache.activemq.artemis domains.