### PR TITLE
ARTEMIS-4459 log when rejecting dupe MQTT QoS2 pub

### DIFF
--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTLogger.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTLogger.java
@@ -61,4 +61,7 @@ public interface MQTTLogger {
 
    @LogMessage(id = 834008, value = "Failed to remove session state for client with ID: {}", level = LogMessage.Level.ERROR)
    void failedToRemoveSessionState(String clientID, Exception e);
+
+   @LogMessage(id = 834009, value = "Ignoring duplicate MQTT QoS2 PUBLISH packet for packet ID {} from client with ID {}.", level = LogMessage.Level.WARN)
+   void ignoringQoS2Publish(String clientId, long packetId);
 }


### PR DESCRIPTION
In accordance with the QoS2 protocol outlined in the MQTT specification(s), once the broker receives a PUBLISH then any other PUBLISH it receives on that same session with the same packet ID must be ignored until the QoS2 protocol for that ID is completed.

The broker does this, but it doesn't log anything so it's not clear when this is actually happening.