### PR TITLE
ARTEMIS-4424 Unecessary AMQ212025 (not connected) when no nodes are c…

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorImpl.java
@@ -1786,7 +1786,10 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
             return null;
          }
 
-         ActiveMQClientLogger.LOGGER.errorConnectingToNodes(traceException);
+         if (logger.isTraceEnabled()) {
+            logger.trace("Could not connect to any nodes. throwing an error now.", new Exception("trace"));
+         }
+
          throw ActiveMQClientMessageBundle.BUNDLE.cannotConnectToStaticConnectors2();
       }
 


### PR DESCRIPTION
…onnected

The exception thrown by serverLocator.connect() should be all you need on such case and the caller should then be responsible for taking appropriate action.