### PR TITLE
ARTEMIS-966 MQTT subscription state isn't durable

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/RandomUtil.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/RandomUtil.java
@@ -60,6 +60,11 @@ public class RandomUtil {
       return Math.abs(RandomUtil.randomInt());
    }
 
+   public static Integer randomPositiveIntOrNull() {
+      Integer random = RandomUtil.randomInt();
+      return random % 5 == 0 ? null : Math.abs(random);
+   }
+
    public static ActiveMQBuffer randomBuffer(final int size, final long... data) {
       ActiveMQBuffer buffer = ActiveMQBuffers.fixedBuffer(size + 8 * data.length);
 

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessage.java
@@ -1270,9 +1270,17 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
    public String toString() {
       try {
          final TypedProperties properties = getProperties();
-         return "CoreMessage[messageID=" + messageID + ",durable=" + isDurable() + ",userID=" + getUserID() + ",priority=" + this.getPriority()  +
-            ", timestamp=" + toDate(getTimestamp()) + ",expiration=" + toDate(getExpiration()) +
-            ", durable=" + durable + ", address=" + getAddress() + ",size=" + getPersistentSize() + ",properties=" + properties + "]@" + System.identityHashCode(this);
+         return "CoreMessage[messageID=" + messageID +
+            ", durable=" + isDurable() +
+            ", userID=" + getUserID() +
+            ", priority=" + this.getPriority() +
+            ", timestamp=" + toDate(getTimestamp()) +
+            ", expiration=" + toDate(getExpiration()) +
+            ", durable=" + durable +
+            ", address=" + getAddress() +
+            ", size=" + getPersistentSize() +
+            ", properties=" + properties +
+            "]@" + System.identityHashCode(this);
       } catch (Throwable e) {
          logger.warn("Error creating String for message: ", e);
          return "ServerMessage[messageID=" + messageID + "]";

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTBundle.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTBundle.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.protocol.mqtt;
+
+import org.apache.activemq.artemis.logs.BundleFactory;
+import org.apache.activemq.artemis.logs.annotation.LogBundle;
+import org.apache.activemq.artemis.logs.annotation.Message;
+
+/**
+ * Logger Code 85
+ */
+@LogBundle(projectCode = "AMQ", regexID = "85[0-9]{4}")
+public interface MQTTBundle {
+
+   MQTTBundle BUNDLE = BundleFactory.newBundle(MQTTBundle.class);
+
+   @Message(id = 850000, value = "Unable to store MQTT state within given timeout: {}ms")
+   IllegalStateException unableToStoreMqttState(long timeout);
+}

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTConnectionManager.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTConnectionManager.java
@@ -67,7 +67,7 @@ public class MQTTConnectionManager {
       boolean cleanStart = connect.variableHeader().isCleanSession();
 
       String clientId = session.getConnection().getClientID();
-      boolean sessionPresent = session.getProtocolManager().getSessionStates().containsKey(clientId);
+      boolean sessionPresent = session.getStateManager().getSessionStates().containsKey(clientId);
       MQTTSessionState sessionState = getSessionState(clientId);
       synchronized (sessionState) {
          session.setSessionState(sessionState);
@@ -120,6 +120,7 @@ public class MQTTConnectionManager {
 
             connackProperties = getConnackProperties();
          } else {
+            sessionState.setClientSessionExpiryInterval(session.getProtocolManager().getDefaultMqttSessionExpiryInterval());
             connackProperties = MqttProperties.NO_PROPERTIES;
          }
 
@@ -193,15 +194,15 @@ public class MQTTConnectionManager {
                 *  ensure that the connection for the client ID matches *this* connection otherwise we could remove the
                 *  entry for the client who "stole" this client ID via [MQTT-3.1.4-2]
                 */
-               if (clientId != null && session.getProtocolManager().isClientConnected(clientId, session.getConnection())) {
-                  session.getProtocolManager().removeConnectedClient(clientId);
+               if (clientId != null && session.getStateManager().isClientConnected(clientId, session.getConnection())) {
+                  session.getStateManager().removeConnectedClient(clientId);
                }
             }
          }
       }
    }
 
-   private synchronized MQTTSessionState getSessionState(String clientId) {
-      return session.getProtocolManager().getSessionState(clientId);
+   private synchronized MQTTSessionState getSessionState(String clientId) throws Exception {
+      return session.getStateManager().getSessionState(clientId);
    }
 }

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTLogger.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTLogger.java
@@ -58,4 +58,7 @@ public interface MQTTLogger {
 
    @LogMessage(id = 834007, value = "Authorization failure sending will message: {}", level = LogMessage.Level.ERROR)
    void authorizationFailureSendingWillMessage(String message);
+
+   @LogMessage(id = 834008, value = "Failed to remove session state for client with ID: {}", level = LogMessage.Level.ERROR)
+   void failedToRemoveSessionState(String clientID, Exception e);
 }

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTProtocolManagerFactory.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTProtocolManagerFactory.java
@@ -84,7 +84,7 @@ public class MQTTProtocolManagerFactory extends AbstractProtocolManagerFactory<M
             if (protocolHandler != null) {
                protocolHandler.getProtocolMap().values().forEach(m -> {
                   if (m instanceof MQTTProtocolManager) {
-                     ((MQTTProtocolManager)m).scanSessions();
+                     ((MQTTProtocolManager)m).getStateManager().scanSessions();
                   }
                });
             }

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTStateManager.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTStateManager.java
@@ -1,0 +1,246 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.core.protocol.mqtt;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import io.netty.handler.codec.mqtt.MqttTopicSubscription;
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.api.core.Message;
+import org.apache.activemq.artemis.api.core.Pair;
+import org.apache.activemq.artemis.api.core.QueueConfiguration;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.core.filter.impl.FilterImpl;
+import org.apache.activemq.artemis.core.message.impl.CoreMessage;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.MessageReference;
+import org.apache.activemq.artemis.core.server.Queue;
+import org.apache.activemq.artemis.core.transaction.Transaction;
+import org.apache.activemq.artemis.core.transaction.TransactionOperationAbstract;
+import org.apache.activemq.artemis.core.transaction.impl.TransactionImpl;
+import org.apache.activemq.artemis.utils.collections.LinkedListIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MQTTStateManager {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private ActiveMQServer server;
+   private final Map<String, MQTTSessionState> sessionStates = new ConcurrentHashMap<>();
+   private final Queue sessionStore;
+   private static Map<Integer, MQTTStateManager> INSTANCES = new HashMap<>();
+   private final Map<String, MQTTConnection> connectedClients  = new ConcurrentHashMap<>();
+
+   /*
+    * Even though there may be multiple instances of MQTTProtocolManager (e.g. for MQTT on different ports) we only want
+    * one instance of MQTTSessionStateManager per-broker with the understanding that there can be multiple brokers in
+    * the same JVM.
+    */
+   public static synchronized MQTTStateManager getInstance(ActiveMQServer server) throws Exception {
+      MQTTStateManager instance = INSTANCES.get(System.identityHashCode(server));
+      if (instance == null) {
+         instance = new MQTTStateManager(server);
+         INSTANCES.put(System.identityHashCode(server), instance);
+      }
+
+      return instance;
+   }
+
+   public static synchronized void removeInstance(ActiveMQServer server) {
+      INSTANCES.remove(System.identityHashCode(server));
+   }
+
+   private MQTTStateManager(ActiveMQServer server) throws Exception {
+      this.server = server;
+      sessionStore = server.createQueue(new QueueConfiguration(MQTTUtil.MQTT_SESSION_STORE).setRoutingType(RoutingType.ANYCAST).setLastValue(true).setDurable(true).setInternal(true).setAutoCreateAddress(true), true);
+
+      // load session data from queue
+      try (LinkedListIterator<MessageReference> iterator = sessionStore.browserIterator()) {
+         try {
+            while (iterator.hasNext()) {
+               MessageReference ref = iterator.next();
+               String clientId = ref.getMessage().getStringProperty(Message.HDR_LAST_VALUE_NAME);
+               MQTTSessionState sessionState = new MQTTSessionState((CoreMessage) ref.getMessage(), this);
+               sessionStates.put(clientId, sessionState);
+            }
+         } catch (NoSuchElementException ignored) {
+            // this could happen through paging browsing
+         }
+      }
+   }
+
+   public void scanSessions() {
+      List<String> toRemove = new ArrayList();
+      for (Map.Entry<String, MQTTSessionState> entry : sessionStates.entrySet()) {
+         MQTTSessionState state = entry.getValue();
+         logger.debug("Inspecting session: {}", state);
+         int sessionExpiryInterval = state.getClientSessionExpiryInterval();
+         if (!state.isAttached() && sessionExpiryInterval > 0 && state.getDisconnectedTime() + (sessionExpiryInterval * 1000) < System.currentTimeMillis()) {
+            toRemove.add(entry.getKey());
+         }
+         if (state.isWill() && !state.isAttached() && state.isFailed() && state.getWillDelayInterval() > 0 && state.getDisconnectedTime() + (state.getWillDelayInterval() * 1000) < System.currentTimeMillis()) {
+            state.getSession().sendWillMessage();
+         }
+      }
+
+      for (String key : toRemove) {
+         try {
+            MQTTSessionState state = removeSessionState(key);
+            if (state != null && state.isWill() && !state.isAttached() && state.isFailed()) {
+               state.getSession().sendWillMessage();
+            }
+         } catch (Exception e) {
+            MQTTLogger.LOGGER.failedToRemoveSessionState(key, e);
+         }
+      }
+   }
+
+   public MQTTSessionState getSessionState(String clientId) throws Exception {
+      /* [MQTT-3.1.2-4] Attach an existing session if one exists otherwise create a new one. */
+      if (sessionStates.containsKey(clientId)) {
+         return sessionStates.get(clientId);
+      } else {
+         MQTTSessionState sessionState = new MQTTSessionState(clientId, this);
+         logger.debug("Adding MQTT session state for: {}", clientId);
+         sessionStates.put(clientId, sessionState);
+         storeSessionState(sessionState);
+         return sessionState;
+      }
+   }
+
+   public MQTTSessionState removeSessionState(String clientId) throws Exception {
+      logger.debug("Removing MQTT session state for: {}", clientId);
+      if (clientId == null) {
+         return null;
+      }
+      removeDurableSessionState(clientId);
+      return sessionStates.remove(clientId);
+   }
+
+   public void removeDurableSessionState(String clientId) throws Exception {
+      int deletedCount = sessionStore.deleteMatchingReferences(FilterImpl.createFilter(new StringBuilder(Message.HDR_LAST_VALUE_NAME).append(" = '").append(clientId).append("'").toString()));
+      logger.debug("Removed {} durable MQTT state records for: {}", deletedCount, clientId);
+   }
+
+   public Map<String, MQTTSessionState> getSessionStates() {
+      return new HashMap<>(sessionStates);
+   }
+
+   @Override
+   public String toString() {
+      return "MQTTSessionStateManager@" + Integer.toHexString(System.identityHashCode(this));
+   }
+
+   public void storeSessionState(MQTTSessionState state) throws Exception {
+      logger.debug("Adding durable MQTT state record for: {}", state.getClientId());
+
+      /*
+       * It is imperative to ensure the routed message is actually *all the way* on the queue before proceeding
+       * otherwise there can be a race with removing it.
+       */
+      CountDownLatch latch = new CountDownLatch(1);
+      Transaction tx = new TransactionImpl(server.getStorageManager());
+      server.getPostOffice().route(serializeState(state, server.getStorageManager().generateID()), tx, false);
+      tx.addOperation(new TransactionOperationAbstract() {
+         @Override
+         public void afterCommit(Transaction tx) {
+            latch.countDown();
+         }
+      });
+      tx.commit();
+      final long timeout = 5000;
+      if (!latch.await(timeout, TimeUnit.MILLISECONDS)) {
+         throw MQTTBundle.BUNDLE.unableToStoreMqttState(timeout);
+      }
+   }
+
+   public static CoreMessage serializeState(MQTTSessionState state, long messageID) {
+      CoreMessage message = new CoreMessage().initBuffer(50).setMessageID(messageID);
+      message.setAddress(MQTTUtil.MQTT_SESSION_STORE);
+      message.setDurable(true);
+      message.putStringProperty(Message.HDR_LAST_VALUE_NAME, state.getClientId());
+      Collection<Pair<MqttTopicSubscription, Integer>> subscriptions = state.getSubscriptionsPlusID();
+      ActiveMQBuffer buf = message.getBodyBuffer();
+
+      /*
+       * This byte represents the "version". If the payload changes at any point in the future then we can detect that
+       * and adjust so that when users are upgrading we can still read the old data format.
+       */
+      buf.writeByte((byte) 0);
+
+      buf.writeInt(subscriptions.size());
+      logger.debug("Serializing {} subscriptions", subscriptions.size());
+      for (Pair<MqttTopicSubscription, Integer> pair : subscriptions) {
+         MqttTopicSubscription sub = pair.getA();
+         buf.writeString(sub.topicName());
+         buf.writeInt(sub.option().qos().value());
+         buf.writeBoolean(sub.option().isNoLocal());
+         buf.writeBoolean(sub.option().isRetainAsPublished());
+         buf.writeInt(sub.option().retainHandling().value());
+         buf.writeNullableInt(pair.getB());
+      }
+
+      return message;
+   }
+
+   public boolean isClientConnected(String clientId, MQTTConnection connection) {
+      MQTTConnection connectedConn = connectedClients.get(clientId);
+
+      if (connectedConn != null) {
+         return connectedConn.equals(connection);
+      }
+
+      return false;
+   }
+
+   public boolean isClientConnected(String clientId) {
+      return connectedClients.containsKey(clientId);
+   }
+
+   public void removeConnectedClient(String clientId) {
+      connectedClients.remove(clientId);
+   }
+
+   /**
+    * @param clientId
+    * @param connection
+    * @return the {@code MQTTConnection} that the added connection replaced or null if there was no previous entry for
+    * the {@code clientId}
+    */
+   public MQTTConnection addConnectedClient(String clientId, MQTTConnection connection) {
+      return connectedClients.put(clientId, connection);
+   }
+
+   public MQTTConnection getConnectedClient(String clientId) {
+      return connectedClients.get(clientId);
+   }
+
+   /** For DEBUG only */
+   public Map<String, MQTTConnection> getConnectedClients() {
+      return connectedClients;
+   }
+}

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTUtil.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTUtil.java
@@ -86,6 +86,8 @@ public class MQTTUtil {
 
    public static final char SLASH = '/';
 
+   public static final String MQTT_SESSION_STORE = DOLLAR + "sys.mqtt.sessions";
+
    public static final String MQTT_RETAIN_ADDRESS_PREFIX = DOLLAR + "sys.mqtt.retain.";
 
    public static final SimpleString MQTT_QOS_LEVEL_KEY = SimpleString.toSimpleString("mqtt.qos.level");

--- a/artemis-protocols/artemis-mqtt-protocol/src/test/java/org/apache/activemq/artemis/core/protocol/mqtt/StateSerDeTest.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/test/java/org/apache/activemq/artemis/core/protocol/mqtt/StateSerDeTest.java
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.core.protocol.mqtt;
+
+import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttSubscriptionOption;
+import io.netty.handler.codec.mqtt.MqttTopicSubscription;
+import org.apache.activemq.artemis.api.core.Pair;
+import org.apache.activemq.artemis.core.message.impl.CoreMessage;
+import org.apache.activemq.artemis.utils.RandomUtil;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class StateSerDeTest {
+
+   @Test(timeout = 30000)
+   public void testSerDe() throws Exception {
+      for (int i = 0; i < 500; i++) {
+         String clientId = RandomUtil.randomString();
+         MQTTSessionState unserialized = new MQTTSessionState(clientId, null);
+         Integer subscriptionIdentifier = RandomUtil.randomPositiveIntOrNull();
+         for (int j = 0; j < RandomUtil.randomInterval(1, 50); j++) {
+            MqttTopicSubscription sub = new MqttTopicSubscription(RandomUtil.randomString(),
+                                                                  new MqttSubscriptionOption(MqttQoS.valueOf(RandomUtil.randomInterval(0, 3)),
+                                                                                             RandomUtil.randomBoolean(),
+                                                                                             RandomUtil.randomBoolean(),
+                                                                                             MqttSubscriptionOption.RetainedHandlingPolicy.valueOf(RandomUtil.randomInterval(0, 3))));
+            unserialized.addSubscription(sub, MQTTUtil.MQTT_WILDCARD, subscriptionIdentifier);
+         }
+
+         CoreMessage serializedState = MQTTStateManager.serializeState(unserialized, 0);
+         MQTTSessionState deserialized = new MQTTSessionState(serializedState, null);
+
+         assertEquals(unserialized.getClientId(), deserialized.getClientId());
+         for (Pair<MqttTopicSubscription, Integer> unserializedEntry : unserialized.getSubscriptionsPlusID()) {
+            MqttTopicSubscription unserializedSub = unserializedEntry.getA();
+            Integer unserializedSubId = unserializedEntry.getB();
+            Pair<MqttTopicSubscription, Integer> deserializedEntry = deserialized.getSubscriptionPlusID(unserializedSub.topicName());
+            MqttTopicSubscription deserializedSub = deserializedEntry.getA();
+            Integer deserializedSubId = deserializedEntry.getB();
+
+            assertTrue(compareSubs(unserializedSub, deserializedSub));
+            assertEquals(unserializedSubId, deserializedSubId);
+         }
+      }
+   }
+
+   private boolean compareSubs(MqttTopicSubscription a, MqttTopicSubscription b) {
+      if (a == b) {
+         return true;
+      }
+      if (a == null || b == null) {
+         return false;
+      }
+      if (a.topicName() == null) {
+         if (b.topicName() != null) {
+            return false;
+         }
+      } else if (!a.topicName().equals(b.topicName())) {
+         return false;
+      }
+      if (a.option() == null) {
+         if (b.option() != null) {
+            return false;
+         }
+      } else {
+         if (a.option().qos() == null) {
+            if (b.option().qos() != null) {
+               return false;
+            }
+         } else if (a.option().qos().value() != b.option().qos().value()) {
+            return false;
+         }
+         if (a.option().retainHandling() == null) {
+            if (b.option().retainHandling() != null) {
+               return false;
+            }
+         } else if (a.option().retainHandling().value() != b.option().retainHandling().value()) {
+            return false;
+         }
+         if (a.option().isRetainAsPublished() != b.option().isRetainAsPublished()) {
+            return false;
+         }
+         if (a.option().isNoLocal() != b.option().isNoLocal()) {
+            return false;
+         }
+      }
+
+      return true;
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMAcceptorFactory.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMAcceptorFactory.java
@@ -40,4 +40,9 @@ public class InVMAcceptorFactory implements AcceptorFactory {
                                   final Map<String, ProtocolManager> protocolMap) {
       return new InVMAcceptor(name, clusterConnection, configuration, handler, listener, protocolMap, threadPool);
    }
+
+   @Override
+   public boolean supportsRemote() {
+      return false;
+   }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
@@ -2226,6 +2226,8 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
          Transaction tx = new TransactionImpl(storageManager);
 
          synchronized (this) {
+            // ensure all messages are moved from intermediateMessageReferences so that they can be seen by the iterator
+            doInternalPoll();
 
             try (LinkedListIterator<MessageReference> iter = iterator()) {
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/remoting/AcceptorFactory.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/remoting/AcceptorFactory.java
@@ -51,4 +51,8 @@ public interface AcceptorFactory {
                            ScheduledExecutorService scheduledThreadPool,
                            Map<String, ProtocolManager> protocolMap);
 
+   default boolean supportsRemote() {
+      return true;
+   }
+
 }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
@@ -585,6 +585,9 @@ public abstract class ActiveMQTestBase extends Assert {
 
       if (netty) {
          configuration.addAcceptorConfiguration(new TransportConfiguration(NETTY_ACCEPTOR_FACTORY, new HashMap<String, Object>(), "netty", new HashMap<String, Object>()));
+      } else {
+         // if we're in-vm it's a waste to resolve protocols since they'll never be used
+         configuration.setResolveProtocols(false);
       }
 
       return configuration;

--- a/docs/user-manual/mqtt.adoc
+++ b/docs/user-manual/mqtt.adoc
@@ -89,6 +89,12 @@ As far as the broker is concerned a payload is just an array of bytes.
 However, to facilitate logging the broker will encode the payloads as UTF-8 strings and print them up to 256 characters.
 Payload logging is limited to avoid filling the logs with potentially hundreds of megabytes of unhelpful information.
 
+== Persistent Subscriptions
+
+The subscription information for MQTT sessions is stored in an internal queue named `$sys.mqtt.sessions` and persisted to disk (assuming persistence is enabled).
+The information is durable so that MQTT subscribers can reconnect and resume their subscriptions seamlessly after a broker restart, failure, etc.
+When brokers are configured for high availability this information will be available on the backup so even in the case of a broker fail-over subscribers will be able to resume their subscriptions.
+
 == Custom Client ID Handling
 
 The client ID used by an MQTT application is very important as it uniquely identifies the application.

--- a/examples/features/standard/divert/src/main/resources/activemq/server0/broker.xml
+++ b/examples/features/standard/divert/src/main/resources/activemq/server0/broker.xml
@@ -45,7 +45,7 @@ under the License.
 
       <!-- We need to create a core queue for the JMS queue explicitly because the bridge will be deployed
       before the JMS queue is deployed, so the first time, it otherwise won't find the queue -->
-      
+
 
       <diverts>
          <divert name="order-divert">

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/largemessages/AmqpReplicatedLargeMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/largemessages/AmqpReplicatedLargeMessageTest.java
@@ -59,8 +59,8 @@ public class AmqpReplicatedLargeMessageTest extends AmqpReplicatedTestSupport {
       super.setUp();
 
       createReplicatedConfigs();
-      liveConfig.addAcceptorConfiguration("amqp", smallFrameLive + "?protocols=AMQP;useEpoll=false;maxFrameSize=512");
-      backupConfig.addAcceptorConfiguration("amqp", smallFrameBackup + "?protocols=AMQP;useEpoll=false;maxFrameSize=512");
+      liveConfig.setResolveProtocols(true).addAcceptorConfiguration("amqp", smallFrameLive + "?protocols=AMQP;useEpoll=false;maxFrameSize=512");
+      backupConfig.setResolveProtocols(true).addAcceptorConfiguration("amqp", smallFrameBackup + "?protocols=AMQP;useEpoll=false;maxFrameSize=512");
       liveServer.start();
       backupServer.start();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MessageExpirationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/MessageExpirationTest.java
@@ -288,6 +288,7 @@ public class MessageExpirationTest extends ActiveMQTestBase {
 
       server = createServer(true);
       server.getConfiguration().addAcceptorConfiguration("amqp", "tcp://127.0.0.1:61616");
+      server.getConfiguration().setResolveProtocols(true);
       server.getConfiguration().setMessageExpiryScanPeriod(200);
       server.start();
       locator = createInVMNonHALocator();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/UpdateQueueTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/UpdateQueueTest.java
@@ -40,9 +40,9 @@ public class UpdateQueueTest extends ActiveMQTestBase {
 
    @Test
    public void testUpdateQueueWithNullUser() throws Exception {
-      ActiveMQServer server = createServer(true, true);
+      ActiveMQServer server = createServer(true, false);
 
-      ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory();
+      ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory("vm://0");
 
       server.start();
 
@@ -80,7 +80,7 @@ public class UpdateQueueTest extends ActiveMQTestBase {
 
       Assert.assertEquals("newUser", user, queue.getUser());
 
-      factory = new ActiveMQConnectionFactory();
+      factory = new ActiveMQConnectionFactory("vm://0");
 
       conn = factory.createConnection();
       session = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
@@ -110,9 +110,9 @@ public class UpdateQueueTest extends ActiveMQTestBase {
 
    @Test
    public void testUpdateQueue() throws Exception {
-      ActiveMQServer server = createServer(true, true);
+      ActiveMQServer server = createServer(true, false);
 
-      ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory();
+      ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory("vm://0");
 
       server.start();
 
@@ -169,7 +169,7 @@ public class UpdateQueueTest extends ActiveMQTestBase {
       Assert.assertEquals("newUser", queue.getUser().toString());
       Assert.assertEquals(180L, queue.getRingSize());
 
-      factory = new ActiveMQConnectionFactory();
+      factory = new ActiveMQConnectionFactory("vm://0");
 
       conn = factory.createConnection();
       session = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/journal/MessageJournalTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/journal/MessageJournalTest.java
@@ -86,7 +86,7 @@ public class MessageJournalTest extends ActiveMQTestBase {
 
    @Test
    public void testStoreAMQP() throws Throwable {
-      ActiveMQServer server = createServer(true);
+      ActiveMQServer server = createServer(true, true);
 
       server.start();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MQTTFQQNTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MQTTFQQNTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.postoffice.Binding;
+import org.apache.activemq.artemis.core.postoffice.Bindings;
 import org.apache.activemq.artemis.core.server.QueueQueryResult;
 import org.junit.Test;
 
@@ -34,8 +35,9 @@ public class MQTTFQQNTest extends MQTTTestSupport {
       try {
          subscriptionProvider.subscribe("foo/bah", AT_MOST_ONCE);
 
-         assertEquals(1, server.getPostOffice().getAllBindings().count());
-         Binding b = server.getPostOffice().getAllBindings().iterator().next();
+         Bindings bindings = server.getPostOffice().getBindingsForAddress(SimpleString.toSimpleString("foo.bah"));
+         assertEquals(1, bindings.size());
+         Binding b = bindings.getBindings().iterator().next();
          //check that query using bare queue name works as before
          QueueQueryResult result = server.queueQuery(b.getUniqueName());
          assertTrue(result.isExists());
@@ -126,8 +128,9 @@ public class MQTTFQQNTest extends MQTTTestSupport {
       try {
          subscriptionProvider.subscribe("foo/bah", AT_MOST_ONCE);
 
-         assertEquals(1, server.getPostOffice().getAllBindings().count());
-         Binding b = server.getPostOffice().getAllBindings().iterator().next();
+         Bindings bindings = server.getPostOffice().getBindingsForAddress(SimpleString.toSimpleString("foo.bah"));
+         assertEquals(1, bindings.size());
+         Binding b = bindings.getBindings().iterator().next();
 
          //check ::queue
          QueueQueryResult result = server.queueQuery(new SimpleString("::" + b.getUniqueName()));

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MQTTSecurityManagerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MQTTSecurityManagerTest.java
@@ -100,7 +100,7 @@ public class MQTTSecurityManagerTest extends MQTTTestSupport {
          if (acceptor instanceof AbstractAcceptor) {
             ProtocolManager protocolManager = ((AbstractAcceptor) acceptor).getProtocolMap().get("MQTT");
             if (protocolManager instanceof MQTTProtocolManager) {
-               sessionStates = ((MQTTProtocolManager) protocolManager).getSessionStates();
+               sessionStates = ((MQTTProtocolManager) protocolManager).getStateManager().getSessionStates();
             }
          }
          assertEquals(1, sessionStates.size());
@@ -132,7 +132,7 @@ public class MQTTSecurityManagerTest extends MQTTTestSupport {
          if (acceptor instanceof AbstractAcceptor) {
             ProtocolManager protocolManager = ((AbstractAcceptor) acceptor).getProtocolMap().get("MQTT");
             if (protocolManager instanceof MQTTProtocolManager) {
-               sessionStates = ((MQTTProtocolManager) protocolManager).getSessionStates();
+               sessionStates = ((MQTTProtocolManager) protocolManager).getStateManager().getSessionStates();
             }
          }
          assertEquals(1, sessionStates.size());

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MQTTTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MQTTTest.java
@@ -2099,10 +2099,10 @@ public class MQTTTest extends MQTTTestSupport {
       final int port2 = 1885;
 
       final Configuration cfg1 = createDefaultConfig(1, false);
-      cfg1.addAcceptorConfiguration("mqtt1", "tcp://localhost:" + port1 + "?protocols=MQTT");
+      cfg1.setResolveProtocols(true).addAcceptorConfiguration("mqtt1", "tcp://localhost:" + port1 + "?protocols=MQTT");
 
       final Configuration cfg2 = createDefaultConfig(2, false);
-      cfg2.addAcceptorConfiguration("mqtt2", "tcp://localhost:" + port2 + "?protocols=MQTT");
+      cfg2.setResolveProtocols(true).addAcceptorConfiguration("mqtt2", "tcp://localhost:" + port2 + "?protocols=MQTT");
 
       final ActiveMQServer server1 = createServer(cfg1);
       server1.start();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MQTTTestSupport.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MQTTTestSupport.java
@@ -387,7 +387,7 @@ public class MQTTTestSupport extends ActiveMQTestBase {
       if (acceptor instanceof AbstractAcceptor) {
          ProtocolManager protocolManager = ((AbstractAcceptor) acceptor).getProtocolMap().get("MQTT");
          if (protocolManager instanceof MQTTProtocolManager) {
-            return ((MQTTProtocolManager) protocolManager).getSessionStates();
+            return ((MQTTProtocolManager) protocolManager).getStateManager().getSessionStates();
          }
 
       }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MqttClusterRemoteSubscribeTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MqttClusterRemoteSubscribeTest.java
@@ -68,14 +68,14 @@ public class MqttClusterRemoteSubscribeTest extends ClusterTestBase {
          Topic[] topics = {new Topic(ANYCAST_TOPIC, QoS.AT_MOST_ONCE)};
          subConnection1 = retrieveMQTTConnection("tcp://localhost:61616", subClientId);
 
-         Wait.assertEquals(1, locateMQTTPM(servers[0]).getConnectedClients()::size);
+         Wait.assertEquals(1, locateMQTTPM(servers[0]).getStateManager().getConnectedClients()::size);
 
          subConnection2 = retrieveMQTTConnection("tcp://localhost:61617", subClientId);
          pubConnection = retrieveMQTTConnection("tcp://localhost:61616", pubClientId);
 
          //Waiting for the first sub connection be closed
          assertTrue(waitConnectionClosed(subConnection1));
-         Wait.assertEquals(1, locateMQTTPM(servers[1]).getConnectedClients()::size);
+         Wait.assertEquals(1, locateMQTTPM(servers[1]).getStateManager().getConnectedClients()::size);
          subConnection1 = null;
          subConnection2.subscribe(topics);
 
@@ -258,14 +258,14 @@ public class MqttClusterRemoteSubscribeTest extends ClusterTestBase {
          Topic[] topics = {new Topic(MULTICAST_TOPIC, QoS.AT_MOST_ONCE)};
          subConnection1 = retrieveMQTTConnection("tcp://localhost:61616", subClientId);
 
-         Wait.assertEquals(1, locateMQTTPM(servers[0]).getConnectedClients()::size);
+         Wait.assertEquals(1, locateMQTTPM(servers[0]).getStateManager().getConnectedClients()::size);
 
          subConnection2 = retrieveMQTTConnection("tcp://localhost:61617", subClientId);
          pubConnection = retrieveMQTTConnection("tcp://localhost:61616", pubClientId);
 
          //Waiting for the first sub connection be closed
          assertTrue(waitConnectionClosed(subConnection1));
-         Wait.assertEquals(1, locateMQTTPM(servers[1]).getConnectedClients()::size);
+         Wait.assertEquals(1, locateMQTTPM(servers[1]).getStateManager().getConnectedClients()::size);
          subConnection1 = null;
 
 
@@ -456,14 +456,14 @@ public class MqttClusterRemoteSubscribeTest extends ClusterTestBase {
          Topic[] topics = {new Topic(ANYCAST_TOPIC, QoS.AT_MOST_ONCE)};
          subConnection1 = retrieveMQTTConnection("tcp://localhost:61616", subClientId);
 
-         Wait.assertEquals(1, locateMQTTPM(servers[0]).getConnectedClients()::size);
+         Wait.assertEquals(1, locateMQTTPM(servers[0]).getStateManager().getConnectedClients()::size);
 
          subConnection2 = retrieveMQTTConnection("tcp://localhost:61617", subClientId);
          pubConnection = retrieveMQTTConnection("tcp://localhost:61616", pubClientId);
 
          //Waiting for the first sub connection be closed
          assertTrue(waitConnectionClosed(subConnection1));
-         Wait.assertEquals(1, locateMQTTPM(servers[1]).getConnectedClients()::size);
+         Wait.assertEquals(1, locateMQTTPM(servers[1]).getStateManager().getConnectedClients()::size);
          subConnection1 = null;
 
          subConnection2.subscribe(topics);
@@ -622,7 +622,7 @@ public class MqttClusterRemoteSubscribeTest extends ClusterTestBase {
          Thread.sleep(1000);
          Topic[] topics = {new Topic(MULTICAST_TOPIC, QoS.AT_MOST_ONCE)};
          subConnection1 = retrieveMQTTConnection("tcp://localhost:61616", subClientId);
-         Wait.assertEquals(1, locateMQTTPM(servers[0]).getConnectedClients()::size);
+         Wait.assertEquals(1, locateMQTTPM(servers[0]).getStateManager().getConnectedClients()::size);
          subConnection2 = retrieveMQTTConnection("tcp://localhost:61617", subClientId);
          pubConnection = retrieveMQTTConnection("tcp://localhost:61616", pubClientId);
 
@@ -711,9 +711,9 @@ public class MqttClusterRemoteSubscribeTest extends ClusterTestBase {
          Thread.sleep(1000);
          Topic[] topics = {new Topic(MULTICAST_TOPIC, QoS.AT_MOST_ONCE)};
          connection1 = retrieveMQTTConnection("tcp://localhost:61616", clientId1);
-         Wait.assertEquals(1, locateMQTTPM(servers[0]).getConnectedClients()::size);
+         Wait.assertEquals(1, locateMQTTPM(servers[0]).getStateManager().getConnectedClients()::size);
          connection2 = retrieveMQTTConnection("tcp://localhost:61617", clientId2);
-         Wait.assertEquals(1, locateMQTTPM(servers[1]).getConnectedClients()::size);
+         Wait.assertEquals(1, locateMQTTPM(servers[1]).getStateManager().getConnectedClients()::size);
          // Subscribe to topics
          connection1.subscribe(topics);
 
@@ -924,7 +924,7 @@ public class MqttClusterRemoteSubscribeTest extends ClusterTestBase {
          Thread.sleep(1000);
          subConnection1 = retrieveMQTTConnection("tcp://localhost:61616", subClientId);
 
-         Wait.assertEquals(1, locateMQTTPM(servers[0]).getConnectedClients()::size);
+         Wait.assertEquals(1, locateMQTTPM(servers[0]).getStateManager().getConnectedClients()::size);
 
          subConnection2 = retrieveMQTTConnection("tcp://localhost:61617", subClientId);
          pubConnection = retrieveMQTTConnection("tcp://localhost:61616", pubClientId);
@@ -1029,7 +1029,7 @@ public class MqttClusterRemoteSubscribeTest extends ClusterTestBase {
          pubConnection = retrieveMQTTConnection("tcp://localhost:61616", pubClientId);
 
          subConnection1 = retrieveMQTTConnection("tcp://localhost:61616", subClientId);
-         Wait.assertEquals(2, locateMQTTPM(servers[0]).getConnectedClients()::size);
+         Wait.assertEquals(2, locateMQTTPM(servers[0]).getStateManager().getConnectedClients()::size);
          subConnection2 = retrieveMQTTConnection("tcp://localhost:61617", subClientId);
 
          //Waiting for the first sub connection be closed

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MqttWildCardSubAutoCreateTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MqttWildCardSubAutoCreateTest.java
@@ -29,6 +29,7 @@ import java.util.LinkedList;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
 import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.protocol.mqtt.MQTTUtil;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
@@ -221,7 +222,14 @@ public class MqttWildCardSubAutoCreateTest extends MQTTTestSupport {
          messageConsumer.close();
          messageConsumerAllNews.close();
 
-         int countOfPageStores = server.getPagingManager().getStoreNames().length;
+         int countOfPageStores = 0;
+         SimpleString[] storeNames = server.getPagingManager().getStoreNames();
+         for (int i = 0; i < storeNames.length; i++) {
+            if (!storeNames[i].equals(SimpleString.toSimpleString(MQTTUtil.MQTT_SESSION_STORE))) {
+               countOfPageStores++;
+            }
+         }
+
          assertEquals("there should be 5", 5, countOfPageStores);
 
          connection.close();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/MQTT5TestSupport.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/MQTT5TestSupport.java
@@ -106,6 +106,10 @@ public class MQTT5TestSupport extends ActiveMQTestBase {
       return new MqttClient(protocol + "://localhost:" + (isUseSsl() ? getSslPort() : getPort()), clientId, new MemoryPersistence());
    }
 
+   protected MqttClient createPahoClient(String clientId, int port) throws MqttException {
+      return new MqttClient(protocol + "://localhost:" + port, clientId, new MemoryPersistence());
+   }
+
    protected org.eclipse.paho.client.mqttv3.MqttClient createPaho3_1_1Client(String clientId) throws org.eclipse.paho.client.mqttv3.MqttException {
       return new org.eclipse.paho.client.mqttv3.MqttClient(protocol + "://localhost:" + (isUseSsl() ? getSslPort() : getPort()), clientId, new org.eclipse.paho.client.mqttv3.persist.MemoryPersistence());
    }
@@ -333,12 +337,12 @@ public class MQTT5TestSupport extends ActiveMQTestBase {
       if (protocolManager == null) {
          return Collections.emptyMap();
       } else {
-         return protocolManager.getSessionStates();
+         return protocolManager.getStateManager().getSessionStates();
       }
    }
 
    public void scanSessions() {
-      getProtocolManager().scanSessions();
+      getProtocolManager().getStateManager().scanSessions();
    }
 
    public MQTTProtocolManager getProtocolManager() {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/MessageReceiptTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/MessageReceiptTests.java
@@ -76,7 +76,13 @@ public class MessageReceiptTests extends MQTT5TestSupport {
       for (int i = 0; i < CONSUMER_COUNT; i++) {
          producer.publish(TOPIC + i, ("hello" + i).getBytes(), 0, false);
       }
-      Wait.assertEquals((long) CONSUMER_COUNT, () -> server.getActiveMQServerControl().getTotalMessagesAdded(), 2000, 100);
+      Wait.assertEquals((long) CONSUMER_COUNT, () -> {
+         int totalMessagesAdded = 0;
+         for (int i = 0; i < CONSUMER_COUNT; i++) {
+            totalMessagesAdded += getSubscriptionQueue(TOPIC + i).getMessagesAdded();
+         }
+         return totalMessagesAdded;
+      }, 2000, 100);
       producer.disconnect();
       producer.close();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/security/SecurityPerAcceptorJmsTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/security/SecurityPerAcceptorJmsTest.java
@@ -99,7 +99,7 @@ public class SecurityPerAcceptorJmsTest extends ActiveMQTestBase {
 
    @Test
    public void testJAASSecurityManagerAuthentication() throws Exception {
-      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(createDefaultInVMConfig().setSecurityEnabled(true).addAcceptorConfiguration("netty", URL + "?securityDomain=PropertiesLogin"), ManagementFactory.getPlatformMBeanServer(), new ActiveMQJAASSecurityManager(), false));
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(createDefaultInVMConfig().setSecurityEnabled(true).setResolveProtocols(true).addAcceptorConfiguration("netty", URL + "?securityDomain=PropertiesLogin"), ManagementFactory.getPlatformMBeanServer(), new ActiveMQJAASSecurityManager(), false));
       server.start();
       try (Connection c = cf.createConnection("first", "secret")) {
          Thread.sleep(200);
@@ -113,7 +113,7 @@ public class SecurityPerAcceptorJmsTest extends ActiveMQTestBase {
       final SimpleString ADDRESS = new SimpleString("address");
 
       ActiveMQJAASSecurityManager securityManager = new ActiveMQJAASSecurityManager();
-      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(createDefaultInVMConfig().addAcceptorConfiguration("netty", "tcp://127.0.0.1:61616?securityDomain=PropertiesLogin").setSecurityEnabled(true), ManagementFactory.getPlatformMBeanServer(), securityManager, false));
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(createDefaultInVMConfig().setResolveProtocols(true).addAcceptorConfiguration("netty", "tcp://127.0.0.1:61616?securityDomain=PropertiesLogin").setSecurityEnabled(true), ManagementFactory.getPlatformMBeanServer(), securityManager, false));
       Set<Role> roles = new HashSet<>();
       roles.add(new Role("programmers", false, false, false, false, false, false, false, false, false, false));
       server.getConfiguration().putSecurityRoles("#", roles);
@@ -163,7 +163,7 @@ public class SecurityPerAcceptorJmsTest extends ActiveMQTestBase {
    public void testJAASSecurityManagerAuthorizationPositive() throws Exception {
       final String ADDRESS = "address";
 
-      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(createDefaultInVMConfig().setSecurityEnabled(true).addAcceptorConfiguration("netty", "tcp://127.0.0.1:61616?securityDomain=PropertiesLogin"), ManagementFactory.getPlatformMBeanServer(), new ActiveMQJAASSecurityManager(), false));
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(createDefaultInVMConfig().setSecurityEnabled(true).setResolveProtocols(true).addAcceptorConfiguration("netty", "tcp://127.0.0.1:61616?securityDomain=PropertiesLogin"), ManagementFactory.getPlatformMBeanServer(), new ActiveMQJAASSecurityManager(), false));
       Set<Role> roles = new HashSet<>();
       roles.add(new Role("programmers", true, true, true, true, true, true, true, true, true, true));
       server.getConfiguration().putSecurityRoles("#", roles);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/security/SecurityTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/security/SecurityTest.java
@@ -328,7 +328,7 @@ public class SecurityTest extends ActiveMQTestBase {
       params.put(TransportConstants.TRUSTSTORE_PASSWORD_PROP_NAME, "securepass");
       params.put(TransportConstants.NEED_CLIENT_AUTH_PROP_NAME, true);
 
-      server.getConfiguration().addAcceptorConfiguration(new TransportConfiguration(NETTY_ACCEPTOR_FACTORY, params));
+      server.getConfiguration().setResolveProtocols(true).addAcceptorConfiguration(new TransportConfiguration(NETTY_ACCEPTOR_FACTORY, params));
 
       // ensure advisory permission is still set for openwire to allow connection to succeed, alternative is url param jms.watchTopicAdvisories=false on the client connection factory
       HashSet<Role> roles = new HashSet<>();
@@ -374,7 +374,7 @@ public class SecurityTest extends ActiveMQTestBase {
       params.put(TransportConstants.TRUSTSTORE_PASSWORD_PROP_NAME, "securepass");
       params.put(TransportConstants.NEED_CLIENT_AUTH_PROP_NAME, true);
 
-      server.getConfiguration().addAcceptorConfiguration(new TransportConfiguration(NETTY_ACCEPTOR_FACTORY, params));
+      server.getConfiguration().setResolveProtocols(true).addAcceptorConfiguration(new TransportConfiguration(NETTY_ACCEPTOR_FACTORY, params));
       server.start();
 
       ActiveMQSslConnectionFactory factory = new ActiveMQSslConnectionFactory("ssl://localhost:61616?verifyHostName=false");


### PR DESCRIPTION
Durable subscrption state is part of the MQTT specification which has not been supported until now. This functionality is implemented via an internal last-value queue. When an MQTT client creates, updates, or adds a subscription a message using the client-ID as the last-value is sent to the internal queue. When the broker restarts this data is read from the queue and populates the in-memory MQTT data-structures. Therefore subscribers can reconnect and resume their session's subscriptions without have to manually resubscribe.

The subscriptions are serialized as raw bytes with a "version" byte for potential future use, but I intentionally avoided adding complex scaffolding to support multiple versions. We can add that complexity later if necessary.