### PR TITLE
ARTEMIS-4569 Blocked Producers will hold runnables until messages are…

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/runnables/RunnableList.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/runnables/RunnableList.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.utils.runnables;
+
+import java.util.HashSet;
+import java.util.function.Consumer;
+
+public class RunnableList {
+
+   private final HashSet<AtomicRunnable> list = new HashSet<>();
+
+   public RunnableList() {
+   }
+
+   public synchronized void add(AtomicRunnable runnable) {
+      runnable.setAcceptedList(this);
+      list.add(runnable);
+   }
+
+   public int size() {
+      return list.size();
+   }
+
+   public synchronized void remove(AtomicRunnable runnable) {
+      list.remove(runnable);
+   }
+
+   public synchronized void cancel() {
+      list.forEach(this::cancel);
+      list.clear();
+   }
+
+   private void cancel(AtomicRunnable atomicRunnable) {
+      atomicRunnable.cancel();
+   }
+
+   public void forEach(Consumer<AtomicRunnable> consumerRunnable) {
+      list.forEach(consumerRunnable);
+   }
+
+}

--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/runnables/RunnableListTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/runnables/RunnableListTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.utils.runnables;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RunnableListTest {
+
+   HashSet<AtomicRunnable> masterList = new HashSet<>();
+
+   @Test
+   public void testRunning() {
+      AtomicInteger result = new AtomicInteger();
+
+      RunnableList listA = new RunnableList();
+      RunnableList listB = new RunnableList();
+      RunnableList listC = new RunnableList();
+
+      RunnableList[] lists = new RunnableList[]{listA, listB, listC};
+      for (RunnableList l : lists) {
+         for (int i = 0; i < 10; i++) {
+            AtomicRunnable runnable = new AtomicRunnable() {
+               @Override
+               public void atomicRun() {
+                  result.incrementAndGet();
+                  masterList.remove(this);
+               }
+            };
+            addItem(l, runnable);
+         }
+      }
+
+      Assert.assertEquals(30, masterList.size());
+
+      runList(listA);
+
+      Assert.assertEquals(10, result.get());
+
+      Assert.assertEquals(20, masterList.size());
+      Assert.assertEquals(0, listA.size());
+      Assert.assertEquals(10, listB.size());
+      Assert.assertEquals(10, listC.size());
+
+      HashSet<AtomicRunnable> copyList = new HashSet<>();
+      copyList.addAll(masterList);
+
+      copyList.forEach(r -> r.run());
+
+      for (RunnableList l : lists) {
+         Assert.assertEquals(0, l.size());
+      }
+
+      Assert.assertEquals(30, result.get());
+   }
+
+   @Test
+   public void testCancel() {
+      AtomicInteger result = new AtomicInteger();
+
+      RunnableList listA = new RunnableList();
+      RunnableList listB = new RunnableList();
+      RunnableList listC = new RunnableList();
+
+      RunnableList[] lists = new RunnableList[]{listA, listB, listC};
+      for (RunnableList l : lists) {
+         for (int i = 0; i < 10; i++) {
+            AtomicRunnable runnable = new AtomicRunnable() {
+               @Override
+               public void atomicRun() {
+                  result.incrementAndGet();
+                  masterList.remove(this);
+               }
+            };
+            addItem(l, runnable);
+         }
+      }
+
+      Assert.assertEquals(30, masterList.size());
+
+      listA.cancel();
+
+      Assert.assertEquals(0, result.get());
+
+      Assert.assertEquals(20, masterList.size());
+      Assert.assertEquals(0, listA.size());
+      Assert.assertEquals(10, listB.size());
+      Assert.assertEquals(10, listC.size());
+
+      listB.cancel();
+      listC.cancel();
+
+      for (RunnableList l : lists) {
+         Assert.assertEquals(0, l.size());
+      }
+
+      Assert.assertEquals(0, masterList.size());
+   }
+
+   // runs all AtomicRunnables inside the list
+   private void runList(RunnableList list) {
+      // make a copy of all the tasks to a new list
+      ArrayList<AtomicRunnable> toRun = new ArrayList<>();
+      list.forEach(toRun::add);
+
+      // run all the elements
+      toRun.forEach(r -> r.run());
+   }
+
+   private void addItem(RunnableList list, AtomicRunnable runnable) {
+      list.add(runnable);
+      runnable.setCancel(masterList::remove);
+      masterList.add(runnable);
+   }
+
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPSessionCallbackTest.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPSessionCallbackTest.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.protocol.amqp.broker;
 
 import java.util.concurrent.Executor;
+import java.util.function.Consumer;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.paging.PagingManager;
@@ -157,7 +158,7 @@ public class AMQPSessionCallbackTest {
       session.flow(new SimpleString("test"), ProtonServerReceiverContext.createCreditRunnable(AMQP_CREDITS_DEFAULT, AMQP_LOW_CREDITS_DEFAULT, receiver, connection));
 
       // Run the credit refill code.
-      Mockito.verify(pagingStore).checkMemory(argument.capture());
+      Mockito.verify(pagingStore).checkMemory(argument.capture(), Mockito.isA(Consumer.class));
       assertNotNull(argument.getValue());
       argument.getValue().run();
 
@@ -188,7 +189,7 @@ public class AMQPSessionCallbackTest {
       session.flow(new SimpleString("test"), ProtonServerReceiverContext.createCreditRunnable(AMQP_CREDITS_DEFAULT, AMQP_LOW_CREDITS_DEFAULT, receiver, connection));
 
       // Run the credit refill code.
-      Mockito.verify(pagingStore).checkMemory(argument.capture());
+      Mockito.verify(pagingStore).checkMemory(argument.capture(), Mockito.isA(Consumer.class));
       assertNotNull(argument.getValue());
       argument.getValue().run();
 
@@ -249,7 +250,7 @@ public class AMQPSessionCallbackTest {
       session.flow(new SimpleString("test"), ProtonServerReceiverContext.createCreditRunnable(1, AMQP_LOW_CREDITS_DEFAULT, receiver, connection));
 
       // Run the credit refill code.
-      Mockito.verify(pagingStore).checkMemory(argument.capture());
+      Mockito.verify(pagingStore).checkMemory(argument.capture(), Mockito.isA(Consumer.class));
       assertNotNull(argument.getValue());
       argument.getValue().run();
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/PagingStore.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/PagingStore.java
@@ -18,6 +18,7 @@ package org.apache.activemq.artemis.core.paging;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.function.Consumer;
 
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.RefCountMessageListener;
@@ -35,6 +36,7 @@ import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.core.settings.impl.PageFullMessagePolicy;
 import org.apache.activemq.artemis.core.transaction.Transaction;
 import org.apache.activemq.artemis.utils.actors.ArtemisExecutor;
+import org.apache.activemq.artemis.utils.runnables.AtomicRunnable;
 
 /**
  * <p>
@@ -175,9 +177,9 @@ public interface PagingStore extends ActiveMQComponent, RefCountMessageListener 
       addSize(size, false);
    }
 
-   boolean checkMemory(Runnable runnable);
+   boolean checkMemory(Runnable runnable, Consumer<AtomicRunnable> blockedCallback);
 
-   boolean checkMemory(boolean runOnFailure, Runnable runnable, Runnable runWhenBlocking);
+   boolean checkMemory(boolean runOnFailure, Runnable runnable, Runnable runWhenBlocking, Consumer<AtomicRunnable> blockedCallback);
 
    boolean isFull();
 

--- a/tests/leak-tests/src/test/java/org/apache/activemq/artemis/tests/leak/MemoryAssertions.java
+++ b/tests/leak-tests/src/test/java/org/apache/activemq/artemis/tests/leak/MemoryAssertions.java
@@ -39,8 +39,12 @@ public class MemoryAssertions {
 
    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-   /** most tests should have these as 0 after execution. */
    public static void basicMemoryAsserts() throws Exception {
+      basicMemoryAsserts(true);
+   }
+
+   /** most tests should have these as 0 after execution. */
+   public static void basicMemoryAsserts(boolean validateMessages) throws Exception {
       CheckLeak checkLeak = new CheckLeak();
       assertMemory(checkLeak, 0, OpenWireConnection.class.getName());
       assertMemory(checkLeak, 0, ProtonServerSenderContext.class.getName());
@@ -53,7 +57,9 @@ public class MemoryAssertions {
       assertMemory(checkLeak, 0, AMQPSessionContext.class.getName());
       assertMemory(checkLeak, 0, ServerConsumerImpl.class.getName());
       assertMemory(checkLeak, 0, RoutingContextImpl.class.getName());
-      assertMemory(checkLeak, 0, MessageReferenceImpl.class.getName());
+      if (validateMessages) {
+         assertMemory(checkLeak, 0, MessageReferenceImpl.class.getName());
+      }
    }
 
    public static void assertMemory(CheckLeak checkLeak, int maxExpected, String clazz) throws Exception {

--- a/tests/leak-tests/src/test/java/org/apache/activemq/artemis/tests/leak/ProducerBlockedLeakTest.java
+++ b/tests/leak-tests/src/test/java/org/apache/activemq/artemis/tests/leak/ProducerBlockedLeakTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.leak;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.github.checkleak.core.CheckLeak;
+import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.QueueConfiguration;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptor;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.Queue;
+import org.apache.activemq.artemis.core.server.impl.AddressInfo;
+import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
+import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
+import org.apache.activemq.artemis.logs.AssertionLoggerHandler;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.apache.activemq.artemis.tests.util.CFUtil;
+import org.apache.activemq.artemis.utils.SpawnedVMSupport;
+import org.apache.activemq.artemis.utils.Wait;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ProducerBlockedLeakTest extends ActiveMQTestBase {
+
+   private static final int OK = 100;
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+   private static final String QUEUE_NAME = "TEST_BLOCKED_QUEUE";
+
+   ActiveMQServer server;
+
+   @BeforeClass
+   public static void beforeClass() throws Exception {
+      Assume.assumeTrue(CheckLeak.isLoaded());
+   }
+
+   @Override
+   @Before
+   public void setUp() throws Exception {
+      super.setUp();
+      server = createServer(true, createDefaultConfig(1, true));
+      server.getConfiguration().getAddressSettings().clear();
+      server.getConfiguration().getAddressSettings().put("#", new AddressSettings().setAddressFullMessagePolicy(AddressFullMessagePolicy.BLOCK).setMaxSizeMessages(10));
+      server.start();
+   }
+
+   @Test
+   public void testOPENWIRE() throws Exception {
+      testBlocked("OPENWIRE");
+   }
+
+   @Test
+   public void testCORE() throws Exception {
+      testBlocked("CORE");
+   }
+
+   @Test
+   public void testAMQP() throws Exception {
+      testBlocked("AMQP");
+   }
+
+   private void testBlocked(String protocol) throws Exception {
+      testBody(protocol);
+      MemoryAssertions.basicMemoryAsserts(false);
+      Queue queue = server.locateQueue(QUEUE_NAME);
+      queue.deleteAllReferences();
+      MemoryAssertions.basicMemoryAsserts(true);
+      server.stop();
+   }
+
+   // separating the test into a sub-method just to allow removing local references
+   // so they would be gone when basicMemoryAsserts is called
+   private void testBody(String protocol) throws Exception {
+      try (AssertionLoggerHandler loggerHandler = new AssertionLoggerHandler()) {
+         AtomicInteger messagesSent = new AtomicInteger(0);
+
+         server.addAddressInfo(new AddressInfo(QUEUE_NAME).addRoutingType(RoutingType.ANYCAST));
+         server.createQueue(new QueueConfiguration(QUEUE_NAME).setAddress(QUEUE_NAME).setRoutingType(RoutingType.ANYCAST).setDurable(true));
+
+         // clients need to be disconnected while blocked. For that reason a new VM is being spawned
+         Process process = SpawnedVMSupport.spawnVM(ProducerBlockedLeakTest.class.getName(), protocol, "10");
+
+         // checking the logs that the destination is blocked...
+         Wait.assertTrue(() -> loggerHandler.findText("AMQ222183"), 5000, 10);
+
+         process.destroyForcibly();
+         Assert.assertTrue(process.waitFor(10, TimeUnit.SECONDS));
+
+         // Making sure there are no connections anywhere in Acceptors or RemotingService.
+         // Just to speed up the test especially in OpenWire
+         server.getRemotingService().getConnections().forEach(c -> c.fail(new ActiveMQException("this is it!")));
+         Wait.assertEquals(0, () -> server.getRemotingService().getConnectionCount());
+         server.getRemotingService().getAcceptors().forEach((a, b) -> {
+            if (b instanceof NettyAcceptor) {
+               ((NettyAcceptor) b).getConnections().clear();
+            }
+         });
+      }
+   }
+
+   public static void main(String[] arg) {
+      String protocol = arg[0];
+      int threads = Integer.parseInt(arg[1]);
+      ConnectionFactory factory = CFUtil.createConnectionFactory(protocol, "tcp://localhost:61616");
+      ExecutorService executorService = Executors.newFixedThreadPool(threads);
+
+      for (int i = 0; i < threads; i++) {
+         executorService.execute(() -> {
+            try {
+               Connection connection = factory.createConnection();
+               Session session = connection.createSession(true, Session.SESSION_TRANSACTED);
+               MessageProducer producer = session.createProducer(session.createQueue(QUEUE_NAME));
+               for (int send = 0; send < 100; send++) {
+                  producer.send(session.createTextMessage("hello"));
+                  session.commit();
+               }
+            } catch (Exception e) {
+               logger.warn(e.getMessage(), e);
+               Runtime.getRuntime().halt(-1);
+            }
+         });
+      }
+      try {
+         while (true) {
+            Thread.sleep(1000);
+         }
+      } catch (Throwable e) {
+         logger.warn(e.getMessage(), e);
+         Runtime.getRuntime().halt(-1);
+      }
+   }
+
+}

--- a/tests/performance-tests/src/test/java/org/apache/activemq/artemis/tests/performance/storage/PersistMultiThreadTest.java
+++ b/tests/performance-tests/src/test/java/org/apache/activemq/artemis/tests/performance/storage/PersistMultiThreadTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.Message;
@@ -44,6 +45,7 @@ import org.apache.activemq.artemis.core.settings.impl.PageFullMessagePolicy;
 import org.apache.activemq.artemis.core.transaction.Transaction;
 import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.actors.ArtemisExecutor;
+import org.apache.activemq.artemis.utils.runnables.AtomicRunnable;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -493,12 +495,12 @@ public class PersistMultiThreadTest extends ActiveMQTestBase {
       }
 
       @Override
-      public boolean checkMemory(boolean runOnFailure, Runnable runnable, Runnable ignoredRunnable) {
+      public boolean checkMemory(boolean runOnFailure, Runnable runnable, Runnable ignoredRunnable, Consumer<AtomicRunnable> accepted) {
          return false;
       }
 
       @Override
-      public boolean checkMemory(Runnable runnable) {
+      public boolean checkMemory(Runnable runnable, Consumer<AtomicRunnable> accepted) {
          return false;
       }
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/paging/impl/PagingStoreImplTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/paging/impl/PagingStoreImplTest.java
@@ -1252,11 +1252,11 @@ public class PagingStoreImplTest extends ActiveMQTestBase {
          };
          store.applySetting(new AddressSettings().setMaxSizeBytes(1000).setAddressFullMessagePolicy(AddressFullMessagePolicy.BLOCK));
          store.addSize(100);
-         store.checkMemory(trackMemoryChecks);
+         store.checkMemory(trackMemoryChecks, null);
          assertEquals(1, calls.get());
 
          store.block();
-         store.checkMemory(trackMemoryChecks);
+         store.checkMemory(trackMemoryChecks, null);
          assertEquals(1, calls.get());
 
          store.unblock();
@@ -1272,7 +1272,7 @@ public class PagingStoreImplTest extends ActiveMQTestBase {
          assertEquals(100, store.getAddressLimitPercent());
 
          // address full blocks
-         store.checkMemory(trackMemoryChecks);
+         store.checkMemory(trackMemoryChecks, null);
          assertEquals(2, calls.get());
 
          store.block();
@@ -1300,7 +1300,7 @@ public class PagingStoreImplTest extends ActiveMQTestBase {
          store.addSize(900);
          assertEquals(100, store.getAddressLimitPercent());
 
-         store.checkMemory(trackMemoryChecks);
+         store.checkMemory(trackMemoryChecks, null);
          assertEquals("no change", 3, calls.get());
          assertEquals("no change to be sure to be sure!", 3, calls.get());
 
@@ -1493,7 +1493,7 @@ public class PagingStoreImplTest extends ActiveMQTestBase {
          // Do an initial check
          final CountingRunnable trackMemoryCheck1 = new CountingRunnable();
          assertEquals(0, trackMemoryCheck1.getCount());
-         store.checkMemory(trackMemoryCheck1);
+         store.checkMemory(trackMemoryCheck1, null);
          assertEquals(1, trackMemoryCheck1.getCount());
 
          // Do another check, this time indicate the disk is full during the first couple
@@ -1501,7 +1501,7 @@ public class PagingStoreImplTest extends ActiveMQTestBase {
          final CountingRunnable trackMemoryCheck2 = new CountingRunnable();
          Mockito.when(mockManager.isDiskFull()).thenReturn(true, true, false);
          assertEquals(0, trackMemoryCheck2.getCount());
-         store.checkMemory(trackMemoryCheck2);
+         store.checkMemory(trackMemoryCheck2, null);
          assertEquals(1, trackMemoryCheck2.getCount());
 
          // Now run the released memory checks. The task should NOT execute again, verify it doesnt.


### PR DESCRIPTION
… consumed.

When initially developed the expectation was that no more producers would keep connecting but in a scenario like this the consumers could actually give up and things will just accumulate on the server.

We should cleanup these upon disconnect.