### PR TITLE
ARTEMIS-4341 refactor JavaDoc generation

### DIFF
--- a/artemis-commons/pom.xml
+++ b/artemis-commons/pom.xml
@@ -106,6 +106,37 @@
       </dependency>
    </dependencies>
 
+   <profiles>
+      <profile>
+         <id>release</id>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-javadoc-plugin</artifactId>
+                  <configuration>
+                     <useStandardDocletOptions>true</useStandardDocletOptions>
+                     <minmemory>128m</minmemory>
+                     <maxmemory>512m</maxmemory>
+                     <noindex>true</noindex>
+                     <sourceFileIncludes>
+                        <sourceFileInclude>**/org/apache/activemq/artemis/api/**/*.java</sourceFileInclude>
+                     </sourceFileIncludes>
+                  </configuration>
+                  <executions>
+                     <execution>
+                        <id>javadocs</id>
+                        <goals>
+                           <goal>jar</goal>
+                        </goals>
+                     </execution>
+                  </executions>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+   </profiles>
+
    <build>
       <plugins>
          <plugin>

--- a/artemis-core-client/pom.xml
+++ b/artemis-core-client/pom.xml
@@ -153,10 +153,11 @@
                      <minmemory>128m</minmemory>
                      <maxmemory>512m</maxmemory>
                      <noindex>true</noindex>
-                     <quiet>false</quiet>
-                     <aggregate>true</aggregate>
-                     <excludePackageNames>org.apache.activemq.artemis.core:org.apache.activemq.artemis.utils,org.apache.activemq.artemis.commons
-                     </excludePackageNames>
+                     <sourceFileIncludes>
+                        <sourceFileInclude>**/org/apache/activemq/artemis/api/**/*.java</sourceFileInclude>
+                        <sourceFileInclude>**/org/apache/activemq/artemis/spi/**/*.java</sourceFileInclude>
+                        <sourceFileInclude>**/org/apache/activemq/artemis/core/config/**/*.java</sourceFileInclude>
+                     </sourceFileIncludes>
                   </configuration>
                   <executions>
                      <execution>

--- a/artemis-jms-client/pom.xml
+++ b/artemis-jms-client/pom.xml
@@ -95,9 +95,9 @@
                      <minmemory>128m</minmemory>
                      <maxmemory>512m</maxmemory>
                      <noindex>true</noindex>
-                     <quiet>false</quiet>
-                     <aggregate>true</aggregate>
-                     <excludePackageNames>org.apache.activemq.artemis.core:org.apache.activemq.artemis.utils</excludePackageNames>
+                     <sourceFileIncludes>
+                        <sourceFileInclude>**/org/apache/activemq/artemis/api/jms/**/*.java</sourceFileInclude>
+                     </sourceFileIncludes>
                   </configuration>
                   <executions>
                      <execution>

--- a/artemis-jms-server/pom.xml
+++ b/artemis-jms-server/pom.xml
@@ -87,36 +87,4 @@
          <artifactId>jakarta.transaction-api</artifactId>
       </dependency>
    </dependencies>
-
-   <profiles>
-      <profile>
-         <id>release</id>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-javadoc-plugin</artifactId>
-                  <configuration>
-                     <useStandardDocletOptions>true</useStandardDocletOptions>
-                     <minmemory>128m</minmemory>
-                     <maxmemory>512m</maxmemory>
-                     <noindex>true</noindex>
-                     <quiet>false</quiet>
-                     <aggregate>true</aggregate>
-                     <excludePackageNames>org.apache.activemq.artemis.core:org.apache.activemq.artemis.utils</excludePackageNames>
-                  </configuration>
-                  <executions>
-                     <execution>
-                        <id>javadocs</id>
-                        <goals>
-                           <goal>jar</goal>
-                        </goals>
-                     </execution>
-                  </executions>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-   </profiles>
-
 </project>

--- a/artemis-server/pom.xml
+++ b/artemis-server/pom.xml
@@ -309,10 +309,15 @@
                      <minmemory>128m</minmemory>
                      <maxmemory>512m</maxmemory>
                      <noindex>true</noindex>
-                     <quiet>false</quiet>
-                     <aggregate>true</aggregate>
-                     <excludePackageNames>org.apache.activemq.artemis.core:org.apache.activemq.artemis.utils
-                     </excludePackageNames>
+                     <sourceFileIncludes>
+                        <sourceFileInclude>**/org/apache/activemq/artemis/spi/**/*.java</sourceFileInclude>
+                        <sourceFileInclude>**/org/apache/activemq/artemis/core/config/**/*.java</sourceFileInclude>
+                        <sourceFileInclude>**/org/apache/activemq/artemis/core/server/plugin/**/*.java</sourceFileInclude>
+                     </sourceFileIncludes>
+                     <sourceFileExcludes>
+                        <sourceFileExclude>**/impl/**/*.java</sourceFileExclude>
+                        <sourceFileExclude>**/*Impl.java</sourceFileExclude>
+                     </sourceFileExcludes>
                   </configuration>
                   <executions>
                      <execution>

--- a/artemis-website/pom.xml
+++ b/artemis-website/pom.xml
@@ -65,18 +65,15 @@
             </dependency>
             <dependency>
                <groupId>org.apache.activemq</groupId>
-               <artifactId>artemis-jms-server</artifactId>
+               <artifactId>artemis-commons</artifactId>
                <version>${project.version}</version>
             </dependency>
             <dependency>
-               <groupId>org.apache.activemq</groupId>
-               <artifactId>artemis-journal</artifactId>
-               <version>${project.version}</version>
-            </dependency>
-            <dependency>
-               <groupId>org.apache.activemq</groupId>
-               <artifactId>artemis-selector</artifactId>
-               <version>${project.version}</version>
+               <groupId>jakarta.json</groupId>
+               <artifactId>jakarta.json-api</artifactId>
+               <scope>compile</scope>
+               <optional>true</optional>
+               <!-- License: EPL 2.0 -->
             </dependency>
 
             <!-- stuff needed to resolve various classes during javadoc processing -->
@@ -113,19 +110,23 @@
                            <skip>${skipWebsiteJavadocGeneration}</skip>
                            <!-- switch on dependency-driven aggregation -->
                            <includeDependencySources>true</includeDependencySources>
-
                            <dependencySourceIncludes>
                               <!-- include ONLY dependencies I control -->
                               <dependencySourceInclude>org.apache.activemq:artemis-core-client</dependencySourceInclude>
                               <dependencySourceInclude>org.apache.activemq:artemis-jms-client</dependencySourceInclude>
                               <dependencySourceInclude>org.apache.activemq:artemis-server</dependencySourceInclude>
-                              <dependencySourceInclude>org.apache.activemq:artemis-jms-server</dependencySourceInclude>
-                              <dependencySourceInclude>org.apache.activemq:artemis-journal</dependencySourceInclude>
-                              <dependencySourceInclude>org.apache.activemq:artemis-selector</dependencySourceInclude>
+                              <dependencySourceInclude>org.apache.activemq:artemis-commons</dependencySourceInclude>
                            </dependencySourceIncludes>
-                           <aggregate>true</aggregate>
-                           <excludePackageNames>org.apache.activemq.artemis.core:org.apache.activemq.artemis.utils
-                           </excludePackageNames>
+                           <sourceFileIncludes>
+                              <sourceFileInclude>**/org/apache/activemq/artemis/api/**/*.java</sourceFileInclude>
+                              <sourceFileInclude>**/org/apache/activemq/artemis/spi/**/*.java</sourceFileInclude>
+                              <sourceFileInclude>**/org/apache/activemq/artemis/core/config/**/*.java</sourceFileInclude>
+                              <sourceFileInclude>**/org/apache/activemq/artemis/core/server/plugin/**/*.java</sourceFileInclude>
+                           </sourceFileIncludes>
+                           <sourceFileExcludes>
+                              <sourceFileExclude>**/impl/**/*.java</sourceFileExclude>
+                              <sourceFileExclude>**/*Impl.java</sourceFileExclude>
+                           </sourceFileExcludes>
                         </configuration>
                      </execution>
                   </executions>


### PR DESCRIPTION
Currently JavaDoc is generated for many classes that don't need it. JavaDoc should be reserved for user-facing classes (e.g. those used by client application developers and developers embedding a broker into their application). This commit narrows down the configuration to just the classes that are needed. This will save time during release builds, and save disk space wherever these files are stored (e.g. Apache website).