### PR TITLE
ARTEMIS-4269: Update Netty from 4.1.86 to 4.1.92

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
       <checkstyle.version>9.2.1</checkstyle.version>
       <mockito.version>5.2.0</mockito.version>
       <jctools.version>2.1.2</jctools.version>
-      <netty.version>4.1.86.Final</netty.version>
+      <netty.version>4.1.92.Final</netty.version>
       <hdrhistogram.version>2.1.12</hdrhistogram.version>
       <curator.version>5.2.0</curator.version>
       <zookeeper.version>3.6.3</zookeeper.version>


### PR DESCRIPTION
Changes:
https://netty.io/news/2023/04/25/4-1-92-Final.html 
https://netty.io/news/2023/04/03/4-1-91-Final.html
https://netty.io/news/2023/03/14/4-1-90-Final.html
https://netty.io/news/2023/02/13/4-1-89-Final.html
https://netty.io/news/2023/02/12/4-1-88-Final.html
https://netty.io/news/2023/01/12/4-1-87-Final.html

Issue: [ARTEMIS-4269](https://issues.apache.org/jira/browse/ARTEMIS-4269)