### PR TITLE
ARTEMIS-4312 dupes w/redistribution and multicast

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/BindingsImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/BindingsImpl.java
@@ -270,6 +270,11 @@ public final class BindingsImpl implements Bindings {
          logger.debug("Message {} being copied as {}", message.getMessageID(), copyRedistribute.getMessageID());
       }
       copyRedistribute.setAddress(message.getAddress());
+      for (SimpleString property : copyRedistribute.getPropertyNames()) {
+         if (property.startsWith(Message.HDR_ROUTE_TO_IDS)) {
+            copyRedistribute.removeProperty(property);
+         }
+      }
 
       if (context.getTransaction() == null) {
          context.setTransaction(new TransactionImpl(storageManager));

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/ClusterTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/ClusterTestBase.java
@@ -630,6 +630,17 @@ public abstract class ClusterTestBase extends ActiveMQTestBase {
                               boolean autoCommitAcks,
                               final String user,
                               final String password) throws Exception {
+      addConsumer(consumerID, node, queueName, filterVal, autoCommitAcks, user, password, ActiveMQClient.DEFAULT_ACK_BATCH_SIZE);
+   }
+
+   protected void addConsumer(final int consumerID,
+                              final int node,
+                              final String queueName,
+                              final String filterVal,
+                              boolean autoCommitAcks,
+                              final String user,
+                              final String password,
+                              final int ackBatchSize) throws Exception {
       try {
          if (consumers[consumerID] != null) {
             throw new IllegalArgumentException("Already a consumer at " + node);
@@ -641,7 +652,7 @@ public abstract class ClusterTestBase extends ActiveMQTestBase {
             throw new IllegalArgumentException("No sf at " + node);
          }
 
-         ClientSession session = addClientSession(sf.createSession(user, password, false, false, autoCommitAcks, ActiveMQClient.DEFAULT_PRE_ACKNOWLEDGE, ActiveMQClient.DEFAULT_ACK_BATCH_SIZE));
+         ClientSession session = addClientSession(sf.createSession(user, password, false, false, autoCommitAcks, ActiveMQClient.DEFAULT_PRE_ACKNOWLEDGE, ackBatchSize));
 
          String filterString = null;
 


### PR DESCRIPTION
Multiple multicast queues on the same address can lead to duplicate messages during redistribution in a cluster.