### PR TITLE
[ARTEMIS-4159] Support duplicate cache size configuration per address

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -342,6 +342,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
    private static final String ENABLE_INGRESS_TIMESTAMP = "enable-ingress-timestamp";
 
+   private static final String ID_CACHE_SIZE = "id-cache-size";
+
    private boolean validateAIO = false;
 
    private boolean printPageMaxSizeUsed = false;
@@ -1456,6 +1458,10 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
             addressSettings.setEnableMetrics(XMLUtil.parseBoolean(child));
          } else if (ENABLE_INGRESS_TIMESTAMP.equalsIgnoreCase(name)) {
             addressSettings.setEnableIngressTimestamp(XMLUtil.parseBoolean(child));
+         } else if (ID_CACHE_SIZE.equalsIgnoreCase(name)) {
+            int idCacheSize = XMLUtil.parseInt(child);
+            Validators.GE_ZERO.validate(ID_CACHE_SIZE, idCacheSize);
+            addressSettings.setIDCacheSize(XMLUtil.parseInt(child));
          }
       }
       return setting;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -1407,9 +1407,15 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
       return null;
    }
 
+   private int resolveIdCacheSize(SimpleString address) {
+      final AddressSettings addressSettings = addressSettingsRepository.getMatch(address.toString());
+      return addressSettings.getIDCacheSize() == null ? idCacheSize : addressSettings.getIDCacheSize();
+   }
+
    @Override
    public DuplicateIDCache getDuplicateIDCache(final SimpleString address) {
-      return getDuplicateIDCache(address, idCacheSize);
+      int resolvedIdCacheSize = resolveIdCacheSize(address);
+      return getDuplicateIDCache(address, resolvedIdCacheSize);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
@@ -293,6 +293,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
    private Boolean enableIngressTimestamp = null;
 
+   private Integer idCacheSize = null;
+
    //from amq5
    //make it transient
    private transient Integer queuePrefetch = null;
@@ -370,6 +372,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       this.managementMessageAttributeSizeLimit = other.managementMessageAttributeSizeLimit;
       this.slowConsumerThresholdMeasurementUnit = other.slowConsumerThresholdMeasurementUnit;
       this.enableIngressTimestamp = other.enableIngressTimestamp;
+      this.idCacheSize = other.idCacheSize;
    }
 
    public AddressSettings() {
@@ -1073,6 +1076,15 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       return this;
    }
 
+   public Integer getIDCacheSize() {
+      return idCacheSize;
+   }
+
+   public AddressSettings setIDCacheSize(int idCacheSize) {
+      this.idCacheSize = idCacheSize;
+      return this;
+   }
+
    /**
     * merge 2 objects in to 1
     *
@@ -1301,6 +1313,9 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       }
       if (pageLimitMessages == null) {
          pageLimitMessages = merged.pageLimitMessages;
+      }
+      if (idCacheSize == null) {
+         idCacheSize = merged.idCacheSize;
       }
    }
 
@@ -1577,6 +1592,10 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       if (buffer.readableBytes() > 0) {
          autoDeleteAddressesSkipUsageCheck = BufferHelper.readNullableBoolean(buffer);
       }
+
+      if (buffer.readableBytes() > 0) {
+         idCacheSize = BufferHelper.readNullableInteger(buffer);
+      }
    }
 
    @Override
@@ -1652,6 +1671,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
          BufferHelper.sizeOfNullableInteger(maxReadPageBytes) +
          BufferHelper.sizeOfNullableLong(pageLimitBytes) +
          BufferHelper.sizeOfNullableLong(pageLimitMessages) +
+         BufferHelper.sizeOfNullableInteger(idCacheSize) +
          BufferHelper.sizeOfNullableSimpleString(pageFullMessagePolicy != null ? pageFullMessagePolicy.toString() : null);
    }
 
@@ -1802,6 +1822,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       BufferHelper.writeNullableBoolean(buffer, autoDeleteQueuesSkipUsageCheck);
 
       BufferHelper.writeNullableBoolean(buffer, autoDeleteAddressesSkipUsageCheck);
+
+      BufferHelper.writeNullableInteger(buffer, idCacheSize);
    }
 
    /* (non-Javadoc)
@@ -1883,6 +1905,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       result = prime * result + ((pageLimitBytes == null) ? 0 : pageLimitBytes.hashCode());
       result = prime * result + ((pageLimitMessages == null) ? 0 : pageLimitMessages.hashCode());
       result = prime * result + ((pageFullMessagePolicy == null) ? 0 : pageFullMessagePolicy.hashCode());
+      result = prime * result + ((idCacheSize == null) ? 0 : idCacheSize.hashCode());
 
       return result;
    }
@@ -2290,6 +2313,13 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
          return false;
       }
 
+      if (idCacheSize == null) {
+         if (other.idCacheSize != null) {
+            return false;
+         }
+      } else if (!idCacheSize.equals(other.idCacheSize)) {
+         return false;
+      }
 
       return true;
    }
@@ -2438,6 +2468,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
          pageLimitMessages +
          ", pageFullMessagePolicy=" +
          pageFullMessagePolicy +
+         ", idCacheSize=" +
+         idCacheSize +
          "]";
    }
 }

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -4281,6 +4281,15 @@
             </xsd:annotation>
          </xsd:element>
 
+         <xsd:element name="id-cache-size" type="xsd:int" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  This will set the Duplicate ID cache size for the matching address. By default the global
+                  setting for `id-cache-size` will be used.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
       </xsd:all>
 
       <xsd:attribute name="match" type="xsd:string" use="required">

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImplTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImplTest.java
@@ -1120,6 +1120,7 @@ public class ConfigurationImplTest extends ActiveMQTestBase {
       properties.put("addressSettings.NeedToSet.autoDeleteCreatedQueues", "true");
       properties.put("addressSettings.NeedToSet.defaultExclusiveQueue", "true");
       properties.put("addressSettings.NeedToSet.defaultMaxConsumers", 10);
+      properties.put("addressSettings.NeedToSet.iDCacheSize", 10);
 
       configuration.parsePrefixedProperties(properties, null);
 
@@ -1185,6 +1186,7 @@ public class ConfigurationImplTest extends ActiveMQTestBase {
       Assert.assertTrue(configuration.getAddressSettings().get("NeedToSet").isAutoDeleteCreatedQueues());
       Assert.assertTrue(configuration.getAddressSettings().get("NeedToSet").isDefaultExclusiveQueue());
       Assert.assertEquals(Integer.valueOf(10), configuration.getAddressSettings().get("NeedToSet").getDefaultMaxConsumers());
+      Assert.assertEquals(Integer.valueOf(10), configuration.getAddressSettings().get("NeedToSet").getIDCacheSize());
    }
 
    @Test

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
@@ -461,6 +461,7 @@ public class FileConfigurationTest extends ConfigurationImplTest {
       assertEquals(0, conf.getAddressSettings().get("a1").getRetroactiveMessageCount());
       assertTrue(conf.getAddressSettings().get("a1").isEnableMetrics());
       assertTrue(conf.getAddressSettings().get("a1").isEnableIngressTimestamp());
+      assertEquals(null, conf.getAddressSettings().get("a1").getIDCacheSize());
 
       assertEquals("a2.1", conf.getAddressSettings().get("a2").getDeadLetterAddress().toString());
       assertEquals(true, conf.getAddressSettings().get("a2").isAutoCreateDeadLetterResources());
@@ -500,6 +501,7 @@ public class FileConfigurationTest extends ConfigurationImplTest {
       assertEquals(10, conf.getAddressSettings().get("a2").getRetroactiveMessageCount());
       assertFalse(conf.getAddressSettings().get("a2").isEnableMetrics());
       assertFalse(conf.getAddressSettings().get("a2").isEnableIngressTimestamp());
+      assertEquals(Integer.valueOf(500), conf.getAddressSettings().get("a2").getIDCacheSize());
 
       assertTrue(conf.getResourceLimitSettings().containsKey("myUser"));
       assertEquals(104, conf.getResourceLimitSettings().get("myUser").getMaxConnections());

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/settings/AddressSettingsTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/settings/AddressSettingsTest.java
@@ -74,6 +74,7 @@ public class AddressSettingsTest extends ActiveMQTestBase {
       addressSettingsToMerge.setExpiryDelay(999L);
       addressSettingsToMerge.setMinExpiryDelay(888L);
       addressSettingsToMerge.setMaxExpiryDelay(777L);
+      addressSettingsToMerge.setIDCacheSize(5);
 
       addressSettings.merge(addressSettingsToMerge);
       Assert.assertEquals(addressSettings.getDeadLetterAddress(), DLQ);
@@ -90,6 +91,7 @@ public class AddressSettingsTest extends ActiveMQTestBase {
       Assert.assertEquals(Long.valueOf(999), addressSettings.getExpiryDelay());
       Assert.assertEquals(Long.valueOf(888), addressSettings.getMinExpiryDelay());
       Assert.assertEquals(Long.valueOf(777), addressSettings.getMaxExpiryDelay());
+      Assert.assertEquals(Integer.valueOf(5), addressSettings.getIDCacheSize());
    }
 
    @Test

--- a/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
@@ -572,6 +572,7 @@
             <enable-metrics>false</enable-metrics>
             <management-browse-page-size>400</management-browse-page-size>
             <management-message-attribute-size-limit>265</management-message-attribute-size-limit>
+            <id-cache-size>500</id-cache-size>
          </address-setting>
       </address-settings>
       <resource-limit-settings>

--- a/artemis-server/src/test/resources/ConfigurationTest-xinclude-config-address-settings.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-xinclude-config-address-settings.xml
@@ -83,5 +83,6 @@
       <default-consumer-window-size>10000</default-consumer-window-size>
       <retroactive-message-count>10</retroactive-message-count>
       <enable-metrics>false</enable-metrics>
+      <id-cache-size>500</id-cache-size>
    </address-setting>
 </address-settings>

--- a/artemis-server/src/test/resources/ConfigurationTest-xinclude-schema-config-address-settings.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-xinclude-schema-config-address-settings.xml
@@ -83,5 +83,6 @@
       <default-consumer-window-size>10000</default-consumer-window-size>
       <retroactive-message-count>10</retroactive-message-count>
       <enable-metrics>false</enable-metrics>
+      <id-cache-size>500</id-cache-size>
    </address-setting>
 </address-settings>

--- a/docs/user-manual/address-settings.adoc
+++ b/docs/user-manual/address-settings.adoc
@@ -76,6 +76,7 @@ Here an example of an `address-setting` entry that might be found in the `broker
       <retroactive-message-count>0</retroactive-message-count>
       <enable-metrics>true</enable-metrics>
       <enable-ingress-timestamp>false</enable-ingress-timestamp>
+      <id-cache-size>500</id-cache-size>
    </address-setting>
 </address-settings>
 ----
@@ -371,3 +372,9 @@ For core messages (used by the core and OpenWire protocols) the broker will add 
 For STOMP messages the broker will add a frame header  named `ingress-timestamp`.
 The value will be the number of milliseconds since the https://en.wikipedia.org/wiki/Unix_time[epoch].
 Default is `false`.
+
+id-cache-size::
+defines the maximum size of the duplicate ID cache for an address, as each address has it's own cache
+that helps to detect and prevent the processing of duplicate messages based on their unique identification.
+By default, the `id-cache-size` setting inherits from the global `id-cache-size`, with a default of `20000`
+elements if not explicitly configured. Read more about xref:duplicate-detection.adoc#configuring-the-duplicate-id-cache[duplicate id cache sizes].

--- a/docs/user-manual/configuration-index.adoc
+++ b/docs/user-manual/configuration-index.adoc
@@ -808,6 +808,10 @@ see `auto-create-queues` & `auto-create-addresses`
 | xref:retroactive-addresses.adoc#retroactive-addresses[retroactive-message-count]
 | the number of messages to preserve for future queues created on the matching address
 | `0`
+
+| xref:duplicate-detection.adoc#configuring-the-duplicate-id-cache[id-cache-size]
+| The duplicate detection circular cache size
+| Inherits from global `id-cache-size`
 |===
 
 == bridge type

--- a/docs/user-manual/duplicate-detection.adoc
+++ b/docs/user-manual/duplicate-detection.adoc
@@ -82,6 +82,13 @@ If the cache has a maximum size of `n` elements, then the ``n + 1``th id stored 
 
 The maximum size of the cache is configured by the parameter `id-cache-size` in `broker.xml`, the default value is `20000` elements.
 
+To implement an address-specific `id-cache-size`, you can add to the
+corresponding address-settings section in `broker.xml`. Specify the
+desired `id-cache-size` value for the particular address. When a message
+is sent to an address with a specific `id-cache-size` configured, it
+will take precedence over the global `id-cache-size` value, allowing
+for greater flexibility and optimization of duplicate ID caching.
+
 The caches can also be configured to persist to disk or not.
 This is configured by the parameter `persist-id-cache`, also in `broker.xml`.
 If this is set to `true` then each id will be persisted to permanent storage as they are received.


### PR DESCRIPTION
### **Why were these changes made?**
This pull request introduces support for configuring a specific id-cache-size per address - [ARTEMIS-4159](https://issues.apache.org/jira/browse/ARTEMIS-4159). The changes include modifications to various files:
* artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
* artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
* artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
* artemis-server/src/main/resources/schema/artemis-configuration.xsd
* artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImplTest.java
* artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
* artemis-server/src/test/java/org/apache/activemq/artemis/core/settings/AddressSettingsTest.java
* artemis-server/src/test/resources/ConfigurationTest-full-config.xml
* artemis-server/src/test/resources/ConfigurationTest-xinclude-config-address-settings.xml
* artemis-server/src/test/resources/ConfigurationTest-xinclude-schema-config-address-settings.xml
* docs/user-manual/en/address-settings.md
* docs/user-manual/en/configuration-index.md
* docs/user-manual/en/duplicate-detection.md
* tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/DuplicateDetectionTest.java

**Changes Made:**
* FileConfigurationParser.java
Added a constant ID_CACHE_SIZE to represent the id-cache-size attribute in the XML configuration.
Updated the FileConfigurationParser to parse the id-cache-size attribute from the XML and set it on the AddressSettings.
* PostOfficeImpl.java
Introduced a new method resolveIdCacheSize to determine the effective id-cache-size for an address.
Updated getDuplicateIDCache method to use the resolveIdCacheSize method to get the proper id-cache-size for the address.
* AddressSettings.java
Added a new attribute idCacheSize to store the id-cache-size configuration for an address.
Implemented getter and setter methods for idCacheSize.
* artemis-configuration.xsd
Updated the XSD schema to include the id-cache-size attribute for the address settings.
* ConfigurationImplTest.java
Added a new test method to verify parsing of id-cache-size configuration from prefixed properties.
* FileConfigurationTest.java
Added a new test method to verify the parsing of the id-cache-size configuration from the XML configuration file.
* ConfigurationTest-full-config.xml, ConfigurationTest-xinclude-config-address-settings.xml, ConfigurationTest-xinclude-schema-config-address-settings.xml
Added <id-cache-size> elements to the address settings to test the configuration.
* DuplicateDetectionTest.java
Added a new test method to verify the functionality of the address-specific id-cache-size setting.
* AddressSettingsTest.java 
Added to the testSingleMerge to make sure idCacheSize merges correctly.

* docs/user-manual/en/address-settings.md, docs/user-manual/en/configuration-index.md, docs/user-manual/en/duplicate-detection.md
Added documentation for the above for address specific information about `id-cache-size`.

**User Facing Changes:**
New Configuration Option: id-cache-size for Address Settings
With this pull request, administrators now have the ability to configure a specific id-cache-size for each address, allowing better customization and optimization of resources for different addresses.


**Motivation:**
This enhancement provides the ability to configure a specific id-cache-size for each address, allowing better customization and optimization of resources for different addresses. Administrators can now specify the cache size for individual addresses, which will default to the global setting if not explicitly set for an address. This improvement eliminates the need for deploying multiple instances of Artemis with different global cache sizes based on address requirements. The pull request aims to simplify configuration and reduce resource consumption in scenarios where different addresses have different caching needs.