### PR TITLE
ARTEMIS-4641 Support events for add of missing federation resources

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationConstants.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationConstants.java
@@ -42,6 +42,12 @@ public final class AMQPFederationConstants {
    public static final Symbol FEDERATION_CONTROL_LINK = Symbol.getSymbol("AMQ_FEDERATION_CONTROL_LINK");
 
    /**
+    * A desired capability added to the federation events links that must be offered
+    * in return for a federation event link to be successfully established.
+    */
+   public static final Symbol FEDERATION_EVENT_LINK = Symbol.getSymbol("AMQ_FEDERATION_EVENT_LINK");
+
+   /**
     * Property name used to embed a nested map of properties meant to be applied if the federation
     * resources created on the remote end of the control link if configured to do so. These properties
     * essentially carry local configuration to the remote side that would otherwise use broker defaults
@@ -196,5 +202,38 @@ public final class AMQPFederationConstants {
     * configuration for the policy.
     */
    public static final String TRANSFORMER_PROPERTIES_MAP = "transformer-properties-map";
+
+   /**
+    * Events sent across the events link will each carry an event type to indicate
+    * the event type which controls how the remote reacts to the given event. The type of
+    * event infers the payload of the structure of the message payload.
+    */
+   public static final Symbol EVENT_TYPE = Symbol.getSymbol("x-opt-amq-federation-ev-type");
+
+   /**
+    * Indicates that the message carries an address and queue name that was previously
+    * requested but did not exist, or that was federated but the remote consumer was closed
+    * due to removal of the queue on the target peer.
+    */
+   public static final String REQUESTED_QUEUE_ADDED = "REQUESTED_QUEUE_ADDED_EVENT";
+
+   /**
+    * Indicates that the message carries an address name that was previously requested
+    * but did not exist, or that was federated but the remote consumer was closed due to
+    * removal of the address on the target peer.
+    */
+   public static final String REQUESTED_ADDRESS_ADDED = "REQUESTED_ADDRESS_ADDED_EVENT";
+
+   /**
+    * Carries the name of a Queue that was either not present when a federation consumer was
+    * initiated and subsequently rejected, or was removed and has been recreated.
+    */
+   public static final String REQUESTED_QUEUE_NAME = "REQUESTED_QUEUE_NAME";
+
+   /**
+    * Carries the name of an Address that was either not present when a federation consumer was
+    * initiated and subsequently rejected, or was removed and has been recreated.
+    */
+   public static final String REQUESTED_ADDRESS_NAME = "REQUESTED_ADDRESS_NAME";
 
 }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationEventDispatcher.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationEventDispatcher.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.protocol.amqp.connect.federation;
+
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederation.FEDERATION_INSTANCE_RECORD;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_EVENT_LINK;
+
+import java.lang.invoke.MethodHandles;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.postoffice.Binding;
+import org.apache.activemq.artemis.core.postoffice.QueueBinding;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.Consumer;
+import org.apache.activemq.artemis.core.server.impl.AddressInfo;
+import org.apache.activemq.artemis.core.server.plugin.ActiveMQServerAddressPlugin;
+import org.apache.activemq.artemis.core.server.plugin.ActiveMQServerBindingPlugin;
+import org.apache.activemq.artemis.protocol.amqp.broker.AMQPMessage;
+import org.apache.activemq.artemis.protocol.amqp.broker.AMQPSessionCallback;
+import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPIllegalStateException;
+import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPInternalErrorException;
+import org.apache.activemq.artemis.protocol.amqp.logger.ActiveMQAMQPProtocolMessageBundle;
+import org.apache.activemq.artemis.protocol.amqp.proton.ProtonServerSenderContext;
+import org.apache.activemq.artemis.protocol.amqp.proton.SenderController;
+import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.amqp.messaging.Terminus;
+import org.apache.qpid.proton.amqp.transport.ErrorCondition;
+import org.apache.qpid.proton.amqp.transport.ReceiverSettleMode;
+import org.apache.qpid.proton.engine.Connection;
+import org.apache.qpid.proton.engine.EndpointState;
+import org.apache.qpid.proton.engine.Sender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Sender controller used to fire events from one side of an AMQP Federation connection
+ * to the other side.
+ */
+public class AMQPFederationEventDispatcher implements SenderController, ActiveMQServerBindingPlugin, ActiveMQServerAddressPlugin {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   private final Sender sender;
+   private final AMQPFederation federation;
+   private final AMQPSessionCallback session;
+   private final ActiveMQServer server;
+
+   private final Set<String> addressWatches = new HashSet<>();
+   private final Set<String> queueWatches = new HashSet<>();
+
+   public AMQPFederationEventDispatcher(AMQPFederation federation, AMQPSessionCallback session, Sender sender) {
+      this.session = session;
+      this.sender = sender;
+      this.federation = federation;
+      this.server = federation.getServer();
+   }
+
+   private String getEventsLinkAddress() {
+      return sender.getName();
+   }
+
+   /**
+    * Raw event send API that accepts an {@link AMQPMessage} instance and routes it using the
+    * server post office instance.
+    *
+    * @param event
+    *    The event message to send to the previously created control address.
+    *
+    * @throws Exception if an error occurs during the message send.
+    */
+   public void sendEvent(AMQPMessage event) throws Exception {
+      Objects.requireNonNull(event, "Null event message is not expected and constitutes an error condition");
+
+      event.setAddress(getEventsLinkAddress());
+
+      server.getPostOffice().route(event, true);
+   }
+
+   @Override
+   public Consumer init(ProtonServerSenderContext senderContext) throws Exception {
+      final Connection protonConnection = senderContext.getSender().getSession().getConnection();
+      final org.apache.qpid.proton.engine.Record attachments = protonConnection.attachments();
+
+      AMQPFederation federation = attachments.get(FEDERATION_INSTANCE_RECORD, AMQPFederation.class);
+
+      if (federation == null) {
+         throw new ActiveMQAMQPIllegalStateException("Cannot create a federation link from non-federation connection");
+      }
+
+      // Match the settlement mode of the remote instead of relying on the default of MIXED.
+      sender.setSenderSettleMode(sender.getRemoteSenderSettleMode());
+
+      // We don't currently support SECOND so enforce that the answer is always FIRST
+      sender.setReceiverSettleMode(ReceiverSettleMode.FIRST);
+
+      // Create a temporary queue using the unique link name which is where events will
+      // be sent to so that they can be held until credit is granted by the remote.
+      final SimpleString queueName = SimpleString.toSimpleString(sender.getName());
+
+      if (sender.getLocalState() != EndpointState.ACTIVE) {
+         // Indicate that event link capabilities is supported.
+         sender.setOfferedCapabilities(new Symbol[]{FEDERATION_EVENT_LINK});
+
+         // When the federation source creates a events receiver link to receive events
+         // from the federation target side we land here on the target as this end should
+         // not be active yet, the federation source should request a dynamic source node
+         // to be created and we should return the address when opening this end.
+         final Terminus remoteTerminus = (Terminus) sender.getRemoteSource();
+
+         if (remoteTerminus == null || !remoteTerminus.getDynamic()) {
+            throw new ActiveMQAMQPInternalErrorException("Remote Terminus did not arrive as dynamic node: " + remoteTerminus);
+         }
+
+         remoteTerminus.setAddress(queueName.toString());
+      }
+
+      try {
+         session.createTemporaryQueue(queueName, RoutingType.ANYCAST);
+      } catch (Exception e) {
+         throw ActiveMQAMQPProtocolMessageBundle.BUNDLE.errorCreatingTemporaryQueue(e.getMessage());
+      }
+
+      // Attach to the federation instance now that we have a queue to put events onto.
+      federation.registerEventSender(this);
+
+      server.registerBrokerPlugin(this); // Start listening for bindings and consumer events.
+
+      return (Consumer) session.createSender(senderContext, queueName, null, false);
+   }
+
+   @Override
+   public void close() {
+      // Make a best effort to remove the temporary queue used for event messages on close.
+      final SimpleString queueName = SimpleString.toSimpleString(sender.getRemoteTarget().getAddress());
+
+      server.unRegisterBrokerPlugin(this);
+
+      try {
+         session.removeTemporaryQueue(queueName);
+      } catch (Exception e) {
+         // Ignored as the temporary queue should be removed on connection termination.
+      }
+   }
+
+   @Override
+   public void close(ErrorCondition error) {
+      // Ensure cleanup on force close using default close API
+      close();
+   }
+
+   /**
+    * Add the given address name to the set of addresses that should be watched for and
+    * if added to the broker send an event to the remote indicating that it now exists
+    * and the remote should attempt to create a new address federation consumer.
+    *
+    * This method must be called from the connection thread.
+    *
+    * @param addressName
+    *    The address name to watch for addition.
+    */
+   public void addAddressWatch(String addressName) {
+      addressWatches.add(addressName);
+   }
+
+   /**
+    * Add the given queue name to the set of queues that should be watched for and
+    * if added to the broker send an event to the remote indicating that it now exists
+    * and the remote should attempt to create a new queue federation consumer.
+    *
+    * This method must be called from the connection thread.
+    *
+    * @param queueName
+    *    The queue name to watch for addition.
+    */
+   public void addQueueWatch(String queueName) {
+      queueWatches.add(queueName);
+   }
+
+   @Override
+   public void afterAddAddress(AddressInfo addressInfo, boolean reload) throws ActiveMQException {
+      final String addressName = addressInfo.getName().toString();
+
+      // Run this on the connection thread so that rejection of a federation consumer
+      // and addition of the address can't race such that the consumer adds its intent
+      // concurrently with the address having been added and we miss the registration.
+      federation.getConnectionContext().runLater(() -> {
+         if (addressWatches.remove(addressName)) {
+            try {
+               sendEvent(AMQPFederationEventSupport.encodeAddressAddedEvent(addressName));
+            } catch (Exception e) {
+               logger.warn("error on send of address added event: {}", e.getMessage());
+               federation.signalError(
+                  new ActiveMQAMQPInternalErrorException("Error while processing address added: " + e.getMessage() ));
+            }
+         }
+      });
+   }
+
+   @Override
+   public void afterAddBinding(Binding binding) throws ActiveMQException {
+      if (binding instanceof QueueBinding) {
+         final String addressName = ((QueueBinding) binding).getAddress().toString();
+         final String queueName = ((QueueBinding) binding).getQueue().getName().toString();
+
+         // Run this on the connection thread so that rejection of a federation consumer
+         // and addition of the binding can't race such that the consumer adds its intent
+         // concurrently with the binding having been added and we miss the registration.
+         federation.getConnectionContext().runLater(() -> {
+            if (queueWatches.remove(queueName)) {
+               try {
+                  sendEvent(AMQPFederationEventSupport.encodeQueueAddedEvent(addressName, queueName));
+               } catch (Exception e) {
+                  // Likely the connection failed if we get here.
+                  logger.warn("Error on send of queue added event: {}", e.getMessage());
+                  federation.signalError(
+                     new ActiveMQAMQPInternalErrorException("Error while processing queue added: " + e.getMessage() ));
+               }
+            }
+         });
+      }
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationEventProcessor.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationEventProcessor.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.protocol.amqp.connect.federation;
+
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.EVENT_TYPE;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_EVENT_LINK;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.REQUESTED_ADDRESS_ADDED;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.REQUESTED_ADDRESS_NAME;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.REQUESTED_QUEUE_ADDED;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.REQUESTED_QUEUE_NAME;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Map;
+
+import org.apache.activemq.artemis.api.core.Message;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.transaction.Transaction;
+import org.apache.activemq.artemis.protocol.amqp.broker.AMQPMessage;
+import org.apache.activemq.artemis.protocol.amqp.broker.AMQPMessageBrokerAccessor;
+import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPInternalErrorException;
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPConnectionContext;
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPSessionContext;
+import org.apache.activemq.artemis.protocol.amqp.proton.ProtonAbstractReceiver;
+import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.amqp.messaging.Accepted;
+import org.apache.qpid.proton.amqp.messaging.DeliveryAnnotations;
+import org.apache.qpid.proton.amqp.messaging.Terminus;
+import org.apache.qpid.proton.amqp.transport.ReceiverSettleMode;
+import org.apache.qpid.proton.engine.Delivery;
+import org.apache.qpid.proton.engine.EndpointState;
+import org.apache.qpid.proton.engine.Receiver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A specialized AMQP Receiver that handles events from a remote Federation connection such
+ * as addition of addresses or queues where federation was requested but they did not exist
+ * at the time and the federation consumer was rejected.
+ */
+public class AMQPFederationEventProcessor extends ProtonAbstractReceiver {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   private static final int PROCESSOR_RECEIVER_CREDITS = 10;
+   private static final int PROCESSOR_RECEIVER_CREDITS_LOW = 3;
+
+   private final ActiveMQServer server;
+   private final AMQPFederation federation;
+
+   /**
+    * Create the new federation event receiver
+    *
+    * @param federation
+    *    The AMQP Federation instance that this event consumer resides in.
+    * @param session
+    *    The associated session for this federation event consumer.
+    * @param receiver
+    *    The proton {@link Receiver} that this event consumer reads from.
+    */
+   public AMQPFederationEventProcessor(AMQPFederation federation, AMQPSessionContext session, Receiver receiver) {
+      super(session.getSessionSPI(), session.getAMQPConnectionContext(), session, receiver);
+
+      this.server = protonSession.getServer();
+      this.federation = federation;
+   }
+
+   @Override
+   public void initialize() throws Exception {
+      initialized = true;
+
+      // Match the settlement mode of the remote instead of relying on the default of MIXED.
+      receiver.setSenderSettleMode(receiver.getRemoteSenderSettleMode());
+
+      // We don't currently support SECOND so enforce that the answer is always FIRST
+      receiver.setReceiverSettleMode(ReceiverSettleMode.FIRST);
+
+      if (receiver.getLocalState() != EndpointState.ACTIVE) {
+         // Indicate that event link capabilities is supported.
+         receiver.setOfferedCapabilities(new Symbol[]{FEDERATION_EVENT_LINK});
+
+         // When the federation source creates a events sender link to send events to the
+         // federation target side we land here on the target as this end should not be
+         // active yet, the federation source should request a dynamic target node to be
+         // created and we should return the address when opening this end.
+         final Terminus remoteTerminus = (Terminus) receiver.getRemoteTarget();
+
+         if (remoteTerminus == null || !remoteTerminus.getDynamic()) {
+            throw new ActiveMQAMQPInternalErrorException("Remote Terminus did not arrive as dynamic node: " + remoteTerminus);
+         }
+
+         remoteTerminus.setAddress(receiver.getName());
+      }
+
+      // Inform the federation that there is an event processor in play.
+      federation.registerEventReceiver(this);
+
+      flow();
+   }
+
+   @Override
+   protected void actualDelivery(Message message, Delivery delivery, DeliveryAnnotations deliveryAnnotations, Receiver receiver, Transaction tx) {
+      logger.trace("{}::actualdelivery called for {}", server, message);
+
+      final AMQPMessage eventMessage = (AMQPMessage) message;
+
+      delivery.setContext(message);
+
+      try {
+         final Object eventType = AMQPMessageBrokerAccessor.getMessageAnnotationProperty(eventMessage, EVENT_TYPE);
+
+         if (REQUESTED_QUEUE_ADDED.equals(eventType)) {
+            final Map<String, Object> eventData = AMQPFederationEventSupport.decodeQueueAddedEvent(eventMessage);
+
+            final String addressName = eventData.get(REQUESTED_ADDRESS_NAME).toString();
+            final String queueName = eventData.get(REQUESTED_QUEUE_NAME).toString();
+
+            logger.trace("Remote event indicates Queue added that matched a previous request [{}::{}]", addressName, queueName);
+
+            federation.processRemoteQueueAdded(addressName, queueName);
+         } else if (REQUESTED_ADDRESS_ADDED.equals(eventType)) {
+            final Map<String, Object> eventData = AMQPFederationEventSupport.decodeAddressAddedEvent(eventMessage);
+
+            final String addressName = eventData.get(REQUESTED_ADDRESS_NAME).toString();
+
+            logger.trace("Remote event indicates Address added that matched a previous request [{}]", addressName);
+
+            federation.processRemoteAddressAdded(addressName);
+         } else {
+            federation.signalError(new ActiveMQAMQPInternalErrorException("Remote sent unknown event."));
+            return;
+         }
+
+         delivery.disposition(Accepted.getInstance());
+         delivery.settle();
+
+         flow();
+
+         connection.flush();
+      } catch (Throwable e) {
+         logger.warn(e.getMessage(), e);
+         federation.signalError(
+            new ActiveMQAMQPInternalErrorException("Error while processing incoming event message: " + e.getMessage() ));
+      }
+   }
+
+   @Override
+   protected Runnable createCreditRunnable(AMQPConnectionContext connection) {
+      // The events processor is not bound to the configurable credit on the connection as it could be set
+      // to zero if trying to create pull federation consumers so we avoid any chance of that happening as
+      // otherwise there would be no credit granted for the remote to send us events.
+      return createCreditRunnable(PROCESSOR_RECEIVER_CREDITS, PROCESSOR_RECEIVER_CREDITS_LOW, receiver, connection, this);
+   }
+
+   @Override
+   public void flow() {
+      creditRunnable.run();
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationEventSupport.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationEventSupport.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.protocol.amqp.connect.federation;
+
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.EVENT_TYPE;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.REQUESTED_ADDRESS_ADDED;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.REQUESTED_ADDRESS_NAME;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.REQUESTED_QUEUE_ADDED;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.REQUESTED_QUEUE_NAME;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.protocol.amqp.broker.AMQPMessage;
+import org.apache.activemq.artemis.protocol.amqp.broker.AMQPStandardMessage;
+import org.apache.activemq.artemis.protocol.amqp.logger.ActiveMQAMQPProtocolMessageBundle;
+import org.apache.activemq.artemis.protocol.amqp.util.NettyWritable;
+import org.apache.activemq.artemis.protocol.amqp.util.TLSEncode;
+import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.amqp.messaging.AmqpValue;
+import org.apache.qpid.proton.amqp.messaging.MessageAnnotations;
+import org.apache.qpid.proton.amqp.messaging.Section;
+import org.apache.qpid.proton.codec.EncoderImpl;
+import org.apache.qpid.proton.codec.WritableBuffer;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+
+/**
+ * Tools used for sending and receiving events inside AMQP message instance.
+ */
+public final class AMQPFederationEventSupport {
+
+   /**
+    * Encode an event that indicates that a Queue that belongs to a federation
+    * request which was not present at the time of the request or was later removed
+    * is now present and the remote should check for demand and attempt to federate
+    * the resource once again.
+    *
+    * @param address
+    *    The address that the queue is currently bound to.
+    * @param queue
+    *    The queue that was part of a previous federation request.
+    *
+    * @return the AMQP message with the encoded event data.
+    */
+   public static AMQPMessage encodeQueueAddedEvent(String address, String queue) {
+      final Map<Symbol, Object> annotations = new LinkedHashMap<>();
+      final MessageAnnotations messageAnnotations = new MessageAnnotations(annotations);
+      final Map<String, Object> eventMap = new LinkedHashMap<>();
+      final Section sectionBody = new AmqpValue(eventMap);
+      final ByteBuf buffer = PooledByteBufAllocator.DEFAULT.heapBuffer(1024);
+
+      annotations.put(EVENT_TYPE, REQUESTED_QUEUE_ADDED);
+
+      eventMap.put(REQUESTED_ADDRESS_NAME, address);
+      eventMap.put(REQUESTED_QUEUE_NAME, queue);
+
+      try {
+         final EncoderImpl encoder = TLSEncode.getEncoder();
+         encoder.setByteBuffer(new NettyWritable(buffer));
+         encoder.writeObject(messageAnnotations);
+         encoder.writeObject(sectionBody);
+
+         final byte[] data = new byte[buffer.writerIndex()];
+         buffer.readBytes(data);
+
+         return new AMQPStandardMessage(0, data, null);
+      } finally {
+         TLSEncode.getEncoder().setByteBuffer((WritableBuffer) null);
+         buffer.release();
+      }
+   }
+
+   /**
+    * Encode an event that indicates that an Address that belongs to a federation
+    * request which was not present at the time of the request or was later removed
+    * is now present and the remote should check for demand and attempt to federate
+    * the resource once again.
+    *
+    * @param address
+    *    The address portion of the previously failed federation request
+    *
+    * @return the AMQP message with the encoded event data.
+    */
+   public static AMQPMessage encodeAddressAddedEvent(String address) {
+      final Map<Symbol, Object> annotations = new LinkedHashMap<>();
+      final MessageAnnotations messageAnnotations = new MessageAnnotations(annotations);
+      final Map<String, Object> eventMap = new LinkedHashMap<>();
+      final Section sectionBody = new AmqpValue(eventMap);
+      final ByteBuf buffer = PooledByteBufAllocator.DEFAULT.heapBuffer(1024);
+
+      annotations.put(EVENT_TYPE, REQUESTED_ADDRESS_ADDED);
+
+      eventMap.put(REQUESTED_ADDRESS_NAME, address);
+
+      try {
+         final EncoderImpl encoder = TLSEncode.getEncoder();
+         encoder.setByteBuffer(new NettyWritable(buffer));
+         encoder.writeObject(messageAnnotations);
+         encoder.writeObject(sectionBody);
+
+         final byte[] data = new byte[buffer.writerIndex()];
+         buffer.readBytes(data);
+
+         return new AMQPStandardMessage(0, data, null);
+      } finally {
+         TLSEncode.getEncoder().setByteBuffer((WritableBuffer) null);
+         buffer.release();
+      }
+   }
+
+   /**
+    * Decode and return the Map containing the event data for a Queue that was
+    * the target of a previous federation request which was not present on the
+    * remote server or was later removed has now been (re)added.
+    *
+    * @param message
+    *    The event message that carries the event data in its body.
+    *
+    * @return a {@link Map} containing the payload of the incoming event.
+    *
+    * @throws ActiveMQException if an error occurs while decoding the event data.
+    */
+   @SuppressWarnings("unchecked")
+   public static Map<String, Object> decodeQueueAddedEvent(AMQPMessage message) throws ActiveMQException {
+      final Section body = message.getBody();
+
+      if (!(body instanceof AmqpValue)) {
+         throw ActiveMQAMQPProtocolMessageBundle.BUNDLE.malformedFederationControlMessage(
+            "Message body was not an AmqpValue type");
+      }
+
+      final AmqpValue bodyValue = (AmqpValue) body;
+
+      if (!(bodyValue.getValue() instanceof Map)) {
+         throw ActiveMQAMQPProtocolMessageBundle.BUNDLE.malformedFederationControlMessage(
+            "Message body AmqpValue did not carry an encoded Map");
+      }
+
+      try {
+         final Map<String, Object> eventMap = (Map<String, Object>) bodyValue.getValue();
+
+         if (!eventMap.containsKey(REQUESTED_ADDRESS_NAME)) {
+            throw ActiveMQAMQPProtocolMessageBundle.BUNDLE.malformedFederationEventMessage(
+               "Message body did not carry the required address name");
+         }
+
+         if (!eventMap.containsKey(REQUESTED_QUEUE_NAME)) {
+            throw ActiveMQAMQPProtocolMessageBundle.BUNDLE.malformedFederationEventMessage(
+               "Message body did not carry the required queue name");
+         }
+
+         return eventMap;
+      } catch (ActiveMQException amqEx) {
+         throw amqEx;
+      } catch (Exception e) {
+         throw ActiveMQAMQPProtocolMessageBundle.BUNDLE.malformedFederationControlMessage(
+            "Invalid encoded queue added event entry: " + e.getMessage());
+      }
+   }
+
+   /**
+    * Decode and return the Map containing the event data for an Address that was
+    * the target of a previous federation request which was not present on the
+    * remote server or was later removed has now been (re)added.
+    *
+    * @param message
+    *    The event message that carries the event data in its body.
+    *
+    * @return a {@link Map} containing the payload of the incoming event.
+    *
+    * @throws ActiveMQException if an error occurs while decoding the event data.
+    */
+   @SuppressWarnings("unchecked")
+   public static Map<String, Object> decodeAddressAddedEvent(AMQPMessage message) throws ActiveMQException {
+      final Section body = message.getBody();
+
+      if (!(body instanceof AmqpValue)) {
+         throw ActiveMQAMQPProtocolMessageBundle.BUNDLE.malformedFederationControlMessage(
+            "Message body was not an AmqpValue type");
+      }
+
+      final AmqpValue bodyValue = (AmqpValue) body;
+
+      if (!(bodyValue.getValue() instanceof Map)) {
+         throw ActiveMQAMQPProtocolMessageBundle.BUNDLE.malformedFederationControlMessage(
+            "Message body AmqpValue did not carry an encoded Map");
+      }
+
+      try {
+         final Map<String, Object> eventMap = (Map<String, Object>) bodyValue.getValue();
+
+         if (!eventMap.containsKey(REQUESTED_ADDRESS_NAME)) {
+            throw ActiveMQAMQPProtocolMessageBundle.BUNDLE.malformedFederationEventMessage(
+               "Message body did not carry the required address name");
+         }
+
+         return eventMap;
+      } catch (ActiveMQException amqEx) {
+         throw amqEx;
+      } catch (Exception e) {
+         throw ActiveMQAMQPProtocolMessageBundle.BUNDLE.malformedFederationControlMessage(
+            "Invalid encoded address added event entry: " + e.getMessage());
+      }
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationSource.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationSource.java
@@ -18,6 +18,7 @@
 package org.apache.activemq.artemis.protocol.amqp.connect.federation;
 
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_CONTROL_LINK;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_EVENT_LINK;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_CONFIGURATION;
 import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.AMQP_LINK_INITIALIZER_KEY;
 
@@ -26,6 +27,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -44,7 +46,6 @@ import org.apache.activemq.artemis.protocol.amqp.proton.AMQPConnectionContext;
 import org.apache.activemq.artemis.protocol.amqp.proton.AMQPSessionContext;
 import org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport;
 import org.apache.activemq.artemis.protocol.amqp.proton.ProtonServerSenderContext;
-import org.apache.activemq.artemis.utils.UUIDGenerator;
 import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.amqp.messaging.DeleteOnClose;
 import org.apache.qpid.proton.amqp.messaging.Source;
@@ -55,6 +56,7 @@ import org.apache.qpid.proton.amqp.transport.ReceiverSettleMode;
 import org.apache.qpid.proton.amqp.transport.SenderSettleMode;
 import org.apache.qpid.proton.engine.Connection;
 import org.apache.qpid.proton.engine.Link;
+import org.apache.qpid.proton.engine.Receiver;
 import org.apache.qpid.proton.engine.Sender;
 import org.apache.qpid.proton.engine.Session;
 import org.slf4j.Logger;
@@ -76,6 +78,9 @@ public class AMQPFederationSource extends AMQPFederation {
    // Capabilities set on the sender link used to send policies or other control messages to
    // the remote federation target.
    private static final Symbol[] CONTROL_LINK_CAPABILITIES = new Symbol[] {FEDERATION_CONTROL_LINK};
+
+   // Capabilities set on the events links used to react to federation resources updates
+   private static final Symbol[] EVENT_LINK_CAPABILITIES = new Symbol[] {FEDERATION_EVENT_LINK};
 
    private final AMQPBrokerConnection brokerConnection;
 
@@ -235,6 +240,22 @@ public class AMQPFederationSource extends AMQPFederation {
          }
       });
 
+      try {
+         eventDispatcher.close();
+      } catch (Exception ex) {
+         errorCaught.compareAndExchange(null, ex);
+      } finally {
+         eventDispatcher = null;
+      }
+
+      try {
+         eventProcessor.close(null);
+      } catch (Exception ex) {
+         errorCaught.compareAndExchange(null, ex);
+      } finally {
+         eventProcessor = null;
+      }
+
       connection = null;
       session = null;
 
@@ -294,14 +315,233 @@ public class AMQPFederationSource extends AMQPFederation {
       return false;
    }
 
+   private void asyncCreateTargetEventsSender(AMQPFederationCommandDispatcher commandLink) {
+      // If no remote policies configured then we don't need an events sender link
+      // currently, if some other use is added for this link this code must be
+      // removed and tests updated to expect this link to always be created.
+      if (remoteAddressMatchPolicies.isEmpty() && remoteQueueMatchPolicies.isEmpty()) {
+         return;
+      }
+
+      // Schedule the outgoing event link creation on the connection event loop thread.
+      //
+      // Eventual establishment of the outgoing events link or refusal informs this side
+      // of the connection as to whether the remote side supports receiving events for
+      // resources that it attempted to federate but they did not exist at the time and
+      // were subsequently added or for resources that might have been later removed via
+      // management and then subsequently re-added.
+      //
+      // Once the outcome of the event link is known then send any remote address or queue
+      // federation policies so that the remote can start federation of local addresses or
+      // queues to itself. This ordering prevents a race on creation of the events link
+      // and any federation consumer creation from the remote.
+      connection.runLater(() -> {
+         if (!isStarted()) {
+            return;
+         }
+
+         try {
+            final Sender sender = session.getSession().sender(
+               "federation-events-sender:" + getName() + ":" + server.getNodeID() + ":" + UUID.randomUUID());
+            final Target target = new Target();
+            final Source source = new Source();
+
+            target.setDynamic(true);
+            target.setCapabilities(new Symbol[] {AmqpSupport.TEMP_TOPIC_CAPABILITY});
+            target.setDurable(TerminusDurability.NONE);
+            target.setExpiryPolicy(TerminusExpiryPolicy.LINK_DETACH);
+            // Set the dynamic node lifetime-policy to indicate this needs to be destroyed on close
+            // we don't want event links nodes remaining once a federation connection is closed.
+            final Map<Symbol, Object> dynamicNodeProperties = new HashMap<>();
+            dynamicNodeProperties.put(AmqpSupport.LIFETIME_POLICY, DeleteOnClose.getInstance());
+            target.setDynamicNodeProperties(dynamicNodeProperties);
+
+            sender.setSenderSettleMode(SenderSettleMode.SETTLED);
+            sender.setReceiverSettleMode(ReceiverSettleMode.FIRST);
+            sender.setDesiredCapabilities(EVENT_LINK_CAPABILITIES);
+            sender.setTarget(target);
+            sender.setSource(source);
+            sender.open();
+
+            final ScheduledFuture<?> futureTimeout;
+            final AtomicBoolean cancelled = new AtomicBoolean(false);
+
+            if (brokerConnection.getConnectionTimeout() > 0) {
+               futureTimeout = brokerConnection.getServer().getScheduledPool().schedule(() -> {
+                  cancelled.set(true);
+                  brokerConnection.connectError(ActiveMQAMQPProtocolMessageBundle.BUNDLE.brokerConnectionTimeout());
+               }, brokerConnection.getConnectionTimeout(), TimeUnit.MILLISECONDS);
+            } else {
+               futureTimeout = null;
+            }
+
+            // Using attachments to set up a Runnable that will be executed inside the remote link opened handler
+            sender.attachments().set(AMQP_LINK_INITIALIZER_KEY, Runnable.class, () -> {
+               try {
+                  if (cancelled.get()) {
+                     return;
+                  }
+
+                  if (futureTimeout != null) {
+                     futureTimeout.cancel(false);
+                  }
+
+                  if (sender.getRemoteTarget() == null || !AmqpSupport.verifyOfferedCapabilities(sender)) {
+                     // Sender rejected or not an event link endpoint so close as we will
+                     // not support sending events to the remote but otherwise will operate
+                     // as normal.
+                     sender.close();
+                  } else {
+                     session.addFederationEventDispatcher(sender);
+                  }
+
+                  // Once we know whether the events support is active or not we can send
+                  // the remote federation policies and allow the remote federation links
+                  // to start forming.
+
+                  remoteQueueMatchPolicies.forEach((key, policy) -> {
+                     try {
+                        commandLink.sendPolicy(policy);
+                     } catch (Exception e) {
+                        brokerConnection.error(e);
+                     }
+                  });
+
+                  remoteAddressMatchPolicies.forEach((key, policy) -> {
+                     try {
+                        commandLink.sendPolicy(policy);
+                     } catch (Exception e) {
+                        brokerConnection.error(e);
+                     }
+                  });
+
+               } catch (Exception e) {
+                  brokerConnection.error(e);
+               }
+            });
+         } catch (Exception e) {
+            brokerConnection.error(e);
+         }
+
+         connection.flush();
+      });
+   }
+
+   private void asnycCreateTargetEventsReceiver() {
+      // If no local policies configured then we don't need an events receiver link
+      // currently, if some other use is added for this link this code must be
+      // removed and tests updated to expect this link to always be created.
+      if (addressMatchPolicies.isEmpty() && queueMatchPolicies.isEmpty()) {
+         return;
+      }
+
+      // Schedule the incoming event link creation on the connection event loop thread.
+      //
+      // Eventual establishment of the incoming event link or refusal informs this side
+      // of the connection as to whether the remote will send events for addresses or
+      // queues that were not present when a federation consumer attempt had failed and
+      // were later added or an existing federation consumer was closed due to management
+      // action and those resource are once again available for federation.
+      //
+      // Once the outcome of the event link is known then start all the policy managers
+      // which will start federation from remote addresses and queues to this broker.
+      // This ordering prevents any races around the events receiver creation and creation
+      // of federation consumers on the remote.
+      connection.runLater(() -> {
+         if (!isStarted()) {
+            return;
+         }
+
+         try {
+            final Receiver receiver = session.getSession().receiver(
+               "federation-events-receiver:" + getName() + ":" + server.getNodeID() + ":" + UUID.randomUUID());
+
+            final Target target = new Target();
+            final Source source = new Source();
+
+            source.setDynamic(true);
+            source.setCapabilities(new Symbol[] {AmqpSupport.TEMP_TOPIC_CAPABILITY});
+            source.setDurable(TerminusDurability.NONE);
+            source.setExpiryPolicy(TerminusExpiryPolicy.LINK_DETACH);
+            // Set the dynamic node lifetime-policy to indicate this needs to be destroyed on close
+            // we don't want event links nodes remaining once a federation connection is closed.
+            final Map<Symbol, Object> dynamicNodeProperties = new HashMap<>();
+            dynamicNodeProperties.put(AmqpSupport.LIFETIME_POLICY, DeleteOnClose.getInstance());
+            source.setDynamicNodeProperties(dynamicNodeProperties);
+
+            receiver.setSenderSettleMode(SenderSettleMode.SETTLED);
+            receiver.setReceiverSettleMode(ReceiverSettleMode.FIRST);
+            receiver.setDesiredCapabilities(EVENT_LINK_CAPABILITIES);
+            receiver.setTarget(target);
+            receiver.setSource(source);
+            receiver.open();
+
+            final ScheduledFuture<?> futureTimeout;
+            final AtomicBoolean cancelled = new AtomicBoolean(false);
+
+            if (brokerConnection.getConnectionTimeout() > 0) {
+               futureTimeout = brokerConnection.getServer().getScheduledPool().schedule(() -> {
+                  cancelled.set(true);
+                  brokerConnection.connectError(ActiveMQAMQPProtocolMessageBundle.BUNDLE.brokerConnectionTimeout());
+               }, brokerConnection.getConnectionTimeout(), TimeUnit.MILLISECONDS);
+            } else {
+               futureTimeout = null;
+            }
+
+            // Using attachments to set up a Runnable that will be executed inside the remote link opened handler
+            receiver.attachments().set(AMQP_LINK_INITIALIZER_KEY, Runnable.class, () -> {
+               try {
+                  if (cancelled.get()) {
+                     return;
+                  }
+
+                  if (futureTimeout != null) {
+                     futureTimeout.cancel(false);
+                  }
+
+                  if (receiver.getRemoteSource() == null || !AmqpSupport.verifyOfferedCapabilities(receiver)) {
+                     // Receiver rejected or not an event link endpoint so close as we will
+                     // not be receiving events from the remote but otherwise will operate
+                     // as normal.
+                     receiver.close();
+                  } else {
+                     session.addFederationEventProcessor(receiver);
+                  }
+
+                  // Once we know whether the events support is active or not we can start the
+                  // local federation policies and allow the outgoing federation links to start
+                  // forming.
+                  //
+                  // Attempt to start the policy managers in another thread to avoid blocking the IO thread
+                  scheduler.execute(() -> {
+                     // Sync action with federation start / stop otherwise we could get out of sync
+                     synchronized (AMQPFederationSource.this) {
+                        if (isStarted()) {
+                           queueMatchPolicies.forEach((k, v) -> v.start());
+                           addressMatchPolicies.forEach((k, v) -> v.start());
+                        }
+                     }
+                  });
+               } catch (Exception e) {
+                  brokerConnection.error(e);
+               }
+            });
+         } catch (Exception e) {
+            brokerConnection.error(e);
+         }
+
+         connection.flush();
+      });
+   }
+
    private void asyncCreateControlLink() {
       // Schedule the control link creation on the connection event loop thread
       // Eventual establishment of the control link indicates successful connection
       // to a remote peer that can support AMQP federation requirements.
       connection.runLater(() -> {
          try {
-            final Sender sender = session.getSession().sender("Federation:" + getName() + ":" + UUIDGenerator.getInstance().generateStringUUID());
-            final AMQPFederationCommandDispatcher commandLink = new AMQPFederationCommandDispatcher(sender, getServer(), session.getSessionSPI());
+            final Sender sender = session.getSession().sender(
+               "federation-control-link:" + getName() + ":" + server.getNodeID() + ":" + UUID.randomUUID());
             final Target target = new Target();
 
             // The control link should be dynamic and the node is destroyed if the connection drops
@@ -383,6 +623,7 @@ public class AMQPFederationSource extends AMQPFederation {
                      throw new ActiveMQAMQPInternalErrorException("Error while configuring interal session metadata");
                   }
 
+                  final AMQPFederationCommandDispatcher commandLink = new AMQPFederationCommandDispatcher(sender, getServer(), session.getSessionSPI());
                   final ProtonServerSenderContext senderContext =
                      new ProtonServerSenderContext(connection, sender, session, session.getSessionSPI(), commandLink);
 
@@ -390,33 +631,13 @@ public class AMQPFederationSource extends AMQPFederation {
 
                   connected = true;
 
-                  remoteQueueMatchPolicies.forEach((key, policy) -> {
-                     try {
-                        commandLink.sendPolicy(policy);
-                     } catch (Exception e) {
-                        brokerConnection.error(e);
-                     }
-                  });
+                  // Setup events sender link to the target if there are any remote policies and
+                  // then send those polices to start remote federation.
+                  asyncCreateTargetEventsSender(commandLink);
 
-                  remoteAddressMatchPolicies.forEach((key, policy) -> {
-                     try {
-                        commandLink.sendPolicy(policy);
-                     } catch (Exception e) {
-                        brokerConnection.error(e);
-                     }
-                  });
-
-                  // Attempt to start the policy managers in another thread to avoid blocking the IO thread
-                  scheduler.execute(() -> {
-                     // Sync action with federation start / stop otherwise we could get out of sync
-                     synchronized (AMQPFederationSource.this) {
-                        if (isStarted()) {
-                           queueMatchPolicies.forEach((k, v) -> v.start());
-                           addressMatchPolicies.forEach((k, v) -> v.start());
-                        }
-                     }
-                  });
-
+                  // Setup events receiver link from the target if there are any local policies
+                  // and then start the policy managers to begin tracking local demand.
+                  asnycCreateTargetEventsReceiver();
                } catch (Exception e) {
                   brokerConnection.error(e);
                }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/federation/FederationReceiveFromQueuePolicy.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/federation/FederationReceiveFromQueuePolicy.java
@@ -104,6 +104,22 @@ public class FederationReceiveFromQueuePolicy implements BiPredicate<String, Str
       return transformerConfig;
    }
 
+   public boolean testQueue(String queue) {
+      for (QueueMatcher matcher : excludeMatchers) {
+         if (matcher.testQueue(queue)) {
+            return false;
+         }
+      }
+
+      for (QueueMatcher matcher : includeMatchers) {
+         if (matcher.testQueue(queue)) {
+            return true;
+         }
+      }
+
+      return false;
+   }
+
    @Override
    public boolean test(String address, String queue) {
       for (QueueMatcher matcher : excludeMatchers) {
@@ -142,7 +158,15 @@ public class FederationReceiveFromQueuePolicy implements BiPredicate<String, Str
 
       @Override
       public boolean test(String address, String queue) {
-         return addressMatch.test(address) && queueMatch.test(queue);
+         return testAddress(address) && testQueue(queue);
+      }
+
+      public boolean testAddress(String address) {
+         return addressMatch.test(address);
+      }
+
+      public boolean testQueue(String queue) {
+         return queueMatch.test(queue);
       }
    }
 }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/federation/internal/FederationAddressEntry.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/federation/internal/FederationAddressEntry.java
@@ -23,7 +23,7 @@ import java.util.Set;
 import org.apache.activemq.artemis.core.postoffice.Binding;
 
 /**
- * Am entry type class used to hold a {@link FederationConsumerInternal} and
+ * An entry type class used to hold a {@link FederationConsumerInternal} and
  * any other state data needed by the manager that is creating them based on the
  * policy configuration for the federation instance.  The entry can be extended
  * by federation implementation to hold additional state data for the federation

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/federation/internal/FederationQueueEntry.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/federation/internal/FederationQueueEntry.java
@@ -23,7 +23,7 @@ import java.util.Set;
 import org.apache.activemq.artemis.core.server.ServerConsumer;
 
 /**
- * Am entry type class used to hold a {@link FederationConsumerInternal} and
+ * An entry type class used to hold a {@link FederationConsumerInternal} and
  * any other state data needed by the manager that is creating them based on the
  * policy configuration for the federation instance.  The entry can be extended
  * by federation implementation to hold additional state data for the federation
@@ -77,16 +77,14 @@ public class FederationQueueEntry {
    }
 
    /**
-    * Reduce the known demand on the resource this entries consumer is associated with
-    * and returns true when demand reaches zero which indicates the consumer should be
-    * closed and the entry cleaned up.
+    * Remove the known demand on the resource from the given {@link ServerConsumer}.
     *
     * @param consumer
     *    The {@link ServerConsumer} that generated the demand on federated resource.
     *
     * @return this federation queue entry instance.
     */
-   public FederationQueueEntry reduceDemand(ServerConsumer consumer) {
+   public FederationQueueEntry removeDemand(ServerConsumer consumer) {
       consumerDemand.remove(identifyConsumer(consumer));
       return this;
    }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/logger/ActiveMQAMQPProtocolMessageBundle.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/logger/ActiveMQAMQPProtocolMessageBundle.java
@@ -111,4 +111,8 @@ public interface ActiveMQAMQPProtocolMessageBundle {
 
    @Message(id = 119027, value = "Invalid AMQPConnection Remote State: {}")
    ActiveMQException invalidAMQPConnectionState(Object state);
+
+   @Message(id = 119028, value = "Malformed Federation event message: {}")
+   ActiveMQException malformedFederationEventMessage(String message);
+
 }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPConnectionContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPConnectionContext.java
@@ -80,6 +80,7 @@ import java.lang.invoke.MethodHandles;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_ADDRESS_RECEIVER;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_CONTROL_LINK;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_CONTROL_LINK_VALIDATION_ADDRESS;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_EVENT_LINK;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_QUEUE_RECEIVER;
 import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.AMQP_LINK_INITIALIZER_KEY;
 import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.FAILOVER_SERVER_LIST;
@@ -403,6 +404,8 @@ public class AMQPConnectionContext extends ProtonInitializable implements EventH
             handleReplicaTargetLinkOpened(protonSession, receiver);
          } else if (isFederationControlLink(receiver)) {
             handleFederationControlLinkOpened(protonSession, receiver);
+         } else if (isFederationEventLink(receiver)) {
+            protonSession.addFederationEventProcessor(receiver);
          } else {
             protonSession.addReceiver(receiver);
          }
@@ -412,6 +415,8 @@ public class AMQPConnectionContext extends ProtonInitializable implements EventH
             protonSession.addSender(sender, new AMQPFederationAddressSenderController(protonSession));
          } else if (isFederationQueueReceiver(sender)) {
             protonSession.addSender(sender, new AMQPFederationQueueSenderController(protonSession));
+         } else if (isFederationEventLink(sender)) {
+            protonSession.addFederationEventDispatcher(sender);
          } else {
             protonSession.addSender(sender);
          }
@@ -478,6 +483,14 @@ public class AMQPConnectionContext extends ProtonInitializable implements EventH
 
    private static boolean isFederationControlLink(Receiver receiver) {
       return verifyDesiredCapability(receiver, FEDERATION_CONTROL_LINK);
+   }
+
+   private static boolean isFederationEventLink(Sender sender) {
+      return verifyDesiredCapability(sender, FEDERATION_EVENT_LINK);
+   }
+
+   private static boolean isFederationEventLink(Receiver receiver) {
+      return verifyDesiredCapability(receiver, FEDERATION_EVENT_LINK);
    }
 
    private static boolean isFederationQueueReceiver(Sender sender) {

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java
@@ -263,6 +263,7 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
 
          connection.runNow(() -> {
             sender.close();
+            controller.close(condition);
             try {
                sessionSPI.closeSender(brokerConsumer);
             } catch (Exception e) {
@@ -270,7 +271,6 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
             } finally {
                messageWriter.close();
             }
-            sender.close();
             connection.flush();
          });
       }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/SenderController.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/SenderController.java
@@ -20,6 +20,7 @@ import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.core.server.Consumer;
 import org.apache.activemq.artemis.core.server.MessageReference;
 import org.apache.activemq.artemis.protocol.amqp.broker.AMQPLargeMessage;
+import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 
 public interface SenderController {
 
@@ -55,6 +56,18 @@ public interface SenderController {
     * @throws Exception if an error occurs during close.
     */
    void close() throws Exception;
+
+   /**
+    * Called when the sender is being locally closed due to some error or forced
+    * shutdown due to resource deletion etc. The default implementation of this
+    * API does nothing in response to this call.
+    *
+    * @param error
+    *    The error condition that triggered the close.
+    */
+   default void close(ErrorCondition error) {
+
+   }
 
    /**
     * Controller selects a outgoing delivery writer that will handle the encoding and writing

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationConfigurationReloadTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationConfigurationReloadTest.java
@@ -22,6 +22,7 @@ import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPF
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.ADDRESS_AUTO_DELETE_MSG_COUNT;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_ADDRESS_RECEIVER;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_CONTROL_LINK;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_EVENT_LINK;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_QUEUE_RECEIVER;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_RECEIVER_PRIORITY;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationPolicySupport.DEFAULT_QUEUE_RECEIVER_PRIORITY_ADJUSTMENT;
@@ -98,6 +99,10 @@ public class AMQPFederationConfigurationReloadTest extends AmqpClientTestSupport
                             .withDesiredCapability(FEDERATION_CONTROL_LINK.toString())
                             .respond()
                             .withOfferedCapabilities(FEDERATION_CONTROL_LINK.toString());
+         peer.expectAttach().ofReceiver()
+                            .withDesiredCapability(FEDERATION_EVENT_LINK.toString())
+                            .respondInKind();
+         peer.expectFlow().withLinkCredit(10);
          peer.start();
 
          final URI remoteURI = peer.getServerURI();
@@ -193,6 +198,10 @@ public class AMQPFederationConfigurationReloadTest extends AmqpClientTestSupport
                             .withDesiredCapability(FEDERATION_CONTROL_LINK.toString())
                             .respond()
                             .withOfferedCapabilities(FEDERATION_CONTROL_LINK.toString());
+         peer.expectAttach().ofReceiver()
+                            .withDesiredCapability(FEDERATION_EVENT_LINK.toString())
+                            .respondInKind();
+         peer.expectFlow().withLinkCredit(10);
          peer.start();
 
          final URI remoteURI = peer.getServerURI();
@@ -251,6 +260,10 @@ public class AMQPFederationConfigurationReloadTest extends AmqpClientTestSupport
                                    .withDesiredCapability(FEDERATION_CONTROL_LINK.toString())
                                    .respond()
                                    .withOfferedCapabilities(FEDERATION_CONTROL_LINK.toString());
+               peer2.expectAttach().ofReceiver()
+                                   .withDesiredCapability(FEDERATION_EVENT_LINK.toString())
+                                   .respondInKind();
+               peer2.expectFlow().withLinkCredit(10);
                peer2.start();
 
                final URI remoteURI2 = peer2.getServerURI();
@@ -313,6 +326,10 @@ public class AMQPFederationConfigurationReloadTest extends AmqpClientTestSupport
                             .withDesiredCapability(FEDERATION_CONTROL_LINK.toString())
                             .respond()
                             .withOfferedCapabilities(FEDERATION_CONTROL_LINK.toString());
+         peer.expectAttach().ofReceiver()
+                            .withDesiredCapability(FEDERATION_EVENT_LINK.toString())
+                            .respondInKind();
+         peer.expectFlow().withLinkCredit(10);
          peer.start();
 
          final URI remoteURI = peer.getServerURI();
@@ -398,6 +415,10 @@ public class AMQPFederationConfigurationReloadTest extends AmqpClientTestSupport
                             .withDesiredCapability(FEDERATION_CONTROL_LINK.toString())
                             .respond()
                             .withOfferedCapabilities(FEDERATION_CONTROL_LINK.toString());
+         peer.expectAttach().ofReceiver()
+                            .withDesiredCapability(FEDERATION_EVENT_LINK.toString())
+                            .respondInKind();
+         peer.expectFlow().withLinkCredit(10);
          peer.start();
 
          final URI remoteURI = peer.getServerURI();
@@ -460,6 +481,10 @@ public class AMQPFederationConfigurationReloadTest extends AmqpClientTestSupport
                                .withDesiredCapability(FEDERATION_CONTROL_LINK.toString())
                                .respond()
                                .withOfferedCapabilities(FEDERATION_CONTROL_LINK.toString());
+            peer.expectAttach().ofReceiver()
+                               .withDesiredCapability(FEDERATION_EVENT_LINK.toString())
+                               .respondInKind();
+            peer.expectFlow().withLinkCredit(10);
             peer.expectAttach().ofReceiver()
                                .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
                                .withName(allOf(containsString("sample-federation"),


### PR DESCRIPTION
When an AMQP federation instance attempts to federate an address or queue it can fail if the remote address or queue is not present or cannot be created based on broker policy. A federation link can also closed if the federated resource is removed from the remote broker by management etc. In those cases the remote broker should note the resources that were targets of federation and send alerts to the source federation broker to notify it that these resources become available for federation and the source should attempt again to create federation links if demand still exists. This allows an AMQP federation instance to heal itself based on updates from the remote.