### PR TITLE
ARTEMIS-4576 ServerSessionImpl#updateProducerMetrics access large messages after being routed

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -2357,11 +2357,15 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
          routingContext.setAddress(art.getName());
          routingContext.setRoutingType(art.getRoutingType());
 
+         // Retrieve message size for metrics update before routing,
+         // since large message backing files may be closed once routing completes
+         int mSize = msg instanceof LargeServerMessageImpl ? ((LargeServerMessageImpl)msg).getBodyBufferSize() : msg.getEncodeSize();
+
          result = postOffice.route(msg, routingContext, direct);
 
          logger.debug("Routing result for {} = {}", msg, result);
 
-         updateProducerMetrics(msg, senderName);
+         updateProducerMetrics(msg, senderName, mSize);
       } finally {
          if (!routingContext.isReusable()) {
             routingContext.clear();
@@ -2520,10 +2524,10 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
       return "ServerSession [id=" + getConnectionID() + ":" + getName() + "]";
    }
 
-   private void updateProducerMetrics(Message msg, String senderName) {
+   private void updateProducerMetrics(Message msg, String senderName, int lmSize) {
       ServerProducer serverProducer = serverProducers.getServerProducer(senderName, msg, this);
       if (serverProducer != null) {
-         serverProducer.updateMetrics(msg.getUserID(), msg instanceof LargeServerMessageImpl ? ((LargeServerMessageImpl)msg).getBodyBufferSize() : msg.getEncodeSize());
+         serverProducer.updateMetrics(msg.getUserID(), lmSize);
       }
    }
 


### PR DESCRIPTION
ServerSessionImpl#updateProducerMetrics method is being called after a message is routed. If the message is a large message, it can be acked quickly and it's backing file will be closed before the method is being called.
This bug causes random failure in test org.apache.activemq.artemis.tests.integration.paging.MessagesExpiredPagingTest#testSendReceiveCORELarge