### PR TITLE
ARTEMIS-4358 upgrade commons-configuration2

### DIFF
--- a/artemis-server/pom.xml
+++ b/artemis-server/pom.xml
@@ -161,25 +161,6 @@
       <dependency>
          <groupId>org.apache.commons</groupId>
          <artifactId>commons-configuration2</artifactId>
-         <exclusions>
-            <exclusion>
-               <!-- Workaround for Maven handling of transitive deps
-                    dependencyManagement when used by dependent projects.
-                    Dep is re-declared below until a newer release of
-                    commons-configuration2 upgrades to -text 1.10.0 -->
-               <groupId>org.apache.commons</groupId>
-               <artifactId>commons-text</artifactId>
-            </exclusion>
-         </exclusions>
-      </dependency>
-      <dependency>
-         <!-- Actually a transitive dep of commons-configuration2 above.
-              Workaround for Maven handling of transitive deps
-              dependencyManagement when used by dependent projects.
-              Declaring dep here until a newer release of
-              commons-configuration2 upgrades to -text 1.10.0 -->
-         <groupId>org.apache.commons</groupId>
-         <artifactId>commons-text</artifactId>
       </dependency>
       <dependency>
          <groupId>io.micrometer</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
       <activemq-artemis-native-version>2.0.0</activemq-artemis-native-version>
       <karaf.version>4.3.3</karaf.version>
       <pax.exam.version>4.13.4</pax.exam.version>
-      <commons.config.version>2.8.0</commons.config.version>
+      <commons.config.version>2.9.0</commons.config.version>
       <commons.lang.version>3.12.0</commons.lang.version>
       <activemq5-version>5.17.2</activemq5-version>
       <apache.derby.version>10.14.2.0</apache.derby.version>


### PR DESCRIPTION
Version 2.9.0 of commons-configuration2 now includes commons-text 1.10.0 so the dependencies can be simplified.