### PR TITLE
ARTEMIS-4216 Queue with autoDelete might get reaped on server start i…

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -1974,7 +1974,7 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
    void reapAddresses(boolean initialCheck) {
       getLocalQueues().forEach(queue -> {
          AddressSettings settings = addressSettingsRepository.getMatch(queue.getAddress().toString());
-         if (!queue.isInternalQueue() && queue.isAutoDelete() && QueueManagerImpl.consumerCountCheck(queue) && (initialCheck || QueueManagerImpl.delayCheck(queue, settings)) && QueueManagerImpl.messageCountCheck(queue) && (initialCheck || queueWasUsed(queue, settings))) {
+         if (!queue.isInternalQueue() && queue.isAutoDelete() && QueueManagerImpl.consumerCountCheck(queue) && (initialCheck || QueueManagerImpl.delayCheck(queue, settings)) && QueueManagerImpl.messageCountCheck(queue) && (initialCheck || queueWasUsed(queue, settings)) && !queue.getPagingStore().isPaging()) {
             if (initialCheck || queue.isSwept()) {
                if (logger.isDebugEnabled()) {
                   if (initialCheck) {


### PR DESCRIPTION
…f containing only paged messages

I really can't seem to replicate this issue in the test suite, but I have been able to stash a journal where this happens repetedly and have verified the change against it successfully.

Diff on that journal is:
Without change: 52861 messages
With change: 83450 messages (as expected)

What I believe is happening here is:
I have DLQs set to get autoCreated on demand.
I have them set to get autoDeleted when no longer holding any messages.
Since in my use-case there is no rush in processing DLQs I have the DLQ address set with: 
max-size-bytes=0 to save on resources

So what happens is that the queue registers with 0 messages on startup since the PageCounters are not built yet.
Postoffice kicks off the address reaper which somewhat correctly determines the queue holds no messages and is set to AutoDelete and so it deletes it.

Suggestions on a working reproducer is welcomed, otherwise I think the solution should be harmless