### PR TITLE
ARTEMIS-4548 refactor MQTT tests

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/MQTT5Test.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/MQTT5Test.java
@@ -61,10 +61,6 @@ public class MQTT5Test extends MQTT5TestSupport {
 
    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-   public MQTT5Test(String protocol) {
-      super(protocol);
-   }
-
    @Test(timeout = DEFAULT_TIMEOUT)
    public void testSimpleSendReceive() throws Exception {
       String topic = RandomUtil.randomString();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/MQTT5TestSupport.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/MQTT5TestSupport.java
@@ -21,8 +21,6 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.security.ProtectionDomain;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -71,15 +69,12 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestName;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.util.Collections.singletonList;
 import static org.apache.activemq.artemis.core.protocol.mqtt.MQTTProtocolManagerFactory.MQTT_PROTOCOL_NAME;
 
-@RunWith(Parameterized.class)
 public class MQTT5TestSupport extends ActiveMQTestBase {
    protected static final String TCP = "tcp";
    protected static final String WS = "ws";
@@ -88,34 +83,28 @@ public class MQTT5TestSupport extends ActiveMQTestBase {
    protected static final SimpleString DEAD_LETTER_ADDRESS = new SimpleString("DLA");
    protected static final SimpleString EXPIRY_ADDRESS = new SimpleString("EXPIRY");
 
-   @Parameterized.Parameters(name = "protocol={0}")
-   public static Collection<Object[]> getParams() {
-      return Arrays.asList(new Object[][] {
-         {TCP},
-         {WS}
-      });
-   }
-
-   protected String protocol;
-
-   public MQTT5TestSupport(String protocol) {
-      this.protocol = protocol;
-   }
-
    protected MqttClient createPahoClient(String clientId) throws MqttException {
-      return new MqttClient(protocol + "://localhost:" + (isUseSsl() ? getSslPort() : getPort()), clientId, new MemoryPersistence());
+      return createPahoClient(TCP, clientId);
+   }
+
+   protected MqttClient createPahoClient(String protocol, String clientId) throws MqttException {
+      return createPahoClient(protocol, clientId, (isUseSsl() ? getSslPort() : getPort()));
    }
 
    protected MqttClient createPahoClient(String clientId, int port) throws MqttException {
+      return createPahoClient(TCP, clientId, port);
+   }
+
+   protected MqttClient createPahoClient(String protocol, String clientId, int port) throws MqttException {
       return new MqttClient(protocol + "://localhost:" + port, clientId, new MemoryPersistence());
    }
 
    protected org.eclipse.paho.client.mqttv3.MqttClient createPaho3_1_1Client(String clientId) throws org.eclipse.paho.client.mqttv3.MqttException {
-      return new org.eclipse.paho.client.mqttv3.MqttClient(protocol + "://localhost:" + (isUseSsl() ? getSslPort() : getPort()), clientId, new org.eclipse.paho.client.mqttv3.persist.MemoryPersistence());
+      return new org.eclipse.paho.client.mqttv3.MqttClient(TCP + "://localhost:" + (isUseSsl() ? getSslPort() : getPort()), clientId, new org.eclipse.paho.client.mqttv3.persist.MemoryPersistence());
    }
 
    protected MqttAsyncClient createAsyncPahoClient(String clientId) throws MqttException {
-      return new MqttAsyncClient(protocol + "://localhost:" + (isUseSsl() ? getSslPort() : getPort()), clientId, new MemoryPersistence());
+      return new MqttAsyncClient(TCP + "://localhost:" + (isUseSsl() ? getSslPort() : getPort()), clientId, new MemoryPersistence());
    }
 
    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/MQTTRetainMessageManagerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/MQTTRetainMessageManagerTest.java
@@ -50,10 +50,6 @@ public class MQTTRetainMessageManagerTest extends MQTT5TestSupport {
    private final int numberOfMessages = 1000;
    private final int numberOfTests = 10;
 
-   public MQTTRetainMessageManagerTest(String protocol) {
-      super(protocol);
-   }
-
    @Before
    public void beforeEach() throws MqttException {
       mqttPublisher = createPahoClient("publisher");

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/ControlPacketFormatTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/ControlPacketFormatTests.java
@@ -49,10 +49,6 @@ import org.junit.Test;
 
 public class ControlPacketFormatTests extends MQTT5TestSupport {
 
-   public ControlPacketFormatTests(String protocol) {
-      super(protocol);
-   }
-
    /*
     * [MQTT-2.2.1-2] A PUBLISH packet MUST NOT contain a Packet Identifier if its QoS value is set to 0.
     */

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/DataFormatTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/DataFormatTests.java
@@ -31,8 +31,4 @@ import org.junit.Ignore;
 
 @Ignore
 public class DataFormatTests extends MQTT5TestSupport {
-
-   public DataFormatTests(String protocol) {
-      super(protocol);
-   }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/EnhancedAuthenticationTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/EnhancedAuthenticationTests.java
@@ -43,10 +43,6 @@ import org.junit.Test;
 
 public class EnhancedAuthenticationTests extends MQTT5TestSupport {
 
-   public EnhancedAuthenticationTests(String protocol) {
-      super(protocol);
-   }
-
    /*
     * [MQTT-4.12.0-1] If the Server does not support the Authentication Method supplied by the Client, it MAY send a
     * CONNACK with a Reason Code of 0x8C (Bad authentication method) or 0x87 (Not Authorized) as described in section

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/FlowControlTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/FlowControlTests.java
@@ -33,8 +33,4 @@ import org.junit.Ignore;
 
 @Ignore
 public class FlowControlTests extends MQTT5TestSupport {
-
-   public FlowControlTests(String protocol) {
-      super(protocol);
-   }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/HandlingErrorTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/HandlingErrorTests.java
@@ -22,7 +22,6 @@ import org.eclipse.paho.mqttv5.client.MqttClient;
 import org.eclipse.paho.mqttv5.client.MqttConnectionOptions;
 import org.eclipse.paho.mqttv5.client.MqttConnectionOptionsBuilder;
 import org.eclipse.paho.mqttv5.common.MqttException;
-import org.junit.Assume;
 import org.junit.Test;
 
 /**
@@ -33,10 +32,6 @@ import org.junit.Test;
 
 public class HandlingErrorTests extends MQTT5TestSupport {
 
-   public HandlingErrorTests(String protocol) {
-      this.protocol = protocol;
-   }
-
    /*
     * [MQTT-4.13.2-1] The CONNACK and DISCONNECT packets allow a Reason Code of 0x80 or greater to indicate that the
     * Network Connection will be closed. If a Reason Code of 0x80 or greater is specified, then the Network Connection
@@ -46,9 +41,6 @@ public class HandlingErrorTests extends MQTT5TestSupport {
     */
    @Test(timeout = DEFAULT_TIMEOUT)
    public void testEmptyClientIDWithoutCleanStart() throws Exception {
-      // This is apparently broken with the Paho client + web socket. The broker never even receives a CONNECT packet.
-      Assume.assumeTrue(protocol.equals(TCP));
-
       MqttClient client = createPahoClient("");
       MqttConnectionOptions options = new MqttConnectionOptionsBuilder()
          .cleanStart(false)

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/MessageDeliveryRetryTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/MessageDeliveryRetryTests.java
@@ -29,10 +29,6 @@ import org.junit.Test;
 
 public class MessageDeliveryRetryTests extends MQTT5TestSupport {
 
-   public MessageDeliveryRetryTests(String protocol) {
-      super(protocol);
-   }
-
    /*
     * [MQTT-4.4.0-1] When a Client reconnects with Clean Start set to 0 and a session is present, both the Client and
     * Server MUST resend any unacknowledged PUBLISH packets (where QoS > 0) and PUBREL packets using their original

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/MessageOrderingTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/MessageOrderingTests.java
@@ -36,8 +36,4 @@ import org.junit.Ignore;
 
 @Ignore
 public class MessageOrderingTests extends MQTT5TestSupport {
-
-   public MessageOrderingTests(String protocol) {
-      super(protocol);
-   }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/MessageReceiptTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/MessageReceiptTests.java
@@ -34,10 +34,6 @@ import org.junit.Test;
 
 public class MessageReceiptTests extends MQTT5TestSupport {
 
-   public MessageReceiptTests(String protocol) {
-      super(protocol);
-   }
-
    /*
     * [MQTT-4.5.0-1] When a Server takes ownership of an incoming Application Message it MUST add it to the Session
     * State for those Clients that have matching Subscriptions.

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/NetworkConnectionTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/NetworkConnectionTests.java
@@ -27,8 +27,4 @@ import org.junit.Ignore;
 
 @Ignore
 public class NetworkConnectionTests extends MQTT5TestSupport {
-
-   public NetworkConnectionTests(String protocol) {
-      super(protocol);
-   }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/QoSTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/QoSTests.java
@@ -60,10 +60,6 @@ import org.junit.Test;
 
 public class QoSTests extends MQTT5TestSupport {
 
-   public QoSTests(String protocol) {
-      super(protocol);
-   }
-
    /*
     * [MQTT-4.3.2-2] In the QoS 1 delivery protocol, the sender MUST send a PUBLISH packet containing this Packet
     * Identifier with QoS 1 and DUP flag set to 0.

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/SessionStateTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/SessionStateTests.java
@@ -27,8 +27,4 @@ import org.junit.Ignore;
 
 @Ignore
 public class SessionStateTests extends MQTT5TestSupport {
-
-   public SessionStateTests(String protocol) {
-      super(protocol);
-   }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/SubscriptionTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/SubscriptionTests.java
@@ -43,10 +43,6 @@ import org.junit.Test;
 
 public class SubscriptionTests extends MQTT5TestSupport {
 
-   public SubscriptionTests(String protocol) {
-      super(protocol);
-   }
-
    /*
     * [MQTT-4.8.2-3] The Server MUST respect the granted QoS for the Client's subscription.
     */

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/TopicNameAndFilterTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/TopicNameAndFilterTests.java
@@ -49,10 +49,6 @@ import org.junit.Test;
 
 public class TopicNameAndFilterTests extends MQTT5TestSupport {
 
-   public TopicNameAndFilterTests(String protocol) {
-      super(protocol);
-   }
-
    /*
     * [MQTT-4.7.2-1] The Server MUST NOT match Topic Filters starting with a wildcard character (# or +) with Topic
     * Names beginning with a $ character.

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/WebSocketTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/WebSocketTests.java
@@ -39,8 +39,4 @@ import org.junit.Ignore;
 
 @Ignore
 public class WebSocketTests extends MQTT5TestSupport {
-
-   public WebSocketTests(String protocol) {
-      super(protocol);
-   }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/AuthTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/AuthTests.java
@@ -39,8 +39,4 @@ import org.junit.Ignore;
 
 @Ignore
 public class AuthTests  extends MQTT5TestSupport {
-
-   public AuthTests(String protocol) {
-      this.protocol = protocol;
-   }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/ConnAckTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/ConnAckTests.java
@@ -41,7 +41,6 @@ import org.eclipse.paho.mqttv5.client.MqttConnectionOptionsBuilder;
 import org.eclipse.paho.mqttv5.client.MqttDisconnectResponse;
 import org.eclipse.paho.mqttv5.common.MqttException;
 import org.eclipse.paho.mqttv5.common.packet.MqttReturnCode;
-import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -82,10 +81,6 @@ import org.junit.Test;
 
 public class ConnAckTests  extends MQTT5TestSupport {
 
-   public ConnAckTests(String protocol) {
-      this.protocol = protocol;
-   }
-
    /*
     * [MQTT-3.1.3-6] A Server MAY allow a Client to supply a ClientID that has a length of zero bytes, however if it
     * does so the Server MUST treat this as a special case and assign a unique ClientID to that Client.
@@ -99,8 +94,6 @@ public class ConnAckTests  extends MQTT5TestSupport {
     */
    @Test(timeout = DEFAULT_TIMEOUT)
    public void testEmptyClientID() throws Exception {
-      // This is apparently broken with the Paho client + web socket. The broker never even receives a CONNECT packet.
-      Assume.assumeTrue(protocol.equals(TCP));
 
       // no session should exist
       assertEquals(0, getSessionStates().size());
@@ -268,8 +261,6 @@ public class ConnAckTests  extends MQTT5TestSupport {
     */
    @Test(timeout = DEFAULT_TIMEOUT)
    public void testSessionPresentWithNonZeroConnackReasonCode() throws Exception {
-      // This is apparently broken with the Paho client + web socket. The broker never even receives a CONNECT packet.
-      Assume.assumeTrue(protocol.equals(TCP));
       CountDownLatch latch = new CountDownLatch(1);
 
       MQTTInterceptor outgoingInterceptor = (packet, connection) -> {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/ConnectTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/ConnectTests.java
@@ -16,6 +16,7 @@
  */
 package org.apache.activemq.artemis.tests.integration.mqtt5.spec.controlpackets;
 
+import java.lang.invoke.MethodHandles;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -42,11 +43,9 @@ import org.eclipse.paho.mqttv5.common.MqttMessage;
 import org.eclipse.paho.mqttv5.common.packet.MqttProperties;
 import org.eclipse.paho.mqttv5.common.packet.MqttReturnCode;
 import org.eclipse.paho.mqttv5.common.packet.UserProperty;
-import org.junit.Assume;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.lang.invoke.MethodHandles;
 
 /**
  * Fulfilled by client or Netty codec (i.e. not tested here):
@@ -103,10 +102,6 @@ import java.lang.invoke.MethodHandles;
 public class ConnectTests extends MQTT5TestSupport {
 
    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-
-   public ConnectTests(String protocol) {
-      super(protocol);
-   }
 
    /*
     * [MQTT-3.1.2-7] If the Will Flag is set to 1 this indicates that, a Will Message MUST be stored on the Server and
@@ -632,9 +627,6 @@ public class ConnectTests extends MQTT5TestSupport {
     */
    @Test(timeout = DEFAULT_TIMEOUT)
    public void testEmptyClientID() throws Exception {
-      // This is apparently broken with the Paho client + web socket. The broker never even receives a CONNECT packet.
-      Assume.assumeTrue(protocol.equals(TCP));
-
       // no session should exist
       assertEquals(0, getSessionStates().size());
 
@@ -658,9 +650,6 @@ public class ConnectTests extends MQTT5TestSupport {
     */
    @Test(timeout = DEFAULT_TIMEOUT)
    public void testEmptyClientIDWithoutCleanStart() throws Exception {
-      // This is apparently broken with the Paho client + web socket. The broker never even receives a CONNECT packet.
-      Assume.assumeTrue(protocol.equals(TCP));
-
       // no session should exist
       assertEquals(0, getSessionStates().size());
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/ConnectTestsWithSecurity.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/ConnectTestsWithSecurity.java
@@ -29,10 +29,6 @@ import org.junit.Test;
 
 public class ConnectTestsWithSecurity extends MQTT5TestSupport {
 
-   public ConnectTestsWithSecurity(String protocol) {
-      super(protocol);
-   }
-
    @Override
    public boolean isSecurityEnabled() {
       return true;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/DisconnectTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/DisconnectTests.java
@@ -53,10 +53,6 @@ import org.junit.Test;
 
 public class DisconnectTests  extends MQTT5TestSupport {
 
-   public DisconnectTests(String protocol) {
-      super(protocol);
-   }
-
    /*
     * [MQTT-3.14.2-1] The Client or Server sending the DISCONNECT packet MUST use one of the DISCONNECT Reason Codes.
     *

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/PingRespTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/PingRespTests.java
@@ -26,8 +26,4 @@ import org.junit.Ignore;
 
 @Ignore
 public class PingRespTests  extends MQTT5TestSupport {
-
-   public PingRespTests(String protocol) {
-      super(protocol);
-   }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/PubAckTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/PubAckTests.java
@@ -37,10 +37,6 @@ import org.junit.Test;
 
 public class PubAckTests extends MQTT5TestSupport {
 
-   public PubAckTests(String protocol) {
-      super(protocol);
-   }
-
    /*
     * [MQTT-3.4.2-1] The Client or Server sending the PUBACK packet MUST use one of the PUBACK Reason Codes.
     */

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/PubCompTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/PubCompTests.java
@@ -37,10 +37,6 @@ import org.junit.Test;
 
 public class PubCompTests extends MQTT5TestSupport {
 
-   public PubCompTests(String protocol) {
-      super(protocol);
-   }
-
    /*
     * [MQTT-3.7.2-1] The Client or Server sending the PUBCOMP packets MUST use one of the PUBCOMP Reason Codes.
     */

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/PubRecTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/PubRecTests.java
@@ -37,10 +37,6 @@ import org.junit.Test;
 
 public class PubRecTests extends MQTT5TestSupport {
 
-   public PubRecTests(String protocol) {
-      super(protocol);
-   }
-
    /*
     * [MQTT-3.5.2-1] The Client or Server sending the PUBREC packet MUST use one of the PUBREC Reason Codes.
     */

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/PubRelTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/PubRelTests.java
@@ -42,10 +42,6 @@ import org.junit.Test;
 
 public class PubRelTests extends MQTT5TestSupport {
 
-   public PubRelTests(String protocol) {
-      super(protocol);
-   }
-
    /*
     * [MQTT-3.6.2-1] The Client or Server sending the PUBREL packet MUST use one of the PUBREL Reason Codes.
     */

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/PublishTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/PublishTests.java
@@ -79,10 +79,6 @@ public class PublishTests extends MQTT5TestSupport {
 
    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-   public PublishTests(String protocol) {
-      super(protocol);
-   }
-
    /*
     * [MQTT-3.3.1-1] The DUP flag MUST be set to 1 by the Client or Server when it attempts to re-deliver a PUBLISH
     * packet.

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/PublishTestsWithSecurity.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/PublishTestsWithSecurity.java
@@ -37,10 +37,6 @@ import org.junit.Test;
 
 public class PublishTestsWithSecurity extends MQTT5TestSupport {
 
-   public PublishTestsWithSecurity(String protocol) {
-      super(protocol);
-   }
-
    @Override
    public boolean isSecurityEnabled() {
       return true;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/SubAckTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/SubAckTests.java
@@ -34,10 +34,6 @@ import org.junit.Test;
 
 public class SubAckTests extends MQTT5TestSupport {
 
-   public SubAckTests(String protocol) {
-      super(protocol);
-   }
-
    /*
     * [MQTT-3.9.3-1] The order of Reason Codes in the SUBACK packet MUST match the order of Topic Filters in the
     * SUBSCRIBE packet.

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/SubscribeTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/SubscribeTests.java
@@ -50,10 +50,6 @@ import org.junit.Test;
 
 public class SubscribeTests extends MQTT5TestSupport {
 
-   public SubscribeTests(String protocol) {
-      super(protocol);
-   }
-
    /*
     * [MQTT-3.8.3-3] Bit 2 of the Subscription Options represents the No Local option. If the value is 1, Application
     * Messages MUST NOT be forwarded to a connection with a ClientID equal to the ClientID of the publishing connection.

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/SubscribeTestsWithSecurity.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/SubscribeTestsWithSecurity.java
@@ -31,10 +31,6 @@ import org.junit.Test;
 
 public class SubscribeTestsWithSecurity extends MQTT5TestSupport {
 
-   public SubscribeTestsWithSecurity(String protocol) {
-      super(protocol);
-   }
-
    @Override
    public boolean isSecurityEnabled() {
       return true;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/UnsubAckTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/UnsubAckTests.java
@@ -35,10 +35,6 @@ import org.junit.Test;
 
 public class UnsubAckTests extends MQTT5TestSupport {
 
-   public UnsubAckTests(String protocol) {
-      super(protocol);
-   }
-
    /*
     * [MQTT-3.11.3-1] The order of Reason Codes in the UNSUBACK packet MUST match the order of Topic Filters in the
     * UNSUBSCRIBE packet.

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/UnsubscribeTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/controlpackets/UnsubscribeTests.java
@@ -48,10 +48,6 @@ import org.junit.Test;
 
 public class UnsubscribeTests extends MQTT5TestSupport {
 
-   public UnsubscribeTests(String protocol) {
-      super(protocol);
-   }
-
    /*
     * [MQTT-3.10.4-1] The Topic Filters (whether they contain wildcards or not) supplied in an UNSUBSCRIBE packet MUST
     * be compared character-by-character with the current set of Topic Filters held by the Server for the Client. If any

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/ssl/BasicSslTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/ssl/BasicSslTests.java
@@ -14,19 +14,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.tests.integration.mqtt5;
+package org.apache.activemq.artemis.tests.integration.mqtt5.ssl;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
+import org.apache.activemq.artemis.tests.integration.mqtt5.MQTT5TestSupport;
+import org.apache.activemq.artemis.tests.util.RandomUtil;
 import org.eclipse.paho.mqttv5.client.MqttClient;
+import org.eclipse.paho.mqttv5.common.MqttMessage;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+@RunWith(Parameterized.class)
 public class BasicSslTests extends MQTT5TestSupport {
 
+   protected String protocol;
+
    public BasicSslTests(String protocol) {
-      super(protocol);
+      this.protocol = protocol;
    }
 
    @Parameterized.Parameters(name = "protocol={0}")
@@ -42,12 +51,26 @@ public class BasicSslTests extends MQTT5TestSupport {
       return true;
    }
 
-   /*
-    * Basic SSL test. Just connect.
-    */
    @Test(timeout = DEFAULT_TIMEOUT)
-   public void testSsl() throws Exception {
-      MqttClient client = createPahoClient("client");
-      client.connect(getSslMqttConnectOptions());
+   public void testSimpleSendReceive() throws Exception {
+      String topic = RandomUtil.randomString();
+      byte[] body = RandomUtil.randomBytes(32);
+
+      CountDownLatch latch = new CountDownLatch(1);
+      MqttClient subscriber = createPahoClient(protocol,"subscriber");
+      subscriber.connect(getSslMqttConnectOptions());
+      subscriber.setCallback(new DefaultMqttCallback() {
+         @Override
+         public void messageArrived(String topic, MqttMessage message) {
+            assertEqualsByteArrays(body, message.getPayload());
+            latch.countDown();
+         }
+      });
+      subscriber.subscribe(topic, AT_LEAST_ONCE);
+
+      MqttClient producer = createPahoClient(protocol,"producer");
+      producer.connect(getSslMqttConnectOptions());
+      producer.publish(topic, body, 1, false);
+      assertTrue(latch.await(500, TimeUnit.MILLISECONDS));
    }
 }


### PR DESCRIPTION
Many MQTT tests are run twice - once using TCP and once using WebSockets. This is essentially a big waste of time since once the connection is established to the broker the tests are identical. The tests should be refactored to run just once and then there can be a small number of tests specifically for WebSockets.

This should knock several minutes off the test-suite.