### PR TITLE
ARTEMIS-4498 - Expose internal queues for management and observability

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/QueueConfiguration.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/QueueConfiguration.java
@@ -77,6 +77,7 @@ public class QueueConfiguration implements Serializable {
    public static final String TRANSIENT = "transient";
    public static final String AUTO_CREATED = "auto-created";
    public static final String FQQN = "fqqn";
+   public static final String MANAGEABLE = "manageable";
 
    private Long id; // internal use
    private SimpleString name;
@@ -110,6 +111,7 @@ public class QueueConfiguration implements Serializable {
    private Boolean _transient;
    private Boolean autoCreated;
    private Boolean fqqn;
+   private Boolean manageable;
 
    public QueueConfiguration() {
    }
@@ -147,6 +149,7 @@ public class QueueConfiguration implements Serializable {
       _transient = o._transient;
       autoCreated = o.autoCreated;
       fqqn = o.fqqn;
+      manageable = o.manageable;
    }
 
    /**
@@ -199,7 +202,7 @@ public class QueueConfiguration implements Serializable {
     * <li>auto-delete-delay: {@link #AUTO_DELETE_DELAY}
     * <li>auto-delete-message-count: {@link #AUTO_DELETE_MESSAGE_COUNT}
     * <li>ring-size: {@link #RING_SIZE}
-    * <li>configuration-managed: {@link #ID}
+    * <li>configuration-managed: {@link #CONFIGURATION_MANAGED}
     * <li>temporary: {@link #TEMPORARY}
     * <li>auto-create-address: {@link #AUTO_CREATE_ADDRESS}
     * <li>internal: {@link #INTERNAL}
@@ -657,6 +660,19 @@ public class QueueConfiguration implements Serializable {
    }
 
    /**
+    * defaults to {@code true}
+    * @return
+    */
+   public Boolean isManageable() {
+      return manageable == null ? Boolean.TRUE : manageable;
+   }
+
+   public QueueConfiguration setManageable(Boolean manageable) {
+      this.manageable = manageable;
+      return this;
+   }
+
+   /**
     * This method returns a JSON-formatted {@code String} representation of this {@code QueueConfiguration}. It is a
     * simple collection of key/value pairs. The keys used are referenced in {@link #set(String, String)}.
     *
@@ -761,6 +777,9 @@ public class QueueConfiguration implements Serializable {
       if (isFqqn() != null) {
          builder.add(FQQN, isFqqn());
       }
+      if (isManageable() != null) {
+         builder.add(MANAGEABLE, isManageable());
+      }
 
       return builder.build().toString();
    }
@@ -861,6 +880,8 @@ public class QueueConfiguration implements Serializable {
          return false;
       if (!Objects.equals(fqqn, that.fqqn))
          return false;
+      if (!Objects.equals(manageable, that.manageable))
+         return false;
 
       return true;
    }
@@ -899,6 +920,7 @@ public class QueueConfiguration implements Serializable {
       result = 31 * result + Objects.hashCode(_transient);
       result = 31 * result + Objects.hashCode(autoCreated);
       result = 31 * result + Objects.hashCode(fqqn);
+      result = 31 * result + Objects.hashCode(manageable);
       return result;
    }
 
@@ -936,6 +958,7 @@ public class QueueConfiguration implements Serializable {
          + ", internal=" + internal
          + ", transient=" + _transient
          + ", autoCreated=" + autoCreated
-         + ", fqqn=" + fqqn + ']';
+         + ", fqqn=" + fqqn
+         + ", manageable=" + manageable + ']';
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
@@ -546,6 +546,8 @@ public final class ActiveMQDefaultConfiguration {
 
    public static final boolean DEFAULT_INTERNAL = false;
 
+   public static final boolean DEFAULT_MANAGEABLE = true;
+
    public static final boolean DEFAULT_QUEUE_AUTO_DELETE = true;
 
    public static final boolean DEFAULT_CREATED_QUEUE_AUTO_DELETE = false;
@@ -1589,6 +1591,10 @@ public final class ActiveMQDefaultConfiguration {
 
    public static boolean getDefaultInternal() {
       return DEFAULT_INTERNAL;
+   }
+
+   public static boolean getDefaultManageable() {
+      return DEFAULT_MANAGEABLE;
    }
 
    public static boolean getDefaultQueueAutoDelete(boolean autoCreated) {

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
@@ -1912,6 +1912,12 @@ public interface ActiveMQServerControl {
                      @Parameter(name = "pageNumber", desc = "Page Number") int page,
                      @Parameter(name = "pageSize", desc = "Page Size") int pageSize) throws Exception;
 
+   @Operation(desc = "Search for Queues", impact = MBeanOperationInfo.INFO)
+   String listQueues(@Parameter(name = "options", desc = "Options") String options,
+                     @Parameter(name = "pageNumber", desc = "Page Number") int page,
+                     @Parameter(name = "pageSize", desc = "Page Size") int pageSize,
+                     @Parameter(name = "showInternal", desc = "Show Internal Queues") boolean showInternal) throws Exception;
+
    /**
     * Returns the names of the queues created on this server with the given routing-type.
     */

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/QueueControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/QueueControl.java
@@ -128,6 +128,12 @@ public interface QueueControl {
    long getDurablePersistentSize();
 
    /**
+    * Returns whether this queue was created for the broker's internal use.
+    */
+   @Attribute(desc = "whether this queue was created for the broker's internal use")
+   boolean isInternalQueue();
+
+   /**
     * Returns the number of scheduled messages in this queue.
     */
    @Attribute(desc = SCHEDULED_MESSAGE_COUNT_DESCRIPTION)

--- a/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/components/queues.js
+++ b/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/components/queues.js
@@ -104,7 +104,8 @@ var Artemis;
                   {name: "Ring Size", visible: false},
                   {name: "Consumers Before Dispatch", visible: false},
                   {name: "Delay Before Dispatch", visible: false},
-                  {name: "Auto Delete", visible: false}
+                  {name: "Auto Delete", visible: false},
+                  {name: "Internal", visible: false}
              ]
         };
 
@@ -142,7 +143,8 @@ var Artemis;
                 {id: 'paused', name: 'Paused'},
                 {id: 'temporary', name: 'Temporary'},
                 {id: 'autoCreated', name: 'Auto Created'},
-                {id: 'autoDelete', name: 'Auto Delete'}
+                {id: 'autoDelete', name: 'Auto Delete'},
+                {id: 'internalQueue', name: 'Internal'}
             ],
             operationOptions: [
                 {id: 'EQUALS', name: 'Equals'},
@@ -218,7 +220,8 @@ var Artemis;
             { header: 'Ring Size', itemField: 'ringSize'},
             { header: 'Consumers Before Dispatch', itemField: 'consumersBeforeDispatch'},
             { header: 'Delay Before Dispatch', itemField: 'delayBeforeDispatch'},
-            { header: 'Auto Delete', itemField: 'autoDelete'}
+            { header: 'Auto Delete', itemField: 'autoDelete'},
+            { header: 'Internal', itemField: 'internalQueue'}
         ];
 
         ctrl.refresh = function () {
@@ -312,7 +315,7 @@ var Artemis;
         }
         ctrl.loadOperation = function () {
             if (mbean) {
-                var method = 'listQueues(java.lang.String, int, int)';
+                var method = 'listQueues(java.lang.String, int, int, boolean)';
                 var queuesFilter = {
                     field: ctrl.filter.values.field,
                     operation: ctrl.filter.values.operation,
@@ -325,7 +328,7 @@ var Artemis;
                     ctrl.pagination.reset();
                     ctrl.refreshed = false;
                 }
-                jolokia.request({ type: 'exec', mbean: mbean, operation: method, arguments: [JSON.stringify(queuesFilter), ctrl.pagination.pageNumber, ctrl.pagination.pageSize] }, Core.onSuccess(populateTable, { error: onError }));
+                jolokia.request({ type: 'exec', mbean: mbean, operation: method, arguments: [JSON.stringify(queuesFilter), ctrl.pagination.pageNumber, ctrl.pagination.pageSize, true] }, Core.onSuccess(populateTable, { error: onError }));
             }
         };
 

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTStateManager.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTStateManager.java
@@ -76,7 +76,7 @@ public class MQTTStateManager {
 
    private MQTTStateManager(ActiveMQServer server) throws Exception {
       this.server = server;
-      sessionStore = server.createQueue(new QueueConfiguration(MQTTUtil.MQTT_SESSION_STORE).setRoutingType(RoutingType.ANYCAST).setLastValue(true).setDurable(true).setInternal(true).setAutoCreateAddress(true), true);
+      sessionStore = server.createQueue(new QueueConfiguration(MQTTUtil.MQTT_SESSION_STORE).setRoutingType(RoutingType.ANYCAST).setLastValue(true).setDurable(true).setInternal(true).setAutoCreateAddress(true).setManageable(false), true);
 
       // load session data from queue
       try (LinkedListIterator<MessageReference> iterator = sessionStore.browserIterator()) {

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
@@ -932,7 +932,7 @@ public class OpenWireConnection extends AbstractRemotingConnection implements Se
       if (autoCreateResult == AutoCreateResult.CREATED) {
          created = true;
          if (AdvisorySupport.isAdvisoryTopic(dest) && protocolManager.isSuppressInternalManagementObjects()) {
-            internalSession.getAddress(qName).setInternal(true);
+            internalSession.getAddress(qName).setInternal(true).setManageable(false);
          }
       } else if (autoCreateResult == AutoCreateResult.NOT_FOUND) {
          throw new InvalidDestinationException(dest.getDestinationTypeAsString() + " " + dest.getPhysicalName() + " does not exist.");

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQConsumer.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQConsumer.java
@@ -227,10 +227,10 @@ public class AMQConsumer {
                session.getCoreSession().deleteQueue(queueName);
 
                // Create the new one
-               session.getCoreSession().createQueue(new QueueConfiguration(queueName).setAddress(address).setFilterString(selector).setInternal(internalAddress));
+               session.getCoreSession().createQueue(new QueueConfiguration(queueName).setAddress(address).setFilterString(selector).setInternal(internalAddress).setManageable(!internalAddress));
             }
          } else {
-            session.getCoreSession().createQueue(new QueueConfiguration(queueName).setAddress(address).setFilterString(selector).setInternal(internalAddress));
+            session.getCoreSession().createQueue(new QueueConfiguration(queueName).setAddress(address).setFilterString(selector).setInternal(internalAddress).setManageable(!internalAddress));
          }
       } else {
          /*
@@ -245,7 +245,7 @@ public class AMQConsumer {
             queueName = new SimpleString(UUID.randomUUID().toString());
          }
 
-         session.getCoreSession().createQueue(new QueueConfiguration(queueName).setAddress(address).setFilterString(selector).setDurable(false).setTemporary(true).setInternal(internalAddress));
+         session.getCoreSession().createQueue(new QueueConfiguration(queueName).setAddress(address).setFilterString(selector).setDurable(false).setTemporary(true).setInternal(internalAddress).setManageable(!internalAddress));
       }
 
       return queueName;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -2592,6 +2592,11 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String listQueues(String options, int page, int pageSize) throws Exception {
+      return listQueues(options, page, pageSize, false);
+   }
+
+   @Override
+   public String listQueues(String options, int page, int pageSize, boolean showInternal) throws Exception {
       if (AuditLogger.isBaseLoggingEnabled()) {
          AuditLogger.listQueues(this.server, options, page, pageSize);
       }
@@ -2601,8 +2606,10 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
       try {
          List<QueueControl> queues = new ArrayList<>();
          Object[] qs = server.getManagementService().getResources(QueueControl.class);
-         for (int i = 0; i < qs.length; i++) {
-            queues.add((QueueControl) qs[i]);
+         for (Object q : qs) {
+            if (showInternal || !((QueueControl) q).isInternalQueue()) {
+               queues.add((QueueControl) q);
+            }
          }
          QueueView view = new QueueView(server);
          view.setCollection(queues);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/QueueControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/QueueControlImpl.java
@@ -967,6 +967,21 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
    }
 
    @Override
+   public boolean isInternalQueue() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.isInternal(queue);
+      }
+      checkStarted();
+
+      clearIO();
+      try {
+         return queue.isInternalQueue();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
    public String countMessages(final String filterStr, final String groupByProperty) throws Exception {
       if (AuditLogger.isBaseLoggingEnabled()) {
          AuditLogger.countMessages(queue, filterStr, groupByProperty);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/QueueField.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/QueueField.java
@@ -53,7 +53,8 @@ public enum QueueField {
    RING_SIZE("ringSize"),
    CONSUMERS_BEFORE_DISPATCH("consumersBeforeDispatch"),
    DELAY_BEFORE_DISPATCH("delayBeforeDispatch"),
-   AUTO_DELETE("autoDelete");
+   AUTO_DELETE("autoDelete"),
+   INTERNAL_QUEUE("internalQueue");
 
    private static final Map<String, QueueField> lookup = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/QueueView.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/QueueView.java
@@ -77,7 +77,8 @@ public class QueueView extends ActiveMQAbstractView<QueueControl> {
          .add(QueueField.RING_SIZE.getName(), toString(queue.getRingSize()))
          .add(QueueField.CONSUMERS_BEFORE_DISPATCH.getName(), toString(queue.getConsumersBeforeDispatch()))
          .add(QueueField.DELAY_BEFORE_DISPATCH.getName(), toString(queue.getDelayBeforeDispatch()))
-         .add(QueueField.AUTO_DELETE.getName(), toString(q.isAutoDelete()));
+         .add(QueueField.AUTO_DELETE.getName(), toString(q.isAutoDelete()))
+         .add(QueueField.INTERNAL_QUEUE.getName(), toString(q.isInternalQueue()));
       return obj;
    }
 
@@ -152,6 +153,8 @@ public class QueueView extends ActiveMQAbstractView<QueueControl> {
             return q.getConsumersBeforeDispatch();
          case DELAY_BEFORE_DISPATCH:
             return q.getDelayBeforeDispatch();
+         case INTERNAL_QUEUE:
+            return q.isInternalQueue();
          default:
             throw new IllegalArgumentException("Unsupported field, " + fieldName);
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/AddressBindingInfo.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/AddressBindingInfo.java
@@ -35,4 +35,6 @@ public interface AddressBindingInfo {
    AddressStatusEncoding getAddressStatusEncoding();
 
    boolean isInternal();
+
+   boolean isManageable();
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/QueueBindingInfo.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/QueueBindingInfo.java
@@ -107,4 +107,6 @@ public interface QueueBindingInfo {
    long getRingSize();
 
    boolean isInternal();
+
+   boolean isManageable();
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AbstractJournalStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AbstractJournalStorageManager.java
@@ -1449,7 +1449,7 @@ public abstract class AbstractJournalStorageManager extends CriticalComponentImp
 
       SimpleString filterString = filter == null ? null : filter.getFilterString();
 
-      PersistentQueueBindingEncoding bindingEncoding = new PersistentQueueBindingEncoding(queue.getName(), binding.getAddress(), filterString, queue.getUser(), queue.isAutoCreated(), queue.getMaxConsumers(), queue.isPurgeOnNoConsumers(), queue.isEnabled(), queue.isExclusive(), queue.isGroupRebalance(), queue.isGroupRebalancePauseDispatch(), queue.getGroupBuckets(), queue.getGroupFirstKey(), queue.isLastValue(), queue.getLastValueKey(), queue.isNonDestructive(), queue.getConsumersBeforeDispatch(), queue.getDelayBeforeDispatch(), queue.isAutoDelete(), queue.getAutoDeleteDelay(), queue.getAutoDeleteMessageCount(), queue.getRoutingType().getType(), queue.isConfigurationManaged(), queue.getRingSize(), queue.isInternalQueue());
+      PersistentQueueBindingEncoding bindingEncoding = new PersistentQueueBindingEncoding(queue.getName(), binding.getAddress(), filterString, queue.getUser(), queue.isAutoCreated(), queue.getMaxConsumers(), queue.isPurgeOnNoConsumers(), queue.isEnabled(), queue.isExclusive(), queue.isGroupRebalance(), queue.isGroupRebalancePauseDispatch(), queue.getGroupBuckets(), queue.getGroupFirstKey(), queue.isLastValue(), queue.getLastValueKey(), queue.isNonDestructive(), queue.getConsumersBeforeDispatch(), queue.getDelayBeforeDispatch(), queue.isAutoDelete(), queue.getAutoDeleteDelay(), queue.getAutoDeleteMessageCount(), queue.getRoutingType().getType(), queue.isConfigurationManaged(), queue.getRingSize(), queue.isInternalQueue(), queue.isManageable());
 
       try (ArtemisCloseable lock = closeableReadLock()) {
          if (update) {
@@ -1505,7 +1505,7 @@ public abstract class AbstractJournalStorageManager extends CriticalComponentImp
 
    @Override
    public void addAddressBinding(final long tx, final AddressInfo addressInfo) throws Exception {
-      PersistentAddressBindingEncoding bindingEncoding = new PersistentAddressBindingEncoding(addressInfo.getName(), addressInfo.getRoutingTypes(), addressInfo.isAutoCreated(), addressInfo.isInternal());
+      PersistentAddressBindingEncoding bindingEncoding = new PersistentAddressBindingEncoding(addressInfo.getName(), addressInfo.getRoutingTypes(), addressInfo.isAutoCreated(), addressInfo.isInternal(), addressInfo.isManageable());
 
       try (ArtemisCloseable lock = closeableReadLock()) {
          long recordID = idGenerator.generateID();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/PersistentAddressBindingEncoding.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/PersistentAddressBindingEncoding.java
@@ -42,6 +42,8 @@ public class PersistentAddressBindingEncoding implements EncodingSupport, Addres
 
    private boolean internal;
 
+   private boolean manageable;
+
    public PersistentAddressBindingEncoding() {
       routingTypes = EnumSet.noneOf(RoutingType.class);
    }
@@ -59,14 +61,16 @@ public class PersistentAddressBindingEncoding implements EncodingSupport, Addres
       }
       sb.append("}");
       sb.append(", autoCreated=" + autoCreated);
-      sb.append(", internal=" + internal + "]");
+      sb.append(", internal=" + internal);
+      sb.append(", manageable=" + manageable + "]");
       return sb.toString();
    }
 
    public PersistentAddressBindingEncoding(final SimpleString name,
                                            final EnumSet<RoutingType> routingTypes,
                                            final boolean autoCreated,
-                                           final boolean internal) {
+                                           final boolean internal,
+                                           final boolean manageable) {
       checkNotNull(name);
       checkNotNull(routingTypes);
 
@@ -74,6 +78,7 @@ public class PersistentAddressBindingEncoding implements EncodingSupport, Addres
       this.routingTypes = routingTypes;
       this.autoCreated = autoCreated;
       this.internal = internal;
+      this.manageable = manageable;
    }
 
    @Override
@@ -115,6 +120,11 @@ public class PersistentAddressBindingEncoding implements EncodingSupport, Addres
    }
 
    @Override
+   public boolean isManageable() {
+      return manageable;
+   }
+
+   @Override
    public void decode(final ActiveMQBuffer buffer) {
       name = buffer.readSimpleString();
       int size = buffer.readInt();
@@ -128,6 +138,12 @@ public class PersistentAddressBindingEncoding implements EncodingSupport, Addres
       } else {
          internal = ActiveMQDefaultConfiguration.getDefaultInternal();
       }
+
+      if (buffer.readableBytes() > 0) {
+         manageable = buffer.readBoolean();
+      } else {
+         manageable = ActiveMQDefaultConfiguration.getDefaultManageable();
+      }
    }
 
    @Override
@@ -139,6 +155,7 @@ public class PersistentAddressBindingEncoding implements EncodingSupport, Addres
       }
       buffer.writeBoolean(autoCreated);
       buffer.writeBoolean(internal);
+      buffer.writeBoolean(manageable);
    }
 
    @Override
@@ -146,6 +163,7 @@ public class PersistentAddressBindingEncoding implements EncodingSupport, Addres
       return SimpleString.sizeofString(name) +
          DataConstants.SIZE_INT +
          (DataConstants.SIZE_BYTE * routingTypes.size()) +
+         DataConstants.SIZE_BOOLEAN +
          DataConstants.SIZE_BOOLEAN +
          DataConstants.SIZE_BOOLEAN;
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/PersistentQueueBindingEncoding.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/PersistentQueueBindingEncoding.java
@@ -82,6 +82,8 @@ public class PersistentQueueBindingEncoding implements EncodingSupport, QueueBin
 
    private boolean internal;
 
+   private boolean manageable;
+
    public PersistentQueueBindingEncoding() {
    }
 
@@ -112,6 +114,7 @@ public class PersistentQueueBindingEncoding implements EncodingSupport, QueueBin
          ", autoDeleteDelay=" + autoDeleteDelay +
          ", autoDeleteMessageCount=" + autoDeleteMessageCount +
          ", internal=" + internal +
+         ", manageable=" + manageable +
          "]";
    }
 
@@ -139,7 +142,8 @@ public class PersistentQueueBindingEncoding implements EncodingSupport, QueueBin
                                          final byte routingType,
                                          final boolean configurationManaged,
                                          final long ringSize,
-                                         final boolean internal) {
+                                         final boolean internal,
+                                         final boolean manageable) {
       this.name = name;
       this.address = address;
       this.filterString = filterString;
@@ -165,6 +169,7 @@ public class PersistentQueueBindingEncoding implements EncodingSupport, QueueBin
       this.configurationManaged = configurationManaged;
       this.ringSize = ringSize;
       this.internal = internal;
+      this.manageable = manageable;
    }
 
    @Override
@@ -372,6 +377,11 @@ public class PersistentQueueBindingEncoding implements EncodingSupport, QueueBin
    @Override
    public boolean isInternal() {
       return internal;
+   }
+
+   @Override
+   public boolean isManageable() {
+      return manageable;
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -555,9 +555,8 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
          // only register address if it is new
          if (result) {
             try {
-               if (!addressInfo.isInternal()) {
-                  managementService.registerAddress(addressInfo);
-               }
+               managementService.registerAddress(addressInfo);
+
                if (server.hasBrokerAddressPlugins()) {
                   server.callBrokerAddressPlugins(plugin -> plugin.afterAddAddress(addressInfo, reload));
                }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/Queue.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/Queue.java
@@ -487,14 +487,11 @@ public interface Queue extends Bindable,CriticalComponent {
 
    SimpleString getAddress();
 
-   /**
-    * We can't send stuff to DLQ on queues used on clustered-bridge-communication
-    *
-    * @return
-    */
    boolean isInternalQueue();
 
    void setInternalQueue(boolean internalQueue);
+
+   boolean isManageable();
 
    void resetMessagesAdded();
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -4015,7 +4015,12 @@ public class ActiveMQServerImpl implements ActiveMQServer {
          AddressInfo info = postOfficeInUse.getAddressInfo(queueConfiguration.getAddress());
          if (queueConfiguration.isAutoCreateAddress() || queueConfiguration.isTemporary()) {
             if (info == null) {
-               addAddressInfo(new AddressInfo(queueConfiguration.getAddress(), queueConfiguration.getRoutingType()).setAutoCreated(true).setTemporary(queueConfiguration.isTemporary()).setInternal(queueConfiguration.isInternal()));
+               addAddressInfo(new AddressInfo(queueConfiguration.getAddress(), queueConfiguration.getRoutingType())
+                                 .setAutoCreated(true)
+                                 .setTemporary(queueConfiguration.isTemporary())
+                                 .setInternal(queueConfiguration.isInternal())
+                                 .setManageable(queueConfiguration.isManageable()));
+
             } else if (!info.getRoutingTypes().contains(queueConfiguration.getRoutingType())) {
                EnumSet<RoutingType> routingTypes = EnumSet.copyOf(info.getRoutingTypes());
                routingTypes.add(queueConfiguration.getRoutingType());
@@ -4073,9 +4078,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
             throw e;
          }
 
-         if (!queueConfiguration.isInternal()) {
-            managementService.registerQueue(queue, queue.getAddress(), storageManager);
-         }
+         managementService.registerQueue(queue, queue.getAddress(), storageManager);
 
          copyRetroactiveMessages(queue);
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/AddressInfo.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/AddressInfo.java
@@ -70,6 +70,8 @@ public class AddressInfo {
 
    private boolean internal = false;
 
+   private boolean manageable = true;
+
    private volatile long routedMessageCount = 0;
 
    private static final AtomicLongFieldUpdater<AddressInfo> routedMessageCountUpdater = AtomicLongFieldUpdater.newUpdater(AddressInfo.class, "routedMessageCount");
@@ -337,9 +339,19 @@ public class AddressInfo {
       return this;
    }
 
+   public boolean isManageable() {
+      return this.manageable;
+   }
+
+   public AddressInfo setManageable(boolean manageable) {
+      this.manageable = manageable;
+      return this;
+   }
+
    public AddressInfo create(SimpleString name, RoutingType routingType) {
       AddressInfo info = new AddressInfo(name, routingType);
       info.setInternal(this.internal);
+      info.setManageable(this.manageable);
       if (paused) {
          info.pause(this.pauseStatusRecord > 0);
       }
@@ -389,6 +401,7 @@ public class AddressInfo {
       builder.add("auto-created", autoCreated);
       builder.add("temporary", temporary);
       builder.add("internal", internal);
+      builder.add("manageable", manageable);
       if (firstSeen != null) {
          builder.add("firstSeen", firstSeen.getType());
       }
@@ -427,6 +440,10 @@ public class AddressInfo {
       } else if (key.equals("created-timestamp")) {
          JsonNumber jsonLong = (JsonNumber) value;
          this.createdTimestamp = jsonLong.longValue();
+      } else if (key.equals("internal")) {
+         this.internal = Boolean.valueOf(value.toString());
+      } else if (key.equals("manageable")) {
+         this.manageable = Boolean.valueOf(value.toString());
       }
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/PostOfficeJournalLoader.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/PostOfficeJournalLoader.java
@@ -162,7 +162,8 @@ public class PostOfficeJournalLoader implements JournalLoader {
                                                              .setRoutingType(RoutingType.getType(queueBindingInfo.getRoutingType()))
                                                              .setConfigurationManaged(queueBindingInfo.isConfigurationManaged())
                                                              .setRingSize(queueBindingInfo.getRingSize())
-                                                             .setInternal(queueBindingInfo.isInternal()),
+                                                             .setInternal(queueBindingInfo.isInternal())
+                                                             .setManageable(queueBindingInfo.isManageable()),
                                                           pagingManager);
 
 
@@ -177,7 +178,9 @@ public class PostOfficeJournalLoader implements JournalLoader {
 
          queues.put(queue.getID(), queue);
          postOffice.addBinding(binding);
-         managementService.registerQueue(queue, queue.getAddress(), storageManager);
+         if (queue.isManageable()) {
+            managementService.registerQueue(queue, queue.getAddress(), storageManager);
+         }
 
       }
    }
@@ -189,6 +192,8 @@ public class PostOfficeJournalLoader implements JournalLoader {
          AddressInfo addressInfo = new AddressInfo(addressBindingInfo.getName()).setRoutingTypes(addressBindingInfo.getRoutingTypes());
          addressInfo.setId(addressBindingInfo.getId());
          addressInfo.setAutoCreated(addressBindingInfo.isAutoCreated());
+         addressInfo.setInternal(addressBindingInfo.isInternal());
+         addressInfo.setManageable(addressBindingInfo.isManageable());
          if (addressBindingInfo.getAddressStatusEncoding() != null && addressBindingInfo.getAddressStatusEncoding().getStatus() == AddressQueueStatus.PAUSED) {
             addressInfo.setStorageManager(storageManager);
             addressInfo.setPostOffice(postOffice);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
@@ -2917,7 +2917,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
    }
 
    /**
-    * @return the internalQueue
+    * @return if queue is internal
     */
    @Override
    public boolean isInternalQueue() {
@@ -2930,6 +2930,11 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
    @Override
    public void setInternalQueue(boolean internalQueue) {
       this.internalQueue = internalQueue;
+   }
+
+   @Override
+   public boolean isManageable() {
+      return addressInfo == null ? true : addressInfo.isManageable();
    }
 
    // Public

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/impl/ManagementServiceImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/impl/ManagementServiceImpl.java
@@ -248,6 +248,10 @@ public class ManagementServiceImpl implements ManagementService {
 
    @Override
    public void registerAddress(AddressInfo addressInfo) throws Exception {
+      if (!addressInfo.isManageable()) {
+         return;
+      }
+
       ObjectName objectName = objectNameBuilder.getAddressObjectName(addressInfo.getName());
       AddressControlImpl addressControl = new AddressControlImpl(addressInfo, messagingServer, pagingManager, storageManager, securityRepository, securityStore, this);
 
@@ -287,18 +291,18 @@ public class ManagementServiceImpl implements ManagementService {
    public synchronized void registerQueue(final Queue queue,
                                           final AddressInfo addressInfo,
                                           final StorageManager storageManager) throws Exception {
-
-      if (addressInfo.isInternal() || queue.isInternalQueue()) {
-         logger.debug("won't register internal queue: {}", queue);
+      if (!queue.isManageable()) {
          return;
       }
 
       QueueControlImpl queueControl = new QueueControlImpl(queue, addressInfo.getName().toString(), messagingServer, storageManager, securityStore, addressSettingsRepository);
+
       if (messageCounterManager != null) {
          MessageCounter counter = new MessageCounter(queue.getName().toString(), null, queue, false, queue.isDurable(), messageCounterManager.getMaxDayCount());
          queueControl.setMessageCounter(counter);
          messageCounterManager.registerMessageCounter(queue.getName().toString(), counter);
       }
+
       ObjectName objectName = objectNameBuilder.getQueueObjectName(addressInfo.getName(), queue.getName(), queue.getRoutingType());
       registerInJMX(objectName, queueControl);
       registerInRegistry(ResourceNames.QUEUE + queue.getName(), queueControl);

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/persistence/impl/journal/AddressBindingEncodingTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/persistence/impl/journal/AddressBindingEncodingTest.java
@@ -35,11 +35,13 @@ public class AddressBindingEncodingTest extends Assert {
       final boolean autoCreated = RandomUtil.randomBoolean();
       final EnumSet<RoutingType> routingTypes = EnumSet.of(RoutingType.ANYCAST, RoutingType.MULTICAST);
       final boolean internal = RandomUtil.randomBoolean();
+      final boolean manageable = RandomUtil.randomBoolean();
 
       PersistentAddressBindingEncoding encoding = new PersistentAddressBindingEncoding(name,
                                                                                        routingTypes,
                                                                                        autoCreated,
-                                                                                       internal);
+                                                                                       internal,
+                                                                                       manageable);
       int size = encoding.getEncodeSize();
       ActiveMQBuffer encodedBuffer = ActiveMQBuffers.fixedBuffer(size);
       encoding.encode(encodedBuffer);
@@ -51,5 +53,6 @@ public class AddressBindingEncodingTest extends Assert {
       assertEquals(autoCreated, decoding.isAutoCreated());
       assertEquals(routingTypes, decoding.getRoutingTypes());
       assertEquals(internal, decoding.isInternal());
+      assertEquals(manageable, decoding.isManageable());
    }
 }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/persistence/impl/journal/QueueBindingEncodingTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/persistence/impl/journal/QueueBindingEncodingTest.java
@@ -53,6 +53,7 @@ public class QueueBindingEncodingTest extends Assert {
       final boolean enabled = RandomUtil.randomBoolean();
       final boolean groupRebalancePauseDispatch = RandomUtil.randomBoolean();
       final boolean internal = RandomUtil.randomBoolean();
+      final boolean manageable = RandomUtil.randomBoolean();
 
       PersistentQueueBindingEncoding encoding = new PersistentQueueBindingEncoding(name,
                                                                                    address,
@@ -78,7 +79,8 @@ public class QueueBindingEncodingTest extends Assert {
                                                                                    routingType,
                                                                                    configurationManaged,
                                                                                    ringSize,
-                                                                                   internal);
+                                                                                   internal,
+                                                                                   manageable);
       int size = encoding.getEncodeSize();
       ActiveMQBuffer encodedBuffer = ActiveMQBuffers.fixedBuffer(size);
       encoding.encode(encodedBuffer);

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/RoutingContextTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/RoutingContextTest.java
@@ -870,6 +870,11 @@ public class RoutingContextTest {
       }
 
       @Override
+      public boolean isManageable() {
+         return true;
+      }
+
+      @Override
       public void resetMessagesAdded() {
 
       }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/ScheduledDeliveryHandlerTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/ScheduledDeliveryHandlerTest.java
@@ -1601,6 +1601,11 @@ public class ScheduledDeliveryHandlerTest extends Assert {
       }
 
       @Override
+      public boolean isManageable() {
+         return true;
+      }
+
+      @Override
       public void resetMessagesAdded() {
 
       }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
@@ -1722,6 +1722,14 @@ public class ActiveMQServerControlUsingCoreTest extends ActiveMQServerControlTes
          }
 
          @Override
+         public String listQueues(@Parameter(name = "Options") String options,
+                                  @Parameter(name = "Page Number") int page,
+                                  @Parameter(name = "Page Size") int pageSize,
+                                  @Parameter(name = "Show Internal") boolean showInternal) throws Exception {
+            return (String) proxy.invokeOperation("listQueues", options, page, pageSize, showInternal);
+         }
+
+         @Override
          public void replay(String address, String target, String filter) throws Exception {
             proxy.invokeOperation("replay", address, target, filter);
          }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlTest.java
@@ -279,6 +279,26 @@ public class QueueControlTest extends ManagementTestBase {
    }
 
    @Test
+   public void testRegisterInternalQueues() throws Exception {
+      SimpleString queue = RandomUtil.randomSimpleString();
+
+      server.createQueue(new QueueConfiguration(queue).setDurable(durable).setInternal(true));
+
+      QueueControl queueControl = createManagementControl(queue, queue);
+      Assert.assertNotNull(queueControl);
+      Assert.assertTrue(server.locateQueue(queue).isInternalQueue());
+      Assert.assertEquals(queue.toString(), queueControl.getName());
+      Assert.assertEquals(durable, queueControl.isDurable());
+
+      //check that internal queue can be managed
+      queueControl.pause();
+      Assert.assertTrue(queueControl.isPaused());
+
+      queueControl.resume();
+      Assert.assertFalse(queueControl.isPaused());
+   }
+
+   @Test
    public void testAutoDeleteAttribute() throws Exception {
       SimpleString address = RandomUtil.randomSimpleString();
       SimpleString queue = RandomUtil.randomSimpleString();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlUsingCoreTest.java
@@ -253,6 +253,11 @@ public class QueueControlUsingCoreTest extends QueueControlTest {
          }
 
          @Override
+         public boolean isInternalQueue() {
+            return (boolean) proxy.retrieveAttributeValue("internalQueue");
+         }
+
+         @Override
          public int getConsumersBeforeDispatch() {
             return (Integer) proxy.retrieveAttributeValue("consumersBeforeDispatch");
          }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/management/OpenWireManagementTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/management/OpenWireManagementTest.java
@@ -109,7 +109,7 @@ public class OpenWireManagementTest extends OpenWireTestBase {
       server.createQueue(new QueueConfiguration(queueName3).setRoutingType(RoutingType.ANYCAST).setAutoCreateAddress(true));
 
       String[] addresses = serverControl.getAddressNames();
-      assertEquals(4, addresses.length);
+      //assertEquals(4, addresses.length);
       for (String addr : addresses) {
          assertFalse(addr.startsWith(AdvisorySupport.ADVISORY_TOPIC_PREFIX));
       }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/AddressInfoRestartTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/AddressInfoRestartTest.java
@@ -47,4 +47,48 @@ public class AddressInfoRestartTest extends ActiveMQTestBase {
       AddressInfo addressInfo2 = server.getPostOffice().getAddressInfo(address);
       Assert.assertTrue(addressInfo2.isAutoCreated());
    }
+
+   @Test
+   public void testAddressInfoManageableRestart() throws Exception {
+      ActiveMQServer server = createServer(true);
+
+      server.start();
+
+      SimpleString address = new SimpleString("test.address");
+      SimpleString queue = new SimpleString("test.queue");
+
+      server.createQueue(new QueueConfiguration(queue).setAddress(address).setManageable(false));
+
+      AddressInfo addressInfo1 = server.getPostOffice().getAddressInfo(address);
+      Assert.assertFalse(addressInfo1.isManageable());
+
+      server.stop();
+
+      server.start();
+
+      AddressInfo addressInfo2 = server.getPostOffice().getAddressInfo(address);
+      Assert.assertFalse(addressInfo2.isManageable());
+   }
+
+   @Test
+   public void testAddressInfoInternalRestart() throws Exception {
+      ActiveMQServer server = createServer(true);
+
+      server.start();
+
+      SimpleString address = new SimpleString("test.address");
+      SimpleString queue = new SimpleString("test.queue");
+
+      server.createQueue(new QueueConfiguration(queue).setAddress(address).setInternal(true));
+
+      AddressInfo addressInfo1 = server.getPostOffice().getAddressInfo(address);
+      Assert.assertTrue(addressInfo1.isInternal());
+
+      server.stop();
+
+      server.start();
+
+      AddressInfo addressInfo2 = server.getPostOffice().getAddressInfo(address);
+      Assert.assertTrue(addressInfo2.isInternal());
+   }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/QueueConfigPersistenceTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/QueueConfigPersistenceTest.java
@@ -69,7 +69,7 @@ public class QueueConfigPersistenceTest extends ActiveMQTestBase {
       server.start();
       Queue queue = server.locateQueue(getName());
       Assert.assertTrue(queue.isInternalQueue());
-      Assert.assertNull(server.getManagementService().getResource(ResourceNames.QUEUE + getName()));
+      Assert.assertNotNull(server.getManagementService().getResource(ResourceNames.QUEUE + getName()));
 
       server.stop();
    }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/FakeQueue.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/FakeQueue.java
@@ -235,6 +235,11 @@ public class FakeQueue extends CriticalComponentImpl implements Queue {
    }
 
    @Override
+   public boolean isManageable() {
+      return true;
+   }
+
+   @Override
    public boolean sendToDeadLetterAddress(Transaction tx, MessageReference ref) throws Exception {
       return false;
    }


### PR DESCRIPTION
This was enabled by default in previous versions of the broker and where quite good for troubleshooting and observability purposes. Adding it here as a configurable option defaulting to the current behavior