### PR TITLE
ARTEMIS-4332 Add management method to close stuck server sessions

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
@@ -1241,6 +1241,14 @@ public interface ActiveMQServerControl {
                               @Parameter(desc = "The session ID", name = "ID") String ID) throws Exception;
 
    /**
+    * Closes the session with the given id.
+    */
+   @Operation(desc = "Closes the session with the id", impact = MBeanOperationInfo.INFO)
+   boolean closeSessionWithID(@Parameter(desc = "The connection ID", name = "connectionID") String connectionID,
+      @Parameter(desc = "The session ID", name = "ID") String ID,
+      @Parameter(desc = "Force session close cancelling pending tasks", name = "force") boolean force) throws Exception;
+
+   /**
     * Closes the consumer with the given id.
     */
    @Operation(desc = "Closes the consumer with the id", impact = MBeanOperationInfo.INFO)

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -2381,6 +2381,11 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public boolean closeSessionWithID(final String connectionID, final String ID) throws Exception {
+      return closeSessionWithID(connectionID, ID, false);
+   }
+
+   @Override
+   public boolean closeSessionWithID(final String connectionID, final String ID, final boolean force) throws Exception {
       // possibly a long running task
       try (AutoCloseable lock = server.managementLock()) {
          if (AuditLogger.isBaseLoggingEnabled()) {
@@ -2393,7 +2398,7 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
             List<ServerSession> sessions = server.getSessions(connectionID);
             for (ServerSession session : sessions) {
                if (session.getName().equals(ID.toString())) {
-                  session.close(true);
+                  session.close(true, force);
                   return true;
                }
             }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/OperationContext.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/OperationContext.java
@@ -61,4 +61,8 @@ public interface OperationContext extends IOCompletion {
     * @throws Exception
     */
    boolean waitCompletion(long timeout) throws Exception;
+
+   default void clear() {
+
+   }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/OperationContextImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/OperationContextImpl.java
@@ -447,4 +447,27 @@ public class OperationContextImpl implements OperationContext {
          executorsPendingField +
          "]";
    }
+
+   @Override
+   public synchronized void clear() {
+      stored = 0;
+      storeLineUpField = 0;
+      minimalReplicated = 0;
+      replicated = 0;
+      replicationLineUpField = 0;
+      paged = 0;
+      minimalPage = 0;
+      pageLineUpField = 0;
+      errorCode = -1;
+      errorMessage = null;
+      executorsPendingField = 0;
+
+      if (tasks != null) {
+         tasks.clear();
+      }
+
+      if (storeOnlyTasks != null) {
+         storeOnlyTasks.clear();
+      }
+   }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ServerSession.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ServerSession.java
@@ -372,6 +372,8 @@ public interface ServerSession extends SecurityAuth {
 
    void close(boolean failed) throws Exception;
 
+   void close(boolean failed, boolean force) throws Exception;
+
    void setTransferring(boolean transferring);
 
    Set<ServerConsumer> getServerConsumers();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -1707,8 +1707,17 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
 
    @Override
    public void close(final boolean failed) {
+      close(failed, false);
+   }
+
+   @Override
+   public void close(final boolean failed, final boolean force) {
       if (closed)
          return;
+
+      if (force) {
+         context.clear();
+      }
 
       context.executeOnCompletion(new IOCallback() {
          @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
@@ -160,6 +160,11 @@ public class ActiveMQServerControlUsingCoreTest extends ActiveMQServerControlTes
          }
 
          @Override
+         public boolean closeSessionWithID(String connectionID, String ID, boolean force) throws Exception {
+            return (Boolean) proxy.invokeOperation("closeSessionWithID", connectionID, ID, force);
+         }
+
+         @Override
          public boolean closeConsumerWithID(String sessionID, String ID) throws Exception {
             return (Boolean) proxy.invokeOperation("closeConsumerWithID", sessionID, ID);
          }


### PR DESCRIPTION
ARTEMIS-4332 Add management method to close stuck server sessions 
In rare cases a store operation could silently fails or starves, blocking the related server session and all delivering messages. Those server sessions can be closed adding a management method that cleans their operation context before closing them.

This PR also includes an optional commit to track store operations that would help to analyze heap dumps with stuck server sessions: ARTEMIS-4332 Add store operation trackers