### PR TITLE
ARTEMIS-4353 clean up Maven dependencies

### DIFF
--- a/artemis-boot/pom.xml
+++ b/artemis-boot/pom.xml
@@ -34,12 +34,4 @@
       <activemq.basedir>${project.basedir}/..</activemq.basedir>
    </properties>
 
-   <dependencies>
-      <dependency>
-         <groupId>junit</groupId>
-         <artifactId>junit</artifactId>
-         <scope>test</scope>
-      </dependency>
-   </dependencies>
-
 </project>

--- a/artemis-cdi-client/pom.xml
+++ b/artemis-cdi-client/pom.xml
@@ -68,7 +68,7 @@
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-jms-server</artifactId>
+         <artifactId>artemis-commons</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
@@ -99,16 +99,22 @@
          <groupId>org.jboss.shrinkwrap</groupId>
          <artifactId>shrinkwrap-api</artifactId>
          <version>1.2.6</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.jboss.arquillian.junit</groupId>
          <artifactId>arquillian-junit-container</artifactId>
       </dependency>
       <dependency>
+         <groupId>org.jboss.arquillian.container</groupId>
+         <artifactId>arquillian-container-test-api</artifactId>
+         <version>${arquillian.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-unit-test-support</artifactId>
          <version>${project.version}</version>
-         <scope>test</scope>
       </dependency>
 
       <!-- The johnzon-core and json-api contents are repackaged in -commons,

--- a/artemis-cli/pom.xml
+++ b/artemis-cli/pom.xml
@@ -34,6 +34,10 @@
 
    <dependencies>
       <dependency>
+         <groupId>jakarta.jms</groupId>
+         <artifactId>jakarta.jms-api</artifactId>
+      </dependency>
+      <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
@@ -57,6 +61,11 @@
          <groupId>org.apache.activemq</groupId>
          <artifactId>activemq-artemis-native</artifactId>
          <version>${activemq-artemis-native-version}</version>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-quorum-api</artifactId>
+         <version>${project.version}</version>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
@@ -97,6 +106,23 @@
          <groupId>org.apache.logging.log4j</groupId>
          <artifactId>log4j-slf4j-impl</artifactId>
          <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-common</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-buffer</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-transport</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>jakarta.xml.bind</groupId>
+         <artifactId>jakarta.xml.bind-api</artifactId>
+         <version>${jakarta.xml.bind-api.version}</version>
       </dependency>
 
       <dependency>
@@ -179,7 +205,6 @@
        <plugin>
          <groupId>org.apache.maven.plugins</groupId>
          <artifactId>maven-dependency-plugin</artifactId>
-         <version>2.2</version>
          <executions>
            <execution>
              <id>unpack</id>

--- a/artemis-commons/pom.xml
+++ b/artemis-commons/pom.xml
@@ -77,11 +77,7 @@
       </dependency>
       <dependency>
          <groupId>io.netty</groupId>
-         <artifactId>netty-transport</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>io.netty</groupId>
-         <artifactId>netty-handler</artifactId>
+         <artifactId>netty-common</artifactId>
       </dependency>
       <dependency>
          <groupId>commons-beanutils</groupId>
@@ -90,12 +86,6 @@
       <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
-         <groupId>org.hamcrest</groupId>
-         <artifactId>hamcrest</artifactId>
-         <version>${hamcrest.version}</version>
          <scope>test</scope>
       </dependency>
       <dependency>

--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/PowerOf2UtilTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/PowerOf2UtilTest.java
@@ -16,9 +16,7 @@
  */
 package org.apache.activemq.artemis.utils;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-
+import org.junit.Assert;
 import org.junit.Test;
 
 import static org.apache.activemq.artemis.utils.PowerOf2Util.align;
@@ -28,17 +26,17 @@ public class PowerOf2UtilTest {
    @Test
    public void shouldAlignToNextMultipleOfAlignment() {
       final int alignment = 512;
-      assertThat(align(0, alignment), is(0));
-      assertThat(align(1, alignment), is(alignment));
-      assertThat(align(alignment, alignment), is(alignment));
-      assertThat(align(alignment + 1, alignment), is(alignment * 2));
+      Assert.assertEquals(0, align(0, alignment));
+      Assert.assertEquals(alignment, align(1, alignment));
+      Assert.assertEquals(alignment, align(alignment, alignment));
+      Assert.assertEquals(alignment * 2, align(alignment + 1, alignment));
 
       final int remainder = Integer.MAX_VALUE % alignment;
       final int alignedMax = Integer.MAX_VALUE - remainder;
-      assertThat(align(alignedMax, alignment), is(alignedMax));
+      Assert.assertEquals(alignedMax, align(alignedMax, alignment));
       //given that Integer.MAX_VALUE is the max value that can be represented with int
       //the aligned value would be > 2^32, but (int)(2^32) = Integer.MIN_VALUE due to the sign bit
-      assertThat(align(Integer.MAX_VALUE, alignment), is(Integer.MIN_VALUE));
+      Assert.assertEquals(Integer.MIN_VALUE, align(Integer.MAX_VALUE, alignment));
    }
 
 }

--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/TypedPropertiesTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/TypedPropertiesTest.java
@@ -20,6 +20,8 @@ import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
 import org.apache.activemq.artemis.api.core.SimpleString;
@@ -28,11 +30,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-
 import static org.apache.activemq.artemis.utils.collections.TypedProperties.searchProperty;
-import static org.hamcrest.Matchers.greaterThan;
 
 public class TypedPropertiesTest {
 
@@ -95,7 +93,7 @@ public class TypedPropertiesTest {
       Assert.assertTrue(props.containsProperty(key));
       Assert.assertNotNull(props.getProperty(key));
 
-      Assert.assertThat(props.getEncodeSize(), greaterThan(0));
+      Assert.assertTrue("encodeSize <= " + 0, props.getEncodeSize() > 0);
 
       props.clear();
 

--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/collections/LongHashSetTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/collections/LongHashSetTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.activemq.artemis.utils.collections;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -25,14 +26,6 @@ import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Test;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.core.IsEqual.equalTo;
 
 /**
  * These tests are based on <a href="https://github.com/real-logic/agrona/blob/master/agrona/src/test/java/org/agrona/collections/IntHashSetTest.java">Agrona IntHashSetTest</a>
@@ -297,8 +290,9 @@ public class LongHashSetTest {
 
       Assert.assertTrue("Failed to remove 8", requiredFields.remove(8L));
       Assert.assertTrue("Failed to remove 9", requiredFields.remove(9L));
-
-      assertThat(requiredFields, containsInAnyOrder(35L, 49L, 56L));
+      Assert.assertTrue("requiredFields does not contain " + 35, requiredFields.contains(35L));
+      Assert.assertTrue("requiredFields does not contain " + 49, requiredFields.contains(49L));
+      Assert.assertTrue("requiredFields does not contain " + 56, requiredFields.contains(56L));
    }
 
    @Test
@@ -543,8 +537,8 @@ public class LongHashSetTest {
          }
       }
 
-      assertThat(testSet, contains(1001L));
-      assertThat(testSet, hasSize(1));
+      Assert.assertTrue("testSet does not contain 1001", testSet.contains(1001L));
+      Assert.assertEquals(1, testSet.size());
    }
 
    @Test
@@ -588,7 +582,9 @@ public class LongHashSetTest {
 
       final Long[] result = testSet.toArray(new Long[testSet.size()]);
 
-      assertThat(result, arrayContainingInAnyOrder(1L, 1001L, LongHashSet.MISSING_VALUE));
+      Assert.assertTrue(Arrays.asList(result).contains(1L));
+      Assert.assertTrue(Arrays.asList(result).contains(1001L));
+      Assert.assertTrue(Arrays.asList(result).contains(LongHashSet.MISSING_VALUE));
    }
 
    @Test
@@ -599,7 +595,9 @@ public class LongHashSetTest {
 
       final Object[] result = testSet.toArray();
 
-      assertThat(result, arrayContainingInAnyOrder(1L, 1001L, LongHashSet.MISSING_VALUE));
+      Assert.assertTrue(Arrays.asList(result).contains(1L));
+      Assert.assertTrue(Arrays.asList(result).contains(1001L));
+      Assert.assertTrue(Arrays.asList(result).contains(LongHashSet.MISSING_VALUE));
    }
 
    @Test
@@ -626,14 +624,14 @@ public class LongHashSetTest {
          testSet.add(i);
       }
 
-      assertThat(testSet, hasSize(10_000));
+      Assert.assertEquals(10_000, testSet.size());
 
       int distinctElements = 0;
       for (final long ignore : testSet) {
          distinctElements++;
       }
 
-      assertThat(distinctElements, is(10_000));
+      Assert.assertEquals(10_000, distinctElements);
    }
 
    @Test
@@ -694,7 +692,7 @@ public class LongHashSetTest {
       }
 
       final String mapAsAString = "{1, 19, 11, 7, 3, 12, -2}";
-      assertThat(testSet.toString(), equalTo(mapAsAString));
+      Assert.assertEquals(testSet.toString(), mapAsAString);
    }
 
    @Test
@@ -763,11 +761,13 @@ public class LongHashSetTest {
    }
 
    private static void assertArrayContainingElements(final Long[] result) {
-      assertThat(result, arrayContainingInAnyOrder(1L, 1001L));
+      Assert.assertTrue(Arrays.asList(result).contains(1L));
+      Assert.assertTrue(Arrays.asList(result).contains(1001L));
    }
 
    private static void assertContainsElements(final Set<Long> other) {
-      assertThat(other, containsInAnyOrder(1L, 1001L));
+      Assert.assertTrue(other.contains(1L));
+      Assert.assertTrue(other.contains(1001L));
    }
 
    private void exhaustIterator() {

--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/collections/SparseArrayLinkedListTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/collections/SparseArrayLinkedListTest.java
@@ -22,8 +22,6 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.hamcrest.core.Is.is;
-
 public class SparseArrayLinkedListTest {
 
    private static final int SPARSE_ARRAY_CAPACITY = 4;
@@ -74,7 +72,7 @@ public class SparseArrayLinkedListTest {
       Assert.assertEquals(elements, list.clear(removed::add));
       Assert.assertEquals(1, list.sparseArraysCount());
       Assert.assertEquals(0, list.size());
-      Assert.assertThat(removed, is(expected));
+      Assert.assertEquals(expected, removed);
    }
 
    @Test

--- a/artemis-core-client/pom.xml
+++ b/artemis-core-client/pom.xml
@@ -71,20 +71,22 @@
          <scope>test</scope>
       </dependency>
       <dependency>
-         <groupId>org.hamcrest</groupId>
-         <artifactId>hamcrest</artifactId>
-         <version>${hamcrest.version}</version>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
          <groupId>io.netty</groupId>
          <artifactId>netty-transport-native-epoll</artifactId>
          <classifier>${netty-transport-native-epoll-classifier}</classifier>
       </dependency>
       <dependency>
          <groupId>io.netty</groupId>
+         <artifactId>netty-transport-classes-epoll</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>io.netty</groupId>
          <artifactId>netty-transport-native-kqueue</artifactId>
          <classifier>${netty-transport-native-kqueue-classifier}</classifier>
+      </dependency>
+      <dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-transport-classes-kqueue</artifactId>
       </dependency>
       <dependency>
          <groupId>io.netty</groupId>
@@ -117,6 +119,10 @@
       <dependency>
          <groupId>io.netty</groupId>
          <artifactId>netty-common</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-resolver</artifactId>
       </dependency>
 
       <!-- The johnzon-core and json-api contents are repackaged in -commons,

--- a/artemis-core-client/src/test/java/org/apache/activemq/artemis/api/core/TransportConfigurationTest.java
+++ b/artemis-core-client/src/test/java/org/apache/activemq/artemis/api/core/TransportConfigurationTest.java
@@ -26,10 +26,6 @@ import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 public class TransportConfigurationTest {
 
    @Test
@@ -95,7 +91,7 @@ public class TransportConfigurationTest {
 
       TransportConfiguration configuration = new TransportConfiguration("SomeClass", params, null);
 
-      assertThat(configuration.toString(), not(containsString("secret_password")));
+      Assert.assertFalse("configuration contains secret_password", configuration.toString().contains("secret_password"));
    }
 
    @Test

--- a/artemis-core-client/src/test/java/org/apache/activemq/artemis/message/CoreMessageTest.java
+++ b/artemis-core-client/src/test/java/org/apache/activemq/artemis/message/CoreMessageTest.java
@@ -37,9 +37,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
-
 public class CoreMessageTest {
 
    public static final SimpleString ADDRESS = new SimpleString("this.local.address");
@@ -371,8 +368,8 @@ public class CoreMessageTest {
       copy.putBytesProperty(Message.HDR_ROUTE_TO_IDS, new byte[Long.BYTES]);
       final int increasedMemoryFootprint = copy.getMemoryEstimate() - memoryEstimate;
       final int increasedPropertyFootprint = copy.getProperties().getMemoryOffset() - msg.getProperties().getMemoryOffset();
-      assertThat("memory estimation isn't accounting for the additional encoded property",
-                 increasedMemoryFootprint, greaterThan(increasedPropertyFootprint));
+      Assert.assertTrue("memory estimation isn't accounting for the additional encoded property",
+                 increasedMemoryFootprint > increasedPropertyFootprint);
    }
 
    @Test

--- a/artemis-core-client/src/test/java/org/apache/activemq/artemis/util/XidCodecSupportTest.java
+++ b/artemis-core-client/src/test/java/org/apache/activemq/artemis/util/XidCodecSupportTest.java
@@ -23,12 +23,11 @@ import org.apache.activemq.artemis.core.transaction.impl.XidImpl;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
 import org.apache.activemq.artemis.utils.XidCodecSupport;
 import org.apache.activemq.artemis.api.core.ActiveMQInvalidBufferException;
+import org.junit.Assert;
 import org.junit.Test;
 
 import javax.transaction.xa.Xid;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.fail;
 
 public class XidCodecSupportTest {
@@ -41,11 +40,11 @@ public class XidCodecSupportTest {
       final ActiveMQBuffer buffer = ActiveMQBuffers.dynamicBuffer(0);
       XidCodecSupport.encodeXid(VALID_XID, buffer);
 
-      assertThat(buffer.readableBytes(), equalTo(51)); // formatId(4) + branchQualLength(4) + branchQual(3) +
+      Assert.assertEquals(51, buffer.readableBytes()); // formatId(4) + branchQualLength(4) + branchQual(3) +
       // globalTxIdLength(4) + globalTx(36)
 
       final Xid readXid = XidCodecSupport.decodeXid(buffer);
-      assertThat(readXid, equalTo(VALID_XID));
+      Assert.assertEquals(VALID_XID, readXid);
    }
 
    @Test

--- a/artemis-jdbc-store/pom.xml
+++ b/artemis-jdbc-store/pom.xml
@@ -58,6 +58,10 @@
          <artifactId>artemis-core-client</artifactId>
          <version>${project.version}</version>
       </dependency>
+      <dependency>
+         <groupId>commons-beanutils</groupId>
+         <artifactId>commons-beanutils</artifactId>
+      </dependency>
 
       <!-- Default DataSource for database -->
       <dependency>

--- a/artemis-jms-client/pom.xml
+++ b/artemis-jms-client/pom.xml
@@ -80,6 +80,11 @@
          <version>${project.version}</version>
          <scope>test</scope>
       </dependency>
+      <dependency>
+         <groupId>commons-beanutils</groupId>
+         <artifactId>commons-beanutils</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
 
    <profiles>

--- a/artemis-journal/src/test/java/org/apache/activemq/artemis/core/journal/impl/ObjIntIntArrayListTest.java
+++ b/artemis-journal/src/test/java/org/apache/activemq/artemis/core/journal/impl/ObjIntIntArrayListTest.java
@@ -22,9 +22,7 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 public class ObjIntIntArrayListTest {
 
@@ -56,9 +54,9 @@ public class ObjIntIntArrayListTest {
          cList.add(c);
          Assert.assertSame(expectedArg, arg);
       }, expectedArg);
-      assertThat(aList, equalTo(expectedAList));
-      assertThat(bList, equalTo(expectedBList));
-      assertThat(cList, equalTo(expectedCList));
+      assertEquals(expectedAList, aList);
+      assertEquals(expectedBList, bList);
+      assertEquals(expectedCList, cList);
    }
 
    @Test(expected = NullPointerException.class)

--- a/artemis-junit/artemis-junit-5/pom.xml
+++ b/artemis-junit/artemis-junit-5/pom.xml
@@ -57,7 +57,7 @@
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-jms-server</artifactId>
+         <artifactId>artemis-core-client</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
@@ -86,11 +86,6 @@
          <artifactId>artemis-unit-test-support</artifactId>
          <version>${project.version}</version>
          <scope>test</scope>
-      </dependency>
-
-      <dependency>
-         <groupId>jakarta.jms</groupId>
-         <artifactId>jakarta.jms-api</artifactId>
       </dependency>
 
       <dependency>

--- a/artemis-log-annotation-processor/pom.xml
+++ b/artemis-log-annotation-processor/pom.xml
@@ -41,6 +41,7 @@
       <dependency>
          <groupId>org.slf4j</groupId>
          <artifactId>slf4j-api</artifactId>
+         <scope>test</scope>
          <!-- License: MIT -->
       </dependency>
       <dependency>

--- a/artemis-protocols/artemis-amqp-protocol/pom.xml
+++ b/artemis-protocols/artemis-amqp-protocol/pom.xml
@@ -81,11 +81,6 @@
          <artifactId>proton-j</artifactId>
       </dependency>
       <dependency>
-         <groupId>commons-collections</groupId>
-         <artifactId>commons-collections</artifactId>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
          <scope>test</scope>
@@ -97,6 +92,10 @@
       <dependency>
          <groupId>io.netty</groupId>
          <artifactId>netty-transport</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-common</artifactId>
       </dependency>
       <dependency>
          <groupId>org.osgi</groupId>

--- a/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/sasl/SCRAMTest.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/sasl/SCRAMTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.activemq.artemis.protocol.amqp.sasl;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -40,7 +39,6 @@ import org.apache.activemq.artemis.spi.core.security.scram.ScramException;
 import org.apache.activemq.artemis.spi.core.security.scram.ScramUtils;
 import org.apache.activemq.artemis.spi.core.security.scram.UserData;
 import org.apache.qpid.proton.codec.DecodeException;
-import org.hamcrest.core.IsInstanceOf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -115,7 +113,7 @@ public class SCRAMTest {
       assertNull(serverFinal);
       assertNotNull(serverSASL.result());
       assertFalse(serverSASL.result().isSuccess());
-      assertThat(serverSASL.exception, IsInstanceOf.instanceOf(ScramException.class));
+      assertTrue(serverSASL.exception + " is not an instance of ScramException", serverSASL.exception instanceof ScramException);
    }
 
    @Test(expected = DecodeException.class)

--- a/artemis-protocols/artemis-hqclient-protocol/pom.xml
+++ b/artemis-protocols/artemis-hqclient-protocol/pom.xml
@@ -43,6 +43,10 @@
          <version>${project.version}</version>
       </dependency>
       <dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-buffer</artifactId>
+      </dependency>
+      <dependency>
          <groupId>org.osgi</groupId>
          <artifactId>osgi.cmpn</artifactId>
       </dependency>

--- a/artemis-protocols/artemis-openwire-protocol/pom.xml
+++ b/artemis-protocols/artemis-openwire-protocol/pom.xml
@@ -82,6 +82,15 @@
          <version>${project.version}</version>
       </dependency>
       <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-selector</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+         <groupId>jakarta.jms</groupId>
+         <artifactId>jakarta.jms-api</artifactId>
+      </dependency>
+      <dependency>
          <groupId>org.fusesource.hawtbuf</groupId>
          <artifactId>hawtbuf</artifactId>
       </dependency>

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireMessageConverter.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireMessageConverter.java
@@ -38,7 +38,6 @@ import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
 import java.util.zip.InflaterOutputStream;
 
-import com.google.common.io.BaseEncoding;
 import org.apache.activemq.ScheduledMessage;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQPropertyConversionException;
@@ -52,6 +51,7 @@ import org.apache.activemq.artemis.core.protocol.openwire.util.OpenWireUtil;
 import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
 import org.apache.activemq.artemis.core.server.MessageReference;
 import org.apache.activemq.artemis.reader.MessageUtil;
+import org.apache.activemq.artemis.utils.ByteUtil;
 import org.apache.activemq.artemis.utils.DataConstants;
 import org.apache.activemq.artemis.utils.UUID;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
@@ -949,7 +949,7 @@ public final class OpenWireMessageConverter {
             if (prop instanceof SimpleString) {
                amqMsg.setObjectProperty(keyStr, prop.toString());
             } else if (prop instanceof byte[]) {
-               amqMsg.setObjectProperty(keyStr,  BaseEncoding.base16().encode((byte[])prop));
+               amqMsg.setObjectProperty(keyStr, ByteUtil.bytesToHex((byte[])prop));
             } else if (keyStr.equals(MessageUtil.JMSXDELIVERYCOUNT) && prop instanceof Long) {
                Long l = (Long) prop;
                amqMsg.setObjectProperty(keyStr, l.intValue());

--- a/artemis-protocols/artemis-stomp-protocol/pom.xml
+++ b/artemis-protocols/artemis-stomp-protocol/pom.xml
@@ -72,10 +72,6 @@
       </dependency>
       <dependency>
          <groupId>io.netty</groupId>
-         <artifactId>netty-buffer</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>io.netty</groupId>
          <artifactId>netty-transport</artifactId>
       </dependency>
       <dependency>

--- a/artemis-quorum-ri/pom.xml
+++ b/artemis-quorum-ri/pom.xml
@@ -34,6 +34,10 @@
    <dependencies>
       <dependency>
          <groupId>org.apache.curator</groupId>
+         <artifactId>curator-framework</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.curator</groupId>
          <artifactId>curator-recipes</artifactId>
       </dependency>
       <dependency>
@@ -43,6 +47,11 @@
       <dependency>
          <groupId>org.apache.zookeeper</groupId>
          <artifactId>zookeeper</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.zookeeper</groupId>
+         <artifactId>zookeeper-jute</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.curator</groupId>
@@ -71,11 +80,6 @@
          <artifactId>log4j-slf4j-impl</artifactId>
          <scope>test</scope>
       </dependency>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-commons</artifactId>
-         <version>${project.version}</version>
-      </dependency>
 
       <!-- tests -->
       <dependency>
@@ -87,12 +91,6 @@
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-unit-test-support</artifactId>
          <version>${project.version}</version>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
-         <groupId>org.hamcrest</groupId>
-         <artifactId>hamcrest</artifactId>
-         <version>${hamcrest.version}</version>
          <scope>test</scope>
       </dependency>
    </dependencies>

--- a/artemis-quorum-ri/src/test/java/org/apache/activemq/artemis/quorum/DistributedLockTest.java
+++ b/artemis-quorum-ri/src/test/java/org/apache/activemq/artemis/quorum/DistributedLockTest.java
@@ -31,9 +31,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-
 public abstract class DistributedLockTest {
 
    private final ArrayList<AutoCloseable> closeables = new ArrayList<>();
@@ -222,7 +219,7 @@ public abstract class DistributedLockTest {
       final long timeoutSec = 1;
       Assert.assertFalse(manager.getDistributedLock("a").tryLock(timeoutSec, TimeUnit.SECONDS));
       final long elapsed = TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - start);
-      assertThat(elapsed, greaterThanOrEqualTo(timeoutSec));
+      Assert.assertTrue(elapsed + " less than timeout of " + timeoutSec + " seconds", elapsed >= timeoutSec);
    }
 
    @Test

--- a/artemis-quorum-ri/src/test/java/org/apache/activemq/artemis/quorum/zookeeper/CuratorDistributedLockTest.java
+++ b/artemis-quorum-ri/src/test/java/org/apache/activemq/artemis/quorum/zookeeper/CuratorDistributedLockTest.java
@@ -27,9 +27,9 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import com.google.common.base.Predicates;
 import org.apache.activemq.artemis.quorum.DistributedLock;
 import org.apache.activemq.artemis.quorum.DistributedPrimitiveManager;
 import org.apache.activemq.artemis.quorum.UnavailableStateException;
@@ -48,7 +48,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import static java.lang.Boolean.TRUE;
-import static org.hamcrest.Matchers.greaterThan;
 
 @RunWith(value = Parameterized.class)
 public class CuratorDistributedLockTest extends DistributedLockTest {
@@ -183,7 +182,7 @@ public class CuratorDistributedLockTest extends DistributedLockTest {
 
    @Test
    public void canAcquireLockOnMajorityRestart() throws Exception {
-      Assume.assumeThat(zkNodes, greaterThan(1));
+      Assume.assumeTrue(zkNodes + " <= 1", zkNodes > 1);
       final DistributedPrimitiveManager manager = createManagedDistributeManager();
       manager.start();
       final DistributedLock lock = manager.getDistributedLock("a");
@@ -206,7 +205,7 @@ public class CuratorDistributedLockTest extends DistributedLockTest {
 
    @Test
    public void cannotStartManagerWithoutQuorum() throws Exception {
-      Assume.assumeThat(zkNodes, greaterThan(1));
+      Assume.assumeTrue(zkNodes + " <= 1", zkNodes > 1);
       DistributedPrimitiveManager manager = createManagedDistributeManager();
       stopMajorityNotLeaderNodes(true);
       Assert.assertFalse(manager.start(2, TimeUnit.SECONDS));
@@ -215,7 +214,7 @@ public class CuratorDistributedLockTest extends DistributedLockTest {
 
    @Test(expected = UnavailableStateException.class)
    public void cannotAcquireLockWithoutQuorum() throws Exception {
-      Assume.assumeThat(zkNodes, greaterThan(1));
+      Assume.assumeTrue(zkNodes + " <= 1", zkNodes > 1);
       DistributedPrimitiveManager manager = createManagedDistributeManager();
       manager.start();
       stopMajorityNotLeaderNodes(true);
@@ -225,7 +224,7 @@ public class CuratorDistributedLockTest extends DistributedLockTest {
 
    @Test
    public void cannotCheckLockWithoutQuorum() throws Exception {
-      Assume.assumeThat(zkNodes, greaterThan(1));
+      Assume.assumeTrue(zkNodes + " <= 1", zkNodes > 1);
       DistributedPrimitiveManager manager = createManagedDistributeManager();
       manager.start();
       stopMajorityNotLeaderNodes(true);
@@ -241,7 +240,7 @@ public class CuratorDistributedLockTest extends DistributedLockTest {
 
    @Test
    public void canGetLockWithoutQuorum() throws Exception {
-      Assume.assumeThat(zkNodes, greaterThan(1));
+      Assume.assumeTrue(zkNodes + " <= 1", zkNodes > 1);
       DistributedPrimitiveManager manager = createManagedDistributeManager();
       manager.start();
       stopMajorityNotLeaderNodes(true);
@@ -251,7 +250,7 @@ public class CuratorDistributedLockTest extends DistributedLockTest {
 
    @Test
    public void notifiedAsUnavailableWhileLoosingQuorum() throws Exception {
-      Assume.assumeThat(zkNodes, greaterThan(1));
+      Assume.assumeTrue(zkNodes + " <= 1", zkNodes > 1);
       DistributedPrimitiveManager manager = createManagedDistributeManager();
       manager.start();
       DistributedLock lock = manager.getDistributedLock("a");
@@ -263,7 +262,7 @@ public class CuratorDistributedLockTest extends DistributedLockTest {
 
    @Test
    public void beNotifiedOnce() throws Exception {
-      Assume.assumeThat(zkNodes, greaterThan(1));
+      Assume.assumeTrue(zkNodes + " <= 1", zkNodes > 1);
       DistributedPrimitiveManager manager = createManagedDistributeManager();
       manager.start();
       DistributedLock lock = manager.getDistributedLock("a");
@@ -279,7 +278,7 @@ public class CuratorDistributedLockTest extends DistributedLockTest {
 
    @Test
    public void beNotifiedOfUnavailabilityWhileBlockedOnTimedLock() throws Exception {
-      Assume.assumeThat(zkNodes, greaterThan(1));
+      Assume.assumeTrue(zkNodes + " <= 1", zkNodes > 1);
       DistributedPrimitiveManager manager = createManagedDistributeManager();
       manager.start();
       DistributedLock lock = manager.getDistributedLock("a");
@@ -315,7 +314,7 @@ public class CuratorDistributedLockTest extends DistributedLockTest {
 
    @Test
    public void beNotifiedOfAlreadyUnavailableManagerAfterAddingListener() throws Exception {
-      Assume.assumeThat(zkNodes, greaterThan(1));
+      Assume.assumeTrue(zkNodes + " <= 1", zkNodes > 1);
       DistributedPrimitiveManager manager = createManagedDistributeManager();
       manager.start();
       final AtomicBoolean unavailable = new AtomicBoolean(false);
@@ -351,7 +350,7 @@ public class CuratorDistributedLockTest extends DistributedLockTest {
    }
 
    private void stopMajorityNotLeaderNodes(boolean fromLast) throws Exception {
-      List<TestingZooKeeperServer> followers = testingServer.getServers().stream().filter(Predicates.not(CuratorDistributedLockTest::isLeader)).collect(Collectors.toList());
+      List<TestingZooKeeperServer> followers = testingServer.getServers().stream().filter(Predicate.not(CuratorDistributedLockTest::isLeader)).collect(Collectors.toList());
       final int quorum = (zkNodes / 2) + 1;
       for (int i = 0; i < quorum; i++) {
          final int nodeIndex = fromLast ? (followers.size() - 1) - i : i;

--- a/artemis-selector/pom.xml
+++ b/artemis-selector/pom.xml
@@ -48,6 +48,11 @@
          <scope>test</scope>
       </dependency>
       <dependency>
+         <groupId>org.slf4j</groupId>
+         <artifactId>slf4j-api</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-unit-test-support</artifactId>
          <version>${project.version}</version>

--- a/artemis-server/pom.xml
+++ b/artemis-server/pom.xml
@@ -112,11 +112,6 @@
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>activemq-artemis-native</artifactId>
-         <version>${activemq-artemis-native-version}</version>
-      </dependency>
-      <dependency>
          <groupId>org.jctools</groupId>
          <artifactId>jctools-core</artifactId>
       </dependency>
@@ -147,8 +142,16 @@
       </dependency>
       <dependency>
          <groupId>io.netty</groupId>
+         <artifactId>netty-transport-classes-epoll</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>io.netty</groupId>
          <artifactId>netty-transport-native-kqueue</artifactId>
          <classifier>${netty-transport-native-kqueue-classifier}</classifier>
+      </dependency>
+      <dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-transport-classes-kqueue</artifactId>
       </dependency>
       <dependency>
          <groupId>io.netty</groupId>
@@ -160,11 +163,25 @@
       </dependency>
       <dependency>
          <groupId>org.apache.commons</groupId>
+         <artifactId>commons-lang3</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.commons</groupId>
          <artifactId>commons-configuration2</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>commons-collections</groupId>
+         <artifactId>commons-collections</artifactId>
       </dependency>
       <dependency>
          <groupId>io.micrometer</groupId>
          <artifactId>micrometer-core</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>activemq-artemis-native</artifactId>
+         <version>${activemq-artemis-native-version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>commons-io</groupId>
@@ -236,12 +253,6 @@
          <artifactId>mockito-core</artifactId>
          <scope>test</scope>
       </dependency>
-      <dependency>
-         <groupId>org.hamcrest</groupId>
-         <artifactId>hamcrest</artifactId>
-         <version>${hamcrest.version}</version>
-         <scope>test</scope>
-      </dependency>
 
       <!-- The johnzon-core and json-api contents are repackaged in -commons,
            However maven can still need them during tests, which run against
@@ -268,6 +279,24 @@
                <artifactId>json-smart</artifactId>
             </exclusion>
          </exclusions>
+      </dependency>
+      <dependency>
+         <groupId>org.mock-server</groupId>
+         <artifactId>mockserver-core</artifactId>
+         <version>${mockserver.version}</version>
+         <scope>test</scope>
+         <exclusions>
+            <exclusion>
+               <groupId>net.minidev</groupId>
+               <artifactId>json-smart</artifactId>
+            </exclusion>
+         </exclusions>
+      </dependency>
+      <dependency>
+         <groupId>org.mock-server</groupId>
+         <artifactId>mockserver-client-java</artifactId>
+         <version>${mockserver.version}</version>
+         <scope>test</scope>
       </dependency>
       <!-- bcprov-jdk18on replaces bcprov-jdk15on excluded from apacheds-protocol-ldap -->
       <dependency>

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/BridgeConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/BridgeConfigurationTest.java
@@ -26,8 +26,7 @@ import org.apache.activemq.artemis.json.JsonObject;
 import org.apache.activemq.artemis.json.JsonObjectBuilder;
 import org.apache.activemq.artemis.json.JsonValue;
 import java.io.StringReader;
-
-import static org.hamcrest.Matchers.containsInAnyOrder;
+import java.util.Set;
 
 public class BridgeConfigurationTest {
 
@@ -47,7 +46,9 @@ public class BridgeConfigurationTest {
       Assert.assertEquals("dg", bridgeConfiguration.getDiscoveryGroupName());
       Assert.assertTrue(bridgeConfiguration.isHA());
       Assert.assertEquals("ClassName", bridgeConfiguration.getTransformerConfiguration().getClassName());
-      Assert.assertThat(bridgeConfiguration.getTransformerConfiguration().getProperties().keySet(), containsInAnyOrder("prop1", "prop2"));
+      Set keys = bridgeConfiguration.getTransformerConfiguration().getProperties().keySet();
+      Assert.assertTrue(keys + " doesn't contain prop1", keys.contains("prop1"));
+      Assert.assertTrue(keys + " doesn't contain prop2", keys.contains("prop2"));
       Assert.assertEquals("val1", bridgeConfiguration.getTransformerConfiguration().getProperties().get("prop1"));
       Assert.assertEquals("val2", bridgeConfiguration.getTransformerConfiguration().getProperties().get("prop2"));
       Assert.assertEquals(1, bridgeConfiguration.getRetryInterval());

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/HAPolicyConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/HAPolicyConfigurationTest.java
@@ -51,12 +51,8 @@ import org.apache.activemq.artemis.quorum.DistributedPrimitiveManager;
 import org.apache.activemq.artemis.quorum.MutableLong;
 import org.apache.activemq.artemis.quorum.UnavailableStateException;
 import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsInstanceOf;
 import org.junit.After;
 import org.junit.Test;
-
-import static org.hamcrest.CoreMatchers.instanceOf;
 
 public class HAPolicyConfigurationTest extends ActiveMQTestBase {
 
@@ -76,7 +72,7 @@ public class HAPolicyConfigurationTest extends ActiveMQTestBase {
       assertEquals(HAPolicyConfiguration.TYPE.LIVE_ONLY, server.getConfiguration().getHAPolicyConfiguration().getType());
       try {
          server.start();
-         assertThat(server.getNodeManager(), instanceOf(FileLockNodeManager.class));
+         assertTrue(server.getNodeManager() + " is not an instance of FileLockNodeManager", server.getNodeManager() instanceof FileLockNodeManager);
       } finally {
          server.stop();
       }
@@ -340,7 +336,7 @@ public class HAPolicyConfigurationTest extends ActiveMQTestBase {
          DistributedPrimitiveManager manager = ((ReplicationPrimaryActivation) activation).getDistributedManager();
          assertNotNull(manager);
          assertEquals(FakeDistributedPrimitiveManager.class.getName(), manager.getClass().getName());
-         MatcherAssert.assertThat(manager, IsInstanceOf.instanceOf(FakeDistributedPrimitiveManager.class));
+         assertTrue(manager + " is not an instance of FakeDistributedPrimitiveManager", manager instanceof FakeDistributedPrimitiveManager);
          FakeDistributedPrimitiveManager forwardingManager = (FakeDistributedPrimitiveManager) manager;
          // validate manager config
          validateManagerConfig(forwardingManager.getConfig());
@@ -396,7 +392,7 @@ public class HAPolicyConfigurationTest extends ActiveMQTestBase {
          DistributedPrimitiveManager manager = ((ReplicationBackupActivation) activation).getDistributedManager();
          assertNotNull(manager);
          assertEquals(FakeDistributedPrimitiveManager.class.getName(), manager.getClass().getName());
-         MatcherAssert.assertThat(manager, IsInstanceOf.instanceOf(FakeDistributedPrimitiveManager.class));
+         assertTrue(manager instanceof FakeDistributedPrimitiveManager);
          FakeDistributedPrimitiveManager forwardingManager = (FakeDistributedPrimitiveManager) manager;
          // validate manager config
          validateManagerConfig(forwardingManager.getConfig());

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalStorageManagerTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalStorageManagerTest.java
@@ -42,7 +42,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import static java.util.stream.Collectors.toList;
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -127,12 +126,12 @@ public class JournalStorageManagerTest extends ActiveMQTestBase {
          directBuffer.writerIndex(size);
          long fileSize = file.size();
          manager.addBytesToLargeMessage(file, 1, directBuffer);
-         Assert.assertThat(file.size(), is(fileSize + size));
+         Assert.assertEquals(fileSize + size, file.size());
          fileSize = file.size();
          final ActiveMQBuffer heapBuffer = ActiveMQBuffers.wrappedBuffer(new byte[size]);
          heapBuffer.writerIndex(size);
          manager.addBytesToLargeMessage(file, 1, heapBuffer);
-         Assert.assertThat(file.size(), is(fileSize + size));
+         Assert.assertEquals(fileSize + size, file.size());
       } finally {
          manager.stop();
          file.close();

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImplTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImplTest.java
@@ -26,9 +26,6 @@ import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.collection.IsEmptyCollection.empty;
-
 public class ActiveMQServerImplTest extends ActiveMQTestBase {
 
    @Test
@@ -38,7 +35,7 @@ public class ActiveMQServerImplTest extends ActiveMQTestBase {
       EmbeddedServerTest.FakeExternalComponent component = new EmbeddedServerTest.FakeExternalComponent();
       server.addExternalComponent(component, true);
       Assert.assertTrue(component.isStarted());
-      Assert.assertThat(server.getExternalComponents(), hasItem(component));
+      Assert.assertTrue(server.getExternalComponents() + " does not contain " + component, server.getExternalComponents().contains(component));
    }
 
    @Test
@@ -48,7 +45,7 @@ public class ActiveMQServerImplTest extends ActiveMQTestBase {
       EmbeddedServerTest.FakeExternalComponent component = new EmbeddedServerTest.FakeExternalComponent();
       server.addExternalComponent(component, false);
       Assert.assertFalse(component.isStarted());
-      Assert.assertThat(server.getExternalComponents(), hasItem(component));
+      Assert.assertTrue(server.getExternalComponents() + " does not contain " + component, server.getExternalComponents().contains(component));
    }
 
    @Test
@@ -60,7 +57,7 @@ public class ActiveMQServerImplTest extends ActiveMQTestBase {
          Assert.fail();
       } catch (IllegalStateException ex) {
          Assert.assertFalse(component.isStarted());
-         Assert.assertThat(server.getExternalComponents(), empty());
+         Assert.assertEquals(0, server.getExternalComponents().size());
       }
    }
 
@@ -75,7 +72,7 @@ public class ActiveMQServerImplTest extends ActiveMQTestBase {
          Assert.fail();
       } catch (IllegalStateException ex) {
          Assert.assertFalse(component.isStarted());
-         Assert.assertThat(server.getExternalComponents(), empty());
+         Assert.assertEquals(0, server.getExternalComponents().size());
       }
    }
 

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/jdbc/JdbcLeaseLockTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/jdbc/JdbcLeaseLockTest.java
@@ -40,7 +40,6 @@ import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.Wait;
 import org.apache.activemq.artemis.utils.actors.ArtemisExecutor;
 import org.apache.activemq.artemis.utils.actors.OrderedExecutorFactory;
-import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -49,11 +48,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
-
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.lessThan;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
 
 @RunWith(Parameterized.class)
 public class JdbcLeaseLockTest extends ActiveMQTestBase {
@@ -366,7 +360,7 @@ public class JdbcLeaseLockTest extends ActiveMQTestBase {
       scheduledLeaseLock.lock().release();
       Assert.assertFalse(scheduledLeaseLock.lock().isHeldByCaller());
       TimeUnit.MILLISECONDS.sleep(3 * scheduledLeaseLock.renewPeriodMillis());
-      MatcherAssert.assertThat(lostLock.get(), is(greaterThanOrEqualTo(2L)));
+      Assert.assertTrue(lostLock.get() + " < 2", lostLock.get() >= 2L);
       scheduledLeaseLock.stop();
       executorService.shutdown();
       scheduledExecutorService.shutdown();
@@ -375,14 +369,14 @@ public class JdbcLeaseLockTest extends ActiveMQTestBase {
    @Test
    public void shouldJdbcAndSystemTimeToBeAligned() throws InterruptedException {
       final LeaseLock lock = lock(TimeUnit.SECONDS.toMillis(10), TimeUnit.SECONDS.toMillis(10));
-      Assume.assumeThat(lock, instanceOf(JdbcLeaseLock.class));
+      Assume.assumeTrue(lock + " is not an instance of JdbcLeaseLock", lock instanceof JdbcLeaseLock);
       final JdbcLeaseLock jdbcLock = JdbcLeaseLock.class.cast(lock);
       final long utcSystemTime = System.currentTimeMillis();
       TimeUnit.SECONDS.sleep(1);
       final long utcJdbcTime = jdbcLock.dbCurrentTimeMillis();
       final long millisDiffJdbcSystem = utcJdbcTime - utcSystemTime;
-      MatcherAssert.assertThat(millisDiffJdbcSystem, greaterThanOrEqualTo(0L));
-      MatcherAssert.assertThat(millisDiffJdbcSystem, lessThan(TimeUnit.SECONDS.toMillis(10)));
+      Assert.assertTrue(millisDiffJdbcSystem + " < 0", millisDiffJdbcSystem >= 0L);
+      Assert.assertTrue(millisDiffJdbcSystem + " >= 10_000", millisDiffJdbcSystem < 10_000);
    }
 
    @Test

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/spi/core/security/jaas/HttpServerAuthenticatorTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/spi/core/security/jaas/HttpServerAuthenticatorTest.java
@@ -34,9 +34,7 @@ import static org.apache.activemq.artemis.spi.core.security.jaas.HttpServerAuthe
 import static org.apache.activemq.artemis.spi.core.security.jaas.HttpServerAuthenticator.DEFAULT_SUBJECT_ATTRIBUTE;
 import static org.apache.activemq.artemis.spi.core.security.jaas.HttpServerAuthenticator.REALM_PROPERTY_NAME;
 import static org.apache.activemq.artemis.spi.core.security.jaas.HttpServerAuthenticator.REQUEST_SUBJECT_ATTRIBUTE_PROPERTY_NAME;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -87,14 +85,14 @@ public class HttpServerAuthenticatorTest {
       Authenticator.Result result = underTest.authenticate(httpsExchange);
 
       assertTrue(result instanceof Authenticator.Success);
-      assertThat(((Authenticator.Success) result).getPrincipal().getUsername(), is("foo"));
+      assertEquals("foo", ((Authenticator.Success) result).getPrincipal().getUsername());
 
       Subject subject = (Subject) httpsExchange.getAttribute(DEFAULT_SUBJECT_ATTRIBUTE);
 
-      assertThat(subject.getPrincipals(UserPrincipal.class), hasSize(1));
-      subject.getPrincipals(UserPrincipal.class).forEach(p -> assertThat(p.getName(), is("foo")));
+      assertEquals(1, subject.getPrincipals(UserPrincipal.class).size());
+      subject.getPrincipals(UserPrincipal.class).forEach(p -> assertEquals("foo", p.getName()));
       Set<RolePrincipal> roles = subject.getPrincipals(RolePrincipal.class);
-      assertThat(roles, hasSize(1));
+      assertEquals(1, roles.size());
    }
 
    @Test
@@ -118,15 +116,15 @@ public class HttpServerAuthenticatorTest {
       Authenticator.Result result = underTest.authenticate(httpsExchange);
 
       assertTrue(result instanceof Authenticator.Success);
-      assertThat(((Authenticator.Success) result).getPrincipal().getUsername(), is("first"));
+      assertEquals("first", ((Authenticator.Success) result).getPrincipal().getUsername());
 
       Subject subject = (Subject) httpsExchange.getAttribute(DEFAULT_SUBJECT_ATTRIBUTE);
 
-      assertThat(subject.getPrincipals(UserPrincipal.class), hasSize(1));
-      subject.getPrincipals(UserPrincipal.class).forEach(p -> assertThat(p.getName(), is("first")));
+      assertEquals(1, subject.getPrincipals(UserPrincipal.class).size());
+      subject.getPrincipals(UserPrincipal.class).forEach(p -> assertEquals("first", p.getName()));
 
       Set<RolePrincipal> roles = subject.getPrincipals(RolePrincipal.class);
-      assertThat(roles, hasSize(2));
+      assertEquals(2, roles.size());
    }
 
 

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/spi/core/security/jaas/KubernetesLoginModuleTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/spi/core/security/jaas/KubernetesLoginModuleTest.java
@@ -17,11 +17,7 @@
 package org.apache.activemq.artemis.spi.core.security.jaas;
 
 import static org.apache.activemq.artemis.spi.core.security.jaas.KubernetesLoginModule.K8S_ROLE_FILE_PROP_NAME;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -82,19 +78,20 @@ public class KubernetesLoginModuleTest {
       assertTrue(loginModule.login());
       assertTrue(loginModule.commit());
 
-      assertThat(subject.getPrincipals(UserPrincipal.class), hasSize(1));
+      assertEquals(1, subject.getPrincipals(UserPrincipal.class).size());
       subject.getPrincipals(ServiceAccountPrincipal.class).forEach(p -> {
-         assertThat(p.getName(), is(USERNAME));
-         assertThat(p.getSaName(), is("kermit"));
-         assertThat(p.getNamespace(), is("some-ns"));
+         assertEquals(USERNAME, p.getName());
+         assertEquals("kermit", p.getSaName());
+         assertEquals("some-ns", p.getNamespace());
       });
       Set<RolePrincipal> roles = subject.getPrincipals(RolePrincipal.class);
-      assertThat(roles, hasSize(2));
-      assertThat(roles, containsInAnyOrder(new RolePrincipal("muppet"), new RolePrincipal("admin")));
+      assertEquals(2, roles.size());
+      assertTrue(roles.contains(new RolePrincipal("muppet")));
+      assertTrue(roles.contains(new RolePrincipal("admin")));
 
       assertTrue(loginModule.logout());
       assertFalse(loginModule.commit());
-      assertThat(subject.getPrincipals(), empty());
+      assertEquals(0, subject.getPrincipals().size());
       verify(client, times(1)).getTokenReview(TOKEN);
    }
 
@@ -109,7 +106,7 @@ public class KubernetesLoginModuleTest {
 
       assertFalse(loginModule.login());
       assertFalse(loginModule.commit());
-      assertThat(subject.getPrincipals(), empty());
+      assertEquals(0, subject.getPrincipals().size());
       verify(client, times(1)).getTokenReview(TOKEN);
    }
 
@@ -127,7 +124,7 @@ public class KubernetesLoginModuleTest {
       }
 
       assertFalse(loginModule.commit());
-      assertThat(subject.getPrincipals(), empty());
+      assertEquals(0, subject.getPrincipals().size());
       verifyNoInteractions(client);
    }
 
@@ -141,7 +138,7 @@ public class KubernetesLoginModuleTest {
 
       assertFalse(loginModule.login());
       assertFalse(loginModule.commit());
-      assertThat(subject.getPrincipals(), empty());
+      assertEquals(0, subject.getPrincipals().size());
       verify(client, times(1)).getTokenReview(TOKEN);
    }
 
@@ -157,19 +154,20 @@ public class KubernetesLoginModuleTest {
       assertTrue(loginModule.login());
       assertTrue(loginModule.commit());
 
-      assertThat(subject.getPrincipals(UserPrincipal.class), hasSize(1));
+      assertEquals(1, subject.getPrincipals(UserPrincipal.class).size());
       subject.getPrincipals(ServiceAccountPrincipal.class).forEach(p -> {
-         assertThat(p.getName(), is(USERNAME));
-         assertThat(p.getSaName(), is("kermit"));
-         assertThat(p.getNamespace(), is("some-ns"));
+         assertEquals(USERNAME, p.getName());
+         assertEquals("kermit", p.getSaName());
+         assertEquals("some-ns", p.getNamespace());
       });
       Set<RolePrincipal> roles = subject.getPrincipals(RolePrincipal.class);
-      assertThat(roles, hasSize(2));
-      assertThat(roles, containsInAnyOrder(new RolePrincipal("developers"), new RolePrincipal("qa")));
+      assertEquals(2, roles.size());
+      assertTrue(roles.contains(new RolePrincipal("developers")));
+      assertTrue(roles.contains(new RolePrincipal("qa")));
 
       assertTrue(loginModule.logout());
       assertFalse(loginModule.commit());
-      assertThat(subject.getPrincipals(), empty());
+      assertTrue(subject.getPrincipals().isEmpty());
       verify(client, times(1)).getTokenReview(TOKEN);
    }
 
@@ -185,18 +183,18 @@ public class KubernetesLoginModuleTest {
       assertTrue(loginModule.login());
       assertTrue(loginModule.commit());
 
-      assertThat(subject.getPrincipals(UserPrincipal.class), hasSize(1));
+      assertEquals(1, subject.getPrincipals(UserPrincipal.class).size());
       subject.getPrincipals(ServiceAccountPrincipal.class).forEach(p -> {
-         assertThat(p.getName(), is(USERNAME));
-         assertThat(p.getSaName(), is("kermit"));
-         assertThat(p.getNamespace(), is("some-ns"));
+         assertEquals(USERNAME, p.getName());
+         assertEquals("kermit", p.getSaName());
+         assertEquals("some-ns", p.getNamespace());
       });
       Set<RolePrincipal> roles = subject.getPrincipals(RolePrincipal.class);
-      assertThat(roles, hasSize(0));
+      assertEquals(0, roles.size());
 
       assertTrue(loginModule.logout());
       assertFalse(loginModule.commit());
-      assertThat(subject.getPrincipals(), empty());
+      assertTrue(subject.getPrincipals().isEmpty());
       verify(client, times(1)).getTokenReview(TOKEN);
    }
 

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/spi/core/security/jaas/kubernetes/client/KubernetesClientImplTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/spi/core/security/jaas/kubernetes/client/KubernetesClientImplTest.java
@@ -21,8 +21,6 @@ import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static org.apache.activemq.artemis.spi.core.security.jaas.KubernetesLoginModuleTest.AUTH_JSON;
 import static org.apache.activemq.artemis.spi.core.security.jaas.KubernetesLoginModuleTest.UNAUTH_JSON;
 import static org.apache.activemq.artemis.spi.core.security.jaas.KubernetesLoginModuleTest.USERNAME;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -148,8 +146,8 @@ public class KubernetesClientImplTest {
       tr = client.getTokenReview("kermit_token");
       assertNotNull(tr);
       assertNotNull(tr.getUser());
-      assertThat(tr.getUsername(), is(USERNAME));
-      assertThat(tr.getUser().getUsername(), is(USERNAME));
+      assertEquals(USERNAME, tr.getUsername());
+      assertEquals(USERNAME, tr.getUser().getUsername());
 
       tr = client.getTokenReview("other");
       assertNotNull(tr);

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/spi/core/security/jaas/kubernetes/model/ServiceAccountPrincipalTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/spi/core/security/jaas/kubernetes/model/ServiceAccountPrincipalTest.java
@@ -16,8 +16,7 @@
  */
 package org.apache.activemq.artemis.spi.core.security.jaas.kubernetes.model;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import org.apache.activemq.artemis.spi.core.security.jaas.ServiceAccountPrincipal;
@@ -31,9 +30,9 @@ public class ServiceAccountPrincipalTest {
 
       ServiceAccountPrincipal principal = new ServiceAccountPrincipal(name);
 
-      assertThat(principal.getNamespace(), is("some-ns"));
-      assertThat(principal.getSaName(), is("some-sa"));
-      assertThat(principal.getName(), is(name));
+      assertEquals("some-ns", principal.getNamespace());
+      assertEquals("some-sa", principal.getSaName());
+      assertEquals(name, principal.getName());
    }
 
    @Test
@@ -42,7 +41,7 @@ public class ServiceAccountPrincipalTest {
 
       ServiceAccountPrincipal principal = new ServiceAccountPrincipal(name);
 
-      assertThat(principal.getName(), is("foo"));
+      assertEquals(name, principal.getName());
       assertNull(principal.getSaName());
       assertNull(principal.getNamespace());
    }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/spi/core/security/jaas/kubernetes/model/TokenReviewTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/spi/core/security/jaas/kubernetes/model/TokenReviewTest.java
@@ -17,15 +17,12 @@
 package org.apache.activemq.artemis.spi.core.security.jaas.kubernetes.model;
 
 import static org.apache.activemq.artemis.spi.core.security.jaas.KubernetesLoginModuleTest.USERNAME;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import org.hamcrest.Matchers;
 import org.junit.Test;
 
 public class TokenReviewTest {
@@ -48,10 +45,10 @@ public class TokenReviewTest {
 
       assertNotNull(tr);
       assertTrue(tr.isAuthenticated());
-      assertThat(tr.getUsername(), is(USERNAME));
+      assertEquals(USERNAME, tr.getUsername());
       assertNotNull(tr.getUser());
-      assertThat(tr.getUser().getUsername(), is(USERNAME));
-      assertThat(tr.getAudiences(), Matchers.empty());
+      assertEquals(USERNAME, tr.getUser().getUsername());
+      assertEquals(0, tr.getAudiences().size());
       assertNull(tr.getUser().getExtra());
    }
 
@@ -86,17 +83,20 @@ public class TokenReviewTest {
 
       assertNotNull(tr);
       assertTrue(tr.isAuthenticated());
-      assertThat(tr.getUsername(), is(USERNAME));
+      assertEquals(USERNAME, tr.getUsername());
       assertNotNull(tr.getUser());
-      assertThat(tr.getUser().getUsername(), is(USERNAME));
-      assertThat(tr.getAudiences(), containsInAnyOrder("audience-1", "audience-2"));
-      assertThat(tr.getUser().getGroups(), containsInAnyOrder("group-1", "group-2"));
-      assertThat(tr.getUser().getUid(), is("kermit-uid"));
+      assertEquals(USERNAME, tr.getUser().getUsername());
+      assertTrue(tr.getAudiences().contains("audience-1"));
+      assertTrue(tr.getAudiences().contains("audience-2"));
+      assertTrue(tr.getUser().getGroups().contains("group-1"));
+      assertTrue(tr.getUser().getGroups().contains("group-2"));
+      assertEquals("kermit-uid", tr.getUser().getUid());
 
       assertNotNull(tr.getUser().getExtra());
-      assertThat(tr.getUser().getExtra().getPodNames(), containsInAnyOrder("pod-1", "pod-2"));
-      assertThat(tr.getUser().getExtra().getPodUids(), containsInAnyOrder("pod-uid-1", "pod-uid-2"));
-
+      assertTrue(tr.getUser().getExtra().getPodNames().contains("pod-1"));
+      assertTrue(tr.getUser().getExtra().getPodNames().contains("pod-2"));
+      assertTrue(tr.getUser().getExtra().getPodUids().contains("pod-uid-1"));
+      assertTrue(tr.getUser().getExtra().getPodUids().contains("pod-uid-2"));
    }
 
 }

--- a/artemis-service-extensions/pom.xml
+++ b/artemis-service-extensions/pom.xml
@@ -73,10 +73,6 @@
          <scope>test</scope>
       </dependency>
       <dependency>
-         <groupId>org.jgroups</groupId>
-         <artifactId>jgroups</artifactId>
-      </dependency>
-      <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-unit-test-support</artifactId>
          <version>${project.version}</version>

--- a/artemis-unit-test-support/pom.xml
+++ b/artemis-unit-test-support/pom.xml
@@ -43,7 +43,12 @@
       </dependency>
       <dependency>
          <groupId>org.apache.logging.log4j</groupId>
-         <artifactId>log4j-slf4j-impl</artifactId>
+         <artifactId>log4j-api</artifactId>
+         <scope>provided</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.logging.log4j</groupId>
+         <artifactId>log4j-core</artifactId>
          <scope>provided</scope>
       </dependency>
    </dependencies>

--- a/artemis-web/pom.xml
+++ b/artemis-web/pom.xml
@@ -61,39 +61,8 @@
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-core-client</artifactId>
-         <version>${project.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-commons</artifactId>
          <version>${project.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-junit</artifactId>
-         <version>${project.version}</version>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
-         <groupId>io.netty</groupId>
-         <artifactId>netty-buffer</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>io.netty</groupId>
-         <artifactId>netty-codec-http</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>io.netty</groupId>
-         <artifactId>netty-transport</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>io.netty</groupId>
-         <artifactId>netty-common</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>io.netty</groupId>
-         <artifactId>netty-handler</artifactId>
       </dependency>
       <dependency>
          <groupId>org.apache.tomcat</groupId>
@@ -112,9 +81,60 @@
          <artifactId>jetty-webapp</artifactId>
       </dependency>
       <dependency>
+         <groupId>org.eclipse.jetty</groupId>
+         <artifactId>jetty-security</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.eclipse.jetty</groupId>
+         <artifactId>jetty-util</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-server</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-core-client</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>activemq-artemis-native</artifactId>
+         <version>${activemq-artemis-native-version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-unit-test-support</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-buffer</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-codec-http</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-transport</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-common</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-handler</artifactId>
          <scope>test</scope>
       </dependency>
       <dependency>
@@ -140,6 +160,11 @@
       <dependency>
          <groupId>org.apache.httpcomponents</groupId>
          <artifactId>httpclient</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.httpcomponents</groupId>
+         <artifactId>httpcore</artifactId>
          <scope>test</scope>
       </dependency>
    </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@
       <hdrhistogram.version>2.1.12</hdrhistogram.version>
       <curator.version>5.2.0</curator.version>
       <zookeeper.version>3.6.3</zookeeper.version>
+      <woodstox.version>4.4.0</woodstox.version>
 
       <!-- tracing -->
       <opentelemetry.version>1.24.0</opentelemetry.version>
@@ -128,6 +129,7 @@
       <qpid.jms.version>1.10.0</qpid.jms.version>
       <johnzon.version>1.2.16</johnzon.version>
       <hawtbuff.version>1.11</hawtbuff.version>
+      <hawtdispatch.version>1.22</hawtdispatch.version>
       <airline.version>2.9.0</airline.version>
       <jakarta.activation-api.version>1.2.2</jakarta.activation-api.version>
       <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
@@ -158,6 +160,7 @@
       <paho.client.mqtt.version>1.2.5</paho.client.mqtt.version>
       <postgresql.version>42.4.3</postgresql.version>
       <testcontainers.version>1.17.6</testcontainers.version>
+      <selenium.version>4.8.3</selenium.version>
       <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
       <apache.httpcore.version>4.4.13</apache.httpcore.version>
       <apache.httpclient.version>4.5.13</apache.httpclient.version>
@@ -469,6 +472,12 @@
             <groupId>org.fusesource.hawtbuf</groupId>
             <artifactId>hawtbuf</artifactId>
             <version>${hawtbuff.version}</version>
+            <!-- License: Apache 2.0 -->
+         </dependency>
+         <dependency>
+            <groupId>org.fusesource.hawtdispatch</groupId>
+            <artifactId>hawtdispatch</artifactId>
+            <version>${hawtdispatch.version}</version>
             <!-- License: Apache 2.0 -->
          </dependency>
          <dependency>
@@ -1016,7 +1025,42 @@
             <version>${testcontainers.version}</version>
             <scope>test</scope>
          </dependency>
-
+         <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-api</artifactId>
+            <version>${selenium.version}</version>
+            <scope>test</scope>
+         </dependency>
+         <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-firefox-driver</artifactId>
+            <version>${selenium.version}</version>
+            <scope>test</scope>
+         </dependency>
+         <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-chrome-driver</artifactId>
+            <version>${selenium.version}</version>
+            <scope>test</scope>
+         </dependency>
+         <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-chromium-driver</artifactId>
+            <version>${selenium.version}</version>
+            <scope>test</scope>
+         </dependency>
+         <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-remote-driver</artifactId>
+            <version>${selenium.version}</version>
+            <scope>test</scope>
+         </dependency>
+         <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-support</artifactId>
+            <version>${selenium.version}</version>
+            <scope>test</scope>
+         </dependency>
 
          <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/tests/artemis-test-support/pom.xml
+++ b/tests/artemis-test-support/pom.xml
@@ -33,6 +33,18 @@
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-core-client</artifactId>
+         <version>${project.version}</version>
+         <scope>provided</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-commons</artifactId>
+         <version>${project.version}</version>
+         <scope>provided</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
          <scope>provided</scope>

--- a/tests/integration-tests-isolated/pom.xml
+++ b/tests/integration-tests-isolated/pom.xml
@@ -36,111 +36,37 @@
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-quorum-ri</artifactId>
-         <version>${project.version}</version>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq.tests</groupId>
-         <artifactId>unit-tests</artifactId>
-         <version>${project.version}</version>
-         <scope>test</scope>
-         <type>test-jar</type>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-jms-server</artifactId>
-         <version>${project.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-ra</artifactId>
-         <version>${project.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-cli</artifactId>
-         <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-commons</artifactId>
          <version>${project.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-spring-integration</artifactId>
-         <version>${project.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-journal</artifactId>
-         <version>${project.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-jdbc-store</artifactId>
-         <version>${project.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-amqp-protocol</artifactId>
-         <version>${project.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-stomp-protocol</artifactId>
-         <version>${project.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-openwire-protocol</artifactId>
-         <version>${project.version}</version>
-         <exclusions>
-            <exclusion>
-               <groupId>org.apache.geronimo.specs</groupId>
-               <artifactId>geronimo-jms_1.1_spec</artifactId>
-            </exclusion>
-         </exclusions>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-hornetq-protocol</artifactId>
-         <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-core-client</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-server</artifactId>
          <version>${project.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>activemq-artemis-native</artifactId>
-         <version>${activemq-artemis-native-version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-service-extensions</artifactId>
-         <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq.tests</groupId>
          <artifactId>artemis-test-support</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-junit</artifactId>
+         <artifactId>artemis-amqp-protocol</artifactId>
          <version>${project.version}</version>
          <scope>test</scope>
       </dependency>
@@ -151,84 +77,9 @@
          <scope>test</scope>
       </dependency>
       <dependency>
-         <groupId>org.hamcrest</groupId>
-         <artifactId>hamcrest</artifactId>
-         <version>${hamcrest.version}</version>
-         <scope>test</scope>
-      </dependency>
-
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>activemq-client</artifactId>
-         <scope>test</scope>
-         <exclusions>
-            <exclusion>
-               <groupId>org.apache.geronimo.specs</groupId>
-               <artifactId>geronimo-jms_1.1_spec</artifactId>
-            </exclusion>
-            <exclusion>
-               <groupId>org.apache.geronimo.specs</groupId>
-               <artifactId>geronimo-j2ee-management_1.1_spec</artifactId>
-            </exclusion>
-         </exclusions>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-mqtt-protocol</artifactId>
-         <version>${project.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.fusesource.mqtt-client</groupId>
-         <artifactId>mqtt-client</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>org.eclipse.paho</groupId>
-         <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>org.eclipse.paho</groupId>
-         <artifactId>org.eclipse.paho.mqttv5.client</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>jakarta.resource</groupId>
-         <artifactId>jakarta.resource-api</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>jakarta.transaction</groupId>
-         <artifactId>jakarta.transaction-api</artifactId>
-      </dependency>
-      <dependency>
          <groupId>jakarta.jms</groupId>
          <artifactId>jakarta.jms-api</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>jakarta.management.j2ee</groupId>
-         <artifactId>jakarta.management.j2ee-api</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>jakarta.annotation</groupId>
-         <artifactId>jakarta.annotation-api</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>io.netty</groupId>
-         <artifactId>netty-buffer</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>io.netty</groupId>
-         <artifactId>netty-codec-http</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>io.netty</groupId>
-         <artifactId>netty-codec-mqtt</artifactId>
-         <version>${netty.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>io.netty</groupId>
-         <artifactId>netty-handler</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>io.netty</groupId>
-         <artifactId>netty-transport</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>junit</groupId>
@@ -237,37 +88,17 @@
       <dependency>
          <groupId>org.apache.qpid</groupId>
          <artifactId>qpid-jms-client</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.qpid</groupId>
-         <artifactId>proton-j</artifactId>
+         <scope>test</scope>
       </dependency>
       <!-- logging -->
       <dependency>
          <groupId>org.slf4j</groupId>
          <artifactId>slf4j-api</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.logging.log4j</groupId>
          <artifactId>log4j-slf4j-impl</artifactId>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-web</artifactId>
-         <version>${project.version}</version>
-         <scope>test</scope>
-      </dependency>
-
-      <!-- DB Test Deps -->
-      <dependency>
-         <groupId>org.apache.derby</groupId>
-         <artifactId>derby</artifactId>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
-         <groupId>org.postgresql</groupId>
-         <artifactId>postgresql</artifactId>
          <scope>test</scope>
       </dependency>
       <dependency>
@@ -308,26 +139,33 @@
          <scope>test</scope>
       </dependency>
       <dependency>
-         <groupId>org.apache.commons</groupId>
-         <artifactId>commons-lang3</artifactId>
+         <groupId>org.apache.directory.server</groupId>
+         <artifactId>apacheds-core-annotations</artifactId>
+         <version>${directory-version}</version>
          <scope>test</scope>
       </dependency>
-
       <dependency>
-         <groupId>org.codehaus.woodstox</groupId>
-         <artifactId>woodstox-core-asl</artifactId>
-         <version>4.4.0</version>
+         <groupId>org.apache.directory.server</groupId>
+         <artifactId>apacheds-core-api</artifactId>
+         <version>${directory-version}</version>
          <scope>test</scope>
-         <exclusions>
-            <exclusion>
-               <groupId>javax.xml.stream</groupId>
-               <artifactId>stax-api</artifactId>
-            </exclusion>
-         </exclusions>
       </dependency>
       <dependency>
-         <groupId>org.apache.hadoop</groupId>
-         <artifactId>hadoop-minikdc</artifactId>
+         <groupId>org.apache.directory.server</groupId>
+         <artifactId>apacheds-protocol-shared</artifactId>
+         <version>${directory-version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.directory.server</groupId>
+         <artifactId>apacheds-protocol-kerberos</artifactId>
+         <version>${directory-version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.directory.server</groupId>
+         <artifactId>apacheds-kerberos-codec</artifactId>
+         <version>${directory-version}</version>
          <scope>test</scope>
       </dependency>
       <dependency>
@@ -337,56 +175,9 @@
          <scope>test</scope>
       </dependency>
       <dependency>
-         <groupId>org.apache.directory.jdbm</groupId>
-         <artifactId>apacheds-jdbm2</artifactId>
-         <version>${directory-jdbm2-version}</version>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
-         <groupId>org.springframework</groupId>
-         <artifactId>spring-context</artifactId>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
-         <groupId>org.springframework</groupId>
-         <artifactId>spring-jms</artifactId>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
          <groupId>commons-io</groupId>
          <artifactId>commons-io</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>org.jgroups</groupId>
-         <artifactId>jgroups</artifactId>
-      </dependency>
-
-      <!-- openSSL test -->
-      <dependency>
-         <groupId>io.netty</groupId>
-         <artifactId>netty-tcnative-boringssl-static</artifactId>
-         <version>${netty-tcnative-version}</version>
-      </dependency>
-
-      <dependency>
-         <groupId>io.vertx</groupId>
-         <artifactId>vertx-proton</artifactId>
-         <version>${vertx.version}</version>
          <scope>test</scope>
-      </dependency>
-
-      <!-- need this for org.apache.activemq.filter.JAXPXPathEvaluator for Xpath selectors with OpenWire JMS clients-->
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>activemq-broker</artifactId>
-         <version>${activemq5-version}</version>
-         <scope>test</scope>
-         <exclusions>
-            <exclusion>
-               <groupId>com.fasterxml.jackson.core</groupId>
-               <artifactId>jackson-databind</artifactId>
-            </exclusion>
-         </exclusions>
       </dependency>
 
       <!-- The johnzon-core and json-api contents are repackaged in -commons,
@@ -403,13 +194,6 @@
          <artifactId>jakarta.json-api</artifactId>
          <scope>test</scope>
       </dependency>
-
-      <dependency>
-         <groupId>org.mockito</groupId>
-         <artifactId>mockito-core</artifactId>
-         <scope>test</scope>
-      </dependency>
-
    </dependencies>
 
    <build>

--- a/tests/integration-tests/pom.xml
+++ b/tests/integration-tests/pom.xml
@@ -35,6 +35,12 @@
    <dependencies>
       <dependency>
          <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-quorum-api</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-quorum-ri</artifactId>
          <version>${project.version}</version>
          <scope>test</scope>
@@ -50,56 +56,61 @@
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-jms-server</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-ra</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-cli</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-commons</artifactId>
          <version>${project.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-spring-integration</artifactId>
-         <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-journal</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-jdbc-store</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-amqp-protocol</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-stomp-protocol</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-openwire-protocol</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
          <exclusions>
             <exclusion>
                <groupId>org.apache.geronimo.specs</groupId>
@@ -109,37 +120,37 @@
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-hornetq-protocol</artifactId>
+         <artifactId>artemis-hqclient-protocol</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-core-client</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-server</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>activemq-artemis-native</artifactId>
          <version>${activemq-artemis-native-version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-service-extensions</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq.tests</groupId>
          <artifactId>artemis-test-support</artifactId>
-         <version>${project.version}</version>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-junit</artifactId>
          <version>${project.version}</version>
          <scope>test</scope>
       </dependency>
@@ -150,9 +161,27 @@
          <scope>test</scope>
       </dependency>
       <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-selector</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-dto</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
          <groupId>org.hamcrest</groupId>
          <artifactId>hamcrest</artifactId>
          <version>${hamcrest.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>io.micrometer</groupId>
+         <artifactId>micrometer-core</artifactId>
+         <version>${version.micrometer}</version>
          <scope>test</scope>
       </dependency>
 
@@ -175,76 +204,109 @@
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-mqtt-protocol</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.fusesource.mqtt-client</groupId>
          <artifactId>mqtt-client</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.eclipse.paho</groupId>
          <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.eclipse.paho</groupId>
          <artifactId>org.eclipse.paho.mqttv5.client</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>jakarta.resource</groupId>
          <artifactId>jakarta.resource-api</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>jakarta.transaction</groupId>
          <artifactId>jakarta.transaction-api</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>jakarta.jms</groupId>
          <artifactId>jakarta.jms-api</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>jakarta.management.j2ee</groupId>
          <artifactId>jakarta.management.j2ee-api</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>jakarta.annotation</groupId>
          <artifactId>jakarta.annotation-api</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>io.netty</groupId>
          <artifactId>netty-buffer</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>io.netty</groupId>
          <artifactId>netty-codec-http</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>io.netty</groupId>
          <artifactId>netty-codec-mqtt</artifactId>
          <version>${netty.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>io.netty</groupId>
          <artifactId>netty-handler</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>io.netty</groupId>
          <artifactId>netty-transport</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-common</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.fusesource.hawtbuf</groupId>
+         <artifactId>hawtbuf</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.fusesource.hawtdispatch</groupId>
+         <artifactId>hawtdispatch</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.qpid</groupId>
          <artifactId>qpid-jms-client</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.qpid</groupId>
          <artifactId>proton-j</artifactId>
+         <scope>test</scope>
       </dependency>
       <!-- logging -->
       <dependency>
          <groupId>org.slf4j</groupId>
          <artifactId>slf4j-api</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.logging.log4j</groupId>
@@ -271,26 +333,23 @@
       </dependency>
 
       <dependency>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-lang3</artifactId>
-          <scope>test</scope>
-      </dependency>
-
-      <dependency>
-         <groupId>org.codehaus.woodstox</groupId>
-         <artifactId>woodstox-core-asl</artifactId>
-         <version>4.4.0</version>
+         <groupId>org.apache.commons</groupId>
+         <artifactId>commons-lang3</artifactId>
          <scope>test</scope>
-         <exclusions>
-            <exclusion>
-               <groupId>javax.xml.stream</groupId>
-               <artifactId>stax-api</artifactId>
-            </exclusion>
-         </exclusions>
+      </dependency>
+      <dependency>
+         <groupId>commons-beanutils</groupId>
+         <artifactId>commons-beanutils</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.hadoop</groupId>
          <artifactId>hadoop-minikdc</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.springframework</groupId>
+         <artifactId>spring-core</artifactId>
          <scope>test</scope>
       </dependency>
       <dependency>
@@ -304,12 +363,9 @@
          <scope>test</scope>
       </dependency>
       <dependency>
-         <groupId>commons-io</groupId>
-         <artifactId>commons-io</artifactId>
-      </dependency>
-      <dependency>
          <groupId>org.jgroups</groupId>
          <artifactId>jgroups</artifactId>
+         <scope>test</scope>
       </dependency>
 
       <!-- openSSL test -->
@@ -325,6 +381,12 @@
          <version>${vertx.version}</version>
          <scope>test</scope>
       </dependency>
+      <dependency>
+         <groupId>io.vertx</groupId>
+         <artifactId>vertx-core</artifactId>
+         <version>${vertx.version}</version>
+         <scope>test</scope>
+      </dependency>
 
       <!-- need this for org.apache.activemq.filter.JAXPXPathEvaluator for Xpath selectors with OpenWire JMS clients-->
       <dependency>
@@ -336,6 +398,19 @@
             <exclusion>
                <groupId>com.fasterxml.jackson.core</groupId>
                <artifactId>jackson-databind</artifactId>
+            </exclusion>
+         </exclusions>
+      </dependency>
+
+      <dependency>
+         <groupId>org.codehaus.woodstox</groupId>
+         <artifactId>woodstox-core-asl</artifactId>
+         <version>${woodstox.version}</version>
+         <scope>test</scope>
+         <exclusions>
+            <exclusion>
+               <groupId>javax.xml.stream</groupId>
+               <artifactId>stax-api</artifactId>
             </exclusion>
          </exclusions>
       </dependency>

--- a/tests/smoke-tests/pom.xml
+++ b/tests/smoke-tests/pom.xml
@@ -47,31 +47,71 @@
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-server</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq.tests</groupId>
+         <artifactId>artemis-test-support</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-core-client</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-commons</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-cli</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-journal</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-common</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.jctools</groupId>
+         <artifactId>jctools-core</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.qpid</groupId>
          <artifactId>qpid-jms-client</artifactId>
+         <scope>test</scope>
       </dependency>
       <!-- logging -->
       <dependency>
          <groupId>org.slf4j</groupId>
          <artifactId>slf4j-api</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.logging.log4j</groupId>
@@ -81,10 +121,12 @@
       <dependency>
          <groupId>org.fusesource.mqtt-client</groupId>
          <artifactId>mqtt-client</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.eclipse.paho</groupId>
          <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>jakarta.jms</groupId>
@@ -97,30 +139,46 @@
          <scope>test</scope>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>activemq-client</artifactId>
+         <groupId>org.seleniumhq.selenium</groupId>
+         <artifactId>selenium-api</artifactId>
          <scope>test</scope>
-         <exclusions>
-            <exclusion>
-               <groupId>org.apache.geronimo.specs</groupId>
-               <artifactId>geronimo-jms_1.1_spec</artifactId>
-            </exclusion>
-            <exclusion>
-               <groupId>org.apache.geronimo.specs</groupId>
-               <artifactId>geronimo-j2ee-management_1.1_spec</artifactId>
-            </exclusion>
-         </exclusions>
       </dependency>
       <dependency>
          <groupId>org.seleniumhq.selenium</groupId>
-         <artifactId>selenium-java</artifactId>
-         <version>4.8.3</version>
+         <artifactId>selenium-firefox-driver</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.seleniumhq.selenium</groupId>
+         <artifactId>selenium-chrome-driver</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.seleniumhq.selenium</groupId>
+         <artifactId>selenium-chromium-driver</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.seleniumhq.selenium</groupId>
+         <artifactId>selenium-remote-driver</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.seleniumhq.selenium</groupId>
+         <artifactId>selenium-support</artifactId>
          <scope>test</scope>
       </dependency>
 
       <dependency>
          <groupId>org.testcontainers</groupId>
          <artifactId>selenium</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.testcontainers</groupId>
+         <artifactId>testcontainers</artifactId>
+         <scope>test</scope>
       </dependency>
 
       <!-- quorum tests -->
@@ -174,17 +232,17 @@
       <dependency>
          <groupId>org.apache.httpcomponents</groupId>
          <artifactId>httpclient</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.httpcomponents</groupId>
+         <artifactId>httpcore</artifactId>
+         <scope>test</scope>
       </dependency>
 
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-unit-test-support</artifactId>
-         <version>${project.version}</version>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq.tests</groupId>
-         <artifactId>artemis-test-support</artifactId>
          <version>${project.version}</version>
          <scope>test</scope>
       </dependency>

--- a/tests/soak-tests/pom.xml
+++ b/tests/soak-tests/pom.xml
@@ -33,25 +33,78 @@
    </properties>
 
    <dependencies>
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>artemis-core-client</artifactId>
-         <version>${project.version}</version>
-         <scope>test</scope>
-      </dependency>
       <!-- logging -->
       <dependency>
          <groupId>org.slf4j</groupId>
          <artifactId>slf4j-api</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.logging.log4j</groupId>
          <artifactId>log4j-slf4j-impl</artifactId>
          <scope>test</scope>
       </dependency>
+
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-mqtt-protocol</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-cli</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.qpid</groupId>
+         <artifactId>qpid-jms-client</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.fusesource.mqtt-client</groupId>
+         <artifactId>mqtt-client</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.eclipse.paho</groupId>
+         <artifactId>org.eclipse.paho.mqttv5.client</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-core-client</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-jms-client</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-server</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-openwire-protocol</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-amqp-protocol</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq.tests</groupId>
+         <artifactId>artemis-test-support</artifactId>
          <version>${project.version}</version>
          <scope>test</scope>
       </dependency>
@@ -63,18 +116,23 @@
          <type>test-jar</type>
       </dependency>
       <dependency>
-         <groupId>junit</groupId>
-         <artifactId>junit</artifactId>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>activemq-client</artifactId>
+         <scope>test</scope>
+         <exclusions>
+            <exclusion>
+               <groupId>org.apache.geronimo.specs</groupId>
+               <artifactId>geronimo-jms_1.1_spec</artifactId>
+            </exclusion>
+            <exclusion>
+               <groupId>org.apache.geronimo.specs</groupId>
+               <artifactId>geronimo-j2ee-management_1.1_spec</artifactId>
+            </exclusion>
+         </exclusions>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-commons</artifactId>
-         <version>${project.version}</version>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq.tests</groupId>
-         <artifactId>artemis-test-support</artifactId>
          <version>${project.version}</version>
          <scope>test</scope>
       </dependency>
@@ -85,8 +143,22 @@
          <scope>test</scope>
       </dependency>
       <dependency>
+         <groupId>junit</groupId>
+         <artifactId>junit</artifactId>
+      </dependency>
+      <dependency>
          <groupId>jakarta.transaction</groupId>
          <artifactId>jakarta.transaction-api</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>jakarta.jms</groupId>
+         <artifactId>jakarta.jms-api</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>jakarta.management.j2ee</groupId>
+         <artifactId>jakarta.management.j2ee-api</artifactId>
          <scope>test</scope>
       </dependency>
 

--- a/tests/stress-tests/pom.xml
+++ b/tests/stress-tests/pom.xml
@@ -34,29 +34,57 @@
 
    <dependencies>
       <dependency>
+         <groupId>org.slf4j</groupId>
+         <artifactId>slf4j-api</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-server</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-journal</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>activemq-artemis-native</artifactId>
          <version>${activemq-artemis-native-version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-core-client</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-commons</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-selector</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-jms-client</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-stomp-protocol</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq.tests</groupId>
@@ -64,6 +92,12 @@
          <version>${project.version}</version>
          <scope>test</scope>
          <type>test-jar</type>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq.tests</groupId>
+         <artifactId>artemis-test-support</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq.tests</groupId>
@@ -76,25 +110,17 @@
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-cli</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>jakarta.transaction</groupId>
-         <artifactId>jakarta.transaction-api</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.derby</groupId>
          <artifactId>derby</artifactId>
          <version>${apache.derby.version}</version>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.activemq.tests</groupId>
-         <artifactId>artemis-test-support</artifactId>
-         <version>${project.version}</version>
          <scope>test</scope>
       </dependency>
       <dependency>

--- a/tests/timing-tests/pom.xml
+++ b/tests/timing-tests/pom.xml
@@ -34,34 +34,45 @@
 
    <dependencies>
       <dependency>
+         <groupId>org.slf4j</groupId>
+         <artifactId>slf4j-api</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-core-client</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-server</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-jms-server</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-journal</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>activemq-artemis-native</artifactId>
          <version>${activemq-artemis-native-version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-commons</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq.tests</groupId>
@@ -79,6 +90,7 @@
       <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
@@ -95,10 +107,12 @@
       <dependency>
          <groupId>jakarta.transaction</groupId>
          <artifactId>jakarta.transaction-api</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>jakarta.jms</groupId>
          <artifactId>jakarta.jms-api</artifactId>
+         <scope>test</scope>
       </dependency>
    </dependencies>
 

--- a/tests/unit-tests/pom.xml
+++ b/tests/unit-tests/pom.xml
@@ -35,6 +35,7 @@
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-core-client</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
@@ -46,60 +47,100 @@
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-server</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-ra</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-cli</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-journal</artifactId>
          <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.activemq</groupId>
          <artifactId>activemq-artemis-native</artifactId>
          <version>${activemq-artemis-native-version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-selector</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-service-extensions</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>jakarta.jms</groupId>
          <artifactId>jakarta.jms-api</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>jakarta.resource</groupId>
          <artifactId>jakarta.resource-api</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>jakarta.transaction</groupId>
          <artifactId>jakarta.transaction-api</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>io.netty</groupId>
          <artifactId>netty-transport</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>io.netty</groupId>
          <artifactId>netty-buffer</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-resolver</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-handler-proxy</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-common</artifactId>
+         <scope>test</scope>
       </dependency>
       <!-- logging -->
       <dependency>
          <groupId>org.slf4j</groupId>
          <artifactId>slf4j-api</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
This commit contains the following changes:
 - eliminate used, undeclared dependencies
 - eliminate unused, declared dependencies
 - fix scope for test dependencies
 - eliminate org.hamcrest completely as its use involved deprecated code as well as dependencies from multiple versions