### PR TITLE
ARTEMIS-4340: fix ThreadLocalByteBufferPool.borrow zeroing

### DIFF
--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/util/ThreadLocalByteBufferPool.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/util/ThreadLocalByteBufferPool.java
@@ -44,6 +44,7 @@ final class ThreadLocalByteBufferPool implements ByteBufferPool {
       } else {
          bytesPool.set(null);
          if (zeroed) {
+            byteBuffer.clear();
             ByteUtil.zeros(byteBuffer, 0, size);
          }
          byteBuffer.clear();


### PR DESCRIPTION
The report for ARTEMIS-4340 was raised about ByteUtil.uncheckedZeros throwing IndexOutOfBoundsException. Though some of ByteUtil's behaviour can perhaps be questioned around its consistency with different buffer types, in this case the problem ultimately starts earlier in the call tree with org.apache.activemq.artemis.core.io.util.ThreadLocalByteBufferPool.borrow(int, boolean) passing it invalid arguments. It passes in a buffer for zeroing, with its limit still set below the requested size to be zero'd, leading to the IndexOutOfBoundsException in this case when tryign to write beyond the limit. The reason this seemingly long-standing bug has perhaps not been hit so far is that it occurs in a less typical case where the buffer either isnt direct and able to be updated with Unsafe, or also doesnt have an array.

ThreadLocalByteBufferPool should clear position+limit before zeroing the buffer.