### PR TITLE
ARTEMIS-4531: Limit logfile output by default to 5

### DIFF
--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/log4j2.properties
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/log4j2.properties
@@ -87,6 +87,8 @@ appender.log_file.policies.type = Policies
 appender.log_file.policies.cron.type = CronTriggeringPolicy
 appender.log_file.policies.cron.schedule = 0 0 0 * * ?
 appender.log_file.policies.cron.evaluateOnStartup = true
+appender.log_file.strategy.type = DefaultRolloverStrategy
+appender.log_file.strategy.max = 5
 
 # Audit log file appender
 appender.audit_log_file.type = RollingFile
@@ -99,3 +101,5 @@ appender.audit_log_file.policies.type = Policies
 appender.audit_log_file.policies.cron.type = CronTriggeringPolicy
 appender.audit_log_file.policies.cron.schedule = 0 0 0 * * ?
 appender.audit_log_file.policies.cron.evaluateOnStartup = true
+appender.audit_log_file.strategy.type = DefaultRolloverStrategy
+appender.audit_log_file.strategy.max = 5 

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/log4j2.properties
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/log4j2.properties
@@ -102,4 +102,4 @@ appender.audit_log_file.policies.cron.type = CronTriggeringPolicy
 appender.audit_log_file.policies.cron.schedule = 0 0 0 * * ?
 appender.audit_log_file.policies.cron.evaluateOnStartup = true
 appender.audit_log_file.strategy.type = DefaultRolloverStrategy
-appender.audit_log_file.strategy.max = 5 
+appender.audit_log_file.strategy.max = 5


### PR DESCRIPTION
Added a DefaultRolloverStrategy with a max of 5 files to the log appenders "log_file" and "audit_log_file" to prevent the (unlikely, I admit) situation where the system runs out of disk space because of the limitless growth of the amount of log files written to disk.