### PR TITLE
ARTEMIS-4640: move os-maven-plugin extension into a profile

### DIFF
--- a/docs/hacking-guide/_building.adoc
+++ b/docs/hacking-guide/_building.adoc
@@ -48,9 +48,17 @@ Generating the user manual's PDF adds almost a minute to the build so this can b
 
 == Offline
 
+Maven dependency:go-offline can be used to download various things the build needs. This necessitates some properties the build doesnt normally need set, so to make this work a helper profile called `go-offline` exists to have the os-maven-plugin set these properties based on the current environment. To run these together, do:
 [,console]
 ----
-$ mvn dependency:go-offline
+$ mvn dependency:go-offline -Pgo-offline
+$ mvn -o ...
+----
+
+Alternatively you can simply specify the needed properties directly, based on your environment preference. For example, on a Linux x86-64 environment you could run:
+[,console]
+----
+$ mvn dependency:go-offline -Dos.detected.name=linux -Dos.detected.arch=x86_64 -Dos.detected.classifier=linux-x86_64
 $ mvn -o ...
 ----
 

--- a/pom.xml
+++ b/pom.xml
@@ -1576,18 +1576,31 @@
             </plugins>
          </build>
       </profile>
+      <profile>
+         <!-- Use along with mvn dependency:go-offline to generate props need to resolve netty deps -->
+         <id>go-offline</id>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>kr.motd.maven</groupId>
+                  <artifactId>os-maven-plugin</artifactId>
+                  <version>1.7.1</version>
+                  <extensions>true</extensions>
+                  <executions>
+                     <execution>
+                        <phase>initialize</phase>
+                        <goals>
+                           <goal>detect</goal>
+                        </goals>
+                     </execution>
+                  </executions>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
    </profiles>
 
    <build>
-      <extensions>
-         <!-- Generate os.detected.classifier property for Netty native dependencies -->
-         <extension>
-            <groupId>kr.motd.maven</groupId>
-            <artifactId>os-maven-plugin</artifactId>
-            <version>1.7.1</version>
-         </extension>
-      </extensions>
-
       <pluginManagement>
          <plugins>
             <plugin>


### PR DESCRIPTION
Move os-maven-plugin extension, added to aid 'offline' maven usage, into a profile to use on request...its default presence breaks reproducibility of the `artemis-commons` module.