### PR TITLE
ARTEMIS-4567 support OpenWire clients for broker embedded in Jakarta environment

### DIFF
--- a/artemis-protocols/artemis-jakarta-openwire-protocol/pom.xml
+++ b/artemis-protocols/artemis-jakarta-openwire-protocol/pom.xml
@@ -1,0 +1,152 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+
+   <parent>
+      <artifactId>artemis-protocols</artifactId>
+      <groupId>org.apache.activemq</groupId>
+      <version>2.32.0-SNAPSHOT</version>
+   </parent>
+
+   <artifactId>artemis-jakarta-openwire-protocol</artifactId>
+   <packaging>bundle</packaging>
+   <name>ActiveMQ Artemis Jakarta OpenWire Protocol</name>
+   <description>To support OpenWire clients from an embedded broker deployed in a Jakarta environment (e.g. Spring Boot 3)</description>
+
+   <properties>
+      <activemq.basedir>${project.basedir}/../..</activemq.basedir>
+      <jakarta.jms-api.version>${jakarta.jms-api.version.alt}</jakarta.jms-api.version>
+      <jakarta.transaction-api.version>${jakarta.transaction-api.version.alt}</jakarta.transaction-api.version>
+      <jakarta.resource-api.version>${jakarta.resource-api.version.alt}</jakarta.resource-api.version>
+   </properties>
+
+   <dependencies>
+      <!-- logging -->
+      <dependency>
+         <groupId>org.slf4j</groupId>
+         <artifactId>slf4j-api</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.logging.log4j</groupId>
+         <artifactId>log4j-slf4j2-impl</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>activemq-client-jakarta</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-jakarta-server</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-jakarta-client</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-core-client</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-commons</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-journal</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-selector</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+         <groupId>jakarta.jms</groupId>
+         <artifactId>jakarta.jms-api</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.fusesource.hawtbuf</groupId>
+         <artifactId>hawtbuf</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-buffer</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-transport</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-codec</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.osgi</groupId>
+         <artifactId>osgi.cmpn</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>junit</groupId>
+         <artifactId>junit</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.mockito</groupId>
+         <artifactId>mockito-core</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.activemq</groupId>
+         <artifactId>artemis-unit-test-support</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
+   </dependencies>
+
+   <build>
+      <plugins>
+         <plugin>
+            <groupId>org.wildfly.extras.batavia</groupId>
+            <artifactId>transformer-tools-mvn</artifactId>
+            <executions>
+               <execution>
+                  <id>transform-sources</id>
+                  <phase>generate-sources</phase>
+                  <goals>
+                     <goal>transform-sources</goal>
+                  </goals>
+                  <configuration>
+                     <source-project>${project.basedir}/../artemis-openwire-protocol</source-project>
+                  </configuration>
+               </execution>
+            </executions>
+            <dependencies>
+               <dependency>
+                  <groupId>org.wildfly.extras.batavia</groupId>
+                  <artifactId>transformer-impl-eclipse</artifactId>
+                  <version>${version.batavia}</version>
+               </dependency>
+            </dependencies>
+         </plugin>
+      </plugins>
+   </build>
+</project>

--- a/artemis-protocols/pom.xml
+++ b/artemis-protocols/pom.xml
@@ -36,6 +36,7 @@
       <module>artemis-amqp-protocol</module>
       <module>artemis-stomp-protocol</module>
       <module>artemis-openwire-protocol</module>
+      <module>artemis-jakarta-openwire-protocol</module>
       <module>artemis-hornetq-protocol</module>
       <module>artemis-hqclient-protocol</module>
       <module>artemis-mqtt-protocol</module>

--- a/pom.xml
+++ b/pom.xml
@@ -781,6 +781,12 @@
          </dependency>
          <dependency>
             <groupId>org.apache.activemq</groupId>
+            <artifactId>activemq-client-jakarta</artifactId>
+            <version>${activemq5-version}</version>
+            <!-- License: Apache 2.0 -->
+         </dependency>
+         <dependency>
+            <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-openwire-legacy</artifactId>
             <version>${activemq5-version}</version>
             <!-- License: Apache 2.0 -->

--- a/tests/compatibility-tests/pom.xml
+++ b/tests/compatibility-tests/pom.xml
@@ -337,6 +337,8 @@
                               <arg>org.apache.activemq:artemis-server:${project.version}</arg>
                               <arg>org.apache.activemq:artemis-journal:${project.version}</arg>
                               <arg>org.apache.activemq:artemis-hornetq-protocol:${project.version}</arg>
+                              <arg>org.apache.activemq:artemis-jakarta-openwire-protocol:${project.version}</arg>
+                              <arg>org.apache.logging.log4j:log4j-slf4j2-impl:${log4j.version}</arg>
                               <arg>org.apache.groovy:groovy-all:pom:${groovy.version}</arg>
                            </libListWithDeps>
                            <libList>
@@ -686,6 +688,7 @@
                            <optional>true</optional>
                            <libListWithDeps>
                               <arg>org.apache.activemq:activemq-client:5.11.0</arg>
+                              <arg>org.apache.logging.log4j:log4j-slf4j2-impl:${log4j.version}</arg>
                               <arg>org.apache.groovy:groovy-all:pom:${groovy.version}</arg>
                            </libListWithDeps>
                            <libList>

--- a/tests/compatibility-tests/src/main/resources/openWireJakarta/artemisJakartaServer.groovy
+++ b/tests/compatibility-tests/src/main/resources/openWireJakarta/artemisJakartaServer.groovy
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License") you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl
+import org.apache.activemq.artemis.core.server.JournalType
+import org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ
+
+String folder = arg[0]
+
+configuration = new ConfigurationImpl()
+configuration.setJournalType(JournalType.NIO)
+configuration.setBrokerInstance(new File(folder + "/server"))
+configuration.addAcceptorConfiguration("artemis", "tcp://0.0.0.0:61616")
+configuration.setSecurityEnabled(false)
+configuration.setPersistenceEnabled(false)
+server = new EmbeddedActiveMQ()
+server.setConfiguration(configuration)
+server.start()

--- a/tests/compatibility-tests/src/main/resources/openWireJakarta/sendReceiveOW.groovy
+++ b/tests/compatibility-tests/src/main/resources/openWireJakarta/sendReceiveOW.groovy
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License") you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.apache.activemq.artemis.tests.compatibility.GroovyRun
+
+import javax.jms.Message
+import javax.jms.MessageConsumer
+import javax.jms.MessageProducer
+import javax.jms.Queue
+import javax.jms.Session
+import org.apache.activemq.ActiveMQConnectionFactory
+
+final ActiveMQConnectionFactory cf = new ActiveMQConnectionFactory("tcp://localhost:61616")
+connection = cf.createConnection()
+try {
+    final int numberOfMessages = Integer.parseInt(arg[0])
+    final Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)
+    final Queue queue = session.createQueue(arg[1])
+    final MessageProducer producer = session.createProducer(queue)
+    for (i in 0..<numberOfMessages) {
+        producer.send(session.createMessage())
+    }
+
+    final MessageConsumer consumer = session.createConsumer(queue)
+    connection.start()
+
+    for (i in 0..<numberOfMessages) {
+        final Message m = consumer.receive(1000)
+        GroovyRun.assertNotNull(m)
+    }
+} finally {
+    connection.close()
+}

--- a/tests/compatibility-tests/src/test/java/org/apache/activemq/artemis/tests/compatibility/OpenWireJakartaTest.java
+++ b/tests/compatibility-tests/src/test/java/org/apache/activemq/artemis/tests/compatibility/OpenWireJakartaTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.tests.compatibility;
+
+import org.apache.activemq.artemis.tests.compatibility.base.ClasspathBase;
+import org.junit.Test;
+
+import static org.apache.activemq.artemis.tests.compatibility.GroovyRun.AMQ_5_11;
+import static org.apache.activemq.artemis.tests.compatibility.GroovyRun.JAKARTAEE;
+
+public class OpenWireJakartaTest extends ClasspathBase {
+
+   @Test
+   public void testOpenWireJakarta() throws Throwable {
+      ClassLoader serverClassloader = getClasspath(JAKARTAEE);
+      evaluate(serverClassloader, "openWireJakarta/artemisJakartaServer.groovy", "openWireJakarta");
+      evaluate(getClasspath(AMQ_5_11), "openWireJakarta/sendReceiveOW.groovy", "20", "test");
+      execute(serverClassloader, "server.stop()");
+   }
+}


### PR DESCRIPTION
If the broker is embedded into a Jakarta environment then the existing artemis-openwire-protocol module won't work because it uses javax classes.

This commit adds a new Jakarta-specific module that can be used to support OpenWire clients in Jakarta environments (e.g. Spring Boot 3). Users will simply need to include this version on their classpath to enable support.