### PR TITLE
ARTEMIS-4467 Core client code visibility change required.

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/RemotingConnectionImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/RemotingConnectionImpl.java
@@ -96,7 +96,7 @@ public class RemotingConnectionImpl extends AbstractRemotingConnection implement
    /*
     * Create a server side connection
     */
-   RemotingConnectionImpl(final PacketDecoder packetDecoder,
+   public RemotingConnectionImpl(final PacketDecoder packetDecoder,
                           final Connection transportConnection,
                           final List<Interceptor> incomingInterceptors,
                           final List<Interceptor> outgoingInterceptors,

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/ActiveMQChannelHandler.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/ActiveMQChannelHandler.java
@@ -40,7 +40,7 @@ public class ActiveMQChannelHandler extends ChannelDuplexHandler {
 
    private final BaseConnectionLifeCycleListener<?> listener;
 
-   volatile boolean active;
+   protected volatile boolean active;
 
    private final Executor listenerExecutor;
 


### PR DESCRIPTION
* Since the constructors in RemotingConnectionImpl can be used from the server and the client. If the server calling code is in a different classloader then the constructor can't be called.
* same for the 'active' boolean property of ActiveMQChannelHandler

Issue: https://issues.apache.org/jira/browse/ARTEMIS-4467