### PR TITLE
ARTEMIS-4637 - Allow unordered xml conf elements for clusters and bri…

### DIFF
--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -1054,6 +1054,37 @@
       </xsd:annotation>
    </xsd:element>
 
+   <xsd:element name="discovery-type" abstract="true"/>
+
+   <xsd:element name="static-connectors" substitutionGroup="discovery-type">
+      <xsd:complexType>
+         <xsd:sequence>
+            <xsd:element name="connector-ref" type="xsd:string" maxOccurs="unbounded" minOccurs="1"/>
+         </xsd:sequence>
+         <xsd:attribute name="allow-direct-connections-only" default="false" type="xsd:boolean" use="optional">
+            <xsd:annotation>
+               <xsd:documentation>
+                  restricts a clusters connections to the listed connector-ref's
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:attribute>
+         <xsd:attributeGroup ref="xml:specialAttrs"/>
+      </xsd:complexType>
+   </xsd:element>
+
+   <xsd:element name="discovery-group-ref" substitutionGroup="discovery-type">
+      <xsd:complexType>
+         <xsd:attribute name="discovery-group-name" type="xsd:IDREF" use="required">
+            <xsd:annotation>
+               <xsd:documentation>
+                  name of the discovery group to use for this connection
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:attribute>
+         <xsd:attributeGroup ref="xml:specialAttrs"/>
+      </xsd:complexType>
+   </xsd:element>
+
    <!-- BROADCAST GROUP CONFIGURATION -->
    <xsd:element name="broadcast-groups">
       <xsd:annotation>
@@ -1222,13 +1253,6 @@
       <xsd:attributeGroup ref="xml:specialAttrs"/>
    </xsd:complexType>
 
-   <xsd:element name="discovery-group-ref">
-      <xsd:complexType>
-         <xsd:attribute name="discovery-group-name" type="xsd:IDREF"/>
-         <xsd:attributeGroup ref="xml:specialAttrs"/>
-      </xsd:complexType>
-   </xsd:element>
-
    <xsd:complexType name="class-name-sequenceType">
       <xsd:annotation>
          <xsd:documentation>
@@ -1281,7 +1305,7 @@
    </xsd:element>
 
    <xsd:complexType name="bridgeType">
-      <xsd:sequence>
+      <xsd:all>
          <xsd:element name="queue-name" type="xsd:string" maxOccurs="1" minOccurs="1">
             <xsd:annotation>
                <xsd:documentation>
@@ -1469,29 +1493,9 @@
             </xsd:annotation>
          </xsd:element>
 
-         <xsd:choice>
-            <xsd:element name="static-connectors" maxOccurs="1" minOccurs="1">
-               <xsd:complexType>
-                  <xsd:sequence>
-                     <xsd:element name="connector-ref" type="xsd:string" maxOccurs="unbounded" minOccurs="1"/>
-                  </xsd:sequence>
-                  <xsd:attributeGroup ref="xml:specialAttrs"/>
-               </xsd:complexType>
-            </xsd:element>
-            <xsd:element name="discovery-group-ref" maxOccurs="1" minOccurs="1">
-               <xsd:complexType>
-                  <xsd:attribute name="discovery-group-name" type="xsd:IDREF" use="required">
-                     <xsd:annotation>
-                        <xsd:documentation>
-                           name of discovery group used by this bridge
-                        </xsd:documentation>
-                     </xsd:annotation>
-                  </xsd:attribute>
-                  <xsd:attributeGroup ref="xml:specialAttrs"/>
-               </xsd:complexType>
-            </xsd:element>
-         </xsd:choice>
-      </xsd:sequence>
+         <xsd:element ref="discovery-type" maxOccurs="1" minOccurs="1"/>
+
+      </xsd:all>
 
       <xsd:attribute name="name" type="xsd:ID" use="required">
          <xsd:annotation>
@@ -2334,7 +2338,7 @@
    </xsd:complexType>
 
    <xsd:complexType name="cluster-connectionType">
-      <xsd:sequence>
+      <xsd:all>
          <xsd:element name="address" type="xsd:string" maxOccurs="1" minOccurs="0">
             <xsd:annotation>
                <xsd:documentation>
@@ -2517,36 +2521,10 @@
             </xsd:annotation>
          </xsd:element>
 
-         <xsd:choice>
-            <xsd:element name="static-connectors" maxOccurs="1" minOccurs="0">
-               <xsd:complexType>
-                  <xsd:sequence>
-                     <xsd:element name="connector-ref" type="xsd:string" maxOccurs="unbounded" minOccurs="0"/>
-                  </xsd:sequence>
-                  <xsd:attribute name="allow-direct-connections-only" default="false" type="xsd:boolean" use="optional">
-                     <xsd:annotation>
-                        <xsd:documentation>
-                           restricts cluster connections to the listed connector-ref's
-                        </xsd:documentation>
-                     </xsd:annotation>
-                  </xsd:attribute>
-                  <xsd:attributeGroup ref="xml:specialAttrs"/>
-               </xsd:complexType>
-            </xsd:element>
-            <xsd:element name="discovery-group-ref" maxOccurs="1" minOccurs="0">
-               <xsd:complexType>
-                  <xsd:attribute name="discovery-group-name" type="xsd:IDREF" use="required">
-                     <xsd:annotation>
-                        <xsd:documentation>
-                           name of discovery group used by this cluster-connection
-                        </xsd:documentation>
-                     </xsd:annotation>
-                  </xsd:attribute>
-                  <xsd:attributeGroup ref="xml:specialAttrs"/>
-               </xsd:complexType>
-            </xsd:element>
-         </xsd:choice>
-      </xsd:sequence>
+         <xsd:element ref="discovery-type" maxOccurs="1" minOccurs="0"/>
+
+      </xsd:all>
+
       <xsd:attribute name="name" type="xsd:ID" use="required">
          <xsd:annotation>
             <xsd:documentation>

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationParserTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationParserTest.java
@@ -311,6 +311,13 @@ public class FileConfigurationParserTest extends ServerTestBase {
          "         <connector-ref>remote-connector</connector-ref>\n" +
          "      </static-connectors>\n" +
          "   </bridge>\n" +
+         "   <bridge name=\"my-other-bridge\">\n" +
+         "      <static-connectors>\n" +
+         "         <connector-ref>remote-connector</connector-ref>\n" +
+         "      </static-connectors>\n" +
+         "      <forwarding-address>mincing-machine</forwarding-address>\n" +
+         "      <queue-name>sausage-factory</queue-name>\n" +
+         "   </bridge>\n" +
          "</bridges>\n"
          + lastPart;
       ByteArrayInputStream input = new ByteArrayInputStream(configStr.getBytes(StandardCharsets.UTF_8));
@@ -318,7 +325,7 @@ public class FileConfigurationParserTest extends ServerTestBase {
       Configuration config = parser.parseMainConfig(input);
 
       List<BridgeConfiguration> bridgeConfigs = config.getBridgeConfigurations();
-      assertEquals(1, bridgeConfigs.size());
+      assertEquals(2, bridgeConfigs.size());
 
       BridgeConfiguration bconfig = bridgeConfigs.get(0);
 

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
@@ -406,6 +406,7 @@ public class FileConfigurationTest extends ConfigurationImplTest {
             Assert.assertEquals("connector2", ccc.getStaticConnectors().get(1));
             Assert.assertEquals(null, ccc.getDiscoveryGroupName());
             Assert.assertEquals(222, ccc.getProducerWindowSize());
+            Assert.assertEquals(true, ccc.isAllowDirectConnectionsOnly());
          } else {
             Assert.assertEquals("cluster-connection2", ccc.getName());
             Assert.assertEquals("queues2", ccc.getAddress());
@@ -418,6 +419,7 @@ public class FileConfigurationTest extends ConfigurationImplTest {
             Assert.assertEquals(Collections.emptyList(), ccc.getStaticConnectors());
             Assert.assertEquals("dg1", ccc.getDiscoveryGroupName());
             Assert.assertEquals(333, ccc.getProducerWindowSize());
+            Assert.assertEquals(false, ccc.isAllowDirectConnectionsOnly());
          }
       }
 

--- a/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
@@ -233,13 +233,13 @@
             <max-retry-interval>10002</max-retry-interval>
             <reconnect-attempts>2</reconnect-attempts>
             <failover-on-server-shutdown>false</failover-on-server-shutdown>
-            <use-duplicate-detection>true</use-duplicate-detection>
             <confirmation-window-size>1G</confirmation-window-size>
             <producer-window-size>444</producer-window-size>
             <routing-type>STRIP</routing-type>
             <static-connectors>
                <connector-ref>connector1</connector-ref>
             </static-connectors>
+            <use-duplicate-detection>true</use-duplicate-detection>
          </bridge>
          <bridge name="bridge2">
             <queue-name>queue2</queue-name>
@@ -249,7 +249,6 @@
          </bridge>
          <bridge name="bridge3">
             <queue-name>queue3</queue-name>
-            <forwarding-address>bridge-forwarding-address2</forwarding-address>
             <transformer>
                <class-name>org.foo.BridgeTransformer3</class-name>
                <property key="bridgeTransformerKey1" value="bridgeTransformerValue1"/>
@@ -257,6 +256,7 @@
             </transformer>
             <producer-window-size>555k</producer-window-size>
             <discovery-group-ref discovery-group-name="dg1"/>
+            <forwarding-address>bridge-forwarding-address2</forwarding-address>
          </bridge>
          <bridge name="bridge4">
             <queue-name>queue3</queue-name>
@@ -421,22 +421,22 @@
             <max-hops>1</max-hops>
             <producer-window-size>222</producer-window-size>
             <call-failover-timeout>123</call-failover-timeout>
-            <static-connectors>
+            <static-connectors allow-direct-connections-only="true">
                <connector-ref>connector1</connector-ref>
                <connector-ref>connector2</connector-ref>
             </static-connectors>
          </cluster-connection>
          <cluster-connection name="cluster-connection2">
+            <discovery-group-ref discovery-group-name="dg1"/>
             <address>queues2</address>
             <connector-ref>connector2</connector-ref>
             <call-timeout>456</call-timeout>
+            <call-failover-timeout>456</call-failover-timeout>
             <retry-interval>4</retry-interval>
             <use-duplicate-detection>false</use-duplicate-detection>
             <message-load-balancing>STRICT</message-load-balancing>
             <max-hops>2</max-hops>
             <producer-window-size>333</producer-window-size>
-            <call-failover-timeout>456</call-failover-timeout>
-            <discovery-group-ref discovery-group-name="dg1"/>
          </cluster-connection>
          <cluster-connection name="cluster-connection3">
             <connector-ref>connector2</connector-ref>

--- a/artemis-server/src/test/resources/ConfigurationTest-xinclude-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-xinclude-config.xml
@@ -302,7 +302,7 @@
             <max-hops>1</max-hops>
             <producer-window-size>222</producer-window-size>
             <call-failover-timeout>123</call-failover-timeout>
-            <static-connectors>
+            <static-connectors allow-direct-connections-only="true">
                <connector-ref>connector1</connector-ref>
                <connector-ref>connector2</connector-ref>
             </static-connectors>

--- a/artemis-server/src/test/resources/ConfigurationTest-xinclude-schema-config-cluster-connections.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-xinclude-schema-config-cluster-connections.xml
@@ -31,7 +31,7 @@
       <max-hops>1</max-hops>
       <producer-window-size>222</producer-window-size>
       <call-failover-timeout>123</call-failover-timeout>
-      <static-connectors>
+      <static-connectors allow-direct-connections-only="true">
          <connector-ref>connector1</connector-ref>
          <connector-ref>connector2</connector-ref>
       </static-connectors>

--- a/tests/integration-tests/src/test/resources/reload-bridge-updated.xml
+++ b/tests/integration-tests/src/test/resources/reload-bridge-updated.xml
@@ -37,9 +37,9 @@ under the License.
 
       <bridges>
          <bridge name="a">
+            <concurrency>2</concurrency>
             <queue-name>a-from</queue-name>
             <forwarding-address>a-new</forwarding-address>
-            <concurrency>2</concurrency>
             <static-connectors>
                <connector-ref>connector</connector-ref>
             </static-connectors>


### PR DESCRIPTION
…dges

I hope this change makes sense as it's a little bit outside of my comfort zone... it's purpose is to fix a minor annoyance of mine and something Ive seen confuse some other users as well, where moving or adding a configuration element in the wrong place causes the config to be invalidated.

A side effect of this change is that the cluster property/attribute `allow-direct-connections-only` in `static-connectors` would pass validation even on core-bridges... setting this property has no effect on the core-bridges either way so I'm hoping it's not a cause for concern. I made it that way to have current configurations validate as before this change instead if adding it as a separate element within the cluster config or similar. Ideas on how to make this better if it's an issue are welcome.

Ideally this would apply to all configuration at some point but I believe that would require moving to xsd version 1.1 which is not scoped in this change.