### PR TITLE
ARTEMIS-4167 Enhanced deserialization filter

### DIFF
--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
@@ -689,6 +689,13 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
       return this.factoryReference.getDeserializationWhiteList();
    }
 
+   public String getSerialFilter() {
+      return this.factoryReference.getSerialFilter();
+   }
+
+   public String getSerialFilterClassName() {
+      return this.factoryReference.getSerialFilterClassName();
+   }
 
    private static class JMSFailureListener implements SessionFailureListener {
 

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnectionFactory.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnectionFactory.java
@@ -95,6 +95,10 @@ public class ActiveMQConnectionFactory extends JNDIStorable implements Connectio
 
    private String deserializationWhiteList;
 
+   private String serialFilter;
+
+   private String serialFilterClassName;
+
    private boolean cacheDestinations;
 
    // keeping this field for serialization compatibility only. do not use it
@@ -187,6 +191,26 @@ public class ActiveMQConnectionFactory extends JNDIStorable implements Connectio
    @Override
    public void setDeserializationWhiteList(String whiteList) {
       this.deserializationWhiteList = whiteList;
+   }
+
+   @Override
+   public String getSerialFilter() {
+      return serialFilter;
+   }
+
+   @Override
+   public void setSerialFilter(String serialFilter) {
+      this.serialFilter = serialFilter;
+   }
+
+   @Override
+   public String getSerialFilterClassName() {
+      return serialFilterClassName;
+   }
+
+   @Override
+   public void setSerialFilterClassName(String serialFilterClassName) {
+      this.serialFilterClassName = serialFilterClassName;
    }
 
    @Override

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQObjectMessage.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQObjectMessage.java
@@ -21,6 +21,7 @@ import javax.jms.MessageFormatException;
 import javax.jms.ObjectMessage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputFilter;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 
@@ -145,6 +146,12 @@ public class ActiveMQObjectMessage extends ActiveMQMessage implements ObjectMess
          if (whiteList != null) {
             ois.setWhiteList(whiteList);
          }
+
+         ObjectInputFilter oif = ObjectInputFilterFactory.getObjectInputFilter(options);
+         if (oif != null) {
+            ois.setObjectInputFilter(oif);
+         }
+
          Serializable object = (Serializable) ois.readObject();
          return object;
       } catch (Exception e) {

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
@@ -694,6 +694,14 @@ public class ActiveMQSession implements QueueSession, TopicSession {
       return connection.getDeserializationWhiteList();
    }
 
+   public String getSerialFilter() {
+      return connection.getSerialFilter();
+   }
+
+   public String getSerialFilterClassName() {
+      return connection.getSerialFilterClassName();
+   }
+
    enum ConsumerDurability {
       DURABLE, NON_DURABLE;
    }

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ConnectionFactoryOptions.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ConnectionFactoryOptions.java
@@ -30,4 +30,11 @@ public interface ConnectionFactoryOptions {
 
    void setDeserializationWhiteList(String whiteList);
 
+   String getSerialFilter();
+
+   void setSerialFilter(String serialFilter);
+
+   String getSerialFilterClassName();
+
+   void setSerialFilterClassName(String serialFilterClassName);
 }

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ObjectInputFilterFactory.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ObjectInputFilterFactory.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.jms.client;
+
+import java.io.ObjectInputFilter;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ObjectInputFilterFactory {
+
+   public static final String SERIAL_FILTER_PROPERTY            = "org.apache.activemq.artemis.jms.serialFilter";
+   public static final String SERIAL_FILTER_CLASS_NAME_PROPERTY = "org.apache.activemq.artemis.jms.serialFilterClassName";
+
+   private static Map<Object, ObjectInputFilter> filterCache = new ConcurrentHashMap<>();
+
+   public static ObjectInputFilter getObjectInputFilter(ConnectionFactoryOptions options) {
+      String className = getFilterClassName(options);
+      if (className != null) {
+         return getObjectInputFilterForClassName(className);
+      }
+
+      String pattern = getFilterPattern(options);
+      if (pattern != null) {
+         return getObjectInputFilterForPattern(pattern);
+      }
+
+      return null;
+   }
+
+   public static ObjectInputFilter getObjectInputFilterForPattern(String pattern) {
+      if (pattern == null) {
+         return null;
+      }
+
+      return filterCache.computeIfAbsent(new PatternKey(pattern),
+                                         k -> ObjectInputFilter.Config.createFilter(pattern));
+   }
+
+   public static ObjectInputFilter getObjectInputFilterForClassName(String className) {
+      if (className == null) {
+         return null;
+      }
+
+      return filterCache.computeIfAbsent(new ClassNameKey(className), k -> {
+         try {
+            return (ObjectInputFilter)Class.forName(className).newInstance();
+         } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Class " + className + " not found.", e);
+         } catch (Exception e) {
+            throw new RuntimeException(e);
+         }
+      });
+   }
+
+   private static String getFilterClassName(ConnectionFactoryOptions options) {
+      if (options != null && options.getSerialFilterClassName() != null) {
+         return options.getSerialFilterClassName();
+      }
+
+      return System.getProperty(SERIAL_FILTER_CLASS_NAME_PROPERTY);
+   }
+
+   private static String getFilterPattern(ConnectionFactoryOptions options) {
+      if (options != null && options.getSerialFilter() != null) {
+         return options.getSerialFilter();
+      }
+
+      return System.getProperty(SERIAL_FILTER_PROPERTY);
+   }
+
+   private static class PatternKey {
+      private String pattern;
+
+      PatternKey(String pattern) {
+         this.pattern = pattern;
+      }
+
+      public String getPattern() {
+         return pattern;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+         if (this == o) return true;
+         if (o == null || getClass() != o.getClass()) return false;
+
+         PatternKey that = (PatternKey) o;
+
+         if (!Objects.equals(pattern, that.pattern)) return false;
+
+         return true;
+      }
+
+      @Override
+      public int hashCode() {
+         return pattern != null ? pattern.hashCode() : 0;
+      }
+   }
+
+   private static class ClassNameKey {
+      private String className;
+
+      ClassNameKey(String className) {
+         this.className = className;
+      }
+
+      public String getClassName() {
+         return className;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+         if (this == o) return true;
+         if (o == null || getClass() != o.getClass()) return false;
+
+         ClassNameKey that = (ClassNameKey) o;
+
+         if (!Objects.equals(className, that.className)) return false;
+
+         return true;
+      }
+
+      @Override
+      public int hashCode() {
+         return className != null ? className.hashCode() : 0;
+      }
+   }
+}

--- a/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/config/ConnectionFactoryConfiguration.java
+++ b/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/config/ConnectionFactoryConfiguration.java
@@ -188,6 +188,14 @@ public interface ConnectionFactoryConfiguration extends EncodingSupport {
 
    void setDeserializationWhiteList(String whiteList);
 
+   String getSerialFilter();
+
+   void setSerialFilter(String serialFilter);
+
+   String getSerialFilterClassName();
+
+   void setSerialFilterClassName(String serialFilterClassName);
+
    int getInitialMessagePacketSize();
 
    ConnectionFactoryConfiguration setInitialMessagePacketSize(int size);

--- a/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/config/impl/ConnectionFactoryConfigurationImpl.java
+++ b/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/config/impl/ConnectionFactoryConfigurationImpl.java
@@ -119,6 +119,10 @@ public class ConnectionFactoryConfigurationImpl implements ConnectionFactoryConf
 
    private String deserializationWhiteList;
 
+   private String serialFilter;
+
+   private String serialFilterClassName;
+
    private int initialMessagePacketSize = ActiveMQClient.DEFAULT_INITIAL_MESSAGE_PACKET_SIZE;
 
    private boolean enable1xPrefixes = ActiveMQJMSClient.DEFAULT_ENABLE_1X_PREFIXES;
@@ -642,6 +646,10 @@ public class ConnectionFactoryConfigurationImpl implements ConnectionFactoryConf
       enableSharedClientID = buffer.readableBytes() > 0 ? BufferHelper.readNullableBoolean(buffer) : ActiveMQClient.DEFAULT_ENABLED_SHARED_CLIENT_ID;
 
       useTopologyForLoadBalancing = buffer.readableBytes() > 0 ? BufferHelper.readNullableBoolean(buffer) : ActiveMQClient.DEFAULT_USE_TOPOLOGY_FOR_LOADBALANCING;
+
+      serialFilter = buffer.readableBytes() > 0 ? BufferHelper.readNullableSimpleStringAsString(buffer) : null;
+
+      serialFilterClassName = buffer.readableBytes() > 0 ? BufferHelper.readNullableSimpleStringAsString(buffer) : null;
    }
 
    @Override
@@ -738,6 +746,10 @@ public class ConnectionFactoryConfigurationImpl implements ConnectionFactoryConf
       BufferHelper.writeNullableBoolean(buffer, enableSharedClientID);
 
       BufferHelper.writeNullableBoolean(buffer, useTopologyForLoadBalancing);
+
+      BufferHelper.writeAsNullableSimpleString(buffer, serialFilter);
+
+      BufferHelper.writeAsNullableSimpleString(buffer, serialFilterClassName);
    }
 
    @Override
@@ -858,7 +870,11 @@ public class ConnectionFactoryConfigurationImpl implements ConnectionFactoryConf
 
          BufferHelper.sizeOfNullableBoolean(enableSharedClientID) +
 
-         BufferHelper.sizeOfNullableBoolean(useTopologyForLoadBalancing);
+         BufferHelper.sizeOfNullableBoolean(useTopologyForLoadBalancing) +
+
+         BufferHelper.sizeOfNullableSimpleString(serialFilter) +
+
+         BufferHelper.sizeOfNullableSimpleString(serialFilterClassName);
 
       return size;
    }
@@ -892,6 +908,26 @@ public class ConnectionFactoryConfigurationImpl implements ConnectionFactoryConf
    @Override
    public void setDeserializationWhiteList(String whiteList) {
       this.deserializationWhiteList = whiteList;
+   }
+
+   @Override
+   public String getSerialFilter() {
+      return serialFilter;
+   }
+
+   @Override
+   public void setSerialFilter(String serialFilter) {
+      this.serialFilter = serialFilter;
+   }
+
+   @Override
+   public String getSerialFilterClassName() {
+      return serialFilterClassName;
+   }
+
+   @Override
+   public void setSerialFilterClassName(String serialFilterClassName) {
+      this.serialFilterClassName = serialFilterClassName;
    }
 
    @Override

--- a/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/impl/JMSServerManagerImpl.java
+++ b/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/impl/JMSServerManagerImpl.java
@@ -1216,6 +1216,8 @@ public class JMSServerManagerImpl extends CleaningActivateCallback implements JM
       cf.setProtocolManagerFactoryStr(cfConfig.getProtocolManagerFactoryStr());
       cf.setDeserializationBlackList(cfConfig.getDeserializationBlackList());
       cf.setDeserializationWhiteList(cfConfig.getDeserializationWhiteList());
+      cf.setSerialFilter(cfConfig.getSerialFilter());
+      cf.setSerialFilterClassName(cfConfig.getSerialFilterClassName());
       cf.setInitialMessagePacketSize(cfConfig.getInitialMessagePacketSize());
       cf.setEnable1xPrefixes(cfConfig.isEnable1xPrefixes());
       cf.setEnableSharedClientID(cfConfig.isEnableSharedClientID());

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
@@ -886,6 +886,30 @@ public class ActiveMQResourceAdapter implements ResourceAdapter, Serializable {
       raProperties.setDeserializationWhiteList(deserializationWhiteList);
    }
 
+   public String getSerialFilter() {
+      logger.trace("getSerialFilter()");
+
+      return raProperties.getSerialFilter();
+   }
+
+   public void setSerialFilter(String serialFilter) {
+      logger.trace("setSerialFilter({})", serialFilter);
+
+      raProperties.setSerialFilter(serialFilter);
+   }
+
+   public String getSerialFilterClassName() {
+      logger.trace("getSerialFilterClassName()");
+
+      return raProperties.getSerialFilterClassName();
+   }
+
+   public void setSerialFilterClassName(String serialFilterClassName) {
+      logger.trace("setSerialFilterClassName({})", serialFilterClassName);
+
+      raProperties.setSerialFilterClassName(serialFilterClassName);
+   }
+
    /**
     * Get min large message size
     *
@@ -1879,6 +1903,14 @@ public class ActiveMQResourceAdapter implements ResourceAdapter, Serializable {
       val5 = overrideProperties.getDeserializationWhiteList() != null ? overrideProperties.getDeserializationWhiteList() : raProperties.getDeserializationWhiteList();
       if (val5 != null) {
          cf.setDeserializationWhiteList(val5);
+      }
+      val5 = overrideProperties.getSerialFilter() != null ? overrideProperties.getSerialFilter() : raProperties.getSerialFilter();
+      if (val5 != null) {
+         cf.setSerialFilter(val5);
+      }
+      val5 = overrideProperties.getSerialFilterClassName() != null ? overrideProperties.getSerialFilterClassName() : raProperties.getSerialFilterClassName();
+      if (val5 != null) {
+         cf.setSerialFilterClassName(val5);
       }
 
       cf.setIgnoreJTA(isIgnoreJTA());

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ConnectionFactoryProperties.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ConnectionFactoryProperties.java
@@ -128,6 +128,10 @@ public class ConnectionFactoryProperties implements ConnectionFactoryOptions {
 
    private String deserializationWhiteList;
 
+   private String serialFilter;
+
+   private String serialFilterClassName;
+
    private Boolean enableSharedClientID;
 
    /**
@@ -687,6 +691,28 @@ public class ConnectionFactoryProperties implements ConnectionFactoryOptions {
       hasBeenUpdated = true;
    }
 
+   @Override
+   public String getSerialFilter() {
+      return serialFilter;
+   }
+
+   @Override
+   public void setSerialFilter(String serialFilter) {
+      this.serialFilter = serialFilter;
+      hasBeenUpdated = true;
+   }
+
+   @Override
+   public String getSerialFilterClassName() {
+      return serialFilterClassName;
+   }
+
+   @Override
+   public void setSerialFilterClassName(String serialFilterClassName) {
+      this.serialFilterClassName = serialFilterClassName;
+      hasBeenUpdated = true;
+   }
+
    public boolean isHasBeenUpdated() {
       return hasBeenUpdated;
    }
@@ -934,6 +960,18 @@ public class ConnectionFactoryProperties implements ConnectionFactoryOptions {
       } else if (!deserializationWhiteList.equals(other.deserializationWhiteList))
          return false;
 
+      if (serialFilter == null) {
+         if (other.serialFilter != null)
+            return false;
+      } else if (!serialFilter.equals(other.serialFilter))
+         return false;
+
+      if (serialFilterClassName == null) {
+         if (other.serialFilterClassName != null)
+            return false;
+      } else if (!serialFilterClassName.equals(other.serialFilterClassName))
+         return false;
+
       if (this.enable1xPrefixes == null) {
          if (other.enable1xPrefixes != null)
             return false;
@@ -997,6 +1035,8 @@ public class ConnectionFactoryProperties implements ConnectionFactoryOptions {
       result = prime * result + ((connectionParameters == null) ? 0 : connectionParameters.hashCode());
       result = prime * result + ((deserializationBlackList == null) ? 0 : deserializationBlackList.hashCode());
       result = prime * result + ((deserializationWhiteList == null) ? 0 : deserializationWhiteList.hashCode());
+      result = prime * result + ((serialFilter == null) ? 0 : serialFilter.hashCode());
+      result = prime * result + ((serialFilterClassName == null) ? 0 : serialFilterClassName.hashCode());
       result = prime * result + ((enable1xPrefixes == null) ? 0 : enable1xPrefixes.hashCode());
       result = prime * result + ((enableSharedClientID == null) ? 0 : enableSharedClientID.hashCode());
       return result;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ra/ActiveMQMessageHandlerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ra/ActiveMQMessageHandlerTest.java
@@ -25,6 +25,7 @@ import javax.jms.Queue;
 import javax.jms.Session;
 import javax.resource.ResourceException;
 import javax.resource.spi.InvalidPropertyException;
+import java.io.ObjectInputFilter;
 import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
@@ -206,9 +207,70 @@ public class ActiveMQMessageHandlerTest extends ActiveMQRATestBase {
    }
 
    private void testDeserialization(String blackList, String whiteList, boolean shouldSucceed) throws Exception {
+      testDeserialization(blackList, whiteList, null, null, shouldSucceed);
+   }
+
+   @Test
+   public void testObjectMessageReceiveSerializationControlSF() throws Exception {
+      String serialFilter = "!org.apache.activemq.artemis.tests.integration.ra.**;*";
+      testDeserializationSerialFilter(serialFilter, false);
+   }
+
+   @Test
+   public void testObjectMessageReceiveSerializationControl1SF() throws Exception {
+      String serialFilter = "!some.other.pkg.**;org.apache.activemq.artemis.tests.integration.ra.*";
+      testDeserializationSerialFilter(serialFilter, true);
+   }
+
+   @Test
+   public void testObjectMessageReceiveSerializationControl2SF() throws Exception {
+      String serialFilter = "!*;org.apache.activemq.artemis.tests.integration.ra.**";
+      testDeserializationSerialFilter(serialFilter, false);
+   }
+
+   @Test
+   public void testObjectMessageReceiveSerializationControl3SF() throws Exception {
+      String serialFilter = "!org.apache.activemq.artemis.tests.**;" +
+                            "org.apache.activemq.artemis.tests.integration.ra.**";
+      testDeserializationSerialFilter(serialFilter, false);
+   }
+
+   @Test
+   public void testObjectMessageReceiveSerializationControl4SF() throws Exception {
+      String serialFilter = "some.other.pkg.**;!*";
+      testDeserializationSerialFilter(serialFilter, false);
+   }
+
+   @Test
+   public void testObjectMessageReceiveSerializationControl5SF() throws Exception {
+      String serialFilter = null;
+      testDeserializationSerialFilter(serialFilter, true);
+   }
+
+   private void testDeserializationSerialFilter(String serialFilter, boolean shouldSucceed) throws Exception {
+      testDeserialization(null, null, serialFilter, null, shouldSucceed);
+   }
+
+   @Test
+   public void testObjectMessageReceiveSerializationControlSFC1() throws Exception {
+      testDeserializationSerialFilterClassName(AlwaysRejectObjectInputFilter.class.getName(), false);
+   }
+
+   @Test
+   public void testObjectMessageReceiveSerializationControlSFC2() throws Exception {
+      testDeserializationSerialFilterClassName(AlwaysAcceptObjectInputFilter.class.getName(), true);
+   }
+
+   private void testDeserializationSerialFilterClassName(String serialFilterClassName, boolean shouldSucceed) throws Exception {
+      testDeserialization(null, null, null, serialFilterClassName, shouldSucceed);
+   }
+
+   private void testDeserialization(String blackList, String whiteList, String serialFilter, String serialFilterClassName, boolean shouldSucceed) throws Exception {
       ActiveMQResourceAdapter qResourceAdapter = newResourceAdapter();
       qResourceAdapter.setDeserializationBlackList(blackList);
       qResourceAdapter.setDeserializationWhiteList(whiteList);
+      qResourceAdapter.setSerialFilter(serialFilter);
+      qResourceAdapter.setSerialFilterClassName(serialFilterClassName);
 
       MyBootstrapContext ctx = new MyBootstrapContext();
       qResourceAdapter.start(ctx);
@@ -1041,5 +1103,19 @@ public class ActiveMQMessageHandlerTest extends ActiveMQRATestBase {
 
    static class DummySerializable implements Serializable {
 
+   }
+
+   public static class AlwaysRejectObjectInputFilter implements ObjectInputFilter {
+      @Override
+      public Status checkInput(FilterInfo filterInfo) {
+         return Status.REJECTED;
+      }
+   }
+
+   public static class AlwaysAcceptObjectInputFilter implements ObjectInputFilter {
+      @Override
+      public Status checkInput(FilterInfo filterInfo) {
+         return Status.ALLOWED;
+      }
    }
 }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/ra/ActiveMQResourceAdapterConfigTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/ra/ActiveMQResourceAdapterConfigTest.java
@@ -414,6 +414,18 @@ public class ActiveMQResourceAdapterConfigTest extends ActiveMQTestBase {
       "         <config-property-value></config-property-value>" +
       "      </config-property>" +
       "      <config-property>" +
+      "         <description>Serial filter pattern to match or reject classes during deserialization</description>" +
+      "         <config-property-name>SerialFilter</config-property-name>" +
+      "         <config-property-type>java.lang.String</config-property-type>" +
+      "         <config-property-value></config-property-value>" +
+      "      </config-property>" +
+      "      <config-property>" +
+      "         <description>Class name of an ObjectInputFilter to use during deserialization</description>" +
+      "         <config-property-name>SerialFilterClassName</config-property-name>" +
+      "         <config-property-type>java.lang.String</config-property-type>" +
+      "         <config-property-value></config-property-value>" +
+      "      </config-property>" +
+      "      <config-property>" +
       "         <description>***add***</description>" +
       "         <config-property-name>IgnoreJTA</config-property-name>" +
       "         <config-property-type>boolean</config-property-type>" +

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/ra/ResourceAdapterTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/ra/ResourceAdapterTest.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.tests.unit.ra;
 
 import javax.jms.Connection;
+import java.io.ObjectInputFilter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -566,6 +567,70 @@ public class ResourceAdapterTest extends ActiveMQTestBase {
    }
 
    @Test
+   public void testActivationDeserializationParameters2() throws Exception {
+      ActiveMQServer server = createServer(false);
+
+      try {
+
+         server.start();
+
+         ActiveMQResourceAdapter ra = new ActiveMQResourceAdapter();
+
+         ra.setConnectorClassName(INVM_CONNECTOR_FACTORY);
+         ra.setUserName("userGlobal");
+         ra.setPassword("passwordGlobal");
+         ra.setSerialFilter("a.b.c.d.e.**;!f.g.h.i.j.**");
+         ra.start(new BootstrapContext());
+
+         ActiveMQConnectionFactory factory = ra.getDefaultActiveMQConnectionFactory();
+         assertEquals("a.b.c.d.e.**;!f.g.h.i.j.**", factory.getSerialFilter());
+
+         ConnectionFactoryProperties overrides = new ConnectionFactoryProperties();
+         overrides.setSerialFilter("k.l.m.n.**;!o.p.q.r.**");
+
+         factory = ra.newConnectionFactory(overrides);
+         assertEquals("k.l.m.n.**;!o.p.q.r.**", factory.getSerialFilter());
+
+         ra.stop();
+
+      } finally {
+         server.stop();
+      }
+   }
+
+   @Test
+   public void testActivationDeserializationParameters3() throws Exception {
+      ActiveMQServer server = createServer(false);
+
+      try {
+
+         server.start();
+
+         ActiveMQResourceAdapter ra = new ActiveMQResourceAdapter();
+
+         ra.setConnectorClassName(INVM_CONNECTOR_FACTORY);
+         ra.setUserName("userGlobal");
+         ra.setPassword("passwordGlobal");
+         ra.setSerialFilterClassName(AlwaysRejectObjectInputFilter.class.getName());
+         ra.start(new BootstrapContext());
+
+         ActiveMQConnectionFactory factory = ra.getDefaultActiveMQConnectionFactory();
+         assertEquals(AlwaysRejectObjectInputFilter.class.getName(), factory.getSerialFilterClassName());
+
+         ConnectionFactoryProperties overrides = new ConnectionFactoryProperties();
+         overrides.setSerialFilterClassName(AlwaysAcceptObjectInputFilter.class.getName());
+
+         factory = ra.newConnectionFactory(overrides);
+         assertEquals(AlwaysAcceptObjectInputFilter.class.getName(), factory.getSerialFilterClassName());
+
+         ra.stop();
+
+      } finally {
+         server.stop();
+      }
+   }
+
+   @Test
    public void testForConnectionLeakDuringActivationWhenSessionCreationFails() throws Exception {
       ActiveMQServer server = createServer(false);
       ActiveMQResourceAdapter ra = null;
@@ -613,6 +678,20 @@ public class ResourceAdapterTest extends ActiveMQTestBase {
          if (ra != null)
             ra.stop();
          server.stop();
+      }
+   }
+
+   public static class AlwaysRejectObjectInputFilter implements ObjectInputFilter {
+      @Override
+      public Status checkInput(FilterInfo filterInfo) {
+         return Status.REJECTED;
+      }
+   }
+
+   public static class AlwaysAcceptObjectInputFilter implements ObjectInputFilter {
+      @Override
+      public Status checkInput(FilterInfo filterInfo) {
+         return Status.ALLOWED;
       }
    }
 }


### PR DESCRIPTION
Now that Artemis is Java 11+ compatible, there is now the ability to set an ObjectInputFilter on an ObjectInputStream. This allows us to write more advanced filter patterns or plug-in our own object filter implementation.