### PR TITLE
NO-JIRA Remove dependency on tree utility

### DIFF
--- a/artemis-docker/prepare-docker.sh
+++ b/artemis-docker/prepare-docker.sh
@@ -184,7 +184,4 @@ fi
 cp ./Dockerfile-* "$ARTEMIS_DIST_DIR/docker"
 cp ./docker-run.sh "$ARTEMIS_DIST_DIR/docker"
 
-echo "Docker file support files at:"
-tree "$ARTEMIS_DIST_DIR/docker"
-
 next_step

--- a/artemis-docker/readme.md
+++ b/artemis-docker/readme.md
@@ -24,14 +24,6 @@ $ ./prepare-docker.sh --from-local-dist --local-dist-path ../artemis-distributio
 
 Using ../artemis-distribution/target/apache-artemis-2.17.0-SNAPSHOT-bin/apache-artemis-2.17.0-SNAPSHOT
 Cleaning up ../artemis-distribution/target/apache-artemis-2.17.0-SNAPSHOT-bin/apache-artemis-2.17.0-SNAPSHOT/docker
-Docker file support files at:
-../artemis-distribution/target/apache-artemis-2.17.0-SNAPSHOT-bin/apache-artemis-2.17.0-SNAPSHOT/docker
-├── Dockerfile-centos7-11
-├── Dockerfile-ubuntu-11
-├── Dockerfile-ubuntu-11-jre
-└── docker-run.sh
-
-0 directories, 4 files
 
 Well done! Now you can continue with building the Docker image:
 
@@ -73,14 +65,6 @@ Downloading apache-artemis-2.16.0-bin.tar.gz from https://downloads.apache.org/a
 ################################################################################################################################################################################################################################ 100,0%
 Expanding _TMP_/artemis/2.16.0/apache-artemis-2.16.0-bin.tar.gz...
 Removing _TMP_/artemis/2.16.0/apache-artemis-2.16.0-bin.tar.gz...
-Docker file support files at:
-_TMP_/artemis/2.16.0/docker
-├── Dockerfile-centos7-11
-├── Dockerfile-ubuntu-11
-├── Dockerfile-ubuntu-11-jre
-└── docker-run.sh
-
-0 directories, 4 files
 
 Well done! Now you can continue with building the Docker image:
 


### PR DESCRIPTION
Tree utility is not present by default in a lot of smaller Linux installations, like for example CentOS or Rocky Linux minimal image. As it serves almost no purpose other than visual, I suggest removing this dependency from Docker build requirements.

Alternatively, I can prepare a PR with `ls -la` alternative if you think it is still needed to list those files.