### PR TITLE
ARTEMIS-4451: fix non-SASL AMQP connection + resource audit logging

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPConnectionCallback.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPConnectionCallback.java
@@ -130,7 +130,7 @@ public class AMQPConnectionCallback implements FailureListener, CloseListener {
    public boolean isSupportsAnonymous() {
       boolean supportsAnonymous = false;
       try {
-         server.getSecurityStore().authenticate(null, null, null);
+         server.getSecurityStore().authenticate(null, null, protonConnectionDelegate);
          supportsAnonymous = true;
       } catch (Exception e) {
          // authentication failed so no anonymous support

--- a/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/logging/AuditLoggerResourceTest.java
+++ b/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/logging/AuditLoggerResourceTest.java
@@ -98,21 +98,26 @@ public class AuditLoggerResourceTest extends AuditLoggerTestBase {
 
    @Test
    public void testCoreConnectionAuditLog() throws Exception {
-      testConnectionAuditLog("CORE");
+      testConnectionAuditLog("CORE", "tcp://localhost:61616");
    }
 
    @Test
    public void testAMQPConnectionAuditLog() throws Exception {
-      testConnectionAuditLog("AMQP");
+      testConnectionAuditLog("AMQP", "amqp://localhost:61616");
+   }
+
+   @Test
+   public void testAMQPNoSaslConnectionAuditLog() throws Exception {
+      testConnectionAuditLog("AMQP", "amqp://localhost:61616?amqp.saslLayer=false");
    }
 
    @Test
    public void testOpenWireConnectionAuditLog() throws Exception {
-      testConnectionAuditLog("OPENWIRE");
+      testConnectionAuditLog("OPENWIRE", "tcp://localhost:61616");
    }
 
-   private void testConnectionAuditLog(String protocol) throws Exception {
-      ConnectionFactory factory = CFUtil.createConnectionFactory(protocol, "tcp://localhost:61616");
+   private void testConnectionAuditLog(String protocol, String url) throws Exception {
+      ConnectionFactory factory = CFUtil.createConnectionFactory(protocol, url);
       Connection connection = factory.createConnection();
       Session s = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
       checkAuditLogRecord(true, "AMQ601767: " + protocol + " connection");


### PR DESCRIPTION
Ensure the eligibility check done can succeed with the audit logging enabled, allowing non-SASL connections if broker config allows (rather than erroneously failing and indicating SASL is required when it shouldnt be).