### PR TITLE
fix NPE crash in PostOfficeImpl

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -1969,7 +1969,9 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
          AddressSettings settings = addressSettingsRepository.getMatch(queue.getAddress().toString());
          if (!queue.isInternalQueue() && queue.isAutoDelete() && QueueManagerImpl.consumerCountCheck(queue) && (initialCheck || QueueManagerImpl.delayCheck(queue, settings)) && QueueManagerImpl.messageCountCheck(queue) && (initialCheck || queueWasUsed(queue, settings))) {
             // we only reap queues on the initialCheck if they are actually empty
-            boolean validInitialCheck = initialCheck && queue.getMessageCount() == 0 && !queue.getPagingStore().isPaging();
+            PagingStore queuePagingStore = queue.getPagingStore();
+            boolean isPaging = queuePagingStore == null || queuePagingStore.isPaging(); 
+            boolean validInitialCheck = initialCheck && queue.getMessageCount() == 0 && !isPaging;
             if (validInitialCheck || queue.isSwept()) {
                if (logger.isDebugEnabled()) {
                   if (initialCheck) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -1970,7 +1970,7 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
          if (!queue.isInternalQueue() && queue.isAutoDelete() && QueueManagerImpl.consumerCountCheck(queue) && (initialCheck || QueueManagerImpl.delayCheck(queue, settings)) && QueueManagerImpl.messageCountCheck(queue) && (initialCheck || queueWasUsed(queue, settings))) {
             // we only reap queues on the initialCheck if they are actually empty
             PagingStore queuePagingStore = queue.getPagingStore();
-            boolean isPaging = queuePagingStore == null || queuePagingStore.isPaging(); 
+            boolean isPaging = queuePagingStore != null && queuePagingStore.isPaging(); 
             boolean validInitialCheck = initialCheck && queue.getMessageCount() == 0 && !isPaging;
             if (validInitialCheck || queue.isSwept()) {
                if (logger.isDebugEnabled()) {


### PR DESCRIPTION
I can't reference an issue in JIRA because I can't register in JIRA.

There's an obvious logic bug which leads to crash on startup (processing some queue that I believe came from upstream federate)

`getPagingStore()` can validly return `null` as can be seen from [QueueFactoryImpl@99](https://github.com/apache/activemq-artemis/blob/36056a5bddeaf431bd282cc0f231f53675549117/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueFactoryImpl.java#L99).

