### PR TITLE
ARTEMIS-4389 The word "mesage" should be corrected to "message"

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1562,7 +1562,7 @@ public interface ActiveMQServerLogger {
    @LogMessage(id = 224119, value = "Unable to refresh security settings: {}", level = LogMessage.Level.WARN)
    void unableToRefreshSecuritySettings(String exceptionMessage);
 
-   @LogMessage(id = 224120, value = "Queue {} on Address {} has more messages than configured page limit. PageLimitMesages={} while currentValue={}", level = LogMessage.Level.WARN)
+   @LogMessage(id = 224120, value = "Queue {} on Address {} has more messages than configured page limit. PageLimitMessages={} while currentValue={}", level = LogMessage.Level.WARN)
    void pageFull(SimpleString queue, SimpleString address, Object pageLImitMessage, Object currentValue);
 
    @LogMessage(id = 224121, value = "Queue {} on Address {} is out of page limit now. We will issue a cleanup to check other queues.", level = LogMessage.Level.WARN)

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpFlowControlFailTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpFlowControlFailTest.java
@@ -115,7 +115,7 @@ public class AmqpFlowControlFailTest {
       }
 
       @Test
-      public void testMesagesNotSent() throws Exception {
+      public void testMessagesNotSent() throws Exception {
          AmqpClient client = createAmqpClient(getBrokerAmqpConnectionURI());
          AmqpConnection connection = client.connect();
          int messagesSent = 0;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/TopicDurableTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/TopicDurableTests.java
@@ -248,7 +248,7 @@ public class TopicDurableTests extends JMSClientTestSupport {
          resultsList.add(new CompletableFuture<>());
          receivedResList.add(new ArrayList<>());
          MessageListener myListener = message -> {
-            logger.debug("Mesages received{} count: {}", message, totalCount.get());
+            logger.debug("Messages received{} count: {}", message, totalCount.get());
             receivedResList.get(index).add(message);
             if (totalCount.decrementAndGet() == 0) {
                for (int j = 0; j < consumer.length; j++) {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/OpenWireFlowControlFailTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/OpenWireFlowControlFailTest.java
@@ -49,7 +49,7 @@ public class OpenWireFlowControlFailTest extends OpenWireTestBase {
    }
 
    @Test(timeout = 60000)
-   public void testMesagesNotSent() throws Exception {
+   public void testMessagesNotSent() throws Exception {
 
       AddressInfo addressInfo = new AddressInfo(SimpleString.toSimpleString("Test"), RoutingType.ANYCAST);
       server.addAddressInfo(addressInfo);


### PR DESCRIPTION
The corrections were made to address typographical errors found in both logging messages and certain test cases.
Jira link - https://issues.apache.org/jira/browse/ARTEMIS-4389
