### PR TITLE
ARTEMIS-4354 Allow the recovery XAResource to be osing and reconnceting

### DIFF
--- a/artemis-service-extensions/src/main/java/org/apache/activemq/artemis/service/extensions/xa/recovery/ActiveMQXAResourceWrapper.java
+++ b/artemis-service-extensions/src/main/java/org/apache/activemq/artemis/service/extensions/xa/recovery/ActiveMQXAResourceWrapper.java
@@ -67,6 +67,13 @@ public class ActiveMQXAResourceWrapper implements XAResource, SessionFailureList
       }
    }
 
+   public void updateRecoveryConfig(XARecoveryConfig... xaRecoveryConfigs) {
+      synchronized (ActiveMQXAResourceWrapper.lock) {
+         close();
+         this.xaRecoveryConfigs = xaRecoveryConfigs;
+      }
+   }
+
    @Override
    public Xid[] recover(final int flag) throws XAException {
       XAResource xaResource = getDelegate(false);


### PR DESCRIPTION
the underlying CLientSession.