### PR TITLE
Exclude slf4j-api from activemq-client to prevent java.lang.LinkageError during artemis-jms-bridge.war deployment

### DIFF
--- a/examples/features/sub-modules/inter-broker-bridge/artemis-jms-bridge/pom.xml
+++ b/examples/features/sub-modules/inter-broker-bridge/artemis-jms-bridge/pom.xml
@@ -59,6 +59,10 @@ under the License.
                <groupId>org.apache.geronimo.specs</groupId>
                <artifactId>geronimo-j2ee-management_1.1_spec</artifactId>
             </exclusion>
+            <exclusion>
+               <groupId>org.slf4j</groupId>
+               <artifactId>slf4j-api</artifactId>
+            </exclusion>
          </exclusions>
       </dependency>
       <dependency>


### PR DESCRIPTION
In version 2.27.1 I was able to build and deploy artemis-jms-bridge-2.27.1.war (examples\features\sub-modules\inter-broker-bridge\artemis-jms-bridge)

After upgrading to version 2.28.0 and now to version 2.31.2 An LinkageError occurs during the deployment of mentioned war-file, caused by a version-conflict of a slf4j-library:

```
2023-03-20 19:08:04,505 WARN  [org.springframework.web.context.support.XmlWebApplicationContext] Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.BeanCreationException: Error creating bean with name '5xConnectionFactory' defined in class path resource [bridge.xml]: Instantiation of bean failed; nested exception is java.lang.LinkageError: loader constraint violation: when resolving method 'org.slf4j.ILoggerFactory org.slf4j.impl.StaticLoggerBinder.getLoggerFactory()' the class loader org.eclipse.jetty.webapp.WebAppClassLoader @467b0f6e of the current class, org/slf4j/LoggerFactory, and the class loader java.net.URLClassLoader @4e0e2f2a for the method's defining class, org/slf4j/impl/StaticLoggerBinder, have different Class objects for the type org/slf4j/ILoggerFactory used in the signature (org.slf4j.LoggerFactory is in unnamed module of loader org.eclipse.jetty.webapp.WebAppClassLoader @467b0f6e, parent loader java.net.URLClassLoader @4e0e2f2a; org.slf4j.impl.StaticLoggerBinder is in unnamed module of loader java.net.URLClassLoader @4e0e2f2a, parent loader 'app')
2023-03-20 19:08:04,532 ERROR [org.springframework.web.context.ContextLoader] Context initialization failed
org.springframework.beans.factory.BeanCreationException: Error creating bean with name '5xConnectionFactory' defined in class path resource [bridge.xml]: Instantiation of bean failed; nested exception is java.lang.LinkageError: loader constraint violation: when resolving method 'org.slf4j.ILoggerFactory org.slf4j.impl.StaticLoggerBinder.getLoggerFactory()' the class loader org.eclipse.jetty.webapp.WebAppClassLoader @467b0f6e of the current class, org/slf4j/LoggerFactory, and the class loader java.net.URLClassLoader @4e0e2f2a for the method's defining class, org/slf4j/impl/StaticLoggerBinder, have different Class objects for the type org/slf4j/ILoggerFactory used in the signature (org.slf4j.LoggerFactory is in unnamed module of loader org.eclipse.jetty.webapp.WebAppClassLoader @467b0f6e, parent loader java.net.URLClassLoader @4e0e2f2a; org.slf4j.impl.StaticLoggerBinder is in unnamed module of loader java.net.URLClassLoader @4e0e2f2a, parent loader 'app')
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateBean(AbstractAutowireCapableBeanFactory.java:1334) ~[spring-beans-5.3.20.jar:5.3.20]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1232) ~[spring-beans-5.3.20.jar:5.3.20]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:582) ~[spring-beans-5.3.20.jar:5.3.20]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:542) ~[spring-beans-5.3.20.jar:5.3.20]
        at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:335) ~[spring-beans-5.3.20.jar:5.3.20]
        at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234) ~[spring-beans-5.3.20.jar:5.3.20]
        at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:333) ~[spring-beans-5.3.20.jar:5.3.20]
        at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:208) ~[spring-beans-5.3.20.jar:5.3.20]
        at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:953) ~[spring-beans-5.3.20.jar:5.3.20]
        at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:918) ~[spring-context-5.3.20.jar:5.3.20]
        at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:583) ~[spring-context-5.3.20.jar:5.3.20]
        at org.springframework.web.context.ContextLoader.configureAndRefreshWebApplicationContext(ContextLoader.java:401) ~[spring-web-5.3.20.jar:5.3.20]
        at org.springframework.web.context.ContextLoader.initWebApplicationContext(ContextLoader.java:292) ~[spring-web-5.3.20.jar:5.3.20]
        at org.springframework.web.context.ContextLoaderListener.contextInitialized(ContextLoaderListener.java:103) ~[spring-web-5.3.20.jar:5.3.20]
        at org.eclipse.jetty.server.handler.ContextHandler.callContextInitialized(ContextHandler.java:1043) ~[jetty-server-10.0.11.jar:10.0.11]
        at org.eclipse.jetty.servlet.ServletContextHandler.callContextInitialized(ServletContextHandler.java:624) ~[jetty-servlet-10.0.11.jar:10.0.11]
        at org.eclipse.jetty.server.handler.ContextHandler.contextInitialized(ContextHandler.java:978) ~[jetty-server-10.0.11.jar:10.0.11]
        at org.eclipse.jetty.servlet.ServletHandler.initialize(ServletHandler.java:740) ~[jetty-servlet-10.0.11.jar:10.0.11]
        at org.eclipse.jetty.servlet.ServletContextHandler.startContext(ServletContextHandler.java:392) ~[jetty-servlet-10.0.11.jar:10.0.11]
        at org.eclipse.jetty.webapp.WebAppContext.startContext(WebAppContext.java:1304) ~[jetty-webapp-10.0.11.jar:10.0.11]
        at org.eclipse.jetty.server.handler.ContextHandler.doStart(ContextHandler.java:895) ~[jetty-server-10.0.11.jar:10.0.11]
        at org.eclipse.jetty.servlet.ServletContextHandler.doStart(ServletContextHandler.java:306) ~[jetty-servlet-10.0.11.jar:10.0.11]
        at org.eclipse.jetty.webapp.WebAppContext.doStart(WebAppContext.java:532) ~[jetty-webapp-10.0.11.jar:10.0.11]
        at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:93) ~[jetty-util-10.0.11.jar:10.0.11]
        at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:171) ~[jetty-util-10.0.11.jar:10.0.11]
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:121) ~[jetty-util-10.0.11.jar:10.0.11]
        at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:89) ~[jetty-server-10.0.11.jar:10.0.11]
        at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:93) ~[jetty-util-10.0.11.jar:10.0.11]
        at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:171) ~[jetty-util-10.0.11.jar:10.0.11]
        at org.eclipse.jetty.server.Server.start(Server.java:469) ~[jetty-server-10.0.11.jar:10.0.11]
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:114) ~[jetty-util-10.0.11.jar:10.0.11]
        at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:89) ~[jetty-server-10.0.11.jar:10.0.11]
        at org.eclipse.jetty.server.Server.doStart(Server.java:414) ~[jetty-server-10.0.11.jar:10.0.11]
        at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:93) ~[jetty-util-10.0.11.jar:10.0.11]
        at org.apache.activemq.artemis.component.WebServerComponent.start(WebServerComponent.java:188) ~[artemis-web-2.28.0.jar:2.28.0]
        at org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl.addExternalComponent(ActiveMQServerImpl.java:988) ~[artemis-server-2.28.0.jar:2.28.0]
        at org.apache.activemq.artemis.cli.commands.Run.execute(Run.java:140) ~[artemis-cli-2.28.0.jar:2.28.0]
        at org.apache.activemq.artemis.cli.Artemis.internalExecute(Artemis.java:212) ~[artemis-cli-2.28.0.jar:2.28.0]
        at org.apache.activemq.artemis.cli.Artemis.execute(Artemis.java:162) ~[artemis-cli-2.28.0.jar:2.28.0]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?]
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:568) ~[?:?]
        at org.apache.activemq.artemis.boot.Artemis.execute(Artemis.java:144) ~[artemis-boot.jar:2.28.0]
        at org.apache.activemq.artemis.boot.Artemis.main(Artemis.java:61) ~[artemis-boot.jar:2.28.0]
Caused by: java.lang.LinkageError: loader constraint violation: when resolving method 'org.slf4j.ILoggerFactory org.slf4j.impl.StaticLoggerBinder.getLoggerFactory()' the class loader org.eclipse.jetty.webapp.WebAppClassLoader @467b0f6e of the current class, org/slf4j/LoggerFactory, and the class loader java.net.URLClassLoader @4e0e2f2a for the method's defining class, org/slf4j/impl/StaticLoggerBinder, have different Class objects for the type org/slf4j/ILoggerFactory used in the signature (org.slf4j.LoggerFactory is in unnamed module of loader org.eclipse.jetty.webapp.WebAppClassLoader @467b0f6e, parent loader java.net.URLClassLoader @4e0e2f2a; org.slf4j.impl.StaticLoggerBinder is in unnamed module of loader java.net.URLClassLoader @4e0e2f2a, parent loader 'app')
        at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:423) ~[slf4j-api-1.7.36.jar:1.7.36]
        at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:362) ~[slf4j-api-1.7.36.jar:1.7.36]
        at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:388) ~[slf4j-api-1.7.36.jar:1.7.36]
        at org.apache.activemq.ActiveMQConnectionFactory.<clinit>(ActiveMQConnectionFactory.java:62) ~[activemq-client-5.17.2.jar:5.17.2]
        at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:?]
        at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77) ~[?:?]
        at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:?]
        at java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499) ~[?:?]
        at java.lang.reflect.Constructor.newInstance(Constructor.java:480) ~[?:?]
        at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:211) ~[spring-beans-5.3.20.jar:5.3.20]
        at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:87) ~[spring-beans-5.3.20.jar:5.3.20]
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateBean(AbstractAutowireCapableBeanFactory.java:1326) ~[spring-beans-5.3.20.jar:5.3.20]
        ... 44 more
```

Excluding slf4j-api from activemq-client-dependency solved this problem during startup.