### PR TITLE
ARTEMIS-4387 Fix empty consumer filter string leak

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -616,8 +616,8 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
 
          props.putSimpleStringProperty(ManagementHelper.HDR_SESSION_NAME, SimpleString.toSimpleString(name));
 
-         if (filterString != null) {
-            props.putSimpleStringProperty(ManagementHelper.HDR_FILTERSTRING, filterString);
+         if (filter != null) {
+            props.putSimpleStringProperty(ManagementHelper.HDR_FILTERSTRING, filter.getFilterString());
          }
 
          if (remotingConnection.getClientID() != null) {


### PR DESCRIPTION
Repeated creation and disposal of queue consumers with empty string (`""`) filters could cause these strings to build up within a `QueueInfo` instance belonging to that queue.