### PR TITLE
ARTEMIS-4390 Fix upgrade-linux smoke test on Windows

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
@@ -756,7 +756,7 @@ public class Create extends InstallAbstract {
          writeEtc(ETC_ARTEMIS_PROFILE_CMD, etcFolder, filters, false);
       }
 
-      if (!IS_WINDOWS || IS_CYGWIN) {
+      if (IS_NIX) {
          write(BIN_ARTEMIS, filters, true);
          makeExec(BIN_ARTEMIS);
          write(BIN_ARTEMIS_SERVICE, filters, true);
@@ -847,7 +847,7 @@ public class Create extends InstallAbstract {
       File service = new File(directory, BIN_ARTEMIS_SERVICE);
       context.out.println("");
 
-      if (!IS_WINDOWS || IS_CYGWIN) {
+      if (IS_NIX) {
          context.out.println("Or you can run the broker in the background using:");
          context.out.println("");
          context.out.println(String.format("   \"%s\" start", path(service)));

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Upgrade.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Upgrade.java
@@ -89,7 +89,7 @@ public class Upgrade extends InstallAbstract {
       final File artemisScript = new File(bin, Create.ARTEMIS);
 
       if (etc == null || etc.equals("etc")) {
-         if (IS_WINDOWS && !IS_CYGWIN) {
+         if (IS_WINDOWS) {
             String pattern = "set ARTEMIS_INSTANCE_ETC=";
             etcFolder = getETC(context, etcFolder, artemisCmdScript, pattern);
          } else {
@@ -157,7 +157,7 @@ public class Upgrade extends InstallAbstract {
                     "set ARTEMIS_INSTANCE=\"", "set ARTEMIS_DATA_DIR=", "set ARTEMIS_ETC_DIR=", "set ARTEMIS_OOME_DUMP=", "set ARTEMIS_INSTANCE_URI=", "set ARTEMIS_INSTANCE_ETC_URI=");
       }
 
-      if (!IS_WINDOWS || IS_CYGWIN) {
+      if (IS_NIX) {
          final File artemisScriptTmp = new File(tmp, Create.ARTEMIS);
          final File artemisScriptBkp = new File(binBkp, Create.ARTEMIS);
 

--- a/tests/smoke-tests/pom.xml
+++ b/tests/smoke-tests/pom.xml
@@ -1276,8 +1276,11 @@
                   </goals>
                   <configuration>
                      <instance>${basedir}/target/classes/servers/linuxUpgrade</instance>
-                     <!-- we don't pass the java memory argumnent on purpose,
-                          as the upgrade should keep the relevant JVM arguments during the upgrade -->
+                     <args>
+                        <arg>--linux</arg>
+                        <!-- we don't pass the java memory argumnent on purpose,
+                             as the upgrade should keep the relevant JVM arguments during the upgrade -->
+                     </args>
                   </configuration>
                </execution>
                <execution>


### PR DESCRIPTION
The test cannot work on Windows unless I can make the `upgrade` CLI command respect my choice to upgrade a Linux distribution. This commit therefore adds a new `--linux` option for the `upgrade` command, and leverages it in the `upgrade-linux` smoke test.

* The `--cygwin` option has been preserved for backwards compatibility.
* The `IS_CYGWIN` attribute has been renamed to `IS_NIX` to reflect the change.
* The OS "recognition" method (in `InstallAbstract::run`) has been updated to reflect the need for enforcing *nix behavior, which is now the default if all other methods fail.