### PR TITLE
ARTEMIS-4630 Validate if the pid is really from Artemis

### DIFF
--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis-service
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis-service
@@ -59,9 +59,13 @@ fi
 status() {
   if [ -f "${PID_FILE}" ] ; then
     pid=`cat "${PID_FILE}"`
+    pid_workdir=$ARTEMIS_INSTANCE
+    if [ `command -v lsof &> /dev/null` ]; then
+      pid_workdir="`lsof -a -d cwd -p ${pid} | awk '{print $9}' | tail -1`"
+    if
     # check to see if it's gone...
     ps -p ${pid} > /dev/null
-    if [ $? -eq 0 ] ; then
+    if [ $? -eq 0 ] && [ "$pid_workdir" = "$ARTEMIS_INSTANCE" ]; then
       return 0
     else
       rm "${PID_FILE}"


### PR DESCRIPTION
In rare cases the status is returning 'running' to a process that is not Artemis. It was create a extra level of verification by validating if the running process working directory is the
same of ${ARTEMIS_INSTANCE}.