### PR TITLE
ARTEMIS-4510 - Add auto-create-destination logic to diverts

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/AddressSettingsInfo.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/AddressSettingsInfo.java
@@ -309,6 +309,10 @@ public final class AddressSettingsInfo {
    }
    private boolean enableMetrics;
 
+   static {
+      META_BEAN.add(Boolean.class, "autoCreateDivertDestination", (o, p) -> o.autoCreateDivertDestination = p, o -> o.autoCreateDivertDestination);
+   }
+   private boolean autoCreateDivertDestination;
 
    public static AddressSettingsInfo fromJSON(final String jsonString) {
       AddressSettingsInfo newInfo = new AddressSettingsInfo();
@@ -553,6 +557,10 @@ public final class AddressSettingsInfo {
 
    public boolean isEnableMetrics() {
       return enableMetrics;
+   }
+
+   public boolean isAutoCreateDivertDestination() {
+      return autoCreateDivertDestination;
    }
 }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -376,6 +376,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
    private static final String ID_CACHE_SIZE = "id-cache-size";
 
+   private static final String AUTO_CREATE_DIVERT_DESTINATION_NODE_NAME = "auto-create-divert-destinations";
+
    private boolean validateAIO = false;
 
    private boolean printPageMaxSizeUsed = false;
@@ -1451,6 +1453,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
             addressSettings.setEnableIngressTimestamp(XMLUtil.parseBoolean(child));
          } else if (ID_CACHE_SIZE.equalsIgnoreCase(name)) {
             addressSettings.setIDCacheSize(GE_ZERO.validate(ID_CACHE_SIZE, XMLUtil.parseInt(child)).intValue());
+         } else if (AUTO_CREATE_DIVERT_DESTINATION_NODE_NAME.equalsIgnoreCase(name)) {
+            addressSettings.setAutoCreateDivertDestination(XMLUtil.parseBoolean(child));
          }
       }
       return setting;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/PostOffice.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/PostOffice.java
@@ -35,6 +35,7 @@ import org.apache.activemq.artemis.core.server.RoutingContext;
 import org.apache.activemq.artemis.core.server.impl.AckReason;
 import org.apache.activemq.artemis.core.server.impl.AddressInfo;
 import org.apache.activemq.artemis.core.server.mirror.MirrorController;
+import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.core.transaction.Transaction;
 
 /**
@@ -113,7 +114,7 @@ public interface PostOffice extends ActiveMQComponent {
 
    List<Queue> listQueuesForAddress(SimpleString address) throws Exception;
 
-
+   AddressSettings getAddressSettingsMatch(String address);
 
    void addBinding(Binding binding) throws Exception;
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -932,6 +932,11 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
       return queues;
    }
 
+   @Override
+   public AddressSettings getAddressSettingsMatch(String address) {
+      return addressSettingsRepository.getMatch(address);
+   }
+
    // TODO - needs to be synchronized to prevent happening concurrently with activate()
    // (and possible removeBinding and other methods)
    // Otherwise can have situation where createQueue comes in before failover, then failover occurs

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
@@ -147,6 +147,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
    public static final boolean DEFAULT_ENABLE_INGRESS_TIMESTAMP = false;
 
+   public static final boolean DEFAULT_AUTO_CREATE_DIVERT_DESTINATIONS = false;
+
    static {
       metaBean.add(AddressFullMessagePolicy.class, "addressFullMessagePolicy", (t, p) -> t.addressFullMessagePolicy = p, t -> t.addressFullMessagePolicy);
    }
@@ -530,6 +532,11 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       metaBean.add(Integer.class, "idCacheSize", (t, p) -> t.idCacheSize = p, t -> t.idCacheSize);
    }
    private Integer idCacheSize = null;
+
+   static {
+      metaBean.add(Boolean.class, "autoCreateDivertDestination", (t, p) -> t.autoCreateDivertDestination = p, t -> t.autoCreateDivertDestination);
+   }
+   private Boolean autoCreateDivertDestination = null;
 
    static {
       metaBean.add(Integer.class, "queuePrefetch", (t, p) -> t.queuePrefetch = p, t -> t.queuePrefetch);
@@ -1281,6 +1288,15 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       return this;
    }
 
+   public boolean isAutoCreateDivertDestination() {
+      return autoCreateDivertDestination != null ? autoCreateDivertDestination : AddressSettings.DEFAULT_AUTO_CREATE_DIVERT_DESTINATIONS;
+   }
+
+   public AddressSettings setAutoCreateDivertDestination(final boolean autoCreateDivertDestination) {
+      this.autoCreateDivertDestination = autoCreateDivertDestination;
+      return this;
+   }
+
    /**
     * Merge two AddressSettings instances in one instance
     *
@@ -1998,7 +2014,9 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
          return false;
       if (!Objects.equals(idCacheSize, that.idCacheSize))
          return false;
-      return Objects.equals(queuePrefetch, that.queuePrefetch);
+      if (!Objects.equals(queuePrefetch, that.queuePrefetch))
+         return false;
+      return Objects.equals(autoCreateDivertDestination, that.autoCreateDivertDestination);
    }
 
    @Override
@@ -2080,11 +2098,12 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       result = 31 * result + (enableIngressTimestamp != null ? enableIngressTimestamp.hashCode() : 0);
       result = 31 * result + (idCacheSize != null ? idCacheSize.hashCode() : 0);
       result = 31 * result + (queuePrefetch != null ? queuePrefetch.hashCode() : 0);
+      result = 31 * result + (autoCreateDivertDestination != null ? autoCreateDivertDestination.hashCode() : 0);
       return result;
    }
 
    @Override
    public String toString() {
-      return "AddressSettings{" + "addressFullMessagePolicy=" + addressFullMessagePolicy + ", maxSizeBytes=" + maxSizeBytes + ", maxReadPageBytes=" + maxReadPageBytes + ", maxReadPageMessages=" + maxReadPageMessages + ", prefetchPageBytes=" + prefetchPageBytes + ", prefetchPageMessages=" + prefetchPageMessages + ", pageLimitBytes=" + pageLimitBytes + ", pageLimitMessages=" + pageLimitMessages + ", pageFullMessagePolicy=" + pageFullMessagePolicy + ", maxSizeMessages=" + maxSizeMessages + ", pageSizeBytes=" + pageSizeBytes + ", pageMaxCache=" + pageCacheMaxSize + ", dropMessagesWhenFull=" + dropMessagesWhenFull + ", maxDeliveryAttempts=" + maxDeliveryAttempts + ", messageCounterHistoryDayLimit=" + messageCounterHistoryDayLimit + ", redeliveryDelay=" + redeliveryDelay + ", redeliveryMultiplier=" + redeliveryMultiplier + ", redeliveryCollisionAvoidanceFactor=" + redeliveryCollisionAvoidanceFactor + ", maxRedeliveryDelay=" + maxRedeliveryDelay + ", deadLetterAddress=" + deadLetterAddress + ", expiryAddress=" + expiryAddress + ", expiryDelay=" + expiryDelay + ", minExpiryDelay=" + minExpiryDelay + ", maxExpiryDelay=" + maxExpiryDelay + ", defaultLastValueQueue=" + defaultLastValueQueue + ", defaultLastValueKey=" + defaultLastValueKey + ", defaultNonDestructive=" + defaultNonDestructive + ", defaultExclusiveQueue=" + defaultExclusiveQueue + ", defaultGroupRebalance=" + defaultGroupRebalance + ", defaultGroupRebalancePauseDispatch=" + defaultGroupRebalancePauseDispatch + ", defaultGroupBuckets=" + defaultGroupBuckets + ", defaultGroupFirstKey=" + defaultGroupFirstKey + ", redistributionDelay=" + redistributionDelay + ", sendToDLAOnNoRoute=" + sendToDLAOnNoRoute + ", slowConsumerThreshold=" + slowConsumerThreshold + ", slowConsumerThresholdMeasurementUnit=" + slowConsumerThresholdMeasurementUnit + ", slowConsumerCheckPeriod=" + slowConsumerCheckPeriod + ", slowConsumerPolicy=" + slowConsumerPolicy + ", autoCreateJmsQueues=" + autoCreateJmsQueues + ", autoDeleteJmsQueues=" + autoDeleteJmsQueues + ", autoCreateJmsTopics=" + autoCreateJmsTopics + ", autoDeleteJmsTopics=" + autoDeleteJmsTopics + ", autoCreateQueues=" + autoCreateQueues + ", autoDeleteQueues=" + autoDeleteQueues + ", autoDeleteCreatedQueues=" + autoDeleteCreatedQueues + ", autoDeleteQueuesDelay=" + autoDeleteQueuesDelay + ", autoDeleteQueuesSkipUsageCheck=" + autoDeleteQueuesSkipUsageCheck + ", autoDeleteQueuesMessageCount=" + autoDeleteQueuesMessageCount + ", defaultRingSize=" + defaultRingSize + ", retroactiveMessageCount=" + retroactiveMessageCount + ", configDeleteQueues=" + configDeleteQueues + ", autoCreateAddresses=" + autoCreateAddresses + ", autoDeleteAddresses=" + autoDeleteAddresses + ", autoDeleteAddressesDelay=" + autoDeleteAddressesDelay + ", autoDeleteAddressesSkipUsageCheck=" + autoDeleteAddressesSkipUsageCheck + ", configDeleteAddresses=" + configDeleteAddresses + ", configDeleteDiverts=" + configDeleteDiverts + ", managementBrowsePageSize=" + managementBrowsePageSize + ", maxSizeBytesRejectThreshold=" + maxSizeBytesRejectThreshold + ", defaultMaxConsumers=" + defaultMaxConsumers + ", defaultPurgeOnNoConsumers=" + defaultPurgeOnNoConsumers + ", defaultConsumersBeforeDispatch=" + defaultConsumersBeforeDispatch + ", defaultDelayBeforeDispatch=" + defaultDelayBeforeDispatch + ", defaultQueueRoutingType=" + defaultQueueRoutingType + ", defaultAddressRoutingType=" + defaultAddressRoutingType + ", defaultConsumerWindowSize=" + defaultConsumerWindowSize + ", autoCreateDeadLetterResources=" + autoCreateDeadLetterResources + ", deadLetterQueuePrefix=" + deadLetterQueuePrefix + ", deadLetterQueueSuffix=" + deadLetterQueueSuffix + ", autoCreateExpiryResources=" + autoCreateExpiryResources + ", expiryQueuePrefix=" + expiryQueuePrefix + ", expiryQueueSuffix=" + expiryQueueSuffix + ", enableMetrics=" + enableMetrics + ", managementMessageAttributeSizeLimit=" + managementMessageAttributeSizeLimit + ", enableIngressTimestamp=" + enableIngressTimestamp + ", idCacheSize=" + idCacheSize + ", queuePrefetch=" + queuePrefetch + '}';
+      return "AddressSettings{" + "addressFullMessagePolicy=" + addressFullMessagePolicy + ", maxSizeBytes=" + maxSizeBytes + ", maxReadPageBytes=" + maxReadPageBytes + ", maxReadPageMessages=" + maxReadPageMessages + ", prefetchPageBytes=" + prefetchPageBytes + ", prefetchPageMessages=" + prefetchPageMessages + ", pageLimitBytes=" + pageLimitBytes + ", pageLimitMessages=" + pageLimitMessages + ", pageFullMessagePolicy=" + pageFullMessagePolicy + ", maxSizeMessages=" + maxSizeMessages + ", pageSizeBytes=" + pageSizeBytes + ", pageMaxCache=" + pageCacheMaxSize + ", dropMessagesWhenFull=" + dropMessagesWhenFull + ", maxDeliveryAttempts=" + maxDeliveryAttempts + ", messageCounterHistoryDayLimit=" + messageCounterHistoryDayLimit + ", redeliveryDelay=" + redeliveryDelay + ", redeliveryMultiplier=" + redeliveryMultiplier + ", redeliveryCollisionAvoidanceFactor=" + redeliveryCollisionAvoidanceFactor + ", maxRedeliveryDelay=" + maxRedeliveryDelay + ", deadLetterAddress=" + deadLetterAddress + ", expiryAddress=" + expiryAddress + ", expiryDelay=" + expiryDelay + ", minExpiryDelay=" + minExpiryDelay + ", maxExpiryDelay=" + maxExpiryDelay + ", defaultLastValueQueue=" + defaultLastValueQueue + ", defaultLastValueKey=" + defaultLastValueKey + ", defaultNonDestructive=" + defaultNonDestructive + ", defaultExclusiveQueue=" + defaultExclusiveQueue + ", defaultGroupRebalance=" + defaultGroupRebalance + ", defaultGroupRebalancePauseDispatch=" + defaultGroupRebalancePauseDispatch + ", defaultGroupBuckets=" + defaultGroupBuckets + ", defaultGroupFirstKey=" + defaultGroupFirstKey + ", redistributionDelay=" + redistributionDelay + ", sendToDLAOnNoRoute=" + sendToDLAOnNoRoute + ", slowConsumerThreshold=" + slowConsumerThreshold + ", slowConsumerThresholdMeasurementUnit=" + slowConsumerThresholdMeasurementUnit + ", slowConsumerCheckPeriod=" + slowConsumerCheckPeriod + ", slowConsumerPolicy=" + slowConsumerPolicy + ", autoCreateJmsQueues=" + autoCreateJmsQueues + ", autoDeleteJmsQueues=" + autoDeleteJmsQueues + ", autoCreateJmsTopics=" + autoCreateJmsTopics + ", autoDeleteJmsTopics=" + autoDeleteJmsTopics + ", autoCreateQueues=" + autoCreateQueues + ", autoDeleteQueues=" + autoDeleteQueues + ", autoDeleteCreatedQueues=" + autoDeleteCreatedQueues + ", autoDeleteQueuesDelay=" + autoDeleteQueuesDelay + ", autoDeleteQueuesSkipUsageCheck=" + autoDeleteQueuesSkipUsageCheck + ", autoDeleteQueuesMessageCount=" + autoDeleteQueuesMessageCount + ", defaultRingSize=" + defaultRingSize + ", retroactiveMessageCount=" + retroactiveMessageCount + ", configDeleteQueues=" + configDeleteQueues + ", autoCreateAddresses=" + autoCreateAddresses + ", autoDeleteAddresses=" + autoDeleteAddresses + ", autoDeleteAddressesDelay=" + autoDeleteAddressesDelay + ", autoDeleteAddressesSkipUsageCheck=" + autoDeleteAddressesSkipUsageCheck + ", configDeleteAddresses=" + configDeleteAddresses + ", configDeleteDiverts=" + configDeleteDiverts + ", managementBrowsePageSize=" + managementBrowsePageSize + ", maxSizeBytesRejectThreshold=" + maxSizeBytesRejectThreshold + ", defaultMaxConsumers=" + defaultMaxConsumers + ", defaultPurgeOnNoConsumers=" + defaultPurgeOnNoConsumers + ", defaultConsumersBeforeDispatch=" + defaultConsumersBeforeDispatch + ", defaultDelayBeforeDispatch=" + defaultDelayBeforeDispatch + ", defaultQueueRoutingType=" + defaultQueueRoutingType + ", defaultAddressRoutingType=" + defaultAddressRoutingType + ", defaultConsumerWindowSize=" + defaultConsumerWindowSize + ", autoCreateDeadLetterResources=" + autoCreateDeadLetterResources + ", deadLetterQueuePrefix=" + deadLetterQueuePrefix + ", deadLetterQueueSuffix=" + deadLetterQueueSuffix + ", autoCreateExpiryResources=" + autoCreateExpiryResources + ", expiryQueuePrefix=" + expiryQueuePrefix + ", expiryQueueSuffix=" + expiryQueueSuffix + ", enableMetrics=" + enableMetrics + ", managementMessageAttributeSizeLimit=" + managementMessageAttributeSizeLimit + ", enableIngressTimestamp=" + enableIngressTimestamp + ", idCacheSize=" + idCacheSize + ", queuePrefetch=" + queuePrefetch + ", autoCreateDivertDestination=" + autoCreateDivertDestination + "}";
    }
 }

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -4411,6 +4411,14 @@
             </xsd:annotation>
          </xsd:element>
 
+         <xsd:element name="auto-create-divert-destinations" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  whether or not to automatically create divert destinations that was computed at runtime
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
       </xsd:all>
 
       <xsd:attribute name="match" type="xsd:string" use="required">

--- a/docs/user-manual/address-settings.adoc
+++ b/docs/user-manual/address-settings.adoc
@@ -80,6 +80,7 @@ Here an example of an `address-setting` entry that might be found in the `broker
       <enable-metrics>true</enable-metrics>
       <enable-ingress-timestamp>false</enable-ingress-timestamp>
       <id-cache-size>500</id-cache-size>
+      <auto-create-divert-destinations>false</auto-create-divert-destinations>
    </address-setting>
 </address-settings>
 ----
@@ -210,12 +211,12 @@ Default is `false`.
 slow-consumer-threshold::
 The minimum rate of message consumption allowed before a consumer is considered "slow."
 Measured in units specified by the slow-consumer-threshold-measurement-unit configuration option.
-Default is `-1`  (i.e. disabled); any other value must be greater than 0 to ensure a queue has messages, and it is the actual consumer that is slow.
+Default is `-1` (i.e. disabled); any other value must be greater than 0 to ensure a queue has messages, and it is the actual consumer that is slow.
 A value of 0 will allow a consumer with no messages pending to be considered slow.
 Read more about xref:slow-consumers.adoc#detecting-slow-consumers[slow consumers].
 
 slow-consumer-threshold-measurement-unit::
-The units used to measure the  slow-consumer-threshold.
+The units used to measure the slow-consumer-threshold.
 Valid options are:
 +
 * MESSAGES_PER_SECOND
@@ -251,32 +252,32 @@ NOTE: automatic queue creation does _not_ work for the core client.
 The core API is a low-level API and is not meant to have such automation.
 
 auto-delete-queues::
-Whether or not the broker should automatically delete auto-created queues when they have both 0 consumers and the message count is  less than or equal to `auto-delete-queues-message-count`.
+Whether or not the broker should automatically delete auto-created queues when they have both 0 consumers and the message count is less than or equal to `auto-delete-queues-message-count`.
 Default is `true`.
 
 auto-delete-created-queues::
-Whether or not the broker should automatically delete created queues when they have both 0 consumers and the message count is  less than or equal to `auto-delete-queues-message-count`.
+Whether or not the broker should automatically delete created queues when they have both 0 consumers and the message count is less than or equal to `auto-delete-queues-message-count`.
 Default is `false`.
 
 auto-delete-queues-delay::
-How long to wait (in milliseconds) before deleting auto-created queues after the queue has 0 consumers and the message count is  less than or equal to `auto-delete-queues-message-count`.
+How long to wait (in milliseconds) before deleting auto-created queues after the queue has 0 consumers and the message count is less than or equal to `auto-delete-queues-message-count`.
 Default is `0` (delete immediately).
 The broker's `address-queue-scan-period` controls how often (in milliseconds) queues are scanned for potential deletion.
 Use `-1` to disable scanning.
 The default scan value is `30000`.
 
 auto-delete-queues-message-count::
-The message count that the queue must be  less than or equal to before deleting auto-created queues.
+The message count that the queue must be less than or equal to before deleting auto-created queues.
 To disable message count check `-1` can be set.
 Default is `0` (empty queue).
 
 auto-delete-queues-skip-usage-check::
-A queue will only be auto-deleted by  default if it has actually been "used." A queue is considered "used" if any messages have been sent to it or any consumers have connected to it during its life.
+A queue will only be auto-deleted by default if it has actually been "used." A queue is considered "used" if any messages have been sent to it or any consumers have connected to it during its life.
 However, there are use-cases where it's useful to skip this check.
 When set to `true` it is *imperative* to also set `auto-delete-queues-delay` to a value greater than `0` otherwise queues may be deleted almost immediately after being created.
 In this case the queue will be deleted based on when it was created rather then when it was last "used." Default is `false`.
 +
-NOTE: the above auto-delete address settings can also be configured  individually at the queue level when a client auto creates the queue.
+NOTE: the above auto-delete address settings can also be configured individually at the queue level when a client auto creates the queue.
 +
 For Core API it is exposed in createQueue methods.
 +
@@ -322,12 +323,12 @@ Default is `OFF`.
 Read more about xref:config-reload.adoc#configuration-reload[configuration reload].
 
 management-browse-page-size::
-is the number of messages a management resource can browse.
+The number of messages a management resource can browse.
 This is relevant for the `browse, list and count-with-filter` management methods exposed on the queue control.
 Default is `200`.
 
 management-message-attribute-size-limit::
-is the number of bytes collected from the message for browse.
+The number of bytes collected from the message for browse.
 This is relevant for the `browse and list` management methods exposed on the queue control.
 Message attributes longer than this value appear truncated.
 Default is `256`.
@@ -336,13 +337,13 @@ Note that memory needs to be allocated for all messages that are visible at a gi
 Setting this value too high may impact the browser stability due to the large amount of memory that may be required to browse through many messages.
 
 default-purge-on-no-consumers::
-defines a queue's default `purge-on-no-consumers` setting if none is provided on the queue itself.
+Defines a queue's default `purge-on-no-consumers` setting if none is provided on the queue itself.
 Default is `false`.
 This value can be overridden at the queue level using the `purge-on-no-consumers` boolean.
 Read more about xref:address-model.adoc#non-durable-subscription-queue[this functionality].
 
 default-max-consumers::
-defines a queue's default `max-consumers` setting if none is provided on the  queue itself.
+Defines a queue's default `max-consumers` setting if none is provided on the queue itself.
 Default is `-1` (i.e. no limit).
 This value can be overridden at the queue level using the `max-consumers` boolean.
 Read more about xref:address-model.adoc#shared-durable-subscription-queue-using-max-consumers[this functionality].
@@ -358,7 +359,7 @@ Default is `MULTICAST`.
 Read more about xref:address-model.adoc#routing-type[routing types].
 
 default-consumer-window-size::
-The default `consumerWindowSize` value  for a `CORE` protocol consumer, if not defined the default will be set to  1 MiB (1024 * 1024 bytes).
+The default `consumerWindowSize` value for a `CORE` protocol consumer, if not defined the default will be set to 1 MiB (1024 * 1024 bytes).
 The consumer will use this value as the window size if the value is not set on the client.
 Read more about xref:flow-control.adoc#flow-control[flow control].
 
@@ -373,24 +374,28 @@ Defaults to 0.
 Read more about xref:retroactive-addresses.adoc#retroactive-addresses[retroactive addresses].
 
 enable-metrics::
-determines whether or not metrics will be published to any configured metrics plugin for the matching address.
+Determines whether or not metrics will be published to any configured metrics plugin for the matching address.
 Default is `true`.
 Read more about xref:metrics.adoc#metrics[metrics].
 
 enable-ingress-timestamp::
-determines whether or not the broker will add its time  to messages sent to the matching address.
-When `true` the exact behavior will  depend on the specific protocol in use.
+Determines whether or not the broker will add its time to messages sent to the matching address.
+When `true` the exact behavior will depend on the specific protocol in use.
 For AMQP messages the broker will add a `long` _message annotation_ named `x-opt-ingress-time`.
 For core messages (used by the core and OpenWire protocols) the broker will add a long property named `_AMQ_INGRESS_TIMESTAMP`.
-For STOMP messages the broker will add a frame header  named `ingress-timestamp`.
+For STOMP messages the broker will add a frame header named `ingress-timestamp`.
 The value will be the number of milliseconds since the https://en.wikipedia.org/wiki/Unix_time[epoch].
 Default is `false`.
 
 id-cache-size::
-defines the maximum size of the duplicate ID cache for an address, as each address has it's own cache
+Defines the maximum size of the duplicate ID cache for an address, as each address has it's own cache
 that helps to detect and prevent the processing of duplicate messages based on their unique identification.
 By default, the `id-cache-size` setting inherits from the global `id-cache-size`, with a default of `20000`
 elements if not explicitly configured. Read more about xref:duplicate-detection.adoc#configuring-the-duplicate-id-cache[duplicate id cache sizes].
+
+auto-create-divert-destinations::
+Determines whether or not a message passing through a `Divert` will get its destination
+automatically created. The default value is `false`. Read more about xref:diverts.adoc#computing-destinations-at-runtime[computing destinations in a divert]
 
 ## Literal Matches
 

--- a/docs/user-manual/configuration-index.adoc
+++ b/docs/user-manual/configuration-index.adoc
@@ -812,6 +812,10 @@ see `auto-create-queues` & `auto-create-addresses`
 | xref:duplicate-detection.adoc#configuring-the-duplicate-id-cache[id-cache-size]
 | The duplicate detection circular cache size
 | Inherits from global `id-cache-size`
+
+| xref:diverts.adoc#computing-destinations-at-runtime[auto-create-divert-destinations]
+| Should a `divert` automatically create its destinations
+|`false`
 |===
 
 == bridge type

--- a/docs/user-manual/diverts.adoc
+++ b/docs/user-manual/diverts.adoc
@@ -120,3 +120,44 @@ Just use a comma separated list in `forwarding-address`, e.g.:
    <exclusive>false</exclusive>
 </divert>
 ----
+
+== Computing destinations at runtime
+
+Using logic in a diverts transformer, it's possible to perform complex routing
+by altering properties on individual messages.
+
+A simple example of this:
+
+[,java]
+----
+@Override
+public Message transform(Message message) {
+
+   if (message.getBooleanProperty("changeDestination")) {
+      message.setAddress(message.getStringProperty("newDestination"));
+   }
+
+   return message;
+}
+----
+
+Here, the computed destination will get used instead of the diverts `forwarding-address`.
+
+If the new destination does not exist on the broker, automatic creation can be
+configured as an xref:address-settings.adoc[address setting] with the property: `auto-create-divert-destinations`.
+This property defaults to `false`.
+
+[NOTE]
+====
+There are two important things to consider when configuring `auto-create-divert-destinations`.
+
+1. When the divert attempts to auto-create a destination it will use the credentials provided by the original sender.
+This means the sender must have permissions covering both the original destination and the new one.
+
+2. To be able to create a new destination, the divert has to know what `routing-type` to use.
+The default behavior of the divert is to remove this information from a message before handing it over to the `transformer`, according to `routingType = STRIP`.
+
+To make sure the messages end up where they are supposed to, either change the diverts `routingType` or
+make sure to add this information in the `transformer` with the messages `setRoutingType()` method.
+
+====

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/artemis/tests/unit/core/server/impl/fakes/FakePostOffice.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/artemis/tests/unit/core/server/impl/fakes/FakePostOffice.java
@@ -42,6 +42,7 @@ import org.apache.activemq.artemis.core.server.impl.AckReason;
 import org.apache.activemq.artemis.core.server.impl.AddressInfo;
 import org.apache.activemq.artemis.core.server.impl.MessageReferenceImpl;
 import org.apache.activemq.artemis.core.server.mirror.MirrorController;
+import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.core.transaction.Transaction;
 
 public class FakePostOffice implements PostOffice {
@@ -167,6 +168,11 @@ public class FakePostOffice implements PostOffice {
 
    @Override
    public List<Queue> listQueuesForAddress(SimpleString address) throws Exception {
+      return null;
+   }
+
+   @Override
+   public AddressSettings getAddressSettingsMatch(String address) {
       return null;
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
@@ -1168,6 +1168,7 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       assertEquals(addressSettings.getExpiryAddress(), info.getExpiryAddress());
       assertEquals(addressSettings.getRedeliveryDelay(), info.getRedeliveryDelay());
    }
+
    @Test
    public void emptyAddressSettings() throws Exception {
       ActiveMQServerControl serverControl = createManagementControl();
@@ -1228,7 +1229,9 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       assertEquals(addressSettings.getExpiryQueuePrefix(), info.getExpiryQueuePrefix());
       assertEquals(addressSettings.getExpiryQueueSuffix(), info.getExpiryQueueSuffix());
       assertEquals(addressSettings.isEnableMetrics(), info.isEnableMetrics());
+      assertEquals(addressSettings.isAutoCreateDivertDestination(), info.isAutoCreateDivertDestination());
    }
+
    @Test
    public void testAddressSettings() throws Exception {
       ActiveMQServerControl serverControl = createManagementControl();
@@ -1288,6 +1291,7 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       String expiryQueuePrefix = RandomUtil.randomString();
       String expiryQueueSuffix = RandomUtil.randomString();
       boolean enableMetrics = RandomUtil.randomBoolean();
+      boolean autoCreateDivertDestination = RandomUtil.randomBoolean();
 
       AddressSettings addressSettings = new AddressSettings();
       addressSettings.setDeadLetterAddress(new SimpleString(DLA))
@@ -1342,7 +1346,8 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
               .setExpiryQueueSuffix(SimpleString.toSimpleString(expiryQueueSuffix))
               .setMinExpiryDelay(minExpiryDelay)
               .setMaxExpiryDelay(maxExpiryDelay)
-              .setEnableMetrics(enableMetrics);
+              .setEnableMetrics(enableMetrics)
+              .setAutoCreateDivertDestination(autoCreateDivertDestination);
 
 
       serverControl.addAddressSettings(addressMatch, addressSettings.toJSON());
@@ -1416,6 +1421,7 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       assertEquals(expiryQueuePrefix, info.getExpiryQueuePrefix());
       assertEquals(expiryQueueSuffix, info.getExpiryQueueSuffix());
       assertEquals(enableMetrics, info.isEnableMetrics());
+      assertEquals(autoCreateDivertDestination, info.isAutoCreateDivertDestination());
 
 
       addressSettings.setMaxSizeBytes(-1).setPageSizeBytes(1000);
@@ -1477,6 +1483,7 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       assertEquals(expiryQueuePrefix, info.getExpiryQueuePrefix());
       assertEquals(expiryQueueSuffix, info.getExpiryQueueSuffix());
       assertEquals(enableMetrics, info.isEnableMetrics());
+      assertEquals(autoCreateDivertDestination, info.isAutoCreateDivertDestination());
 
 
       addressSettings.setMaxSizeBytes(-2).setPageSizeBytes(1000);
@@ -1554,6 +1561,7 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       String expiryQueuePrefix = RandomUtil.randomString();
       String expiryQueueSuffix = RandomUtil.randomString();
       boolean enableMetrics = RandomUtil.randomBoolean();
+      boolean autoCreateDivertDestination = RandomUtil.randomBoolean();
 
       AddressSettings addressSettings = new AddressSettings();
       addressSettings.setDeadLetterAddress(new SimpleString(DLA))
@@ -1608,7 +1616,8 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
               .setExpiryQueueSuffix(SimpleString.toSimpleString(expiryQueueSuffix))
               .setMinExpiryDelay(minExpiryDelay)
               .setMaxExpiryDelay(maxExpiryDelay)
-              .setEnableMetrics(enableMetrics);
+              .setEnableMetrics(enableMetrics)
+              .setAutoCreateDivertDestination(autoCreateDivertDestination);
 
       serverControl.addAddressSettings(root, addressSettings.toJSON());
 


### PR DESCRIPTION
This enables the use of dynamic routing decisions within the transformer by setting the message address. It also covers for a rare problem where if any of the forwarding addresses are removed during runtime, such as from auto-delete, the message would get silently dropped.