### PR TITLE
ARTEMIS-4535 prevent big stacktrack when invalid filter given by user

### DIFF
--- a/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/components/browse.js
+++ b/artemis-hawtio/artemis-plugin/src/main/webapp/plugin/js/components/browse.js
@@ -32,7 +32,7 @@ var Artemis;
                     <div class="col-sm-20">
                         <form class="toolbar-pf-actions">
                             <div class="form-group toolbar-pf-filter">
-                                <div class="input-group">
+                                <div class="input-group" style="padding-left: 10px">
                                     <input type="text" class="form-control" ng-model="$ctrl.filter" placeholder="Filter..." autocomplete="off" id="filterInput">
                                     <div class="input-group-btn">
                                         <button class="btn btn-link btn-find" ng-click="$ctrl.refresh()" type="button">
@@ -688,7 +688,7 @@ var Artemis;
                 ctrl.dlq = ctrl.dlq || (message['StringProperties'] ? (message['StringProperties']['_AMQ_ORIG_QUEUE'] ? true : (message['StringProperties']['extraProperties._AMQ_ORIG_QUEUE'] ? true : false)) : false);
                 message.bodyText = createBodyText(message);
                 if (idx == 0 && !ctrl.loadPrevousPage) {
-                //always load n the first message for paination when viewing message details
+                //always load n the first message for pagination when viewing message details
                     ctrl.currentMessage = message;
                     ctrl.currentMessage.headers = createHeaders(ctrl.currentMessage)
                     ctrl.currentMessage.properties = createProperties(ctrl.currentMessage);
@@ -893,12 +893,12 @@ var Artemis;
             if (ctrl.objName) {
                 //make sure to count only filtered messages
                 if (ctrl.filter) {
-                    jolokia.request({ type: 'exec', mbean: ctrl.objName, operation: 'countMessages(java.lang.String)', arguments: [ctrl.filter] }, Core.onSuccess(function(response) { ctrl.pagination.page(response.value); }));
+                    jolokia.request({ type: 'exec', mbean: ctrl.objName, operation: 'countMessages(java.lang.String)', arguments: [ctrl.filter] }, Core.onSuccess(function(response) { ctrl.pagination.page(response.value); }, { error: onError }));
                 } else {
-                    jolokia.request({ type: 'exec', mbean: ctrl.objName, operation: 'countMessages()'}, Core.onSuccess(function(response) { ctrl.pagination.page(response.value); }));
+                    jolokia.request({ type: 'exec', mbean: ctrl.objName, operation: 'countMessages()'}, Core.onSuccess(function(response) { ctrl.pagination.page(response.value); }, { error: onError }));
                 }
 
-                jolokia.request({ type: 'exec', mbean: ctrl.objName, operation: 'browse(int, int, java.lang.String)', arguments: [ctrl.pagination.pageNumber, ctrl.pagination.pageSize, ctrl.filter] }, Core.onSuccess(populateTable));
+                jolokia.request({ type: 'exec', mbean: ctrl.objName, operation: 'browse(int, int, java.lang.String)', arguments: [ctrl.pagination.pageNumber, ctrl.pagination.pageSize, ctrl.filter] }, Core.onSuccess(populateTable, { error: onError }));
             }
         }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/QueueControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/QueueControlImpl.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.ActiveMQInvalidFilterExpressionException;
 import org.apache.activemq.artemis.api.core.JsonUtil;
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.SimpleString;
@@ -1639,7 +1640,10 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
                return rc;
             }
          } catch (Exception e) {
-            logger.warn(e.getMessage(), e);
+            if (!(e instanceof ActiveMQInvalidFilterExpressionException)) {
+               // only log when not caused by user input
+               logger.warn(e.getMessage(), e);
+            }
             if (AuditLogger.isResourceLoggingEnabled()) {
                AuditLogger.browseMessagesFailure(queue.getName().toString());
             }


### PR DESCRIPTION
see https://issues.apache.org/jira/browse/ARTEMIS-4535

* prevent a large stack trace when the user-supplied message filter has errors
* improve feedback to user for filter-validity
* indent the search-field in the "Browse Queue" screen same as on other screens
* fixed a spelling error in a nearby comment