### PR TITLE
ARTEMIS-4328 add timeout to test which can hang

### DIFF
--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/embedded/MainTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/embedded/MainTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 public class MainTest {
 
-   @Test(expected = IOException.class)
+   @Test(expected = IOException.class, timeout = 5000)
    public void testNull() throws Exception {
       Main.main(new String[]{});
    }


### PR DESCRIPTION
`org.apache.activemq.artemis.core.server.embedded.MainTest` expects the broker to throw a `java.io.IOException` when it is started due to its inability to find the file app/data/server.lock. However, if that files just happens to exist then the test will simply hang indefinitely. This commit adds a timeout to avoid hanging.