### PR TITLE
ARTEMIS-4174 Listen only to provided connector-host for JMX RMI sockets

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/ManagementConnector.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/ManagementConnector.java
@@ -55,6 +55,7 @@ public class ManagementConnector implements ActiveMQComponent {
    public void start() throws Exception {
       rmiRegistryFactory = new RmiRegistryFactory();
       rmiRegistryFactory.setPort(configuration.getConnectorPort());
+      rmiRegistryFactory.setHost(configuration.getConnectorHost());
       rmiRegistryFactory.init();
 
       mbeanServerFactory = new MBeanServerFactory();

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/management/JMXRMIRegistryPortTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/management/JMXRMIRegistryPortTest.java
@@ -1,0 +1,52 @@
+package org.apache.activemq.artemis.core.server.management;
+
+import org.apache.activemq.artemis.core.config.JMXConnectorConfiguration;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+
+public class JMXRMIRegistryPortTest {
+
+    @Test
+    public void explicitLocalhostRegistry() throws IOException {
+        RmiRegistryFactory registryFactory = new RmiRegistryFactory();
+        registryFactory.setHost("localhost");
+        registryFactory.setPort(1099);
+        registryFactory.init();
+        try (ServerSocket testSocket = registryFactory.createTestSocket()) {
+            Assert.assertEquals(InetAddress.getByName("localhost"),
+                    testSocket.getInetAddress());
+        }
+        registryFactory.destroy();
+    }
+
+    @Test
+    public void unlimitedHostRegistry() throws IOException {
+        RmiRegistryFactory registryFactory = new RmiRegistryFactory();
+        registryFactory.setHost(null);
+        registryFactory.setPort(1099);
+        registryFactory.init();
+        try (ServerSocket testSocket = registryFactory.createTestSocket()) {
+            Assert.assertEquals(InetAddress.getByAddress(new byte[] { 0, 0, 0, 0 }),
+                    testSocket.getInetAddress());
+        }
+        registryFactory.destroy();
+    }
+
+    @Test
+    public void defaultRegistry() throws IOException {
+        RmiRegistryFactory registryFactory = new RmiRegistryFactory();
+        JMXConnectorConfiguration configuration = new JMXConnectorConfiguration();
+        registryFactory.setHost(configuration.getConnectorHost());
+        registryFactory.setPort(configuration.getConnectorPort());
+        registryFactory.init();
+        try (ServerSocket testSocket = registryFactory.createTestSocket()) {
+            Assert.assertEquals(InetAddress.getByName("localhost"),
+                    testSocket.getInetAddress());
+        }
+        registryFactory.destroy();
+    }
+}


### PR DESCRIPTION
With this change applied, artemis now only listens to localhost when passing connector-host as localhost (or leaving it empty, as it is the default) in management.xml.

**Testing done**

I created an instanced and uncommented the "<connector…" line in etc/management.xml:

`  <connector connector-port="1099"/>`

With this set, I started the instance and confirmed it was only listening to localhost:

`$ netstat -tan | grep 1099 | grep LISTEN
tcp6       0      0 127.0.0.1:1099          :::*                    LISTEN `

I was still able to connect via jconsole when connecting to localhost:1099.

![Screenshot from 2023-02-17 17-44-50](https://user-images.githubusercontent.com/2778554/219713543-d2ef69e7-9c62-4fa0-befa-8bdbfd7c27f2.png)

Connection attempts from another system were refused as expected.