### PR TITLE
ARTEMIS-4431 Re-encode the AMQP message annotations if hops are updates

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationAddressConsumer.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationAddressConsumer.java
@@ -374,6 +374,9 @@ public class AMQPFederationAddressConsumer implements FederationConsumerInternal
          message.setAnnotation(MESSAGE_HOPS_ANNOTATION, numHops.intValue() + 1);
       }
 
+      // Annotations need to be rewritten to carry the change forward.
+      message.reencode();
+
       return message;
    }
 


### PR DESCRIPTION
When updating or adding the hops value the AMQP message needs a re-encode to carry that value forward when the message is sent to the next broker.