### PR TITLE
ARTEMIS-4283 Fail fast CORE client connect on closing

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/ActiveMQClientMessageBundle.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/ActiveMQClientMessageBundle.java
@@ -237,4 +237,7 @@ public interface ActiveMQClientMessageBundle {
 
    @Message(id = 219067, value = "Keystore alias {} not found in {}")
    IllegalArgumentException keystoreAliasNotFound(String keystoreAlias, String keystorePath);
+
+   @Message(id = 219068, value = "Connection closed while receiving cluster topology. Group:{}")
+   ActiveMQObjectClosedException connectionClosedOnReceiveTopology(DiscoveryGroup discoveryGroup);
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorImpl.java
@@ -684,6 +684,8 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
                   // We always try to connect here with only one attempt,
                   // as we will perform the initial retry here, looking for all possible connectors
                   factory.connect(1, false);
+
+                  addFactory(factory);
                } finally {
                   removeFromConnecting(factory);
                }
@@ -737,11 +739,16 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       // how the sendSubscription happens.
       // in case this ever changes.
       if (topology != null && !factory.waitForTopology(config.callTimeout, TimeUnit.MILLISECONDS)) {
+         factoryClosed(factory);
+
          factory.cleanup();
+
+         if (isClosed()) {
+            throw ActiveMQClientMessageBundle.BUNDLE.connectionClosedOnReceiveTopology(discoveryGroup);
+         }
+
          throw ActiveMQClientMessageBundle.BUNDLE.connectionTimedOutOnReceiveTopology(discoveryGroup);
       }
-
-      addFactory(factory);
 
       return factory;
    }


### PR DESCRIPTION
ServerLocatorImpl waits for topology after connecting a new session factory. It should interrupt waiting for topology when it is closed to fail fast.