### PR TITLE
ARTEMIS-4477: remove incorrect services file

### DIFF
--- a/artemis-commons/pom.xml
+++ b/artemis-commons/pom.xml
@@ -140,6 +140,14 @@
                   </goals>
                   <configuration>
                      <createDependencyReducedPom>true</createDependencyReducedPom>
+                     <filters>
+                        <filter>
+                           <artifact>*:*</artifact>
+                           <excludes>
+                              <exclude>META-INF/services/*</exclude>
+                           </excludes>
+                        </filter>
+                     </filters>
                      <relocations>
                         <relocation>
                            <pattern>javax.json</pattern>


### PR DESCRIPTION
Possible alternative to fix the issue raised in #4657. Partially restores the exclusion filter that was previously removed, narrowing it to drop the services file.