### PR TITLE
ARTEMIS-4193 Large Message Files orphaned after server killed

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPLargeMessage.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPLargeMessage.java
@@ -460,26 +460,6 @@ public class AMQPLargeMessage extends AMQPMessage implements LargeServerMessage 
    }
 
    @Override
-   public void clearPendingRecordID() {
-      largeBody.clearPendingRecordID();
-   }
-
-   @Override
-   public boolean hasPendingRecord() {
-      return largeBody.hasPendingRecord();
-   }
-
-   @Override
-   public void setPendingRecordID(long pendingRecordID) {
-      largeBody.setPendingRecordID(pendingRecordID);
-   }
-
-   @Override
-   public long getPendingRecordID() {
-      return largeBody.getPendingRecordID();
-   }
-
-   @Override
    protected void releaseComplete() {
       largeBody.releaseComplete();
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -4648,7 +4648,7 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
    public void rebuildPageCounters() throws Exception {
       // managementLock will guarantee there's only one management operation being called
       try (AutoCloseable lock = server.managementLock()) {
-         Future<Object> task = server.getPagingManager().rebuildCounters();
+         Future<Object> task = server.getPagingManager().rebuildCounters(null);
          task.get();
       }
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/PagingManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/PagingManager.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.core.paging;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.function.BiConsumer;
 
@@ -84,6 +85,11 @@ public interface PagingManager extends ActiveMQComponent, HierarchicalRepository
    void addBlockedStore(PagingStore store);
 
    void injectMonitor(FileStoreMonitor monitor) throws Exception;
+
+   /** Execute a runnable inside the PagingManager's executor */
+   default void execute(Runnable runnable) {
+      throw new UnsupportedOperationException("not implemented");
+   }
 
    /**
     * Lock the manager. This method should not be called during normal PagingManager usage.
@@ -164,7 +170,7 @@ public interface PagingManager extends ActiveMQComponent, HierarchicalRepository
    /**
     * Rebuilds all page counters for destinations that are paging in the background.
     */
-   default Future<Object> rebuildCounters() {
+   default Future<Object> rebuildCounters(Set<Long> storedLargeMessages) {
       return null;
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingManagerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingManagerImpl.java
@@ -221,6 +221,11 @@ public final class PagingManagerImpl implements PagingManager {
    }
 
    @Override
+   public void execute(Runnable run) {
+      managerExecutor.execute(run);
+   }
+
+   @Override
    public void injectMonitor(FileStoreMonitor monitor) throws Exception {
       pagingStoreFactory.injectMonitor(monitor);
       monitor.addCallback(new LocalMonitor());
@@ -569,13 +574,13 @@ public final class PagingManagerImpl implements PagingManager {
    }
 
    @Override
-   public Future<Object> rebuildCounters() {
+   public Future<Object> rebuildCounters(Set<Long> storedLargeMessages) {
       LongHashSet transactionsSet = new LongHashSet();
       transactions.forEach((txId, tx) -> {
          transactionsSet.add(txId);
       });
       stores.forEach((address, pgStore) -> {
-         PageCounterRebuildManager rebuildManager = new PageCounterRebuildManager(pgStore, transactionsSet);
+         PageCounterRebuildManager rebuildManager = new PageCounterRebuildManager(pgStore, transactionsSet, storedLargeMessages);
          logger.debug("Setting destination {} to rebuild counters", address);
          managerExecutor.execute(rebuildManager);
       });

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/StorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/StorageManager.java
@@ -79,6 +79,9 @@ public interface StorageManager extends IDGenerator, ActiveMQComponent {
       return Long.MAX_VALUE;
    }
 
+   default void recoverLargeMessagesOnFolder(Set<Long> files) throws Exception {
+   }
+
    default SequentialFileFactory getJournalSequentialFileFactory() {
       return null;
    }
@@ -281,12 +284,24 @@ public interface StorageManager extends IDGenerator, ActiveMQComponent {
 
    void deletePageTransactional(long recordID) throws Exception;
 
+   default JournalLoadInformation loadMessageJournal(PostOffice postOffice,
+                                             PagingManager pagingManager,
+                                             ResourceManager resourceManager,
+                                             Map<Long, QueueBindingInfo> queueInfos,
+                                             Map<SimpleString, List<Pair<byte[], Long>>> duplicateIDMap,
+                                             Set<Pair<Long, Long>> pendingLargeMessages,
+                                             List<PageCountPending> pendingNonTXPageCounter,
+                                             JournalLoader journalLoader) throws Exception {
+      return loadMessageJournal(postOffice, pagingManager, resourceManager, queueInfos, duplicateIDMap, pendingLargeMessages, null, pendingNonTXPageCounter, journalLoader);
+   }
+
    JournalLoadInformation loadMessageJournal(PostOffice postOffice,
                                              PagingManager pagingManager,
                                              ResourceManager resourceManager,
                                              Map<Long, QueueBindingInfo> queueInfos,
                                              Map<SimpleString, List<Pair<byte[], Long>>> duplicateIDMap,
                                              Set<Pair<Long, Long>> pendingLargeMessages,
+                                             Set<Long> largeMessagesInFolder,
                                              List<PageCountPending> pendingNonTXPageCounter,
                                              JournalLoader journalLoader) throws Exception;
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/LargeBody.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/LargeBody.java
@@ -60,6 +60,8 @@ public class LargeBody {
    // This is to be used only for appending
    private SequentialFile file;
 
+   private boolean deleted;
+
    public LargeBody(LargeServerMessage message, StorageManager storageManager) {
       this.storageManager = storageManager;
       this.message = message;
@@ -113,6 +115,7 @@ public class LargeBody {
 
    public synchronized void deleteFile() {
       try {
+         this.deleted = true;
          validateFile();
          releaseResources(false, false);
          storageManager.deleteLargeMessageBody(message);
@@ -279,6 +282,9 @@ public class LargeBody {
    }
 
    public int getBodyBufferSize() {
+      if (deleted) {
+         return 0;
+      }
       final boolean closeFile = file == null || !file.isOpen();
       try {
          openFile();
@@ -445,23 +451,4 @@ public class LargeBody {
          return getBodySize();
       }
    }
-
-   public boolean hasPendingRecord() {
-      return pendingRecordID != NO_PENDING_ID;
-   }
-
-   public void clearPendingRecordID() {
-      setPendingRecordID(NO_PENDING_ID);
-   }
-
-
-   public long getPendingRecordID() {
-      return this.pendingRecordID;
-   }
-
-   public void setPendingRecordID(long pendingRecordID) {
-      this.pendingRecordID = pendingRecordID;
-   }
-
-
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/LargeServerMessageImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/LargeServerMessageImpl.java
@@ -170,29 +170,6 @@ public final class LargeServerMessageImpl extends CoreMessage implements CoreLar
    }
 
    @Override
-   public long getPendingRecordID() {
-      return largeBody.getPendingRecordID();
-   }
-
-   @Override
-   public void clearPendingRecordID() {
-      largeBody.clearPendingRecordID();
-   }
-
-   @Override
-   public boolean hasPendingRecord() {
-      return largeBody.hasPendingRecord();
-   }
-
-   /**
-    * @param pendingRecordID
-    */
-   @Override
-   public void setPendingRecordID(long pendingRecordID) {
-      largeBody.setPendingRecordID(pendingRecordID);
-   }
-
-   @Override
    public void setPaged() {
       largeBody.setPaged();
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/LargeServerMessageInSync.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/LargeServerMessageInSync.java
@@ -157,25 +157,4 @@ public final class LargeServerMessageInSync implements ReplicatedLargeMessage {
       }
       storageManager.addBytesToLargeMessage(appendFile, mainLM.getMessageID(), bytes);
    }
-
-   @Override
-   public void clearPendingRecordID() {
-      mainLM.clearPendingRecordID();
-   }
-
-   @Override
-   public boolean hasPendingRecord() {
-      return mainLM.hasPendingRecord();
-   }
-
-   @Override
-   public void setPendingRecordID(long pendingRecordID) {
-      mainLM.setPendingRecordID(pendingRecordID);
-   }
-
-   @Override
-   public long getPendingRecordID() {
-      return mainLM.getPendingRecordID();
-   }
-
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/nullpm/NullStorageLargeServerMessage.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/nullpm/NullStorageLargeServerMessage.java
@@ -140,25 +140,6 @@ class NullStorageLargeServerMessage extends CoreMessage implements CoreLargeServ
    }
 
    @Override
-   public void setPendingRecordID(long pendingRecordID) {
-   }
-
-   @Override
-   public void clearPendingRecordID() {
-
-   }
-
-   @Override
-   public boolean hasPendingRecord() {
-      return false;
-   }
-
-   @Override
-   public long getPendingRecordID() {
-      return -1;
-   }
-
-   @Override
    public SequentialFile getAppendFile() {
       return null;
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/nullpm/NullStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/nullpm/NullStorageManager.java
@@ -365,6 +365,7 @@ public class NullStorageManager implements StorageManager {
                                                     final Map<Long, QueueBindingInfo> queueInfos,
                                                     final Map<SimpleString, List<Pair<byte[], Long>>> duplicateIDMap,
                                                     final Set<Pair<Long, Long>> pendingLargeMessages,
+                                                    final Set<Long> storedLargeMessages,
                                                     List<PageCountPending> pendingNonTXPageCounter,
                                                     final JournalLoader journalLoader) throws Exception {
       return new JournalLoadInformation();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/replication/ReplicatedLargeMessage.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/replication/ReplicatedLargeMessage.java
@@ -52,12 +52,4 @@ public interface ReplicatedLargeMessage {
     */
    void addBytes(byte[] body) throws Exception;
 
-   void clearPendingRecordID();
-
-   void setPendingRecordID(long pendingRecordID);
-
-   long getPendingRecordID();
-
-   boolean hasPendingRecord();
-
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/replication/ReplicationEndpoint.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/replication/ReplicationEndpoint.java
@@ -607,7 +607,6 @@ public final class ReplicationEndpoint implements ChannelHandler, ActiveMQCompon
       }
       final ReplicatedLargeMessage message = lookupLargeMessage(packet.getMessageId(), packet.isDelete(), false);
       if (message != null) {
-         message.setPendingRecordID(packet.getPendingRecordId());
          if (!packet.isDelete()) {
             if (logger.isTraceEnabled()) {
                logger.trace("Closing LargeMessage {} on the executor @ handleLargeMessageEnd", packet.getMessageId());

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -80,6 +80,7 @@ import org.apache.activemq.artemis.core.deployers.impl.FileConfigurationParser;
 import org.apache.activemq.artemis.core.filter.Filter;
 import org.apache.activemq.artemis.core.filter.impl.FilterImpl;
 import org.apache.activemq.artemis.core.io.IOCriticalErrorListener;
+import org.apache.activemq.artemis.core.io.SequentialFile;
 import org.apache.activemq.artemis.core.io.aio.AIOSequentialFileFactory;
 import org.apache.activemq.artemis.core.journal.JournalLoadInformation;
 import org.apache.activemq.artemis.core.management.impl.ActiveMQServerControlImpl;
@@ -3381,10 +3382,24 @@ public class ActiveMQServerImpl implements ActiveMQServer {
 
       pagingManager.reloadStores();
 
-      JournalLoadInformation[] journalInfo = loadJournals();
+      Set<Long> storedLargeMessages = new HashSet<>();
+      JournalLoadInformation[] journalInfo = loadJournals(storedLargeMessages);
 
       if (rebuildCounters) {
-         pagingManager.rebuildCounters();
+         pagingManager.rebuildCounters(storedLargeMessages);
+
+         pagingManager.execute(() -> {
+            storedLargeMessages.forEach(id -> {
+               try {
+                  SequentialFile file = storageManager.createFileForLargeMessage(id, true);
+                  logger.debug("Removing pending large message for file={}", file);
+                  file.delete();
+               } catch (Exception e) {
+                  // this shouldn't really happen, unless something is off with the storage
+                  logger.warn("It was not possible to remove previously stored large message on folder::It will be retried on next startup", e);
+               }
+            });
+         });
       }
 
       removeExtraAddressStores();
@@ -3695,7 +3710,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
 
 
 
-   private JournalLoadInformation[] loadJournals() throws Exception {
+   private JournalLoadInformation[] loadJournals(Set<Long> storedLargeMessages) throws Exception {
       JournalLoader journalLoader = activation.createJournalLoader(postOffice, pagingManager, storageManager, queueFactory, nodeManager, managementService, groupingHandler, configuration, parentServer);
 
       JournalLoadInformation[] journalInfo = new JournalLoadInformation[2];
@@ -3724,7 +3739,9 @@ public class ActiveMQServerImpl implements ActiveMQServer {
 
       List<PageCountPending> pendingNonTXPageCounter = new LinkedList<>();
 
-      journalInfo[1] = storageManager.loadMessageJournal(postOffice, pagingManager, resourceManager, queueBindingInfosMap, duplicateIDMap, pendingLargeMessages, pendingNonTXPageCounter, journalLoader);
+      storageManager.recoverLargeMessagesOnFolder(storedLargeMessages);
+
+      journalInfo[1] = storageManager.loadMessageJournal(postOffice, pagingManager, resourceManager, queueBindingInfosMap, duplicateIDMap, pendingLargeMessages, storedLargeMessages, pendingNonTXPageCounter, journalLoader);
 
       journalLoader.handleDuplicateIds(duplicateIDMap);
 
@@ -3732,7 +3749,6 @@ public class ActiveMQServerImpl implements ActiveMQServer {
          ActiveMQServerLogger.LOGGER.deletingPendingMessage(msgToDelete);
          LargeServerMessage msg = storageManager.createLargeMessage();
          msg.setMessageID(msgToDelete.getB());
-         msg.setPendingRecordID(msgToDelete.getA());
          msg.setDurable(true);
          msg.deleteFile();
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/protocol/EmbedMessageUtil.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/protocol/EmbedMessageUtil.java
@@ -114,12 +114,6 @@ public class EmbedMessageUtil {
 
       Message largeMessageReturn = readEncoded(message, storageManager, buffer);
 
-      if (message instanceof LargeServerMessage && largeMessageReturn instanceof LargeServerMessage) {
-         LargeServerMessage returnMessage = (LargeServerMessage) largeMessageReturn;
-         LargeServerMessage sourceMessage = (LargeServerMessage) message;
-         returnMessage.setPendingRecordID(sourceMessage.getPendingRecordID());
-      }
-
       return largeMessageReturn;
    }
 

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalStorageManagerTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalStorageManagerTest.java
@@ -19,27 +19,17 @@ package org.apache.activemq.artemis.core.persistence.impl.journal;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
-import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.io.SequentialFile;
 import org.apache.activemq.artemis.core.io.aio.AIOSequentialFileFactory;
-import org.apache.activemq.artemis.core.message.impl.CoreMessage;
-import org.apache.activemq.artemis.core.paging.PagingManager;
 import org.apache.activemq.artemis.core.postoffice.PostOffice;
-import org.apache.activemq.artemis.core.replication.ReplicationManager;
 import org.apache.activemq.artemis.core.server.JournalType;
-import org.apache.activemq.artemis.core.server.LargeServerMessage;
 import org.apache.activemq.artemis.core.server.impl.JournalLoader;
 import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.ExecutorFactory;
@@ -58,7 +48,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 
 @RunWith(Parameterized.class)
 public class JournalStorageManagerTest extends ActiveMQTestBase {
@@ -109,68 +98,6 @@ public class JournalStorageManagerTest extends ActiveMQTestBase {
       Assert.assertEquals(8192, manager.fixJournalFileSize(8192, 4096));
    }
 
-   @Test(timeout = 20_000)
-   public void testStopReplicationDoesNotDeadlockWhileStopping() throws Exception {
-      if (journalType == JournalType.ASYNCIO) {
-         assumeTrue("AIO is not supported on this platform", AIOSequentialFileFactory.isSupported());
-      }
-      final Configuration configuration = createDefaultInVMConfig().setJournalType(journalType);
-      final ExecutorFactory executorFactory = new OrderedExecutorFactory(executor);
-      final ExecutorFactory ioExecutorFactory = new OrderedExecutorFactory(ioExecutor);
-      final JournalStorageManager manager = spy(new JournalStorageManager(configuration, null, executorFactory, null, ioExecutorFactory));
-      manager.start();
-      manager.loadBindingJournal(new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
-      final PostOffice postOffice = mock(PostOffice.class);
-      final JournalLoader journalLoader = mock(JournalLoader.class);
-      manager.loadMessageJournal(postOffice, null, null, null, null, null, null, journalLoader);
-      final ReplicationManager replicationManager = mock(ReplicationManager.class);
-      final PagingManager pagingManager = mock(PagingManager.class);
-      when(pagingManager.getStoreNames()).thenReturn(new SimpleString[0]);
-      manager.startReplication(replicationManager, pagingManager, UUID.randomUUID().toString(), false, 0);
-      final LargeServerMessage largeMessage = manager.createLargeMessage(manager.generateID() + 1, new CoreMessage());
-      largeMessage.setDurable(true);
-      when(replicationManager.isSynchronizing()).thenReturn(true);
-      largeMessage.deleteFile();
-      final long pendingRecordID = largeMessage.getPendingRecordID();
-      final AtomicReference<CompletableFuture<Void>> stopReplication = new AtomicReference<>();
-      doAnswer(invocation -> {
-         final CompletableFuture<Void> finished = new CompletableFuture<>();
-         final CountDownLatch beforeStopReplication;
-         if (stopReplication.compareAndSet(null, finished)) {
-            beforeStopReplication = new CountDownLatch(1);
-            //before the deadlock fix:
-            //manager::stop is already owning the large message lock here
-            //but not yet the manager read lock
-            testExecutor.execute(() -> {
-               beforeStopReplication.countDown();
-               try {
-                  //it needs to acquire the manager write lock
-                  //and large message lock next
-                  manager.stopReplication();
-                  finished.complete(null);
-               } catch (Exception e) {
-                  finished.completeExceptionally(e);
-               }
-            });
-         } else {
-            beforeStopReplication = null;
-         }
-         if (beforeStopReplication != null) {
-            beforeStopReplication.await();
-            //do not remove this sleep: before the deadlock fix
-            //it was needed to give manager::stopReplication the chance to acquire
-            //the manager write lock before manager::stop
-            TimeUnit.MILLISECONDS.sleep(500);
-         }
-         //confirmPendingLargeMessage will acquire manager read lock
-         return invocation.callRealMethod();
-      }).when(manager).confirmPendingLargeMessage(pendingRecordID);
-      manager.stop();
-      final CompletableFuture<Void> stoppedReplication = stopReplication.get();
-      Assert.assertNotNull(stoppedReplication);
-      stoppedReplication.get();
-   }
-
    @Test
    public void testAddBytesToLargeMessageNotLeakingByteBuffer() throws Exception {
       if (journalType == JournalType.ASYNCIO) {
@@ -185,7 +112,7 @@ public class JournalStorageManagerTest extends ActiveMQTestBase {
       manager.loadBindingJournal(new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
       final PostOffice postOffice = mock(PostOffice.class);
       final JournalLoader journalLoader = mock(JournalLoader.class);
-      manager.loadMessageJournal(postOffice, null, null, null, null, null, null, journalLoader);
+      manager.loadMessageJournal(postOffice, null, null, null, null, null, null, null, journalLoader);
       final long id = manager.generateID() + 1;
       final SequentialFile file = manager.createFileForLargeMessage(id, false);
       try {

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/persistence/impl/journal/LargeServerMessageImplTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/persistence/impl/journal/LargeServerMessageImplTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.core.persistence.impl.journal;
+
+import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
+import org.apache.activemq.artemis.core.io.SequentialFile;
+import org.apache.activemq.artemis.core.io.nio.NIOSequentialFileFactory;
+import org.apache.activemq.artemis.core.persistence.impl.nullpm.NullStorageManager;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LargeServerMessageImplTest extends ActiveMQTestBase {
+
+   @Test
+   public void testDeleteNoRecreateFile() throws Exception {
+      NIOSequentialFileFactory factory = new NIOSequentialFileFactory(getTestDirfile(), 1);
+      SequentialFile file = factory.createSequentialFile("1.msg");
+      file.open();
+      file.write(ActiveMQBuffers.wrappedBuffer(new byte[100]), true);
+      file.close();
+      LargeServerMessageImpl message = new LargeServerMessageImpl((byte)0, 1, new NullStorageManager(), file);
+      file.delete();
+      message.deleteFile();
+      message.getBodyBufferSize();
+      Assert.assertFalse(file.exists());
+   }
+}

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/transaction/impl/TransactionImplTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/transaction/impl/TransactionImplTest.java
@@ -526,6 +526,7 @@ public class TransactionImplTest extends ActiveMQTestBase {
                                                        Map<Long, QueueBindingInfo> queueInfos,
                                                        Map<SimpleString, List<Pair<byte[], Long>>> duplicateIDMap,
                                                        Set<Pair<Long, Long>> pendingLargeMessages,
+                                                       Set<Long> largeMessagesInFolder,
                                                        List<PageCountPending> pendingNonTXPageCounter,
                                                        JournalLoader journalLoader) throws Exception {
          return null;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/largemessages/InterruptedAMQPLargeMessage.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/largemessages/InterruptedAMQPLargeMessage.java
@@ -129,8 +129,6 @@ public class InterruptedAMQPLargeMessage extends AmqpClientTestSupport {
 
          Assert.assertNotNull(message);
          Assert.assertTrue(message instanceof LargeServerMessage);
-
-         Assert.assertFalse(((LargeServerMessage)message).hasPendingRecord());
       }
       browserIterator.close();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/largemessages/SimpleStreamingLargeMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/largemessages/SimpleStreamingLargeMessageTest.java
@@ -342,8 +342,6 @@ public class SimpleStreamingLargeMessageTest extends AmqpClientTestSupport {
 
             Assert.assertNotNull(message);
             Assert.assertTrue(message instanceof LargeServerMessage);
-
-            Assert.assertFalse(((LargeServerMessage)message).hasPendingRecord());
          }
          browserIterator.close();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/LargeMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/LargeMessageTest.java
@@ -440,8 +440,6 @@ public class LargeMessageTest extends LargeMessageTestBase {
 
          Assert.assertNotNull(message);
          Assert.assertTrue(message instanceof LargeServerMessage);
-
-         Assert.assertFalse(((LargeServerMessage)message).hasPendingRecord());
       }
       browserIterator.close();
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SendAckFailTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SendAckFailTest.java
@@ -599,9 +599,10 @@ public class SendAckFailTest extends SpawnedTestBase {
                                                        Map<Long, QueueBindingInfo> queueInfos,
                                                        Map<SimpleString, List<Pair<byte[], Long>>> duplicateIDMap,
                                                        Set<Pair<Long, Long>> pendingLargeMessages,
+                                                       Set<Long> largeMessagesInFolder,
                                                        List<PageCountPending> pendingNonTXPageCounter,
                                                        JournalLoader journalLoader) throws Exception {
-         return manager.loadMessageJournal(postOffice, pagingManager, resourceManager, queueInfos, duplicateIDMap, pendingLargeMessages, pendingNonTXPageCounter, journalLoader);
+         return manager.loadMessageJournal(postOffice, pagingManager, resourceManager, queueInfos, duplicateIDMap, pendingLargeMessages, largeMessagesInFolder, pendingNonTXPageCounter, journalLoader);
       }
 
       @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingCounterTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingCounterTest.java
@@ -294,7 +294,7 @@ public class PagingCounterTest extends ActiveMQTestBase {
          assertEquals(2100, counter.getValue());
          assertEquals(2100 * 1000, counter.getPersistentSize());
 
-         server.getPagingManager().rebuildCounters();
+         server.getPagingManager().rebuildCounters(null);
 
          // it should be zero after rebuild, since no actual messages were sent
          Wait.assertEquals(0, counter::getValue);
@@ -419,7 +419,7 @@ public class PagingCounterTest extends ActiveMQTestBase {
       Wait.assertEquals(11_000, counterAfterRestart::getPersistentSize);
       counterAfterRestart.finishRebuild();
 
-      server.getPagingManager().rebuildCounters();
+      server.getPagingManager().rebuildCounters(null);
 
       Wait.assertEquals(0, counterAfterRestart::getValue);
       Wait.assertEquals(0, counterAfterRestart::getPersistentSize);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/DeleteMessagesOnStartupTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/DeleteMessagesOnStartupTest.java
@@ -82,7 +82,7 @@ public class DeleteMessagesOnStartupTest extends StorageManagerTestBase {
 
       FakePostOffice postOffice = new FakePostOffice();
 
-      journal.loadMessageJournal(postOffice, null, null, null, null, null, null, new PostOfficeJournalLoader(postOffice, null, journal, null, null, null, null, null, queues));
+      journal.loadMessageJournal(postOffice, null, null, null, null, null, null, null, new PostOfficeJournalLoader(postOffice, null, journal, null, null, null, null, null, queues));
 
       Assert.assertEquals(98, deletedMessage.size());
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/StorageManagerTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/StorageManagerTestBase.java
@@ -133,7 +133,7 @@ public abstract class StorageManagerTestBase extends ActiveMQTestBase {
 
       journal.loadBindingJournal(new ArrayList<QueueBindingInfo>(), new ArrayList<GroupingInfo>(), new ArrayList<AddressBindingInfo>());
 
-      journal.loadMessageJournal(new FakePostOffice(), null, null, null, null, null, null, new FakeJournalLoader());
+      journal.loadMessageJournal(new FakePostOffice(), null, null, null, null, null, null, null, new FakeJournalLoader());
    }
 
    /**

--- a/tests/soak-tests/pom.xml
+++ b/tests/soak-tests/pom.xml
@@ -247,6 +247,31 @@
                      </args>
                   </configuration>
                </execution>
+               <!-- Used on LargeMessageInterruptTest -->
+               <execution>
+                  <phase>test-compile</phase>
+                  <id>create-interruptlm</id>
+                  <goals>
+                     <goal>create</goal>
+                  </goals>
+                  <configuration>
+                     <role>amq</role>
+                     <user>artemis</user>
+                     <password>artemis</password>
+                     <allowAnonymous>true</allowAnonymous>
+                     <noWeb>false</noWeb>
+                     <instance>${basedir}/target/interruptlm</instance>
+                     <configuration>${basedir}/target/classes/servers/interruptlm</configuration>
+                     <args>
+                        <arg>--java-options</arg>
+                        <arg>-Djava.rmi.server.hostname=localhost</arg>
+                        <arg>--queues</arg>
+                        <arg>LargeMessageInterruptTest</arg>
+                        <arg>--name</arg>
+                        <arg>interruptlm</arg>
+                     </args>
+                  </configuration>
+               </execution>
 
             </executions>
          </plugin>

--- a/tests/soak-tests/src/main/resources/servers/interruptlm/broker.xml
+++ b/tests/soak-tests/src/main/resources/servers/interruptlm/broker.xml
@@ -1,0 +1,259 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration xmlns="urn:activemq"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:xi="http://www.w3.org/2001/XInclude"
+               xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+
+   <core xmlns="urn:activemq:core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="urn:activemq:core ">
+
+      <name>lminterrupt</name>
+
+
+      <persistence-enabled>true</persistence-enabled>
+
+      <!-- this could be ASYNCIO, MAPPED, NIO
+           ASYNCIO: Linux Libaio
+           MAPPED: mmap files
+           NIO: Plain Java Files
+       -->
+      <journal-type>NIO</journal-type>
+
+      <paging-directory>./data/paging</paging-directory>
+
+      <bindings-directory>./data/bindings</bindings-directory>
+
+      <journal-directory>./data/journal</journal-directory>
+
+      <large-messages-directory>./data/large-messages</large-messages-directory>
+
+      
+      <!-- if you want to retain your journal uncomment this following configuration.
+
+      This will allow your system to keep 7 days of your data, up to 10G. Tweak it accordingly to your use case and capacity.
+
+      it is recommended to use a separate storage unit from the journal for performance considerations.
+
+      <journal-retention-directory period="7" unit="DAYS" storage-limit="10G">data/retention</journal-retention-directory>
+
+      You can also enable retention by using the argument journal-retention on the `artemis create` command -->
+
+
+
+      <journal-datasync>true</journal-datasync>
+
+      <journal-min-files>2</journal-min-files>
+
+      <journal-pool-files>10</journal-pool-files>
+
+      <journal-device-block-size>4096</journal-device-block-size>
+
+      <journal-file-size>10M</journal-file-size>
+            <!--
+        You can verify the network health of a particular NIC by specifying the <network-check-NIC> element.
+         <network-check-NIC>theNicName</network-check-NIC>
+        -->
+
+      <!--
+        Use this to use an HTTP server to validate the network
+         <network-check-URL-list>http://www.apache.org</network-check-URL-list> -->
+
+      <!-- <network-check-period>10000</network-check-period> -->
+      <!-- <network-check-timeout>1000</network-check-timeout> -->
+
+      <!-- this is a comma separated list, no spaces, just DNS or IPs
+           it should accept IPV6
+
+           Warning: Make sure you understand your network topology as this is meant to validate if your network is valid.
+                    Using IPs that could eventually disappear or be partially visible may defeat the purpose.
+                    You can use a list of multiple IPs, and if any successful ping will make the server OK to continue running -->
+      <!-- <network-check-list>10.0.0.1</network-check-list> -->
+
+      <!-- use this to customize the ping used for ipv4 addresses -->
+      <!-- <network-check-ping-command>ping -c 1 -t %d %s</network-check-ping-command> -->
+
+      <!-- use this to customize the ping used for ipv6 addresses -->
+      <!-- <network-check-ping6-command>ping6 -c 1 %2$s</network-check-ping6-command> -->
+
+
+
+
+      <!-- how often we are looking for how many bytes are being used on the disk in ms -->
+      <disk-scan-period>5000</disk-scan-period>
+
+      <!-- once the disk hits this limit the system will block, or close the connection in certain protocols
+           that won't support flow control. -->
+      <max-disk-usage>90</max-disk-usage>
+
+      <!-- should the broker detect dead locks and other issues -->
+      <critical-analyzer>true</critical-analyzer>
+
+      <critical-analyzer-timeout>120000</critical-analyzer-timeout>
+
+      <critical-analyzer-check-period>60000</critical-analyzer-check-period>
+
+      <critical-analyzer-policy>HALT</critical-analyzer-policy>
+
+      
+
+      <!-- the system will enter into page mode once you hit this limit. This is an estimate in bytes of how much the messages are using in memory
+
+      The system will use half of the available memory (-Xmx) by default for the global-max-size.
+      You may specify a different value here if you need to customize it to your needs.
+
+      <global-max-size>100Mb</global-max-size> -->
+
+      <!-- the maximum number of messages accepted before entering full address mode.
+           if global-max-size is specified the full address mode will be specified by whatever hits it first. -->
+      <global-max-messages>-1</global-max-messages>
+
+      <acceptors>
+
+         <!-- useEpoll means: it will use Netty epoll if you are on a system (Linux) that supports it -->
+         <!-- amqpCredits: The number of credits sent to AMQP producers -->
+         <!-- amqpLowCredits: The server will send the # credits specified at amqpCredits at this low mark -->
+         <!-- amqpDuplicateDetection: If you are not using duplicate detection, set this to false
+                                      as duplicate detection requires applicationProperties to be parsed on the server. -->
+         <!-- amqpMinLargeMessageSize: Determines how many bytes are considered large, so we start using files to hold their data.
+                                       default: 102400, -1 would mean to disable large mesasge control -->
+
+         <!-- Note: If an acceptor needs to be compatible with HornetQ and/or Artemis 1.x clients add
+                    "anycastPrefix=jms.queue.;multicastPrefix=jms.topic." to the acceptor url.
+                    See https://issues.apache.org/jira/browse/ARTEMIS-1644 for more information. -->
+
+
+         <!-- Acceptor for every supported protocol -->
+         <acceptor name="artemis">tcp://0.0.0.0:61616?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;amqpMinLargeMessageSize=102400;protocols=CORE,AMQP,STOMP,HORNETQ,MQTT,OPENWIRE;useEpoll=true;amqpCredits=1000;amqpLowCredits=300;amqpDuplicateDetection=true;supportAdvisory=false;suppressInternalManagementObjects=false</acceptor>
+
+         <!-- AMQP Acceptor.  Listens on default AMQP port for AMQP traffic.-->
+         <acceptor name="amqp">tcp://0.0.0.0:5672?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=AMQP;useEpoll=true;amqpCredits=1000;amqpLowCredits=300;amqpMinLargeMessageSize=102400;amqpDuplicateDetection=true</acceptor>
+
+         <!-- STOMP Acceptor. -->
+         <acceptor name="stomp">tcp://0.0.0.0:61613?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=STOMP;useEpoll=true</acceptor>
+
+         <!-- HornetQ Compatibility Acceptor.  Enables HornetQ Core and STOMP for legacy HornetQ clients. -->
+         <acceptor name="hornetq">tcp://0.0.0.0:5445?anycastPrefix=jms.queue.;multicastPrefix=jms.topic.;protocols=HORNETQ,STOMP;useEpoll=true</acceptor>
+
+         <!-- MQTT Acceptor -->
+         <acceptor name="mqtt">tcp://0.0.0.0:1883?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=MQTT;useEpoll=true</acceptor>
+
+      </acceptors>
+
+
+      <security-settings>
+         <security-setting match="#">
+            <permission type="createNonDurableQueue" roles="amq"/>
+            <permission type="deleteNonDurableQueue" roles="amq"/>
+            <permission type="createDurableQueue" roles="amq"/>
+            <permission type="deleteDurableQueue" roles="amq"/>
+            <permission type="createAddress" roles="amq"/>
+            <permission type="deleteAddress" roles="amq"/>
+            <permission type="consume" roles="amq"/>
+            <permission type="browse" roles="amq"/>
+            <permission type="send" roles="amq"/>
+            <!-- we need this otherwise ./artemis data imp wouldn't work -->
+            <permission type="manage" roles="amq"/>
+         </security-setting>
+      </security-settings>
+
+      <address-settings>
+         <!-- if you define auto-create on certain queues, management has to be auto-create -->
+         <address-setting match="activemq.management#">
+            <dead-letter-address>DLQ</dead-letter-address>
+            <expiry-address>ExpiryQueue</expiry-address>
+            <redelivery-delay>0</redelivery-delay>
+            <!-- with -1 only the global-max-size is in use for limiting -->
+            <max-size-bytes>-1</max-size-bytes>
+            <message-counter-history-day-limit>10</message-counter-history-day-limit>
+            <address-full-policy>PAGE</address-full-policy>
+            <auto-create-queues>true</auto-create-queues>
+            <auto-create-addresses>true</auto-create-addresses>
+         </address-setting>
+         <!--default for catch all-->
+         <address-setting match="#">
+            <dead-letter-address>DLQ</dead-letter-address>
+            <expiry-address>ExpiryQueue</expiry-address>
+            <redelivery-delay>0</redelivery-delay>
+
+            <!-- if max-size-bytes and max-size-messages were both enabled, the system will enter into paging
+                 based on the first attribute to hits the maximum value -->
+            <!-- limit for the address in bytes, -1 means unlimited -->
+            <max-size-bytes>-1</max-size-bytes>
+
+            <!-- limit for the address in messages, -1 means unlimited -->
+            <max-size-messages>300</max-size-messages>
+
+            <!-- the size of each file on paging. Notice we keep files in memory while they are in use.
+                 Lower this setting if you have too many queues in memory. -->
+            <page-size-bytes>10M</page-size-bytes>
+
+            <!-- limit how many messages are read from paging into the Queue. -->
+            <max-read-page-messages>-1</max-read-page-messages>
+
+            <!-- limit how much memory is read from paging into the Queue. -->
+            <max-read-page-bytes>20M</max-read-page-bytes>
+
+            <message-counter-history-day-limit>10</message-counter-history-day-limit>
+            <address-full-policy>PAGE</address-full-policy>
+            <auto-create-queues>true</auto-create-queues>
+            <auto-create-addresses>true</auto-create-addresses>
+            <auto-delete-queues>false</auto-delete-queues>
+            <auto-delete-addresses>false</auto-delete-addresses>
+         </address-setting>
+      </address-settings>
+
+      <addresses>
+         <address name="DLQ">
+            <anycast>
+               <queue name="DLQ" />
+            </anycast>
+         </address>
+         <address name="ExpiryQueue">
+            <anycast>
+               <queue name="ExpiryQueue" />
+            </anycast>
+         </address>
+         <address name="LargeMessageInterruptTest">
+            <anycast>
+               <queue name="LargeMessageInterruptTest" />
+            </anycast>
+         </address>
+
+      </addresses>
+
+
+      <!-- Uncomment the following if you want to use the Standard LoggingActiveMQServerPlugin pluging to log in events
+      <broker-plugins>
+         <broker-plugin class-name="org.apache.activemq.artemis.core.server.plugin.impl.LoggingActiveMQServerPlugin">
+            <property key="LOG_ALL_EVENTS" value="true"/>
+            <property key="LOG_CONNECTION_EVENTS" value="true"/>
+            <property key="LOG_SESSION_EVENTS" value="true"/>
+            <property key="LOG_CONSUMER_EVENTS" value="true"/>
+            <property key="LOG_DELIVERING_EVENTS" value="true"/>
+            <property key="LOG_SENDING_EVENTS" value="true"/>
+            <property key="LOG_INTERNAL_EVENTS" value="true"/>
+         </broker-plugin>
+      </broker-plugins>
+      -->
+
+   </core>
+</configuration>

--- a/tests/soak-tests/src/main/resources/servers/interruptlm/management.xml
+++ b/tests/soak-tests/src/main/resources/servers/interruptlm/management.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License. You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<management-context xmlns="http://activemq.apache.org/schema">
+   <connector connector-port="1099"/>
+   <authorisation>
+      <allowlist>
+         <entry domain="hawtio"/>
+      </allowlist>
+      <default-access>
+         <access method="list*" roles="amq"/>
+         <access method="get*" roles="amq"/>
+         <access method="is*" roles="amq"/>
+         <access method="set*" roles="amq"/>
+         <access method="*" roles="amq"/>
+      </default-access>
+      <role-access>
+         <match domain="org.apache.activemq.artemis">
+            <access method="list*" roles="amq"/>
+            <access method="get*" roles="amq"/>
+            <access method="is*" roles="amq"/>
+            <access method="set*" roles="amq"/>
+            <!-- Note count and browse are need to access the browse tab in the console-->
+            <access method="browse*" roles="amq"/>
+            <access method="count*" roles="amq"/>
+            <access method="*" roles="amq"/>
+         </match>
+         <!--example of how to configure a specific object-->
+         <!--<match domain="org.apache.activemq.artemis" key="subcomponent=queues">
+            <access method="list*" roles="view,update,amq"/>
+            <access method="get*" roles="view,update,amq"/>
+            <access method="is*" roles="view,update,amq"/>
+            <access method="set*" roles="update,amq"/>
+            <access method="*" roles="amq"/>
+         </match>-->
+      </role-access>
+   </authorisation>
+</management-context>

--- a/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/SoakTestBase.java
+++ b/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/SoakTestBase.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.tests.soak;
 
 import javax.management.MBeanServerInvocationHandler;
+import javax.management.ObjectName;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
@@ -28,8 +29,11 @@ import java.net.MalformedURLException;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl;
 import org.apache.activemq.artemis.api.core.management.ObjectNameBuilder;
+import org.apache.activemq.artemis.api.core.management.QueueControl;
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
 import org.apache.activemq.artemis.cli.commands.Stop;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
@@ -143,6 +147,34 @@ public class SoakTestBase extends ActiveMQTestBase {
             serverControl.isActive(); // making one call to make sure it's working
             return serverControl;
          } catch (Throwable e) {
+            lastException = e;
+            Thread.sleep(500);
+         }
+      }
+      while (expireLoop > System.currentTimeMillis());
+
+      throw lastException;
+   }
+
+   protected static QueueControl getQueueControl(String uri,
+                                                  ObjectNameBuilder builder,
+                                                  String address,
+                                                  String queueName,
+                                                  RoutingType routingType,
+                                                  long timeout) throws Throwable {
+      long expireLoop = System.currentTimeMillis() + timeout;
+      Throwable lastException = null;
+      do {
+         try {
+            JMXConnector connector = newJMXFactory(uri);
+
+            ObjectName objectQueueName = builder.getQueueObjectName(SimpleString.toSimpleString(address), SimpleString.toSimpleString(queueName), routingType);
+
+            QueueControl queueControl = MBeanServerInvocationHandler.newProxyInstance(connector.getMBeanServerConnection(), objectQueueName, QueueControl.class, false);
+            queueControl.getMessagesAcknowledged(); // making one call
+            return queueControl;
+         } catch (Throwable e) {
+            logger.warn(e.getMessage(), e);
             lastException = e;
             Thread.sleep(500);
          }

--- a/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/interruptlm/LargeMessageInterruptTest.java
+++ b/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/interruptlm/LargeMessageInterruptTest.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.tests.soak.interruptlm;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import java.io.File;
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.management.ObjectNameBuilder;
+import org.apache.activemq.artemis.api.core.management.QueueControl;
+import org.apache.activemq.artemis.tests.soak.SoakTestBase;
+import org.apache.activemq.artemis.tests.util.CFUtil;
+import org.apache.activemq.artemis.tests.util.Wait;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// This is used to kill a server and make sure the server will remove any pending files.
+public class LargeMessageInterruptTest extends SoakTestBase {
+
+   public static final String SERVER_NAME_0 = "interruptlm";
+   private static final String JMX_SERVER_HOSTNAME = "localhost";
+   private static final int JMX_SERVER_PORT_0 = 1099;
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   static String liveURI = "service:jmx:rmi:///jndi/rmi://" + JMX_SERVER_HOSTNAME + ":" + JMX_SERVER_PORT_0 + "/jmxrmi";
+   static ObjectNameBuilder liveNameBuilder = ObjectNameBuilder.create(ActiveMQDefaultConfiguration.getDefaultJmxDomain(), "lminterrupt", true);
+   Process serverProcess;
+
+   public ConnectionFactory createConnectionFactory(String protocol) {
+      return CFUtil.createConnectionFactory(protocol, "tcp://localhost:61616");
+   }
+
+   @Before
+   public void before() throws Exception {
+      cleanupData(SERVER_NAME_0);
+      serverProcess = startServer(SERVER_NAME_0, 0, 30000);
+      disableCheckThread();
+   }
+
+   @Test
+   public void testInterruptLargeMessageAMQPTX() throws Throwable {
+      testInterruptLM("AMQP", true, false);
+   }
+
+   @Test
+   public void testInterruptLargeMessageAMQPTXPaging() throws Throwable {
+      testInterruptLM("AMQP", true, true);
+   }
+
+   @Test
+   public void testInterruptLargeMessageCORETX() throws Throwable {
+      testInterruptLM("CORE", true, false);
+   }
+
+   @Test
+   public void testInterruptLargeMessageCORETXPaging() throws Throwable {
+      testInterruptLM("CORE", true, true);
+   }
+
+
+   @Test
+   public void testInterruptLargeMessageOPENWIRETX() throws Throwable {
+      testInterruptLM("OPENWIRE", true, false);
+   }
+
+   @Test
+   public void testInterruptLargeMessageOPENWIRETXPaging() throws Throwable {
+      testInterruptLM("OPENWIRE", true, true);
+   }
+
+
+   @Test
+   public void testInterruptLargeMessageAMQPNonTX() throws Throwable {
+      testInterruptLM("AMQP", false, false);
+   }
+
+   @Test
+   public void testInterruptLargeMessageAMQPNonTXPaging() throws Throwable {
+      testInterruptLM("AMQP", false, true);
+   }
+
+   @Test
+   public void testInterruptLargeMessageCORENonTX() throws Throwable {
+      testInterruptLM("CORE", false, false);
+   }
+
+   @Test
+   public void testInterruptLargeMessageCORENonTXPaging() throws Throwable {
+      testInterruptLM("CORE", false, true);
+   }
+
+   private void testInterruptLM(String protocol, boolean tx, boolean paging) throws Throwable {
+      final int BODY_SIZE = 500 * 1024;
+      final int NUMBER_OF_MESSAGES = 10; // this is per producer
+      final int SENDING_THREADS = 10;
+      CyclicBarrier startFlag = new CyclicBarrier(SENDING_THREADS);
+      final CountDownLatch done = new CountDownLatch(SENDING_THREADS);
+      final AtomicInteger produced = new AtomicInteger(0);
+      final ConnectionFactory factory = createConnectionFactory(protocol);
+      final AtomicInteger errors = new AtomicInteger(0); // I don't expect many errors since this test is disconnecting and reconnecting the server
+      final CountDownLatch killAt = new CountDownLatch(40);
+
+      ExecutorService executorService = Executors.newFixedThreadPool(SENDING_THREADS);
+      runAfter(executorService::shutdownNow);
+
+      String queueName = "LargeMessageInterruptTest";
+
+      String largebody;
+
+      {
+         StringBuffer buffer = new StringBuffer();
+         while (buffer.length() < BODY_SIZE) {
+            buffer.append("LOREM IPSUM WHATEVER THEY SAY IN THERE I DON'T REALLY CARE. I'M NOT SURE IF IT'S LOREM, LAUREM, LAUREN, IPSUM OR YPSUM AND I DON'T REALLY CARE ");
+         }
+         largebody = buffer.toString();
+      }
+
+      if (paging) {
+         try (Connection connection = factory.createConnection()) {
+            Session session = connection.createSession(true, Session.SESSION_TRANSACTED);
+            MessageProducer producer = session.createProducer(session.createQueue(queueName));
+            for (int i = 0; i < 1000; i++) {
+               producer.send(session.createTextMessage("forcePage"));
+            }
+            session.commit();
+         }
+      }
+
+      for (int i = 0; i < SENDING_THREADS; i++) {
+         executorService.execute(() -> {
+            int numberOfMessages = 0;
+            try {
+               Connection connection = factory.createConnection();
+               Session session = connection.createSession(tx, tx ? Session.SESSION_TRANSACTED : Session.AUTO_ACKNOWLEDGE);
+               MessageProducer producer = session.createProducer(session.createQueue(queueName));
+
+               startFlag.await(10, TimeUnit.SECONDS);
+               while (numberOfMessages < NUMBER_OF_MESSAGES) {
+                  try {
+                     producer.send(session.createTextMessage(largebody));
+                     if (tx) {
+                        session.commit();
+                     }
+                     produced.incrementAndGet();
+                     killAt.countDown();
+                     if (numberOfMessages++ % 10 == 0) {
+                        logger.info("Sent {}", numberOfMessages);
+                     }
+                  } catch (Exception e) {
+                     logger.warn(e.getMessage(), e);
+
+                     logger.warn(e.getMessage(), e);
+                     try {
+                        connection.close();
+                     } catch (Throwable ignored) {
+                     }
+
+                     for (int retryNumber = 0; retryNumber < 100; retryNumber++) {
+                        try {
+                           Connection ctest = factory.createConnection();
+                           ctest.close();
+                           break;
+                        } catch (Throwable retry) {
+                           Thread.sleep(100);
+                        }
+                     }
+
+                     connection = factory.createConnection();
+                     session = connection.createSession(tx, tx ? Session.SESSION_TRANSACTED : Session.AUTO_ACKNOWLEDGE);
+                     producer = session.createProducer(session.createQueue(queueName));
+                     connection.start();
+
+                  }
+               }
+            } catch (Exception e) {
+               logger.warn("Error getting the initial connection", e);
+               errors.incrementAndGet();
+            }
+
+            logger.info("Done sending");
+            done.countDown();
+         });
+      }
+
+      Assert.assertTrue(killAt.await(60, TimeUnit.SECONDS));
+      serverProcess.destroyForcibly();
+      serverProcess = startServer(SERVER_NAME_0, 0, 0);
+
+      Assert.assertTrue(done.await(60, TimeUnit.SECONDS));
+      Assert.assertEquals(0, errors.get());
+
+      QueueControl queueControl = getQueueControl(liveURI, liveNameBuilder, queueName, queueName, RoutingType.ANYCAST, 5000);
+
+      long numberOfMessages = queueControl.getMessageCount();
+      logger.info("there are {} messages", numberOfMessages);
+
+      try (Connection connection = factory.createConnection()) {
+         Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+         MessageConsumer consumer = session.createConsumer(session.createQueue(queueName));
+         connection.start();
+         for (int i = 0; i < numberOfMessages; i++) {
+            TextMessage message = (TextMessage) consumer.receive(5000);
+            Assert.assertNotNull(message);
+            Assert.assertTrue(message.getText().equals("forcePage") || message.getText().equals(largebody));
+         }
+      }
+
+      File lmFolder = new File(getServerLocation(SERVER_NAME_0) + "/data/large-messages");
+      Assert.assertTrue(lmFolder.exists());
+      Wait.assertEquals(0, () -> lmFolder.listFiles().length);
+
+   }
+
+}


### PR DESCRIPTION
This fix is scanning journal and paging for existing large messages. We will remove any large messages that do not have a corresponding record in journals or paging.