### PR TITLE
ARTEMIS-4452: Allow to customize http header in http-upgrade request …

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/TransportConstants.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/TransportConstants.java
@@ -46,6 +46,8 @@ public class TransportConstants {
 
    public static final String HTTP_CLIENT_IDLE_SCAN_PERIOD = "httpClientIdleScanPeriod";
 
+   public static final String NETTY_HTTP_HEADER_PREFIX = "nettyHttpHeader.";
+
    public static final String HTTP_RESPONSE_TIME_PROP_NAME = "httpResponseTime";
 
    public static final String HTTP_SERVER_SCAN_PERIOD_PROP_NAME = "httpServerScanPeriod";


### PR DESCRIPTION
…from Artemis.

Using a prefix "netty.http.header." to be able to define http headers used for http request from the netty connector.

Issue: https://issues.apache.org/jira/browse/ARTEMIS-4452