### PR TITLE
ARTEMIS-4617 upgrade JLine to 3.25.1

### DIFF
--- a/artemis-boot/src/main/java/org/apache/activemq/artemis/boot/Artemis.java
+++ b/artemis-boot/src/main/java/org/apache/activemq/artemis/boot/Artemis.java
@@ -61,7 +61,7 @@ public class Artemis {
 
 
 
-      Object result = execute(fileHome, fileInstance, fileBrokerETC, true, args);
+      Object result = execute(fileHome, fileInstance, fileBrokerETC, true, true, args);
       if (result instanceof Exception) {
          // Set a nonzero status code for the exceptions caught and printed by org.apache.activemq.artemis.cli.Artemis.execute
          System.exit(1);
@@ -71,14 +71,14 @@ public class Artemis {
    /**
     * This is a good method for booting an embedded command
     */
-   public static Object execute(File artemisHome, File artemisInstance, File fileBrokerETC, boolean useSystemOut, List<String> args) throws Throwable {
-      return execute(artemisHome, artemisInstance, fileBrokerETC, useSystemOut, args.toArray(new String[args.size()]));
+   public static Object execute(File artemisHome, File artemisInstance, File fileBrokerETC, boolean useSystemOut, boolean enableShell, List<String> args) throws Throwable {
+      return execute(artemisHome, artemisInstance, fileBrokerETC, useSystemOut, enableShell, args.toArray(new String[args.size()]));
    }
 
    /**
     * This is a good method for booting an embedded command
     */
-   public static Object execute(File fileHome, File fileInstance, File fileBrokerETC, boolean useSystemOut, String... args) throws Throwable {
+   public static Object execute(File fileHome, File fileInstance, File fileBrokerETC, boolean useSystemOut, boolean enableShell, String... args) throws Throwable {
       ArrayList<File> dirs = new ArrayList<>();
       if (fileHome != null) {
          dirs.add(new File(fileHome, "lib"));
@@ -151,10 +151,10 @@ public class Artemis {
       URLClassLoader loader = new URLClassLoader(urls.toArray(new URL[urls.size()]));
       Thread.currentThread().setContextClassLoader(loader);
       Class<?> clazz = loader.loadClass("org.apache.activemq.artemis.cli.Artemis");
-      Method method = clazz.getMethod("execute", Boolean.TYPE, Boolean.TYPE, File.class, File.class, File.class, args.getClass());
+      Method method = clazz.getMethod("execute", Boolean.TYPE, Boolean.TYPE, Boolean.TYPE, File.class, File.class, File.class, args.getClass());
 
       try {
-         return method.invoke(null, useSystemOut, useSystemOut, fileHome, fileInstance, fileBrokerETC, args);
+         return method.invoke(null, useSystemOut, useSystemOut, enableShell, fileHome, fileInstance, fileBrokerETC, args);
       } catch (InvocationTargetException e) {
          throw e.getTargetException();
       } finally {

--- a/artemis-cli/pom.xml
+++ b/artemis-cli/pom.xml
@@ -136,11 +136,6 @@
          <groupId>org.jline</groupId>
          <artifactId>jline</artifactId>
       </dependency>
-      <!-- Jansi is an optional dependency for jline, to provide a proper ANSI Terminal -->
-      <dependency>
-         <groupId>org.fusesource.jansi</groupId>
-         <artifactId>jansi</artifactId>
-      </dependency>
       <dependency>
          <groupId>org.apache.commons</groupId>
          <artifactId>commons-lang3</artifactId>

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/Shell.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/Shell.java
@@ -86,7 +86,7 @@ public class Shell implements Runnable {
 
          PicocliCommands.PicocliCommandsFactory factory = new PicocliCommands.PicocliCommandsFactory();
 
-         CommandLine commandLine = Artemis.buildCommand(isInstance, !isInstance, true);
+         CommandLine commandLine = Artemis.buildCommand(isInstance, !isInstance, false);
 
          PicocliCommands picocliCommands = new PicocliCommands(commandLine);
 
@@ -119,7 +119,7 @@ public class Shell implements Runnable {
             while (true) {
                try {
                   // We build a new command every time, as they could have state from previous executions
-                  systemRegistry.setCommandRegistries(new PicocliCommands(Artemis.buildCommand(isInstance, !isInstance, true)));
+                  systemRegistry.setCommandRegistries(new PicocliCommands(Artemis.buildCommand(isInstance, !isInstance, false)));
                   systemRegistry.cleanUp();
                   line = reader.readLine(prompt, rightPrompt, (MaskingCallback) null, null);
                   systemRegistry.execute(line);

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/AutoCompletion.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/AutoCompletion.java
@@ -42,7 +42,7 @@ public class AutoCompletion implements Runnable {
    @Override
    public void run() {
       try {
-         CommandLine artemisCommand = Artemis.buildCommand(true, true);
+         CommandLine artemisCommand = Artemis.buildCommand(true, true, true);
          AutoComplete.bash(startScript, autoCompleteFile, null, artemisCommand);
          System.out.println("Type the following commands before you can use auto-complete:");
          System.out.println("*******************************************************************************************************************************");

--- a/artemis-cli/src/test/java/org/apache/activemq/cli/test/ArtemisTest.java
+++ b/artemis-cli/src/test/java/org/apache/activemq/cli/test/ArtemisTest.java
@@ -1288,14 +1288,14 @@ public class ArtemisTest extends CliTestBase {
           * it will read from the InputStream in the ActionContext. It can't read the password since it's using
           * System.console.readPassword() for that.
           */
-         assertEquals(Long.valueOf(100), Artemis.internalExecute(null, null, null, new String[] {"producer", "--destination", "queue://q1", "--message-count", "100", "--password", "admin"}, context));
+         assertEquals(Long.valueOf(100), Artemis.internalExecute(false, null, null, null, new String[] {"producer", "--destination", "queue://q1", "--message-count", "100", "--password", "admin"}, context));
 
          /*
           * This is the same as above except it will prompt the user to re-enter both the URL and the username.
           */
          in = new ByteArrayInputStream("tcp://localhost:61616\nadmin\n".getBytes());
          context = new ActionContext(in, System.out, System.err);
-         assertEquals(Long.valueOf(100), Artemis.internalExecute(null, null, null, new String[] {"producer", "--destination", "queue://q1", "--message-count", "100", "--password", "admin", "--url", "tcp://badhost:11111"}, context));
+         assertEquals(Long.valueOf(100), Artemis.internalExecute(false, null, null, null, new String[] {"producer", "--destination", "queue://q1", "--message-count", "100", "--password", "admin", "--url", "tcp://badhost:11111"}, context));
       } finally {
          stopServer();
       }

--- a/artemis-maven-plugin/pom.xml
+++ b/artemis-maven-plugin/pom.xml
@@ -71,6 +71,18 @@
          <groupId>org.apache.activemq</groupId>
          <artifactId>artemis-cli</artifactId>
          <version>${project.version}</version>
+         <exclusions>
+            <exclusion>
+               <!-- see https://github.com/jline/jline3/issues/937 -->
+               <groupId>info.picocli</groupId>
+               <artifactId>picocli-shell-jline3</artifactId>
+            </exclusion>
+            <exclusion>
+               <!-- see https://github.com/jline/jline3/issues/937 -->
+               <groupId>org.jline</groupId>
+               <artifactId>jline</artifactId>
+            </exclusion>
+         </exclusions>
       </dependency>
       <dependency>
          <groupId>org.apache.maven.plugin-tools</groupId>

--- a/artemis-maven-plugin/src/main/java/org/apache/activemq/artemis/maven/ArtemisCLIPlugin.java
+++ b/artemis-maven-plugin/src/main/java/org/apache/activemq/artemis/maven/ArtemisCLIPlugin.java
@@ -120,7 +120,7 @@ public class ArtemisCLIPlugin extends ArtemisAbstractPlugin {
                }
             }
          } else {
-            Artemis.execute(home, location, etc, useSystemOutput, args);
+            Artemis.execute(home, location, etc, useSystemOutput, false, args);
          }
 
          Thread.sleep(600);

--- a/artemis-maven-plugin/src/main/java/org/apache/activemq/artemis/maven/ArtemisCreatePlugin.java
+++ b/artemis-maven-plugin/src/main/java/org/apache/activemq/artemis/maven/ArtemisCreatePlugin.java
@@ -261,7 +261,7 @@ public class ArtemisCreatePlugin extends ArtemisAbstractPlugin {
          commandLineStream.println("# These are the commands used to create " + instance.getName());
          commandLineStream.println(getCommandline(listCommands));
 
-         Artemis.execute(home, null, null, useSystemOutput, listCommands);
+         Artemis.execute(home, null, null, useSystemOutput, false, listCommands);
 
          if (configuration != null) {
             String[] list = configuration.list();

--- a/artemis-maven-plugin/src/main/java/org/apache/activemq/artemis/maven/ArtemisUpgradePlugin.java
+++ b/artemis-maven-plugin/src/main/java/org/apache/activemq/artemis/maven/ArtemisUpgradePlugin.java
@@ -100,7 +100,7 @@ public class ArtemisUpgradePlugin extends ArtemisAbstractPlugin {
       getLog().debug("***** Server upgrading at " + instance + " with home=" + home + " *****");
 
       try {
-         Artemis.execute(home, null, null, useSystemOutput, listCommands);
+         Artemis.execute(home, null, null, useSystemOutput, false, listCommands);
       } catch (Throwable e) {
          getLog().error(e);
          throw new MojoFailureException(e.getMessage());

--- a/pom.xml
+++ b/pom.xml
@@ -138,8 +138,7 @@
       <hawtbuff.version>1.11</hawtbuff.version>
       <hawtdispatch.version>1.22</hawtdispatch.version>
       <picocli.version>4.7.5</picocli.version>
-      <jline.version>3.23.0</jline.version>
-      <jansi.version>2.4.1</jansi.version>
+      <jline.version>3.25.1</jline.version>
       <jakarta.activation-api.version>1.2.2</jakarta.activation-api.version>
       <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
       <jakarta.ejb-api.version>3.2.6</jakarta.ejb-api.version>
@@ -621,13 +620,6 @@
             <artifactId>jline</artifactId>
             <version>${jline.version}</version>
             <!-- License: BSD 3-Clause -->
-         </dependency>
-         <dependency>
-            <!-- used by jline to provide an ansi terminal -->
-            <groupId>org.fusesource.jansi</groupId>
-            <artifactId>jansi</artifactId>
-            <version>${jansi.version}</version>
-            <!-- License: Apache 2.0 -->
          </dependency>
          <!--needed to compile transport jar-->
          <dependency>

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/artemis/utils/cli/helper/HelperCreate.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/artemis/utils/cli/helper/HelperCreate.java
@@ -341,7 +341,7 @@ public class HelperCreate extends HelperBase {
       logger.debug("server created at {} with home = {}", artemisInstance, artemisHome);
       artemisInstance.mkdirs();
 
-      Artemis.execute(false, true, artemisHome, null, null, (String[]) listCommands.toArray(new String[listCommands.size()]));
+      Artemis.execute(false, true, false, artemisHome, null, null, (String[]) listCommands.toArray(new String[listCommands.size()]));
 
       if (configuration != null) {
          String[] list = configuration.list();


### PR DESCRIPTION
I had to remove the indirect dependency between the maven plugin and jline to avoid the maven plugin to parse some classes in jline that require experimental features on the JDK even when they are not in use.