### PR TITLE
ARTEMIS-4497 export summary on cluster-topology as metrics

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
@@ -31,6 +31,8 @@ public interface ActiveMQServerControl {
    String ADDRESS_MEMORY_USAGE_DESCRIPTION = "Memory used by all the addresses on broker for in-memory messages";
    String ADDRESS_MEMORY_USAGE_PERCENTAGE_DESCRIPTION = "Memory used by all the addresses on broker as a percentage of the global-max-size";
    String DISK_STORE_USAGE_DESCRIPTION = "Fraction of total disk store used";
+   String CLUSTER_LIVES_COUNT_DESCRIPTION = "Number of live brokers in the broker cluster topology";
+   String CLUSTER_BACKUPS_COUNT_DESCRIPTION = "Number of backup brokers in the broker cluster topology";
 
    /**
     * Returns this server's name.

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
@@ -2025,5 +2025,9 @@ public interface ActiveMQServerControl {
 
    @Operation(desc = "Clear the authorization cache", impact = MBeanOperationInfo.ACTION)
    void clearAuthorizationCache() throws Exception;
+
+   int getNetworkTopologyLives();
+
+   int getNetworkTopologyBackups();
 }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -4693,5 +4693,45 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
       }
       ((SecurityStoreImpl)server.getSecurityStore()).invalidateAuthorizationCache();
    }
+
+   @Override
+   public int getNetworkTopologyLives() {
+      ClusterManager clusterManager = server.getClusterManager();
+      int cnt = 0;
+      if (clusterManager != null) {
+         Set<ClusterConnection> clusterConnections = clusterManager.getClusterConnections();
+         for (ClusterConnection clusterConnection : clusterConnections) {
+            Topology topology = clusterConnection.getTopology();
+            Collection<TopologyMemberImpl> members = topology.getMembers();
+            for (TopologyMemberImpl member : members) {
+               TransportConfiguration live = member.getLive();
+               if (live != null) {
+                  cnt++;
+               }
+            }
+         }
+      }
+      return cnt;
+   }
+
+   @Override
+   public int getNetworkTopologyBackups() {
+      ClusterManager clusterManager = server.getClusterManager();
+      int cnt = 0;
+      if (clusterManager != null) {
+         Set<ClusterConnection> clusterConnections = clusterManager.getClusterConnections();
+         for (ClusterConnection clusterConnection : clusterConnections) {
+            Topology topology = clusterConnection.getTopology();
+            Collection<TopologyMemberImpl> members = topology.getMembers();
+            for (TopologyMemberImpl member : members) {
+               TransportConfiguration backup = member.getBackup();
+               if (backup != null) {
+                  cnt++;
+               }
+            }
+         }
+      }
+      return cnt;
+   }
 }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServer.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServer.java
@@ -997,4 +997,8 @@ public interface ActiveMQServer extends ServiceComponent {
    default String getStatus() {
       return "";
    }
+
+   int getNetworkTopologyLives();
+
+   int getNetworkTopologyBackups();
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -4738,4 +4738,8 @@ public class ActiveMQServerImpl implements ActiveMQServer {
          return managementLock::unlock;
       }
    }
+
+   public int getNetworkTopologyLives() { return 9; }
+
+   public int getNetworkTopologyBackups() { return 7; }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -65,6 +65,7 @@ import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
 import org.apache.activemq.artemis.core.client.impl.ClientSessionFactoryImpl;
+import org.apache.activemq.artemis.core.client.impl.Topology;
 import org.apache.activemq.artemis.core.config.BridgeConfiguration;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.ConfigurationUtils;
@@ -4739,7 +4740,11 @@ public class ActiveMQServerImpl implements ActiveMQServer {
       }
    }
 
-   public int getNetworkTopologyLives() { return 9; }
+   public int getNetworkTopologyLives() {
+	   return messagingServerControl.getNetworkTopologyLives();
+   }
 
-   public int getNetworkTopologyBackups() { return 7; }
+   public int getNetworkTopologyBackups() { 
+	   return messagingServerControl.getNetworkTopologyBackups();
+   }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/impl/ManagementServiceImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/impl/ManagementServiceImpl.java
@@ -232,6 +232,8 @@ public class ManagementServiceImpl implements ManagementService {
             builder.build(BrokerMetricNames.ADDRESS_MEMORY_USAGE, messagingServer, metrics -> Double.valueOf(messagingServerControl.getAddressMemoryUsage()), ActiveMQServerControl.ADDRESS_MEMORY_USAGE_DESCRIPTION);
             builder.build(BrokerMetricNames.ADDRESS_MEMORY_USAGE_PERCENTAGE, messagingServer, metrics -> Double.valueOf(messagingServerControl.getAddressMemoryUsagePercentage()), ActiveMQServerControl.ADDRESS_MEMORY_USAGE_PERCENTAGE_DESCRIPTION);
             builder.build(BrokerMetricNames.DISK_STORE_USAGE, messagingServer, metrics -> Double.valueOf(messagingServer.getDiskStoreUsage()), ActiveMQServerControl.DISK_STORE_USAGE_DESCRIPTION);
+            builder.build(BrokerMetricNames.CLUSTER_LIVES_COUNT, messagingServer, metrics -> Double.valueOf(messagingServer.getNetworkTopologyLives()), ActiveMQServerControl.CLUSTER_LIVES_COUNT_DESCRIPTION);
+            builder.build(BrokerMetricNames.CLUSTER_BACKUPS_COUNT, messagingServer, metrics -> Double.valueOf(messagingServer.getNetworkTopologyBackups()), ActiveMQServerControl.CLUSTER_BACKUPS_COUNT_DESCRIPTION);
          });
       }
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/metrics/BrokerMetricNames.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/metrics/BrokerMetricNames.java
@@ -23,4 +23,6 @@ public class BrokerMetricNames {
    public static final String ADDRESS_MEMORY_USAGE = "address.memory.usage";
    public static final String ADDRESS_MEMORY_USAGE_PERCENTAGE = "address.memory.usage.percentage";
    public static final String DISK_STORE_USAGE = "disk.store.usage";
+   public static final String CLUSTER_LIVES_COUNT = "cluster.lives.count";
+   public static final String CLUSTER_BACKUPS_COUNT = "cluster.backups.count";
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/plugin/MetricsPluginTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/plugin/MetricsPluginTest.java
@@ -169,7 +169,10 @@ public class MetricsPluginTest extends ActiveMQTestBase {
               new Metric("artemis.address.size", "the number of estimated bytes being used by all the queue(s) bound to this address; used to control paging and blocking", 0.0),
               new Metric("artemis.address.size", "the number of estimated bytes being used by all the queue(s) bound to this address; used to control paging and blocking", 0.0),
               new Metric("artemis.number.of.pages", "number of pages used by this address", 0.0),
-              new Metric("artemis.number.of.pages", "number of pages used by this address", 0.0)
+              new Metric("artemis.number.of.pages", "number of pages used by this address", 0.0),
+              new Metric("artemis.cluster.lives.count", "Number of live brokers in the broker cluster topology", 0.0),
+              new Metric("artemis.cluster.backups.count", "Number of backup brokers in the broker cluster topology", 0.0)
+
       ));
    }
 


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/ARTEMIS-4497

my design decision:
re-use the code from the implementation of `listNetworkTopology` and add it separate to provide these metrics:
* `artemis_cluster_lives_count`
* `artemis_cluster_backups_count`

this is a bit of code duplication, but prevents risk of breaking a refactored `listNetworkTopology`