### PR TITLE
ARTEMIS-4205 Database Primitive Manager

### DIFF
--- a/artemis-quorum-ri/pom.xml
+++ b/artemis-quorum-ri/pom.xml
@@ -76,8 +76,19 @@
          <artifactId>artemis-commons</artifactId>
          <version>${project.version}</version>
       </dependency>
+      <dependency>
+         <groupId>com.sangupta</groupId>
+         <artifactId>murmur</artifactId>
+         <version>1.0.0</version>
+      </dependency>
 
       <!-- tests -->
+      <dependency>
+         <groupId>com.h2database</groupId>
+         <artifactId>h2</artifactId>
+         <version>2.1.214</version>
+         <scope>test</scope>
+      </dependency>
       <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>

--- a/artemis-quorum-ri/src/main/java/org/apache/activemq/artemis/quorum/db/BaseDatabaseAdapter.java
+++ b/artemis-quorum-ri/src/main/java/org/apache/activemq/artemis/quorum/db/BaseDatabaseAdapter.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.quorum.db;
+
+import org.apache.activemq.artemis.quorum.UnavailableStateException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+
+public abstract class BaseDatabaseAdapter {
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   protected DatabaseConnectionProvider provider;
+
+   static DatabaseConnectionProvider getProvider(Map<String, String> properties) throws Exception {
+      // a DatabaseConnectionProvider implementation class can be implemented so that the mechanism to get
+      // database connections can be injected by an implementation where artemis is embedded or other circumstances
+      if (properties.containsKey("database-connection-provider-class")) {
+         return (DatabaseConnectionProvider) Class.forName(properties.get("database-connection-provider-class"))
+            .getDeclaredConstructor(Map.class).newInstance(properties);
+      } else {
+         return new DefaultDatabaseConnectionProvider(properties);
+      }
+   }
+
+   public BaseDatabaseAdapter(Map<String, String> properties) throws Exception {
+      this.provider = getProvider(properties);
+   }
+
+   /**
+    * this shouldn't generally be called by the adapter implementation as it gets a new connection.
+    * Connections are retrieved when the DatabaseDistributedLock is created and live for the life of that lock.
+    * From within the adapter call  DatabaseDistributedLock.getAssociatedConnection() instead to get the connection
+    * associated with the lock context.
+    */
+   Connection getConnection() throws SQLException {
+      return provider.getConnection();
+   }
+
+   /**
+    * Implementations must return true if a lock is successfully acquired for the given connection,
+    * false if the lock is unable to be acquired but the attempt was otherwise functional,
+    * exceptions in case things didn't work
+    */
+   abstract boolean tryLock(DatabaseDistributedLock lock) throws UnavailableStateException, InterruptedException;
+
+   /**
+    * release the database lock associated with the given connector
+    */
+   abstract void releaseLock(DatabaseDistributedLock lock);
+
+   public void updateLastAccessTime(DatabaseDistributedLock lock) throws SQLException {
+      try (PreparedStatement update = lock.getAssociatedConnection().prepareStatement("update ARTEMIS_LOCKS set LAST_ACCESS=CURRENT_TIMESTAMP where LOCKID=?")) {
+         update.setString(1, lock.getLockId());
+         update.executeUpdate();
+      }
+   }
+
+
+   /**
+    * purge the record associated with this lock
+    * records with longs are the ones that ultimately get a record in the ARTEMIS_LOCKS.  If a record has been around for a long time and no one has a lock on it
+    * it is time to get rid of it
+    */
+   public void cleanup(DatabaseDistributedLock lock) {
+      try (PreparedStatement delete = lock.getAssociatedConnection().prepareStatement("delete from ARTEMIS_LOCKS where LOCKID=?")) {
+         delete.setString(1, lock.getLockId());
+         delete.executeUpdate();
+      } catch (SQLException ex) {
+         logger.warn("exception thrown deleting lock ", ex);
+      }
+   }
+
+   /**
+    * Database lock is held
+    */
+   protected Long readCurrentValue(DatabaseDistributedLock lock) throws SQLException {
+      Long ret = null;
+      try (PreparedStatement read = lock.getAssociatedConnection().prepareStatement("select LONG_VALUE from ARTEMIS_LOCKS where LOCKID=?")) {
+         read.setString(1, lock.getLockId());
+         ResultSet rs = read.executeQuery();
+         if (rs.next()) {
+            ret = rs.getLong("LONG_VALUE");
+         }
+      }
+      updateLastAccessTime(lock);
+      return ret;
+   }
+
+
+   /* must return the lock ids that are considered old and might be defunct at this point.  the maintenance
+   routine in DatabasePrimitiveManager will get these ids, verify that it can lock them and then delete them */
+   public List<String> getOldLockIds(Connection c) {
+      return findOldLocks(c);
+   }
+
+   /* common implementation that should kind of work for everyone, override getLockIds() if this doesn't work
+   for your adapter implementation
+   */
+   protected List<String> findOldLocks(Connection c) {
+      List<String> ret = new ArrayList<>();
+      try (Statement st = c.createStatement()) {
+         ResultSet rs = st.executeQuery(findOldLocksQuery());
+         while (rs.next()) {
+            ret.add(rs.getString(1));
+         }
+      } catch (SQLException ex) {
+         logger.error("exception getting old lockIds", ex);
+      }
+      return ret;
+   }
+
+   // this wasn't declared abstract to leave it open for an implementer to getOldLockIds() directly instead and
+   // do something different than this query approach
+   protected String findOldLocksQuery() {
+      return "Implement findOldLocksQuery for your database"; // intentional syntax error
+   }
+
+   /**
+    * get the current value of the long associated with the lockId
+    */
+   public long getLong(DatabaseDistributedLock lock) throws SQLException {
+      Long val = readCurrentValue(lock);
+      return val == null ? 0L : val;
+   }
+
+   /**
+    * set the value associated with the lockId
+    */
+   public void setLong(DatabaseDistributedLock lock, long val) throws SQLException {
+      Long curr = readCurrentValue(lock);
+      if (curr == null) {
+         try (PreparedStatement insert = lock.getAssociatedConnection().prepareStatement("insert into ARTEMIS_LOCKS(LOCKID,LONG_VALUE,LAST_ACCESS) " +
+            "values (?,?,CURRENT_TIMESTAMP)")) {
+            insert.setString(1, lock.getLockId());
+            insert.setLong(2, val);
+            insert.executeUpdate();
+         }
+      } else {
+         try (PreparedStatement insert = lock.getAssociatedConnection().prepareStatement("update ARTEMIS_LOCKS set LONG_VALUE=?, LAST_ACCESS=CURRENT_TIMESTAMP where LOCKID=?")) {
+            insert.setLong(1, val);
+            insert.setString(2, lock.getLockId());
+            insert.executeUpdate();
+         }
+      }
+   }
+
+   boolean isConnectionHealthy(DatabaseDistributedLock lock) {
+      try (Statement st = lock.getAssociatedConnection().createStatement()) {
+         st.execute("select 1");
+         return true;
+      } catch (SQLException ex) {
+         return false;
+      }
+   }
+
+   public void close(DatabaseDistributedLock lock) {
+      Connection c = lock.getAssociatedConnection();
+      try {
+         c.close();
+      } catch (SQLException ex) {
+         // should never happy, really
+         logger.warn("Exception during connection close ", ex);
+      }
+   }
+
+   protected Long getDatabaseLong(Statement st, String query) throws SQLException {
+      ResultSet rs = st.executeQuery(query);
+      rs.next();
+      return rs.getLong(1);
+   }
+
+}

--- a/artemis-quorum-ri/src/main/java/org/apache/activemq/artemis/quorum/db/DatabaseConnectionProvider.java
+++ b/artemis-quorum-ri/src/main/java/org/apache/activemq/artemis/quorum/db/DatabaseConnectionProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.quorum.db;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * If you are embedding artemis or wish to otherwise provide your own mechanism for getting database connections,
+ * you can provide a class that implements this interface and specify it in a property with the key "database-connection-provider-class"
+ * in the properties of the manager.
+ */
+
+/* The parameter to the constructor for this class are expected to be
+    DatabaseConnectionProvider (Map<String, String> properties)
+  And the property for the PrimitiveManager will be passed along.
+ */
+public interface DatabaseConnectionProvider {
+   Connection getConnection() throws SQLException;
+}

--- a/artemis-quorum-ri/src/main/java/org/apache/activemq/artemis/quorum/db/DatabaseDistributedLock.java
+++ b/artemis-quorum-ri/src/main/java/org/apache/activemq/artemis/quorum/db/DatabaseDistributedLock.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.quorum.db;
+
+import org.apache.activemq.artemis.quorum.DistributedLock;
+import org.apache.activemq.artemis.quorum.UnavailableStateException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+
+public class DatabaseDistributedLock implements DistributedLock {
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private final CopyOnWriteArrayList<UnavailableLockListener> listeners;
+   private final BaseDatabaseAdapter adapter;
+
+   private final Connection c;
+   private final String lockId;
+   private final Consumer<String> onClosedLock;
+   private final DatabasePrimitiveManager manager;
+   private boolean closed;
+   private boolean locked;
+   private Object adapterLockContext;
+   private final boolean maintenanceLock;
+
+
+   DatabaseDistributedLock(Consumer<String> onClosedLock, DatabasePrimitiveManager manager, BaseDatabaseAdapter adapter, String lockId) throws SQLException {
+      this.onClosedLock = onClosedLock;
+      this.manager = manager;
+      this.adapter = adapter;
+      this.lockId = lockId;
+      this.closed = false;
+      this.listeners = new CopyOnWriteArrayList<>();
+      // maintenance behaviors are usually just noise for the logs
+      this.maintenanceLock = DatabasePrimitiveManager.MAINTENANCE_LOCK.equals(lockId);
+
+      // Most databases bind the locks to the session/connection and release the lock if that session is disconnected.
+      // Hold the connection at the lock level.
+      c = adapter.getConnection();
+      if (maintenanceLock) {
+         logger.trace("Create lock {}", lockId);
+      } else {
+         logger.debug("Create lock {}", lockId);
+      }
+   }
+
+
+   // should be called from within a call to the adapter, which should already be synchronized on the manager
+   public Connection getAssociatedConnection() {
+      return c;
+   }
+
+   private void checkNotClosed() {
+      if (closed) {
+         throw new IllegalStateException("This lock is closed (" + lockId + ")");
+      }
+   }
+
+   public void handleLost() {
+      if (logger.isDebugEnabled()) {
+         logger.debug("Notifying listeners {} of lost lock {}", listeners.size(), lockId);
+      }
+      for (UnavailableLockListener listener : listeners) {
+         listener.onUnavailableLockEvent();
+      }
+   }
+
+   @FunctionalInterface
+   protected interface Action<R, T extends Throwable> {
+      R call() throws T;
+   }
+
+   @FunctionalInterface
+   protected interface InterruptableAction<R, T extends Throwable> {
+
+      R call() throws InterruptedException, T;
+   }
+
+   protected final <R, T extends Throwable> R tryRun(InterruptableAction<R, T> action) throws InterruptedException, T {
+      synchronized (manager) {
+         checkNotClosed();
+         return action.call();
+      }
+   }
+
+   protected final <R, T extends Throwable> R run(Action<R, T> action) throws T {
+      synchronized (manager) {
+         checkNotClosed();
+         return action.call();
+      }
+   }
+
+   @Override
+   public String getLockId() {
+      return run(() -> {
+         checkNotClosed();
+         return lockId;
+      });
+   }
+
+   @Override
+   public boolean isHeldByCaller() {
+      return run(() -> {
+         checkNotClosed();
+         return locked;
+      });
+   }
+
+   @Override
+   public boolean tryLock() throws UnavailableStateException, InterruptedException {
+      return tryRun(() -> {
+         checkNotClosed();
+         logger.trace("Attempting to lock {}", lockId);
+         if (locked)
+            throw new IllegalStateException("Already have the lock");
+         locked = adapter.tryLock(this);
+         if (maintenanceLock) {
+            logger.trace("tryLock of {} was {}", lockId, locked ? "successful" : "unsuccessful");
+         } else {
+            logger.debug("tryLock of {} was {}", lockId, locked ? "successful" : "unsuccessful");
+         }
+         return locked;
+      });
+   }
+
+   @Override
+   public void unlock() {
+      run(() -> {
+         checkNotClosed();
+         if (locked) {
+            locked = false;
+            adapter.releaseLock(this);
+            if (maintenanceLock) {
+               logger.trace("Released lock {}", lockId);
+            } else {
+               logger.debug("Released lock {}", lockId);
+            }
+         }
+         return null;
+      });
+   }
+
+   @Override
+   public void addListener(UnavailableLockListener listener) {
+      run(() -> {
+         listeners.add(listener);
+         return null;
+      });
+   }
+
+   @Override
+   public void removeListener(UnavailableLockListener listener) {
+      run(() -> {
+         listeners.remove(listener);
+         return null;
+      });
+   }
+
+   public boolean isClosed() {
+      return run(() -> {
+         return closed;
+      });
+   }
+
+   public void close(boolean useCallback) {
+      synchronized (manager) {
+         if (closed) {
+            return;
+         }
+         try {
+            if (maintenanceLock) {
+               logger.trace("Closing lock {}", lockId);
+            } else {
+               logger.debug("Closing lock {}", lockId);
+            }
+            if (useCallback) {
+               onClosedLock.accept(lockId);
+            }
+            unlock();
+            adapter.close(this);
+         } finally {
+            closed = true;
+         }
+      }
+   }
+
+   @Override
+   public void close() {
+      close(true);
+   }
+
+   public long getLong() throws SQLException {
+      return run(() -> {
+         checkNotClosed();
+         long val = adapter.getLong(this);
+         logger.debug("Retrieved long value {} for lock {}",val,lockId);
+         return val;
+      });
+   }
+
+   public void setLong(long val) throws SQLException {
+      run(() -> {
+         checkNotClosed();
+         adapter.setLong(this, val);
+         logger.debug("Set long value {} for lock {}",val,lockId);
+         return null;
+      });
+   }
+
+   public Object getAdapterLockContext() {
+      return adapterLockContext;
+   }
+
+   public void setAdapterLockContext(Object adapterLockContext) {
+      this.adapterLockContext = adapterLockContext;
+   }
+}

--- a/artemis-quorum-ri/src/main/java/org/apache/activemq/artemis/quorum/db/DatabasePrimitiveManager.java
+++ b/artemis-quorum-ri/src/main/java/org/apache/activemq/artemis/quorum/db/DatabasePrimitiveManager.java
@@ -1,0 +1,249 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.quorum.db;
+
+import org.apache.activemq.artemis.quorum.DistributedLock;
+import org.apache.activemq.artemis.quorum.DistributedPrimitiveManager;
+import org.apache.activemq.artemis.quorum.MutableLong;
+import org.apache.activemq.artemis.quorum.UnavailableStateException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.InvocationTargetException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/* Configuration examples:  Add the adapter-class in below, 3 are currently implemented
+ * -- OracleDatabaseAdapter, MSSQLDatabaseAdapter and PostgresDatabaseAdapter
+ * The url, user and password values are utilized by the DefaultDatabaseConnectionProvider and will provide a simple
+ * connection via the JDBC DriverManager. If you wish to provide your own mechanism for getting a database connection,
+ * you can implement the DatabaseConnectionProvider interface and then in the properties for the DatabasePrimitiveManager
+ * add the property database-connection-provider-class and set it to your implementations classname. This should work
+ * well for embedded systems. The
+ *
+ *       <ha-policy>
+ *          <replication>
+ *             <primary>
+ *                <manager>
+ *                   <class-name>org.apache.activemq.artemis.quorum.db.DatabasePrimitiveManager</class-name>
+ *                   <properties>
+ *                      <property key="adapter-class" value="org.apache.activemq.artemis.quorum.db.MSSQLDatabaseAdapter"/>
+ *                      <property key="url" value="jdbc:sqlserver://localhost:1433;databaseName=TestDB;trustServerCertificate=true"/>
+ *                      <property key="user" value="testuser"/>
+ *                      <property key="password" value="testpassword"/>
+ *                   </properties>
+ *                </manager>
+ *             </primary>
+ *          </replication>
+ *       </ha-policy>
+ *
+ */
+
+
+public class DatabasePrimitiveManager implements DistributedPrimitiveManager {
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private final Map<String, DatabaseDistributedLock> locks = new HashMap<>();
+   private final BaseDatabaseAdapter adapter;
+   private boolean started;
+   private ScheduledExecutorService maintenance;
+
+   public DatabasePrimitiveManager(Map<String, String> args) throws ClassNotFoundException, NoSuchMethodException,
+      InvocationTargetException, InstantiationException, IllegalAccessException {
+      if (!args.containsKey("adapter-class"))
+         throw new IllegalStateException("adapter-class property must be configured for DatabasePrimitiveManager");
+      // pass along the manager properties map to the adapter class to allow it to be used for initialization if needed
+      adapter = (BaseDatabaseAdapter) Class.forName(args.get("adapter-class")).
+         getDeclaredConstructor(Map.class).newInstance(args);
+   }
+
+   // The locking model is such that only one method is going to be executed at a time.
+   // if we have enough locks that this periodic maintenance becomes problematic, then we'll need to adjust the
+   // locking model.
+   static final String MAINTENANCE_LOCK = "artemis_lockid_maintenance";
+
+   synchronized void cleanupOldLocks() {
+      try {
+         DistributedLock maintenanceLock = getDistributedLock(MAINTENANCE_LOCK);
+         if (maintenanceLock.tryLock()) { // if someone already has the maintenance lock, just let it go
+            lockAndRemoveOldLocks();
+            maintenanceLock.unlock();
+         }
+      } catch (Exception ex) {
+         logger.debug("cleaning up old locks failed for now, will try again later", ex);
+      }
+   }
+
+   private void lockAndRemoveOldLocks() {
+      try (Connection c = adapter.getConnection()) {
+         List<String> lockIds = adapter.getOldLockIds(c); // this should filter and old return IDs that are actually "old"
+         for (String lockId : lockIds) {
+            boolean alreadyHadLock = locks.containsKey(lockId);
+            DatabaseDistributedLock lock = (DatabaseDistributedLock) getDistributedLock(lockId);
+            if (lock.tryLock()) { // the lock is old and we are able to lock it, we are assuming it is safe to get rid of
+               logger.debug("Removing stale lock {} record as part of maintenance", lockId);
+               adapter.cleanup(lock);  // because no one has accessed it within the maintenance window
+               lock.close();
+            } else {
+               // the lock is still in use because someone still has it, update its LAST_ACCESS
+               // so we'll leave it alone for another maintenance cycle
+               logger.debug("Lock {} has old time but is still in use (locked), updating last access time", lockId);
+               adapter.updateLastAccessTime(lock);
+               if (!alreadyHadLock)  // this lock was not already instantiated outside of this maintenance cycle,
+                  lock.close();    // close it to avoid unnecessarily holding a database connection
+            }
+         }
+      } catch (Exception ex) {
+         logger.warn("exception getting database connection for periodic maintenance, " + ex.getMessage());
+      }
+   }
+
+   private synchronized void verifyLiveness() {
+      // check connections
+      for (DatabaseDistributedLock lock : locks.values()) {
+         if (!adapter.isConnectionHealthy(lock)) {
+            lock.handleLost();
+            lock.close();
+         }
+      }
+   }
+
+
+   @Override
+   public synchronized boolean isStarted() {
+      return started;
+   }
+
+   @Override
+   public synchronized void addUnavailableManagerListener(UnavailableManagerListener listener) {
+      // todo
+   }
+
+   @Override
+   public synchronized void removeUnavailableManagerListener(UnavailableManagerListener listener) {
+      // todo
+   }
+
+   @Override
+   public synchronized boolean start(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException {
+      logger.debug("DatabasePrimitiveManager[{}] starting", adapter.getClass().getName());
+      if (timeout >= 0) {
+         Objects.requireNonNull(unit);
+      }
+      if (started) {
+         return true;
+      }
+      started = true;
+      // is there another accessible thread pool we should just use for this maintenance operation?
+      maintenance = Executors.newSingleThreadScheduledExecutor();
+      maintenance.scheduleWithFixedDelay(this::cleanupOldLocks, 0, 2, TimeUnit.HOURS); // first run right away on startup
+      maintenance.scheduleWithFixedDelay(this::verifyLiveness, 1, 1, TimeUnit.MINUTES);
+      return true;
+   }
+
+   @Override
+   public void start() throws InterruptedException, ExecutionException {
+      start(-1, null);
+   }
+
+   @Override
+   public synchronized void stop() {
+      if (!started) {
+         return;
+      }
+      logger.debug("DatabasePrimitiveManager[{}] stopping", adapter.getClass().getName());
+      try {
+         maintenance.shutdownNow();
+         locks.forEach((lockId, lock) -> {
+            try {
+               lock.close(false);
+            } catch (Throwable t) {
+               logger.warn("exception closing lock", t);
+            }
+         });
+         locks.clear();
+         try {
+            maintenance.awaitTermination(10, TimeUnit.SECONDS);
+         } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+         }
+      } finally {
+         started = false;
+      }
+   }
+
+   @Override
+   public synchronized DistributedLock getDistributedLock(String lockId) throws ExecutionException {
+      Objects.requireNonNull(lockId);
+      if (!started) {
+         throw new IllegalStateException("manager should be started first");
+      }
+      final DatabaseDistributedLock lock = locks.get(lockId);
+      if (lock != null && !lock.isClosed()) {
+         return lock;
+      }
+      try {
+         final DatabaseDistributedLock newLock = new DatabaseDistributedLock(locks::remove, this, adapter, lockId);
+         locks.put(lockId, newLock);
+         return newLock;
+      } catch (SQLException ioEx) {
+         throw new ExecutionException(ioEx);
+      }
+   }
+
+   @Override
+   public MutableLong getMutableLong(final String mutableLongId) throws ExecutionException {
+      final DatabaseDistributedLock lock = (DatabaseDistributedLock) getDistributedLock(mutableLongId);
+      return new MutableLong() {
+         @Override
+         public String getMutableLongId() {
+            return mutableLongId;
+         }
+
+         @Override
+         public long get() throws UnavailableStateException {
+            try {
+               return lock.getLong();
+            } catch (SQLException e) {
+               throw new UnavailableStateException(e);
+            }
+         }
+
+         @Override
+         public void set(long value) throws UnavailableStateException {
+            try {
+               lock.setLong(value);
+            } catch (SQLException e) {
+               throw new UnavailableStateException(e);
+            }
+         }
+
+         @Override
+         public void close() {
+            //lock.close();
+         }
+      };
+   }
+}

--- a/artemis-quorum-ri/src/main/java/org/apache/activemq/artemis/quorum/db/DefaultDatabaseConnectionProvider.java
+++ b/artemis-quorum-ri/src/main/java/org/apache/activemq/artemis/quorum/db/DefaultDatabaseConnectionProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.quorum.db;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Map;
+
+public class DefaultDatabaseConnectionProvider implements DatabaseConnectionProvider {
+   final String url;
+   final String user;
+   final String pwd;
+
+   public DefaultDatabaseConnectionProvider(Map<String, String> properties) {
+      url = properties.get("url");
+      if (url == null)
+         throw new IllegalStateException("url property required for DatabasePrimitiveManager with BasicDatabaseConnectionProvider");
+      user = properties.get("user");
+      if (user == null)
+         throw new IllegalStateException("user property required for DatabasePrimitiveManager with BasicDatabaseConnectionProvider");
+      pwd = properties.get("password");
+      if (pwd == null)
+         throw new IllegalStateException("password property required for DatabasePrimitiveManager with BasicDatabaseConnectionProvider");
+   }
+
+   @Override
+   public Connection getConnection() throws SQLException {
+      return DriverManager.getConnection(url, user, pwd);
+   }
+}

--- a/artemis-quorum-ri/src/main/java/org/apache/activemq/artemis/quorum/db/MSSQLDatabaseAdapter.java
+++ b/artemis-quorum-ri/src/main/java/org/apache/activemq/artemis/quorum/db/MSSQLDatabaseAdapter.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.quorum.db;
+
+import org.apache.activemq.artemis.quorum.UnavailableStateException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InterruptedIOException;
+import java.lang.invoke.MethodHandles;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.Map;
+
+public class MSSQLDatabaseAdapter extends BaseDatabaseAdapter {
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   public MSSQLDatabaseAdapter(Map<String, String> properties) throws Exception {
+      super(properties);
+      verifyInitialization();
+   }
+
+   @Override
+   boolean tryLock(DatabaseDistributedLock lock) throws UnavailableStateException, InterruptedException {
+      try {
+         return mssqlTryLock(lock.getAssociatedConnection(), lock.getLockId());
+      } catch (SQLException e) {
+         Throwable cause = e;
+         do {
+            if (cause instanceof InterruptedIOException)
+               throw new InterruptedException("Interrupt during tryLock");
+            cause = e.getCause();
+         }
+         while (cause != null);
+         logger.debug("Exception occurred in MSSQLDatabaseAdapter.tryLock()", e);
+         throw new UnavailableStateException(e.getMessage(), e);
+      }
+   }
+
+   private boolean mssqlTryLock(Connection c, String lockId) throws SQLException {
+      try (CallableStatement getLock = c.prepareCall(
+         "{? = call sp_getapplock(@Resource=?, @LockMode='Exclusive', @LockOwner='Session', @LockTimeout=0)}")) {
+         getLock.setString(2, lockId);
+         getLock.registerOutParameter(1, Types.INTEGER);
+         getLock.execute();
+         int statusCode = getLock.getInt(1);
+         // 0 = lock granted synchronously, 1 = lock granted after waiting for other locks to be released
+         // -1 = timeout, -2 = cancelled, -3 = chosen as deadlock victim, -999 = illegal parameter or call error
+         if (statusCode >= 0) {
+            return true;
+         } else if (statusCode == -1 || statusCode == -2 || statusCode == -3)  // couldn't get it
+            return false;
+         else {
+            throw new SQLException("MSSQL returned code " + statusCode + " from sp_getapplock() request");
+         }
+      }
+   }
+
+
+   @Override
+   void releaseLock(DatabaseDistributedLock lock) {
+      try {
+         mssqlReleaseLock(lock.getAssociatedConnection(), lock.getLockId());
+      } catch (SQLException e) {
+         logger.debug("Exception occurred in MSSQLDatabaseAdapter.releaseLock()", e);
+      }
+   }
+
+   void mssqlReleaseLock(Connection c, String lockid) throws SQLException {
+      try (CallableStatement releaseLock = c.prepareCall("{? = call sp_releaseapplock(@Resource=?, @LockOwner='Session')}")) {
+         releaseLock.setString(2, lockid);
+         releaseLock.registerOutParameter(1, Types.INTEGER);
+         releaseLock.execute();
+         int statusCode = releaseLock.getInt(1);
+         if (statusCode != 0) {
+            throw new IllegalStateException("Unable to properly release lock, received status code " + statusCode);
+         }
+      }
+   }
+
+   protected String findOldLocksQuery() {
+      return "select LOCKID from ARTEMIS_LOCKS where LAST_ACCESS < DATEADD(HOUR,-2,CURRENT_TIMESTAMP)";
+   }
+
+   private static final String TABLE_CREATION = "create table ARTEMIS_LOCKS(LOCKID varchar(64),LONG_VALUE bigint,LAST_ACCESS datetime, primary key(LOCKID))";
+
+   private void verifyInitialization() {
+      try (Connection c = getConnection(); Statement st = c.createStatement()) {
+         Long locksTableExists = getDatabaseLong(st, "select count(*) from INFORMATION_SCHEMA.TABLES where TABLE_NAME='ARTEMIS_LOCKS'");
+         if (locksTableExists == 0) {
+            logger.warn("MSSQLDatabaseAdapter artemis locks table does not exist, attempting to create with: {}", TABLE_CREATION);
+            st.execute(TABLE_CREATION); // attempt to automatically create
+         }
+         if (mssqlTryLock(c, "locktest")) {  // if we have an execute rights issue, it should blow up here and we give the user an error
+            mssqlReleaseLock(c, "locktest");
+         }
+      } catch (SQLException e) {  // we come here if the user doesn't have rights to create the table
+         logger.error("Error initializing MSSQLDatabaseAdapter", e);
+         logger.error("Please ensure that the ARTEMIS_LOCKS table is created and that your user has execute rights to sp_getapplock() and sp_releaseapplock()");
+      }
+   }
+
+}

--- a/artemis-quorum-ri/src/main/java/org/apache/activemq/artemis/quorum/db/MySQLDatabaseAdapter.java
+++ b/artemis-quorum-ri/src/main/java/org/apache/activemq/artemis/quorum/db/MySQLDatabaseAdapter.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.quorum.db;
+
+import org.apache.activemq.artemis.quorum.UnavailableStateException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InterruptedIOException;
+import java.lang.invoke.MethodHandles;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.Map;
+
+public class MySQLDatabaseAdapter extends BaseDatabaseAdapter {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   public MySQLDatabaseAdapter(Map<String, String> properties) throws Exception {
+      super(properties);
+      verifyInitialization();
+   }
+
+   @Override
+   boolean tryLock(DatabaseDistributedLock lock) throws UnavailableStateException, InterruptedException {
+      try {
+         return mysqlTryLock(lock.getAssociatedConnection(), lock.getLockId());
+      } catch (SQLException e) {
+         Throwable cause = e;
+         do {
+            if (cause instanceof InterruptedIOException)
+               throw new InterruptedException("Interrupt during tryLock");
+            cause = e.getCause();
+         }
+         while (cause != null);
+         logger.debug("Exception occurred in MSSQLDatabaseAdapter.tryLock()", e);
+         throw new UnavailableStateException(e.getMessage(), e);
+      }
+   }
+
+   private boolean mysqlTryLock(Connection c, String lockId) throws SQLException {
+      try (CallableStatement getLock = c.prepareCall("{? = call GET_LOCK(?, 0)}")) {
+         getLock.setString(2, lockId);
+         getLock.registerOutParameter(1, Types.INTEGER);
+         getLock.execute();
+         Object result = getLock.getObject(1);
+         if (result == null)
+            throw new SQLException("Error occurred acquiring lock");
+         int ret = getLock.getInt(1);  // 1 = successful, 0 = timeout, null on error
+         return ret == 1;
+      }
+   }
+
+   @Override
+   void releaseLock(DatabaseDistributedLock lock) {
+      try {
+         mysqlReleaseLock(lock.getAssociatedConnection(), lock.getLockId());
+      } catch (SQLException e) {
+         logger.debug("Exception occurred in MySQLDatabaseAdapter.releaseLock()", e);
+      }
+   }
+
+   private void mysqlReleaseLock(Connection c, String lockId) throws SQLException {
+      try (CallableStatement releaseLock = c.prepareCall("{? = call RELEASE_LOCK(?)}")) {
+         releaseLock.setString(2, lockId);
+         releaseLock.registerOutParameter(1, Types.INTEGER);
+         releaseLock.execute();
+         Object result = releaseLock.getObject(1); // 1 = successful, 0 = this session doesn't own the lock, NULL = lock name doesn't exist
+         if (result != null) {
+            int ret = releaseLock.getInt(1);
+            if (ret == 0) {
+               throw new SQLException("Received request in to unlock " + lockId + " but ");
+            }
+         }
+      }
+   }
+
+   @Override
+   protected String findOldLocksQuery() {
+      return "select LOCKID from ARTEMIS_LOCKS where LAST_ACCESS < DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 2 HOUR)";  // Oracle and MSSQL will interpret this as 2 hours ago
+   }
+
+   private static final String TABLE_CREATION = "create table ARTEMIS_LOCKS(LOCKID varchar(64),LONG_VALUE bigint,LAST_ACCESS timestamp(3), primary key(LOCKID))";
+
+   private void verifyInitialization() {
+      try (Connection c = getConnection(); Statement st = c.createStatement()) {
+         Long locksTableExists = getDatabaseLong(st, "select count(*) from INFORMATION_SCHEMA.TABLES where TABLE_NAME='ARTEMIS_LOCKS'");
+         if (locksTableExists == 0) {
+            logger.warn("MySQLDatabaseAdapter artemis locks table does not exist, attempting to create with: {}", TABLE_CREATION);
+            st.execute(TABLE_CREATION); // attempt to automatically create
+         }
+         if (mysqlTryLock(c, "testlock")) {
+            mysqlReleaseLock(c, "testlock");
+         }
+      } catch (SQLException e) {  // we come here if the user doesn't have rights to create the table
+         logger.error("Error initializing MySQLDatabaseAdapter", e);
+         logger.error("Please ensure that the ARTEMIS_LOCKS table is created and that your user has execute rights to the DBMS_LOCK package (GRANT EXECUTE on DBMS_LOCK to [youruser])");
+      }
+   }
+
+}

--- a/artemis-quorum-ri/src/main/java/org/apache/activemq/artemis/quorum/db/OracleDatabaseAdapter.java
+++ b/artemis-quorum-ri/src/main/java/org/apache/activemq/artemis/quorum/db/OracleDatabaseAdapter.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.quorum.db;
+
+import org.apache.activemq.artemis.api.core.Pair;
+import org.apache.activemq.artemis.quorum.UnavailableStateException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InterruptedIOException;
+import java.lang.invoke.MethodHandles;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.CallableStatement;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.Map;
+
+/*  You need to do this:
+ GRANT EXECUTE on dbms_lock to <dbuser>;
+
+
+create table ARTEMIS_LOCKS(lockid VARCHAR2(64),VAL NUMBER(16),LAST_ACCESS TIMESTAMP);
+create index ARTEMIS_LOCKS_IX(lockid)
+
+*/
+public class OracleDatabaseAdapter extends BaseDatabaseAdapter {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   public OracleDatabaseAdapter(Map<String, String> properties) throws Exception {
+      super(properties);
+      verifyInitialization();
+   }
+
+   @Override
+   public boolean tryLock(DatabaseDistributedLock lock) throws UnavailableStateException, InterruptedException {
+      try {
+         Pair<Boolean, String> ret = oracleTryLock(lock.getAssociatedConnection(), lock.getLockId());
+         if (ret.getA()) {
+            lock.setAdapterLockContext(ret.getB());
+         }
+         return ret.getA();
+      } catch (SQLException e) {
+         Throwable cause = e;
+         do {
+            if (cause instanceof InterruptedIOException) {
+               throw new InterruptedException("Interrupt during tryLock");
+            }
+            cause = e.getCause();
+         }
+         while (cause != null);
+         throw new UnavailableStateException(e.getMessage(), e);
+      }
+   }
+
+   private Pair<Boolean, String> oracleTryLock(Connection c, String lockid) throws SQLException {
+      try (CallableStatement getLockHandle = c.prepareCall("{call dbms_lock.allocate_unique(?, ?)}");
+           CallableStatement getLock = c.prepareCall("{ ? = call dbms_lock.request( lockhandle => ?, lockmode => DBMS_LOCK.X_MODE, timeout => 0)}")) {
+         getLockHandle.setString(1, lockid);
+         getLockHandle.registerOutParameter(2, Types.NUMERIC);
+         getLockHandle.execute();
+         String lockHandle = getLockHandle.getString(2);
+         getLock.setString(2, lockHandle);
+         getLock.registerOutParameter(1, Types.INTEGER);
+         getLock.execute();
+         int statusCode = getLock.getInt(1);
+         // 0 = success, 4 = already own lock,  1 = timeout, 2 = deadlock, 3 = parameter error, 5 = illegal lock handle
+         if (statusCode == 0) {
+            return new Pair<>(true, lockHandle);
+         } else if (statusCode == 1) // couldn't get it
+            return new Pair<>(false, null);
+         else if (statusCode == 4) // spec doesn't want us allowing tryLock() twice
+            throw new IllegalStateException("Already have the lock");
+         else
+            throw new SQLException("Oracle returned code " + statusCode + " from DBMS_LOCK.REQUEST");
+      }
+   }
+
+   @Override
+   public void releaseLock(DatabaseDistributedLock lock) {
+      if (lock.getAdapterLockContext() == null) // we can unlock anything if we don't actually have the handle (we shouldn't have the lock)
+         return;
+      String lockHandle = (String) lock.getAdapterLockContext();
+      try {
+         oracleReleaseLock(lock.getAssociatedConnection(), lockHandle);
+      } catch (SQLException e) {
+         logger.error("Exception occurred in OracleDatabaseAdapter.releaseLock()", e);
+      }
+   }
+
+   private void oracleReleaseLock(Connection c, String lockHandle) throws SQLException {
+      try (CallableStatement releaseLock = c.prepareCall("{? = call dbms_lock.release(lockhandle => ?)}")) {
+         releaseLock.setString(2, lockHandle);
+         releaseLock.registerOutParameter(1, Types.INTEGER);
+         releaseLock.execute();
+         int statusCode = releaseLock.getInt(1);
+         if (statusCode != 0) {
+            throw new SQLException("Unable to properly release lock, received status code " + statusCode);
+         }
+      }
+   }
+
+   @Override
+   boolean isConnectionHealthy(DatabaseDistributedLock lock) {
+      try (Statement st = lock.getAssociatedConnection().createStatement()) {
+         st.execute("select 1 from DUAL");
+         return true;
+      } catch (SQLException ex) {
+         return false;
+      }
+   }
+
+   protected String findOldLocksQuery() {
+      return "select LOCKID from ARTEMIS_LOCKS where LAST_ACCESS < CURRENT_TIMESTAMP - NUMTODSINTERVAL(2, 'HOUR')";
+   }
+
+   private static final String TABLE_CREATION = "create table ARTEMIS_LOCKS(LOCKID varchar2(64),LONG_VALUE number(16),LAST_ACCESS timestamp, primary key(LOCKID))";
+
+   private void verifyInitialization() {
+      try (Connection c = getConnection(); Statement st = c.createStatement()) {
+         Long locksTableExists = getDatabaseLong(st, "select count(*) from USER_TABLES where TABLE_NAME='ARTEMIS_LOCKS'");
+         if (locksTableExists == 0) {
+            logger.warn("OracleDatabaseAdapter artemis locks table does not exist, attempting to create with: {}", TABLE_CREATION);
+            st.execute(TABLE_CREATION); // attempt to automatically create
+         }
+         Pair<Boolean, String> test = oracleTryLock(c, "testlock");
+         if (test.getA()) {
+            oracleReleaseLock(c, test.getB());
+         }
+      } catch (SQLException e) {  // we come here if the user doesn't have rights to create the table
+         logger.error("Error initializing OracleDatabaseAdapter", e);
+         logger.error("Please ensure that the ARTEMIS_LOCKS table is created and that your user has execute rights to the DBMS_LOCK package (GRANT EXECUTE on DBMS_LOCK to [youruser])");
+      }
+   }
+}

--- a/artemis-quorum-ri/src/main/java/org/apache/activemq/artemis/quorum/db/PostgresDatabaseAdapter.java
+++ b/artemis-quorum-ri/src/main/java/org/apache/activemq/artemis/quorum/db/PostgresDatabaseAdapter.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.quorum.db;
+
+import com.sangupta.murmur.Murmur2;
+import org.apache.activemq.artemis.api.core.Pair;
+import org.apache.activemq.artemis.quorum.UnavailableStateException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InterruptedIOException;
+import java.lang.invoke.MethodHandles;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.Map;
+
+public class PostgresDatabaseAdapter extends BaseDatabaseAdapter {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   public PostgresDatabaseAdapter(Map<String, String> properties) throws Exception {
+      super(properties);
+      verifyInitialization();
+   }
+
+   @Override
+   boolean tryLock(DatabaseDistributedLock lock) throws UnavailableStateException, InterruptedException {
+      try {
+         Pair<Boolean, Long> ret = postgresTryLock(lock.getAssociatedConnection(), lock.getLockId());
+         if (ret.getA()) {
+            lock.setAdapterLockContext(ret.getB());
+         }
+         return ret.getA();
+      } catch (SQLException e) {
+         Throwable cause = e;
+         do {
+            if (cause instanceof InterruptedIOException)
+               throw new InterruptedException("Interrupt during tryLock");
+            cause = e.getCause();
+         }
+         while (cause != null);
+         throw new UnavailableStateException(e.getMessage(), e);
+      }
+   }
+
+   private Pair<Boolean, Long> postgresTryLock(Connection c, String lockId) throws SQLException {
+      try (CallableStatement getLock = c.prepareCall(
+         "{? = call pg_try_advisory_lock(?) }")) {
+         // postgres takes a 64-bit integer to represent the lockId. I am hashing our lock id.
+         // is there a better way than this? Is it worth pulling in the Murmur hashing library?
+         // open to ideas on this.
+         long numericLockId = Murmur2.hash64(lockId.getBytes(), lockId.length(), 509803945L);
+         getLock.setLong(2, numericLockId);
+         getLock.registerOutParameter(1, Types.BOOLEAN);
+         getLock.execute();
+         return new Pair<>(getLock.getBoolean(1), numericLockId);
+      }
+   }
+
+   @Override
+   void releaseLock(DatabaseDistributedLock lock) {
+      if (lock.getAdapterLockContext() == null)
+         return;
+      try {
+         postgresReleaseLock(lock.getAssociatedConnection(), lock.getLockId(), (Long) lock.getAdapterLockContext());
+      } catch (SQLException e) {
+         logger.error("Exception occurred in PostgresDatabaseAdapter.releaseLock()", e);
+      }
+   }
+
+   private void postgresReleaseLock(Connection c, String lockId, long lockNumber) throws SQLException {
+      try (CallableStatement releaseLock = c.prepareCall("{? = call pg_advisory_unlock(?) }")) {
+         releaseLock.setLong(2, lockNumber);
+         releaseLock.registerOutParameter(1, Types.BOOLEAN);
+         releaseLock.execute();
+         boolean ret = releaseLock.getBoolean(1);
+         if (!ret) {
+            throw new IllegalStateException("Attempted to release lock " + lockId + " but postgres says we don't hold it!");
+         }
+      }
+
+   }
+
+   @Override
+   protected String findOldLocksQuery() {
+      return "select LOCKID from ARTEMIS_LOCKS where LAST_ACCESS + interval '2 hours' < CURRENT_TIMESTAMP";
+   }
+
+   /* We call this when the adapter is initialized to verify that the database meets the criteria for running.
+      We will attempt to use current access rights to simply fix the situation and get running
+    */
+   private static final String TABLE_CREATION = "create table ARTEMIS_LOCKS(LOCKID varchar(64),LONG_VALUE bigint,LAST_ACCESS timestamp, primary key(LOCKID))";
+
+   private void verifyInitialization() {
+      try (Connection c = getConnection(); Statement st = c.createStatement()) {
+         Long locksTableExists = getDatabaseLong(st, "select count(*) from INFORMATION_SCHEMA.TABLES where TABLE_NAME='artemis_locks'"); // postgres lowers case
+         if (locksTableExists == 0) {
+            logger.warn("PostgresDatabaseAdapter artemis locks table does not exist, attempting to create with: {}", TABLE_CREATION);
+            st.execute(TABLE_CREATION); // attempt to automatically create
+         }
+         Pair<Boolean, Long> test = postgresTryLock(c, "testlock");
+         if (test.getA()) {
+            postgresReleaseLock(c, "testlock", test.getB());
+         }
+      } catch (SQLException e) {  // we come here if the user doesn't have rights to create the table
+         logger.error("Error initializing OracleDatabaseAdapter", e);
+         logger.error("Please ensure that the 'artemis_locks' table is created and that your user has execute rights to pg_try_advistory_lock and pg_advisory_unlock");
+      }
+   }
+}

--- a/artemis-quorum-ri/src/test/java/org/apache/activemq/artemis/quorum/db/DatabaseDistributedLockTest.java
+++ b/artemis-quorum-ri/src/test/java/org/apache/activemq/artemis/quorum/db/DatabaseDistributedLockTest.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.quorum.db;
+
+import org.apache.activemq.artemis.quorum.DistributedLockTest;
+import org.apache.activemq.artemis.quorum.DistributedPrimitiveManager;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DatabaseDistributedLockTest extends DistributedLockTest {
+
+/*  To run these tests against MSSQL
+You will need the microsoft proprietary JDBC driver.  (alternatively you could probably configure and use the open source jTDS driver it will have a different URL and mvn dependency)
+
+Download the jar for the microsoft driver that you wish to use and add it to your maven using a variation of the following:
+   mvn install:install-file -DgroupId=com.microsoft -DartifactId=mssql-jdbc -Dversion=12.2.0.jre11 -Dpackaging=jar -Dfile=mssql-jdbc-12.2.0.jre11.jar -DgeneratePom=true
+then adjust the pom.xml for artemis-quorum-ri to have a testing dependency on the driver you just added:
+      <dependency>
+         <groupId>com.microsoft</groupId>
+         <artifactId>mssql-jdbc</artifactId>
+         <version>12.2.0.jre11</version>
+      </dependency>
+
+ Uncomment the below "setConfig" method and comment out the default H2 one.  Adjust the username, password, and URL to fit your environment
+ */
+//   private static Map<String,String> setConfig(Map<String,String> config)
+//   {
+//       config.put("adapter-class",  MSSQLDatabaseAdapter.class.getCanonicalName());
+//       config.put("user","testuser");
+//       config.put("password","testuser");
+//       config.put("url","jdbc:sqlserver://localhost:1433;databaseName=TestDB;trustServerCertificate=true");
+//       return config;
+//   }
+
+/* To run these tests against ORACLE,
+Get the latest Oracle driver from Oracle via their download process.  Then add it into mvn using a variation of the following:
+
+  mvn install:install-file -DgroupId=com.oracle -DartifactId=ojdbc8 -Dversion=21.9.0.0.0 -Dpackaging=jar -Dfile=ojdbc8.jar -DgeneratePom=true
+
+match those settings when you update pom.xml
+  <dependency>
+     <groupId>com.oracle</groupId>
+     <artifactId>ojdbc8</artifactId>
+     <version>21.9.0.0.0</version>
+  </dependency>
+
+  Remember that the Oracle user needs access to DBMS_LOCK, which even SYSTEM doesn't have by default.  So execute the following grant:
+
+  GRANT EXECUTE on DBMS_LOCK to [youruser]
+
+  Uncomment the "setConfig" method below and adjust your settings and environment
+ */
+
+
+//    private static Map<String,String> setConfig(Map<String,String> config)
+//    {
+//        config.put("adapter-class",  OracleDatabaseAdapter.class.getCanonicalName());
+//        config.put("user","testuser");
+//        config.put("password","testuser");
+//        config.put("url","jdbc:oracle:thin:@localhost:1521/orcl");
+//        return config;
+//    }
+
+
+/* To run these tests against POSTGRES
+Just add the following dependency to pom.xml. This is the postgres driver:
+
+<dependency>
+    <groupId>org.postgresql</groupId>
+    <artifactId>postgresql</artifactId>
+    <version>42.5.4</version>
+</dependency>
+
+Also add the following, which I have added for 64 bit hashing. see the comment in PostgresDatabaseAdapter
+
+<dependency>
+    <groupId>com.sangupta</groupId>
+    <artifactId>murmur</artifactId>
+    <version>1.0.0</version>
+</dependency>
+
+    Uncomment the "setConfig" method below and adjust your settings and environment
+ */
+
+//    private static Map<String,String> setConfig(Map<String,String> config)
+//    {
+//        config.put("adapter-class",  PostgresDatabaseAdapter.class.getCanonicalName());
+//        config.put("user","testuser");
+//        config.put("password","testuser");
+//        config.put("url","jdbc:postgresql://localhost:5432/testdb?sslmode=disable");
+//        return config;
+//    }
+
+/* To run these tests against MySQL
+
+<dependency>
+    <groupId>mysql</groupId>
+    <artifactId>mysql-connector-java</artifactId>
+    <version>8.0.27</version>
+</dependency>
+    Uncomment the "setConfig" method below and adjust your settings and environment
+
+ */
+//   private static Map<String, String> setConfig(Map<String, String> config) {
+//      config.put("adapter-class", MySQLDatabaseAdapter.class.getCanonicalName());
+//      config.put("user", "testuser");
+//      config.put("password", "testuser");
+//      config.put("url", "jdbc:mysql://localhost:3306/testdb");
+//      return config;
+//   }
+
+   //H2  This configuration is default and is included so that the unit tests can be run by anyone with no fuss
+   private static Map<String, String> setConfig(Map<String, String> config) {
+      config.put("adapter-class", H2DatabaseAdapter.class.getCanonicalName());
+      config.put("user", "sa");
+      config.put("password", "sa");
+      config.put("url", "jdbc:h2:mem:test");
+      return config;
+   }
+
+   // we will initialize and hold an H2 database in memory database with the name "test" so that all other tests
+   // share a database, as close as possible to if it was an external Oracle/MSSQL/Postgres/etc
+   static Connection h2;
+
+   @BeforeClass
+   public static void h2Setup() throws SQLException {
+      DatabaseConnectionProvider prov = new DefaultDatabaseConnectionProvider(setConfig(new HashMap<>()));
+      h2 = prov.getConnection();
+   }
+
+   @Before
+   @Override
+   public void setupEnv() throws Throwable {
+      super.setupEnv();
+      DatabaseConnectionProvider setup = new DefaultDatabaseConnectionProvider(setConfig(new HashMap<>()));
+      try (Connection c = setup.getConnection()) {
+         deleteAllLocks(c);
+      }
+   }
+
+   private void deleteAllLocks(Connection c) throws SQLException {
+
+      try (Statement st = c.createStatement()) {
+         runAndSwallow(st, "delete from ARTEMIS_LOCKS");
+      }
+   }
+
+   private boolean verifyLockExistence(Connection c, String lockid) throws SQLException {
+      try (PreparedStatement ps = c.prepareStatement("select count(*) from ARTEMIS_LOCKS where LOCKID=?")) {
+         ps.setString(1, lockid);
+         ResultSet rs = ps.executeQuery();
+         rs.next();
+         return rs.getLong(1) > 0;
+      }
+   }
+
+   private void addSomeDummyOldDataToBePurged(Connection c) throws SQLException {
+        /* if your database is running in a different timezone than you are running, this can get interesting here (because we are
+        putting a java time stamp into the DB.  MSSQL for instance can be fun.
+        */
+      try (PreparedStatement insert = c.prepareStatement("insert into ARTEMIS_LOCKS(LOCKID,LONG_VALUE,LAST_ACCESS) values (?,?,?)")) {
+         insert.setLong(2, 12L);
+         insert.setString(1, "first");
+         insert.setTimestamp(3, new Timestamp(631180861L));  // Jan 1, 1990 -- just something really old
+         insert.execute();
+
+         insert.setString(1, "second");
+         insert.setTimestamp(3, new Timestamp(System.currentTimeMillis() - (4 * 60 * 60 * 1000))); // 4 hours ago
+         insert.execute();
+
+         insert.setString(1, "third");
+         insert.setTimestamp(3, new Timestamp(System.currentTimeMillis()));
+         insert.execute();
+      }
+   }
+
+   private void runAndSwallow(Statement st, String query) {
+      try {
+         st.executeUpdate(query);
+      } catch (SQLException ex) {
+         // let it go
+      }
+   }
+
+   @Override
+   protected void configureManager(Map<String, String> config) {
+      setConfig(config);
+   }
+
+   @Override
+   protected String managerClassName() {
+      return DatabasePrimitiveManager.class.getName();
+   }
+
+   @Test
+   public void reflectiveManagerCreation() throws Exception {
+      DistributedPrimitiveManager.newInstanceOf(managerClassName(), setConfig(new HashMap<>()));
+   }
+
+
+   @Test
+   public void specifyDatabaseProvider() throws Exception {
+      Map<String,String> config = setConfig(new HashMap<>());
+      config.put("database-connection-provider-class",TestDatabaseConnectionProvider.class.getCanonicalName());
+      DistributedPrimitiveManager mgr = DistributedPrimitiveManager.newInstanceOf(managerClassName(), setConfig(config));
+      mgr.start();
+      mgr.stop();
+   }
+
+   @Test(expected = InvocationTargetException.class)
+   public void reflectiveManagerCreationFailIfNoAdapterSpecified() throws Exception {
+      DistributedPrimitiveManager.newInstanceOf(managerClassName(), Collections.emptyMap());
+   }
+
+   @Test
+   public void lockMaintenanceTest() throws Exception {
+      DatabaseConnectionProvider setup = new DefaultDatabaseConnectionProvider(setConfig(new HashMap<>()));
+      try (Connection c = setup.getConnection()) {
+         DatabasePrimitiveManager pm = new DatabasePrimitiveManager(setConfig(new HashMap<>()));
+         deleteAllLocks(c);
+         addSomeDummyOldDataToBePurged(c);
+         assertTrue("Lock must exist before maintenance is run", verifyLockExistence(c, "first"));
+         pm.start(); // technically this starts a race condition with the line below because of maintenance thread
+         pm.cleanupOldLocks();  // but it doesn't matter because they both lock and do the same things
+         assertFalse(verifyLockExistence(c, "first"));
+         assertFalse(verifyLockExistence(c, "second"));
+         assertTrue(verifyLockExistence(c, "third"));
+         pm.stop();
+      }
+   }
+}

--- a/artemis-quorum-ri/src/test/java/org/apache/activemq/artemis/quorum/db/H2DatabaseAdapter.java
+++ b/artemis-quorum-ri/src/test/java/org/apache/activemq/artemis/quorum/db/H2DatabaseAdapter.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.quorum.db;
+
+import org.apache.activemq.artemis.quorum.UnavailableStateException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InterruptedIOException;
+import java.lang.invoke.MethodHandles;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.HashMap;
+import java.util.Map;
+
+public class H2DatabaseAdapter extends BaseDatabaseAdapter {
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   public H2DatabaseAdapter(Map<String, String> properties) throws Exception {
+      super(properties);
+      verifyInitialization();
+   }
+
+   @Override
+   boolean tryLock(DatabaseDistributedLock lock) throws UnavailableStateException, InterruptedException {
+      try (CallableStatement getLock = lock.getAssociatedConnection().prepareCall(
+         "{? = call lock_trylock(?)}")) {
+         getLock.setString(2, lock.getLockId());
+         getLock.registerOutParameter(1, Types.INTEGER);
+         getLock.execute();
+         int statusCode = getLock.getInt(1);
+         // 0 = lock ok, 1 = no lock
+         return statusCode == 0;
+      } catch (SQLException e) {
+         Throwable cause = e;
+         do {
+            if (cause instanceof InterruptedIOException)
+               throw new InterruptedException("Interrupt during tryLock");
+            cause = e.getCause();
+         }
+         while (cause != null);
+         logger.debug("Exception occurred in H2DatabaseAdapter.tryLock()", e);
+         throw new UnavailableStateException(e.getMessage(), e);
+      }
+   }
+
+   @Override
+   void releaseLock(DatabaseDistributedLock lock) {
+      try (CallableStatement releaseLock = lock.getAssociatedConnection().prepareCall("{? = call lock_unlock(?)}")) {
+         releaseLock.setString(2, lock.getLockId());
+         releaseLock.registerOutParameter(1, Types.INTEGER);
+         releaseLock.execute();
+         int statusCode = releaseLock.getInt(1);
+         if (statusCode != 0) {
+            throw new IllegalStateException("Unable to properly release lock, received status code " + statusCode);
+         }
+      } catch (SQLException e) {
+         logger.debug("Exception occurred in H2DatabaseAdapter.releaseLock()", e);
+      }
+   }
+
+   @Override
+   boolean isConnectionHealthy(DatabaseDistributedLock lock) {
+      return true;
+   }
+
+   void verifyInitialization() {
+      try (Connection c = getConnection(); Statement st = c.createStatement()) {
+         st.execute("create table if not exists ARTEMIS_LOCKS(LOCKID varchar(64),LONG_VALUE bigint,LAST_ACCESS timestamp,primary key(LOCKID))");
+         st.execute("create alias if not exists lock_unlock for \"org.apache.activemq.artemis.quorum.db.H2DatabaseAdapter.h2ReleaseLock\"");
+         st.execute("create alias if not exists lock_trylock for \"org.apache.activemq.artemis.quorum.db.H2DatabaseAdapter.h2TryLock\"");
+      } catch (SQLException e) {
+         logger.error("Error verifying setup", e);
+      }
+   }
+
+   private static final Map<String, Integer> databaseLocks = new HashMap<>();
+
+   public static Integer h2TryLock(Connection conn, String lockid) {
+      Integer currentSessionId = ((org.h2.engine.SessionLocal) ((org.h2.jdbc.JdbcConnection) conn).getSession()).getId();
+      synchronized (databaseLocks) {
+         Integer owningSession = databaseLocks.get(lockid);
+         if (owningSession != null) {
+            if (owningSession.equals(currentSessionId)) { // we already have the lock
+               return 0;
+            } else {
+               return 1; // someone else has the lock
+            }
+         } else {
+            databaseLocks.put(lockid, currentSessionId); // we just acquired the lock
+            return 0;
+         }
+      }
+   }
+
+   public static Integer h2ReleaseLock(Connection conn, String lockid) {
+      Integer currentSessionId = ((org.h2.engine.SessionLocal) ((org.h2.jdbc.JdbcConnection) conn).getSession()).getId();
+      synchronized (databaseLocks) {
+         Integer owningSession = databaseLocks.get(lockid);
+         if (owningSession != null) {
+            if (owningSession.equals(currentSessionId)) { // we had the lock and it was ours, release
+               databaseLocks.remove(lockid);
+               return 0;
+            } else {
+               return 2;  // we don't own this lock! we can't unlock it
+            }
+         } else {
+            return 1; // we never had the lock to begin with
+         }
+      }
+   }
+
+   protected String findOldLocksQuery() {
+      return "select LOCKID from ARTEMIS_LOCKS where LAST_ACCESS < DATEADD(HOUR,-2,CURRENT_TIMESTAMP)";
+   }
+}

--- a/artemis-quorum-ri/src/test/java/org/apache/activemq/artemis/quorum/db/TestDatabaseConnectionProvider.java
+++ b/artemis-quorum-ri/src/test/java/org/apache/activemq/artemis/quorum/db/TestDatabaseConnectionProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.quorum.db;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Map;
+
+/* Users could implement one of these simple connection providers, and they could add decryption to the password
+that was passed via configuration or they could use an existing connection pool, etc
+* */
+public class TestDatabaseConnectionProvider implements DatabaseConnectionProvider {
+   private final String url;
+   private final String user;
+   private final String pwd;
+
+   public TestDatabaseConnectionProvider(Map<String, String> properties) {
+      url = properties.get("url");
+      user = properties.get("user");
+      pwd = properties.get("password");
+   }
+
+   @Override
+   public Connection getConnection() throws SQLException {
+      return DriverManager.getConnection(url, user, pwd);
+   }
+}


### PR DESCRIPTION
Using locking capabilities of the database, implement the a primitive manager to allow quorum voting to occur. This implementation has support for Oracle, MSSQL and Postgres -- with H2 being used for unit tests.

The locking features used are not locks against a tables, but instead the idea of an arbitrarily named "application" lock. There is no SQL standard for this behavior and each database implementation is different. I have accounted for this by creating the concept of a database adapter -- i.e. adapting the primitive manager to work for the particular database. I have attempted to reduce duplication by declaring a BaseDatabaseAdapter which I think should work generally for all databases.

Additionally, I introduced the concept of a DatabaseConnectionProvider. This was done for any users that are utilizing Artemis as an embedded feature or that otherwise need to declare their own mechanism for getting credentials. For instance, they may very well want to utilize some encryption for storing a database password in the configuration. The DefaultDatabaseConnectionProvider just gets url, username and password from the properties. It is likely that this implementation is enough for most uses, but we may want to see if we can make it optional to store the password encrypted. I am wondering if there is stuff already in existence for this kind of thing?

I tried to follow the same locking approach in the zookeeper curator implementation to keep the threading/calling equivalently safe, but review of this is welcome.

In the end it was only necessary to create a database record when storing a mutable long value. These records are held in an ARTEMIS_LOCKS table. A lock that doesn't use and store a long value can come and go without any lasting signature in the database signature. The default value for a lock is 0 and doesn't require a record in the database until the long value is updated. The longs must be stored in the database for a different node to be able to acquire a lock and have the same long value present there, of course.

I would welcome logical review of my approach to maintenance and cleanup by someone more familiar with all aspects of using these locks:
I store a "LAST_ACCESS" value with each of those LONG_VALUE records. Periodically I enumerate the records that have LAST_ACCESS over two hours ago, then grab the lock. The assumption is this: if the maintenance system can grab the lock and it hasn't been accessed in over two hours, it is probably defunct and should be cleaned up.

I didn't know what exactly was culture regarding the database drivers. Oracle and MSSQL drivers are both proprietary and Postgres is open source. Ultimately in order for anyone to use this feature, they need to provide the right driver for the database they are using. But to make the code implementation testable via unit tests, I used the open source H2 database and wrote a little piece that extended the database to add locking functions similar to Oracle, MSSQL and Postgres. I include instructions in the comments at the top of the DatabaseDistributedLockTest on how someone can setup to run the unit tests in Oracle, MSSQL or Postgres modes. I am ultimately leaving this running as much of the code as possible via unit tests, but inherently to run all of it would require 3 database servers with logins.

My rationale for creating this feature is that I believe if someone is using the broker in an application environment where there is a database already present, it would be nice for them to be able to simply use that database and not have to have yet another piece of infrastructure to provide for the quorum based ha replication that Artemis supports. And I also think that it should be possible to do this kind of thing with just 2 broker nodes without requiring a shared file system -- if someone wanted this.