### PR TITLE
ARTEMIS-4295 artemis-docker: replace 'tree' command with 'ls -l'

### DIFF
--- a/artemis-docker/prepare-docker.sh
+++ b/artemis-docker/prepare-docker.sh
@@ -185,6 +185,6 @@ cp ./Dockerfile-* "$ARTEMIS_DIST_DIR/docker"
 cp ./docker-run.sh "$ARTEMIS_DIST_DIR/docker"
 
 echo "Docker file support files at:"
-tree "$ARTEMIS_DIST_DIR/docker"
+ls -l "$ARTEMIS_DIST_DIR/docker"
 
 next_step


### PR DESCRIPTION
'tree' command is not available in base image, so cloud build failed:

`./prepare-docker.sh: 188: tree: not found`

