### PR TITLE
ARTEMIS-4316 fix example doc formatting

### DIFF
--- a/artemis-distribution/pom.xml
+++ b/artemis-distribution/pom.xml
@@ -209,9 +209,9 @@
             </executions>
          </plugin>
          <plugin>
-            <groupId>com.vladsch.flexmark</groupId>
+            <groupId>com.ruleoftech</groupId>
             <artifactId>markdown-page-generator-plugin</artifactId>
-            <version>0.27.0</version>
+            <version>2.4.0</version>
             <executions>
                <execution>
                   <phase>compile</phase>
@@ -226,6 +226,7 @@
                <inputDirectory>${activemq.basedir}/examples</inputDirectory>
                <outputDirectory>${project.build.directory}/markdown-pages/examples</outputDirectory>
                <recursiveInput>true</recursiveInput>
+               <pegdownExtensions>FENCED_CODE_BLOCKS</pegdownExtensions>
             </configuration>
          </plugin>
       </plugins>


### PR DESCRIPTION
This commit also updates the artifact used to generate the HTML from the MarkDown as the existing artifact is now defunct.