### PR TITLE
ARTEMIS-4185 - Revision on sending already compressed messages

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientConsumerImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientConsumerImpl.java
@@ -646,6 +646,7 @@ public final class ClientConsumerImpl implements ClientConsumerInternal {
       qbuff.readBytes(body);
       largeMessage.setLargeMessageController(new CompressedLargeMessageControllerImpl(currentLargeMessageController));
       currentLargeMessageController.addPacket(body, body.length, false);
+      largeMessage.putBooleanProperty(Message.HDR_LARGE_COMPRESSED, false);
 
       handleRegularMessage(largeMessage);
    }
@@ -674,6 +675,7 @@ public final class ClientConsumerImpl implements ClientConsumerInternal {
 
       if (clientLargeMessage.isCompressed()) {
          clientLargeMessage.setLargeMessageController(new CompressedLargeMessageControllerImpl(currentLargeMessageController));
+         clientLargeMessage.putBooleanProperty(Message.HDR_LARGE_COMPRESSED, false);
       } else {
          clientLargeMessage.setLargeMessageController(currentLargeMessageController);
       }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientProducerImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientProducerImpl.java
@@ -443,10 +443,6 @@ public class ClientProducerImpl implements ClientProducerInternal {
          deflaterReader = new DeflaterReader(inputStreamParameter, messageSize);
          deflaterReader.setLevel(session.getCompressionLevel());
          input = deflaterReader;
-      } else if (msgI.getBooleanProperty(Message.HDR_LARGE_COMPRESSED)) {
-         //This needs to be false if we do not intend to compress the message
-         //and the header already exists
-         msgI.putBooleanProperty(Message.HDR_LARGE_COMPRESSED, false);
       }
 
       long totalSize = 0;


### PR DESCRIPTION
I made this revision because I encountered an issue with the previous fix.
It's a bit tricky to write a test for, since it is actually already fixed in the most recent broker version for other reasons but I felt there might be some other scenario out there that can still get affected by the current implementation of "ARTEMIS-4185".

In short, broker versions after "ARTEMIS-4185" and before "ARTEMIS-4382" would not be able to export and then import compressed messages without them breaking. It's because the COMPRESSED-header is set to false by the producer without a consumer having decompressed the message first.

This revision sets the COMPRESSED-header to true at the producer (where compression happens) and to false at the consumer (where decompression happens). I feel this makes more sense regardless of the issue I observed is otherwise fixed or not.

I also changed the test to mimic the necessary conditions to trigger the issue I saw with previous broker versions, as well as the previous, more general issue.