### PR TITLE
ARTEMIS-4508 the recovery connection factory ignores useTopologyForLoadBalancing.

### DIFF
--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
@@ -1702,6 +1702,7 @@ public class ActiveMQResourceAdapter implements ResourceAdapter, Serializable {
       setParams(cf, overrideProperties);
 
       //now make sure we are HA in any way
+      cf.setUseTopologyForLoadBalancing(raProperties.isUseTopologyForLoadBalancing());
 
       cf.setReconnectAttempts(0);
       cf.setInitialConnectAttempts(0);


### PR DESCRIPTION
Fixing the creation of the recovery connection factory so that useTopologyForLoadBalancing is properly set.

Issue: https://issues.apache.org/jira/browse/ARTEMIS-4508