### PR TITLE
ARTEMIS-4318 migrate to Airline 2

### DIFF
--- a/artemis-cli/pom.xml
+++ b/artemis-cli/pom.xml
@@ -100,7 +100,7 @@
       </dependency>
 
       <dependency>
-         <groupId>io.airlift</groupId>
+         <groupId>com.github.rvesse</groupId>
          <artifactId>airline</artifactId>
       </dependency>
       <dependency>

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/Artemis.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/Artemis.java
@@ -22,7 +22,8 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.util.List;
 
-import io.airlift.airline.Cli;
+import com.github.rvesse.airline.Cli;
+import com.github.rvesse.airline.builder.CliBuilder;
 import org.apache.activemq.artemis.cli.commands.Action;
 import org.apache.activemq.artemis.cli.commands.ActionContext;
 import org.apache.activemq.artemis.cli.commands.Create;
@@ -213,9 +214,9 @@ public class Artemis {
       return action.execute(context);
    }
 
-   private static Cli.CliBuilder<Action> builder(File artemisInstance) {
+   private static CliBuilder<Action> builder(File artemisInstance) {
       String instance = artemisInstance != null ? artemisInstance.getAbsolutePath() : System.getProperty("artemis.instance");
-      Cli.CliBuilder<Action> builder = Cli.<Action>builder("artemis").withDescription("ActiveMQ Artemis Command Line").
+      CliBuilder<Action> builder = Cli.<Action>builder("artemis").withDescription("ActiveMQ Artemis Command Line").
          withCommand(HelpAction.class).withCommand(Producer.class).withCommand(Transfer.class).withCommand(Consumer.class).
          withCommand(Browse.class).withCommand(Mask.class).withCommand(PrintVersion.class).withDefaultCommand(HelpAction.class);
 

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/ActionAbstract.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/ActionAbstract.java
@@ -21,7 +21,7 @@ import java.net.InetAddress;
 import java.net.URI;
 import java.util.Map;
 
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.FileDeploymentManager;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Configurable.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Configurable.java
@@ -17,15 +17,15 @@
 
 package org.apache.activemq.artemis.cli.commands;
 
-import javax.inject.Inject;
 import java.io.File;
 
-import io.airlift.airline.Arguments;
-import io.airlift.airline.Help;
-import io.airlift.airline.Option;
-import io.airlift.airline.model.CommandGroupMetadata;
-import io.airlift.airline.model.CommandMetadata;
-import io.airlift.airline.model.GlobalMetadata;
+import com.github.rvesse.airline.annotations.AirlineModule;
+import com.github.rvesse.airline.annotations.Arguments;
+import com.github.rvesse.airline.annotations.Option;
+import com.github.rvesse.airline.help.Help;
+import com.github.rvesse.airline.model.CommandGroupMetadata;
+import com.github.rvesse.airline.model.CommandMetadata;
+import com.github.rvesse.airline.model.GlobalMetadata;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.cli.factory.BrokerFactory;
 import org.apache.activemq.artemis.cli.factory.jmx.ManagementFactory;
@@ -36,6 +36,8 @@ import org.apache.activemq.artemis.dto.ManagementContextDTO;
 import org.apache.activemq.artemis.jms.server.config.impl.FileJMSConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 
 /**
@@ -51,8 +53,8 @@ public abstract class Configurable extends ActionAbstract {
    @Option(name = "--broker", description = "Override the broker configuration from the bootstrap.xml.")
    String brokerConfig;
 
-   @Inject
-   public GlobalMetadata global;
+   @AirlineModule
+   public GlobalMetadata<Object> global;
 
    private BrokerDTO brokerDTO = null;
 
@@ -75,7 +77,11 @@ public abstract class Configurable extends ActionAbstract {
          if (group.getName().equals(groupName)) {
             for (CommandMetadata command : group.getCommands()) {
                if (command.getName().equals(commandName)) {
-                  Help.help(command);
+                  try {
+                     Help.help(command);
+                  } catch (IOException e) {
+                     throw new RuntimeException(e);
+                  }
                }
             }
             break;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
@@ -25,8 +25,8 @@ import java.text.DecimalFormat;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.cli.commands.util.HashUtil;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/HelpAction.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/HelpAction.java
@@ -18,7 +18,7 @@ package org.apache.activemq.artemis.cli.commands;
 
 import java.io.File;
 
-import io.airlift.airline.Help;
+import com.github.rvesse.airline.help.Help;
 
 public class HelpAction extends Help implements Action {
 

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/InputAbstract.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/InputAbstract.java
@@ -19,7 +19,7 @@ package org.apache.activemq.artemis.cli.commands;
 
 import java.util.Scanner;
 
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Option;
 
 public class InputAbstract extends ActionAbstract {
 

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/InstallAbstract.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/InstallAbstract.java
@@ -30,13 +30,15 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import io.airlift.airline.Arguments;
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Arguments;
+import com.github.rvesse.airline.annotations.Option;
+import com.github.rvesse.airline.annotations.restrictions.Required;
 import org.apache.activemq.artemis.cli.CLIException;
 
 public class InstallAbstract extends InputAbstract {
 
-   @Arguments(description = "The instance directory to hold the broker's configuration and data. Path must be writable.", required = true)
+   @Arguments(description = "The instance directory to hold the broker's configuration and data. Path must be writable.")
+   @Required
    protected File directory;
 
    @Option(name = "--etc", description = "Directory where ActiveMQ configuration is located. Paths can be absolute or relative to artemis.instance directory. Default: etc.")

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Kill.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Kill.java
@@ -18,7 +18,7 @@ package org.apache.activemq.artemis.cli.commands;
 
 import java.io.File;
 
-import io.airlift.airline.Command;
+import com.github.rvesse.airline.annotations.Command;
 import org.apache.activemq.artemis.dto.BrokerDTO;
 
 @Command(name = "kill", description = "Kill a broker started with --allow-kill.")

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Mask.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Mask.java
@@ -19,9 +19,10 @@ package org.apache.activemq.artemis.cli.commands;
 import java.util.HashMap;
 import java.util.Map;
 
-import io.airlift.airline.Arguments;
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Arguments;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
+import com.github.rvesse.airline.annotations.restrictions.Required;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.utils.DefaultSensitiveStringCodec;
 import org.apache.activemq.artemis.utils.PasswordMaskingUtil;
@@ -30,7 +31,8 @@ import org.apache.activemq.artemis.utils.SensitiveDataCodec;
 @Command(name = "mask", description = "Mask a password and print it out.")
 public class Mask extends ActionAbstract {
 
-   @Arguments(description = "The password to be masked.", required = true)
+   @Arguments(description = "The password to be masked.")
+   @Required
    String password;
 
    @Option(name = "--hash", description = "Whether to use a hash (one-way). Default: false.")

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/OptionsUtil.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/OptionsUtil.java
@@ -20,7 +20,7 @@ import java.lang.reflect.Field;
 import java.util.HashSet;
 import java.util.Set;
 
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Option;
 
 public class OptionsUtil {
 

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/PrintVersion.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/PrintVersion.java
@@ -16,7 +16,7 @@
  */
 package org.apache.activemq.artemis.cli.commands;
 
-import io.airlift.airline.Command;
+import com.github.rvesse.airline.annotations.Command;
 import org.apache.activemq.artemis.core.version.Version;
 import org.apache.activemq.artemis.utils.VersionLoader;
 

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Run.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Run.java
@@ -21,8 +21,8 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.Pair;
 import org.apache.activemq.artemis.cli.Artemis;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Stop.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Stop.java
@@ -18,7 +18,7 @@ package org.apache.activemq.artemis.cli.commands;
 
 import java.io.File;
 
-import io.airlift.airline.Command;
+import com.github.rvesse.airline.annotations.Command;
 import org.apache.activemq.artemis.dto.BrokerDTO;
 
 @Command(name = "stop", description = "Stop the broker.")

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Upgrade.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Upgrade.java
@@ -30,7 +30,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import io.airlift.airline.Command;
+import com.github.rvesse.airline.annotations.Command;
 import org.apache.activemq.artemis.util.JVMArgumentParser;
 
 @Command(name = "upgrade", description = "Update a broker instance to the current artemis.home, keeping all the data and broker.xml. Warning: backup your instance before using this command and compare the files.")

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/activation/ActivationSequenceList.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/activation/ActivationSequenceList.java
@@ -20,8 +20,8 @@ import java.io.PrintStream;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.cli.commands.ActionContext;
 import org.apache.activemq.artemis.cli.commands.tools.LockAbstract;
 import org.apache.activemq.artemis.core.config.Configuration;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/activation/ActivationSequenceSet.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/activation/ActivationSequenceSet.java
@@ -20,8 +20,9 @@ import java.io.PrintStream;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
+import com.github.rvesse.airline.annotations.restrictions.Required;
 import org.apache.activemq.artemis.cli.commands.ActionContext;
 import org.apache.activemq.artemis.cli.commands.tools.LockAbstract;
 import org.apache.activemq.artemis.core.config.Configuration;
@@ -41,13 +42,18 @@ import static org.apache.activemq.artemis.cli.commands.activation.ActivationSequ
 public class ActivationSequenceSet extends LockAbstract {
 
    private static final int MANAGER_START_TIMEOUT_SECONDS = 60;
+
    @Option(name = "--node-id", description = "Target sequence for this UUID overwriting the NodeID of this broker too. If not set, broker NodeID is used instead.")
    public String nodeId = null;
+
    @Option(name = "--remote", description = "Set just remote (i.e. coordinated) activation sequence.")
    public boolean remote = false;
+
    @Option(name = "--local", description = "Set just local activation sequence.")
    public boolean local = false;
-   @Option(name = "--to", description = "The new activation sequence.", required = true)
+
+   @Option(name = "--to", description = "The new activation sequence.")
+   @Required
    public long value;
 
    @Override

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/address/AddressAbstract.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/address/AddressAbstract.java
@@ -16,7 +16,7 @@
  */
 package org.apache.activemq.artemis.cli.commands.address;
 
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.cli.commands.AbstractAction;
 
 public abstract class AddressAbstract extends AbstractAction {

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/address/CreateAddress.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/address/CreateAddress.java
@@ -17,7 +17,7 @@
 
 package org.apache.activemq.artemis.cli.commands.address;
 
-import io.airlift.airline.Command;
+import com.github.rvesse.airline.annotations.Command;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.management.ManagementHelper;
 import org.apache.activemq.artemis.cli.commands.ActionContext;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/address/DeleteAddress.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/address/DeleteAddress.java
@@ -17,8 +17,8 @@
 
 package org.apache.activemq.artemis.cli.commands.address;
 
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.management.ManagementHelper;
 import org.apache.activemq.artemis.cli.commands.ActionContext;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/address/HelpAddress.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/address/HelpAddress.java
@@ -21,7 +21,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.airlift.airline.Help;
+import com.github.rvesse.airline.help.Help;
 import org.apache.activemq.artemis.cli.commands.Action;
 import org.apache.activemq.artemis.cli.commands.ActionContext;
 import org.apache.activemq.artemis.cli.commands.InvalidOptionsError;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/address/ShowAddress.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/address/ShowAddress.java
@@ -17,8 +17,8 @@
 
 package org.apache.activemq.artemis.cli.commands.address;
 
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.management.ManagementHelper;
 import org.apache.activemq.artemis.cli.commands.ActionContext;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/address/UpdateAddress.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/address/UpdateAddress.java
@@ -16,7 +16,7 @@
  */
 package org.apache.activemq.artemis.cli.commands.address;
 
-import io.airlift.airline.Command;
+import com.github.rvesse.airline.annotations.Command;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.management.ManagementHelper;
 import org.apache.activemq.artemis.cli.commands.AbstractAction;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/check/CheckAbstract.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/check/CheckAbstract.java
@@ -23,7 +23,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.api.core.management.ActiveMQManagementProxy;
 import org.apache.activemq.artemis.cli.CLIException;
 import org.apache.activemq.artemis.cli.commands.AbstractAction;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/check/HelpCheck.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/check/HelpCheck.java
@@ -21,7 +21,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.airlift.airline.Help;
+import com.github.rvesse.airline.help.Help;
 import org.apache.activemq.artemis.cli.commands.Action;
 import org.apache.activemq.artemis.cli.commands.ActionContext;
 import org.apache.activemq.artemis.cli.commands.InvalidOptionsError;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/check/NodeCheck.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/check/NodeCheck.java
@@ -19,8 +19,8 @@ package org.apache.activemq.artemis.cli.commands.check;
 
 import java.util.ArrayList;
 
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.api.core.management.NodeInfo;
 
 @Command(name = "node", description = "Check a node.")

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/check/QueueCheck.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/check/QueueCheck.java
@@ -27,8 +27,8 @@ import javax.jms.Session;
 import java.util.ArrayList;
 import java.util.Enumeration;
 
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
 
 @Command(name = "queue", description = "Check a queue.")

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/Browse.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/Browse.java
@@ -22,8 +22,8 @@ import javax.jms.ConnectionFactory;
 import javax.jms.Destination;
 import javax.jms.Session;
 
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.cli.commands.ActionContext;
 
 @Command(name = "browser", description = "Browse messages on a queue.")

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/ConnectionAbstract.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/ConnectionAbstract.java
@@ -21,7 +21,7 @@ import javax.jms.ConnectionFactory;
 import javax.jms.JMSException;
 import javax.jms.JMSSecurityException;
 
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.cli.commands.ActionContext;
 import org.apache.activemq.artemis.cli.commands.InputAbstract;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/Consumer.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/Consumer.java
@@ -26,8 +26,8 @@ import javax.jms.Session;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.cli.commands.ActionContext;
 import org.apache.activemq.artemis.cli.factory.serialize.MessageSerializer;
 

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/DestAbstract.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/DestAbstract.java
@@ -21,7 +21,7 @@ import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.Session;
 
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.cli.factory.serialize.MessageSerializer;
 import org.apache.activemq.artemis.cli.factory.serialize.XMLMessageSerializer;
 import org.apache.activemq.artemis.jms.client.ActiveMQDestination;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/Producer.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/Producer.java
@@ -27,8 +27,8 @@ import javax.jms.Session;
 import java.io.FileInputStream;
 import java.io.InputStream;
 
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.cli.commands.ActionContext;
 import org.apache.activemq.artemis.cli.factory.serialize.MessageSerializer;
 

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/Transfer.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/Transfer.java
@@ -28,8 +28,8 @@ import javax.jms.Queue;
 import javax.jms.Session;
 import javax.jms.Topic;
 
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.api.core.Pair;
 import org.apache.activemq.artemis.cli.commands.ActionContext;
 import org.apache.activemq.artemis.cli.commands.InputAbstract;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/perf/PerfClientCommand.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/perf/PerfClientCommand.java
@@ -25,8 +25,8 @@ import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
 import io.netty.channel.DefaultEventLoop;
 import io.netty.channel.DefaultEventLoopGroup;
 import io.netty.channel.EventLoop;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/perf/PerfCommand.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/perf/PerfCommand.java
@@ -26,8 +26,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 
-import io.airlift.airline.Arguments;
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Arguments;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.cli.commands.ActionContext;
 import org.apache.activemq.artemis.cli.commands.messages.ConnectionAbstract;
 import org.apache.activemq.artemis.cli.commands.messages.DestAbstract;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/perf/PerfConsumerCommand.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/perf/PerfConsumerCommand.java
@@ -21,8 +21,8 @@ import javax.jms.Destination;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.cli.commands.ActionContext;
 
 @Command(name = "consumer", description = "Consume messages from a queue.")

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/perf/PerfProducerCommand.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/perf/PerfProducerCommand.java
@@ -25,8 +25,8 @@ import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
 import io.netty.channel.DefaultEventLoop;
 import io.netty.channel.DefaultEventLoopGroup;
 import io.netty.channel.EventLoop;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/queue/CreateQueue.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/queue/CreateQueue.java
@@ -17,7 +17,7 @@
 
 package org.apache.activemq.artemis.cli.commands.queue;
 
-import io.airlift.airline.Command;
+import com.github.rvesse.airline.annotations.Command;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.management.ManagementHelper;
 import org.apache.activemq.artemis.cli.commands.ActionContext;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/queue/DeleteQueue.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/queue/DeleteQueue.java
@@ -17,8 +17,8 @@
 
 package org.apache.activemq.artemis.cli.commands.queue;
 
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.management.ManagementHelper;
 import org.apache.activemq.artemis.cli.commands.ActionContext;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/queue/HelpQueue.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/queue/HelpQueue.java
@@ -21,7 +21,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.airlift.airline.Help;
+import com.github.rvesse.airline.help.Help;
 import org.apache.activemq.artemis.cli.commands.Action;
 import org.apache.activemq.artemis.cli.commands.ActionContext;
 import org.apache.activemq.artemis.cli.commands.InvalidOptionsError;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/queue/PurgeQueue.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/queue/PurgeQueue.java
@@ -17,8 +17,8 @@
 
 package org.apache.activemq.artemis.cli.commands.queue;
 
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.management.ManagementHelper;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/queue/QueueAbstract.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/queue/QueueAbstract.java
@@ -16,7 +16,7 @@
  */
 package org.apache.activemq.artemis.cli.commands.queue;
 
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.cli.commands.AbstractAction;
 
 public class QueueAbstract extends AbstractAction {

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/queue/StatQueue.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/queue/StatQueue.java
@@ -21,8 +21,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.api.core.JsonUtil;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.management.ManagementHelper;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/queue/UpdateQueue.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/queue/UpdateQueue.java
@@ -16,7 +16,7 @@
  */
 package org.apache.activemq.artemis.cli.commands.queue;
 
-import io.airlift.airline.Command;
+import com.github.rvesse.airline.annotations.Command;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.management.ManagementHelper;
 import org.apache.activemq.artemis.cli.commands.ActionContext;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/DBOption.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/DBOption.java
@@ -25,7 +25,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.cli.commands.ActionContext;
 import org.apache.activemq.artemis.core.config.Configuration;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/DataAbstract.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/DataAbstract.java
@@ -19,7 +19,7 @@ package org.apache.activemq.artemis.cli.commands.tools;
 
 import java.io.File;
 
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.cli.commands.Configurable;
 
 /**

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/HelpData.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/HelpData.java
@@ -21,7 +21,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.airlift.airline.Help;
+import com.github.rvesse.airline.help.Help;
 import org.apache.activemq.artemis.cli.commands.Action;
 import org.apache.activemq.artemis.cli.commands.ActionContext;
 import org.apache.activemq.artemis.cli.commands.InvalidOptionsError;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/OptionalLocking.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/OptionalLocking.java
@@ -18,7 +18,7 @@ package org.apache.activemq.artemis.cli.commands.tools;
 
 import java.io.File;
 
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Option;
 
 /**
  * This is for commands where --f on ignoring lock could be valid.

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/PrintData.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/PrintData.java
@@ -27,8 +27,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
 import org.apache.activemq.artemis.api.core.SimpleString;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/RecoverMessages.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/RecoverMessages.java
@@ -20,8 +20,9 @@ import java.io.File;
 import java.util.HashSet;
 import java.util.List;
 
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
+import com.github.rvesse.airline.annotations.restrictions.Required;
 import org.apache.activemq.artemis.api.core.Pair;
 import org.apache.activemq.artemis.cli.commands.ActionContext;
 import org.apache.activemq.artemis.core.config.Configuration;
@@ -48,7 +49,8 @@ public class RecoverMessages extends DBOption {
    @Option(name = "--reclaimed", description = "Try to recover as many records as possible from reclaimed files.")
    private boolean reclaimed = false;
 
-   @Option(name = "--target", description = "Output folder container the new journal with all the generated messages.", required = true)
+   @Option(name = "--target", description = "Output folder container the new journal with all the generated messages.")
+   @Required
    private String outputJournal;
 
 

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/journal/CompactJournal.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/journal/CompactJournal.java
@@ -18,7 +18,7 @@ package org.apache.activemq.artemis.cli.commands.tools.journal;
 
 import java.io.File;
 
-import io.airlift.airline.Command;
+import com.github.rvesse.airline.annotations.Command;
 import org.apache.activemq.artemis.cli.commands.ActionContext;
 import org.apache.activemq.artemis.cli.commands.tools.LockAbstract;
 import org.apache.activemq.artemis.core.config.Configuration;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/journal/DecodeJournal.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/journal/DecodeJournal.java
@@ -27,8 +27,9 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
+import com.github.rvesse.airline.annotations.restrictions.Required;
 import org.apache.activemq.artemis.cli.commands.ActionContext;
 import org.apache.activemq.artemis.cli.commands.tools.LockAbstract;
 import org.apache.activemq.artemis.core.io.nio.NIOSequentialFileFactory;
@@ -51,7 +52,8 @@ public class DecodeJournal extends LockAbstract {
    @Option(name = "--file-size", description = "The journal size. Default: 10485760.")
    public int size = 10485760;
 
-   @Option(name = "--input", description = "The input file name. Default: exp.dmp.", required = true)
+   @Option(name = "--input", description = "The input file name. Default: exp.dmp.")
+   @Required
    public String input = "exp.dmp";
 
    @Override

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/journal/EncodeJournal.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/journal/EncodeJournal.java
@@ -22,8 +22,8 @@ import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.util.List;
 
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.cli.commands.ActionContext;
 import org.apache.activemq.artemis.cli.commands.tools.LockAbstract;
 import org.apache.activemq.artemis.core.io.SequentialFileFactory;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/journal/PerfJournal.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/journal/PerfJournal.java
@@ -18,8 +18,8 @@ package org.apache.activemq.artemis.cli.commands.tools.journal;
 
 import java.text.DecimalFormat;
 
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.cli.commands.ActionContext;
 import org.apache.activemq.artemis.cli.commands.tools.OptionalLocking;
 import org.apache.activemq.artemis.cli.commands.util.SyncCalculation;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/xml/XmlDataExporter.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/xml/XmlDataExporter.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
-import io.airlift.airline.Command;
+import com.github.rvesse.airline.annotations.Command;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
 import org.apache.activemq.artemis.api.core.ICoreMessage;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/xml/XmlDataImporter.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/xml/XmlDataImporter.java
@@ -34,8 +34,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
 
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
+import com.github.rvesse.airline.annotations.restrictions.Required;
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.QueueConfiguration;
 import org.apache.activemq.artemis.api.core.RoutingType;
@@ -106,7 +107,8 @@ public final class XmlDataImporter extends ActionAbstract {
    @Option(name = "--password", description = "User name used to import the data. Default: null.")
    public String password = null;
 
-   @Option(name = "--input", description = "The input file name. Default: exp.dmp.", required = true)
+   @Option(name = "--input", description = "The input file name. Default: exp.dmp.")
+   @Required
    public String input = "exp.dmp";
 
    @Option(name = "--sort", description = "Sort the messages from the input (used for older versions that won't sort messages).")

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/user/AddUser.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/user/AddUser.java
@@ -16,8 +16,8 @@
  */
 package org.apache.activemq.artemis.cli.commands.user;
 
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.management.ManagementHelper;
 import org.apache.activemq.artemis.cli.commands.AbstractAction;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/user/HelpUser.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/user/HelpUser.java
@@ -20,7 +20,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.airlift.airline.Help;
+import com.github.rvesse.airline.help.Help;
 import org.apache.activemq.artemis.cli.commands.Action;
 import org.apache.activemq.artemis.cli.commands.ActionContext;
 import org.apache.activemq.artemis.cli.commands.InvalidOptionsError;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/user/ListUser.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/user/ListUser.java
@@ -19,7 +19,7 @@ package org.apache.activemq.artemis.cli.commands.user;
 import org.apache.activemq.artemis.json.JsonArray;
 import org.apache.activemq.artemis.json.JsonObject;
 
-import io.airlift.airline.Command;
+import com.github.rvesse.airline.annotations.Command;
 import org.apache.activemq.artemis.api.core.JsonUtil;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.management.ManagementHelper;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/user/PasswordAction.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/user/PasswordAction.java
@@ -16,7 +16,7 @@
  */
 package org.apache.activemq.artemis.cli.commands.user;
 
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Option;
 
 public class PasswordAction extends UserAction {
 

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/user/RemoveUser.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/user/RemoveUser.java
@@ -16,7 +16,7 @@
  */
 package org.apache.activemq.artemis.cli.commands.user;
 
-import io.airlift.airline.Command;
+import com.github.rvesse.airline.annotations.Command;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.management.ManagementHelper;
 import org.apache.activemq.artemis.cli.commands.AbstractAction;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/user/ResetUser.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/user/ResetUser.java
@@ -16,8 +16,8 @@
  */
 package org.apache.activemq.artemis.cli.commands.user;
 
-import io.airlift.airline.Command;
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.management.ManagementHelper;
 import org.apache.activemq.artemis.cli.commands.AbstractAction;

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/user/UserAction.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/user/UserAction.java
@@ -16,7 +16,7 @@
  */
 package org.apache.activemq.artemis.cli.commands.user;
 
-import io.airlift.airline.Option;
+import com.github.rvesse.airline.annotations.Option;
 import org.apache.activemq.artemis.cli.commands.AbstractAction;
 
 public abstract class UserAction extends AbstractAction {

--- a/artemis-cli/src/test/java/org/apache/activemq/cli/test/OptionsValidationTest.java
+++ b/artemis-cli/src/test/java/org/apache/activemq/cli/test/OptionsValidationTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.activemq.cli.test;
 
-import io.airlift.airline.ParseArgumentsUnexpectedException;
+import com.github.rvesse.airline.parser.errors.ParseArgumentsUnexpectedException;
 import org.apache.activemq.artemis.cli.Artemis;
 import org.apache.activemq.artemis.cli.commands.ActionContext;
 import org.apache.activemq.artemis.cli.commands.InvalidOptionsError;

--- a/docs/user-manual/en/architecture.md
+++ b/docs/user-manual/en/architecture.md
@@ -60,14 +60,14 @@ Artemis server. User Application 1 is using the JMS API, while User Application
 You can see from the diagram that the JMS API is implemented by a thin facade
 layer on the client side.
 
-## Stand-alone Broker
+## Standalone Broker
 
 The normal stand-alone messaging broker configuration comprises a core
 messaging broker and a number of protocol managers that provide support for the
 various protocol mentioned earlier.
 
-The stand-alone broker configuration uses
-[Airline](https://github.com/airlift/airline) for bootstrapping the Broker.
+The standalone broker configuration uses
+[Airline](http://rvesse.github.io/airline/) for bootstrapping the Broker.
 
 The stand-alone broker architecture is shown in figure 3.3 below:
 

--- a/docs/user-manual/en/embedding-activemq.md
+++ b/docs/user-manual/en/embedding-activemq.md
@@ -125,4 +125,4 @@ Framework. See [Spring Integration](spring-integration.md) for more details on
 Spring and Apache ActiveMQ Artemis.
 
 Apache ActiveMQ Artemis standalone uses
-[Airline](https://github.com/airlift/airline) to bootstrap.
+[Airline](http://rvesse.github.io/airline/) to bootstrap.

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
       <qpid.jms.version>1.9.0</qpid.jms.version>
       <johnzon.version>1.2.16</johnzon.version>
       <hawtbuff.version>1.11</hawtbuff.version>
-      <airlift.version>0.8</airlift.version>
+      <airline.version>2.9.0</airline.version>
       <jakarta.activation-api.version>1.2.2</jakarta.activation-api.version>
       <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
       <jakarta.ejb-api.version>3.2.6</jakarta.ejb-api.version>
@@ -568,17 +568,13 @@
             <!-- License: Apache 2.0 -->
          </dependency>
          <dependency>
-            <groupId>io.airlift</groupId>
+            <groupId>com.github.rvesse</groupId>
             <artifactId>airline</artifactId>
-            <version>${airlift.version}</version>
+            <version>${airline.version}</version>
             <exclusions>
                <exclusion>
-                  <groupId>javax.inject</groupId>
-                  <artifactId>javax.inject</artifactId>
-               </exclusion>
-               <exclusion>
-                  <groupId>com.google.code.findbugs</groupId>
-                  <artifactId>jsr305</artifactId>
+                  <groupId>com.github.rvesse</groupId>
+                  <artifactId>airline-backcompat-javaxinject</artifactId>
                </exclusion>
             </exclusions>
             <!-- License: Apache 2.0 -->


### PR DESCRIPTION
The "Airline" library we're currently using is deprecated according the GitHub project - https://github.com/airlift/airline. It recommends using either Airline 2 or Picocli. The former offers the simplest migration path as it's almost completely compatible with the current code. This commit implements that migration.