### PR TITLE
ARTEMIS-4444 Support custom directories to add runtime dependencies

### DIFF
--- a/artemis-boot/src/main/java/org/apache/activemq/artemis/boot/Artemis.java
+++ b/artemis-boot/src/main/java/org/apache/activemq/artemis/boot/Artemis.java
@@ -35,6 +35,9 @@ import java.util.List;
  */
 public class Artemis {
 
+   public static final String EXTRA_LIBS_SYSTEM_PROPERTY = "artemis.extra.libs";
+   public static final String EXTRA_LIBS_ENVIRONMENT_VARIABLE = "ARTEMIS_EXTRA_LIBS";
+
    public static void main(String[] args) throws Throwable {
       String home = System.getProperty("artemis.home");
 
@@ -82,6 +85,16 @@ public class Artemis {
       }
       if (fileInstance != null) {
          dirs.add(new File(fileInstance, "lib"));
+      }
+
+      String extraLibs = System.getProperty(EXTRA_LIBS_SYSTEM_PROPERTY);
+      if (extraLibs == null) {
+         extraLibs = System.getenv(EXTRA_LIBS_ENVIRONMENT_VARIABLE);
+      }
+      if (extraLibs != null) {
+         for (String extraLib: extraLibs.split(",")) {
+            dirs.add(new File(extraLib));
+         }
       }
 
       ArrayList<URL> urls = new ArrayList<>();

--- a/docs/user-manual/using-server.adoc
+++ b/docs/user-manual/using-server.adoc
@@ -532,10 +532,22 @@ NOTE: the environment variable `JAVA_ARGS_APPEND` can be used to append or overr
 
 Runtime dependencies like diverts, transformers, broker plugins, JDBC drivers, password decoders, etc. must be accessible by the broker at runtime.
 Package the dependency in a jar, and put it on the broker's classpath.
-This can be done by placing the jar file in the `lib` directory of the broker distribution itself or in the `lib` directory of the broker instance.
+This can be done by placing the jar file in the `lib` directory of the broker distribution itself,
+by placing the jar file in the `lib` directory of the broker instance,
+by setting the system property `artemis.extra.libs` with the directory that contains the jar file, or
+by setting the environment variable `ARTEMIS_EXTRA_LIBS` with the directory that contains the jar file,
 A broker instance does not have a `lib` directory by default so it may need to be created.
 It should be on the "top" level with the `bin`, `data`, `log`, etc.
 directories.
+The system property `artemis.extra.libs` is a comma separated list of directories that contains jar files, i.e.
+```
+-Dartemis.extra.libs=/usr/local/share/java/lib1,/usr/local/share/java/lib2
+```
+The environment variable `ARTEMIS_EXTRA_LIBS` is a comma separated list of directories that contains jar files and
+is ignored if the system property `artemis.extra.libs` is defined, i.e.
+```
+export ARTEMIS_EXTRA_LIBS=/usr/local/share/java/lib1,/usr/local/share/java/lib2
+```
 
 === Library Path
 

--- a/tests/db-tests/pom.xml
+++ b/tests/db-tests/pom.xml
@@ -233,18 +233,31 @@
                      <instance>${basedir}/target/derby</instance>
                      <configuration>${basedir}/target/classes/servers/derby</configuration>
                      <noWeb>true</noWeb>
-                     <libList>
-                        <arg>org.apache.derby:derby:${apache.derby.version}</arg>
-                     </libList>
                      <args>
                         <arg>--jdbc</arg>
                         <arg>--global-max-messages</arg>
                         <arg>100</arg>
                         <arg>--java-options</arg>
+                        <arg>-Dartemis.extra.libs=${basedir}/target/derby/jdbc-jars</arg>
+                        <arg>--java-options</arg>
                         <arg>-ea</arg>
                      </args>
                   </configuration>
                </execution>
+               <execution>
+                  <phase>test-compile</phase>
+                  <id>create-derby-jdbc</id>
+                  <goals>
+                     <goal>dependency-scan</goal>
+                  </goals>
+                  <configuration>
+                     <libList>
+                        <arg>org.apache.derby:derby:${apache.derby.version}</arg>
+                     </libList>
+                     <targetFolder>${basedir}/target/derby/jdbc-jars</targetFolder>
+                  </configuration>
+               </execution>
+
                <execution>
                   <phase>test-compile</phase>
                   <id>create-mysql</id>


### PR DESCRIPTION
The system property `artemis.extra.libs` is a comma separated list of directories that contains jar files, i.e.
```
-Dartemis.extra.libs=/usr/local/share/java/lib1,/usr/local/share/java/lib2
```
The environment variable `ARTEMIS_EXTRA_LIBS` is a comma separated list of directories that contains jar files and
is ignored if the system property `artemis.extra.libs` is defined, i.e.
```
export ARTEMIS_EXTRA_LIBS=/usr/local/share/java/lib1,/usr/local/share/java/lib2
```