### PR TITLE
ARTEMIS-3831 scale-down w/jgroups fails if using same dg as cluster-connection

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/JGroupsBroadcastEndpoint.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/JGroupsBroadcastEndpoint.java
@@ -96,6 +96,9 @@ public abstract class JGroupsBroadcastEndpoint implements BroadcastEndpoint {
       if (clientOpened) {
          return;
       }
+      if (channel.getChannel() == null || channel.getChannel().isClosed()) {
+         initChannel();
+      }
       internalOpen();
       receiver = new JGroupsReceiver();
       channel.addReceiver(receiver);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/discovery/DiscoveryTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/discovery/DiscoveryTest.java
@@ -140,6 +140,15 @@ public class DiscoveryTest extends DiscoveryBaseTest {
       assertEqualsDiscoveryEntries(Arrays.asList(live1), entries);
    }
 
+   @Test
+   public void testJGroupsOpenClientInitializesChannel() throws Exception {
+      JGroupsFileBroadcastEndpointFactory factory = new JGroupsFileBroadcastEndpointFactory().setFile(TEST_JGROUPS_CONF_FILE).setChannelName("tst");
+      BroadcastEndpoint endpoint = factory.createBroadcastEndpoint();
+      endpoint.close(false);
+      endpoint.openClient();
+      endpoint.close(false);
+   }
+
    /**
     * Create one broadcaster and 100 receivers. Make sure broadcasting works.
     * Then stop 99 of the receivers, the last one could still be working.


### PR DESCRIPTION
If both scale-down and cluster-connection are using the same JGroups discovery-group then when the cluster-connection stops it  will close the underlying org.jgroups.JChannel and when the scale-down process tries to use it to find a server it will fail.
    
This commit ensures that the JGroupsBroadcastEndpoint implementation of BroadcastEndpoint#openClient initializes the channel if it has been closed.