### PR TITLE
Move the queue consumer count inside the initialization block

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/federation/FederatedAbstract.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/federation/FederatedAbstract.java
@@ -117,6 +117,7 @@ public abstract class FederatedAbstract implements ActiveMQServerBasePlugin {
             remoteQueueConsumer = new FederatedQueueConsumerImpl(federation, server, transformer, key, upstream, callback);
             remoteQueueConsumer.start();
             remoteQueueConsumers.put(key, remoteQueueConsumer);
+            remoteQueueConsumer.incrementCount();
 
             if (server.hasBrokerFederationPlugins()) {
                try {
@@ -128,7 +129,6 @@ public abstract class FederatedAbstract implements ActiveMQServerBasePlugin {
                }
             }
          }
-         remoteQueueConsumer.incrementCount();
       }
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/federation/FederatedAddressTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/federation/FederatedAddressTest.java
@@ -725,7 +725,7 @@ public class FederatedAddressTest extends FederatedTestBase {
       // Verify that federated queues have indeed been removed from both servers
       assertTrue(server0.getPostOffice().getBindingsForAddress(sAddress).getBindings().isEmpty());
       assertTrue(server1.getPostOffice().getBindingsForAddress(sAddress).getBindings().isEmpty());
-   
+
       // Close the connections
       connection0.close();
       connection1.close();


### PR DESCRIPTION
Artemis currently fails to cleanup federated queues after consumers disconnect from an address.

This happens because the `remoteQueueConsumer` counter is incremented many more times than the number of consumers. This mismatch prevents proper cleanup in the `removeRemoteConsumer()` method below because the `if (remoteQueueConsumer.decrementCount() <= 0) {` is never invoked.

I have manually validated this change with a fully connected federation of 3 regions using MQTT publishers and subscribers and auto-delete enabled on the federation: when the subscriber leaves, the local queue is eliminated immediately and the federation queues (all 6) are closed and removed after a few minutes.

NOTE: this is a severe liability and consistently leads to OutOfMemory issues no matter the JVM heap size in environments that create a lot of ephemeral addresses.