### PR TITLE
ARTEMIS-4291 Add the "broker" tag in a consistent manner

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/metrics/MetricsManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/metrics/MetricsManager.java
@@ -57,20 +57,23 @@ public class MetricsManager {
                          MetricsConfiguration metricsConfiguration,
                          HierarchicalRepository<AddressSettings> addressSettingsRepository) {
       this.brokerName = brokerName;
-      meterRegistry = metricsConfiguration.getPlugin().getRegistry();
-      Metrics.globalRegistry.add(meterRegistry);
+      this.meterRegistry = metricsConfiguration.getPlugin().getRegistry();
       this.addressSettingsRepository = addressSettingsRepository;
-      if (metricsConfiguration.isJvmMemory()) {
-         new JvmMemoryMetrics().bindTo(meterRegistry);
-      }
-      if (metricsConfiguration.isJvmGc()) {
-         new JvmGcMetrics().bindTo(meterRegistry);
-      }
-      if (metricsConfiguration.isJvmThread()) {
-         new JvmThreadMetrics().bindTo(meterRegistry);
-      }
-      if (metricsConfiguration.isNettyPool()) {
-         new NettyPooledAllocatorMetrics(PooledByteBufAllocator.DEFAULT.metric()).bindTo(meterRegistry);
+      if (meterRegistry != null) {
+         Metrics.globalRegistry.add(meterRegistry);
+         meterRegistry.config().commonTags("broker", brokerName);
+         if (metricsConfiguration.isJvmMemory()) {
+            new JvmMemoryMetrics().bindTo(meterRegistry);
+         }
+         if (metricsConfiguration.isJvmGc()) {
+            new JvmGcMetrics().bindTo(meterRegistry);
+         }
+         if (metricsConfiguration.isJvmThread()) {
+            new JvmThreadMetrics().bindTo(meterRegistry);
+         }
+         if (metricsConfiguration.isNettyPool()) {
+            new NettyPooledAllocatorMetrics(PooledByteBufAllocator.DEFAULT.metric()).bindTo(meterRegistry);
+         }
       }
    }
 
@@ -92,7 +95,6 @@ public class MetricsManager {
       builder.accept((metricName, state, f, description) -> {
          Gauge.Builder meter = Gauge
             .builder("artemis." + metricName, state, f)
-            .tag("broker", brokerName)
             .tag("address", address)
             .tag("queue", queue)
             .description(description);
@@ -109,7 +111,6 @@ public class MetricsManager {
       builder.accept((metricName, state, f, description) -> {
          Gauge.Builder meter = Gauge
             .builder("artemis." + metricName, state, f)
-            .tag("broker", brokerName)
             .tag("address", address)
             .description(description);
          gaugeBuilders.add(meter);
@@ -125,7 +126,6 @@ public class MetricsManager {
       builder.accept((metricName, state, f, description) -> {
          Gauge.Builder meter = Gauge
             .builder("artemis." + metricName, state, f)
-            .tag("broker", brokerName)
             .description(description);
          gaugeBuilders.add(meter);
       });

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/plugin/NettyMetricsTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/plugin/NettyMetricsTest.java
@@ -25,7 +25,7 @@ import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 import org.junit.Test;
 
-public class JvmMetricsTest extends ActiveMQTestBase {
+public class NettyMetricsTest extends ActiveMQTestBase {
 
    @Override
    @Before
@@ -34,42 +34,20 @@ public class JvmMetricsTest extends ActiveMQTestBase {
    }
 
    @Test
-   public void testJvmMemoryMetricsPositive() throws Exception {
-      internalTestMetrics(true, true, false, false, "jvm.memory");
+   public void testNettyPoolMetricsPositive() throws Exception {
+      internalTestMetrics(true, true, "netty.pooled");
    }
 
    @Test
-   public void testJvmMemoryMetricsNegative() throws Exception {
-      internalTestMetrics(false, false, false, false, "jvm.memory");
+   public void testNettyPoolMetricsNegative() throws Exception {
+      internalTestMetrics(false, false, "netty.pooled");
    }
 
-   @Test
-   public void testJvmGcMetricsPositive() throws Exception {
-      internalTestMetrics(true, false, true, false, "jvm.gc");
-   }
-
-   @Test
-   public void testJvmGcMetricsNegative() throws Exception {
-      internalTestMetrics(false, false, false, false, "jvm.gc");
-   }
-
-   @Test
-   public void testJvmThreadMetricsPositive() throws Exception {
-      internalTestMetrics(true, false, false, true, "jvm.thread");
-   }
-
-   @Test
-   public void testJvmThreadMetricsNegative() throws Exception {
-      internalTestMetrics(false, false, false, false, "jvm.thread");
-   }
-
-   private void internalTestMetrics(boolean found, boolean memory, boolean gc, boolean thread, String match) throws Exception {
+   private void internalTestMetrics(boolean found, boolean pool, String match) throws Exception {
       ActiveMQServer server = createServer(false, createDefaultInVMConfig()
          .setMetricsConfiguration(new MetricsConfiguration()
                                      .setPlugin(new SimpleMetricsPlugin().init(null))
-                                     .setJvmMemory(memory)
-                                     .setJvmGc(gc)
-                                     .setJvmThread(thread)));
+                                     .setNettyPool(pool)));
       server.start();
       boolean result = false;
       String brokerTagValue = "";


### PR DESCRIPTION
ARTEMIS-4291 Add the "broker" tag in a consistent manner to all exported metrics.
    
Some scrapers, e.g. prometheus, add an "instance" tag. This value may not be the same as
the broker name, which results in these metrics becoming more difficult to match up with
the corresponding broker.