### PR TITLE
ARTEMIS-4558 Idempotent Mirrored ACKs

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/util/ServerUtil.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/util/ServerUtil.java
@@ -55,7 +55,7 @@ public class ServerUtil {
       final Process process = internalStartServer(artemisInstance, serverName, brokerProperties);
 
       // wait for start
-      if (timeout != 0) {
+      if (timeout > 0) {
          waitForServerToStart(id, timeout);
       }
 

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/AMQPBrokerConnection.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/AMQPBrokerConnection.java
@@ -501,6 +501,8 @@ public class AMQPBrokerConnection implements ClientConnectionLifeCycleListener, 
          mirrorControlQueue = server.createQueue(new QueueConfiguration(getMirrorSNF(replicaConfig)).setAddress(getMirrorSNF(replicaConfig)).setRoutingType(RoutingType.ANYCAST).setDurable(replicaConfig.isDurable()).setInternal(true), true);
       }
 
+      server.registerQueueOnManagement(mirrorControlQueue, true);
+
       logger.debug("Mirror queue {}", mirrorControlQueue.getName());
 
       mirrorControlQueue.setMirrorController(true);

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/mirror/AMQPMirrorControllerTarget.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/mirror/AMQPMirrorControllerTarget.java
@@ -504,6 +504,7 @@ public class AMQPMirrorControllerTarget extends ProtonAbstractReceiver implement
       byte[] duplicateIDBytes = ByteUtil.longToBytes(internalIDLong);
 
       if (duplicateIDCache.contains(duplicateIDBytes)) {
+         message.usageDown(); // large messages would be removed here
          flow();
          return false;
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPMirrorBrokerConnectionElement.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPMirrorBrokerConnectionElement.java
@@ -23,7 +23,7 @@ import org.apache.activemq.artemis.api.core.SimpleString;
 
 public class AMQPMirrorBrokerConnectionElement extends AMQPBrokerConnectionElement {
 
-   boolean durable;
+   boolean durable = true;
 
    boolean queueCreation = true;
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/StorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/StorageManager.java
@@ -275,6 +275,8 @@ public interface StorageManager extends IDGenerator, ActiveMQComponent {
 
    void commit(long txID, boolean lineUpContext) throws Exception;
 
+   void asyncCommit(long txID) throws Exception;
+
    void rollback(long txID) throws Exception;
 
    void rollbackBindings(long txID) throws Exception;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AbstractJournalStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AbstractJournalStorageManager.java
@@ -665,6 +665,13 @@ public abstract class AbstractJournalStorageManager extends CriticalComponentImp
    }
 
    @Override
+   public void asyncCommit(final long txID) throws Exception {
+      try (ArtemisCloseable lock = closeableReadLock()) {
+         messageJournal.appendCommitRecord(txID, false, getContext(true), true);
+      }
+   }
+
+   @Override
    public void rollback(final long txID) throws Exception {
       try (ArtemisCloseable lock = closeableReadLock()) {
          messageJournal.appendRollbackRecord(txID, syncTransactional, getContext(syncTransactional));

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/nullpm/NullStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/nullpm/NullStorageManager.java
@@ -209,6 +209,10 @@ public class NullStorageManager implements StorageManager {
    }
 
    @Override
+   public void asyncCommit(final long txID) {
+   }
+
+   @Override
    public JournalLoadInformation loadBindingJournal(final List<QueueBindingInfo> queueBindingInfos,
                                                     final List<GroupingInfo> groupingInfos,
                                                     final List<AddressBindingInfo> addressBindingInfos) throws Exception {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServer.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServer.java
@@ -973,6 +973,8 @@ public interface ActiveMQServer extends ServiceComponent {
     */
    void autoRemoveAddressInfo(SimpleString address, SecurityAuth auth) throws Exception;
 
+   void registerQueueOnManagement(Queue queue, boolean registerInternal) throws Exception;
+
    /**
     * Remove an {@code AddressInfo} from the broker.
     *

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -3944,6 +3944,12 @@ public class ActiveMQServerImpl implements ActiveMQServer {
       removeAddressInfo(address, auth);
    }
 
+   /** Register a queue on the management registry */
+   @Override
+   public void registerQueueOnManagement(Queue queue, boolean registerInternal) throws Exception {
+      managementService.registerQueue(queue, queue.getAddress(), storageManager, registerInternal);
+   }
+
    @Override
    public void removeAddressInfo(final SimpleString address, final SecurityAuth auth, boolean force) throws Exception {
       if (auth != null) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/ManagementService.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/ManagementService.java
@@ -100,6 +100,8 @@ public interface ManagementService extends NotificationService, ActiveMQComponen
 
    void registerQueue(Queue queue, SimpleString address, StorageManager storageManager) throws Exception;
 
+   void registerQueue(Queue queue, SimpleString address, StorageManager storageManager, boolean forceInternal) throws Exception;
+
    void unregisterQueue(SimpleString name, SimpleString address, RoutingType routingType) throws Exception;
 
    void registerAcceptor(Acceptor acceptor, TransportConfiguration configuration) throws Exception;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/impl/ManagementServiceImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/impl/ManagementServiceImpl.java
@@ -287,8 +287,15 @@ public class ManagementServiceImpl implements ManagementService {
    public synchronized void registerQueue(final Queue queue,
                                           final AddressInfo addressInfo,
                                           final StorageManager storageManager) throws Exception {
+      registerQueue(queue, addressInfo, storageManager, false);
+   }
 
-      if (addressInfo.isInternal() || queue.isInternalQueue()) {
+   private synchronized void registerQueue(final Queue queue,
+                                          final AddressInfo addressInfo,
+                                          final StorageManager storageManager,
+                                          boolean forceInternal) throws Exception {
+
+      if (!forceInternal && (addressInfo.isInternal() || queue.isInternalQueue())) {
          logger.debug("won't register internal queue: {}", queue);
          return;
       }
@@ -312,6 +319,14 @@ public class ManagementServiceImpl implements ManagementService {
                                           final SimpleString address,
                                           final StorageManager storageManager) throws Exception {
       registerQueue(queue, new AddressInfo(address), storageManager);
+   }
+
+   @Override
+   public synchronized void registerQueue(final Queue queue,
+                                          final SimpleString address,
+                                          final StorageManager storageManager,
+                                          final boolean forceInternal) throws Exception {
+      registerQueue(queue, new AddressInfo(address), storageManager, forceInternal);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/transaction/Transaction.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/transaction/Transaction.java
@@ -74,6 +74,8 @@ public interface Transaction {
 
    void addOperation(TransactionOperation sync);
 
+   void afterWired(Runnable runnable);
+
    /**
     * This is an operation that will be called right after the storage is completed.
     * addOperation could only happen after paging and replication, while these operations will just be
@@ -102,4 +104,9 @@ public interface Transaction {
    void setTimeout(int timeout);
 
    RefsOperation createRefsOperation(Queue queue, AckReason reason);
+
+   boolean isAsync();
+
+   /** To be used on control transactions that are meant as internal and don't really require a hard sync. */
+   Transaction setAsync(boolean async);
 }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/group/impl/ClusteredResetMockTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/group/impl/ClusteredResetMockTest.java
@@ -269,6 +269,11 @@ public class ClusteredResetMockTest extends ActiveMQTestBase {
       }
 
       @Override
+      public void registerQueue(Queue queue, SimpleString address, StorageManager storageManager, boolean forceInternal) throws Exception {
+
+      }
+
+      @Override
       public void unregisterQueue(SimpleString name, SimpleString address, RoutingType routingType) throws Exception {
 
       }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/transaction/impl/TransactionImplTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/transaction/impl/TransactionImplTest.java
@@ -330,6 +330,11 @@ public class TransactionImplTest extends ActiveMQTestBase {
       }
 
       @Override
+      public void asyncCommit(long txID) throws Exception {
+
+      }
+
+      @Override
       public ArtemisCloseable closeableReadLock() {
          return () -> { };
       }

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/artemis/utils/cli/helper/HelperBase.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/artemis/utils/cli/helper/HelperBase.java
@@ -76,5 +76,18 @@ public class HelperBase {
       return this;
    }
 
+   public HelperBase addArgs(String... args) {
+      int initialLength = this.args == null ? 0 : this.args.length;
+      String[] newArgs = new String[initialLength + args.length];
+      for (int i = 0; i < initialLength; i++) {
+         newArgs[i] = this.args[i];
+      }
+      for (int i = 0; i < args.length; i++) {
+         newArgs[i + initialLength] = args[i];
+      }
+      this.args = newArgs;
+      return this;
+   }
+
    String[] args = new String[0];
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPReplicaTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPReplicaTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.activemq.artemis.api.core.QueueConfiguration;
 import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.api.core.management.SimpleManagement;
 import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBrokerConnectConfiguration;
 import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBrokerConnectionAddressType;
 import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPMirrorBrokerConnectionElement;
@@ -92,6 +93,11 @@ public class AMQPReplicaTest extends AmqpClientTestSupport {
       } finally {
          loggerHandler.close();
       }
+   }
+
+   @Override
+   protected String getConfiguredProtocols() {
+      return "AMQP,OPENWIRE,CORE";
    }
 
    @Override
@@ -578,6 +584,9 @@ public class AMQPReplicaTest extends AmqpClientTestSupport {
          // Check some messages were sent to SnF queue
          Assert.assertTrue(server_2.locateQueue(replica.getMirrorSNF()).getMessagesAdded() > 0);
       }
+
+      SimpleManagement simpleManagement = new SimpleManagement("tcp://localhost:" + AMQP_PORT_2, null, null);
+      Wait.assertEquals(0, () -> simpleManagement.getMessageCountOnQueue("$ACTIVEMQ_ARTEMIS_MIRROR_mirror-source"), 5000);
 
       try (Connection connection = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT).createConnection()) {
          connection.start();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPReplicaTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPReplicaTest.java
@@ -1306,5 +1306,69 @@ public class AMQPReplicaTest extends AmqpClientTestSupport {
    }
 
 
+   @Test
+   public void testSimpleReplicaTX() throws Exception {
+
+      String brokerConnectionName = "brokerConnectionName:" + UUIDGenerator.getInstance().generateStringUUID();
+      server.setIdentity("targetServer");
+      server.start();
+      server_2 = createServer(AMQP_PORT_2, false);
+      server_2.setIdentity("server_2");
+      server_2.getConfiguration().setName("thisone");
+
+      AMQPBrokerConnectConfiguration amqpConnection = new AMQPBrokerConnectConfiguration(brokerConnectionName, "tcp://localhost:" + AMQP_PORT).setReconnectAttempts(-1).setRetryInterval(100);
+      AMQPMirrorBrokerConnectionElement replica = new AMQPMirrorBrokerConnectionElement().setMessageAcknowledgements(true).setDurable(true);
+      replica.setName("theReplica");
+      amqpConnection.addElement(replica);
+      server_2.getConfiguration().addAMQPConnection(amqpConnection);
+      server_2.getConfiguration().setName("server_2");
+
+      int NUMBER_OF_MESSAGES = 10;
+
+      server_2.start();
+      Wait.assertTrue(server_2::isStarted);
+
+      // We create the address to avoid auto delete on the queue
+      server_2.addAddressInfo(new AddressInfo(getQueueName()).addRoutingType(RoutingType.ANYCAST).setAutoCreated(false));
+      server_2.createQueue(new QueueConfiguration(getQueueName()).setRoutingType(RoutingType.ANYCAST).setAddress(getQueueName()).setAutoCreated(false));
+
+      ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT_2);
+      Connection connection = factory.createConnection();
+      Session session = connection.createSession(true, Session.SESSION_TRANSACTED);
+      MessageProducer producer = session.createProducer(session.createQueue(getQueueName()));
+
+      for (int i = 0; i < NUMBER_OF_MESSAGES; i++) {
+         Message message = session.createTextMessage(getText(true, i));
+         message.setIntProperty("i", i);
+         producer.send(message);
+      }
+      session.commit();
+
+      Queue queueOnServer1 = locateQueue(server, getQueueName());
+      Queue snfreplica = server_2.locateQueue(replica.getMirrorSNF());
+      Assert.assertNotNull(snfreplica);
+
+      Wait.assertEquals(0, snfreplica::getMessageCount);
+
+      Wait.assertEquals(NUMBER_OF_MESSAGES, queueOnServer1::getMessageCount, 2000);
+      Queue queueOnServer2 = locateQueue(server_2, getQueueName());
+      Wait.assertEquals(NUMBER_OF_MESSAGES, queueOnServer1::getMessageCount);
+      Wait.assertEquals(NUMBER_OF_MESSAGES, queueOnServer2::getMessageCount);
+
+      MessageConsumer consumer = session.createConsumer(session.createQueue(getQueueName()));
+      connection.start();
+
+      for (int i = 0; i < NUMBER_OF_MESSAGES; i++) {
+         Message m = consumer.receive(1000);
+         Assert.assertNotNull(m);
+      }
+      session.commit();
+
+      Wait.assertEquals(0, snfreplica::getMessageCount);
+      Wait.assertEquals(0, queueOnServer1::getMessageCount);
+      Wait.assertEquals(0, queueOnServer2::getMessageCount);
+   }
+
+
 
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/BrokerInSyncTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/BrokerInSyncTest.java
@@ -691,7 +691,7 @@ public class BrokerInSyncTest extends AmqpClientTestSupport {
       server_2.createQueue(new QueueConfiguration(getQueueName()).setDurable(true).setRoutingType(RoutingType.ANYCAST));
 
       Wait.assertTrue(() -> server_2.locateQueue(getQueueName()) != null);
-      Wait.assertTrue(() -> server.locateQueue(getQueueName()) != null);
+      Wait.assertTrue(() -> server.locateQueue(getQueueName()) != null, 5000);
 
       ConnectionFactory cf1 = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
       Connection connection1 = cf1.createConnection();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/MirrorControllerBasicTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/MirrorControllerBasicTest.java
@@ -94,7 +94,7 @@ public class MirrorControllerBasicTest extends ActiveMQTestBase {
       server.createQueue(new QueueConfiguration("test").setAddress("test").setRoutingType(RoutingType.ANYCAST));
 
       Message message = AMQPMirrorMessageFactory.createMessage("test", SimpleString.toSimpleString("ad1"), SimpleString.toSimpleString("qu1"), "test", "someUID", "body-test", AckReason.KILLED);
-      AMQPMirrorControllerSource.route(server, message);
+      AMQPMirrorControllerSource.routeMirrorCommand(server, message);
 
       AmqpClient client = new AmqpClient(new URI("tcp://localhost:61616"), null, null);
       AmqpConnection connection = client.connect();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/PagedMirrorTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/PagedMirrorTest.java
@@ -68,14 +68,14 @@ public class PagedMirrorTest extends ActiveMQTestBase {
       server1.getConfiguration().getAcceptorConfigurations().clear();
       server1.getConfiguration().addAcceptorConfiguration("server", "tcp://localhost:61616");
       AMQPBrokerConnectConfiguration brokerConnectConfiguration = new AMQPBrokerConnectConfiguration("other", "tcp://localhost:61617").setReconnectAttempts(-1).setRetryInterval(1000);
-      brokerConnectConfiguration.addElement(new AMQPMirrorBrokerConnectionElement());
+      brokerConnectConfiguration.addElement(new AMQPMirrorBrokerConnectionElement().setDurable(false));
       server1.getConfiguration().addAMQPConnection(brokerConnectConfiguration);
 
       server2 = createServer(true, createDefaultConfig(1, true), 1024, 10 * 1024, -1, -1);
       server2.getConfiguration().getAcceptorConfigurations().clear();
       server2.getConfiguration().addAcceptorConfiguration("server", "tcp://localhost:61617");
       brokerConnectConfiguration = new AMQPBrokerConnectConfiguration("other", "tcp://localhost:61616").setReconnectAttempts(-1).setRetryInterval(1000);
-      brokerConnectConfiguration.addElement(new AMQPMirrorBrokerConnectionElement());
+      brokerConnectConfiguration.addElement(new AMQPMirrorBrokerConnectionElement().setDurable(false));
       server2.getConfiguration().addAMQPConnection(brokerConnectConfiguration);
 
       server1.start();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SendAckFailTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SendAckFailTest.java
@@ -308,6 +308,11 @@ public class SendAckFailTest extends SpawnedTestBase {
       }
 
       @Override
+      public void asyncCommit(long txID) throws Exception {
+
+      }
+
+      @Override
       public void updateQueueBinding(long tx, Binding binding) throws Exception {
          manager.updateQueueBinding(tx, binding);
       }

--- a/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/brokerConnection/mirror/IdempotentACKTest.java
+++ b/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/brokerConnection/mirror/IdempotentACKTest.java
@@ -1,0 +1,313 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.tests.soak.brokerConnection.mirror;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import javax.jms.TransactionRolledBackException;
+import java.io.File;
+import java.io.StringWriter;
+import java.lang.invoke.MethodHandles;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.activemq.artemis.api.core.management.SimpleManagement;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBrokerConnectionAddressType;
+import org.apache.activemq.artemis.tests.soak.SoakTestBase;
+import org.apache.activemq.artemis.tests.util.CFUtil;
+import org.apache.activemq.artemis.tests.util.Wait;
+import org.apache.activemq.artemis.util.ServerUtil;
+import org.apache.activemq.artemis.utils.cli.helper.HelperCreate;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class IdempotentACKTest extends SoakTestBase {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   private static String largeBody;
+
+   static {
+      StringWriter writer = new StringWriter();
+      while (writer.getBuffer().length() < 1024 * 1024) {
+         writer.append("This is a large string ..... ");
+      }
+      largeBody = writer.toString();
+   }
+
+   private static final String QUEUE_NAME = "myQueue";
+
+   public static final String DC1_NODE_A = "idempotentMirror/DC1";
+   public static final String DC2_NODE_A = "idempotentMirror/DC2";
+
+   Process processDC1_node_A;
+   Process processDC2_node_A;
+
+   private static String DC1_NODEA_URI = "tcp://localhost:61616";
+   private static String DC2_NODEA_URI = "tcp://localhost:61618";
+
+   private static void createServer(String serverName,
+                                    String connectionName,
+                                    String mirrorURI,
+                                    int porOffset) throws Exception {
+      File serverLocation = getFileServerLocation(serverName);
+      deleteDirectory(serverLocation);
+
+      HelperCreate cliCreateServer = new HelperCreate();
+      cliCreateServer.setAllowAnonymous(true).setNoWeb(true).setArtemisInstance(serverLocation);
+      cliCreateServer.setMessageLoadBalancing("ON_DEMAND");
+      cliCreateServer.setClustered(false);
+      cliCreateServer.setNoWeb(true);
+      cliCreateServer.setArgs("--no-stomp-acceptor", "--no-hornetq-acceptor", "--no-mqtt-acceptor", "--no-amqp-acceptor", "--max-hops", "1", "--name", DC1_NODE_A);
+      cliCreateServer.addArgs("--queues", QUEUE_NAME);
+      cliCreateServer.setPortOffset(porOffset);
+      cliCreateServer.createServer();
+
+      Properties brokerProperties = new Properties();
+      brokerProperties.put("AMQPConnections." + connectionName + ".uri", mirrorURI);
+      brokerProperties.put("AMQPConnections." + connectionName + ".retryInterval", "1000");
+      brokerProperties.put("AMQPConnections." + connectionName + ".type", AMQPBrokerConnectionAddressType.MIRROR.toString());
+      brokerProperties.put("AMQPConnections." + connectionName + ".connectionElements.mirror.sync", "false");
+      brokerProperties.put("largeMessageSync", "false");
+      File brokerPropertiesFile = new File(serverLocation, "broker.properties");
+      saveProperties(brokerProperties, brokerPropertiesFile);
+   }
+
+   @BeforeClass
+   public static void createServers() throws Exception {
+      createServer(DC1_NODE_A, "mirror", DC2_NODEA_URI, 0);
+      createServer(DC2_NODE_A, "mirror", DC1_NODEA_URI, 2);
+   }
+
+   private void startServers() throws Exception {
+      processDC1_node_A = startServer(DC1_NODE_A, -1, -1, new File(getServerLocation(DC1_NODE_A), "broker.properties"));
+      processDC2_node_A = startServer(DC2_NODE_A, -1, -1, new File(getServerLocation(DC2_NODE_A), "broker.properties"));
+
+      ServerUtil.waitForServerToStart(0, 10_000);
+      ServerUtil.waitForServerToStart(2, 10_000);
+   }
+
+   @Before
+   public void cleanupServers() {
+      cleanupData(DC1_NODE_A);
+      cleanupData(DC2_NODE_A);
+   }
+
+   private void transactSend(Session session, MessageProducer producer, int initialCounter, int numberOfMessages, int largeMessageFactor) throws Throwable {
+      try {
+         for (int i = initialCounter; i < initialCounter + numberOfMessages; i++) {
+            TextMessage message;
+            String unique = "Unique " + i;
+            if (i % largeMessageFactor == 0) {
+               message = session.createTextMessage(largeBody);
+               message.setBooleanProperty("large", true);
+            } else {
+               message = session.createTextMessage("this is small");
+               message.setBooleanProperty("large", false);
+            }
+            message.setIntProperty("i", i);
+            message.setStringProperty(org.apache.activemq.artemis.api.core.Message.HDR_DUPLICATE_DETECTION_ID.toString(), unique);
+            producer.send(message);
+         }
+         session.commit();
+      } catch (JMSException e) {
+         if (e instanceof TransactionRolledBackException && e.getMessage().contains("Duplicate message detected")) {
+            logger.debug("OK Exception {}", e.getMessage(), e);
+            return; // ok
+         } else {
+            logger.warn("Not OK Exception {}", e.getMessage(), e);
+            throw e;
+         }
+      }
+   }
+
+
+   @Test
+   public void testAMQP() throws Exception {
+      testACKs("AMQP");
+   }
+
+   @Test
+   public void testCORE() throws Exception {
+      testACKs("CORE");
+   }
+
+   private void testACKs(final String protocol) throws Exception {
+      startServers();
+
+      final int consumers = 10;
+      final int numberOfMessages = 1000;
+      final int largeMessageFactor = 30;
+      final int messagesPerConsumer = 30;
+
+      // Just a reminder: if you change number on this test, this needs to be true:
+      Assert.assertEquals("Invalid test config", 0, numberOfMessages % consumers);
+
+      AtomicBoolean running = new AtomicBoolean(true);
+      runAfter(() -> running.set(false));
+
+      String snfQueue = "$ACTIVEMQ_ARTEMIS_MIRROR_mirror";
+
+      ExecutorService executor = Executors.newFixedThreadPool(consumers);
+      runAfter(executor::shutdownNow);
+
+      final ConnectionFactory connectionFactoryDC1A;
+      connectionFactoryDC1A = CFUtil.createConnectionFactory(protocol, DC1_NODEA_URI);
+      CountDownLatch sendDone = new CountDownLatch(1);
+      CountDownLatch killSend = new CountDownLatch(1);
+
+      executor.execute(() -> {
+         int messagesSent = 0;
+         while (running.get() && messagesSent < numberOfMessages) {
+            try (Connection connection = connectionFactoryDC1A.createConnection()) {
+               Session session = connection.createSession(true, Session.SESSION_TRANSACTED);
+               Queue queue = session.createQueue(QUEUE_NAME);
+               MessageProducer producer = session.createProducer(queue);
+               if (messagesSent < 100) {
+                  transactSend(session, producer, messagesSent, 1, 1);
+                  messagesSent++;
+                  logger.debug("Sent {}", messagesSent);
+                  if (messagesSent == 100) {
+                     logger.debug("Signal to kill");
+                     killSend.countDown();
+                  }
+               } else {
+                  transactSend(session, producer, messagesSent, 100, largeMessageFactor);
+                  messagesSent += 100;
+                  logger.debug("Sent {}", messagesSent);
+               }
+            } catch (Throwable e) {
+               logger.warn(e.getMessage(), e);
+               try {
+                  Thread.sleep(100);
+               } catch (Throwable ignored) {
+               }
+            }
+         }
+         sendDone.countDown();
+      });
+
+      Assert.assertTrue(killSend.await(50, TimeUnit.SECONDS));
+
+      restartDC1_ServerA();
+
+      Assert.assertTrue(sendDone.await(50, TimeUnit.SECONDS));
+
+      SimpleManagement simpleManagementDC1A = new SimpleManagement(DC1_NODEA_URI, null, null);
+      SimpleManagement simpleManagementDC2A = new SimpleManagement(DC2_NODEA_URI, null, null);
+
+      Wait.assertEquals(0, () -> getCount(simpleManagementDC1A, snfQueue));
+      Wait.assertEquals(numberOfMessages, () -> getCount(simpleManagementDC1A, QUEUE_NAME));
+      Wait.assertEquals(numberOfMessages, () -> getCount(simpleManagementDC2A, QUEUE_NAME));
+
+      CountDownLatch latchKill = new CountDownLatch(consumers);
+
+      CountDownLatch latchDone = new CountDownLatch(consumers);
+
+      Runnable runnableConsumer = () -> {
+         int messagesConsumed = 0;
+         while (running.get() && messagesConsumed < messagesPerConsumer) {
+            try (Connection connection = connectionFactoryDC1A.createConnection()) {
+               Session session = connection.createSession(true, Session.SESSION_TRANSACTED);
+               Queue queue = session.createQueue(QUEUE_NAME);
+               MessageConsumer consumer = session.createConsumer(queue);
+               connection.start();
+               while (messagesConsumed < messagesPerConsumer) {
+                  Message message = consumer.receive(100);
+                  if (message instanceof TextMessage) {
+                     logger.debug("message received={}", message);
+                     session.commit();
+                     messagesConsumed++;
+                     logger.debug("Received {}", messagesConsumed);
+                     if (messagesConsumed == 10) {
+                        latchKill.countDown();
+                     }
+                  } else {
+                     logger.info("no messages...");
+                  }
+               }
+            } catch (Throwable e) {
+               logger.warn(e.getMessage(), e);
+               try {
+                  Thread.sleep(100);
+               } catch (Throwable ignored) {
+               }
+            }
+         }
+         latchDone.countDown();
+      };
+
+      for (int i = 0; i < consumers; i++) {
+         executor.execute(runnableConsumer);
+      }
+
+      Assert.assertTrue(latchKill.await(10, TimeUnit.SECONDS));
+
+      restartDC1_ServerA();
+
+      Assert.assertTrue(latchDone.await(4, TimeUnit.MINUTES));
+
+      long flushedMessages = 0;
+
+      try (Connection connection = connectionFactoryDC1A.createConnection()) {
+         Session session = connection.createSession(true, Session.SESSION_TRANSACTED);
+         Queue queue = session.createQueue(QUEUE_NAME);
+         MessageConsumer consumer = session.createConsumer(queue);
+         connection.start();
+         while (consumer.receive(500) != null) {
+            flushedMessages++;
+         }
+         session.commit();
+      }
+
+      logger.debug("Flushed {}", flushedMessages);
+
+      // after all flushed messages, we should have 0 messages on both nodes
+
+      Wait.assertEquals(0, () -> getCount(simpleManagementDC1A, snfQueue));
+      Wait.assertEquals(0, () -> getCount(simpleManagementDC2A, QUEUE_NAME));
+   }
+
+   private void restartDC1_ServerA() throws Exception {
+      processDC1_node_A.destroyForcibly();
+      Assert.assertTrue(processDC1_node_A.waitFor(10, TimeUnit.SECONDS));
+      processDC1_node_A = startServer(DC1_NODE_A, -1, -1, new File(getServerLocation(DC1_NODE_A), "broker.properties"));
+      ServerUtil.waitForServerToStart(0, 10_000);
+   }
+
+   public long getCount(SimpleManagement simpleManagement, String queue) throws Exception {
+      long value = simpleManagement.getMessageCountOnQueue(queue);
+      logger.debug("count on queue {} is {}", queue, value);
+      return value;
+   }
+}

--- a/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/brokerConnection/mirror/InterruptedLargeMessageTest.java
+++ b/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/brokerConnection/mirror/InterruptedLargeMessageTest.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.tests.soak.brokerConnection.mirror;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import java.io.File;
+import java.io.StringWriter;
+import java.lang.invoke.MethodHandles;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.activemq.artemis.api.core.management.SimpleManagement;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBrokerConnectionAddressType;
+import org.apache.activemq.artemis.tests.soak.SoakTestBase;
+import org.apache.activemq.artemis.tests.util.CFUtil;
+import org.apache.activemq.artemis.tests.util.Wait;
+import org.apache.activemq.artemis.util.ServerUtil;
+import org.apache.activemq.artemis.utils.cli.helper.HelperCreate;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InterruptedLargeMessageTest extends SoakTestBase {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   private static String largeBody;
+
+   static {
+      StringWriter writer = new StringWriter();
+      while (writer.getBuffer().length() < 1024 * 1024) {
+         writer.append("This is a large string ..... ");
+      }
+      largeBody = writer.toString();
+   }
+
+   private static final String QUEUE_NAME = "myQueue";
+
+   public static final String DC1_NODE_A = "interruptLarge/DC1";
+   public static final String DC2_NODE_A = "interruptLarge/DC2";
+
+   Process processDC1_node_A;
+   Process processDC2_node_A;
+
+   private static String DC1_NODEA_URI = "tcp://localhost:61616";
+   private static String DC2_NODEA_URI = "tcp://localhost:61618";
+
+   private static void createServer(String serverName,
+                                    String connectionName,
+                                    String mirrorURI,
+                                    int porOffset) throws Exception {
+      File serverLocation = getFileServerLocation(serverName);
+      deleteDirectory(serverLocation);
+
+      HelperCreate cliCreateServer = new HelperCreate();
+      cliCreateServer.setAllowAnonymous(true).setNoWeb(true).setArtemisInstance(serverLocation);
+      cliCreateServer.setMessageLoadBalancing("ON_DEMAND");
+      cliCreateServer.setClustered(false);
+      cliCreateServer.setNoWeb(true);
+      cliCreateServer.setArgs("--no-stomp-acceptor", "--no-hornetq-acceptor", "--no-mqtt-acceptor", "--no-amqp-acceptor", "--max-hops", "1", "--name", DC1_NODE_A);
+      cliCreateServer.addArgs("--queues", QUEUE_NAME);
+      cliCreateServer.setPortOffset(porOffset);
+      cliCreateServer.createServer();
+
+      Properties brokerProperties = new Properties();
+      brokerProperties.put("AMQPConnections." + connectionName + ".uri", mirrorURI);
+      brokerProperties.put("AMQPConnections." + connectionName + ".retryInterval", "1000");
+      brokerProperties.put("AMQPConnections." + connectionName + ".type", AMQPBrokerConnectionAddressType.MIRROR.toString());
+      brokerProperties.put("AMQPConnections." + connectionName + ".connectionElements.mirror.sync", "false");
+      brokerProperties.put("largeMessageSync", "false");
+      File brokerPropertiesFile = new File(serverLocation, "broker.properties");
+      saveProperties(brokerProperties, brokerPropertiesFile);
+   }
+
+   @BeforeClass
+   public static void createServers() throws Exception {
+      createServer(DC1_NODE_A, "mirror", DC2_NODEA_URI, 0);
+      createServer(DC2_NODE_A, "mirror", DC1_NODEA_URI, 2);
+   }
+
+   private void startDC1() throws Exception {
+      processDC1_node_A = startServer(DC1_NODE_A, -1, -1, new File(getServerLocation(DC1_NODE_A), "broker.properties"));
+      ServerUtil.waitForServerToStart(0, 10_000);
+   }
+
+   @Before
+   public void cleanupServers() {
+      cleanupData(DC1_NODE_A);
+      cleanupData(DC2_NODE_A);
+   }
+
+   @Test
+   public void testAMQP() throws Exception {
+      testInterrupt("AMQP");
+   }
+
+   @Test
+   public void testCORE() throws Exception {
+      testInterrupt("CORE");
+   }
+
+   private void testInterrupt(final String protocol) throws Exception {
+      startDC1();
+
+      final int numberOfMessages = 400;
+
+      String snfQueue = "$ACTIVEMQ_ARTEMIS_MIRROR_mirror";
+
+      ConnectionFactory connectionFactoryDC1A = CFUtil.createConnectionFactory(protocol, DC1_NODEA_URI);
+      ConnectionFactory connectionFactoryDC2A = CFUtil.createConnectionFactory(protocol, DC2_NODEA_URI);
+
+      SimpleManagement simpleManagementDC1A = new SimpleManagement(DC1_NODEA_URI, null, null);
+      SimpleManagement simpleManagementDC2A = new SimpleManagement(DC2_NODEA_URI, null, null);
+
+      try (Connection connection = connectionFactoryDC1A.createConnection()) {
+         Session session = connection.createSession(true, Session.SESSION_TRANSACTED);
+         Queue queue = session.createQueue(QUEUE_NAME);
+         MessageProducer producer = session.createProducer(queue);
+
+         for (int i = 0; i < numberOfMessages; i++) {
+            TextMessage message = session.createTextMessage(largeBody);
+            message.setIntProperty("id", i);
+            producer.send(message);
+            if (i % 10 == 0) {
+               logger.debug("Sent {} messages", i);
+               session.commit();
+            }
+         }
+         session.commit();
+
+         startDC2();
+
+         // Waiting for at least one large message file in the target server
+         Wait.assertTrue(() -> getNumberOfLargeMessages(DC2_NODE_A) > 0, 5000, 100);
+
+         stopDC2();
+         startDC2();
+      }
+
+      try (Connection connection = connectionFactoryDC2A.createConnection()) {
+         Session session = connection.createSession(true, Session.SESSION_TRANSACTED);
+         connection.start();
+         MessageConsumer consumer = session.createConsumer(session.createQueue(QUEUE_NAME));
+         for (int i = 0; i < numberOfMessages; i++) {
+            TextMessage message = (TextMessage) consumer.receive(5000);
+            Assert.assertNotNull(message);
+            Assert.assertEquals(i, message.getIntProperty("id"));
+            if (i % 10 == 0) {
+               session.commit();
+               logger.debug("Received {} messages", i);
+            }
+         }
+         session.commit();
+      }
+
+      Wait.assertEquals(0, () -> getCount(simpleManagementDC1A, snfQueue));
+      Wait.assertEquals(0, () -> getCount(simpleManagementDC2A, snfQueue));
+      Wait.assertEquals(0, () -> getCount(simpleManagementDC2A, QUEUE_NAME));
+      Wait.assertEquals(0, () -> getCount(simpleManagementDC1A, QUEUE_NAME));
+
+      Wait.assertEquals(0, () -> getNumberOfLargeMessages(DC1_NODE_A), 5000);
+      Wait.assertEquals(0, () -> getNumberOfLargeMessages(DC2_NODE_A), 5000);
+   }
+
+   int getNumberOfLargeMessages(String serverName) throws Exception {
+      File lmFolder = new File(getServerLocation(serverName) + "/data/large-messages");
+      Assert.assertTrue(lmFolder.exists());
+      return lmFolder.list().length;
+   }
+
+   private void stopDC2() throws Exception {
+      processDC2_node_A.destroyForcibly();
+      Assert.assertTrue(processDC2_node_A.waitFor(10, TimeUnit.SECONDS));
+   }
+
+   private void startDC2() throws Exception {
+      processDC2_node_A = startServer(DC2_NODE_A, -1, -1, new File(getServerLocation(DC2_NODE_A), "broker.properties"));
+      ServerUtil.waitForServerToStart(2, 10_000);
+   }
+
+   public long getCount(SimpleManagement simpleManagement, String queue) throws Exception {
+      long value = simpleManagement.getMessageCountOnQueue(queue);
+      logger.debug("count on queue {} is {}", queue, value);
+      return value;
+   }
+}

--- a/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/brokerConnection/mirror/MirroredTopicSoakTest.java
+++ b/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/brokerConnection/mirror/MirroredTopicSoakTest.java
@@ -1,0 +1,307 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.tests.soak.brokerConnection.mirror;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import javax.jms.Topic;
+import java.io.File;
+import java.io.StringWriter;
+import java.lang.invoke.MethodHandles;
+import java.util.Properties;
+
+import org.apache.activemq.artemis.api.core.management.SimpleManagement;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBrokerConnectionAddressType;
+import org.apache.activemq.artemis.tests.soak.SoakTestBase;
+import org.apache.activemq.artemis.tests.util.CFUtil;
+import org.apache.activemq.artemis.tests.util.Wait;
+import org.apache.activemq.artemis.util.ServerUtil;
+import org.apache.activemq.artemis.utils.cli.helper.HelperCreate;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MirroredTopicSoakTest extends SoakTestBase {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   private static String largeBody;
+   private static String smallBody = "This is a small body";
+
+   static {
+      StringWriter writer = new StringWriter();
+      while (writer.getBuffer().length() < 1024 * 1024) {
+         writer.append("This is a large string ..... ");
+      }
+      largeBody = writer.toString();
+   }
+
+   public static final String DC1_NODE_A = "mirror/DC1/A";
+   public static final String DC2_NODE_A = "mirror/DC2/A";
+   public static final String DC1_NODE_B = "mirror/DC1/B";
+   public static final String DC2_NODE_B = "mirror/DC2/B";
+
+   Process processDC1_node_A;
+   Process processDC1_node_B;
+   Process processDC2_node_A;
+   Process processDC2_node_B;
+
+
+   private static String DC1_NODEA_URI = "tcp://localhost:61616";
+   private static String DC1_NODEB_URI = "tcp://localhost:61617";
+   private static String DC2_NODEA_URI = "tcp://localhost:61618";
+   private static String DC2_NODEB_URI = "tcp://localhost:61619";
+
+   private static void createServer(String serverName, String connectionName, String clusterURI, String mirrorURI, int porOffset) throws Exception {
+      File serverLocation = getFileServerLocation(serverName);
+      deleteDirectory(serverLocation);
+
+      HelperCreate cliCreateServer = new HelperCreate();
+      cliCreateServer.setAllowAnonymous(true).setNoWeb(true).setArtemisInstance(serverLocation);
+      cliCreateServer.setMessageLoadBalancing("ON_DEMAND");
+      cliCreateServer.setClustered(true);
+      cliCreateServer.setNoWeb(true);
+      cliCreateServer.setStaticCluster(clusterURI);
+      cliCreateServer.setArgs("--no-stomp-acceptor", "--no-hornetq-acceptor", "--no-mqtt-acceptor", "--no-amqp-acceptor", "--max-hops", "1", "--name", DC1_NODE_A);
+      cliCreateServer.addArgs("--addresses", "order");
+      cliCreateServer.addArgs("--queues", "myQueue");
+      cliCreateServer.setPortOffset(porOffset);
+      cliCreateServer.createServer();
+
+      Properties brokerProperties = new Properties();
+      brokerProperties.put("AMQPConnections." + connectionName + ".uri", mirrorURI);
+      brokerProperties.put("AMQPConnections." + connectionName + ".retryInterval", "1000");
+      brokerProperties.put("AMQPConnections." + connectionName + ".type", AMQPBrokerConnectionAddressType.MIRROR.toString());
+      brokerProperties.put("AMQPConnections." + connectionName + ".connectionElements.mirror.sync", "false");
+      brokerProperties.put("largeMessageSync", "false");
+      File brokerPropertiesFile = new File(serverLocation, "broker.properties");
+      saveProperties(brokerProperties, brokerPropertiesFile);
+   }
+
+   @BeforeClass
+   public static void createServers() throws Exception {
+      createServer(DC1_NODE_A, "mirror", DC1_NODEB_URI, DC2_NODEA_URI, 0);
+      createServer(DC1_NODE_B, "mirror", DC1_NODEA_URI, DC2_NODEB_URI, 1);
+      createServer(DC2_NODE_A, "mirror", DC2_NODEB_URI, DC1_NODEA_URI, 2);
+      createServer(DC2_NODE_B, "mirror", DC2_NODEA_URI, DC1_NODEB_URI, 3);
+   }
+
+   private void startServers() throws Exception {
+      processDC1_node_A = startServer(DC1_NODE_A, -1, -1, new File(getServerLocation(DC1_NODE_A), "broker.properties"));
+      processDC1_node_B = startServer(DC1_NODE_B, -1, -1, new File(getServerLocation(DC1_NODE_B), "broker.properties"));
+      processDC2_node_A = startServer(DC2_NODE_A, -1, -1, new File(getServerLocation(DC2_NODE_A), "broker.properties"));
+      processDC2_node_B = startServer(DC2_NODE_B, -1, -1, new File(getServerLocation(DC2_NODE_B), "broker.properties"));
+
+      ServerUtil.waitForServerToStart(0, 10_000);
+      ServerUtil.waitForServerToStart(1, 10_000);
+      ServerUtil.waitForServerToStart(2, 10_000);
+      ServerUtil.waitForServerToStart(3, 10_000);
+   }
+
+   @Test
+   public void testQueue() throws Exception {
+      startServers();
+
+      final int numberOfMessages = 200;
+
+      Assert.assertTrue("numberOfMessages must be even", numberOfMessages % 2 == 0);
+
+      ConnectionFactory connectionFactoryDC1A = CFUtil.createConnectionFactory("amqp", DC1_NODEA_URI);
+      ConnectionFactory connectionFactoryDC2A = CFUtil.createConnectionFactory("amqp", DC2_NODEA_URI);
+      String snfQueue = "$ACTIVEMQ_ARTEMIS_MIRROR_mirror";
+
+      SimpleManagement simpleManagementDC1A = new SimpleManagement(DC1_NODEA_URI, null, null);
+
+      try (Connection connection = connectionFactoryDC1A.createConnection()) {
+         Session session = connection.createSession(true, Session.SESSION_TRANSACTED);
+         Queue queue = session.createQueue("myQueue");
+         MessageProducer producer = session.createProducer(queue);
+
+         for (int i = 0; i < numberOfMessages; i++) {
+            TextMessage message;
+            boolean large;
+            if (i % 1 == 2) {
+               message = session.createTextMessage(largeBody);
+               large = true;
+            } else {
+               message = session.createTextMessage(smallBody);
+               large = false;
+            }
+            message.setIntProperty("i", i);
+            message.setBooleanProperty("large", large);
+            producer.send(message);
+            if (i % 100 == 0) {
+               logger.debug("commit {}", i);
+               session.commit();
+            }
+         }
+         session.commit();
+      }
+
+      logger.debug("All messages were sent");
+
+      try (Connection connection = connectionFactoryDC1A.createConnection()) {
+         connection.start();
+         Session session = connection.createSession(true, Session.SESSION_TRANSACTED);
+         Queue queue = session.createQueue("myQueue");
+         MessageConsumer consumer = session.createConsumer(queue);
+
+         for (int i = 0; i < numberOfMessages / 2; i++) {
+            TextMessage message = (TextMessage) consumer.receive(5000);
+            Assert.assertNotNull(message);
+            logger.debug("Received message {}, large={}", message.getIntProperty("i"), message.getBooleanProperty("large"));
+         }
+         session.commit();
+      }
+
+      processDC2_node_A.destroyForcibly();
+      processDC2_node_A.waitFor();
+      processDC2_node_A = startServer(DC2_NODE_A, 2, 5000, new File(getServerLocation(DC2_NODE_A), "broker.properties"));
+
+      Wait.assertEquals(0L, () -> getCount(simpleManagementDC1A, snfQueue), 250_000, 1000);
+
+      try (Connection connection = connectionFactoryDC2A.createConnection()) {
+         connection.start();
+         Session session = connection.createSession(true, Session.SESSION_TRANSACTED);
+         Queue queue = session.createQueue("myQueue");
+         MessageConsumer consumer = session.createConsumer(queue);
+
+         for (int i = 0; i < numberOfMessages / 2; i++) {
+            TextMessage message = (TextMessage) consumer.receive(5000);
+            Assert.assertNotNull(message);
+            logger.debug("Received message {}, large={}", message.getIntProperty("i"), message.getBooleanProperty("large"));
+         }
+         session.commit();
+      }
+   }
+
+   @Test
+   public void testMirroredTopics() throws Exception {
+      startServers();
+
+      final int numberOfMessages = 200;
+
+      Assert.assertTrue("numberOfMessages must be even", numberOfMessages % 2 == 0);
+
+      String clientIDA = "nodeA";
+      String clientIDB = "nodeB";
+      String subscriptionID = "my-order";
+      String snfQueue = "$ACTIVEMQ_ARTEMIS_MIRROR_mirror";
+
+      ConnectionFactory connectionFactoryDC1A = CFUtil.createConnectionFactory("amqp", "tcp://localhost:61616");
+      ConnectionFactory connectionFactoryDC1B = CFUtil.createConnectionFactory("amqp", "tcp://localhost:61617");
+      ConnectionFactory connectionFactoryDC2A = CFUtil.createConnectionFactory("amqp", "tcp://localhost:61618");
+      ConnectionFactory connectionFactoryDC2B = CFUtil.createConnectionFactory("amqp", "tcp://localhost:61619");
+
+      SimpleManagement simpleManagementDC1B = new SimpleManagement(DC1_NODEB_URI, null, null);
+      SimpleManagement simpleManagementDC2B = new SimpleManagement(DC2_NODEB_URI, null, null);
+
+      consume(connectionFactoryDC1A, clientIDA, subscriptionID,  0, 0, false);
+      consume(connectionFactoryDC1B, clientIDB, subscriptionID,  0, 0, false);
+
+      try (Connection connection = connectionFactoryDC1B.createConnection()) {
+         Session session = connection.createSession(true, Session.SESSION_TRANSACTED);
+         Topic topic = session.createTopic("order");
+         MessageProducer producer = session.createProducer(topic);
+
+         for (int i = 0; i < numberOfMessages; i++) {
+            TextMessage message;
+            boolean large;
+            message = session.createTextMessage(largeBody);
+            large = true;
+            message.setIntProperty("i", i);
+            message.setBooleanProperty("large", large);
+            producer.send(message);
+            if (i % 100 == 0) {
+               logger.debug("commit {}", i);
+               session.commit();
+            }
+         }
+         session.commit();
+      }
+
+      logger.debug("Consuming from DC1B");
+      consume(connectionFactoryDC1B, clientIDB, subscriptionID,  0, numberOfMessages / 2, false);
+
+      processDC2_node_B.destroyForcibly();
+      processDC2_node_B.waitFor();
+      processDC2_node_B = startServer(DC2_NODE_B, 3, 5000, new File(getServerLocation(DC2_NODE_B), "broker.properties"));
+
+      Wait.assertEquals(0L, () -> getCount(simpleManagementDC1B, snfQueue), 250_000, 1000);
+      Wait.assertEquals(numberOfMessages / 2, () -> simpleManagementDC2B.getMessageCountOnQueue("nodeB.my-order"), 10000);
+
+      logger.debug("Consuming from DC2B with {}", simpleManagementDC2B.getMessageCountOnQueue("nodeB.my-order"));
+
+      consume(connectionFactoryDC2B, clientIDB, subscriptionID,  numberOfMessages / 2, numberOfMessages / 2, true);
+
+      Wait.assertEquals(0, () -> simpleManagementDC2B.getMessageCountOnQueue("nodeB.my-order"), 10000);
+
+      Wait.assertEquals(0, () -> simpleManagementDC1B.getMessageCountOnQueue("nodeB.my-order"), 10000);
+      consume(connectionFactoryDC1B, clientIDB, subscriptionID,  numberOfMessages, 0, true);
+      logger.debug("DC1B nodeB.my-order=0");
+   }
+
+   public long getCount(SimpleManagement simpleManagement, String queue) throws Exception {
+      long value = simpleManagement.getMessageCountOnQueue(queue);
+      logger.debug("count on queue {} is {}", queue, value);
+      return value;
+   }
+
+   private static void consume(ConnectionFactory factory, String clientID, String subscriptionID, int start, int numberOfMessages, boolean expectEmpty) throws Exception {
+      try (Connection connection = factory.createConnection()) {
+         connection.setClientID(clientID);
+         Session session = connection.createSession(true, Session.SESSION_TRANSACTED);
+         Topic topic = session.createTopic("order");
+         connection.start();
+         MessageConsumer consumer = session.createDurableConsumer(topic, subscriptionID);
+         boolean failed = false;
+
+         for (int i = start; i < start + numberOfMessages; i++) {
+            TextMessage message = (TextMessage) consumer.receive(10_000);
+            Assert.assertNotNull(message);
+            logger.debug("Received message {}, large={}", message.getIntProperty("i"), message.getBooleanProperty("large"));
+            if (message.getIntProperty("i") != i) {
+               failed = true;
+               logger.warn("Expected message {} but got {}", i, message.getIntProperty("i"));
+            }
+            if (message.getBooleanProperty("large")) {
+               Assert.assertEquals(largeBody, message.getText());
+            } else {
+               Assert.assertEquals(smallBody, message.getText());
+            }
+            logger.debug("Consumed {}, large={}", i, message.getBooleanProperty("large"));
+         }
+         session.commit();
+
+         Assert.assertFalse(failed);
+
+         if (expectEmpty) {
+            Assert.assertNull(consumer.receiveNoWait());
+         }
+      }
+
+   }
+
+}

--- a/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/brokerConnection/sender/SenderSoakTest.java
+++ b/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/brokerConnection/sender/SenderSoakTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.tests.soak.brokerConnection.sender;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import java.io.File;
+import java.io.StringWriter;
+import java.lang.invoke.MethodHandles;
+import java.util.Properties;
+
+import org.apache.activemq.artemis.tests.soak.SoakTestBase;
+import org.apache.activemq.artemis.tests.util.CFUtil;
+import org.apache.activemq.artemis.util.ServerUtil;
+import org.apache.activemq.artemis.utils.cli.helper.HelperCreate;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SenderSoakTest extends SoakTestBase {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   private static String largeBody;
+   private static String smallBody = "This is a small body";
+
+   {
+      StringWriter writer = new StringWriter();
+      while (writer.getBuffer().length() < 1024 * 1024) {
+         writer.append("This is a large string ..... ");
+      }
+      largeBody = writer.toString();
+   }
+
+   public static final String DC1_NODE_A = "sender/DC1/A";
+   public static final String DC2_NODE_A = "sender/DC2/A";
+
+   Process processDC1_node_A;
+   Process processDC2_node_A;
+
+   private static String DC1_NODEA_URI = "tcp://localhost:61616";
+   private static String DC2_NODEA_URI = "tcp://localhost:61618";
+
+   private static void createServer(String serverName, int porOffset) throws Exception {
+      File serverLocation = getFileServerLocation(serverName);
+      deleteDirectory(serverLocation);
+
+      HelperCreate cliCreateServer = new HelperCreate();
+      cliCreateServer.setAllowAnonymous(true).setNoWeb(true).setArtemisInstance(serverLocation);
+      cliCreateServer.setMessageLoadBalancing("STRICT");
+      cliCreateServer.setClustered(false);
+      cliCreateServer.setNoWeb(true);
+      cliCreateServer.setArgs("--no-stomp-acceptor", "--no-hornetq-acceptor", "--no-mqtt-acceptor", "--no-amqp-acceptor", "--max-hops", "1", "--name", DC1_NODE_A);
+      cliCreateServer.addArgs("--addresses", "order");
+      cliCreateServer.addArgs("--queues", "myQueue");
+      cliCreateServer.setPortOffset(porOffset);
+      cliCreateServer.createServer();
+   }
+
+   public static void createServers(boolean useMirror) throws Exception {
+      createServer(DC1_NODE_A, 0);
+
+      if (useMirror) {
+         Properties brokerProperties = new Properties();
+         brokerProperties.put("AMQPConnections.sender.uri", "tcp://localhost:61618");
+         brokerProperties.put("AMQPConnections.sender.retryInterval", "100");
+         brokerProperties.put("AMQPConnections.sender.connectionElements.sender.type", "MIRROR");
+         brokerProperties.put("largeMessageSync", "false");
+         File brokerPropertiesFile = new File(getServerLocation(DC1_NODE_A), "broker.properties");
+         saveProperties(brokerProperties, brokerPropertiesFile);
+      } else {
+         Properties brokerProperties = new Properties();
+         brokerProperties.put("AMQPConnections.sender.uri", "tcp://localhost:61618");
+         brokerProperties.put("AMQPConnections.sender.retryInterval", "100");
+         brokerProperties.put("AMQPConnections.sender.connectionElements.sender.type", "SENDER");
+         brokerProperties.put("AMQPConnections.sender.connectionElements.sender.queueName", "myQueue");
+         brokerProperties.put("largeMessageSync", "false");
+         File brokerPropertiesFile = new File(getServerLocation(DC1_NODE_A), "broker.properties");
+         saveProperties(brokerProperties, brokerPropertiesFile);
+      }
+
+      createServer(DC2_NODE_A, 2);
+   }
+
+   private void startServers() throws Exception {
+      processDC2_node_A = startServer(DC2_NODE_A, -1, -1);
+      processDC1_node_A = startServer(DC1_NODE_A, -1, -1, new File(getServerLocation(DC1_NODE_A), "broker.properties"));
+
+      ServerUtil.waitForServerToStart(0, 10_000);
+      ServerUtil.waitForServerToStart(2, 10_000);
+   }
+
+   @Test
+   public void testMirror() throws Exception {
+      testSender(true);
+   }
+
+   @Test
+   public void testSender() throws Exception {
+      testSender(false);
+   }
+
+   public void testSender(boolean mirror) throws Exception {
+      createServers(mirror);
+      startServers();
+
+      final int numberOfMessages = 1000;
+
+      Assert.assertTrue("numberOfMessages must be even", numberOfMessages % 2 == 0);
+
+      ConnectionFactory connectionFactoryDC1A = CFUtil.createConnectionFactory("amqp", "tcp://localhost:61616");
+      ConnectionFactory connectionFactoryDC2A = CFUtil.createConnectionFactory("amqp", "tcp://localhost:61618");
+
+      try (Connection connection = connectionFactoryDC1A.createConnection()) {
+         Session session = connection.createSession(true, Session.SESSION_TRANSACTED);
+         Queue queue = session.createQueue("myQueue");
+         MessageProducer producer = session.createProducer(queue);
+
+         for (int i = 0; i < numberOfMessages; i++) {
+            TextMessage message;
+            boolean large;
+            if (i % 1 == 10) {
+               message = session.createTextMessage(largeBody);
+               large = true;
+            } else {
+               message = session.createTextMessage(smallBody);
+               large = false;
+            }
+            message.setIntProperty("i", i);
+            message.setBooleanProperty("large", large);
+            producer.send(message);
+            if (i % 100 == 0) {
+               logger.debug("commit {}", i);
+               session.commit();
+            }
+         }
+         session.commit();
+      }
+
+      logger.debug("All messages were sent");
+
+      try (Connection connection = connectionFactoryDC2A.createConnection()) {
+         connection.start();
+         Session session = connection.createSession(true, Session.SESSION_TRANSACTED);
+         Queue queue = session.createQueue("myQueue");
+         MessageConsumer consumer = session.createConsumer(queue);
+
+         for (int i = 0; i < numberOfMessages; i++) {
+            TextMessage message = (TextMessage) consumer.receive(5000);
+            Assert.assertNotNull(message);
+            logger.debug("Received message {}, large={}", message.getIntProperty("i"), message.getBooleanProperty("large"));
+         }
+         session.commit();
+      }
+   }
+
+}

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/BindingsImplTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/BindingsImplTest.java
@@ -138,7 +138,22 @@ public class BindingsImplTest extends ActiveMQTestBase {
       }
 
       @Override
+      public boolean isAsync() {
+         return false;
+      }
+
+      @Override
+      public Transaction setAsync(boolean async) {
+         return null;
+      }
+
+      @Override
       public void setProtocolData(Object data) {
+
+      }
+
+      @Override
+      public void afterWired(Runnable runnable) {
 
       }
 


### PR DESCRIPTION
Mirror acks should be performed atomically with the storage of the source ACK. Both the send of the ack and the recording of the ack should be part of the same transaction (in case of transactional).
    
We are also adding support on transactions for an afterWired callback for the proper plug of OperationContext sync.