### PR TITLE
ARTEMIS-4309 Fix for large, compressed, ObjectMessage types, getting UTFDataFormat…

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireMessageConverter.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireMessageConverter.java
@@ -267,7 +267,7 @@ public final class OpenWireMessageConverter {
          int n = ois.read(buf);
          while (n != -1) {
             decompressed.write(buf, 0, n);
-            n = ois.read();
+            n = ois.read(buf);
          }
          //read done
          return decompressed.toByteSequence();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/interop/CompressedInteropTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/interop/CompressedInteropTest.java
@@ -38,6 +38,7 @@ import org.junit.Test;
 public class CompressedInteropTest extends BasicOpenWireTest {
 
    private static final String TEXT;
+   private static final String LARGE_TEXT;
 
    static {
       StringBuilder builder = new StringBuilder();
@@ -46,6 +47,7 @@ public class CompressedInteropTest extends BasicOpenWireTest {
          builder.append("The quick red fox jumped over the lazy brown dog. ");
       }
       TEXT = builder.toString();
+      LARGE_TEXT = TEXT + TEXT + TEXT + TEXT + TEXT;
    }
 
    @Before
@@ -90,6 +92,9 @@ public class CompressedInteropTest extends BasicOpenWireTest {
       //ObjectMessage
       sendCompressedObjectMessageUsingOpenWire();
       receiveObjectMessage(useCore);
+      //Large ObjectMessage
+      sendCompressedLargeObjectMessageUsingOpenWire();
+      receiveLargeObjectMessage(useCore);
    }
 
    private void sendCompressedStreamMessageUsingOpenWire() throws Exception {
@@ -162,6 +167,24 @@ public class CompressedInteropTest extends BasicOpenWireTest {
       ObjectMessage objectMessage = (ObjectMessage) receiveMessage(useCore);
       Object objectVal = objectMessage.getObject();
       assertEquals(TEXT, objectVal);
+   }
+
+   private void sendCompressedLargeObjectMessageUsingOpenWire() throws Exception {
+      Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+      ActiveMQDestination destination = createDestination(session, ActiveMQDestination.QUEUE_TYPE);
+
+      final ActiveMQMessageProducer producer = (ActiveMQMessageProducer) session.createProducer(destination);
+
+      ObjectMessage objectMessage = session.createObjectMessage();
+      objectMessage.setObject(LARGE_TEXT);
+
+      producer.send(objectMessage);
+   }
+
+   private void receiveLargeObjectMessage(boolean useCore) throws Exception {
+      ObjectMessage objectMessage = (ObjectMessage) receiveMessage(useCore);
+      Object objectVal = objectMessage.getObject();
+      assertEquals(LARGE_TEXT, objectVal);
    }
 
    private void sendCompressedMapMessageUsingOpenWire() throws Exception {


### PR DESCRIPTION
…Exception when deserializing message on client side

When larger object types (greater than 1024 bytes), and compressed, are de-serialized,  UTFDataFormatException occurs on the client side.

The InputStream object, `ois`, just needs to keep reading into the `buf` byte[] until all the bytes are ready. Currently, if the ByteSequence object, `contents`, is larger that 1024 bytes, the while loop will only ready a byte at a time instead of the intended 'as many bytes as can fit into `buf`' paradigm.