### PR TITLE
ARTEMIS-4376 add Dockerfile for Alpine + JRE 11

### DIFF
--- a/artemis-docker/Dockerfile-alpine-11-jre
+++ b/artemis-docker/Dockerfile-alpine-11-jre
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# ActiveMQ Artemis
+
+FROM eclipse-temurin:11-jre-alpine
+LABEL maintainer="Apache ActiveMQ Team"
+
+# add user and group for artemis
+RUN addgroup --gid 1001 --system artemis && adduser --uid 1001 --ingroup artemis --disabled-password --no-create-home artemis
+
+# alpine doesn't come with bash
+RUN /bin/sh -c "apk update && apk upgrade --no-cache && apk add --no-cache bash libaio"
+
+# Make sure pipes are considered to determine success, see: https://github.com/hadolint/hadolint/wiki/DL4006
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+WORKDIR /opt
+
+ENV ARTEMIS_USER artemis
+ENV ARTEMIS_PASSWORD artemis
+ENV ANONYMOUS_LOGIN false
+ENV EXTRA_ARGS --http-host 0.0.0.0 --relax-jolokia
+
+USER artemis
+
+ADD . /opt/activemq-artemis
+
+# Web Server
+EXPOSE 8161 \
+# JMX Exporter
+    9404 \
+# Port for CORE,MQTT,AMQP,HORNETQ,STOMP,OPENWIRE
+    61616 \
+# Port for HORNETQ,STOMP
+    5445 \
+# Port for AMQP
+    5672 \
+# Port for MQTT
+    1883 \
+#Port for STOMP
+    61613
+
+USER root
+
+RUN mkdir /var/lib/artemis-instance && chown -R artemis.artemis /var/lib/artemis-instance
+
+COPY ./docker/docker-run.sh /
+
+USER artemis
+
+# Expose some outstanding folders
+VOLUME ["/var/lib/artemis-instance"]
+WORKDIR /var/lib/artemis-instance
+
+ENTRYPOINT ["/docker-run.sh"]
+CMD ["run"]
+

--- a/artemis-docker/prepare-docker.sh
+++ b/artemis-docker/prepare-docker.sh
@@ -53,14 +53,20 @@ Well done! Now you can continue with building the Docker image:
   # Go to $ARTEMIS_DIST_DIR
   $ cd $ARTEMIS_DIST_DIR
 
-  # For CentOS with full JDK
+  # For CentOS with full JDK 11
   $ docker build -f ./docker/Dockerfile-centos7-11 -t artemis-centos .
 
-  # For Ubuntu with full JDK
+  # For Ubuntu with full JDK 11
   $ docker build -f ./docker/Dockerfile-ubuntu-11 -t artemis-ubuntu .
 
-  # For Ubuntu with just JRE
-  $ docker build -f ./docker/Dockerfile-ubuntu-11-jre -t artemis-ubuntu .
+  # For Ubuntu with just JRE 11
+  $ docker build -f ./docker/Dockerfile-ubuntu-11-jre -t artemis-ubuntu-jre .
+
+  # For Alpine with full JDK 17
+  $ docker build -f ./docker/Dockerfile-alpine-17 -t artemis-alpine .
+
+  # For Alpine with just JRE 11
+  $ docker build -f ./docker/Dockerfile-alpine-11-jre -t artemis-alpine-jre .
 
   # For Ubuntu on Linux ARMv7/ARM64 with full JDK
   $ docker buildx build --platform linux/arm64,linux/arm/v7 --push -t {your-repository}/apache-artemis:2.17.0-SNAPSHOT -f ./docker/Dockerfile-ubuntu-11 .

--- a/artemis-docker/readme.md
+++ b/artemis-docker/readme.md
@@ -38,14 +38,20 @@ Well done! Now you can continue with building the Docker image:
   # Go to ../artemis-distribution/target/apache-artemis-2.17.0-SNAPSHOT-bin/apache-artemis-2.17.0-SNAPSHOT
   $ cd ../artemis-distribution/target/apache-artemis-2.17.0-SNAPSHOT-bin/apache-artemis-2.17.0-SNAPSHOT
 
-  # For CentOS with full JDK
+  # For CentOS with full JDK 11
   $ docker build -f ./docker/Dockerfile-centos7-11 -t artemis-centos .
 
-  # For Ubuntu with full JDK
+  # For Ubuntu with full JDK 11
   $ docker build -f ./docker/Dockerfile-ubuntu-11 -t artemis-ubuntu .
 
-  # For Ubuntu with just JRE
-  $ docker build -f ./docker/Dockerfile-ubuntu-11-jre -t artemis-ubuntu .
+  # For Ubuntu with just JRE 11
+  $ docker build -f ./docker/Dockerfile-ubuntu-11-jre -t artemis-ubuntu-jre .
+
+  # For Alpine with full JDK 17
+  $ docker build -f ./docker/Dockerfile-alpine-17 -t artemis-alpine .
+
+  # For Alpine with just JRE 11
+  $ docker build -f ./docker/Dockerfile-alpine-11-jre -t artemis-alpine-jre .
 
   # For Ubuntu on Linux ARMv7/ARM64 with full JDK
   $ docker buildx build --platform linux/arm64,linux/arm/v7 --push -t {your-repository}/apache-artemis:2.17.0-SNAPSHOT -f ./docker/Dockerfile-ubuntu-11 .


### PR DESCRIPTION
The goal for this file is to be used in conjunction with the existing Dockerfile-ubuntu-11-jre when pushing images to
https://hub.docker.com/r/apache/activemq-artemis.

I also updated the documentation.