### PR TITLE
ARTEMIS-3057 Add min-disk-free feature

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
@@ -524,6 +524,8 @@ public final class ActiveMQDefaultConfiguration {
       DEFAULT_MAX_DISK_USAGE = maxDisk;
    }
 
+   public static final long DEFAULT_MIN_DISK_FREE = -1;
+
    public static final int DEFAULT_DISK_SCAN = 5000;
 
    public static final int DEFAULT_MAX_QUEUE_CONSUMERS = -1;
@@ -1543,6 +1545,10 @@ public final class ActiveMQDefaultConfiguration {
 
    public static int getDefaultMaxDiskUsage() {
       return DEFAULT_MAX_DISK_USAGE;
+   }
+
+   public static long getDefaultMinDiskFree() {
+      return DEFAULT_MIN_DISK_FREE;
    }
 
    public static int getDefaultDiskScanPeriod() {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
@@ -1274,6 +1274,10 @@ public interface Configuration {
 
    Configuration setMaxDiskUsage(int maxDiskUsage);
 
+   long getMinDiskFree();
+
+   Configuration setMinDiskFree(long minDiskFree);
+
    ConfigurationImpl setInternalNamingPrefix(String internalNamingPrefix);
 
    Configuration setDiskScanPeriod(int diskScanPeriod);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
@@ -379,6 +379,8 @@ public class ConfigurationImpl implements Configuration, Serializable {
 
    private int maxDiskUsage = ActiveMQDefaultConfiguration.getDefaultMaxDiskUsage();
 
+   private long minDiskFree = ActiveMQDefaultConfiguration.getDefaultMinDiskFree();
+
    private int diskScanPeriod = ActiveMQDefaultConfiguration.getDefaultDiskScanPeriod();
 
    private String systemPropertyPrefix = ActiveMQDefaultConfiguration.getDefaultSystemPropertyPrefix();
@@ -903,6 +905,17 @@ public class ConfigurationImpl implements Configuration, Serializable {
    @Override
    public ConfigurationImpl setMaxDiskUsage(int maxDiskUsage) {
       this.maxDiskUsage = maxDiskUsage;
+      return this;
+   }
+
+   @Override
+   public long getMinDiskFree() {
+      return minDiskFree;
+   }
+
+   @Override
+   public ConfigurationImpl setMinDiskFree(long minDiskFree) {
+      this.minDiskFree = minDiskFree;
       return this;
    }
 
@@ -2825,6 +2838,9 @@ public class ConfigurationImpl implements Configuration, Serializable {
          return false;
       }
       if (maxDiskUsage != other.maxDiskUsage) {
+         return false;
+      }
+      if (minDiskFree != other.minDiskFree) {
          return false;
       }
       if (diskScanPeriod != other.diskScanPeriod) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -327,7 +327,9 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
    private static final String GLOBAL_MAX_MESSAGES = "global-max-messages";
 
-   private static final String MAX_DISK_USAGE = "max-disk-usage";
+   public static final String MAX_DISK_USAGE = "max-disk-usage";
+
+   public static final String MIN_DISK_FREE = "min-disk-free";
 
    private static final String DISK_SCAN_PERIOD = "disk-scan-period";
 
@@ -473,6 +475,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       long globalMaxMessages = getLong(e, GLOBAL_MAX_MESSAGES, -1, Validators.MINUS_ONE_OR_GT_ZERO);
 
       config.setGlobalMaxMessages(globalMaxMessages);
+
+      config.setMinDiskFree(getTextBytesAsLongBytes(e, MIN_DISK_FREE, config.getMinDiskFree(), Validators.MINUS_ONE_OR_GT_ZERO));
 
       config.setMaxDiskUsage(getInteger(e, MAX_DISK_USAGE, config.getMaxDiskUsage(), Validators.PERCENTAGE_OR_MINUS_ONE));
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -932,10 +932,10 @@ public interface ActiveMQServerLogger {
    void impossibleToRouteGrouped();
 
    @LogMessage(id = 222210, value = "Free storage space is at {} of {} total. Usage rate is {} which is beyond the configured <max-disk-usage>. System will start blocking producers.", level = LogMessage.Level.WARN)
-   void diskBeyondCapacity(String usableSpace, String totalSpace, String usage);
+   void maxDiskUsageReached(String usableSpace, String totalSpace, String usage);
 
-   @LogMessage(id = 222211, value = "Free storage space is at {} of {} total. Usage rate is {} which is below the configured <max-disk-usage>.", level = LogMessage.Level.INFO)
-   void diskCapacityRestored(String usableSpace, String totalSpace, String usage);
+   @LogMessage(id = 222211, value = "Free storage space is at {} of {} total. Usage rate is {} which is below the configured <max-disk-usage>. System will unblock producers.", level = LogMessage.Level.INFO)
+   void maxDiskUsageRestored(String usableSpace, String totalSpace, String usage);
 
    @LogMessage(id = 222212, value = "Disk Full! Blocking message production on address '{}'. Clients will report blocked.", level = LogMessage.Level.WARN)
    void blockingDiskFull(SimpleString addressName);
@@ -1584,4 +1584,13 @@ public interface ActiveMQServerLogger {
    void failureDuringProtocolHandshake(SocketAddress localAddress, SocketAddress remoteAddress, Throwable e);
 
    // notice loggerID=224127 is reserved as it's been used at ActiveMQQueueLogger
+
+   @LogMessage(id = 224128, value = "Free storage space is at {} which is below the configured <min-disk-free>. System will start blocking producers.", level = LogMessage.Level.WARN)
+   void minDiskFreeReached(String usableSpace);
+
+   @LogMessage(id = 224129, value = "Free storage space is at {} which is above the configured <min-disk-free>. System will unblock producers.", level = LogMessage.Level.WARN)
+   void minDiskFreeRestored(String usableSpace);
+
+   @LogMessage(id = 224130, value = "The {} value {} will override the {} value {} since both are set.", level = LogMessage.Level.INFO)
+   void configParamOverride(String overridingParam, Object overridingParamValue, String overriddenParam, Object overriddenParamValue);
 }

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -801,7 +801,17 @@
          <xsd:element name="max-disk-usage" type="xsd:int" default="90" maxOccurs="1" minOccurs="0">
             <xsd:annotation>
                <xsd:documentation>
-                  Max percentage of disk usage before the system blocks or fails clients.
+                  Max percentage of disk usage before the system blocks or fails clients. Will be overrided by
+                  min-disk-free if both are set.
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         
+         <xsd:element name="min-disk-free" type="xsd:string" default="-1" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Min free bytes on disk below which the system blocks or fails clients. Supports byte notation like
+                  "K", "Mb", "GB", etc. Will override max-disk-usage if both are set.
                </xsd:documentation>
             </xsd:annotation>
          </xsd:element>

--- a/artemis-server/src/test/resources/ConfigurationTest-full-config-wrong-address.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-full-config-wrong-address.xml
@@ -103,6 +103,8 @@ under the License.
       <!-- once the disk hits this limit the system will block, or close the connection in certain protocols
            that won't support flow control. -->
       <max-disk-usage>90</max-disk-usage>
+      <!-- when min-disk-free is set, it will override max-disk-usage -->
+      <min-disk-free>1GB</min-disk-free>
 
       <!-- should the broker detect dead locks and other issues -->
       <critical-analyzer>true</critical-analyzer>

--- a/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
@@ -62,6 +62,7 @@
       <temporary-queue-namespace>TEMP</temporary-queue-namespace>
       <global-max-size>1234567</global-max-size>
       <max-disk-usage>37</max-disk-usage>
+      <min-disk-free>500Mb</min-disk-free>
       <disk-scan-period>123</disk-scan-period>
       <critical-analyzer-policy>HALT</critical-analyzer-policy>
       <critical-analyzer-check-period>333</critical-analyzer-check-period>

--- a/docs/user-manual/paging.adoc
+++ b/docs/user-manual/paging.adoc
@@ -196,12 +196,28 @@ For example:
 In this example all the other 9 queues will be consuming messages from the page system.
 This may cause performance issues if this is an undesirable state.
 
-== Max Disk Usage
+== Monitoring Disk
 
-The System will perform scans on the disk to determine if the disk is beyond a configured limit.
-These are configured through `max-disk-usage` in percentage.
-Once that limit is reached any message will be blocked.
-(unless the protocol doesn't support flow control on which case there will be an exception thrown and the connection for those clients dropped).
+The broker can be configured to perform scans on the disk to determine if disk is beyond a configured limit.
+Since the disk is a critical piece of infrastructure for data integrity the broker will automatically shut itself down if it runs out of disk space.
+Configuring a limit allows the broker to enforce flow control on clients sending messages to the broker so that the disk never fills up completely.
+
+WARNING: If the protocol used to send the messages doesn't support flow control (e.g. STOMP) then an exception will be thrown and the connection for the client will be dropped so that it can no longer send messages and consume disk space.
+
+=== Max Disk Usage
+
+A limit on the _maximum_ disk space used can be configured through `max-disk-usage`
+This is the *percentage* of disk used.
+For example, if the disk's capacity was 500GiB and `max-disk-usage` was `50` then the broker would start blocking producers once 250GiB of disk space was used.
+
+=== Minimum Disk Free
+
+A limit on the _minimum_ disk space free can be configured through `min-disk-free`
+This is specific amount and not a percentage like with `max-disk-usage`.
+For example, if the disk's capacity was 500GiB and `min-disk-free` was `100GiB` then the broker would start blocking producers once 400GiB of disk space was used.
+
+NOTE: If _both_ `max-disk-usage` and `min-disk-free` are configured then `min-disk-free` will take priority.
+
 
 == Page Sync Timeout
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/GlobalDiskFullTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/GlobalDiskFullTest.java
@@ -44,19 +44,8 @@ public class GlobalDiskFullTest extends AmqpClientTestSupport {
    public void testProducerOnDiskFull() throws Exception {
       FileStoreMonitor monitor = ((ActiveMQServerImpl)server).getMonitor().setMaxUsage(0.0);
       final CountDownLatch latch = new CountDownLatch(1);
-      monitor.addCallback(new FileStoreMonitor.Callback() {
-
-         @Override
-         public void tick(long usableSpace, long totalSpace) {
-         }
-
-         @Override
-         public void over(long usableSpace, long totalSpace) {
-            latch.countDown();
-         }
-         @Override
-         public void under(long usableSpace, long totalSpace) {
-         }
+      monitor.addCallback((usableSpace, totalSpace, ok, type) -> {
+         latch.countDown();
       });
 
       Assert.assertTrue(latch.await(1, TimeUnit.MINUTES));


### PR DESCRIPTION
This is a follow-up to #3812 with the following changes:

 - Resolved conflicts.
 - Eliminated a lot of code duplication.
 - Simplified `org.apache.activemq.artemis.core.server.files.FileStoreMonitor.Callback` and its support for multiple settings.
 - I didn't bother with deprecating anything since these are internal classes.
 - Added documentation. 