### PR TITLE
ARTEMIS-3932 Deprecate and replace addAddressSettings with json version

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/bean/MetaBean.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/bean/MetaBean.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.utils.bean;
+
+import java.io.StringReader;
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.json.JsonObject;
+import org.apache.activemq.artemis.json.JsonObjectBuilder;
+import org.apache.activemq.artemis.utils.JsonLoader;
+import org.apache.activemq.artemis.utils.RandomUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Receives a metadata about a class with methods to read, write and certain gates.
+ * And provides a generic logic to convert to and from JSON.
+ * <p>
+ * As a historical context the first try to make a few objects more dynamic (e.g AddressSettings) was
+ * around BeanUtils however there was some implicit logic on when certain settins were Null or default values.
+ * for that reason I decided for a meta-data approach where extra semantic could be applied for each individual attributes
+ * rather than a generic BeanUtils parser.
+ */
+public class MetaBean<T> {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   private CopyOnWriteArrayList<MetaData<T>> metaData = new CopyOnWriteArrayList<>();
+
+   /**
+    * Accepted types:
+    * String.class
+    * SimpleString.class
+    * Integer.class
+    * Long.class
+    * Double.class
+    * Float.class
+    * Enumerations
+    */
+   public MetaBean add(Class type,
+                       String name,
+                       BiConsumer<T, ? extends Object> setter,
+                       Function<T, ? extends Object> getter,
+                       Predicate<T> gate) {
+      if (type != String.class && type != SimpleString.class && type != Integer.class && type != Long.class && type != Double.class && type != Float.class && type != Boolean.class && !Enum.class.isAssignableFrom(type)) {
+         throw new IllegalArgumentException("invalid type " + type);
+      }
+
+      metaData.add(new MetaData(type, name, setter, getter, gate));
+      return this;
+   }
+
+   public <Z extends Object> MetaBean add(Class<Z> type,
+                                          String name,
+                                          BiConsumer<T, Z> setter,
+                                          Function<T, Z> getter) {
+      return add(type, name, setter, getter, null);
+   }
+
+   public JsonObject toJSON(T object, boolean ignoreNullAttributes) {
+      JsonObjectBuilder builder = JsonLoader.createObjectBuilder();
+      parseToJSON(object, builder, ignoreNullAttributes);
+      return builder.build();
+   }
+
+   public void parseToJSON(T object, JsonObjectBuilder builder, boolean ignoreNullAttributes) {
+      logger.debug("Parsing object {}", object);
+      this.forEach((type, name, setter, getter, gate) -> {
+         logger.debug("Parsing {} {} {} {} {}", type, name, setter, getter, gate);
+         Object value = getter.apply(object);
+         if (ignoreNullAttributes && value == null) {
+            logger.debug("Ignoring null attribute {}", name);
+            return;
+         }
+         if (gate == null || gate.test(object)) {
+
+            if (logger.isTraceEnabled()) {
+
+               if (gate != null) {
+                  logger.trace("Gate passed for {}", name);
+               }
+
+               if (value == null) {
+                  logger.debug("Result for {} = IS NULL", name);
+               } else {
+                  logger.debug("Result for {} = {}, type={}", name, value, value.getClass());
+               }
+            }
+
+            if (value == null) {
+               logger.trace("Setting {} as null", name);
+               builder.addNull(name);
+            } else if (type == String.class || type == SimpleString.class) {
+               logger.trace("Setting {} as String {}", name, value);
+               builder.add(name, String.valueOf(value));
+            } else if (Number.class.isAssignableFrom(type) && value instanceof Number) {
+               if (value instanceof Double || value instanceof Float) {
+                  logger.trace("Setting {} as double {}", name, value);
+                  builder.add(name, ((Number) value).doubleValue());
+               } else {
+                  logger.trace("Setting {} as long {}", name, value);
+                  builder.add(name, ((Number) value).longValue());
+               }
+            } else if (type == Boolean.class) {
+               builder.add(name, (Boolean) value);
+            } else if (Enum.class.isAssignableFrom(type)) {
+               // I know this is the same as the default else clause further down
+               // but i wanted to have a separate branch in case we have to deal with it later
+               builder.add(name, String.valueOf(value));
+            } else {
+               builder.add(name, String.valueOf(value));
+            }
+         } else {
+            logger.debug("Gate ignored on {}", name);
+         }
+      });
+   }
+
+   /** Generates a random Object using the setters for testing purposes. */
+   public void setRandom(T randomObject) {
+      forEach((type, name, setter, getter, gate) -> {
+         if (Enum.class.isAssignableFrom(type)) {
+            Object[] enumValues = type.getEnumConstants();
+            int randomInt = RandomUtil.randomInterval(0, enumValues.length - 1);
+            setter.accept(randomObject, enumValues[randomInt]);
+         } else if (type == String.class) {
+            setter.accept(randomObject, RandomUtil.randomString());
+         } else if (type == SimpleString.class) {
+            setter.accept(randomObject, RandomUtil.randomSimpleString());
+         } else if (type == Integer.class) {
+            setter.accept(randomObject, RandomUtil.randomPositiveInt());
+         } else if (type == Long.class) {
+            setter.accept(randomObject, RandomUtil.randomPositiveLong());
+         } else if (type == Double.class) {
+            setter.accept(randomObject, RandomUtil.randomDouble());
+         } else if (type == Float.class) {
+            setter.accept(randomObject, RandomUtil.randomFloat());
+         } else if (type == Boolean.class) {
+            setter.accept(randomObject, RandomUtil.randomBoolean());
+         }
+      });
+   }
+
+   public void copy(T source, T target) {
+      forEach((type, name, setter, getter, gate) -> {
+         Object sourceAttribute = getter.apply(source);
+         setter.accept(target, sourceAttribute);
+      });
+   }
+
+   public void forEach(MetadataListener listener) {
+      metaData.forEach(m -> {
+         try {
+            listener.metaItem(m.type, m.name, m.setter, m.getter, m.gate);
+         } catch (Throwable e) {
+            logger.warn("Error parsing {}", m, e);
+            throw new RuntimeException("Error while parsing " + m, e);
+         }
+      });
+   }
+
+   public void fromJSON(T resultObject, String jsonString) {
+
+      logger.debug("Parsing JSON {}", jsonString);
+
+      JsonObject json = JsonLoader.readObject(new StringReader(jsonString));
+
+      this.forEach((type, name, setter, getter, gate) -> {
+         if (json.containsKey(name)) {
+            if (json.isNull(name)) {
+               setter.accept(resultObject, null);
+            } else if (type == String.class) {
+               setter.accept(resultObject, json.getString(name));
+            } else if (type == SimpleString.class) {
+               setter.accept(resultObject, SimpleString.toSimpleString(json.getString(name)));
+            } else if (type == Integer.class) {
+               setter.accept(resultObject, json.getInt(name));
+            } else if (type == Long.class) {
+               setter.accept(resultObject, json.getJsonNumber(name).longValue());
+            } else if (type == Double.class) {
+               setter.accept(resultObject, json.getJsonNumber(name).doubleValue());
+            } else if (type == Float.class) {
+               setter.accept(resultObject, json.getJsonNumber(name).numberValue().floatValue());
+            } else if (type == Boolean.class) {
+               setter.accept(resultObject, json.getBoolean(name));
+            } else if (Enum.class.isAssignableFrom(type)) {
+               String value = json.getString(name);
+               Object enumValue = Enum.valueOf(type, value);
+               setter.accept(resultObject, enumValue);
+            }
+         }
+      });
+   }
+
+   static class MetaData<T> {
+
+      Class type;
+      String name;
+      BiConsumer<T, ?> setter;
+      Function<T, ?> getter;
+      Predicate<?> gate;
+
+      <Z> MetaData(Class<Z> type,
+                          String name,
+                          BiConsumer<T, Object> setter,
+                          Function<T, Object> getter,
+                          Predicate<T> gate) {
+         this.type = type;
+         this.name = name;
+         this.setter = setter;
+         this.getter = getter;
+         this.gate = gate;
+      }
+
+      @Override
+      public String toString() {
+         return "MetaData{" + "type=" + type + ", name='" + name + '\'' + '}';
+      }
+   }
+
+   public interface MetadataListener<T> {
+
+      void metaItem(Class type,
+                    String name,
+                    BiConsumer<T, Object> setter,
+                    Function<T, Object> getter,
+                    Predicate<Object> gate);
+   }
+
+}

--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/bean/MetaBeanTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/bean/MetaBeanTest.java
@@ -1,0 +1,321 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.utils.bean;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Objects;
+
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.json.JsonObject;
+import org.apache.activemq.artemis.utils.RandomUtil;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MetaBeanTest {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   @Test
+   public void testToJson() throws Exception {
+
+      MYClass sourceObject = new MYClass();
+      sourceObject.setA(RandomUtil.randomString());
+      sourceObject.setB(RandomUtil.randomInt());
+      sourceObject.setC(RandomUtil.randomInt());
+      sourceObject.setD(null);
+      sourceObject.setIdCacheSize(333);
+      sourceObject.setSimpleString(SimpleString.toSimpleString("mySimpleString"));
+      sourceObject.setFloatValue(33.33f);
+      sourceObject.setDoubleValue(11.11);
+      sourceObject.setBoolValue(true);
+      sourceObject.setMyEnum(MyEnum.TWO);
+
+
+      JsonObject jsonObject = MYClass.metaBean.toJSON(sourceObject, false);
+      Assert.assertFalse(jsonObject.containsKey("gated"));
+
+      logger.debug("Result::" + jsonObject.toString());
+
+      MYClass result = new MYClass();
+      MYClass.metaBean.fromJSON(result, jsonObject.toString());
+      Assert.assertEquals(sourceObject, result);
+
+
+      Assert.assertEquals(null, result.getD());
+      Assert.assertNotNull(result.getIdCacheSize());
+      Assert.assertEquals(333, result.getIdCacheSize().intValue());
+      Assert.assertEquals(33.33f, result.getFloatValue().floatValue(), 0);
+      Assert.assertEquals(11.11, result.getDoubleValue().doubleValue(), 0);
+      Assert.assertEquals(MyEnum.TWO, result.getMyEnum());
+      Assert.assertTrue(result.getBoolValue());
+
+      sourceObject.setGated(SimpleString.toSimpleString("gated-now-has-value"));
+      jsonObject = MYClass.metaBean.toJSON(sourceObject, false);
+      Assert.assertTrue(jsonObject.containsKey("gated"));
+      Assert.assertEquals("gated-now-has-value", jsonObject.getString("gated"));
+   }
+
+   @Test
+   public void testRandom() throws Exception {
+      MYClass randomObject = new MYClass();
+      MYClass.metaBean.setRandom(randomObject);
+      String json = MYClass.metaBean.toJSON(randomObject, false).toString();
+      MYClass target = new MYClass();
+      MYClass.metaBean.fromJSON(target, json);
+      Assert.assertEquals(randomObject, target);
+      MYClass copy = new MYClass();
+      MYClass.metaBean.copy(randomObject, copy);
+      Assert.assertEquals(randomObject, copy);
+   }
+
+   public enum MyEnum {
+      ONE, TWO, TRHEE
+   }
+
+   public static class MYClass {
+
+      public static MetaBean<MYClass> metaBean = new MetaBean<>();
+
+      {
+         metaBean.add(String.class, "a", (theInstance, parameter) -> theInstance.a = parameter, theInstance -> theInstance.a);
+      }
+      String a;
+
+      {
+         metaBean.add(Integer.class, "b", (theInstance, parameter) -> theInstance.b = parameter, theInstance -> theInstance.b);
+      }
+      int b;
+
+      {
+         metaBean.add(Integer.class, "c", (theInstance, parameter) -> theInstance.c = parameter, theInstance -> theInstance.c);
+      }
+      Integer c;
+
+      {
+         metaBean.add(String.class, "d", (theInstance, parameter) -> theInstance.d = parameter, theInstance -> theInstance.d);
+      }
+      String d = "defaultString";
+
+      {
+         metaBean.add(Integer.class, "IdCacheSize", (obj, value) -> obj.setIdCacheSize(value), obj -> obj.getIdCacheSize());
+      }
+      Integer idCacheSize;
+
+      {
+         metaBean.add(SimpleString.class, "simpleString", (obj, value) -> obj.setSimpleString(value), obj -> obj.getSimpleString());
+      }
+      SimpleString simpleString;
+
+      {
+         metaBean.add(SimpleString.class, "gated", (obj, value) -> obj.setGated((SimpleString) value), obj -> obj.getGated(), obj -> obj.gated != null);
+      }
+      SimpleString gated;
+
+      {
+         metaBean.add(Long.class, "longValue", (obj, value) -> obj.setLongValue(value), obj -> obj.getLongValue());
+      }
+      Long longValue;
+      {
+         metaBean.add(Double.class, "doubleValue", (obj, value) -> obj.setDoubleValue(value), obj -> obj.getDoubleValue());
+      }
+      Double doubleValue;
+
+      {
+         metaBean.add(Float.class, "floatValue", (obj, value) -> obj.setFloatValue(value), obj -> obj.getFloatValue());
+      }
+      Float floatValue;
+
+      {
+         metaBean.add(Boolean.class, "boolValue", (obj, value) -> obj.boolValue = value, obj -> obj.boolValue);
+      }
+      boolean boolValue;
+
+      {
+         metaBean.add(MyEnum.class, "myEnum", (o, v) -> o.myEnum = v, o -> o.myEnum);
+      }
+      MyEnum myEnum;
+
+      public MyEnum getMyEnum() {
+         return myEnum;
+      }
+
+      public MYClass setMyEnum(MyEnum myEnum) {
+         this.myEnum = myEnum;
+         return this;
+      }
+
+      public String getA() {
+         return a;
+      }
+
+      public MYClass setA(String a) {
+         this.a = a;
+         return this;
+      }
+
+      public int getB() {
+         return b;
+      }
+
+      public MYClass setB(int b) {
+         this.b = b;
+         return this;
+      }
+
+      public Integer getC() {
+         return c;
+      }
+
+      public MYClass setC(Integer c) {
+         this.c = c;
+         return this;
+      }
+
+      public String getD() {
+         return d;
+      }
+
+      public MYClass setD(String d) {
+         this.d = d;
+         return this;
+      }
+
+      public Long getLongValue() {
+         return longValue;
+      }
+
+      public MYClass setLongValue(Long longValue) {
+         this.longValue = longValue;
+         return this;
+      }
+
+      public Double getDoubleValue() {
+         return doubleValue;
+      }
+
+      public MYClass setDoubleValue(Double doubleValue) {
+         this.doubleValue = doubleValue;
+         return this;
+      }
+
+      public Float getFloatValue() {
+         return floatValue;
+      }
+
+      public MYClass setFloatValue(Float floatValue) {
+         this.floatValue = floatValue;
+         return this;
+      }
+
+      public Integer getIdCacheSize() {
+         return idCacheSize;
+      }
+
+      public MYClass setIdCacheSize(Integer idCacheSize) {
+         this.idCacheSize = idCacheSize;
+         return this;
+      }
+
+      public SimpleString getSimpleString() {
+         return simpleString;
+      }
+
+      public MYClass setSimpleString(SimpleString simpleString) {
+         this.simpleString = simpleString;
+         return this;
+      }
+
+      public SimpleString getGated() {
+         return gated;
+      }
+
+      public MYClass setGated(SimpleString gated) {
+         this.gated = gated;
+         return this;
+      }
+
+      public boolean getBoolValue() {
+         return boolValue;
+      }
+
+      public MYClass setBoolValue(boolean boolValue) {
+         this.boolValue = boolValue;
+         return this;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+         if (this == o)
+            return true;
+         if (o == null || getClass() != o.getClass())
+            return false;
+
+         MYClass myClass = (MYClass) o;
+
+         if (b != myClass.b)
+            return false;
+         if (boolValue != myClass.boolValue)
+            return false;
+         if (!Objects.equals(a, myClass.a))
+            return false;
+         if (!Objects.equals(c, myClass.c))
+            return false;
+         if (!Objects.equals(d, myClass.d))
+            return false;
+         if (!Objects.equals(idCacheSize, myClass.idCacheSize))
+            return false;
+         if (!Objects.equals(simpleString, myClass.simpleString))
+            return false;
+         if (!Objects.equals(gated, myClass.gated))
+            return false;
+         if (!Objects.equals(longValue, myClass.longValue))
+            return false;
+         if (!Objects.equals(doubleValue, myClass.doubleValue))
+            return false;
+         if (!Objects.equals(floatValue, myClass.floatValue))
+            return false;
+         return myEnum == myClass.myEnum;
+      }
+
+      @Override
+      public int hashCode() {
+         int result = a != null ? a.hashCode() : 0;
+         result = 31 * result + b;
+         result = 31 * result + (c != null ? c.hashCode() : 0);
+         result = 31 * result + (d != null ? d.hashCode() : 0);
+         result = 31 * result + (idCacheSize != null ? idCacheSize.hashCode() : 0);
+         result = 31 * result + (simpleString != null ? simpleString.hashCode() : 0);
+         result = 31 * result + (gated != null ? gated.hashCode() : 0);
+         result = 31 * result + (longValue != null ? longValue.hashCode() : 0);
+         result = 31 * result + (doubleValue != null ? doubleValue.hashCode() : 0);
+         result = 31 * result + (floatValue != null ? floatValue.hashCode() : 0);
+         result = 31 * result + (boolValue ? 1 : 0);
+         result = 31 * result + (myEnum != null ? myEnum.hashCode() : 0);
+         return result;
+      }
+
+      @Override
+      public String toString() {
+         return "MYClass{" + "a='" + a + '\'' + ", b=" + b + ", c=" + c + ", d='" + d + '\'' + ", idCacheSize=" + idCacheSize + ", simpleString=" + simpleString + ", gated=" + gated + ", longValue=" + longValue + ", doubleValue=" + doubleValue + ", floatValue=" + floatValue + ", boolValue=" + boolValue + ", myEnum=" + myEnum + '}';
+      }
+
+   }
+
+}

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
@@ -1418,6 +1418,7 @@ public interface ActiveMQServerControl {
    /**
     * adds a new address setting for a specific address
     */
+   @Deprecated
    @Operation(desc = "Add address settings for addresses matching the addressMatch", impact = MBeanOperationInfo.ACTION)
    void addAddressSettings(@Parameter(desc = "an address match", name = "addressMatch") String addressMatch,
                            @Parameter(desc = "the dead letter address setting", name = "DLA") String DLA,
@@ -1445,6 +1446,7 @@ public interface ActiveMQServerControl {
    /**
     * adds a new address setting for a specific address
     */
+   @Deprecated
    @Operation(desc = "Add address settings for addresses matching the addressMatch", impact = MBeanOperationInfo.ACTION)
    void addAddressSettings(@Parameter(desc = "an address match", name = "addressMatch") String addressMatch,
                            @Parameter(desc = "the dead letter address setting", name = "DLA") String DLA,
@@ -1476,6 +1478,7 @@ public interface ActiveMQServerControl {
    /**
     * adds a new address setting for a specific address
     */
+   @Deprecated
    @Operation(desc = "Add address settings for addresses matching the addressMatch", impact = MBeanOperationInfo.ACTION)
    void addAddressSettings(@Parameter(desc = "an address match", name = "addressMatch") String addressMatch,
                            @Parameter(desc = "the dead letter address setting", name = "DLA") String DLA,
@@ -1530,6 +1533,7 @@ public interface ActiveMQServerControl {
    /**
     * adds a new address setting for a specific address
     */
+   @Deprecated
    @Operation(desc = "Add address settings for addresses matching the addressMatch", impact = MBeanOperationInfo.ACTION)
    void addAddressSettings(@Parameter(desc = "an address match", name = "addressMatch") String addressMatch,
                            @Parameter(desc = "the dead letter address setting", name = "DLA") String DLA,
@@ -1590,6 +1594,7 @@ public interface ActiveMQServerControl {
    /**
     * adds a new address setting for a specific address
     */
+   @Deprecated
    @Operation(desc = "Add address settings for addresses matching the addressMatch", impact = MBeanOperationInfo.ACTION)
    void addAddressSettings(@Parameter(desc = "an address match", name = "addressMatch") String addressMatch,
                            @Parameter(desc = "the dead letter address setting", name = "DLA") String DLA,
@@ -1649,6 +1654,13 @@ public interface ActiveMQServerControl {
                            @Parameter(desc = "the minimum expiry delay setting", name = "minExpiryDelay") long minExpiryDelay,
                            @Parameter(desc = "the maximum expiry delay setting", name = "maxExpiryDelay") long maxExpiryDelay,
                            @Parameter(desc = "whether or not to enable metrics", name = "enableMetrics") boolean enableMetrics) throws Exception;
+
+
+   /**
+    * adds a new address setting for a specific address
+    */
+   @Operation(desc = "Add address settings for addresses matching the addressMatch", impact = MBeanOperationInfo.ACTION)
+   String addAddressSettings(@Parameter(desc = "an address match", name = "addressMatch") String address, @Parameter(desc = "The configuration of the address settings as JSON", name = "addressSettingsConfigurationAsJson")  String addressSettingsConfigurationAsJson) throws Exception;
 
    @Operation(desc = "Remove address settings", impact = MBeanOperationInfo.ACTION)
    void removeAddressSettings(@Parameter(desc = "an address match", name = "addressMatch") String addressMatch) throws Exception;

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/AddressSettingsInfo.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/AddressSettingsInfo.java
@@ -16,304 +16,307 @@
  */
 package org.apache.activemq.artemis.api.core.management;
 
-import org.apache.activemq.artemis.json.JsonObject;
+import org.apache.activemq.artemis.utils.bean.MetaBean;
 
-import org.apache.activemq.artemis.api.core.JsonUtil;
-
-// XXX no javadocs
 public final class AddressSettingsInfo {
 
-   private final String addressFullMessagePolicy;
+   static final MetaBean<AddressSettingsInfo> META_BEAN = new MetaBean<>();
 
-   private final long maxSizeBytes;
 
-   private final int pageSizeBytes;
+   {
+      META_BEAN.add(String.class, "addressFullMessagePolicy", (o, p) -> o.addressFullMessagePolicy = p, o -> o.addressFullMessagePolicy);
+   }
+   private String addressFullMessagePolicy;
 
+   {
+      META_BEAN.add(Long.class, "maxSizeBytes", (o, p) -> o.maxSizeBytes = p, o -> o.maxSizeBytes);
+   }
+   private long maxSizeBytes;
+
+   {
+      META_BEAN.add(Integer.class, "pageSizeBytes", (o, p) -> o.pageSizeBytes = p, o -> o.pageSizeBytes);
+   }
+   private int pageSizeBytes;
+
+   {
+      META_BEAN.add(Integer.class, "pageCacheMaxSize", (o, p) -> o.pageCacheMaxSize = p, o -> o.pageCacheMaxSize);
+   }
    private int pageCacheMaxSize;
 
-   private final int maxDeliveryAttempts;
+   {
+      META_BEAN.add(Integer.class, "maxDeliveryAttempts", (o, p) -> o.maxDeliveryAttempts = p, o -> o.maxDeliveryAttempts);
+   }
+   private int maxDeliveryAttempts;
 
-   private final double redeliveryMultiplier;
+   {
+      META_BEAN.add(Double.class, "redeliveryMultiplier", (o, p) -> o.redeliveryMultiplier = p, o -> o.redeliveryMultiplier);
+   }
+   private double redeliveryMultiplier;
 
-   private final long maxRedeliveryDelay;
+   {
+      META_BEAN.add(Long.class, "maxRedeliveryDelay", (o, p) -> o.maxRedeliveryDelay = p, o -> o.maxRedeliveryDelay);
+   }
+   private long maxRedeliveryDelay;
 
-   private final long redeliveryDelay;
+   {
+      META_BEAN.add(Long.class, "redeliveryDelay", (o, p) -> o.redeliveryDelay = p, o -> o.redeliveryDelay);
+   }
+   private long redeliveryDelay;
 
-   private final String deadLetterAddress;
+   {
+      META_BEAN.add(String.class, "deadLetterAddress", (o, p) -> o.deadLetterAddress = p, o -> o.deadLetterAddress);
+   }
+   private String deadLetterAddress;
 
-   private final String expiryAddress;
+   {
+      META_BEAN.add(String.class, "expiryAddress", (o, p) -> o.expiryAddress = p, o -> o.expiryAddress);
+   }
+   private String expiryAddress;
 
-   private final boolean lastValueQueue;
+   {
+      META_BEAN.add(Boolean.class, "defaultLastValueQueue", (o, p) -> o.defaultLastValueQueue = p, o -> o.defaultLastValueQueue);
+   }
+   private boolean defaultLastValueQueue;
 
-   private final long redistributionDelay;
+   {
+      META_BEAN.add(Long.class, "redistributionDelay", (o, p) -> o.redistributionDelay = p, o -> o.redistributionDelay);
+   }
+   private long redistributionDelay;
 
-   private final boolean sendToDLAOnNoRoute;
+   {
+      META_BEAN.add(Boolean.class, "sendToDLAOnNoRoute", (o, p) -> o.sendToDLAOnNoRoute = p, o -> o.sendToDLAOnNoRoute);
+   }
+   private boolean sendToDLAOnNoRoute;
 
-   private final long slowConsumerThreshold;
+   {
+      META_BEAN.add(Long.class, "slowConsumerThreshold", (o, p) -> o.slowConsumerThreshold = p, o -> o.slowConsumerThreshold);
+   }
+   private long slowConsumerThreshold;
 
-   private final long slowConsumerCheckPeriod;
+   {
+      META_BEAN.add(Long.class, "slowConsumerCheckPeriod", (o, p) -> o.slowConsumerCheckPeriod = p, o -> o.slowConsumerCheckPeriod);
+   }
+   private long slowConsumerCheckPeriod;
 
-   private final String slowConsumerPolicy;
+   {
+      META_BEAN.add(String.class, "slowConsumerPolicy", (o, p) -> o.slowConsumerPolicy = p, o -> o.slowConsumerPolicy);
+   }
+   private String slowConsumerPolicy;
 
-   private final boolean autoCreateJmsQueues;
+   {
+      META_BEAN.add(Boolean.class, "autoCreateJmsQueues", (o, p) -> o.autoCreateJmsQueues = p, o -> o.autoCreateJmsQueues);
+   }
+   private boolean autoCreateJmsQueues;
 
-   private final boolean autoDeleteJmsQueues;
+   {
+      META_BEAN.add(Boolean.class, "autoDeleteJmsQueues", (o, p) -> o.autoDeleteJmsQueues = p, o -> o.autoDeleteJmsQueues);
+   }
+   private boolean autoDeleteJmsQueues;
 
-   private final boolean autoCreateJmsTopics;
+   {
+      META_BEAN.add(Boolean.class, "autoCreateJmsTopics", (o, p) -> o.autoCreateJmsTopics = p, o -> o.autoCreateJmsTopics);
+   }
+   private boolean autoCreateJmsTopics;
 
-   private final boolean autoDeleteJmsTopics;
+   {
+      META_BEAN.add(Boolean.class, "autoDeleteJmsTopics", (o, p) -> o.autoDeleteJmsTopics = p, o -> o.autoDeleteJmsTopics);
+   }
+   private boolean autoDeleteJmsTopics;
 
-   private final boolean autoCreateQueues;
+   {
+      META_BEAN.add(Boolean.class, "autoCreateQueues", (o, p) -> o.autoCreateQueues = p, o -> o.autoCreateQueues);
+   }
+   private boolean autoCreateQueues;
 
-   private final boolean autoDeleteQueues;
+   {
+      META_BEAN.add(Boolean.class, "autoDeleteQueues", (o, p) -> o.autoDeleteQueues = p, o -> o.autoDeleteQueues);
+   }
+   private boolean autoDeleteQueues;
 
-   private final boolean autoCreateAddresses;
+   {
+      META_BEAN.add(Boolean.class, "autoCreateAddresses", (o, p) -> o.autoCreateAddresses = p, o -> o.autoCreateAddresses);
+   }
+   private boolean autoCreateAddresses;
 
-   private final boolean autoDeleteAddresses;
+   {
+      META_BEAN.add(Boolean.class, "autoDeleteAddresses", (o, p) -> o.autoDeleteAddresses = p, o -> o.autoDeleteAddresses);
+   }
+   private boolean autoDeleteAddresses;
 
-   private final String configDeleteQueues;
+   {
+      META_BEAN.add(String.class, "configDeleteQueues", (o, p) -> o.configDeleteQueues = p, o -> o.configDeleteQueues);
+   }
+   private String configDeleteQueues;
 
-   private final String configDeleteAddresses;
+   {
+      META_BEAN.add(String.class, "configDeleteAddresses", (o, p) -> o.configDeleteAddresses = p, o -> o.configDeleteAddresses);
+   }
+   private String configDeleteAddresses;
 
-   private final long maxSizeBytesRejectThreshold;
+   {
+      META_BEAN.add(Long.class, "maxSizeBytesRejectThreshold", (o, p) -> o.maxSizeBytesRejectThreshold = p, o -> o.maxSizeBytesRejectThreshold);
+   }
+   private long maxSizeBytesRejectThreshold;
 
-   private final String defaultLastValueKey;
+   {
+      META_BEAN.add(String.class, "defaultLastValueKey", (o, p) -> o.defaultLastValueKey = p, o -> o.defaultLastValueKey);
+   }
+   private String defaultLastValueKey;
 
-   private final boolean defaultNonDestructive;
+   {
+      META_BEAN.add(Boolean.class, "defaultNonDestructive", (o, p) -> o.defaultNonDestructive = p, o -> o.defaultNonDestructive);
+   }
+   private boolean defaultNonDestructive;
 
-   private final boolean defaultExclusiveQueue;
+   {
+      META_BEAN.add(Boolean.class, "defaultExclusiveQueue", (o, p) -> o.defaultExclusiveQueue = p, o -> o.defaultExclusiveQueue);
+   }
+   private boolean defaultExclusiveQueue;
 
-   private final boolean defaultGroupRebalance;
+   {
+      META_BEAN.add(Boolean.class, "defaultGroupRebalance", (o, p) -> o.defaultGroupRebalance = p, o -> o.defaultGroupRebalance);
+   }
+   private boolean defaultGroupRebalance;
 
-   private final int defaultGroupBuckets;
+   {
+      META_BEAN.add(Integer.class, "defaultGroupBuckets", (o, p) -> o.defaultGroupBuckets = p, o -> o.defaultGroupBuckets);
+   }
+   private int defaultGroupBuckets;
 
-   private final String defaultGroupFirstKey;
+   {
+      META_BEAN.add(String.class, "defaultGroupFirstKey", (o, p) -> o.defaultGroupFirstKey = p, o -> o.defaultGroupFirstKey);
+   }
+   private String defaultGroupFirstKey;
 
-   private final int defaultMaxConsumers;
+   {
+      META_BEAN.add(Integer.class, "defaultMaxConsumers", (o, p) -> o.defaultMaxConsumers = p, o -> o.defaultMaxConsumers);
+   }
+   private int defaultMaxConsumers;
 
-   private final boolean defaultPurgeOnNoConsumers;
+   {
+      META_BEAN.add(Boolean.class, "defaultPurgeOnNoConsumers", (o, p) -> o.defaultPurgeOnNoConsumers = p, o -> o.defaultPurgeOnNoConsumers);
+   }
+   private boolean defaultPurgeOnNoConsumers;
 
-   private final int defaultConsumersBeforeDispatch;
+   {
+      META_BEAN.add(Integer.class, "defaultConsumersBeforeDispatch", (o, p) -> o.defaultConsumersBeforeDispatch = p, o -> o.defaultConsumersBeforeDispatch);
+   }
+   private int defaultConsumersBeforeDispatch;
 
-   private final long defaultDelayBeforeDispatch;
+   {
+      META_BEAN.add(Long.class, "defaultDelayBeforeDispatch", (o, p) -> o.defaultDelayBeforeDispatch = p, o -> o.defaultDelayBeforeDispatch);
+   }
+   private long defaultDelayBeforeDispatch;
 
-   private final String defaultQueueRoutingType;
+   {
+      META_BEAN.add(String.class, "defaultQueueRoutingType", (o, p) -> o.defaultQueueRoutingType = p, o -> o.defaultQueueRoutingType);
+   }
+   private String defaultQueueRoutingType;
 
-   private final String defaultAddressRoutingType;
+   {
+      META_BEAN.add(String.class, "defaultAddressRoutingType", (o, p) -> o.defaultAddressRoutingType = p, o -> o.defaultAddressRoutingType);
+   }
+   private String defaultAddressRoutingType;
 
-   private final int defaultConsumerWindowSize;
+   {
+      META_BEAN.add(Integer.class, "defaultConsumerWindowSize", (o, p) -> o.defaultConsumerWindowSize = p, o -> o.defaultConsumerWindowSize);
+   }
+   private int defaultConsumerWindowSize;
 
-   private final long defaultRingSize;
+   {
+      META_BEAN.add(Long.class, "defaultRingSize", (o, p) -> o.defaultRingSize = p, o -> o.defaultRingSize);
+   }
+   private long defaultRingSize;
 
-   private final boolean autoDeleteCreatedQueues;
+   {
+      META_BEAN.add(Boolean.class, "autoDeleteCreatedQueues", (o, p) -> o.autoDeleteCreatedQueues = p, o -> o.autoDeleteCreatedQueues);
+   }
+   private boolean autoDeleteCreatedQueues;
 
-   private final long autoDeleteQueuesDelay;
+   {
+      META_BEAN.add(Long.class, "autoDeleteQueuesDelay", (o, p) -> o.autoDeleteQueuesDelay = p, o -> o.autoDeleteQueuesDelay);
+   }
+   private long autoDeleteQueuesDelay;
 
-   private final long autoDeleteQueuesMessageCount;
+   {
+      META_BEAN.add(Long.class, "autoDeleteQueuesMessageCount", (o, p) -> o.autoDeleteQueuesMessageCount = p, o -> o.autoDeleteQueuesMessageCount);
+   }
+   private long autoDeleteQueuesMessageCount;
 
-   private final long autoDeleteAddressesDelay;
+   {
+      META_BEAN.add(Long.class, "autoDeleteAddressesDelay", (o, p) -> o.autoDeleteAddressesDelay = p, o -> o.autoDeleteAddressesDelay);
+   }
+   private long autoDeleteAddressesDelay;
 
-   private final double redeliveryCollisionAvoidanceFactor;
+   {
+      META_BEAN.add(Double.class, "redeliveryCollisionAvoidanceFactor", (o, p) -> o.redeliveryCollisionAvoidanceFactor = p, o -> o.redeliveryCollisionAvoidanceFactor);
+   }
+   private double redeliveryCollisionAvoidanceFactor;
 
-   private final long retroactiveMessageCount;
+   {
+      META_BEAN.add(Long.class, "retroactiveMessageCount", (o, p) -> o.retroactiveMessageCount = p, o -> o.retroactiveMessageCount);
+   }
+   private long retroactiveMessageCount;
 
-   private final boolean autoCreateDeadLetterResources;
+   {
+      META_BEAN.add(Boolean.class, "autoCreateDeadLetterResources", (o, p) -> o.autoCreateDeadLetterResources = p, o -> o.autoCreateDeadLetterResources);
+   }
+   private boolean autoCreateDeadLetterResources;
 
-   private final String deadLetterQueuePrefix;
+   {
+      META_BEAN.add(String.class, "deadLetterQueuePrefix", (o, p) -> o.deadLetterQueuePrefix = p, o -> o.deadLetterQueuePrefix);
+   }
+   private String deadLetterQueuePrefix;
 
-   private final String deadLetterQueueSuffix;
+   {
+      META_BEAN.add(String.class, "deadLetterQueueSuffix", (o, p) -> o.deadLetterQueueSuffix = p, o -> o.deadLetterQueueSuffix);
+   }
+   private String deadLetterQueueSuffix;
 
-   private final boolean autoCreateExpiryResources;
-
-   private final String expiryQueuePrefix;
-
-   private final String expiryQueueSuffix;
-
-   private final long expiryDelay;
-
-   private final long minExpiryDelay;
-
-   private final long maxExpiryDelay;
-
-   private final boolean enableMetrics;
+   {
+      META_BEAN.add(Boolean.class, "autoCreateExpiryResources", (o, p) -> o.autoCreateExpiryResources = p, o -> o.autoCreateExpiryResources);
+   }
+   private boolean autoCreateExpiryResources;
 
 
-   public static AddressSettingsInfo from(final String jsonString) {
-      JsonObject object = JsonUtil.readJsonObject(jsonString);
-      return new AddressSettingsInfo(object.getString("addressFullMessagePolicy"),
-                                     object.getJsonNumber("maxSizeBytes").longValue(),
-                                     object.getInt("pageSizeBytes"),
-                                     object.getInt("pageCacheMaxSize"),
-                                     object.getInt("maxDeliveryAttempts"),
-                                     object.getJsonNumber("redeliveryDelay").longValue(),
-                                     object.getJsonNumber("redeliveryMultiplier").doubleValue(),
-                                     object.getJsonNumber("maxRedeliveryDelay").longValue(),
-                                     object.getString("DLA"),
-                                     object.getString("expiryAddress"),
-                                     object.getBoolean("lastValueQueue"),
-                                     object.getJsonNumber("redistributionDelay").longValue(),
-                                     object.getBoolean("sendToDLAOnNoRoute"),
-                                     object.getJsonNumber("slowConsumerThreshold").longValue(),
-                                     object.getJsonNumber("slowConsumerCheckPeriod").longValue(),
-                                     object.getString("slowConsumerPolicy"),
-                                     object.getBoolean("autoCreateJmsQueues"),
-                                     object.getBoolean("autoCreateJmsTopics"),
-                                     object.getBoolean("autoDeleteJmsQueues"),
-                                     object.getBoolean("autoDeleteJmsTopics"),
-                                     object.getBoolean("autoCreateQueues"),
-                                     object.getBoolean("autoDeleteQueues"),
-                                     object.getBoolean("autoCreateAddresses"),
-                                     object.getBoolean("autoDeleteAddresses"),
-                                     object.getString("configDeleteQueues"),
-                                     object.getString("configDeleteAddresses"),
-                                     object.getJsonNumber("maxSizeBytesRejectThreshold").longValue(),
-                                     object.getString("defaultLastValueKey"),
-                                     object.getBoolean("defaultNonDestructive"),
-                                     object.getBoolean("defaultExclusiveQueue"),
-                                     object.getBoolean("defaultGroupRebalance"),
-                                     object.getInt("defaultGroupBuckets"),
-                                     object.getString("defaultGroupFirstKey"),
-                                     object.getInt("defaultMaxConsumers"),
-                                     object.getBoolean("defaultPurgeOnNoConsumers"),
-                                     object.getInt("defaultConsumersBeforeDispatch"),
-                                     object.getJsonNumber("defaultDelayBeforeDispatch").longValue(),
-                                     object.getString("defaultQueueRoutingType"),
-                                     object.getString("defaultAddressRoutingType"),
-                                     object.getInt("defaultConsumerWindowSize"),
-                                     object.getJsonNumber("defaultRingSize").longValue(),
-                                     object.getBoolean("autoDeleteCreatedQueues"),
-                                     object.getJsonNumber("autoDeleteQueuesDelay").longValue(),
-                                     object.getJsonNumber("autoDeleteQueuesMessageCount").longValue(),
-                                     object.getJsonNumber("autoDeleteAddressesDelay").longValue(),
-                                     object.getJsonNumber("redeliveryCollisionAvoidanceFactor").doubleValue(),
-                                     object.getJsonNumber("retroactiveMessageCount").longValue(),
-                                     object.getBoolean("autoCreateDeadLetterResources"),
-                                     object.getString("deadLetterQueuePrefix"),
-                                     object.getString("deadLetterQueueSuffix"),
-                                     object.getBoolean("autoCreateExpiryResources"),
-                                     object.getString("expiryQueuePrefix"),
-                                     object.getString("expiryQueueSuffix"),
-                                     object.getJsonNumber("expiryDelay").longValue(),
-                                     object.getJsonNumber("minExpiryDelay").longValue(),
-                                     object.getJsonNumber("maxExpiryDelay").longValue(),
-                                     object.getBoolean("enableMetrics"));
+   {
+      META_BEAN.add(String.class, "expiryQueuePrefix", (o, p) -> o.expiryQueuePrefix = p, o -> o.expiryQueuePrefix);
+   }
+   private String expiryQueuePrefix;
+
+   {
+      META_BEAN.add(String.class, "expiryQueueSuffix", (o, p) -> o.expiryQueueSuffix = p, o -> o.expiryQueueSuffix);
+   }
+   private String expiryQueueSuffix;
+
+   {
+      META_BEAN.add(Long.class, "expiryDelay", (o, p) -> o.expiryDelay = p, o -> o.expiryDelay);
+   }
+   private long expiryDelay;
+
+   {
+      META_BEAN.add(Long.class, "minExpiryDelay", (o, p) -> o.minExpiryDelay = p, o -> o.minExpiryDelay);
+   }
+   private long minExpiryDelay;
+
+   {
+      META_BEAN.add(Long.class, "maxExpiryDelay", (o, p) -> o.maxExpiryDelay = p, o -> o.maxExpiryDelay);
+   }
+   private long maxExpiryDelay;
+
+   {
+      META_BEAN.add(Boolean.class, "enableMetrics", (o, p) -> o.enableMetrics = p, o -> o.enableMetrics);
+   }
+   private boolean enableMetrics;
+
+
+   public static AddressSettingsInfo fromJSON(final String jsonString) {
+      AddressSettingsInfo newInfo = new AddressSettingsInfo();
+      META_BEAN.fromJSON(newInfo, jsonString);
+      return newInfo;
    }
 
-
-   public AddressSettingsInfo(String addressFullMessagePolicy,
-                              long maxSizeBytes,
-                              int pageSizeBytes,
-                              int pageCacheMaxSize,
-                              int maxDeliveryAttempts,
-                              long redeliveryDelay,
-                              double redeliveryMultiplier,
-                              long maxRedeliveryDelay,
-                              String deadLetterAddress,
-                              String expiryAddress,
-                              boolean lastValueQueue,
-                              long redistributionDelay,
-                              boolean sendToDLAOnNoRoute,
-                              long slowConsumerThreshold,
-                              long slowConsumerCheckPeriod,
-                              String slowConsumerPolicy,
-                              boolean autoCreateJmsQueues,
-                              boolean autoCreateJmsTopics,
-                              boolean autoDeleteJmsQueues,
-                              boolean autoDeleteJmsTopics,
-                              boolean autoCreateQueues,
-                              boolean autoDeleteQueues,
-                              boolean autoCreateAddresses,
-                              boolean autoDeleteAddresses,
-                              String configDeleteQueues,
-                              String configDeleteAddresses,
-                              long maxSizeBytesRejectThreshold,
-                              String defaultLastValueKey,
-                              boolean defaultNonDestructive,
-                              boolean defaultExclusiveQueue,
-                              boolean defaultGroupRebalance,
-                              int defaultGroupBuckets,
-                              String defaultGroupFirstKey,
-                              int defaultMaxConsumers,
-                              boolean defaultPurgeOnNoConsumers,
-                              int defaultConsumersBeforeDispatch,
-                              long defaultDelayBeforeDispatch,
-                              String defaultQueueRoutingType,
-                              String defaultAddressRoutingType,
-                              int defaultConsumerWindowSize,
-                              long defaultRingSize,
-                              boolean autoDeleteCreatedQueues,
-                              long autoDeleteQueuesDelay,
-                              long autoDeleteQueuesMessageCount,
-                              long autoDeleteAddressesDelay,
-                              double redeliveryCollisionAvoidanceFactor,
-                              long retroactiveMessageCount,
-                              boolean autoCreateDeadLetterResources,
-                              String deadLetterQueuePrefix,
-                              String deadLetterQueueSuffix,
-                              boolean autoCreateExpiryResources,
-                              String expiryQueuePrefix,
-                              String expiryQueueSuffix,
-                              long expiryDelay,
-                              long minExpiryDelay,
-                              long maxExpiryDelay,
-                              boolean enableMetrics) {
-      this.addressFullMessagePolicy = addressFullMessagePolicy;
-      this.maxSizeBytes = maxSizeBytes;
-      this.pageSizeBytes = pageSizeBytes;
-      this.pageCacheMaxSize = pageCacheMaxSize;
-      this.maxDeliveryAttempts = maxDeliveryAttempts;
-      this.redeliveryDelay = redeliveryDelay;
-      this.redeliveryMultiplier = redeliveryMultiplier;
-      this.maxRedeliveryDelay = maxRedeliveryDelay;
-      this.deadLetterAddress = deadLetterAddress;
-      this.expiryAddress = expiryAddress;
-      this.lastValueQueue = lastValueQueue;
-      this.redistributionDelay = redistributionDelay;
-      this.sendToDLAOnNoRoute = sendToDLAOnNoRoute;
-      this.slowConsumerThreshold = slowConsumerThreshold;
-      this.slowConsumerCheckPeriod = slowConsumerCheckPeriod;
-      this.slowConsumerPolicy = slowConsumerPolicy;
-      this.autoCreateJmsQueues = autoCreateJmsQueues;
-      this.autoDeleteJmsQueues = autoDeleteJmsQueues;
-      this.autoCreateJmsTopics = autoCreateJmsTopics;
-      this.autoDeleteJmsTopics = autoDeleteJmsTopics;
-      this.autoCreateQueues = autoCreateQueues;
-      this.autoDeleteQueues = autoDeleteQueues;
-      this.autoCreateAddresses = autoCreateAddresses;
-      this.autoDeleteAddresses = autoDeleteAddresses;
-      this.configDeleteQueues = configDeleteQueues;
-      this.configDeleteAddresses = configDeleteAddresses;
-      this.maxSizeBytesRejectThreshold = maxSizeBytesRejectThreshold;
-      this.defaultLastValueKey = defaultLastValueKey;
-      this.defaultNonDestructive = defaultNonDestructive;
-      this.defaultExclusiveQueue = defaultExclusiveQueue;
-      this.defaultGroupRebalance = defaultGroupRebalance;
-      this.defaultGroupBuckets = defaultGroupBuckets;
-      this.defaultGroupFirstKey = defaultGroupFirstKey;
-      this.defaultMaxConsumers = defaultMaxConsumers;
-      this.defaultPurgeOnNoConsumers = defaultPurgeOnNoConsumers;
-      this.defaultConsumersBeforeDispatch = defaultConsumersBeforeDispatch;
-      this.defaultDelayBeforeDispatch = defaultDelayBeforeDispatch;
-      this.defaultQueueRoutingType = defaultQueueRoutingType;
-      this.defaultAddressRoutingType = defaultAddressRoutingType;
-      this.defaultConsumerWindowSize = defaultConsumerWindowSize;
-      this.defaultRingSize = defaultRingSize;
-      this.autoDeleteCreatedQueues = autoDeleteCreatedQueues;
-      this.autoDeleteQueuesDelay = autoDeleteQueuesDelay;
-      this.autoDeleteQueuesMessageCount = autoDeleteQueuesMessageCount;
-      this.autoDeleteAddressesDelay = autoDeleteAddressesDelay;
-      this.redeliveryCollisionAvoidanceFactor = redeliveryCollisionAvoidanceFactor;
-      this.retroactiveMessageCount = retroactiveMessageCount;
-      this.autoCreateDeadLetterResources = autoCreateDeadLetterResources;
-      this.deadLetterQueuePrefix = deadLetterQueuePrefix;
-      this.deadLetterQueueSuffix = deadLetterQueueSuffix;
-      this.autoCreateExpiryResources = autoCreateExpiryResources;
-      this.expiryQueuePrefix = expiryQueuePrefix;
-      this.expiryQueueSuffix = expiryQueueSuffix;
-      this.expiryDelay = expiryDelay;
-      this.minExpiryDelay = minExpiryDelay;
-      this.maxExpiryDelay = maxExpiryDelay;
-      this.enableMetrics = enableMetrics;
+   public AddressSettingsInfo() {
    }
 
    public int getPageCacheMaxSize() {
@@ -352,8 +355,8 @@ public final class AddressSettingsInfo {
       return expiryAddress;
    }
 
-   public boolean isLastValueQueue() {
-      return lastValueQueue;
+   public boolean isDefaultLastValueQueue() {
+      return defaultLastValueQueue;
    }
 
    public long getRedistributionDelay() {

--- a/artemis-core-client/src/test/java/org/apache/activemq/artemis/api/core/management/AddressSettingsInfoTest.java
+++ b/artemis-core-client/src/test/java/org/apache/activemq/artemis/api/core/management/AddressSettingsInfoTest.java
@@ -39,9 +39,9 @@ public class AddressSettingsInfoTest {
          "\"redeliveryDelay\":70000,\n" +
          "\"redeliveryMultiplier\":1.5,\n" +
          "\"maxRedeliveryDelay\":100000,\n" +
-         "\"DLA\":\"deadLettersGoHere\",\n" +
+         "\"deadLetterAddress\":\"deadLettersGoHere\",\n" +
          "\"expiryAddress\":\"\",\n" +
-         "\"lastValueQueue\":true,\n" +
+         "\"defaultLastValueQueue\":true,\n" +
          "\"redistributionDelay\":10004,\n" +
          "\"sendToDLAOnNoRoute\":true,\n" +
          "\"slowConsumerThreshold\":200,\n" +
@@ -89,7 +89,7 @@ public class AddressSettingsInfoTest {
          "\"maxExpiryDelay\":4004,\n" +
          "\"enableMetrics\":false\n" +
          "}";
-      AddressSettingsInfo addressSettingsInfo = AddressSettingsInfo.from(json);
+      AddressSettingsInfo addressSettingsInfo = AddressSettingsInfo.fromJSON(json);
       assertEquals("fullPolicy", addressSettingsInfo.getAddressFullMessagePolicy());
       assertEquals(500L, addressSettingsInfo.getMaxSizeBytes());
       assertEquals(200L, addressSettingsInfo.getPageSizeBytes());
@@ -100,7 +100,7 @@ public class AddressSettingsInfoTest {
       assertEquals(100000, addressSettingsInfo.getMaxRedeliveryDelay());
       assertEquals("deadLettersGoHere", addressSettingsInfo.getDeadLetterAddress());
       assertEquals("", addressSettingsInfo.getExpiryAddress());
-      assertTrue(addressSettingsInfo.isLastValueQueue());
+      assertTrue(addressSettingsInfo.isDefaultLastValueQueue());
       assertEquals(10004L, addressSettingsInfo.getRedistributionDelay());
       assertTrue(addressSettingsInfo.isSendToDLAOnNoRoute());
       assertEquals(200L, addressSettingsInfo.getSlowConsumerThreshold());

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -88,6 +88,7 @@ import org.apache.activemq.artemis.core.messagecounter.MessageCounterManager;
 import org.apache.activemq.artemis.core.messagecounter.impl.MessageCounterManagerImpl;
 import org.apache.activemq.artemis.core.persistence.StorageManager;
 import org.apache.activemq.artemis.core.persistence.config.PersistedAddressSetting;
+import org.apache.activemq.artemis.core.persistence.config.PersistedAddressSettingJSON;
 import org.apache.activemq.artemis.core.persistence.config.PersistedConnector;
 import org.apache.activemq.artemis.core.persistence.config.PersistedSecuritySetting;
 import org.apache.activemq.artemis.core.postoffice.Binding;
@@ -3023,78 +3024,11 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
       checkStarted();
 
       AddressSettings addressSettings = server.getAddressSettingsRepository().getMatch(address);
-      String policy = addressSettings.getAddressFullMessagePolicy() == AddressFullMessagePolicy.PAGE ? "PAGE" : addressSettings.getAddressFullMessagePolicy() == AddressFullMessagePolicy.BLOCK ? "BLOCK" : addressSettings.getAddressFullMessagePolicy() == AddressFullMessagePolicy.DROP ? "DROP" : "FAIL";
-      String consumerPolicy = addressSettings.getSlowConsumerPolicy() == SlowConsumerPolicy.NOTIFY ? "NOTIFY" : "KILL";
-      JsonObjectBuilder settings = JsonLoader.createObjectBuilder();
-      if (addressSettings.getDeadLetterAddress() != null) {
-         settings.add("DLA", addressSettings.getDeadLetterAddress().toString());
-      }
-      if (addressSettings.getExpiryAddress() != null) {
-         settings.add("expiryAddress", addressSettings.getExpiryAddress().toString());
-      }
-
-      return settings.add("expiryDelay", addressSettings.getExpiryDelay())
-            .add("minExpiryDelay", addressSettings.getMinExpiryDelay())
-            .add("maxExpiryDelay", addressSettings.getMaxExpiryDelay())
-            .add("maxDeliveryAttempts", addressSettings.getMaxDeliveryAttempts())
-            .add("pageCacheMaxSize", addressSettings.getPageCacheMaxSize())
-            .add("maxSizeBytes", addressSettings.getMaxSizeBytes())
-            .add("pageSizeBytes", addressSettings.getPageSizeBytes())
-            .add("redeliveryDelay", addressSettings.getRedeliveryDelay())
-            .add("redeliveryMultiplier", addressSettings.getRedeliveryMultiplier())
-            .add("maxRedeliveryDelay", addressSettings.getMaxRedeliveryDelay())
-            .add("redistributionDelay", addressSettings.getRedistributionDelay())
-            .add("lastValueQueue", addressSettings.isDefaultLastValueQueue())
-            .add("sendToDLAOnNoRoute", addressSettings.isSendToDLAOnNoRoute())
-            .add("addressFullMessagePolicy", policy)
-            .add("slowConsumerThreshold", addressSettings.getSlowConsumerThreshold())
-            .add("slowConsumerThresholdMeasurementUnit", addressSettings.getSlowConsumerThresholdMeasurementUnit().toString())
-            .add("slowConsumerCheckPeriod", addressSettings.getSlowConsumerCheckPeriod())
-            .add("slowConsumerPolicy", consumerPolicy)
-            .add("autoCreateJmsQueues", addressSettings.isAutoCreateJmsQueues())
-            .add("autoDeleteJmsQueues", addressSettings.isAutoDeleteJmsQueues())
-            .add("autoCreateJmsTopics", addressSettings.isAutoCreateJmsTopics())
-            .add("autoDeleteJmsTopics", addressSettings.isAutoDeleteJmsTopics())
-            .add("autoCreateQueues", addressSettings.isAutoCreateQueues())
-            .add("autoDeleteQueues", addressSettings.isAutoDeleteQueues())
-            .add("autoCreateAddresses", addressSettings.isAutoCreateAddresses())
-            .add("autoDeleteAddresses", addressSettings.isAutoDeleteAddresses())
-            .add("configDeleteQueues", addressSettings.getConfigDeleteQueues().toString())
-            .add("configDeleteAddresses", addressSettings.getConfigDeleteAddresses().toString())
-            .add("maxSizeBytesRejectThreshold", addressSettings.getMaxSizeBytesRejectThreshold())
-            .add("defaultLastValueKey", addressSettings.getDefaultLastValueKey() == null ? "" : addressSettings.getDefaultLastValueKey().toString())
-            .add("defaultNonDestructive", addressSettings.isDefaultNonDestructive())
-            .add("defaultExclusiveQueue", addressSettings.isDefaultExclusiveQueue())
-            .add("defaultGroupRebalance", addressSettings.isDefaultGroupRebalance())
-            .add("defaultGroupRebalancePauseDispatch", addressSettings.isDefaultGroupRebalancePauseDispatch())
-            .add("defaultGroupBuckets", addressSettings.getDefaultGroupBuckets())
-            .add("defaultGroupFirstKey", addressSettings.getDefaultGroupFirstKey() == null ? "" : addressSettings.getDefaultGroupFirstKey().toString())
-            .add("defaultMaxConsumers", addressSettings.getDefaultMaxConsumers())
-            .add("defaultPurgeOnNoConsumers", addressSettings.isDefaultPurgeOnNoConsumers())
-            .add("defaultConsumersBeforeDispatch", addressSettings.getDefaultConsumersBeforeDispatch())
-            .add("defaultDelayBeforeDispatch", addressSettings.getDefaultDelayBeforeDispatch())
-            .add("defaultQueueRoutingType", addressSettings.getDefaultQueueRoutingType().toString())
-            .add("defaultAddressRoutingType", addressSettings.getDefaultAddressRoutingType().toString())
-            .add("defaultConsumerWindowSize", addressSettings.getDefaultConsumerWindowSize())
-            .add("defaultRingSize", addressSettings.getDefaultRingSize())
-            .add("autoDeleteCreatedQueues", addressSettings.isAutoDeleteCreatedQueues())
-            .add("autoDeleteQueuesDelay", addressSettings.getAutoDeleteQueuesDelay())
-            .add("autoDeleteQueuesMessageCount", addressSettings.getAutoDeleteQueuesMessageCount())
-            .add("autoDeleteAddressesDelay", addressSettings.getAutoDeleteAddressesDelay())
-            .add("redeliveryCollisionAvoidanceFactor", addressSettings.getRedeliveryCollisionAvoidanceFactor())
-            .add("retroactiveMessageCount", addressSettings.getRetroactiveMessageCount())
-            .add("autoCreateDeadLetterResources", addressSettings.isAutoCreateDeadLetterResources())
-            .add("deadLetterQueuePrefix", addressSettings.getDeadLetterQueuePrefix().toString())
-            .add("deadLetterQueueSuffix", addressSettings.getDeadLetterQueueSuffix().toString())
-            .add("autoCreateExpiryResources", addressSettings.isAutoCreateExpiryResources())
-            .add("expiryQueuePrefix", addressSettings.getExpiryQueuePrefix().toString())
-            .add("expiryQueueSuffix", addressSettings.getExpiryQueueSuffix().toString())
-            .add("enableMetrics", addressSettings.isEnableMetrics())
-            .build()
-            .toString();
+      return addressSettings.toJSON();
    }
 
    @Override
+   @Deprecated
    public void addAddressSettings(final String address,
                                   final String DLA,
                                   final String expiryAddress,
@@ -3146,6 +3080,7 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
    }
 
    @Override
+   @Deprecated
    public void addAddressSettings(final String address,
                                   final String DLA,
                                   final String expiryAddress,
@@ -3224,6 +3159,7 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
    }
 
    @Override
+   @Deprecated
    public void addAddressSettings(final String address,
                                   final String DLA,
                                   final String expiryAddress,
@@ -3331,6 +3267,7 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
    }
 
    @Override
+   @Deprecated
    public void addAddressSettings(final String address,
                                   final String DLA,
                                   final String expiryAddress,
@@ -3447,6 +3384,7 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
    }
 
    @Override
+   @Deprecated
    public void addAddressSettings(final String address,
                                   final String DLA,
                                   final String expiryAddress,
@@ -3594,6 +3532,40 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
       storageManager.storeAddressSetting(new PersistedAddressSetting(new SimpleString(address), addressSettings));
 
+   }
+
+   @Override
+   public String addAddressSettings(String address, String addressSettingsConfigurationAsJson) throws Exception {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.addAddressSettings(this.server, addressSettingsConfigurationAsJson);
+      }
+      checkStarted();
+
+      clearIO();
+
+      try {
+         AddressSettings addressSettingsConfiguration = AddressSettings.fromJSON(addressSettingsConfigurationAsJson);
+
+         if (addressSettingsConfiguration == null) {
+            throw ActiveMQMessageBundle.BUNDLE.failedToParseJson(addressSettingsConfigurationAsJson);
+         }
+         // JBPAPP-6334 requested this to be pageSizeBytes > maxSizeBytes
+         if (addressSettingsConfiguration.getPageSizeBytes() > addressSettingsConfiguration.getMaxSizeBytes() && addressSettingsConfiguration.getMaxSizeBytes() > 0) {
+            throw new IllegalStateException("pageSize has to be lower than maxSizeBytes. Invalid argument (" + addressSettingsConfiguration.getPageSizeBytes() + " < " + addressSettingsConfiguration.getMaxSizeBytes() + ")");
+         }
+
+         if (addressSettingsConfiguration.getMaxSizeBytes() < -1) {
+            throw new IllegalStateException("Invalid argument on maxSizeBytes");
+         }
+         server.getAddressSettingsRepository().addMatch(address, addressSettingsConfiguration);
+
+         storageManager.storeAddressSetting(new PersistedAddressSettingJSON(new SimpleString(address), addressSettingsConfiguration, SimpleString.toSimpleString(addressSettingsConfigurationAsJson)));
+         return addressSettingsConfiguration.toJSON();
+      } catch (ActiveMQException e) {
+         throw new IllegalStateException(e.getMessage());
+      } finally {
+         blockOnIO();
+      }
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/StorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/StorageManager.java
@@ -38,7 +38,9 @@ import org.apache.activemq.artemis.core.paging.PagedMessage;
 import org.apache.activemq.artemis.core.paging.PagingManager;
 import org.apache.activemq.artemis.core.paging.PagingStore;
 import org.apache.activemq.artemis.core.paging.cursor.PagePosition;
+import org.apache.activemq.artemis.core.persistence.config.AbstractPersistedAddressSetting;
 import org.apache.activemq.artemis.core.persistence.config.PersistedAddressSetting;
+import org.apache.activemq.artemis.core.persistence.config.PersistedAddressSettingJSON;
 import org.apache.activemq.artemis.core.persistence.config.PersistedBridgeConfiguration;
 import org.apache.activemq.artemis.core.persistence.config.PersistedConnector;
 import org.apache.activemq.artemis.core.persistence.config.PersistedDivertConfiguration;
@@ -348,9 +350,11 @@ public interface StorageManager extends IDGenerator, ActiveMQComponent {
 
    void storeAddressSetting(PersistedAddressSetting addressSetting) throws Exception;
 
+   void storeAddressSetting(PersistedAddressSettingJSON addressSetting) throws Exception;
+
    void deleteAddressSetting(SimpleString addressMatch) throws Exception;
 
-   List<PersistedAddressSetting> recoverAddressSettings() throws Exception;
+   List<AbstractPersistedAddressSetting> recoverAddressSettings() throws Exception;
 
    void storeSecuritySetting(PersistedSecuritySetting persistedRoles) throws Exception;
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/config/AbstractPersistedAddressSetting.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/config/AbstractPersistedAddressSetting.java
@@ -14,59 +14,54 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.activemq.artemis.core.persistence.config;
 
-import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.journal.EncodingSupport;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 
-public class PersistedAddressSetting extends AbstractPersistedAddressSetting implements EncodingSupport {
+public abstract class AbstractPersistedAddressSetting implements EncodingSupport {
 
+   protected long storeId;
 
-   public PersistedAddressSetting() {
+   protected SimpleString addressMatch;
+
+   protected AddressSettings setting;
+
+   public AbstractPersistedAddressSetting() {
       super();
    }
 
-   /* (non-Javadoc)
-    * @see java.lang.Object#toString()
-    */
-   @Override
-   public String toString() {
-      return "PersistedAddressSetting [storeId=" + storeId +
-         ", addressMatch=" +
-         addressMatch +
-         ", setting=" +
-         setting +
-         "]";
+   public AbstractPersistedAddressSetting(SimpleString addressMatch, AddressSettings setting) {
+      this.addressMatch = addressMatch;
+      this.setting = setting;
    }
 
-   /**
-    * @param addressMatch
-    * @param setting
-    */
-   public PersistedAddressSetting(SimpleString addressMatch, AddressSettings setting) {
-      super(addressMatch, setting);
+   public long getStoreId() {
+      return storeId;
    }
 
-   @Override
-   public void decode(ActiveMQBuffer buffer) {
-      addressMatch = buffer.readSimpleString();
-
-      setting = new AddressSettings();
-      setting.decode(buffer);
+   public AbstractPersistedAddressSetting setStoreId(long storeId) {
+      this.storeId = storeId;
+      return this;
    }
 
-   @Override
-   public void encode(ActiveMQBuffer buffer) {
-      buffer.writeSimpleString(addressMatch);
-
-      setting.encode(buffer);
+   public SimpleString getAddressMatch() {
+      return addressMatch;
    }
 
-   @Override
-   public int getEncodeSize() {
-      return addressMatch.sizeof() + setting.getEncodeSize();
+   public AbstractPersistedAddressSetting setAddressMatch(SimpleString addressMatch) {
+      this.addressMatch = addressMatch;
+      return this;
    }
 
+   public AddressSettings getSetting() {
+      return setting;
+   }
+
+   public AbstractPersistedAddressSetting setSetting(AddressSettings setting) {
+      this.setting = setting;
+      return this;
+   }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/config/PersistedAddressSettingJSON.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/config/PersistedAddressSettingJSON.java
@@ -21,52 +21,51 @@ import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.journal.EncodingSupport;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 
-public class PersistedAddressSetting extends AbstractPersistedAddressSetting implements EncodingSupport {
+public class PersistedAddressSettingJSON extends AbstractPersistedAddressSetting implements EncodingSupport {
 
+   SimpleString jsonSetting;
 
-   public PersistedAddressSetting() {
+   public PersistedAddressSettingJSON() {
       super();
    }
 
-   /* (non-Javadoc)
-    * @see java.lang.Object#toString()
-    */
    @Override
-   public String toString() {
-      return "PersistedAddressSetting [storeId=" + storeId +
-         ", addressMatch=" +
-         addressMatch +
-         ", setting=" +
-         setting +
-         "]";
+   public AddressSettings getSetting() {
+      if (setting == null) {
+         setting = AddressSettings.fromJSON(jsonSetting.toString());
+      }
+      return super.getSetting();
    }
 
    /**
     * @param addressMatch
     * @param setting
     */
-   public PersistedAddressSetting(SimpleString addressMatch, AddressSettings setting) {
+   public PersistedAddressSettingJSON(SimpleString addressMatch, AddressSettings setting, SimpleString jsonSetting) {
       super(addressMatch, setting);
+      this.jsonSetting = jsonSetting;
    }
 
    @Override
    public void decode(ActiveMQBuffer buffer) {
       addressMatch = buffer.readSimpleString();
-
-      setting = new AddressSettings();
-      setting.decode(buffer);
+      jsonSetting = buffer.readSimpleString();
+      setting = AddressSettings.fromJSON(jsonSetting.toString());
    }
 
    @Override
    public void encode(ActiveMQBuffer buffer) {
       buffer.writeSimpleString(addressMatch);
-
-      setting.encode(buffer);
+      buffer.writeSimpleString(jsonSetting);
    }
 
    @Override
    public int getEncodeSize() {
-      return addressMatch.sizeof() + setting.getEncodeSize();
+      return addressMatch.sizeof() + jsonSetting.sizeof();
    }
 
+   @Override
+   public String toString() {
+      return "PersistedAddressSettingJSON{" + "jsonSetting=" + jsonSetting + ", storeId=" + storeId + ", addressMatch=" + addressMatch + ", setting=" + setting + '}';
+   }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/DescribeJournal.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/DescribeJournal.java
@@ -78,6 +78,7 @@ import static org.apache.activemq.artemis.core.persistence.impl.journal.JournalR
 import static org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds.ACKNOWLEDGE_REF;
 import static org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds.ADDRESS_BINDING_RECORD;
 import static org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds.ADDRESS_SETTING_RECORD;
+import static org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds.ADDRESS_SETTING_RECORD_JSON;
 import static org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds.ADDRESS_STATUS_RECORD;
 import static org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds.ADD_LARGE_MESSAGE;
 import static org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds.ADD_LARGE_MESSAGE_PENDING;
@@ -745,6 +746,9 @@ public final class DescribeJournal {
 
          case ADDRESS_SETTING_RECORD:
             return AbstractJournalStorageManager.newAddressEncoding(id, buffer);
+
+         case ADDRESS_SETTING_RECORD_JSON:
+            return AbstractJournalStorageManager.newAddressJSONEncoding(id, buffer);
 
          case SECURITY_SETTING_RECORD:
             return AbstractJournalStorageManager.newSecurityRecord(id, buffer);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalRecordIds.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/JournalRecordIds.java
@@ -104,4 +104,6 @@ public final class JournalRecordIds {
    public static final byte KEY_VALUE_PAIR_RECORD = 50;
 
    public static final byte CONNECTOR_RECORD = 51;
+
+   public static final byte ADDRESS_SETTING_RECORD_JSON = 52;
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/nullpm/NullStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/nullpm/NullStorageManager.java
@@ -46,7 +46,9 @@ import org.apache.activemq.artemis.core.persistence.OperationContext;
 import org.apache.activemq.artemis.core.persistence.QueueBindingInfo;
 import org.apache.activemq.artemis.core.persistence.AddressQueueStatus;
 import org.apache.activemq.artemis.core.persistence.StorageManager;
+import org.apache.activemq.artemis.core.persistence.config.AbstractPersistedAddressSetting;
 import org.apache.activemq.artemis.core.persistence.config.PersistedAddressSetting;
+import org.apache.activemq.artemis.core.persistence.config.PersistedAddressSettingJSON;
 import org.apache.activemq.artemis.core.persistence.config.PersistedBridgeConfiguration;
 import org.apache.activemq.artemis.core.persistence.config.PersistedConnector;
 import org.apache.activemq.artemis.core.persistence.config.PersistedDivertConfiguration;
@@ -448,12 +450,16 @@ public class NullStorageManager implements StorageManager {
    }
 
    @Override
-   public List<PersistedAddressSetting> recoverAddressSettings() throws Exception {
+   public List<AbstractPersistedAddressSetting> recoverAddressSettings() throws Exception {
       return Collections.emptyList();
    }
 
    @Override
    public void storeAddressSetting(final PersistedAddressSetting addressSetting) throws Exception {
+   }
+
+   @Override
+   public void storeAddressSetting(final PersistedAddressSettingJSON addressSetting) throws Exception {
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -97,7 +97,7 @@ import org.apache.activemq.artemis.core.persistence.GroupingInfo;
 import org.apache.activemq.artemis.core.persistence.OperationContext;
 import org.apache.activemq.artemis.core.persistence.QueueBindingInfo;
 import org.apache.activemq.artemis.core.persistence.StorageManager;
-import org.apache.activemq.artemis.core.persistence.config.PersistedAddressSetting;
+import org.apache.activemq.artemis.core.persistence.config.AbstractPersistedAddressSetting;
 import org.apache.activemq.artemis.core.persistence.config.PersistedBridgeConfiguration;
 import org.apache.activemq.artemis.core.persistence.config.PersistedConnector;
 import org.apache.activemq.artemis.core.persistence.config.PersistedDivertConfiguration;
@@ -3881,8 +3881,8 @@ public class ActiveMQServerImpl implements ActiveMQServer {
    }
 
    private void recoverStoredAddressSettings() throws Exception {
-      List<PersistedAddressSetting> adsettings = storageManager.recoverAddressSettings();
-      for (PersistedAddressSetting set : adsettings) {
+      List<AbstractPersistedAddressSetting> adsettings = storageManager.recoverAddressSettings();
+      for (AbstractPersistedAddressSetting set : adsettings) {
          addressSettingsRepository.addMatch(set.getAddressMatch().toString(), set.getSetting());
       }
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.core.settings.impl;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
@@ -25,6 +26,7 @@ import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.core.journal.EncodingSupport;
 import org.apache.activemq.artemis.core.settings.Mergeable;
+import org.apache.activemq.artemis.utils.bean.MetaBean;
 import org.apache.activemq.artemis.utils.BufferHelper;
 import org.apache.activemq.artemis.utils.DataConstants;
 
@@ -32,6 +34,8 @@ import org.apache.activemq.artemis.utils.DataConstants;
  * Configuration settings that are applied on the address level
  */
 public class AddressSettings implements Mergeable<AddressSettings>, Serializable, EncodingSupport {
+
+   static MetaBean<AddressSettings> metaBean = new MetaBean<>();
 
    private static final long serialVersionUID = 1607502280582336366L;
 
@@ -143,160 +147,388 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
    public static final boolean DEFAULT_ENABLE_INGRESS_TIMESTAMP = false;
 
+   {
+      metaBean.add(AddressFullMessagePolicy.class, "addressFullMessagePolicy", (t, p) -> t.addressFullMessagePolicy = p, t -> t.addressFullMessagePolicy);
+   }
    private AddressFullMessagePolicy addressFullMessagePolicy = null;
 
+   {
+      metaBean.add(Long.class, "maxSizeBytes", (t, p) -> t.maxSizeBytes = p, t -> t.maxSizeBytes);
+   }
    private Long maxSizeBytes = null;
 
+   {
+      metaBean.add(Integer.class, "maxReadPageBytes", (t, p) -> t.maxReadPageBytes = p, t -> t.maxReadPageBytes);
+   }
    private Integer maxReadPageBytes = null;
 
+   {
+      metaBean.add(Integer.class, "maxReadPageMessages", (t, p) -> t.maxReadPageMessages = p, t -> t.maxReadPageMessages);
+   }
    private Integer maxReadPageMessages = null;
 
+   {
+      metaBean.add(Integer.class, "prefetchPageBytes", (t, p) -> t.prefetchPageBytes = p, t -> t.prefetchPageBytes);
+   }
    private Integer prefetchPageBytes = null;
 
+   {
+      metaBean.add(Integer.class, "prefetchPageMessages", (t, p) -> t.prefetchPageMessages = p, t -> t.prefetchPageMessages);
+   }
    private Integer prefetchPageMessages = null;
 
+   {
+      metaBean.add(Long.class, "pageLimitBytes", (t, p) -> t.pageLimitBytes = p, t -> t.pageLimitBytes);
+   }
    private Long pageLimitBytes = null;
 
+   {
+      metaBean.add(Long.class, "pageLimitMessages", (t, p) -> t.pageLimitMessages = p, t -> t.pageLimitMessages);
+   }
    private Long pageLimitMessages = null;
 
+   {
+      metaBean.add(PageFullMessagePolicy.class, "pageFullMessagePolicy", (t, p) -> t.pageFullMessagePolicy = p, t -> t.pageFullMessagePolicy);
+   }
    private PageFullMessagePolicy pageFullMessagePolicy = null;
 
+   {
+      metaBean.add(Long.class, "maxSizeMessages", (t, p) -> t.maxSizeMessages = p, t -> t.maxSizeMessages);
+   }
    private Long maxSizeMessages = null;
 
+   {
+      metaBean.add(Integer.class, "pageSizeBytes", (t, p) -> t.pageSizeBytes = p, t -> t.pageSizeBytes);
+   }
    private Integer pageSizeBytes = null;
 
-   private Integer pageMaxCache = null;
+   {
+      metaBean.add(Integer.class, "pageCacheMaxSize", (t, p) -> t.pageCacheMaxSize = p, t -> t.pageCacheMaxSize);
+   }
+   private Integer pageCacheMaxSize = null;
 
+   {
+      metaBean.add(Boolean.class, "dropMessagesWhenFull", (t, p) -> t.dropMessagesWhenFull = p, t -> t.dropMessagesWhenFull);
+   }
    private Boolean dropMessagesWhenFull = null;
 
+   {
+      metaBean.add(Integer.class, "maxDeliveryAttempts", (t, p) -> t.maxDeliveryAttempts = p, t -> t.maxDeliveryAttempts);
+   }
    private Integer maxDeliveryAttempts = null;
 
+   {
+      metaBean.add(Integer.class, "messageCounterHistoryDayLimit", (t, p) -> t.messageCounterHistoryDayLimit = p, t -> t.messageCounterHistoryDayLimit);
+   }
    private Integer messageCounterHistoryDayLimit = null;
 
+   {
+      metaBean.add(Long.class, "redeliveryDelay", (t, p) -> t.redeliveryDelay = p, t -> t.redeliveryDelay);
+   }
    private Long redeliveryDelay = null;
 
+   {
+      metaBean.add(Double.class, "redeliveryMultiplier", (t, p) -> t.redeliveryMultiplier = p, t -> t.redeliveryMultiplier);
+   }
    private Double redeliveryMultiplier = null;
 
+   {
+      metaBean.add(Double.class, "redeliveryCollisionAvoidanceFactor", (t, p) -> t.redeliveryCollisionAvoidanceFactor = p, t -> t.redeliveryCollisionAvoidanceFactor);
+   }
    private Double redeliveryCollisionAvoidanceFactor = null;
 
+   {
+      metaBean.add(Long.class, "maxRedeliveryDelay", (t, p) -> t.maxRedeliveryDelay = p, t -> t.maxRedeliveryDelay);
+   }
    private Long maxRedeliveryDelay = null;
 
+   {
+      metaBean.add(SimpleString.class, "deadLetterAddress", (t, p) -> t.deadLetterAddress = p, t -> t.deadLetterAddress);
+   }
    private SimpleString deadLetterAddress = null;
 
+   {
+      metaBean.add(SimpleString.class, "expiryAddress", (t, p) -> t.expiryAddress = p, t -> t.expiryAddress);
+   }
    private SimpleString expiryAddress = null;
 
+   {
+      metaBean.add(Long.class, "expiryDelay", (t, p) -> t.expiryDelay = p, t -> t.expiryDelay);
+   }
    private Long expiryDelay = null;
 
+   {
+      metaBean.add(Long.class, "minExpiryDelay", (t, p) -> t.minExpiryDelay = p, t -> t.minExpiryDelay);
+   }
    private Long minExpiryDelay = null;
 
+   {
+      metaBean.add(Long.class, "maxExpiryDelay", (t, p) -> t.maxExpiryDelay = p, t -> t.maxExpiryDelay);
+   }
    private Long maxExpiryDelay = null;
 
+   {
+      metaBean.add(Boolean.class, "defaultLastValueQueue", (t, p) -> t.defaultLastValueQueue = p, t -> t.defaultLastValueQueue);
+   }
    private Boolean defaultLastValueQueue = null;
 
+   {
+      metaBean.add(SimpleString.class, "defaultLastValueKey", (t, p) -> t.defaultLastValueKey = p, t -> t.defaultLastValueKey);
+   }
    private SimpleString defaultLastValueKey = null;
 
+   {
+      metaBean.add(Boolean.class, "defaultNonDestructive", (t, p) -> t.defaultNonDestructive = p, t -> t.defaultNonDestructive);
+   }
    private Boolean defaultNonDestructive = null;
 
+   {
+      metaBean.add(Boolean.class, "defaultExclusiveQueue", (t, p) -> t.defaultExclusiveQueue = p, t -> t.defaultExclusiveQueue);
+   }
    private Boolean defaultExclusiveQueue = null;
 
+   {
+      metaBean.add(Boolean.class, "defaultGroupRebalance", (t, p) -> t.defaultGroupRebalance = p, t -> t.defaultGroupRebalance);
+   }
    private Boolean defaultGroupRebalance = null;
 
+   {
+      metaBean.add(Boolean.class, "defaultGroupRebalancePauseDispatch", (t, p) -> t.defaultGroupRebalancePauseDispatch = p, t -> t.defaultGroupRebalancePauseDispatch);
+   }
    private Boolean defaultGroupRebalancePauseDispatch = null;
 
+   {
+      metaBean.add(Integer.class, "defaultGroupBuckets", (t, p) -> t.defaultGroupBuckets = p, t -> t.defaultGroupBuckets);
+   }
    private Integer defaultGroupBuckets = null;
 
+   {
+      metaBean.add(SimpleString.class, "defaultGroupFirstKey", (t, p) -> t.defaultGroupFirstKey = p, t -> t.defaultGroupFirstKey);
+   }
    private SimpleString defaultGroupFirstKey = null;
 
+   {
+      metaBean.add(Long.class, "redistributionDelay", (t, p) -> t.redistributionDelay = p, t -> t.redistributionDelay);
+   }
    private Long redistributionDelay = null;
 
+   {
+      metaBean.add(Boolean.class, "sendToDLAOnNoRoute", (t, p) -> t.sendToDLAOnNoRoute = p, t -> t.sendToDLAOnNoRoute);
+   }
    private Boolean sendToDLAOnNoRoute = null;
 
+   {
+      metaBean.add(Long.class, "slowConsumerThreshold", (t, p) -> t.slowConsumerThreshold = p, t -> t.slowConsumerThreshold);
+   }
    private Long slowConsumerThreshold = null;
 
+   {
+      metaBean.add(SlowConsumerThresholdMeasurementUnit.class, "slowConsumerThresholdMeasurementUnit", (t, p) -> t.slowConsumerThresholdMeasurementUnit = p, t -> t.slowConsumerThresholdMeasurementUnit);
+   }
    private SlowConsumerThresholdMeasurementUnit slowConsumerThresholdMeasurementUnit = DEFAULT_SLOW_CONSUMER_THRESHOLD_MEASUREMENT_UNIT;
 
+   {
+      metaBean.add(Long.class, "slowConsumerCheckPeriod", (t, p) -> t.slowConsumerCheckPeriod = p, t -> t.slowConsumerCheckPeriod);
+   }
    private Long slowConsumerCheckPeriod = null;
 
+   {
+      metaBean.add(SlowConsumerPolicy.class, "slowConsumerPolicy", (t, p) -> t.slowConsumerPolicy = p, t -> t.slowConsumerPolicy);
+   }
    private SlowConsumerPolicy slowConsumerPolicy = null;
 
+   {
+      metaBean.add(Boolean.class, "autoCreateJmsQueues", (t, p) -> t.autoCreateJmsQueues = (Boolean) p, t -> t.autoCreateJmsQueues, t -> t.autoCreateJmsQueues != null);
+   }
    @Deprecated
    private Boolean autoCreateJmsQueues = null;
 
+   {
+      metaBean.add(Boolean.class, "autoDeleteJmsQueues", (t, p) -> t.autoDeleteJmsQueues = (Boolean) p, t -> t.autoDeleteJmsQueues, t -> t.autoDeleteJmsQueues != null);
+   }
    @Deprecated
    private Boolean autoDeleteJmsQueues = null;
 
+   {
+      metaBean.add(Boolean.class, "autoCreateJmsTopics", (t, p) -> t.autoCreateJmsTopics = (Boolean) p, t -> t.autoCreateJmsTopics, t -> t.autoCreateJmsTopics != null);
+   }
    @Deprecated
    private Boolean autoCreateJmsTopics = null;
 
+   {
+      metaBean.add(Boolean.class, "autoDeleteJmsTopics", (t, p) -> t.autoDeleteJmsTopics = (Boolean) p, t -> t.autoDeleteJmsTopics, t -> t.autoDeleteJmsTopics != null);
+   }
    @Deprecated
    private Boolean autoDeleteJmsTopics = null;
 
+   {
+      metaBean.add(Boolean.class, "autoCreateQueues", (t, p) -> t.autoCreateQueues = p, t -> t.autoCreateQueues);
+   }
    private Boolean autoCreateQueues = null;
 
+   {
+      metaBean.add(Boolean.class, "autoDeleteQueues", (t, p) -> t.autoDeleteQueues = p, t -> t.autoDeleteQueues);
+   }
    private Boolean autoDeleteQueues = null;
 
+   {
+      metaBean.add(Boolean.class, "autoDeleteCreatedQueues", (t, p) -> t.autoDeleteCreatedQueues = p, t -> t.autoDeleteCreatedQueues);
+   }
    private Boolean autoDeleteCreatedQueues = null;
 
+   {
+      metaBean.add(Long.class, "autoDeleteQueuesDelay", (t, p) -> t.autoDeleteQueuesDelay = p, t -> t.autoDeleteQueuesDelay);
+   }
    private Long autoDeleteQueuesDelay = null;
 
+   {
+      metaBean.add(Boolean.class, "autoDeleteQueuesSkipUsageCheck", (t, p) -> t.autoDeleteQueuesSkipUsageCheck = p, t -> t.autoDeleteQueuesSkipUsageCheck);
+   }
    private Boolean autoDeleteQueuesSkipUsageCheck = null;
 
+   {
+      metaBean.add(Long.class, "autoDeleteQueuesMessageCount", (t, p) -> t.autoDeleteQueuesMessageCount = p, t -> t.autoDeleteQueuesMessageCount);
+   }
    private Long autoDeleteQueuesMessageCount = null;
 
+   {
+      metaBean.add(Long.class, "defaultRingSize", (t, p) -> t.defaultRingSize = p, t -> t.defaultRingSize);
+   }
    private Long defaultRingSize = null;
 
+   {
+      metaBean.add(Long.class, "retroactiveMessageCount", (t, p) -> t.retroactiveMessageCount = p, t -> t.retroactiveMessageCount);
+   }
    private Long retroactiveMessageCount = null;
 
+   {
+      metaBean.add(DeletionPolicy.class, "configDeleteQueues", (t, p) -> t.configDeleteQueues = p, t -> t.configDeleteQueues);
+   }
    private DeletionPolicy configDeleteQueues = null;
 
+   {
+      metaBean.add(Boolean.class, "autoCreateAddresses", (t, p) -> t.autoCreateAddresses = p, t -> t.autoCreateAddresses);
+   }
    private Boolean autoCreateAddresses = null;
 
+   {
+      metaBean.add(Boolean.class, "autoDeleteAddresses", (t, p) -> t.autoDeleteAddresses = p, t -> t.autoDeleteAddresses);
+   }
    private Boolean autoDeleteAddresses = null;
 
+   {
+      metaBean.add(Long.class, "autoDeleteAddressesDelay", (t, p) -> t.autoDeleteAddressesDelay = p, t -> t.autoDeleteAddressesDelay);
+   }
    private Long autoDeleteAddressesDelay = null;
 
+   {
+      metaBean.add(Boolean.class, "autoDeleteAddressesSkipUsageCheck", (t, p) -> t.autoDeleteAddressesSkipUsageCheck = p, t -> t.autoDeleteAddressesSkipUsageCheck);
+   }
    private Boolean autoDeleteAddressesSkipUsageCheck = null;
 
+   {
+      metaBean.add(DeletionPolicy.class, "configDeleteAddresses", (t, p) -> t.configDeleteAddresses = p, t -> t.configDeleteAddresses);
+   }
    private DeletionPolicy configDeleteAddresses = null;
 
+   {
+      metaBean.add(DeletionPolicy.class, "configDeleteDiverts", (t, p) -> t.configDeleteDiverts = p, t -> t.configDeleteDiverts);
+   }
    private DeletionPolicy configDeleteDiverts = null;
 
+   {
+      metaBean.add(Integer.class, "managementBrowsePageSize", (t, p) -> t.managementBrowsePageSize = p, t -> t.managementBrowsePageSize);
+   }
    private Integer managementBrowsePageSize = AddressSettings.MANAGEMENT_BROWSE_PAGE_SIZE;
 
+   {
+      metaBean.add(Long.class, "maxSizeBytesRejectThreshold", (t, p) -> t.maxSizeBytesRejectThreshold = p, t -> t.maxSizeBytesRejectThreshold);
+   }
    private Long maxSizeBytesRejectThreshold = null;
 
+   {
+      metaBean.add(Integer.class, "defaultMaxConsumers", (t, p) -> t.defaultMaxConsumers = p, t -> t.defaultMaxConsumers);
+   }
    private Integer defaultMaxConsumers = null;
 
+   {
+      metaBean.add(Boolean.class, "defaultPurgeOnNoConsumers", (t, p) -> t.defaultPurgeOnNoConsumers = p, t -> t.defaultPurgeOnNoConsumers);
+   }
    private Boolean defaultPurgeOnNoConsumers = null;
 
+   {
+      metaBean.add(Integer.class, "defaultConsumersBeforeDispatch", (t, p) -> t.defaultConsumersBeforeDispatch = p, t -> t.defaultConsumersBeforeDispatch);
+   }
    private Integer defaultConsumersBeforeDispatch = null;
 
+   {
+      metaBean.add(Long.class, "defaultDelayBeforeDispatch", (t, p) -> t.defaultDelayBeforeDispatch = p, t -> t.defaultDelayBeforeDispatch);
+   }
    private Long defaultDelayBeforeDispatch = null;
 
+   {
+      metaBean.add(RoutingType.class, "defaultQueueRoutingType", (t, p) -> t.defaultQueueRoutingType = p, t -> t.defaultQueueRoutingType);
+   }
    private RoutingType defaultQueueRoutingType = null;
 
+   {
+      metaBean.add(RoutingType.class, "defaultAddressRoutingType", (t, p) -> t.defaultAddressRoutingType = p, t -> t.defaultAddressRoutingType);
+   }
    private RoutingType defaultAddressRoutingType = null;
 
+   {
+      metaBean.add(Integer.class, "defaultConsumerWindowSize", (t, p) -> t.defaultConsumerWindowSize = p, t -> t.defaultConsumerWindowSize);
+   }
    private Integer defaultConsumerWindowSize = null;
 
+   {
+      metaBean.add(Boolean.class, "autoCreateDeadLetterResources", (t, p) -> t.autoCreateDeadLetterResources = p, t -> t.autoCreateDeadLetterResources);
+   }
    private Boolean autoCreateDeadLetterResources = null;
 
+   {
+      metaBean.add(SimpleString.class, "deadLetterQueuePrefix", (t, p) -> t.deadLetterQueuePrefix = p, t -> t.deadLetterQueuePrefix);
+   }
    private SimpleString deadLetterQueuePrefix = null;
 
+   {
+      metaBean.add(SimpleString.class, "deadLetterQueueSuffix", (t, p) -> t.deadLetterQueueSuffix = p, t -> t.deadLetterQueueSuffix);
+   }
    private SimpleString deadLetterQueueSuffix = null;
 
+   {
+      metaBean.add(Boolean.class, "autoCreateExpiryResources", (t, p) -> t.autoCreateExpiryResources = p, t -> t.autoCreateExpiryResources);
+   }
    private Boolean autoCreateExpiryResources = null;
 
+   {
+      metaBean.add(SimpleString.class, "expiryQueuePrefix", (t, p) -> t.expiryQueuePrefix = p, t -> t.expiryQueuePrefix);
+   }
    private SimpleString expiryQueuePrefix = null;
 
+   {
+      metaBean.add(SimpleString.class, "expiryQueueSuffix", (t, p) -> t.expiryQueueSuffix = p, t -> t.expiryQueueSuffix);
+   }
    private SimpleString expiryQueueSuffix = null;
 
+   {
+      metaBean.add(Boolean.class, "enableMetrics", (t, p) -> t.enableMetrics = p, t -> t.enableMetrics);
+   }
    private Boolean enableMetrics = null;
 
+   {
+      metaBean.add(Integer.class, "managementMessageAttributeSizeLimit", (t, p) -> t.managementMessageAttributeSizeLimit = p, t -> t.managementMessageAttributeSizeLimit);
+   }
    private Integer managementMessageAttributeSizeLimit = null;
 
+   {
+      metaBean.add(Boolean.class, "enableIngressTimestamp", (t, p) -> t.enableIngressTimestamp = p, t -> t.enableIngressTimestamp);
+   }
    private Boolean enableIngressTimestamp = null;
 
+   {
+      metaBean.add(Integer.class, "idCacheSize", (t, p) -> t.idCacheSize = p, t -> t.idCacheSize);
+   }
    private Integer idCacheSize = null;
 
    //from amq5
@@ -304,79 +536,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    private transient Integer queuePrefetch = null;
 
    public AddressSettings(AddressSettings other) {
-      this.addressFullMessagePolicy = other.addressFullMessagePolicy;
-      this.maxSizeBytes = other.maxSizeBytes;
-      this.maxSizeMessages = other.maxSizeMessages;
-      this.maxReadPageMessages = other.maxReadPageMessages;
-      this.maxReadPageBytes = other.maxReadPageBytes;
-      this.pageLimitBytes = other.pageLimitBytes;
-      this.pageLimitMessages = other.pageLimitMessages;
-      this.pageFullMessagePolicy = other.pageFullMessagePolicy;
-      this.pageSizeBytes = other.pageSizeBytes;
-      this.pageMaxCache = other.pageMaxCache;
-      this.dropMessagesWhenFull = other.dropMessagesWhenFull;
-      this.maxDeliveryAttempts = other.maxDeliveryAttempts;
-      this.messageCounterHistoryDayLimit = other.messageCounterHistoryDayLimit;
-      this.redeliveryDelay = other.redeliveryDelay;
-      this.redeliveryMultiplier = other.redeliveryMultiplier;
-      this.redeliveryCollisionAvoidanceFactor = other.redeliveryCollisionAvoidanceFactor;
-      this.maxRedeliveryDelay = other.maxRedeliveryDelay;
-      this.deadLetterAddress = other.deadLetterAddress;
-      this.autoCreateDeadLetterResources = other.autoCreateDeadLetterResources;
-      this.deadLetterQueuePrefix = other.deadLetterQueuePrefix;
-      this.deadLetterQueueSuffix = other.deadLetterQueueSuffix;
-      this.expiryAddress = other.expiryAddress;
-      this.autoCreateExpiryResources = other.autoCreateExpiryResources;
-      this.expiryQueuePrefix = other.expiryQueuePrefix;
-      this.expiryQueueSuffix = other.expiryQueueSuffix;
-      this.expiryDelay = other.expiryDelay;
-      this.minExpiryDelay = other.minExpiryDelay;
-      this.maxExpiryDelay = other.maxExpiryDelay;
-      this.defaultLastValueQueue = other.defaultLastValueQueue;
-      this.defaultLastValueKey = other.defaultLastValueKey;
-      this.defaultNonDestructive = other.defaultNonDestructive;
-      this.defaultExclusiveQueue = other.defaultExclusiveQueue;
-      this.redistributionDelay = other.redistributionDelay;
-      this.sendToDLAOnNoRoute = other.sendToDLAOnNoRoute;
-      this.slowConsumerThreshold = other.slowConsumerThreshold;
-      this.slowConsumerCheckPeriod = other.slowConsumerCheckPeriod;
-      this.slowConsumerPolicy = other.slowConsumerPolicy;
-      this.autoCreateJmsQueues = other.autoCreateJmsQueues;
-      this.autoDeleteJmsQueues = other.autoDeleteJmsQueues;
-      this.autoCreateJmsTopics = other.autoCreateJmsTopics;
-      this.autoDeleteJmsTopics = other.autoDeleteJmsTopics;
-      this.autoCreateQueues = other.autoCreateQueues;
-      this.autoDeleteQueues = other.autoDeleteQueues;
-      this.autoDeleteCreatedQueues = other.autoDeleteCreatedQueues;
-      this.autoDeleteQueuesDelay = other.autoDeleteQueuesDelay;
-      this.autoDeleteQueuesSkipUsageCheck = other.autoDeleteQueuesSkipUsageCheck;
-      this.configDeleteQueues = other.configDeleteQueues;
-      this.autoCreateAddresses = other.autoCreateAddresses;
-      this.autoDeleteAddresses = other.autoDeleteAddresses;
-      this.autoDeleteAddressesDelay = other.autoDeleteAddressesDelay;
-      this.autoDeleteAddressesSkipUsageCheck = other.autoDeleteAddressesSkipUsageCheck;
-      this.configDeleteAddresses = other.configDeleteAddresses;
-      this.configDeleteDiverts = other.configDeleteDiverts;
-      this.managementBrowsePageSize = other.managementBrowsePageSize;
-      this.queuePrefetch = other.queuePrefetch;
-      this.maxSizeBytesRejectThreshold = other.maxSizeBytesRejectThreshold;
-      this.defaultMaxConsumers = other.defaultMaxConsumers;
-      this.defaultPurgeOnNoConsumers = other.defaultPurgeOnNoConsumers;
-      this.defaultConsumersBeforeDispatch = other.defaultConsumersBeforeDispatch;
-      this.defaultDelayBeforeDispatch = other.defaultDelayBeforeDispatch;
-      this.defaultQueueRoutingType = other.defaultQueueRoutingType;
-      this.defaultAddressRoutingType = other.defaultAddressRoutingType;
-      this.defaultConsumerWindowSize = other.defaultConsumerWindowSize;
-      this.defaultGroupRebalance = other.defaultGroupRebalance;
-      this.defaultGroupRebalancePauseDispatch = other.defaultGroupRebalancePauseDispatch;
-      this.defaultGroupBuckets = other.defaultGroupBuckets;
-      this.defaultGroupFirstKey = other.defaultGroupFirstKey;
-      this.defaultRingSize = other.defaultRingSize;
-      this.enableMetrics = other.enableMetrics;
-      this.managementMessageAttributeSizeLimit = other.managementMessageAttributeSizeLimit;
-      this.slowConsumerThresholdMeasurementUnit = other.slowConsumerThresholdMeasurementUnit;
-      this.enableIngressTimestamp = other.enableIngressTimestamp;
-      this.idCacheSize = other.idCacheSize;
+      metaBean.copy(other, this);
    }
 
    public AddressSettings() {
@@ -385,6 +545,16 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    @Deprecated
    public boolean isAutoCreateJmsQueues() {
       return autoCreateJmsQueues != null ? autoCreateJmsQueues : AddressSettings.DEFAULT_AUTO_CREATE_JMS_QUEUES;
+   }
+
+   public String toJSON() {
+      return metaBean.toJSON(this, true).toString();
+   }
+
+   public static AddressSettings fromJSON(String jsonString) {
+      AddressSettings newSettings = new AddressSettings();
+      metaBean.fromJSON(newSettings, jsonString);
+      return newSettings;
    }
 
    @Deprecated
@@ -653,11 +823,11 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public int getPageCacheMaxSize() {
-      return pageMaxCache != null ? pageMaxCache : AddressSettings.DEFAULT_PAGE_MAX_CACHE;
+      return pageCacheMaxSize != null ? pageCacheMaxSize : AddressSettings.DEFAULT_PAGE_MAX_CACHE;
    }
 
-   public AddressSettings setPageCacheMaxSize(final int pageMaxCache) {
-      this.pageMaxCache = pageMaxCache;
+   public AddressSettings setPageCacheMaxSize(final int pageCacheMaxSize) {
+      this.pageCacheMaxSize = pageCacheMaxSize;
       return this;
    }
 
@@ -1133,8 +1303,8 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       if (maxReadPageMessages == null) {
          maxReadPageMessages = merged.maxReadPageMessages;
       }
-      if (pageMaxCache == null) {
-         pageMaxCache = merged.pageMaxCache;
+      if (pageCacheMaxSize == null) {
+         pageCacheMaxSize = merged.pageCacheMaxSize;
       }
       if (pageSizeBytes == null) {
          pageSizeBytes = merged.pageSizeBytes;
@@ -1374,7 +1544,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       Long pageSizeLong = BufferHelper.readNullableLong(buffer);
       pageSizeBytes = pageSizeLong == null ? null : pageSizeLong.intValue();
 
-      pageMaxCache = BufferHelper.readNullableInteger(buffer);
+      pageCacheMaxSize = BufferHelper.readNullableInteger(buffer);
 
       dropMessagesWhenFull = BufferHelper.readNullableBoolean(buffer);
 
@@ -1641,7 +1811,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       return BufferHelper.sizeOfNullableSimpleString(addressFullMessagePolicy != null ? addressFullMessagePolicy.toString() : null) +
          BufferHelper.sizeOfNullableLong(maxSizeBytes) +
          BufferHelper.sizeOfNullableLong(pageSizeBytes == null ? null : Long.valueOf(pageSizeBytes)) +
-         BufferHelper.sizeOfNullableInteger(pageMaxCache) +
+         BufferHelper.sizeOfNullableInteger(pageCacheMaxSize) +
          BufferHelper.sizeOfNullableBoolean(dropMessagesWhenFull) +
          BufferHelper.sizeOfNullableInteger(maxDeliveryAttempts) +
          BufferHelper.sizeOfNullableInteger(messageCounterHistoryDayLimit) +
@@ -1722,7 +1892,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
       BufferHelper.writeNullableLong(buffer, pageSizeBytes == null ? null : Long.valueOf(pageSizeBytes));
 
-      BufferHelper.writeNullableInteger(buffer, pageMaxCache);
+      BufferHelper.writeNullableInteger(buffer, pageCacheMaxSize);
 
       BufferHelper.writeNullableBoolean(buffer, dropMessagesWhenFull);
 
@@ -1869,672 +2039,254 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
       BufferHelper.writeNullableInteger(buffer, prefetchPageMessages);
    }
 
-   /* (non-Javadoc)
-       * @see java.lang.Object#hashCode()
-       */
+   @Override
+   public boolean equals(Object o) {
+      if (this == o)
+         return true;
+      if (o == null || getClass() != o.getClass())
+         return false;
+
+      AddressSettings that = (AddressSettings) o;
+
+      if (addressFullMessagePolicy != that.addressFullMessagePolicy)
+         return false;
+      if (!Objects.equals(maxSizeBytes, that.maxSizeBytes))
+         return false;
+      if (!Objects.equals(maxReadPageBytes, that.maxReadPageBytes))
+         return false;
+      if (!Objects.equals(maxReadPageMessages, that.maxReadPageMessages))
+         return false;
+      if (!Objects.equals(prefetchPageBytes, that.prefetchPageBytes))
+         return false;
+      if (!Objects.equals(prefetchPageMessages, that.prefetchPageMessages))
+         return false;
+      if (!Objects.equals(pageLimitBytes, that.pageLimitBytes))
+         return false;
+      if (!Objects.equals(pageLimitMessages, that.pageLimitMessages))
+         return false;
+      if (pageFullMessagePolicy != that.pageFullMessagePolicy)
+         return false;
+      if (!Objects.equals(maxSizeMessages, that.maxSizeMessages))
+         return false;
+      if (!Objects.equals(pageSizeBytes, that.pageSizeBytes))
+         return false;
+      if (!Objects.equals(pageCacheMaxSize, that.pageCacheMaxSize))
+         return false;
+      if (!Objects.equals(dropMessagesWhenFull, that.dropMessagesWhenFull))
+         return false;
+      if (!Objects.equals(maxDeliveryAttempts, that.maxDeliveryAttempts))
+         return false;
+      if (!Objects.equals(messageCounterHistoryDayLimit, that.messageCounterHistoryDayLimit))
+         return false;
+      if (!Objects.equals(redeliveryDelay, that.redeliveryDelay))
+         return false;
+      if (!Objects.equals(redeliveryMultiplier, that.redeliveryMultiplier))
+         return false;
+      if (!Objects.equals(redeliveryCollisionAvoidanceFactor, that.redeliveryCollisionAvoidanceFactor))
+         return false;
+      if (!Objects.equals(maxRedeliveryDelay, that.maxRedeliveryDelay))
+         return false;
+      if (!Objects.equals(deadLetterAddress, that.deadLetterAddress))
+         return false;
+      if (!Objects.equals(expiryAddress, that.expiryAddress))
+         return false;
+      if (!Objects.equals(expiryDelay, that.expiryDelay))
+         return false;
+      if (!Objects.equals(minExpiryDelay, that.minExpiryDelay))
+         return false;
+      if (!Objects.equals(maxExpiryDelay, that.maxExpiryDelay))
+         return false;
+      if (!Objects.equals(defaultLastValueQueue, that.defaultLastValueQueue))
+         return false;
+      if (!Objects.equals(defaultLastValueKey, that.defaultLastValueKey))
+         return false;
+      if (!Objects.equals(defaultNonDestructive, that.defaultNonDestructive))
+         return false;
+      if (!Objects.equals(defaultExclusiveQueue, that.defaultExclusiveQueue))
+         return false;
+      if (!Objects.equals(defaultGroupRebalance, that.defaultGroupRebalance))
+         return false;
+      if (!Objects.equals(defaultGroupRebalancePauseDispatch, that.defaultGroupRebalancePauseDispatch))
+         return false;
+      if (!Objects.equals(defaultGroupBuckets, that.defaultGroupBuckets))
+         return false;
+      if (!Objects.equals(defaultGroupFirstKey, that.defaultGroupFirstKey))
+         return false;
+      if (!Objects.equals(redistributionDelay, that.redistributionDelay))
+         return false;
+      if (!Objects.equals(sendToDLAOnNoRoute, that.sendToDLAOnNoRoute))
+         return false;
+      if (!Objects.equals(slowConsumerThreshold, that.slowConsumerThreshold))
+         return false;
+      if (slowConsumerThresholdMeasurementUnit != that.slowConsumerThresholdMeasurementUnit)
+         return false;
+      if (!Objects.equals(slowConsumerCheckPeriod, that.slowConsumerCheckPeriod))
+         return false;
+      if (slowConsumerPolicy != that.slowConsumerPolicy)
+         return false;
+      if (!Objects.equals(autoCreateJmsQueues, that.autoCreateJmsQueues))
+         return false;
+      if (!Objects.equals(autoDeleteJmsQueues, that.autoDeleteJmsQueues))
+         return false;
+      if (!Objects.equals(autoCreateJmsTopics, that.autoCreateJmsTopics))
+         return false;
+      if (!Objects.equals(autoDeleteJmsTopics, that.autoDeleteJmsTopics))
+         return false;
+      if (!Objects.equals(autoCreateQueues, that.autoCreateQueues))
+         return false;
+      if (!Objects.equals(autoDeleteQueues, that.autoDeleteQueues))
+         return false;
+      if (!Objects.equals(autoDeleteCreatedQueues, that.autoDeleteCreatedQueues))
+         return false;
+      if (!Objects.equals(autoDeleteQueuesDelay, that.autoDeleteQueuesDelay))
+         return false;
+      if (!Objects.equals(autoDeleteQueuesSkipUsageCheck, that.autoDeleteQueuesSkipUsageCheck))
+         return false;
+      if (!Objects.equals(autoDeleteQueuesMessageCount, that.autoDeleteQueuesMessageCount))
+         return false;
+      if (!Objects.equals(defaultRingSize, that.defaultRingSize))
+         return false;
+      if (!Objects.equals(retroactiveMessageCount, that.retroactiveMessageCount))
+         return false;
+      if (configDeleteQueues != that.configDeleteQueues)
+         return false;
+      if (!Objects.equals(autoCreateAddresses, that.autoCreateAddresses))
+         return false;
+      if (!Objects.equals(autoDeleteAddresses, that.autoDeleteAddresses))
+         return false;
+      if (!Objects.equals(autoDeleteAddressesDelay, that.autoDeleteAddressesDelay))
+         return false;
+      if (!Objects.equals(autoDeleteAddressesSkipUsageCheck, that.autoDeleteAddressesSkipUsageCheck))
+         return false;
+      if (configDeleteAddresses != that.configDeleteAddresses)
+         return false;
+      if (configDeleteDiverts != that.configDeleteDiverts)
+         return false;
+      if (!Objects.equals(managementBrowsePageSize, that.managementBrowsePageSize))
+         return false;
+      if (!Objects.equals(maxSizeBytesRejectThreshold, that.maxSizeBytesRejectThreshold))
+         return false;
+      if (!Objects.equals(defaultMaxConsumers, that.defaultMaxConsumers))
+         return false;
+      if (!Objects.equals(defaultPurgeOnNoConsumers, that.defaultPurgeOnNoConsumers))
+         return false;
+      if (!Objects.equals(defaultConsumersBeforeDispatch, that.defaultConsumersBeforeDispatch))
+         return false;
+      if (!Objects.equals(defaultDelayBeforeDispatch, that.defaultDelayBeforeDispatch))
+         return false;
+      if (defaultQueueRoutingType != that.defaultQueueRoutingType)
+         return false;
+      if (defaultAddressRoutingType != that.defaultAddressRoutingType)
+         return false;
+      if (!Objects.equals(defaultConsumerWindowSize, that.defaultConsumerWindowSize))
+         return false;
+      if (!Objects.equals(autoCreateDeadLetterResources, that.autoCreateDeadLetterResources))
+         return false;
+      if (!Objects.equals(deadLetterQueuePrefix, that.deadLetterQueuePrefix))
+         return false;
+      if (!Objects.equals(deadLetterQueueSuffix, that.deadLetterQueueSuffix))
+         return false;
+      if (!Objects.equals(autoCreateExpiryResources, that.autoCreateExpiryResources))
+         return false;
+      if (!Objects.equals(expiryQueuePrefix, that.expiryQueuePrefix))
+         return false;
+      if (!Objects.equals(expiryQueueSuffix, that.expiryQueueSuffix))
+         return false;
+      if (!Objects.equals(enableMetrics, that.enableMetrics))
+         return false;
+      if (!Objects.equals(managementMessageAttributeSizeLimit, that.managementMessageAttributeSizeLimit))
+         return false;
+      if (!Objects.equals(enableIngressTimestamp, that.enableIngressTimestamp))
+         return false;
+      if (!Objects.equals(idCacheSize, that.idCacheSize))
+         return false;
+      return Objects.equals(queuePrefetch, that.queuePrefetch);
+   }
+
    @Override
    public int hashCode() {
-      final int prime = 31;
-      int result = 1;
-      result = prime * result + ((addressFullMessagePolicy == null) ? 0 : addressFullMessagePolicy.hashCode());
-      result = prime * result + ((deadLetterAddress == null) ? 0 : deadLetterAddress.hashCode());
-      result = prime * result + ((dropMessagesWhenFull == null) ? 0 : dropMessagesWhenFull.hashCode());
-      result = prime * result + ((expiryAddress == null) ? 0 : expiryAddress.hashCode());
-      result = prime * result + ((expiryDelay == null) ? 0 : expiryDelay.hashCode());
-      result = prime * result + ((minExpiryDelay == null) ? 0 : expiryDelay.hashCode());
-      result = prime * result + ((maxExpiryDelay == null) ? 0 : expiryDelay.hashCode());
-      result = prime * result + ((defaultLastValueQueue == null) ? 0 : defaultLastValueQueue.hashCode());
-      result = prime * result + ((defaultLastValueKey == null) ? 0 : defaultLastValueKey.hashCode());
-      result = prime * result + ((defaultNonDestructive == null) ? 0 : defaultNonDestructive.hashCode());
-      result = prime * result + ((defaultExclusiveQueue == null) ? 0 : defaultExclusiveQueue.hashCode());
-      result = prime * result + ((maxDeliveryAttempts == null) ? 0 : maxDeliveryAttempts.hashCode());
-      result = prime * result + ((maxSizeBytes == null) ? 0 : maxSizeBytes.hashCode());
-      result = prime * result + ((messageCounterHistoryDayLimit == null) ? 0 : messageCounterHistoryDayLimit.hashCode());
-      result = prime * result + ((pageSizeBytes == null) ? 0 : pageSizeBytes.hashCode());
-      result = prime * result + ((pageMaxCache == null) ? 0 : pageMaxCache.hashCode());
-      result = prime * result + ((redeliveryDelay == null) ? 0 : redeliveryDelay.hashCode());
-      result = prime * result + ((redeliveryMultiplier == null) ? 0 : redeliveryMultiplier.hashCode());
-      result = prime * result + ((redeliveryCollisionAvoidanceFactor == null) ? 0 : redeliveryCollisionAvoidanceFactor.hashCode());
-      result = prime * result + ((maxRedeliveryDelay == null) ? 0 : maxRedeliveryDelay.hashCode());
-      result = prime * result + ((redistributionDelay == null) ? 0 : redistributionDelay.hashCode());
-      result = prime * result + ((sendToDLAOnNoRoute == null) ? 0 : sendToDLAOnNoRoute.hashCode());
-      result = prime * result + ((slowConsumerThreshold == null) ? 0 : slowConsumerThreshold.hashCode());
-      result = prime * result + ((slowConsumerCheckPeriod == null) ? 0 : slowConsumerCheckPeriod.hashCode());
-      result = prime * result + ((slowConsumerPolicy == null) ? 0 : slowConsumerPolicy.hashCode());
-      result = prime * result + ((autoCreateJmsQueues == null) ? 0 : autoCreateJmsQueues.hashCode());
-      result = prime * result + ((autoDeleteJmsQueues == null) ? 0 : autoDeleteJmsQueues.hashCode());
-      result = prime * result + ((autoCreateJmsTopics == null) ? 0 : autoCreateJmsTopics.hashCode());
-      result = prime * result + ((autoDeleteJmsTopics == null) ? 0 : autoDeleteJmsTopics.hashCode());
-      result = prime * result + ((autoCreateQueues == null) ? 0 : autoCreateQueues.hashCode());
-      result = prime * result + ((autoDeleteQueues == null) ? 0 : autoDeleteQueues.hashCode());
-      result = prime * result + ((autoDeleteCreatedQueues == null) ? 0 : autoDeleteCreatedQueues.hashCode());
-      result = prime * result + ((autoDeleteQueuesDelay == null) ? 0 : autoDeleteQueuesDelay.hashCode());
-      result = prime * result + ((autoDeleteQueuesSkipUsageCheck == null) ? 0 : autoDeleteQueuesSkipUsageCheck.hashCode());
-      result = prime * result + ((autoDeleteQueuesMessageCount == null) ? 0 : autoDeleteQueuesMessageCount.hashCode());
-      result = prime * result + ((configDeleteQueues == null) ? 0 : configDeleteQueues.hashCode());
-      result = prime * result + ((autoCreateAddresses == null) ? 0 : autoCreateAddresses.hashCode());
-      result = prime * result + ((autoDeleteAddresses == null) ? 0 : autoDeleteAddresses.hashCode());
-      result = prime * result + ((autoDeleteAddressesDelay == null) ? 0 : autoDeleteAddressesDelay.hashCode());
-      result = prime * result + ((autoDeleteAddressesSkipUsageCheck == null) ? 0 : autoDeleteAddressesSkipUsageCheck.hashCode());
-      result = prime * result + ((configDeleteAddresses == null) ? 0 : configDeleteAddresses.hashCode());
-      result = prime * result + ((configDeleteDiverts == null) ? 0 : configDeleteDiverts.hashCode());
-      result = prime * result + ((managementBrowsePageSize == null) ? 0 : managementBrowsePageSize.hashCode());
-      result = prime * result + ((queuePrefetch == null) ? 0 : queuePrefetch.hashCode());
-      result = prime * result + ((maxSizeBytesRejectThreshold == null) ? 0 : maxSizeBytesRejectThreshold.hashCode());
-      result = prime * result + ((defaultMaxConsumers == null) ? 0 : defaultMaxConsumers.hashCode());
-      result = prime * result + ((defaultPurgeOnNoConsumers == null) ? 0 : defaultPurgeOnNoConsumers.hashCode());
-      result = prime * result + ((defaultQueueRoutingType == null) ? 0 : defaultQueueRoutingType.hashCode());
-      result = prime * result + ((defaultAddressRoutingType == null) ? 0 : defaultAddressRoutingType.hashCode());
-      result = prime * result + ((defaultConsumersBeforeDispatch == null) ? 0 : defaultConsumersBeforeDispatch.hashCode());
-      result = prime * result + ((defaultDelayBeforeDispatch == null) ? 0 : defaultDelayBeforeDispatch.hashCode());
-      result = prime * result + ((defaultConsumerWindowSize == null) ? 0 : defaultConsumerWindowSize.hashCode());
-      result = prime * result + ((defaultGroupRebalance == null) ? 0 : defaultGroupRebalance.hashCode());
-      result = prime * result + ((defaultGroupRebalancePauseDispatch == null) ? 0 : defaultGroupRebalancePauseDispatch.hashCode());
-      result = prime * result + ((defaultGroupBuckets == null) ? 0 : defaultGroupBuckets.hashCode());
-      result = prime * result + ((defaultGroupFirstKey == null) ? 0 : defaultGroupFirstKey.hashCode());
-      result = prime * result + ((defaultRingSize == null) ? 0 : defaultRingSize.hashCode());
-      result = prime * result + ((retroactiveMessageCount == null) ? 0 : retroactiveMessageCount.hashCode());
-      result = prime * result + ((autoCreateDeadLetterResources == null) ? 0 : autoCreateDeadLetterResources.hashCode());
-      result = prime * result + ((deadLetterQueuePrefix == null) ? 0 : deadLetterQueuePrefix.hashCode());
-      result = prime * result + ((deadLetterQueueSuffix == null) ? 0 : deadLetterQueueSuffix.hashCode());
-      result = prime * result + ((autoCreateExpiryResources == null) ? 0 : autoCreateExpiryResources.hashCode());
-      result = prime * result + ((expiryQueuePrefix == null) ? 0 : expiryQueuePrefix.hashCode());
-      result = prime * result + ((expiryQueueSuffix == null) ? 0 : expiryQueueSuffix.hashCode());
-      result = prime * result + ((enableMetrics == null) ? 0 : enableMetrics.hashCode());
-      result = prime * result + ((managementMessageAttributeSizeLimit == null) ? 0 : managementMessageAttributeSizeLimit.hashCode());
-      result = prime * result + ((slowConsumerThresholdMeasurementUnit == null) ? 0 : slowConsumerThresholdMeasurementUnit.hashCode());
-      result = prime * result + ((enableIngressTimestamp == null) ? 0 : enableIngressTimestamp.hashCode());
-      result = prime * result + ((maxSizeMessages == null) ? 0 : maxSizeMessages.hashCode());
-      result = prime * result + ((pageLimitBytes == null) ? 0 : pageLimitBytes.hashCode());
-      result = prime * result + ((pageLimitMessages == null) ? 0 : pageLimitMessages.hashCode());
-      result = prime * result + ((pageFullMessagePolicy == null) ? 0 : pageFullMessagePolicy.hashCode());
-      result = prime * result + ((idCacheSize == null) ? 0 : idCacheSize.hashCode());
-      result = prime * result + ((prefetchPageBytes == null) ? 0 : prefetchPageBytes.hashCode());
-      result = prime * result + ((prefetchPageMessages == null) ? 0 : prefetchPageMessages.hashCode());
-
+      int result = addressFullMessagePolicy != null ? addressFullMessagePolicy.hashCode() : 0;
+      result = 31 * result + (maxSizeBytes != null ? maxSizeBytes.hashCode() : 0);
+      result = 31 * result + (maxReadPageBytes != null ? maxReadPageBytes.hashCode() : 0);
+      result = 31 * result + (maxReadPageMessages != null ? maxReadPageMessages.hashCode() : 0);
+      result = 31 * result + (prefetchPageBytes != null ? prefetchPageBytes.hashCode() : 0);
+      result = 31 * result + (prefetchPageMessages != null ? prefetchPageMessages.hashCode() : 0);
+      result = 31 * result + (pageLimitBytes != null ? pageLimitBytes.hashCode() : 0);
+      result = 31 * result + (pageLimitMessages != null ? pageLimitMessages.hashCode() : 0);
+      result = 31 * result + (pageFullMessagePolicy != null ? pageFullMessagePolicy.hashCode() : 0);
+      result = 31 * result + (maxSizeMessages != null ? maxSizeMessages.hashCode() : 0);
+      result = 31 * result + (pageSizeBytes != null ? pageSizeBytes.hashCode() : 0);
+      result = 31 * result + (pageCacheMaxSize != null ? pageCacheMaxSize.hashCode() : 0);
+      result = 31 * result + (dropMessagesWhenFull != null ? dropMessagesWhenFull.hashCode() : 0);
+      result = 31 * result + (maxDeliveryAttempts != null ? maxDeliveryAttempts.hashCode() : 0);
+      result = 31 * result + (messageCounterHistoryDayLimit != null ? messageCounterHistoryDayLimit.hashCode() : 0);
+      result = 31 * result + (redeliveryDelay != null ? redeliveryDelay.hashCode() : 0);
+      result = 31 * result + (redeliveryMultiplier != null ? redeliveryMultiplier.hashCode() : 0);
+      result = 31 * result + (redeliveryCollisionAvoidanceFactor != null ? redeliveryCollisionAvoidanceFactor.hashCode() : 0);
+      result = 31 * result + (maxRedeliveryDelay != null ? maxRedeliveryDelay.hashCode() : 0);
+      result = 31 * result + (deadLetterAddress != null ? deadLetterAddress.hashCode() : 0);
+      result = 31 * result + (expiryAddress != null ? expiryAddress.hashCode() : 0);
+      result = 31 * result + (expiryDelay != null ? expiryDelay.hashCode() : 0);
+      result = 31 * result + (minExpiryDelay != null ? minExpiryDelay.hashCode() : 0);
+      result = 31 * result + (maxExpiryDelay != null ? maxExpiryDelay.hashCode() : 0);
+      result = 31 * result + (defaultLastValueQueue != null ? defaultLastValueQueue.hashCode() : 0);
+      result = 31 * result + (defaultLastValueKey != null ? defaultLastValueKey.hashCode() : 0);
+      result = 31 * result + (defaultNonDestructive != null ? defaultNonDestructive.hashCode() : 0);
+      result = 31 * result + (defaultExclusiveQueue != null ? defaultExclusiveQueue.hashCode() : 0);
+      result = 31 * result + (defaultGroupRebalance != null ? defaultGroupRebalance.hashCode() : 0);
+      result = 31 * result + (defaultGroupRebalancePauseDispatch != null ? defaultGroupRebalancePauseDispatch.hashCode() : 0);
+      result = 31 * result + (defaultGroupBuckets != null ? defaultGroupBuckets.hashCode() : 0);
+      result = 31 * result + (defaultGroupFirstKey != null ? defaultGroupFirstKey.hashCode() : 0);
+      result = 31 * result + (redistributionDelay != null ? redistributionDelay.hashCode() : 0);
+      result = 31 * result + (sendToDLAOnNoRoute != null ? sendToDLAOnNoRoute.hashCode() : 0);
+      result = 31 * result + (slowConsumerThreshold != null ? slowConsumerThreshold.hashCode() : 0);
+      result = 31 * result + (slowConsumerThresholdMeasurementUnit != null ? slowConsumerThresholdMeasurementUnit.hashCode() : 0);
+      result = 31 * result + (slowConsumerCheckPeriod != null ? slowConsumerCheckPeriod.hashCode() : 0);
+      result = 31 * result + (slowConsumerPolicy != null ? slowConsumerPolicy.hashCode() : 0);
+      result = 31 * result + (autoCreateJmsQueues != null ? autoCreateJmsQueues.hashCode() : 0);
+      result = 31 * result + (autoDeleteJmsQueues != null ? autoDeleteJmsQueues.hashCode() : 0);
+      result = 31 * result + (autoCreateJmsTopics != null ? autoCreateJmsTopics.hashCode() : 0);
+      result = 31 * result + (autoDeleteJmsTopics != null ? autoDeleteJmsTopics.hashCode() : 0);
+      result = 31 * result + (autoCreateQueues != null ? autoCreateQueues.hashCode() : 0);
+      result = 31 * result + (autoDeleteQueues != null ? autoDeleteQueues.hashCode() : 0);
+      result = 31 * result + (autoDeleteCreatedQueues != null ? autoDeleteCreatedQueues.hashCode() : 0);
+      result = 31 * result + (autoDeleteQueuesDelay != null ? autoDeleteQueuesDelay.hashCode() : 0);
+      result = 31 * result + (autoDeleteQueuesSkipUsageCheck != null ? autoDeleteQueuesSkipUsageCheck.hashCode() : 0);
+      result = 31 * result + (autoDeleteQueuesMessageCount != null ? autoDeleteQueuesMessageCount.hashCode() : 0);
+      result = 31 * result + (defaultRingSize != null ? defaultRingSize.hashCode() : 0);
+      result = 31 * result + (retroactiveMessageCount != null ? retroactiveMessageCount.hashCode() : 0);
+      result = 31 * result + (configDeleteQueues != null ? configDeleteQueues.hashCode() : 0);
+      result = 31 * result + (autoCreateAddresses != null ? autoCreateAddresses.hashCode() : 0);
+      result = 31 * result + (autoDeleteAddresses != null ? autoDeleteAddresses.hashCode() : 0);
+      result = 31 * result + (autoDeleteAddressesDelay != null ? autoDeleteAddressesDelay.hashCode() : 0);
+      result = 31 * result + (autoDeleteAddressesSkipUsageCheck != null ? autoDeleteAddressesSkipUsageCheck.hashCode() : 0);
+      result = 31 * result + (configDeleteAddresses != null ? configDeleteAddresses.hashCode() : 0);
+      result = 31 * result + (configDeleteDiverts != null ? configDeleteDiverts.hashCode() : 0);
+      result = 31 * result + (managementBrowsePageSize != null ? managementBrowsePageSize.hashCode() : 0);
+      result = 31 * result + (maxSizeBytesRejectThreshold != null ? maxSizeBytesRejectThreshold.hashCode() : 0);
+      result = 31 * result + (defaultMaxConsumers != null ? defaultMaxConsumers.hashCode() : 0);
+      result = 31 * result + (defaultPurgeOnNoConsumers != null ? defaultPurgeOnNoConsumers.hashCode() : 0);
+      result = 31 * result + (defaultConsumersBeforeDispatch != null ? defaultConsumersBeforeDispatch.hashCode() : 0);
+      result = 31 * result + (defaultDelayBeforeDispatch != null ? defaultDelayBeforeDispatch.hashCode() : 0);
+      result = 31 * result + (defaultQueueRoutingType != null ? defaultQueueRoutingType.hashCode() : 0);
+      result = 31 * result + (defaultAddressRoutingType != null ? defaultAddressRoutingType.hashCode() : 0);
+      result = 31 * result + (defaultConsumerWindowSize != null ? defaultConsumerWindowSize.hashCode() : 0);
+      result = 31 * result + (autoCreateDeadLetterResources != null ? autoCreateDeadLetterResources.hashCode() : 0);
+      result = 31 * result + (deadLetterQueuePrefix != null ? deadLetterQueuePrefix.hashCode() : 0);
+      result = 31 * result + (deadLetterQueueSuffix != null ? deadLetterQueueSuffix.hashCode() : 0);
+      result = 31 * result + (autoCreateExpiryResources != null ? autoCreateExpiryResources.hashCode() : 0);
+      result = 31 * result + (expiryQueuePrefix != null ? expiryQueuePrefix.hashCode() : 0);
+      result = 31 * result + (expiryQueueSuffix != null ? expiryQueueSuffix.hashCode() : 0);
+      result = 31 * result + (enableMetrics != null ? enableMetrics.hashCode() : 0);
+      result = 31 * result + (managementMessageAttributeSizeLimit != null ? managementMessageAttributeSizeLimit.hashCode() : 0);
+      result = 31 * result + (enableIngressTimestamp != null ? enableIngressTimestamp.hashCode() : 0);
+      result = 31 * result + (idCacheSize != null ? idCacheSize.hashCode() : 0);
+      result = 31 * result + (queuePrefetch != null ? queuePrefetch.hashCode() : 0);
       return result;
    }
 
-   /* (non-Javadoc)
-    * @see java.lang.Object#equals(java.lang.Object)
-    */
-   @Override
-   public boolean equals(Object obj) {
-      if (this == obj)
-         return true;
-      if (obj == null)
-         return false;
-      if (getClass() != obj.getClass())
-         return false;
-      AddressSettings other = (AddressSettings) obj;
-      if (addressFullMessagePolicy == null) {
-         if (other.addressFullMessagePolicy != null)
-            return false;
-      } else if (!addressFullMessagePolicy.equals(other.addressFullMessagePolicy))
-         return false;
-      if (deadLetterAddress == null) {
-         if (other.deadLetterAddress != null)
-            return false;
-      } else if (!deadLetterAddress.equals(other.deadLetterAddress))
-         return false;
-      if (dropMessagesWhenFull == null) {
-         if (other.dropMessagesWhenFull != null)
-            return false;
-      } else if (!dropMessagesWhenFull.equals(other.dropMessagesWhenFull))
-         return false;
-      if (expiryAddress == null) {
-         if (other.expiryAddress != null)
-            return false;
-      } else if (!expiryAddress.equals(other.expiryAddress))
-         return false;
-      if (expiryDelay == null) {
-         if (other.expiryDelay != null)
-            return false;
-      } else if (!expiryDelay.equals(other.expiryDelay))
-         return false;
-      if (minExpiryDelay == null) {
-         if (other.minExpiryDelay != null)
-            return false;
-      } else if (!minExpiryDelay.equals(other.minExpiryDelay))
-         return false;
-      if (maxExpiryDelay == null) {
-         if (other.maxExpiryDelay != null)
-            return false;
-      } else if (!maxExpiryDelay.equals(other.maxExpiryDelay))
-         return false;
-      if (defaultLastValueQueue == null) {
-         if (other.defaultLastValueQueue != null)
-            return false;
-      } else if (!defaultLastValueQueue.equals(other.defaultLastValueQueue))
-         return false;
-      if (defaultLastValueKey == null) {
-         if (other.defaultLastValueKey != null)
-            return false;
-      } else if (!defaultLastValueKey.equals(other.defaultLastValueKey))
-         return false;
-      if (defaultNonDestructive == null) {
-         if (other.defaultNonDestructive != null)
-            return false;
-      } else if (!defaultNonDestructive.equals(other.defaultNonDestructive))
-         return false;
-      if (defaultExclusiveQueue == null) {
-         if (other.defaultExclusiveQueue != null)
-            return false;
-      } else if (!defaultExclusiveQueue.equals(other.defaultExclusiveQueue))
-         return false;
-      if (maxDeliveryAttempts == null) {
-         if (other.maxDeliveryAttempts != null)
-            return false;
-      } else if (!maxDeliveryAttempts.equals(other.maxDeliveryAttempts))
-         return false;
-      if (maxSizeBytes == null) {
-         if (other.maxSizeBytes != null)
-            return false;
-      } else if (!maxSizeBytes.equals(other.maxSizeBytes))
-         return false;
-      if (messageCounterHistoryDayLimit == null) {
-         if (other.messageCounterHistoryDayLimit != null)
-            return false;
-      } else if (!messageCounterHistoryDayLimit.equals(other.messageCounterHistoryDayLimit))
-         return false;
-      if (pageSizeBytes == null) {
-         if (other.pageSizeBytes != null)
-            return false;
-      } else if (!pageSizeBytes.equals(other.pageSizeBytes))
-         return false;
-      if (pageMaxCache == null) {
-         if (other.pageMaxCache != null)
-            return false;
-      } else if (!pageMaxCache.equals(other.pageMaxCache))
-         return false;
-      if (redeliveryDelay == null) {
-         if (other.redeliveryDelay != null)
-            return false;
-      } else if (!redeliveryDelay.equals(other.redeliveryDelay))
-         return false;
-      if (redeliveryMultiplier == null) {
-         if (other.redeliveryMultiplier != null)
-            return false;
-      } else if (!redeliveryMultiplier.equals(other.redeliveryMultiplier))
-         return false;
-      if (redeliveryCollisionAvoidanceFactor == null) {
-         if (other.redeliveryCollisionAvoidanceFactor != null)
-            return false;
-      } else if (!redeliveryCollisionAvoidanceFactor.equals(other.redeliveryCollisionAvoidanceFactor))
-         return false;
-      if (maxRedeliveryDelay == null) {
-         if (other.maxRedeliveryDelay != null)
-            return false;
-      } else if (!maxRedeliveryDelay.equals(other.maxRedeliveryDelay))
-         return false;
-      if (redistributionDelay == null) {
-         if (other.redistributionDelay != null)
-            return false;
-      } else if (!redistributionDelay.equals(other.redistributionDelay))
-         return false;
-      if (sendToDLAOnNoRoute == null) {
-         if (other.sendToDLAOnNoRoute != null)
-            return false;
-      } else if (!sendToDLAOnNoRoute.equals(other.sendToDLAOnNoRoute))
-         return false;
-      if (slowConsumerThreshold == null) {
-         if (other.slowConsumerThreshold != null)
-            return false;
-      } else if (!slowConsumerThreshold.equals(other.slowConsumerThreshold))
-         return false;
-      if (slowConsumerCheckPeriod == null) {
-         if (other.slowConsumerCheckPeriod != null)
-            return false;
-      } else if (!slowConsumerCheckPeriod.equals(other.slowConsumerCheckPeriod))
-         return false;
-      if (slowConsumerPolicy == null) {
-         if (other.slowConsumerPolicy != null)
-            return false;
-      } else if (!slowConsumerPolicy.equals(other.slowConsumerPolicy))
-         return false;
-      if (autoCreateJmsQueues == null) {
-         if (other.autoCreateJmsQueues != null)
-            return false;
-      } else if (!autoCreateJmsQueues.equals(other.autoCreateJmsQueues))
-         return false;
-      if (autoDeleteJmsQueues == null) {
-         if (other.autoDeleteJmsQueues != null)
-            return false;
-      } else if (!autoDeleteJmsQueues.equals(other.autoDeleteJmsQueues))
-         return false;
-      if (autoCreateJmsTopics == null) {
-         if (other.autoCreateJmsTopics != null)
-            return false;
-      } else if (!autoCreateJmsTopics.equals(other.autoCreateJmsTopics))
-         return false;
-      if (autoDeleteJmsTopics == null) {
-         if (other.autoDeleteJmsTopics != null)
-            return false;
-      } else if (!autoDeleteJmsTopics.equals(other.autoDeleteJmsTopics))
-         return false;
-      if (autoCreateQueues == null) {
-         if (other.autoCreateQueues != null)
-            return false;
-      } else if (!autoCreateQueues.equals(other.autoCreateQueues))
-         return false;
-      if (autoDeleteQueues == null) {
-         if (other.autoDeleteQueues != null)
-            return false;
-      } else if (!autoDeleteQueues.equals(other.autoDeleteQueues))
-         return false;
-      if (autoDeleteCreatedQueues == null) {
-         if (other.autoDeleteCreatedQueues != null)
-            return false;
-      } else if (!autoDeleteCreatedQueues.equals(other.autoDeleteCreatedQueues))
-         return false;
-      if (autoDeleteQueuesDelay == null) {
-         if (other.autoDeleteQueuesDelay != null)
-            return false;
-      } else if (!autoDeleteQueuesDelay.equals(other.autoDeleteQueuesDelay))
-         return false;
-      if (autoDeleteQueuesSkipUsageCheck == null) {
-         if (other.autoDeleteQueuesSkipUsageCheck != null)
-            return false;
-      } else if (!autoDeleteQueuesSkipUsageCheck.equals(other.autoDeleteQueuesSkipUsageCheck))
-         return false;
-      if (autoDeleteQueuesMessageCount == null) {
-         if (other.autoDeleteQueuesMessageCount != null)
-            return false;
-      } else if (!autoDeleteQueuesMessageCount.equals(other.autoDeleteQueuesMessageCount))
-         return false;
-      if (configDeleteQueues == null) {
-         if (other.configDeleteQueues != null)
-            return false;
-      } else if (!configDeleteQueues.equals(other.configDeleteQueues))
-         return false;
-      if (autoCreateAddresses == null) {
-         if (other.autoCreateAddresses != null)
-            return false;
-      } else if (!autoCreateAddresses.equals(other.autoCreateAddresses))
-         return false;
-      if (autoDeleteAddresses == null) {
-         if (other.autoDeleteAddresses != null)
-            return false;
-      } else if (!autoDeleteAddresses.equals(other.autoDeleteAddresses))
-         return false;
-      if (autoDeleteAddressesDelay == null) {
-         if (other.autoDeleteAddressesDelay != null)
-            return false;
-      } else if (!autoDeleteAddressesDelay.equals(other.autoDeleteAddressesDelay))
-         return false;
-      if (autoDeleteAddressesSkipUsageCheck == null) {
-         if (other.autoDeleteAddressesSkipUsageCheck != null)
-            return false;
-      } else if (!autoDeleteAddressesSkipUsageCheck.equals(other.autoDeleteAddressesSkipUsageCheck))
-         return false;
-      if (configDeleteAddresses == null) {
-         if (other.configDeleteAddresses != null)
-            return false;
-      } else if (!configDeleteAddresses.equals(other.configDeleteAddresses))
-         return false;
-      if (configDeleteDiverts == null) {
-         if (other.configDeleteDiverts != null)
-            return false;
-      } else if (!configDeleteDiverts.equals(other.configDeleteDiverts))
-         return false;
-      if (managementBrowsePageSize == null) {
-         if (other.managementBrowsePageSize != null)
-            return false;
-      } else if (!managementBrowsePageSize.equals(other.managementBrowsePageSize))
-         return false;
-      if (managementMessageAttributeSizeLimit == null) {
-         if (other.managementMessageAttributeSizeLimit != null)
-            return false;
-      } else if (!managementMessageAttributeSizeLimit.equals(other.managementMessageAttributeSizeLimit))
-         return false;
-      if (queuePrefetch == null) {
-         if (other.queuePrefetch != null)
-            return false;
-      } else if (!queuePrefetch.equals(other.queuePrefetch))
-         return false;
-
-      if (maxSizeBytesRejectThreshold == null) {
-         if (other.maxSizeBytesRejectThreshold != null)
-            return false;
-      } else if (!maxSizeBytesRejectThreshold.equals(other.maxSizeBytesRejectThreshold))
-         return false;
-
-      if (defaultMaxConsumers == null) {
-         if (other.defaultMaxConsumers != null)
-            return false;
-      } else if (!defaultMaxConsumers.equals(other.defaultMaxConsumers))
-         return false;
-
-      if (defaultPurgeOnNoConsumers == null) {
-         if (other.defaultPurgeOnNoConsumers != null)
-            return false;
-      } else if (!defaultPurgeOnNoConsumers.equals(other.defaultPurgeOnNoConsumers))
-         return false;
-
-      if (defaultQueueRoutingType == null) {
-         if (other.defaultQueueRoutingType != null)
-            return false;
-      } else if (!defaultQueueRoutingType.equals(other.defaultQueueRoutingType))
-         return false;
-
-      if (defaultAddressRoutingType == null) {
-         if (other.defaultAddressRoutingType != null)
-            return false;
-      } else if (!defaultAddressRoutingType.equals(other.defaultAddressRoutingType))
-         return false;
-
-      if (defaultConsumersBeforeDispatch == null) {
-         if (other.defaultConsumersBeforeDispatch != null)
-            return false;
-      } else if (!defaultConsumersBeforeDispatch.equals(other.defaultConsumersBeforeDispatch))
-         return false;
-
-      if (defaultDelayBeforeDispatch == null) {
-         if (other.defaultDelayBeforeDispatch != null)
-            return false;
-      } else if (!defaultDelayBeforeDispatch.equals(other.defaultDelayBeforeDispatch))
-         return false;
-
-      if (defaultConsumerWindowSize == null) {
-         if (other.defaultConsumerWindowSize != null)
-            return false;
-      } else if (!defaultConsumerWindowSize.equals(other.defaultConsumerWindowSize))
-         return false;
-
-      if (defaultGroupRebalance == null) {
-         if (other.defaultGroupRebalance != null)
-            return false;
-      } else if (!defaultGroupRebalance.equals(other.defaultGroupRebalance))
-         return false;
-
-      if (defaultGroupRebalancePauseDispatch == null) {
-         if (other.defaultGroupRebalancePauseDispatch != null)
-            return false;
-      } else if (!defaultGroupRebalancePauseDispatch.equals(other.defaultGroupRebalancePauseDispatch))
-         return false;
-
-      if (defaultGroupBuckets == null) {
-         if (other.defaultGroupBuckets != null)
-            return false;
-      } else if (!defaultGroupBuckets.equals(other.defaultGroupBuckets))
-         return false;
-
-      if (defaultGroupFirstKey == null) {
-         if (other.defaultGroupFirstKey != null)
-            return false;
-      } else if (!defaultGroupFirstKey.equals(other.defaultGroupFirstKey))
-         return false;
-
-      if (defaultRingSize == null) {
-         if (other.defaultRingSize != null)
-            return false;
-      } else if (!defaultRingSize.equals(other.defaultRingSize))
-         return false;
-
-      if (retroactiveMessageCount == null) {
-         if (other.retroactiveMessageCount != null)
-            return false;
-      } else if (!retroactiveMessageCount.equals(other.retroactiveMessageCount))
-         return false;
-
-      if (autoCreateDeadLetterResources == null) {
-         if (other.autoCreateDeadLetterResources != null)
-            return false;
-      } else if (!autoCreateDeadLetterResources.equals(other.autoCreateDeadLetterResources))
-         return false;
-
-      if (deadLetterQueuePrefix == null) {
-         if (other.deadLetterQueuePrefix != null)
-            return false;
-      } else if (!deadLetterQueuePrefix.equals(other.deadLetterQueuePrefix))
-         return false;
-
-      if (deadLetterQueueSuffix == null) {
-         if (other.deadLetterQueueSuffix != null)
-            return false;
-      } else if (!deadLetterQueueSuffix.equals(other.deadLetterQueueSuffix))
-         return false;
-
-      if (autoCreateExpiryResources == null) {
-         if (other.autoCreateExpiryResources != null)
-            return false;
-      } else if (!autoCreateExpiryResources.equals(other.autoCreateExpiryResources))
-         return false;
-
-      if (expiryQueuePrefix == null) {
-         if (other.expiryQueuePrefix != null)
-            return false;
-      } else if (!expiryQueuePrefix.equals(other.expiryQueuePrefix))
-         return false;
-
-      if (expiryQueueSuffix == null) {
-         if (other.expiryQueueSuffix != null)
-            return false;
-      } else if (!expiryQueueSuffix.equals(other.expiryQueueSuffix))
-         return false;
-
-      if (enableMetrics == null) {
-         if (other.enableMetrics != null)
-            return false;
-      } else if (!enableMetrics.equals(other.enableMetrics))
-         return false;
-
-      if (slowConsumerThresholdMeasurementUnit != other.slowConsumerThresholdMeasurementUnit)
-         return false;
-
-      if (enableIngressTimestamp == null) {
-         if (other.enableIngressTimestamp != null)
-            return false;
-      } else if (!enableIngressTimestamp.equals(other.enableIngressTimestamp))
-         return false;
-
-      if (maxSizeMessages == null) {
-         if (other.maxSizeMessages != null)
-            return false;
-      } else if (!maxSizeMessages.equals(other.maxSizeMessages))
-         return false;
-
-      if (pageLimitBytes == null) {
-         if (other.pageLimitBytes != null) {
-            return false;
-         }
-      } else if (!pageLimitBytes.equals(other.pageLimitBytes)) {
-         return false;
-      }
-
-      if (pageLimitMessages == null) {
-         if (other.pageLimitMessages != null) {
-            return false;
-         }
-      } else if (!pageLimitMessages.equals(other.pageLimitMessages)) {
-         return false;
-      }
-
-      if (pageFullMessagePolicy == null) {
-         if (other.pageFullMessagePolicy != null) {
-            return false;
-         }
-      } else if (!pageFullMessagePolicy.equals(other.pageFullMessagePolicy)) {
-         return false;
-      }
-
-      if (idCacheSize == null) {
-         if (other.idCacheSize != null) {
-            return false;
-         }
-      } else if (!idCacheSize.equals(other.idCacheSize)) {
-         return false;
-      }
-
-      if (prefetchPageMessages == null) {
-         if (other.prefetchPageMessages != null) {
-            return false;
-         }
-      } else if (!prefetchPageMessages.equals(other.prefetchPageMessages)) {
-         return false;
-      }
-
-      if (prefetchPageBytes == null) {
-         if (other.prefetchPageBytes != null) {
-            return false;
-         }
-      } else if (!prefetchPageBytes.equals(other.prefetchPageBytes)) {
-         return false;
-      }
-
-      return true;
-   }
-
-   /* (non-Javadoc)
-    * @see java.lang.Object#toString()
-    */
    @Override
    public String toString() {
-      return "AddressSettings [addressFullMessagePolicy=" + addressFullMessagePolicy +
-         ", deadLetterAddress=" +
-         deadLetterAddress +
-         ", dropMessagesWhenFull=" +
-         dropMessagesWhenFull +
-         ", expiryAddress=" +
-         expiryAddress +
-         ", expiryDelay=" +
-         expiryDelay +
-         ", minExpiryDelay=" +
-         minExpiryDelay +
-         ", maxExpiryDelay=" +
-         maxExpiryDelay +
-         ", defaultLastValueQueue=" +
-         defaultLastValueQueue +
-         ", defaultLastValueKey=" +
-         defaultLastValueKey +
-         ", defaultNonDestructive=" +
-         defaultNonDestructive +
-         ", defaultExclusiveQueue=" +
-         defaultExclusiveQueue +
-         ", maxDeliveryAttempts=" +
-         maxDeliveryAttempts +
-         ", maxSizeBytes=" +
-         maxSizeBytes +
-         ", maxSizeBytesRejectThreshold=" +
-         maxSizeBytesRejectThreshold +
-         ", messageCounterHistoryDayLimit=" +
-         messageCounterHistoryDayLimit +
-         ", pageSizeBytes=" +
-         pageSizeBytes +
-         ", pageMaxCache=" +
-         pageMaxCache +
-         ", redeliveryDelay=" +
-         redeliveryDelay +
-         ", redeliveryMultiplier=" +
-         redeliveryMultiplier +
-         ", redeliveryCollisionAvoidanceFactor=" +
-         redeliveryCollisionAvoidanceFactor +
-         ", maxRedeliveryDelay=" +
-         maxRedeliveryDelay +
-         ", redistributionDelay=" +
-         redistributionDelay +
-         ", sendToDLAOnNoRoute=" +
-         sendToDLAOnNoRoute +
-         ", slowConsumerThreshold=" +
-         slowConsumerThreshold +
-         ", slowConsumerThresholdMeasurementUnit=" +
-         slowConsumerThresholdMeasurementUnit +
-         ", slowConsumerCheckPeriod=" +
-         slowConsumerCheckPeriod +
-         ", slowConsumerPolicy=" +
-         slowConsumerPolicy +
-         ", autoCreateJmsQueues=" +
-         autoCreateJmsQueues +
-         ", autoDeleteJmsQueues=" +
-         autoDeleteJmsQueues +
-         ", autoCreateJmsTopics=" +
-         autoCreateJmsTopics +
-         ", autoDeleteJmsTopics=" +
-         autoDeleteJmsTopics +
-         ", autoCreateQueues=" +
-         autoCreateQueues +
-         ", autoDeleteQueues=" +
-         autoDeleteQueues +
-         ", autoDeleteCreatedQueues=" +
-         autoDeleteCreatedQueues +
-         ", autoDeleteQueuesDelay=" +
-         autoDeleteQueuesDelay +
-         ", autoDeleteQueuesSkipUsageCheck=" +
-         autoDeleteQueuesSkipUsageCheck +
-         ", autoDeleteQueuesMessageCount=" +
-         autoDeleteQueuesMessageCount +
-         ", configDeleteQueues=" +
-         configDeleteQueues +
-         ", autoCreateAddresses=" +
-         autoCreateAddresses +
-         ", autoDeleteAddresses=" +
-         autoDeleteAddresses +
-         ", autoDeleteAddressesDelay=" +
-         autoDeleteAddressesDelay +
-         ", autoDeleteAddressesSkipUsageCheck=" +
-         autoDeleteAddressesSkipUsageCheck +
-         ", configDeleteAddresses=" +
-         configDeleteAddresses  +
-         ", configDeleteDiverts=" +
-         configDeleteDiverts +
-         ", managementBrowsePageSize=" +
-         managementBrowsePageSize +
-         ", managementMessageAttributeSizeLimit=" +
-         managementMessageAttributeSizeLimit +
-         ", defaultMaxConsumers=" +
-         defaultMaxConsumers +
-         ", defaultPurgeOnNoConsumers=" +
-         defaultPurgeOnNoConsumers +
-         ", defaultQueueRoutingType=" +
-         defaultQueueRoutingType +
-         ", defaultAddressRoutingType=" +
-         defaultAddressRoutingType +
-         ", defaultConsumersBeforeDispatch=" +
-         defaultConsumersBeforeDispatch +
-         ", defaultDelayBeforeDispatch=" +
-         defaultDelayBeforeDispatch +
-         ", defaultClientWindowSize=" +
-         defaultConsumerWindowSize +
-         ", defaultGroupRebalance=" +
-         defaultGroupRebalance +
-         ", defaultGroupRebalancePauseDispatch=" +
-         defaultGroupRebalancePauseDispatch +
-         ", defaultGroupBuckets=" +
-         defaultGroupBuckets +
-         ", defaultGroupFirstKey=" +
-         defaultGroupFirstKey +
-         ", defaultRingSize=" +
-         defaultRingSize +
-         ", retroactiveMessageCount=" +
-         retroactiveMessageCount +
-         ", autoCreateDeadLetterResources=" +
-         autoCreateDeadLetterResources +
-         ", deadLetterQueuePrefix=" +
-         deadLetterQueuePrefix +
-         ", deadLetterQueueSuffix=" +
-         deadLetterQueueSuffix +
-         ", autoCreateExpiryResources=" +
-         autoCreateExpiryResources +
-         ", expiryQueuePrefix=" +
-         expiryQueuePrefix +
-         ", expiryQueueSuffix=" +
-         expiryQueueSuffix +
-         ", enableMetrics=" +
-         enableMetrics +
-         ", enableIngressTime=" +
-         enableIngressTimestamp +
-         ", pageLimitBytes=" +
-         pageLimitBytes +
-         ", pageLimitMessages=" +
-         pageLimitMessages +
-         ", pageFullMessagePolicy=" +
-         pageFullMessagePolicy +
-         ", idCacheSize=" +
-         idCacheSize +
-         ", prefetchPageMessages=" +
-         prefetchPageMessages +
-         ", prefetchPageBytes=" +
-         prefetchPageBytes +
-         "]";
+      return "AddressSettings{" + "addressFullMessagePolicy=" + addressFullMessagePolicy + ", maxSizeBytes=" + maxSizeBytes + ", maxReadPageBytes=" + maxReadPageBytes + ", maxReadPageMessages=" + maxReadPageMessages + ", prefetchPageBytes=" + prefetchPageBytes + ", prefetchPageMessages=" + prefetchPageMessages + ", pageLimitBytes=" + pageLimitBytes + ", pageLimitMessages=" + pageLimitMessages + ", pageFullMessagePolicy=" + pageFullMessagePolicy + ", maxSizeMessages=" + maxSizeMessages + ", pageSizeBytes=" + pageSizeBytes + ", pageMaxCache=" + pageCacheMaxSize + ", dropMessagesWhenFull=" + dropMessagesWhenFull + ", maxDeliveryAttempts=" + maxDeliveryAttempts + ", messageCounterHistoryDayLimit=" + messageCounterHistoryDayLimit + ", redeliveryDelay=" + redeliveryDelay + ", redeliveryMultiplier=" + redeliveryMultiplier + ", redeliveryCollisionAvoidanceFactor=" + redeliveryCollisionAvoidanceFactor + ", maxRedeliveryDelay=" + maxRedeliveryDelay + ", deadLetterAddress=" + deadLetterAddress + ", expiryAddress=" + expiryAddress + ", expiryDelay=" + expiryDelay + ", minExpiryDelay=" + minExpiryDelay + ", maxExpiryDelay=" + maxExpiryDelay + ", defaultLastValueQueue=" + defaultLastValueQueue + ", defaultLastValueKey=" + defaultLastValueKey + ", defaultNonDestructive=" + defaultNonDestructive + ", defaultExclusiveQueue=" + defaultExclusiveQueue + ", defaultGroupRebalance=" + defaultGroupRebalance + ", defaultGroupRebalancePauseDispatch=" + defaultGroupRebalancePauseDispatch + ", defaultGroupBuckets=" + defaultGroupBuckets + ", defaultGroupFirstKey=" + defaultGroupFirstKey + ", redistributionDelay=" + redistributionDelay + ", sendToDLAOnNoRoute=" + sendToDLAOnNoRoute + ", slowConsumerThreshold=" + slowConsumerThreshold + ", slowConsumerThresholdMeasurementUnit=" + slowConsumerThresholdMeasurementUnit + ", slowConsumerCheckPeriod=" + slowConsumerCheckPeriod + ", slowConsumerPolicy=" + slowConsumerPolicy + ", autoCreateJmsQueues=" + autoCreateJmsQueues + ", autoDeleteJmsQueues=" + autoDeleteJmsQueues + ", autoCreateJmsTopics=" + autoCreateJmsTopics + ", autoDeleteJmsTopics=" + autoDeleteJmsTopics + ", autoCreateQueues=" + autoCreateQueues + ", autoDeleteQueues=" + autoDeleteQueues + ", autoDeleteCreatedQueues=" + autoDeleteCreatedQueues + ", autoDeleteQueuesDelay=" + autoDeleteQueuesDelay + ", autoDeleteQueuesSkipUsageCheck=" + autoDeleteQueuesSkipUsageCheck + ", autoDeleteQueuesMessageCount=" + autoDeleteQueuesMessageCount + ", defaultRingSize=" + defaultRingSize + ", retroactiveMessageCount=" + retroactiveMessageCount + ", configDeleteQueues=" + configDeleteQueues + ", autoCreateAddresses=" + autoCreateAddresses + ", autoDeleteAddresses=" + autoDeleteAddresses + ", autoDeleteAddressesDelay=" + autoDeleteAddressesDelay + ", autoDeleteAddressesSkipUsageCheck=" + autoDeleteAddressesSkipUsageCheck + ", configDeleteAddresses=" + configDeleteAddresses + ", configDeleteDiverts=" + configDeleteDiverts + ", managementBrowsePageSize=" + managementBrowsePageSize + ", maxSizeBytesRejectThreshold=" + maxSizeBytesRejectThreshold + ", defaultMaxConsumers=" + defaultMaxConsumers + ", defaultPurgeOnNoConsumers=" + defaultPurgeOnNoConsumers + ", defaultConsumersBeforeDispatch=" + defaultConsumersBeforeDispatch + ", defaultDelayBeforeDispatch=" + defaultDelayBeforeDispatch + ", defaultQueueRoutingType=" + defaultQueueRoutingType + ", defaultAddressRoutingType=" + defaultAddressRoutingType + ", defaultConsumerWindowSize=" + defaultConsumerWindowSize + ", autoCreateDeadLetterResources=" + autoCreateDeadLetterResources + ", deadLetterQueuePrefix=" + deadLetterQueuePrefix + ", deadLetterQueueSuffix=" + deadLetterQueueSuffix + ", autoCreateExpiryResources=" + autoCreateExpiryResources + ", expiryQueuePrefix=" + expiryQueuePrefix + ", expiryQueueSuffix=" + expiryQueueSuffix + ", enableMetrics=" + enableMetrics + ", managementMessageAttributeSizeLimit=" + managementMessageAttributeSizeLimit + ", enableIngressTimestamp=" + enableIngressTimestamp + ", idCacheSize=" + idCacheSize + ", queuePrefetch=" + queuePrefetch + '}';
    }
 }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/settings/AddressSettingsTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/settings/AddressSettingsTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.settings;
 
+import java.lang.invoke.MethodHandles;
+
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
@@ -24,8 +26,12 @@ import org.apache.activemq.artemis.core.settings.impl.DeletionPolicy;
 import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Assert;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AddressSettingsTest extends ActiveMQTestBase {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    @Test
    public void testDefaults() {
@@ -165,5 +171,31 @@ public class AddressSettingsTest extends ActiveMQTestBase {
       Assert.assertEquals(addressSettings.getRedeliveryMultiplier(), 1.0, 0.000001);
       Assert.assertEquals(addressSettings.getMaxRedeliveryDelay(), 5000);
       Assert.assertEquals(AddressFullMessagePolicy.DROP, addressSettings.getAddressFullMessagePolicy());
+   }
+
+   @Test
+   public void testToJSON() {
+      AddressSettings addressSettings = new AddressSettings();
+      SimpleString DLQ = new SimpleString("testDLQ");
+      SimpleString exp = new SimpleString("testExpiryQueue");
+      addressSettings.setDeadLetterAddress(DLQ);
+      addressSettings.setExpiryAddress(exp);
+      addressSettings.setMaxSizeBytes(1001);
+      addressSettings.setPrefetchPageMessages(1000);
+      addressSettings.setRedeliveryDelay(1003);
+      addressSettings.setRedeliveryMultiplier(1.0);
+      addressSettings.setAddressFullMessagePolicy(AddressFullMessagePolicy.DROP);
+
+      String json = addressSettings.toJSON();
+      logger.info("Json:: {}", json);
+
+      AddressSettings jsonClone = AddressSettings.fromJSON(json);
+      Assert.assertEquals(1001, jsonClone.getMaxSizeBytes());
+      System.err.println("AddressSettings::" + addressSettings);
+      System.err.println("clonedSettings ::" + jsonClone);
+      Assert.assertEquals(addressSettings.getAddressFullMessagePolicy(), jsonClone.getAddressFullMessagePolicy());
+
+      Assert.assertEquals(addressSettings, jsonClone);
+
    }
 }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/settings/impl/AddressSettingsRandomTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/settings/impl/AddressSettingsRandomTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.core.settings.impl;
+
+import java.lang.invoke.MethodHandles;
+
+import org.apache.activemq.artemis.utils.bean.MetaBean;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AddressSettingsRandomTest {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   @Test
+   public void testRandomGeneration() {
+
+      MetaBean json = AddressSettings.metaBean;
+
+      AddressSettings randomSettings = new AddressSettings();
+
+      json.setRandom(randomSettings);
+
+      String jsonOutput = randomSettings.toJSON();
+      logger.debug(jsonOutput);
+
+      AddressSettings outputSettings = AddressSettings.fromJSON(jsonOutput);
+      Assert.assertEquals(randomSettings, outputSettings);
+
+      AddressSettings copy = new AddressSettings(randomSettings);
+      Assert.assertEquals(randomSettings, copy);
+
+   }
+}

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/transaction/impl/TransactionImplTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/transaction/impl/TransactionImplTest.java
@@ -44,7 +44,9 @@ import org.apache.activemq.artemis.core.persistence.GroupingInfo;
 import org.apache.activemq.artemis.core.persistence.OperationContext;
 import org.apache.activemq.artemis.core.persistence.QueueBindingInfo;
 import org.apache.activemq.artemis.core.persistence.StorageManager;
+import org.apache.activemq.artemis.core.persistence.config.AbstractPersistedAddressSetting;
 import org.apache.activemq.artemis.core.persistence.config.PersistedAddressSetting;
+import org.apache.activemq.artemis.core.persistence.config.PersistedAddressSettingJSON;
 import org.apache.activemq.artemis.core.persistence.config.PersistedBridgeConfiguration;
 import org.apache.activemq.artemis.core.persistence.config.PersistedConnector;
 import org.apache.activemq.artemis.core.persistence.config.PersistedDivertConfiguration;
@@ -354,6 +356,11 @@ public class TransactionImplTest extends ActiveMQTestBase {
 
       @Override
       public void updateQueueBinding(long tx, Binding binding) throws Exception {
+
+      }
+
+      @Override
+      public void storeAddressSetting(PersistedAddressSettingJSON addressSetting) throws Exception {
 
       }
 
@@ -698,7 +705,7 @@ public class TransactionImplTest extends ActiveMQTestBase {
       }
 
       @Override
-      public List<PersistedAddressSetting> recoverAddressSettings() throws Exception {
+      public List<AbstractPersistedAddressSetting> recoverAddressSettings() throws Exception {
          return null;
       }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SendAckFailTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SendAckFailTest.java
@@ -60,7 +60,9 @@ import org.apache.activemq.artemis.core.persistence.OperationContext;
 import org.apache.activemq.artemis.core.persistence.QueueBindingInfo;
 import org.apache.activemq.artemis.core.persistence.AddressQueueStatus;
 import org.apache.activemq.artemis.core.persistence.StorageManager;
+import org.apache.activemq.artemis.core.persistence.config.AbstractPersistedAddressSetting;
 import org.apache.activemq.artemis.core.persistence.config.PersistedAddressSetting;
+import org.apache.activemq.artemis.core.persistence.config.PersistedAddressSettingJSON;
 import org.apache.activemq.artemis.core.persistence.config.PersistedBridgeConfiguration;
 import org.apache.activemq.artemis.core.persistence.config.PersistedConnector;
 import org.apache.activemq.artemis.core.persistence.config.PersistedDivertConfiguration;
@@ -308,6 +310,10 @@ public class SendAckFailTest extends SpawnedTestBase {
       @Override
       public void updateQueueBinding(long tx, Binding binding) throws Exception {
          manager.updateQueueBinding(tx, binding);
+      }
+
+      @Override
+      public void storeAddressSetting(PersistedAddressSettingJSON addressSetting) throws Exception {
       }
 
       @Override
@@ -685,7 +691,7 @@ public class SendAckFailTest extends SpawnedTestBase {
       }
 
       @Override
-      public List<PersistedAddressSetting> recoverAddressSettings() throws Exception {
+      public List<AbstractPersistedAddressSetting> recoverAddressSettings() throws Exception {
          return manager.recoverAddressSettings();
       }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/RedeployTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/RedeployTest.java
@@ -334,7 +334,10 @@ public class RedeployTest extends ActiveMQTestBase {
          AddressSettings addressSettings = embeddedActiveMQ.getActiveMQServer().getAddressSettingsRepository().getMatch("foo");
          assertEquals("a", addressSettings.getDeadLetterAddress().toString());
 
-         embeddedActiveMQ.getActiveMQServer().getActiveMQServerControl().addAddressSettings("bar", "c", null, 0, false, 0, 0, 0, 0, 0, 0, 0, 0, false, null, 0, 0, null, false, false, false, false);
+         AddressSettings settings = new AddressSettings();
+         settings.setDeadLetterAddress(SimpleString.toSimpleString("c")).setExpiryDelay(0L);
+
+         embeddedActiveMQ.getActiveMQServer().getActiveMQServerControl().addAddressSettings("bar", settings.toJSON());
          addressSettings = embeddedActiveMQ.getActiveMQServer().getAddressSettingsRepository().getMatch("bar");
          assertEquals("c", addressSettings.getDeadLetterAddress().toString());
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/journal/DuplicateRecordIdTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/journal/DuplicateRecordIdTest.java
@@ -22,7 +22,9 @@ import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl;
 import org.apache.activemq.artemis.api.core.management.AddressSettingsInfo;
 import org.apache.activemq.artemis.cli.commands.tools.PrintData;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
+import org.apache.activemq.artemis.core.settings.impl.SlowConsumerPolicy;
 import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,8 +47,16 @@ public class DuplicateRecordIdTest extends ActiveMQTestBase {
          server.start();
          ActiveMQServerControl serverControl = server.getActiveMQServerControl();
          serverControl.removeAddressSettings("q");
-         AddressSettingsInfo defaultSettings = AddressSettingsInfo.from(serverControl.getAddressSettingsAsJSON("#"));
-         serverControl.addAddressSettings("q", "dlq", defaultSettings.getExpiryAddress(), -1, false, 1, defaultSettings.getMaxSizeBytes(), defaultSettings.getPageSizeBytes(), defaultSettings.getPageCacheMaxSize(), defaultSettings.getRedeliveryDelay(), defaultSettings.getRedeliveryMultiplier(), defaultSettings.getMaxRedeliveryDelay(), defaultSettings.getRedistributionDelay(), defaultSettings.isSendToDLAOnNoRoute(), defaultSettings.getAddressFullMessagePolicy(), defaultSettings.getSlowConsumerThreshold(), defaultSettings.getSlowConsumerCheckPeriod(), defaultSettings.getSlowConsumerPolicy(), defaultSettings.isAutoCreateJmsQueues(), defaultSettings.isAutoDeleteJmsQueues(), defaultSettings.isAutoCreateJmsQueues(), defaultSettings.isAutoDeleteJmsTopics());
+         AddressSettingsInfo defaultSettings = AddressSettingsInfo.fromJSON(serverControl.getAddressSettingsAsJSON("#"));
+         AddressSettings settings = new AddressSettings();
+         settings.setExpiryAddress(SimpleString.toSimpleString(defaultSettings.getExpiryAddress())).setExpiryDelay(defaultSettings.getExpiryDelay()).setMaxDeliveryAttempts(1)
+                 .setMaxSizeBytes(defaultSettings.getMaxSizeBytes()).setPageSizeBytes(defaultSettings.getPageSizeBytes())
+                 .setPageCacheMaxSize(defaultSettings.getPageCacheMaxSize()).setRedeliveryDelay(defaultSettings.getRedeliveryDelay())
+                 .setMaxExpiryDelay(defaultSettings.getMaxRedeliveryDelay()).setRedistributionDelay(defaultSettings.getRedistributionDelay())
+                 .setSendToDLAOnNoRoute(defaultSettings.isSendToDLAOnNoRoute()).setAddressFullMessagePolicy(AddressFullMessagePolicy.valueOf(defaultSettings.getAddressFullMessagePolicy()))
+                 .setSlowConsumerThreshold(defaultSettings.getSlowConsumerThreshold())
+                 .setSlowConsumerCheckPeriod(defaultSettings.getSlowConsumerCheckPeriod()).setSlowConsumerPolicy(SlowConsumerPolicy.valueOf(defaultSettings.getSlowConsumerPolicy()));
+         serverControl.addAddressSettings("q", settings.toJSON());
          server.stop();
          PrintData.printData(server.getConfiguration().getBindingsLocation().getAbsoluteFile(), server.getConfiguration().getJournalLocation().getAbsoluteFile(), server.getConfiguration().getPagingLocation().getAbsoluteFile());
       }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
@@ -98,6 +98,7 @@ import org.apache.activemq.artemis.core.server.ServiceComponent;
 import org.apache.activemq.artemis.core.server.impl.AddressInfo;
 import org.apache.activemq.artemis.core.server.impl.ServerLegacyProducersImpl;
 import org.apache.activemq.artemis.core.server.plugin.ActiveMQServerSessionPlugin;
+import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.core.settings.impl.DeletionPolicy;
 import org.apache.activemq.artemis.core.settings.impl.SlowConsumerPolicy;
@@ -1142,6 +1143,92 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
    }
 
    @Test
+   public void mergeAddressSettings() throws Exception {
+      ActiveMQServerControl serverControl = createManagementControl();
+      AddressSettings addressSettings = new AddressSettings();
+      addressSettings.setDeadLetterAddress(new SimpleString("DLA"));
+      String returnedSettings = serverControl.addAddressSettings("foo", addressSettings.toJSON());
+      AddressSettings info = AddressSettings.fromJSON(returnedSettings);
+      assertEquals(addressSettings.getDeadLetterAddress(), info.getDeadLetterAddress());
+      assertNull(info.getExpiryAddress());
+      assertEquals(addressSettings.getRedeliveryDelay(), 0);
+
+
+      addressSettings.setExpiryAddress(SimpleString.toSimpleString("EA"));
+      returnedSettings = serverControl.addAddressSettings("foo", addressSettings.toJSON());
+      info = AddressSettings.fromJSON(returnedSettings);
+      assertEquals(addressSettings.getDeadLetterAddress(), info.getDeadLetterAddress());
+      assertEquals(addressSettings.getExpiryAddress(), info.getExpiryAddress());
+
+      addressSettings.setRedeliveryDelay(1000);
+      returnedSettings = serverControl.addAddressSettings("foo", addressSettings.toJSON());
+      info = AddressSettings.fromJSON(returnedSettings);
+      assertEquals(addressSettings.getDeadLetterAddress(), info.getDeadLetterAddress());
+      assertEquals(addressSettings.getExpiryAddress(), info.getExpiryAddress());
+      assertEquals(addressSettings.getRedeliveryDelay(), info.getRedeliveryDelay());
+   }
+   @Test
+   public void emptyAddressSettings() throws Exception {
+      ActiveMQServerControl serverControl = createManagementControl();
+      AddressSettings addressSettings = new AddressSettings();
+      String returnedSettings = serverControl.addAddressSettings("foo", addressSettings.toJSON());
+      AddressSettings info = AddressSettings.fromJSON(returnedSettings);
+
+      assertEquals(addressSettings.getDeadLetterAddress(), info.getDeadLetterAddress());
+      assertEquals(addressSettings.getExpiryAddress(), info.getExpiryAddress());
+      assertEquals(addressSettings.getExpiryDelay(), info.getExpiryDelay());
+      assertEquals(addressSettings.getMinExpiryDelay(), info.getMinExpiryDelay());
+      assertEquals(addressSettings.getMaxExpiryDelay(), info.getMaxExpiryDelay());
+      assertEquals(addressSettings.isDefaultLastValueQueue(), info.isDefaultLastValueQueue());
+      assertEquals(addressSettings.getMaxDeliveryAttempts(), info.getMaxDeliveryAttempts());
+      assertEquals(addressSettings.getMaxSizeBytes(), info.getMaxSizeBytes());
+      assertEquals(addressSettings.getPageCacheMaxSize(), info.getPageCacheMaxSize());
+      assertEquals(addressSettings.getPageSizeBytes(), info.getPageSizeBytes());
+      assertEquals(addressSettings.getRedeliveryDelay(), info.getRedeliveryDelay());
+      assertEquals(addressSettings.getRedeliveryMultiplier(), info.getRedeliveryMultiplier(), 0.000001);
+      assertEquals(addressSettings.getMaxRedeliveryDelay(), info.getMaxRedeliveryDelay());
+      assertEquals(addressSettings.getRedistributionDelay(), info.getRedistributionDelay());
+      assertEquals(addressSettings.isSendToDLAOnNoRoute(), info.isSendToDLAOnNoRoute());
+      assertEquals(addressSettings.getAddressFullMessagePolicy(), info.getAddressFullMessagePolicy());
+      assertEquals(addressSettings.getSlowConsumerThreshold(), info.getSlowConsumerThreshold());
+      assertEquals(addressSettings.getSlowConsumerCheckPeriod(), info.getSlowConsumerCheckPeriod());
+      assertEquals(addressSettings.getSlowConsumerPolicy(), info.getSlowConsumerPolicy());
+      assertEquals(addressSettings.isAutoCreateQueues(), info.isAutoCreateQueues());
+      assertEquals(addressSettings.isAutoDeleteQueues(), info.isAutoDeleteQueues());
+      assertEquals(addressSettings.isAutoCreateAddresses(), info.isAutoCreateAddresses());
+      assertEquals(addressSettings.isAutoDeleteAddresses(), info.isAutoDeleteAddresses());
+      assertEquals(addressSettings.getConfigDeleteQueues(), info.getConfigDeleteQueues());
+      assertEquals(addressSettings.getConfigDeleteAddresses(), info.getConfigDeleteAddresses());
+      assertEquals(addressSettings.getMaxSizeBytesRejectThreshold(), info.getMaxSizeBytesRejectThreshold());
+      assertEquals(addressSettings.getDefaultLastValueKey(), info.getDefaultLastValueKey());
+      assertEquals(addressSettings.isDefaultNonDestructive(), info.isDefaultNonDestructive());
+      assertEquals(addressSettings.isDefaultExclusiveQueue(), info.isDefaultExclusiveQueue());
+      assertEquals(addressSettings.isDefaultGroupRebalance(), info.isDefaultGroupRebalance());
+      assertEquals(addressSettings.getDefaultGroupBuckets(), info.getDefaultGroupBuckets());
+      assertEquals(addressSettings.getDefaultGroupFirstKey(), info.getDefaultGroupFirstKey());
+      assertEquals(addressSettings.getDefaultMaxConsumers(), info.getDefaultMaxConsumers());
+      assertEquals(addressSettings.isDefaultPurgeOnNoConsumers(), info.isDefaultPurgeOnNoConsumers());
+      assertEquals(addressSettings.getDefaultConsumersBeforeDispatch(), info.getDefaultConsumersBeforeDispatch());
+      assertEquals(addressSettings.getDefaultDelayBeforeDispatch(), info.getDefaultDelayBeforeDispatch());
+      assertEquals(addressSettings.getDefaultQueueRoutingType(), info.getDefaultQueueRoutingType());
+      assertEquals(addressSettings.getDefaultAddressRoutingType(), info.getDefaultAddressRoutingType());
+      assertEquals(addressSettings.getDefaultConsumerWindowSize(), info.getDefaultConsumerWindowSize());
+      assertEquals(addressSettings.getDefaultRingSize(), info.getDefaultRingSize());
+      assertEquals(addressSettings.isAutoDeleteCreatedQueues(), info.isAutoDeleteCreatedQueues());
+      assertEquals(addressSettings.getAutoDeleteQueuesDelay(), info.getAutoDeleteQueuesDelay());
+      assertEquals(addressSettings.getAutoDeleteQueuesMessageCount(), info.getAutoDeleteQueuesMessageCount());
+      assertEquals(addressSettings.getAutoDeleteAddressesDelay(), info.getAutoDeleteAddressesDelay());
+      assertEquals(addressSettings.getRedeliveryCollisionAvoidanceFactor(), info.getRedeliveryCollisionAvoidanceFactor(), 0);
+      assertEquals(addressSettings.getRetroactiveMessageCount(), info.getRetroactiveMessageCount());
+      assertEquals(addressSettings.isAutoCreateDeadLetterResources(), info.isAutoCreateDeadLetterResources());
+      assertEquals(addressSettings.getDeadLetterQueuePrefix(), info.getDeadLetterQueuePrefix());
+      assertEquals(addressSettings.getDeadLetterQueueSuffix(), info.getDeadLetterQueueSuffix());
+      assertEquals(addressSettings.isAutoCreateExpiryResources(), info.isAutoCreateExpiryResources());
+      assertEquals(addressSettings.getExpiryQueuePrefix(), info.getExpiryQueuePrefix());
+      assertEquals(addressSettings.getExpiryQueueSuffix(), info.getExpiryQueueSuffix());
+      assertEquals(addressSettings.isEnableMetrics(), info.isEnableMetrics());
+   }
+   @Test
    public void testAddressSettings() throws Exception {
       ActiveMQServerControl serverControl = createManagementControl();
       String addressMatch = "test.#";
@@ -1166,10 +1253,6 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       long slowConsumerThreshold = 5;
       long slowConsumerCheckPeriod = 10;
       String slowConsumerPolicy = SlowConsumerPolicy.getType(RandomUtil.randomPositiveInt() % 2).toString();
-      boolean autoCreateJmsQueues = RandomUtil.randomBoolean();
-      boolean autoDeleteJmsQueues = RandomUtil.randomBoolean();
-      boolean autoCreateJmsTopics = RandomUtil.randomBoolean();
-      boolean autoDeleteJmsTopics = RandomUtil.randomBoolean();
       boolean autoCreateQueues = RandomUtil.randomBoolean();
       boolean autoDeleteQueues = RandomUtil.randomBoolean();
       boolean autoCreateAddresses = RandomUtil.randomBoolean();
@@ -1205,125 +1288,69 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       String expiryQueueSuffix = RandomUtil.randomString();
       boolean enableMetrics = RandomUtil.randomBoolean();
 
-      serverControl.addAddressSettings(addressMatch,
-                                       DLA,
-                                       expiryAddress,
-                                       expiryDelay,
-                                       lastValueQueue,
-                                       deliveryAttempts,
-                                       maxSizeBytes,
-                                       pageSizeBytes,
-                                       pageMaxCacheSize,
-                                       redeliveryDelay,
-                                       redeliveryMultiplier,
-                                       maxRedeliveryDelay,
-                                       redistributionDelay,
-                                       sendToDLAOnNoRoute,
-                                       addressFullMessagePolicy,
-                                       slowConsumerThreshold,
-                                       slowConsumerCheckPeriod,
-                                       slowConsumerPolicy,
-                                       autoCreateJmsQueues,
-                                       autoDeleteJmsQueues,
-                                       autoCreateJmsTopics,
-                                       autoDeleteJmsTopics,
-                                       autoCreateQueues,
-                                       autoDeleteQueues,
-                                       autoCreateAddresses,
-                                       autoDeleteAddresses,
-                                       configDeleteQueues,
-                                       configDeleteAddresses,
-                                       maxSizeBytesRejectThreshold,
-                                       defaultLastValueKey,
-                                       defaultNonDestructive,
-                                       defaultExclusiveQueue,
-                                       defaultGroupRebalance,
-                                       defaultGroupBuckets,
-                                       defaultGroupFirstKey,
-                                       defaultMaxConsumers,
-                                       defaultPurgeOnNoConsumers,
-                                       defaultConsumersBeforeDispatch,
-                                       defaultDelayBeforeDispatch,
-                                       defaultQueueRoutingType,
-                                       defaultAddressRoutingType,
-                                       defaultConsumerWindowSize,
-                                       defaultRingSize,
-                                       autoDeleteCreatedQueues,
-                                       autoDeleteQueuesDelay,
-                                       autoDeleteQueuesMessageCount,
-                                       autoDeleteAddressesDelay,
-                                       redeliveryCollisionAvoidanceFactor,
-                                       retroactiveMessageCount,
-                                       autoCreateDeadLetterResources,
-                                       deadLetterQueuePrefix,
-                                       deadLetterQueueSuffix,
-                                       autoCreateExpiryResources,
-                                       expiryQueuePrefix,
-                                       expiryQueueSuffix,
-                                       minExpiryDelay,
-                                       maxExpiryDelay,
-                                       enableMetrics);
+      AddressSettings addressSettings = new AddressSettings();
+      addressSettings.setDeadLetterAddress(new SimpleString(DLA))
+              .setExpiryAddress(new SimpleString(expiryAddress))
+              .setExpiryDelay(expiryDelay)
+              .setDefaultLastValueQueue(lastValueQueue)
+              .setMaxDeliveryAttempts(deliveryAttempts)
+              .setMaxSizeBytes(maxSizeBytes)
+              .setPageSizeBytes(pageSizeBytes)
+              .setPageCacheMaxSize(pageMaxCacheSize)
+              .setRedeliveryDelay(redeliveryDelay)
+              .setRedeliveryMultiplier(redeliveryMultiplier)
+              .setMaxRedeliveryDelay(maxRedeliveryDelay)
+              .setRedistributionDelay(redistributionDelay)
+              .setSendToDLAOnNoRoute(sendToDLAOnNoRoute)
+              .setAddressFullMessagePolicy(AddressFullMessagePolicy.valueOf(addressFullMessagePolicy))
+              .setSlowConsumerThreshold(slowConsumerThreshold)
+              .setSlowConsumerCheckPeriod(slowConsumerCheckPeriod)
+              .setSlowConsumerPolicy(SlowConsumerPolicy.valueOf(slowConsumerPolicy))
+              .setAutoCreateQueues(autoCreateQueues)
+              .setAutoDeleteQueues(autoDeleteQueues)
+              .setAutoCreateAddresses(autoCreateAddresses)
+              .setAutoDeleteAddresses(autoDeleteAddresses)
+              .setConfigDeleteQueues(DeletionPolicy.valueOf(configDeleteQueues))
+              .setConfigDeleteAddresses(DeletionPolicy.valueOf(configDeleteAddresses))
+              .setMaxSizeBytesRejectThreshold(maxSizeBytesRejectThreshold)
+              .setDefaultLastValueKey(SimpleString.toSimpleString(defaultLastValueKey))
+              .setDefaultNonDestructive(defaultNonDestructive)
+              .setDefaultExclusiveQueue(defaultExclusiveQueue)
+              .setDefaultGroupRebalance(defaultGroupRebalance)
+              .setDefaultGroupBuckets(defaultGroupBuckets)
+              .setDefaultGroupFirstKey(SimpleString.toSimpleString(defaultGroupFirstKey))
+              .setDefaultMaxConsumers(defaultMaxConsumers)
+              .setDefaultPurgeOnNoConsumers(defaultPurgeOnNoConsumers)
+              .setDefaultConsumersBeforeDispatch(defaultConsumersBeforeDispatch)
+              .setDefaultDelayBeforeDispatch(defaultDelayBeforeDispatch)
+              .setDefaultQueueRoutingType(RoutingType.valueOf(defaultQueueRoutingType))
+              .setDefaultAddressRoutingType(RoutingType.valueOf(defaultAddressRoutingType))
+              .setDefaultConsumerWindowSize(defaultConsumerWindowSize)
+              .setDefaultRingSize(defaultRingSize)
+              .setAutoDeleteCreatedQueues(autoDeleteCreatedQueues)
+              .setAutoDeleteQueuesDelay(autoDeleteQueuesDelay)
+              .setAutoDeleteQueuesMessageCount(autoDeleteQueuesMessageCount)
+              .setAutoDeleteAddressesDelay(autoDeleteAddressesDelay)
+              .setRedeliveryCollisionAvoidanceFactor(redeliveryCollisionAvoidanceFactor)
+              .setRetroactiveMessageCount(retroactiveMessageCount)
+              .setAutoCreateDeadLetterResources(autoCreateDeadLetterResources)
+              .setDeadLetterQueuePrefix(SimpleString.toSimpleString(deadLetterQueuePrefix))
+              .setDeadLetterQueueSuffix(SimpleString.toSimpleString(deadLetterQueueSuffix))
+              .setAutoCreateExpiryResources(autoCreateExpiryResources)
+              .setExpiryQueuePrefix(SimpleString.toSimpleString(expiryQueuePrefix))
+              .setExpiryQueueSuffix(SimpleString.toSimpleString(expiryQueueSuffix))
+              .setMinExpiryDelay(minExpiryDelay)
+              .setMaxExpiryDelay(maxExpiryDelay)
+              .setEnableMetrics(enableMetrics);
+
+
+      serverControl.addAddressSettings(addressMatch, addressSettings.toJSON());
+
+      addressSettings.setMaxSizeBytes(100).setPageSizeBytes(1000);
 
       boolean ex = false;
       try {
-         serverControl.addAddressSettings(addressMatch,
-                                          DLA,
-                                          expiryAddress,
-                                          expiryDelay,
-                                          lastValueQueue,
-                                          deliveryAttempts,
-                                          100,
-                                          1000,
-                                          pageMaxCacheSize,
-                                          redeliveryDelay,
-                                          redeliveryMultiplier,
-                                          maxRedeliveryDelay,
-                                          redistributionDelay,
-                                          sendToDLAOnNoRoute,
-                                          addressFullMessagePolicy,
-                                          slowConsumerThreshold,
-                                          slowConsumerCheckPeriod,
-                                          slowConsumerPolicy,
-                                          autoCreateJmsQueues,
-                                          autoDeleteJmsQueues,
-                                          autoCreateJmsTopics,
-                                          autoDeleteJmsTopics,
-                                          autoCreateQueues,
-                                          autoDeleteQueues,
-                                          autoCreateAddresses,
-                                          autoDeleteAddresses,
-                                          configDeleteQueues,
-                                          configDeleteAddresses,
-                                          maxSizeBytesRejectThreshold,
-                                          defaultLastValueKey,
-                                          defaultNonDestructive,
-                                          defaultExclusiveQueue,
-                                          defaultGroupRebalance,
-                                          defaultGroupBuckets,
-                                          defaultGroupFirstKey,
-                                          defaultMaxConsumers,
-                                          defaultPurgeOnNoConsumers,
-                                          defaultConsumersBeforeDispatch,
-                                          defaultDelayBeforeDispatch,
-                                          defaultQueueRoutingType,
-                                          defaultAddressRoutingType,
-                                          defaultConsumerWindowSize,
-                                          defaultRingSize,
-                                          autoDeleteCreatedQueues,
-                                          autoDeleteQueuesDelay,
-                                          autoDeleteQueuesMessageCount,
-                                          autoDeleteAddressesDelay,
-                                          redeliveryCollisionAvoidanceFactor,
-                                          retroactiveMessageCount,
-                                          autoCreateDeadLetterResources,
-                                          deadLetterQueuePrefix,
-                                          deadLetterQueueSuffix,
-                                          autoCreateExpiryResources,
-                                          expiryQueuePrefix,
-                                          expiryQueueSuffix,
-                                          minExpiryDelay,
-                                          maxExpiryDelay,
-                                          enableMetrics);
+         serverControl.addAddressSettings(addressMatch, addressSettings.toJSON());
       } catch (Exception expected) {
          ex = true;
       }
@@ -1333,14 +1360,14 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       serverControl = createManagementControl();
 
       String jsonString = serverControl.getAddressSettingsAsJSON(exactAddress);
-      AddressSettingsInfo info = AddressSettingsInfo.from(jsonString);
+      AddressSettingsInfo info = AddressSettingsInfo.fromJSON(jsonString);
 
       assertEquals(DLA, info.getDeadLetterAddress());
       assertEquals(expiryAddress, info.getExpiryAddress());
       assertEquals(expiryDelay, info.getExpiryDelay());
       assertEquals(minExpiryDelay, info.getMinExpiryDelay());
       assertEquals(maxExpiryDelay, info.getMaxExpiryDelay());
-      assertEquals(lastValueQueue, info.isLastValueQueue());
+      assertEquals(lastValueQueue, info.isDefaultLastValueQueue());
       assertEquals(deliveryAttempts, info.getMaxDeliveryAttempts());
       assertEquals(maxSizeBytes, info.getMaxSizeBytes());
       assertEquals(pageMaxCacheSize, info.getPageCacheMaxSize());
@@ -1354,10 +1381,6 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       assertEquals(slowConsumerThreshold, info.getSlowConsumerThreshold());
       assertEquals(slowConsumerCheckPeriod, info.getSlowConsumerCheckPeriod());
       assertEquals(slowConsumerPolicy, info.getSlowConsumerPolicy());
-      assertEquals(autoCreateJmsQueues, info.isAutoCreateJmsQueues());
-      assertEquals(autoDeleteJmsQueues, info.isAutoDeleteJmsQueues());
-      assertEquals(autoCreateJmsTopics, info.isAutoCreateJmsTopics());
-      assertEquals(autoDeleteJmsTopics, info.isAutoDeleteJmsTopics());
       assertEquals(autoCreateQueues, info.isAutoCreateQueues());
       assertEquals(autoDeleteQueues, info.isAutoDeleteQueues());
       assertEquals(autoCreateAddresses, info.isAutoCreateAddresses());
@@ -1393,74 +1416,19 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       assertEquals(expiryQueueSuffix, info.getExpiryQueueSuffix());
       assertEquals(enableMetrics, info.isEnableMetrics());
 
-      serverControl.addAddressSettings(addressMatch,
-                                       DLA,
-                                       expiryAddress,
-                                       expiryDelay,
-                                       lastValueQueue,
-                                       deliveryAttempts,
-                                       -1,
-                                       1000,
-                                       pageMaxCacheSize,
-                                       redeliveryDelay,
-                                       redeliveryMultiplier,
-                                       maxRedeliveryDelay,
-                                       redistributionDelay,
-                                       sendToDLAOnNoRoute,
-                                       addressFullMessagePolicy,
-                                       slowConsumerThreshold,
-                                       slowConsumerCheckPeriod,
-                                       slowConsumerPolicy,
-                                       autoCreateJmsQueues,
-                                       autoDeleteJmsQueues,
-                                       autoCreateJmsTopics,
-                                       autoDeleteJmsTopics,
-                                       autoCreateQueues,
-                                       autoDeleteQueues,
-                                       autoCreateAddresses,
-                                       autoDeleteAddresses,
-                                       configDeleteQueues,
-                                       configDeleteAddresses,
-                                       maxSizeBytesRejectThreshold,
-                                       defaultLastValueKey,
-                                       defaultNonDestructive,
-                                       defaultExclusiveQueue,
-                                       defaultGroupRebalance,
-                                       defaultGroupBuckets,
-                                       defaultGroupFirstKey,
-                                       defaultMaxConsumers,
-                                       defaultPurgeOnNoConsumers,
-                                       defaultConsumersBeforeDispatch,
-                                       defaultDelayBeforeDispatch,
-                                       defaultQueueRoutingType,
-                                       defaultAddressRoutingType,
-                                       defaultConsumerWindowSize,
-                                       defaultRingSize,
-                                       autoDeleteCreatedQueues,
-                                       autoDeleteQueuesDelay,
-                                       autoDeleteQueuesMessageCount,
-                                       autoDeleteAddressesDelay,
-                                       redeliveryCollisionAvoidanceFactor,
-                                       retroactiveMessageCount,
-                                       autoCreateDeadLetterResources,
-                                       deadLetterQueuePrefix,
-                                       deadLetterQueueSuffix,
-                                       autoCreateExpiryResources,
-                                       expiryQueuePrefix,
-                                       expiryQueueSuffix,
-                                       minExpiryDelay,
-                                       maxExpiryDelay,
-                                       enableMetrics);
+
+      addressSettings.setMaxSizeBytes(-1).setPageSizeBytes(1000);
+      serverControl.addAddressSettings(addressMatch, addressSettings.toJSON());
 
       jsonString = serverControl.getAddressSettingsAsJSON(exactAddress);
-      info = AddressSettingsInfo.from(jsonString);
+      info = AddressSettingsInfo.fromJSON(jsonString);
 
       assertEquals(DLA, info.getDeadLetterAddress());
       assertEquals(expiryAddress, info.getExpiryAddress());
       assertEquals(expiryDelay, info.getExpiryDelay());
       assertEquals(minExpiryDelay, info.getMinExpiryDelay());
       assertEquals(maxExpiryDelay, info.getMaxExpiryDelay());
-      assertEquals(lastValueQueue, info.isLastValueQueue());
+      assertEquals(lastValueQueue, info.isDefaultLastValueQueue());
       assertEquals(deliveryAttempts, info.getMaxDeliveryAttempts());
       assertEquals(-1, info.getMaxSizeBytes());
       assertEquals(pageMaxCacheSize, info.getPageCacheMaxSize());
@@ -1474,10 +1442,6 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       assertEquals(slowConsumerThreshold, info.getSlowConsumerThreshold());
       assertEquals(slowConsumerCheckPeriod, info.getSlowConsumerCheckPeriod());
       assertEquals(slowConsumerPolicy, info.getSlowConsumerPolicy());
-      assertEquals(autoCreateJmsQueues, info.isAutoCreateJmsQueues());
-      assertEquals(autoDeleteJmsQueues, info.isAutoDeleteJmsQueues());
-      assertEquals(autoCreateJmsTopics, info.isAutoCreateJmsTopics());
-      assertEquals(autoDeleteJmsTopics, info.isAutoDeleteJmsTopics());
       assertEquals(autoCreateQueues, info.isAutoCreateQueues());
       assertEquals(autoDeleteQueues, info.isAutoDeleteQueues());
       assertEquals(autoCreateAddresses, info.isAutoCreateAddresses());
@@ -1513,66 +1477,11 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       assertEquals(expiryQueueSuffix, info.getExpiryQueueSuffix());
       assertEquals(enableMetrics, info.isEnableMetrics());
 
+
+      addressSettings.setMaxSizeBytes(-2).setPageSizeBytes(1000);
       ex = false;
       try {
-         serverControl.addAddressSettings(addressMatch,
-                                          DLA,
-                                          expiryAddress,
-                                          expiryDelay,
-                                          lastValueQueue,
-                                          deliveryAttempts,
-                                          -2,
-                                          1000,
-                                          pageMaxCacheSize,
-                                          redeliveryDelay,
-                                          redeliveryMultiplier,
-                                          maxRedeliveryDelay,
-                                          redistributionDelay,
-                                          sendToDLAOnNoRoute,
-                                          addressFullMessagePolicy,
-                                          slowConsumerThreshold,
-                                          slowConsumerCheckPeriod,
-                                          slowConsumerPolicy,
-                                          autoCreateJmsQueues,
-                                          autoDeleteJmsQueues,
-                                          autoCreateJmsTopics,
-                                          autoDeleteJmsTopics,
-                                          autoCreateQueues,
-                                          autoDeleteQueues,
-                                          autoCreateAddresses,
-                                          autoDeleteAddresses,
-                                          configDeleteQueues,
-                                          configDeleteAddresses,
-                                          maxSizeBytesRejectThreshold,
-                                          defaultLastValueKey,
-                                          defaultNonDestructive,
-                                          defaultExclusiveQueue,
-                                          defaultGroupRebalance,
-                                          defaultGroupBuckets,
-                                          defaultGroupFirstKey,
-                                          defaultMaxConsumers,
-                                          defaultPurgeOnNoConsumers,
-                                          defaultConsumersBeforeDispatch,
-                                          defaultDelayBeforeDispatch,
-                                          defaultQueueRoutingType,
-                                          defaultAddressRoutingType,
-                                          defaultConsumerWindowSize,
-                                          defaultRingSize,
-                                          autoDeleteCreatedQueues,
-                                          autoDeleteQueuesDelay,
-                                          autoDeleteQueuesMessageCount,
-                                          autoDeleteAddressesDelay,
-                                          redeliveryCollisionAvoidanceFactor,
-                                          retroactiveMessageCount,
-                                          autoCreateDeadLetterResources,
-                                          deadLetterQueuePrefix,
-                                          deadLetterQueueSuffix,
-                                          autoCreateExpiryResources,
-                                          expiryQueuePrefix,
-                                          expiryQueueSuffix,
-                                          minExpiryDelay,
-                                          maxExpiryDelay,
-                                          enableMetrics);
+         serverControl.addAddressSettings(addressMatch, addressSettings.toJSON());
       } catch (Exception e) {
          ex = true;
       }
@@ -1645,136 +1554,79 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       String expiryQueueSuffix = RandomUtil.randomString();
       boolean enableMetrics = RandomUtil.randomBoolean();
 
-      serverControl.addAddressSettings(root,
-              DLA,
-              expiryAddress,
-              expiryDelay,
-              lastValueQueue,
-              deliveryAttempts,
-              maxSizeBytes,
-              pageSizeBytes,
-              pageMaxCacheSize,
-              redeliveryDelay,
-              redeliveryMultiplier,
-              maxRedeliveryDelay,
-              redistributionDelay,
-              sendToDLAOnNoRoute,
-              addressFullMessagePolicy,
-              slowConsumerThreshold,
-              slowConsumerCheckPeriod,
-              slowConsumerPolicy,
-              autoCreateJmsQueues,
-              autoDeleteJmsQueues,
-              autoCreateJmsTopics,
-              autoDeleteJmsTopics,
-              autoCreateQueues,
-              autoDeleteQueues,
-              autoCreateAddresses,
-              autoDeleteAddresses,
-              configDeleteQueues,
-              configDeleteAddresses,
-              maxSizeBytesRejectThreshold,
-              defaultLastValueKey,
-              defaultNonDestructive,
-              defaultExclusiveQueue,
-              defaultGroupRebalance,
-              defaultGroupBuckets,
-              defaultGroupFirstKey,
-              defaultMaxConsumers,
-              defaultPurgeOnNoConsumers,
-              defaultConsumersBeforeDispatch,
-              defaultDelayBeforeDispatch,
-              defaultQueueRoutingType,
-              defaultAddressRoutingType,
-              defaultConsumerWindowSize,
-              defaultRingSize,
-              autoDeleteCreatedQueues,
-              autoDeleteQueuesDelay,
-              autoDeleteQueuesMessageCount,
-              autoDeleteAddressesDelay,
-              redeliveryCollisionAvoidanceFactor,
-              retroactiveMessageCount,
-              autoCreateDeadLetterResources,
-              deadLetterQueuePrefix,
-              deadLetterQueueSuffix,
-              autoCreateExpiryResources,
-              expiryQueuePrefix,
-              expiryQueueSuffix,
-              minExpiryDelay,
-              maxExpiryDelay,
-              enableMetrics);
+      AddressSettings addressSettings = new AddressSettings();
+      addressSettings.setDeadLetterAddress(new SimpleString(DLA))
+              .setExpiryAddress(new SimpleString(expiryAddress))
+              .setExpiryDelay(expiryDelay)
+              .setDefaultLastValueQueue(lastValueQueue)
+              .setMaxDeliveryAttempts(deliveryAttempts)
+              .setMaxSizeBytes(maxSizeBytes)
+              .setPageSizeBytes(pageSizeBytes)
+              .setPageCacheMaxSize(pageMaxCacheSize)
+              .setRedeliveryDelay(redeliveryDelay)
+              .setRedeliveryMultiplier(redeliveryMultiplier)
+              .setMaxRedeliveryDelay(maxRedeliveryDelay)
+              .setRedistributionDelay(redistributionDelay)
+              .setSendToDLAOnNoRoute(sendToDLAOnNoRoute)
+              .setAddressFullMessagePolicy(AddressFullMessagePolicy.valueOf(addressFullMessagePolicy))
+              .setSlowConsumerThreshold(slowConsumerThreshold)
+              .setSlowConsumerCheckPeriod(slowConsumerCheckPeriod)
+              .setSlowConsumerPolicy(SlowConsumerPolicy.valueOf(slowConsumerPolicy))
+              .setAutoCreateQueues(autoCreateQueues)
+              .setAutoDeleteQueues(autoDeleteQueues)
+              .setAutoCreateAddresses(autoCreateAddresses)
+              .setAutoDeleteAddresses(autoDeleteAddresses)
+              .setConfigDeleteQueues(DeletionPolicy.valueOf(configDeleteQueues))
+              .setConfigDeleteAddresses(DeletionPolicy.valueOf(configDeleteAddresses))
+              .setMaxSizeBytesRejectThreshold(maxSizeBytesRejectThreshold)
+              .setDefaultLastValueKey(SimpleString.toSimpleString(defaultLastValueKey))
+              .setDefaultNonDestructive(defaultNonDestructive)
+              .setDefaultExclusiveQueue(defaultExclusiveQueue)
+              .setDefaultGroupRebalance(defaultGroupRebalance)
+              .setDefaultGroupBuckets(defaultGroupBuckets)
+              .setDefaultGroupFirstKey(SimpleString.toSimpleString(defaultGroupFirstKey))
+              .setDefaultMaxConsumers(defaultMaxConsumers)
+              .setDefaultPurgeOnNoConsumers(defaultPurgeOnNoConsumers)
+              .setDefaultConsumersBeforeDispatch(defaultConsumersBeforeDispatch)
+              .setDefaultDelayBeforeDispatch(defaultDelayBeforeDispatch)
+              .setDefaultQueueRoutingType(RoutingType.valueOf(defaultQueueRoutingType))
+              .setDefaultAddressRoutingType(RoutingType.valueOf(defaultAddressRoutingType))
+              .setDefaultConsumerWindowSize(defaultConsumerWindowSize)
+              .setDefaultRingSize(defaultRingSize)
+              .setAutoDeleteCreatedQueues(autoDeleteCreatedQueues)
+              .setAutoDeleteQueuesDelay(autoDeleteQueuesDelay)
+              .setAutoDeleteQueuesMessageCount(autoDeleteQueuesMessageCount)
+              .setAutoDeleteAddressesDelay(autoDeleteAddressesDelay)
+              .setRedeliveryCollisionAvoidanceFactor(redeliveryCollisionAvoidanceFactor)
+              .setRetroactiveMessageCount(retroactiveMessageCount)
+              .setAutoCreateDeadLetterResources(autoCreateDeadLetterResources)
+              .setDeadLetterQueuePrefix(SimpleString.toSimpleString(deadLetterQueuePrefix))
+              .setDeadLetterQueueSuffix(SimpleString.toSimpleString(deadLetterQueueSuffix))
+              .setAutoCreateExpiryResources(autoCreateExpiryResources)
+              .setExpiryQueuePrefix(SimpleString.toSimpleString(expiryQueuePrefix))
+              .setExpiryQueueSuffix(SimpleString.toSimpleString(expiryQueueSuffix))
+              .setMinExpiryDelay(minExpiryDelay)
+              .setMaxExpiryDelay(maxExpiryDelay)
+              .setEnableMetrics(enableMetrics);
 
-      AddressSettingsInfo rootInfo = AddressSettingsInfo.from(serverControl.getAddressSettingsAsJSON(root));
+      serverControl.addAddressSettings(root, addressSettings.toJSON());
+
+      AddressSettingsInfo rootInfo = AddressSettingsInfo.fromJSON(serverControl.getAddressSettingsAsJSON(root));
 
       // Give settings for addr different values to the root
       final long addrMinExpiryDelay = rootInfo.getMinExpiryDelay() + 1;
       final long addrMaxExpiryDelay = rootInfo.getMaxExpiryDelay() - 1;
-      serverControl.addAddressSettings(addr,
-              DLA,
-              expiryAddress,
-              expiryDelay,
-              lastValueQueue,
-              deliveryAttempts,
-              maxSizeBytes,
-              pageSizeBytes,
-              pageMaxCacheSize,
-              redeliveryDelay,
-              redeliveryMultiplier,
-              maxRedeliveryDelay,
-              redistributionDelay,
-              sendToDLAOnNoRoute,
-              addressFullMessagePolicy,
-              slowConsumerThreshold,
-              slowConsumerCheckPeriod,
-              slowConsumerPolicy,
-              autoCreateJmsQueues,
-              autoDeleteJmsQueues,
-              autoCreateJmsTopics,
-              autoDeleteJmsTopics,
-              autoCreateQueues,
-              autoDeleteQueues,
-              autoCreateAddresses,
-              autoDeleteAddresses,
-              configDeleteQueues,
-              configDeleteAddresses,
-              maxSizeBytesRejectThreshold,
-              defaultLastValueKey,
-              defaultNonDestructive,
-              defaultExclusiveQueue,
-              defaultGroupRebalance,
-              defaultGroupBuckets,
-              defaultGroupFirstKey,
-              defaultMaxConsumers,
-              defaultPurgeOnNoConsumers,
-              defaultConsumersBeforeDispatch,
-              defaultDelayBeforeDispatch,
-              defaultQueueRoutingType,
-              defaultAddressRoutingType,
-              defaultConsumerWindowSize,
-              defaultRingSize,
-              autoDeleteCreatedQueues,
-              autoDeleteQueuesDelay,
-              autoDeleteQueuesMessageCount,
-              autoDeleteAddressesDelay,
-              redeliveryCollisionAvoidanceFactor,
-              retroactiveMessageCount,
-              autoCreateDeadLetterResources,
-              deadLetterQueuePrefix,
-              deadLetterQueueSuffix,
-              autoCreateExpiryResources,
-              expiryQueuePrefix,
-              expiryQueueSuffix,
-              addrMinExpiryDelay,
-              addrMaxExpiryDelay,
-              enableMetrics);
-      AddressSettingsInfo addrInfo = AddressSettingsInfo.from(serverControl.getAddressSettingsAsJSON(addr));
+
+      addressSettings.setMinExpiryDelay(addrMinExpiryDelay).setMaxExpiryDelay(addrMaxExpiryDelay);
+      serverControl.addAddressSettings(addr, addressSettings.toJSON());
+      AddressSettingsInfo addrInfo = AddressSettingsInfo.fromJSON(serverControl.getAddressSettingsAsJSON(addr));
 
       assertEquals("settings for addr should carry update", addrMinExpiryDelay, addrInfo.getMinExpiryDelay());
       assertEquals("settings for addr should carry update", addrMaxExpiryDelay, addrInfo.getMaxExpiryDelay());
 
       serverControl.removeAddressSettings(addr);
 
-      AddressSettingsInfo rereadAddrInfo = AddressSettingsInfo.from(serverControl.getAddressSettingsAsJSON(addr));
+      AddressSettingsInfo rereadAddrInfo = AddressSettingsInfo.fromJSON(serverControl.getAddressSettingsAsJSON(addr));
 
       assertEquals("settings for addr should have reverted to original value after removal", rootInfo.getMinExpiryDelay(), rereadAddrInfo.getMinExpiryDelay());
       assertEquals("settings for addr should have reverted to original value after removal", rootInfo.getMaxExpiryDelay(), rereadAddrInfo.getMaxExpiryDelay());

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
@@ -1409,6 +1409,11 @@ public class ActiveMQServerControlUsingCoreTest extends ActiveMQServerControlTes
          }
 
          @Override
+         public String addAddressSettings(String address, String addressSettingsConfigurationAsJson) throws Exception {
+            return (String) proxy.invokeOperation("addAddressSettings", address, addressSettingsConfigurationAsJson);
+         }
+
+         @Override
          public String listNetworkTopology() throws Exception {
             return (String) proxy.invokeOperation("listNetworkTopology");
          }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingOrderTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/paging/PagingOrderTest.java
@@ -52,6 +52,7 @@ import org.apache.activemq.artemis.core.server.impl.AddressInfo;
 import org.apache.activemq.artemis.core.server.impl.QueueImpl;
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
+import org.apache.activemq.artemis.core.settings.impl.SlowConsumerPolicy;
 import org.apache.activemq.artemis.jms.client.ActiveMQJMSConnectionFactory;
 import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
 import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
@@ -615,7 +616,13 @@ public class PagingOrderTest extends ActiveMQTestBase {
 
       jmsServer.createTopic(true, "tt", "/topic/TT");
 
-      server.getActiveMQServerControl().addAddressSettings("TT", "DLQ", "DLQ", -1, false, 5, 1024 * 1024, 1024 * 10, 5, 5, 1, 1000, 0, false, "PAGE", -1, 10, "KILL", true, true, true, true);
+      AddressSettings addressSettings = new AddressSettings();
+      addressSettings.setDeadLetterAddress(SimpleString.toSimpleString("DLQ")).setExpiryAddress(SimpleString.toSimpleString("DLQ")).setExpiryDelay(-1L).setMaxDeliveryAttempts(5)
+                      .setMaxSizeBytes(1024 * 1024).setPageSizeBytes(1024 * 10).setPageCacheMaxSize(5).setRedeliveryDelay(5).setRedeliveryMultiplier(1L)
+              .setMaxRedeliveryDelay(1000).setRedistributionDelay(0).setSendToDLAOnNoRoute(false).setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE).setSlowConsumerThreshold(-1)
+                      .setSlowConsumerCheckPeriod(10L).setSlowConsumerPolicy(SlowConsumerPolicy.KILL);
+
+      server.getActiveMQServerControl().addAddressSettings("TT", addressSettings.toJSON());
 
       ActiveMQJMSConnectionFactory cf = (ActiveMQJMSConnectionFactory) ActiveMQJMSClient.createConnectionFactoryWithoutHA(JMSFactoryType.CF, new TransportConfiguration(INVM_CONNECTOR_FACTORY));
 
@@ -671,7 +678,13 @@ public class PagingOrderTest extends ActiveMQTestBase {
       jmsServer.setRegistry(new JndiBindingRegistry(context));
       jmsServer.start();
 
-      server.getActiveMQServerControl().addAddressSettings("Q1", "DLQ", "DLQ", -1, false, 5, 100 * 1024, 10 * 1024, 5, 5, 1, 1000, 0, false, "PAGE", -1, 10, "KILL", true, true, true, true);
+      AddressSettings addressSettings = new AddressSettings();
+      addressSettings.setDeadLetterAddress(SimpleString.toSimpleString("DLQ")).setExpiryAddress(SimpleString.toSimpleString("DLQ")).setExpiryDelay(-1L).setMaxDeliveryAttempts(5)
+              .setMaxSizeBytes(100 * 1024).setPageSizeBytes(1024 * 10).setPageCacheMaxSize(5).setRedeliveryDelay(5).setRedeliveryMultiplier(1L)
+              .setMaxRedeliveryDelay(1000).setRedistributionDelay(0).setSendToDLAOnNoRoute(false).setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE).setSlowConsumerThreshold(-1)
+              .setSlowConsumerCheckPeriod(10L).setSlowConsumerPolicy(SlowConsumerPolicy.KILL);
+
+      server.getActiveMQServerControl().addAddressSettings("Q1", addressSettings.toJSON());
 
       jmsServer.createQueue(true, "Q1", null, true, "/queue/Q1");
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/AddressSettingsConfigurationStorageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/AddressSettingsConfigurationStorageTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.config.StoreConfiguration;
 import org.apache.activemq.artemis.core.persistence.StorageManager;
+import org.apache.activemq.artemis.core.persistence.config.AbstractPersistedAddressSetting;
 import org.apache.activemq.artemis.core.persistence.config.PersistedAddressSetting;
 import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
@@ -117,11 +118,11 @@ public class AddressSettingsConfigurationStorageTest extends StorageManagerTestB
     * @throws Exception
     */
    private void checkAddresses(StorageManager journal1) throws Exception {
-      List<PersistedAddressSetting> listSetting = journal1.recoverAddressSettings();
+      List<AbstractPersistedAddressSetting> listSetting = journal1.recoverAddressSettings();
 
       assertEquals(mapExpectedAddresses.size(), listSetting.size());
 
-      for (PersistedAddressSetting el : listSetting) {
+      for (AbstractPersistedAddressSetting el : listSetting) {
          PersistedAddressSetting el2 = mapExpectedAddresses.get(el.getAddressMatch());
 
          assertEquals(el.getAddressMatch(), el2.getAddressMatch());


### PR DESCRIPTION
As I worked through implementing a more generic JSON marshaller, I tried using reflection through BeanUtils and other ways however the endresult was always worse as there were a few caveats that were not as easy to accomplish.

For that reason I went to a declarative appraoch where I define a meta-data object on AddressSettings and AddressSettingsInfo and reuse the metadata in a few other places.