### PR TITLE
Fix a memory leak in HandlerBase.

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/actors/HandlerBase.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/actors/HandlerBase.java
@@ -37,11 +37,18 @@ public abstract class HandlerBase {
    }
 
    public static boolean inHandler() {
-      return inHandler.get().count > 0;
+      int count = inHandler.get().count;
+      if (count == 0) {
+         inHandler.remove();
+      }
+      return count > 0;
    }
 
    protected static void leave() {
-      inHandler.get().count--;
+      int count = --inHandler.get().count;
+      if (count == 0) {
+         inHandler.remove();
+      }
    }
 
 }


### PR DESCRIPTION
The `ThreadLocal`'s value in `HandlerBase` is never cleaned up.

Found by log statements issued by Tomcat during the undeployment of a web application that uses an embedded broker instance.