### PR TITLE
ARTEMIS-4408 Update docker-run.sh for overriding etc folder after instance creation

### DIFF
--- a/artemis-docker/docker-run.sh
+++ b/artemis-docker/docker-run.sh
@@ -40,6 +40,9 @@ echo CREATE_ARGUMENTS=${CREATE_ARGUMENTS}
 
 if ! [ -f ./etc/broker.xml ]; then
     /opt/activemq-artemis/bin/artemis create ${CREATE_ARGUMENTS} .
+    if [ -d ./etc-override ]; then
+        for file in `ls ./etc-override`; do echo copying file to etc folder: $file; cp ./etc-override/$file ./etc || :; done
+    fi
 else
     echo "broker already created, ignoring creation"
 fi

--- a/artemis-docker/readme.md
+++ b/artemis-docker/readme.md
@@ -186,7 +186,14 @@ This will hold the configuration and the data of the running broker. This is use
 
 A broker instance will be created during the execution of the instance. If you pass a mapped folder for `/var/lib/artemis-instance` an image will be created or reused depending on the contents of the folder.
 
+# Overriding files in etc folder
 
+You can use customized configuration for the artemis instance by replacing the files residing in `etc` folder with the custom ones, eg. `broker.xml` or `artemis.profile`. Put the replacement files inside a folder and map it as a volume to:
+- `/var/lib/artemis-instance/etc-override`
+
+The contents of `etc-override` folder will be copied over to etc folder after the instance creation. Therefore, the image will always start with user-supplied configuration.
+
+It you are mapping the whole `var/lib/artemis-instance` to an outside folder for persistence, you can place an `etc-override` folder inside the mapped one, its contents will again be copied over etc folder after creating the instance.
 
 ## Running a CentOS image
 


### PR DESCRIPTION
**Issue**: After creating the artemis docker image using the official docker scripts, it is not possible to map a user supplied broker.xml using a volume mapping, before running the container at least once. 

Some questions related to this issue on stackoverflow: 
* https://stackoverflow.com/questions/75493917/how-to-customize-the-broker-xml-file-in-the-standard-apache-activemq-artemis-doc
* https://stackoverflow.com/questions/71149959/how-to-provide-a-custom-broker-xml-to-activemq-artemis-broker-instance
* https://stackoverflow.com/questions/76071388/how-can-i-replace-the-broker-xml-in-activemq-artemis-with-a-customized-broker-xm

This very small patch solves the problem by introducing an **etc-override** folder. If an outside folder is mapped as volume to **/var/lib/artemis-instance/etc-override**, its contents will be copied to **etc** folder after instance creation. Therefore, the image will always start with user-supplied configuration, eg. custom broker.xml / artemis.profile files.

This change does not modify the use case of mapping the whole instance folder.  If the instance folder is mapped as volume, it is sufficient to place an **etc-override** folder inside the mapped folder, its contents will again be copied over **etc** folder.