### PR TITLE
ARTEMIS-4303 Fix windows service

### DIFF
--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis-service.xml
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis-service.xml
@@ -26,7 +26,7 @@
    <env name="ARTEMIS_INSTANCE" value="@artemis.instance@"/>
    <env name="ARTEMIS_INSTANCE_ETC" value="${artemis.instance.etc}"/>
    <env name="ARTEMIS_INSTANCE_URI" value="${artemis.instance.uri}"/>
-   <env name="ARTEMIS_INSTANCE_ETC_URI" value="${artemis.instance.etc.uri.windows}"/>
+   <env name="ARTEMIS_INSTANCE_ETC_URI" value="${artemis.instance.etc.uri}"/>
    <env name="ARTEMIS_DATA_DIR" value="${artemis.instance.data}"/>
 
    <logpath>@artemis.instance@\log</logpath>


### PR DESCRIPTION
When installing artemis on windows as a service, if your chosen installation path contained a space, then an extra escape character (%) was being inserted in the generated
artemis-service.xml, causing the service to fail to start. This fix changes the value of ARTEMIS_INSTANCE_ETC_URI in that file from "artemis.instance.etc.uri.windows" to "artemis.instance.etc.uri" to get rid of that unnecessary escape character.