### PR TITLE
NO-JIRA Cleanup MBeanServer usage in the testsuite as it is leaking

### DIFF
--- a/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.tests.util;
 
+import javax.management.MBeanServer;
+import javax.management.MBeanServerFactory;
 import javax.naming.Context;
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.Xid;
@@ -175,6 +177,12 @@ import org.junit.runner.Description;
  * Base class with basic utilities on starting up a basic server
  */
 public abstract class ActiveMQTestBase extends Assert {
+
+   public MBeanServer getMBeanServer() {
+      MBeanServer mBeanServer = MBeanServerFactory.createMBeanServer();
+      runAfter(() -> MBeanServerFactory.releaseMBeanServer(mBeanServer));
+      return mBeanServer;
+   }
 
    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 

--- a/tests/integration-tests/pom.xml
+++ b/tests/integration-tests/pom.xml
@@ -155,6 +155,7 @@
          <version>${hamcrest.version}</version>
          <scope>test</scope>
       </dependency>
+
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>activemq-client</artifactId>

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpClientTestSupport.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpClientTestSupport.java
@@ -23,7 +23,6 @@ import javax.jms.DeliveryMode;
 import javax.jms.MessageProducer;
 import javax.jms.Session;
 import javax.management.MBeanServer;
-import javax.management.MBeanServerFactory;
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
@@ -96,7 +95,7 @@ public class AmqpClientTestSupport extends AmqpTestSupport {
 
    protected ActiveMQServer server;
 
-   protected MBeanServer mBeanServer = MBeanServerFactory.createMBeanServer();
+   protected MBeanServer mBeanServer = getMBeanServer();
 
    @Before
    @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/HeuristicXATest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/HeuristicXATest.java
@@ -17,7 +17,6 @@
 package org.apache.activemq.artemis.tests.integration.client;
 
 import javax.management.MBeanServer;
-import javax.management.MBeanServerFactory;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 
@@ -413,7 +412,7 @@ public class HeuristicXATest extends ActiveMQTestBase {
    @Before
    public void setUp() throws Exception {
       super.setUp();
-      mbeanServer = MBeanServerFactory.createMBeanServer();
+      mbeanServer = getMBeanServer();
       locator = createInVMNonHALocator();
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/federation/FederatedTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/federation/FederatedTestBase.java
@@ -17,7 +17,6 @@
 package org.apache.activemq.artemis.tests.integration.federation;
 
 import javax.management.MBeanServer;
-import javax.management.MBeanServerFactory;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -44,7 +43,7 @@ public class FederatedTestBase extends ActiveMQTestBase {
    public void setUp() throws Exception {
       super.setUp();
       for (int i = 0; i < numberOfServers(); i++) {
-         MBeanServer mBeanServer = MBeanServerFactory.createMBeanServer();
+         MBeanServer mBeanServer = getMBeanServer();
          mBeanServers.add(mBeanServer);
          Configuration config = createDefaultConfig(i, false).setSecurityEnabled(false);
          for (int j = 0; j < numberOfServers(); j++) {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/multiprotocol/MultiprotocolJMSClientTestSupport.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/multiprotocol/MultiprotocolJMSClientTestSupport.java
@@ -19,7 +19,6 @@ package org.apache.activemq.artemis.tests.integration.jms.multiprotocol;
 import javax.jms.Connection;
 import javax.jms.JMSException;
 import javax.management.MBeanServer;
-import javax.management.MBeanServerFactory;
 import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.util.HashMap;
@@ -71,7 +70,7 @@ public abstract class MultiprotocolJMSClientTestSupport extends ActiveMQTestBase
 
    protected ActiveMQServer server;
 
-   protected MBeanServer mBeanServer = MBeanServerFactory.createMBeanServer();
+   protected MBeanServer mBeanServer = getMBeanServer();
 
    protected ConnectionSupplier AMQPConnection = () -> createConnection();
    protected ConnectionSupplier CoreConnection = () -> createCoreConnection();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/BridgeControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/BridgeControlTest.java
@@ -17,7 +17,6 @@
 package org.apache.activemq.artemis.tests.integration.management;
 
 import javax.management.MBeanServer;
-import javax.management.MBeanServerFactory;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -139,7 +138,7 @@ public class BridgeControlTest extends ManagementTestBase {
 
       Configuration conf_0 = createBasicConfig().addAcceptorConfiguration(new TransportConfiguration(InVMAcceptorFactory.class.getName())).addConnectorConfiguration(connectorConfig.getName(), connectorConfig).addQueueConfiguration(sourceQueueConfig).addBridgeConfiguration(bridgeConfig);
 
-      server_1 = addServer(ActiveMQServers.newActiveMQServer(conf_1, MBeanServerFactory.createMBeanServer(), false));
+      server_1 = addServer(ActiveMQServers.newActiveMQServer(conf_1, getMBeanServer(), false));
       addServer(server_1);
       server_1.start();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/BridgeControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/BridgeControlUsingCoreTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.activemq.artemis.tests.integration.management;
 
-import javax.management.MBeanServerFactory;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -116,7 +115,7 @@ public class BridgeControlUsingCoreTest extends ManagementTestBase {
 
       Configuration conf_0 = createBasicConfig().addAcceptorConfiguration(new TransportConfiguration(INVM_ACCEPTOR_FACTORY)).addConnectorConfiguration(connectorConfig.getName(), connectorConfig).addQueueConfiguration(sourceQueueConfig).addBridgeConfiguration(bridgeConfig);
 
-      server_1 = addServer(ActiveMQServers.newActiveMQServer(conf_1, MBeanServerFactory.createMBeanServer(), false));
+      server_1 = addServer(ActiveMQServers.newActiveMQServer(conf_1, getMBeanServer(), false));
       server_1.start();
 
       server_0 = addServer(ActiveMQServers.newActiveMQServer(conf_0, mbeanServer, false));

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ClusterConnectionControl2Test.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ClusterConnectionControl2Test.java
@@ -17,7 +17,6 @@
 package org.apache.activemq.artemis.tests.integration.management;
 
 import javax.management.MBeanServer;
-import javax.management.MBeanServerFactory;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -118,7 +117,7 @@ public class ClusterConnectionControl2Test extends ManagementTestBase {
 
       Configuration conf_0 = createBasicConfig(1).addClusterConfiguration(clusterConnectionConfig_0).addAcceptorConfiguration(acceptorConfig_0).addConnectorConfiguration("netty", connectorConfig_0).addDiscoveryGroupConfiguration(discoveryName, discoveryGroupConfig).addBroadcastGroupConfiguration(broadcastGroupConfig);
 
-      mbeanServer_1 = MBeanServerFactory.createMBeanServer();
+      mbeanServer_1 = getMBeanServer();
       server1 = addServer(ActiveMQServers.newActiveMQServer(conf_1, mbeanServer_1, false));
 
       server0 = addServer(ActiveMQServers.newActiveMQServer(conf_0, mbeanServer, false));
@@ -129,7 +128,6 @@ public class ClusterConnectionControl2Test extends ManagementTestBase {
    @Override
    @After
    public void tearDown() throws Exception {
-      MBeanServerFactory.releaseMBeanServer(mbeanServer_1);
       super.tearDown();
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ClusterConnectionControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ClusterConnectionControlTest.java
@@ -18,7 +18,6 @@ package org.apache.activemq.artemis.tests.integration.management;
 
 import org.apache.activemq.artemis.json.JsonArray;
 import javax.management.MBeanServer;
-import javax.management.MBeanServerFactory;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -206,7 +205,7 @@ public class ClusterConnectionControlTest extends ManagementTestBase {
 
       Configuration conf_0 = createBasicConfig().addAcceptorConfiguration(new TransportConfiguration(InVMAcceptorFactory.class.getName())).addConnectorConfiguration(connectorConfig.getName(), connectorConfig).addClusterConfiguration(clusterConnectionConfig1).addClusterConfiguration(clusterConnectionConfig2).addDiscoveryGroupConfiguration(discoveryGroupName, discoveryGroupConfig);
 
-      mbeanServer_1 = MBeanServerFactory.createMBeanServer();
+      mbeanServer_1 = getMBeanServer();
       server_1 = addServer(ActiveMQServers.newActiveMQServer(conf_1, mbeanServer_1, false));
       server_1.start();
 
@@ -217,7 +216,6 @@ public class ClusterConnectionControlTest extends ManagementTestBase {
    @Override
    @After
    public void tearDown() throws Exception {
-      MBeanServerFactory.releaseMBeanServer(mbeanServer_1);
       super.tearDown();
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ConnectionRouterControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ConnectionRouterControlTest.java
@@ -30,7 +30,6 @@ import org.junit.Test;
 import org.apache.activemq.artemis.json.JsonObject;
 import org.apache.activemq.artemis.json.JsonValue;
 import javax.management.MBeanServer;
-import javax.management.MBeanServerFactory;
 import javax.management.openmbean.CompositeData;
 import javax.management.openmbean.TabularData;
 import java.util.Map;
@@ -44,15 +43,13 @@ public class ConnectionRouterControlTest extends RoutingTestBase {
    public void setUp() throws Exception {
       super.setUp();
 
-      mbeanServer = MBeanServerFactory.createMBeanServer();
+      mbeanServer = getMBeanServer();
    }
 
    @Override
    @After
    public void tearDown() throws Exception {
       super.tearDown();
-
-      MBeanServerFactory.releaseMBeanServer(mbeanServer);
    }
 
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ManagementTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ManagementTestBase.java
@@ -17,7 +17,6 @@
 package org.apache.activemq.artemis.tests.integration.management;
 
 import javax.management.MBeanServer;
-import javax.management.MBeanServerFactory;
 import javax.management.ObjectName;
 
 import org.apache.activemq.artemis.api.core.RoutingType;
@@ -35,7 +34,7 @@ import org.junit.Before;
 public abstract class ManagementTestBase extends ActiveMQTestBase {
 
 
-   protected MBeanServer mbeanServer;
+   protected MBeanServer mbeanServer = getMBeanServer();
 
 
 
@@ -71,17 +70,12 @@ public abstract class ManagementTestBase extends ActiveMQTestBase {
    public void setUp() throws Exception {
       super.setUp();
 
-      createMBeanServer();
-   }
-
-   protected void createMBeanServer() {
-      mbeanServer = MBeanServerFactory.createMBeanServer();
+      getMBeanServer();
    }
 
    @Override
    @After
    public void tearDown() throws Exception {
-      MBeanServerFactory.releaseMBeanServer(mbeanServer);
       super.tearDown();
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/OpenWireTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/OpenWireTestBase.java
@@ -18,7 +18,6 @@ package org.apache.activemq.artemis.tests.integration.openwire;
 
 import javax.jms.ConnectionFactory;
 import javax.management.MBeanServer;
-import javax.management.MBeanServerFactory;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -114,7 +113,7 @@ public class OpenWireTestBase extends ActiveMQTestBase {
          securityManager.getConfiguration().addRole("openwireDestinationManager", "advisoryReceiver");
       }
 
-      mbeanServer = MBeanServerFactory.createMBeanServer();
+      mbeanServer = getMBeanServer();
       server.setMBeanServer(mbeanServer);
       addServer(server);
       server.start();
@@ -133,7 +132,6 @@ public class OpenWireTestBase extends ActiveMQTestBase {
    @Override
    @After
    public void tearDown() throws Exception {
-      MBeanServerFactory.releaseMBeanServer(mbeanServer);
       mbeanServer = null;
       server.stop();
       super.tearDown();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/routing/ElasticQueueTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/routing/ElasticQueueTest.java
@@ -23,7 +23,6 @@ import javax.jms.MessageConsumer;
 import javax.jms.MessageProducer;
 import javax.jms.Session;
 import javax.management.MBeanServer;
-import javax.management.MBeanServerFactory;
 import javax.security.auth.Subject;
 import java.io.File;
 import java.net.URI;
@@ -366,7 +365,7 @@ public class ElasticQueueTest extends ActiveMQTestBase {
       }
    }
 
-   MBeanServer mBeanServer = MBeanServerFactory.createMBeanServer();
+   MBeanServer mBeanServer = getMBeanServer();
 
    // hardwire authenticaton to map USER to EQ_USER etc
    final ActiveMQSecurityManager5 customSecurityManager = new ActiveMQSecurityManager5() {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/xa/BasicXaRecoveryTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/xa/BasicXaRecoveryTest.java
@@ -17,7 +17,6 @@
 package org.apache.activemq.artemis.tests.integration.xa;
 
 import javax.management.MBeanServer;
-import javax.management.MBeanServerFactory;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 import java.util.Arrays;
@@ -109,7 +108,7 @@ public class BasicXaRecoveryTest extends ActiveMQTestBase {
          configuration = createDefaultInVMConfig().setJMXManagementEnabled(true);
       }
 
-      mbeanServer = MBeanServerFactory.createMBeanServer();
+      mbeanServer = getMBeanServer();
 
       server = createServer(true, configuration, -1, -1, addressSettings);
       server.setMBeanServer(mbeanServer);
@@ -124,7 +123,6 @@ public class BasicXaRecoveryTest extends ActiveMQTestBase {
    @Override
    @After
    public void tearDown() throws Exception {
-      MBeanServerFactory.releaseMBeanServer(mbeanServer);
       super.tearDown();
       if (storeType == StoreConfiguration.StoreType.DATABASE) {
          destroyTables(Arrays.asList("BINDINGS", "LARGE_MESSAGE", "MESSAGE", "NODE_MANAGER_STORE"));

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/util/JMSClusteredTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/util/JMSClusteredTestBase.java
@@ -20,7 +20,6 @@ import javax.jms.ConnectionFactory;
 import javax.jms.Queue;
 import javax.jms.Topic;
 import javax.management.MBeanServer;
-import javax.management.MBeanServerFactory;
 import java.util.ArrayList;
 
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
@@ -119,7 +118,7 @@ public class JMSClusteredTestBase extends ActiveMQTestBase {
 
       JMSConfigurationImpl jmsconfig = new JMSConfigurationImpl();
 
-      mBeanServer2 = MBeanServerFactory.createMBeanServer();
+      mBeanServer2 = getMBeanServer();
       server2 = addServer(ActiveMQServers.newActiveMQServer(configuration, mBeanServer2, enablePersistence()));
       jmsServer2 = new JMSServerManagerImpl(server2, jmsconfig);
       context2 = new InVMNamingContext();
@@ -134,7 +133,7 @@ public class JMSClusteredTestBase extends ActiveMQTestBase {
 
       JMSConfigurationImpl jmsconfig = new JMSConfigurationImpl();
 
-      mBeanServer1 = MBeanServerFactory.createMBeanServer();
+      mBeanServer1 = getMBeanServer();
       server1 = addServer(ActiveMQServers.newActiveMQServer(configuration, mBeanServer1, enablePersistence()));
       jmsServer1 = new JMSServerManagerImpl(server1, jmsconfig);
       context1 = new InVMNamingContext();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/util/JMSTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/util/JMSTestBase.java
@@ -27,7 +27,6 @@ import javax.jms.Message;
 import javax.jms.Queue;
 import javax.jms.Topic;
 import javax.management.MBeanServer;
-import javax.management.MBeanServerFactory;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -127,7 +126,7 @@ public class JMSTestBase extends ActiveMQTestBase {
    public void setUp() throws Exception {
       super.setUp();
 
-      mbeanServer = MBeanServerFactory.createMBeanServer();
+      mbeanServer = getMBeanServer();
 
       Configuration config = createDefaultConfig(true).setSecurityEnabled(useSecurity()).
          addConnectorConfiguration("invm", new TransportConfiguration(INVM_CONNECTOR_FACTORY)).
@@ -198,8 +197,6 @@ public class JMSTestBase extends ActiveMQTestBase {
       jmsServer = null;
 
       namingContext = null;
-
-      MBeanServerFactory.releaseMBeanServer(mbeanServer);
 
       mbeanServer = null;
 


### PR DESCRIPTION
Basically I started the testsuite and attached check leak with "java -jar check-leak.jar --pid <pid> --report testsuite-report --sleep 1000" and saw the allocations of this were pretty high.