### PR TITLE
ARTEMIS-4279 Shutdown critical analyzer thread if error on broker ini…

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -689,7 +689,13 @@ public class ActiveMQServerImpl implements ActiveMQServer {
 
          nodeManager = createNodeManager(configuration.getNodeManagerLockLocation(), false);
 
-         nodeManager.start();
+         try {
+            nodeManager.start();
+         } catch (Exception e) {
+            //if there's an error here, ensure remaining threads shut down
+            stopTheServer(true);
+            throw e;
+         }
 
          ActiveMQServerLogger.LOGGER.serverStarting((haPolicy.isBackup() ? "backup" : "live"), configuration);
 

--- a/tests/smoke-tests/pom.xml
+++ b/tests/smoke-tests/pom.xml
@@ -1281,7 +1281,33 @@
                      </args>
                   </configuration>
                </execution>
-
+               <execution>
+                  <phase>test-compile</phase>
+                  <id>create-jdbc-bad-driver</id>
+                  <goals>
+                     <goal>create</goal>
+                  </goals>
+                  <configuration>
+                     <role>amq</role>
+                     <user>admin</user>
+                     <password>admin</password>
+                     <allowAnonymous>false</allowAnonymous>
+                     <noWeb>true</noWeb>
+                     <instance>${basedir}/target/jdbc-bad-driver</instance>
+                     <args>
+                        <arg>--http-host</arg>
+                        <arg>${sts-http-host}</arg>
+                        <arg>--http-port</arg>
+                        <arg>8161</arg>
+                        <arg>--shared-store</arg>
+                        <arg>--jdbc</arg>
+                        <arg>--jdbc-connection-url</arg>
+                        <arg>tcp://noexist</arg>
+                        <arg>--jdbc-driver-class-name</arg>
+                        <arg>badDriver</arg>
+                     </args>
+                  </configuration>
+               </execution>
             </executions>
             <dependencies>
                <dependency>

--- a/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/jdbc/JdbcStartupTest.java
+++ b/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/jdbc/JdbcStartupTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.smoke.jdbc;
+
+import org.apache.activemq.artemis.tests.smoke.common.SmokeTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class JdbcStartupTest extends SmokeTestBase {
+
+   protected static final String SERVER_NAME = "jdbc-bad-driver";
+
+   @Test
+   public void startupBadJdbcConnectionTest() throws Exception {
+
+      Integer exitVal = -1;
+      Process p = startServer(SERVER_NAME, 0, 0);
+      try {
+         p.waitFor(10, TimeUnit.SECONDS);
+         exitVal = p.exitValue();
+      } catch (Exception e) {
+         Assert.fail();
+      }
+
+      Assert.assertEquals(0, (long) exitVal);
+   }
+}


### PR DESCRIPTION
…tialization

The broker process fails to exit if an error is encountered starting the NodeManager.  The issue is resolved by converting the critical analyzer thread to a daemon thread.  As added protection, the thread is manually stopped when this error is encountered.