### PR TITLE
ARTEMIS-4642 Fix tracked federated demand when links are rejected or …

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationAddressConsumer.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationAddressConsumer.java
@@ -165,7 +165,7 @@ public class AMQPFederationAddressConsumer implements FederationConsumerInternal
          if (started) {
             started = false;
             connection.runLater(() -> {
-               federation.removeLinkClosedInterceptor(consumerInfo.getFqqn());
+               federation.removeLinkClosedInterceptor(consumerInfo.getId());
 
                if (receiver != null) {
                   try {
@@ -350,7 +350,7 @@ public class AMQPFederationAddressConsumer implements FederationConsumerInternal
                   // Intercept remote close and check for valid reasons for remote closure such as
                   // the remote peer not having a matching queue for this subscription or from an
                   // operator manually closing the link.
-                  federation.addLinkClosedInterceptor(consumerInfo.getFqqn(), remoteCloseInterceptor);
+                  federation.addLinkClosedInterceptor(consumerInfo.getId(), remoteCloseInterceptor);
 
                   receiver = new AMQPFederatedAddressDeliveryReceiver(session, consumerInfo, protonReceiver);
 

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationQueueConsumer.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationQueueConsumer.java
@@ -162,7 +162,7 @@ public class AMQPFederationQueueConsumer implements FederationConsumerInternal {
          if (started) {
             started = false;
             connection.runLater(() -> {
-               federation.removeLinkClosedInterceptor(consumerInfo.getFqqn());
+               federation.removeLinkClosedInterceptor(consumerInfo.getId());
 
                if (receiver != null) {
                   try {
@@ -341,7 +341,7 @@ public class AMQPFederationQueueConsumer implements FederationConsumerInternal {
                   // Intercept remote close and check for valid reasons for remote closure such as
                   // the remote peer not having a matching queue for this subscription or from an
                   // operator manually closing the link.
-                  federation.addLinkClosedInterceptor(consumerInfo.getFqqn(), remoteCloseIntercepter);
+                  federation.addLinkClosedInterceptor(consumerInfo.getId(), remoteCloseIntercepter);
 
                   receiver = new AMQPFederatedQueueDeliveryReceiver(localQueue, protonReceiver);
 

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/federation/FederationConsumerInfo.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/federation/FederationConsumerInfo.java
@@ -39,6 +39,11 @@ public interface FederationConsumerInfo {
    }
 
    /**
+    * @return a unique Id for the consumer being represented.
+    */
+   String getId();
+
+   /**
     * @return the type of federation consumer being represented.
     */
    Role getRole();

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/federation/internal/FederationGenericConsumerInfo.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/federation/internal/FederationGenericConsumerInfo.java
@@ -18,6 +18,7 @@
 package org.apache.activemq.artemis.protocol.amqp.federation.internal;
 
 import java.util.Objects;
+import java.util.UUID;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.RoutingType;
@@ -48,6 +49,7 @@ public class FederationGenericConsumerInfo implements FederationConsumerInfo {
    private final String filterString;
    private final String fqqn;
    private final int priority;
+   private final String id;
 
    protected FederationGenericConsumerInfo(Role role, String address, String queueName, RoutingType routingType,
                                            String filterString, String fqqn, int priority) {
@@ -58,6 +60,7 @@ public class FederationGenericConsumerInfo implements FederationConsumerInfo {
       this.filterString = filterString;
       this.fqqn = fqqn;
       this.priority = priority;
+      this.id = UUID.randomUUID().toString();
    }
 
    /**
@@ -114,6 +117,11 @@ public class FederationGenericConsumerInfo implements FederationConsumerInfo {
                                                filterString,
                                                CompositeAddress.toFullyQualified(address, queueName),
                                                ActiveMQDefaultConfiguration.getDefaultConsumerPriority());
+   }
+
+   @Override
+   public String getId() {
+      return id;
    }
 
    @Override

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/federation/internal/FederationQueueEntry.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/federation/internal/FederationQueueEntry.java
@@ -18,9 +18,11 @@
 package org.apache.activemq.artemis.protocol.amqp.federation.internal;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.activemq.artemis.core.server.ServerConsumer;
+import org.apache.activemq.artemis.protocol.amqp.federation.FederationConsumerInfo;
 
 /**
  * An entry type class used to hold a {@link FederationConsumerInternal} and
@@ -29,24 +31,46 @@ import org.apache.activemq.artemis.core.server.ServerConsumer;
  * by federation implementation to hold additional state data for the federation
  * consumer and the managing of its lifetime.
  *
- * This entry type provides a reference counter that can be used to register demand
+ * This entry type provides reference tracking state for current demand (bindings)
  * on a federation resource such that it is not torn down until all demand has been
  * removed from the local resource.
  */
 public class FederationQueueEntry {
 
-   private final FederationConsumerInternal consumer;
-
+   private final FederationConsumerInfo consumerInfo;
    private final Set<String> consumerDemand = new HashSet<>();
+
+   private FederationConsumerInternal consumer;
 
    /**
     * Creates a new queue entry with a single reference
     *
-    * @param consumer
-    *    The federation consumer that will be carried in this entry.
+    * @param consumerInfo
+    *       Consumer information object used to define the federation queue consumer
     */
-   public FederationQueueEntry(FederationConsumerInternal consumer) {
-      this.consumer = consumer;
+   public FederationQueueEntry(FederationConsumerInfo consumerInfo) {
+      this.consumerInfo = consumerInfo;
+   }
+
+   /**
+    * @return the name of the queue that this entry tracks demand for.
+    */
+   public String getQueueName() {
+      return consumerInfo.getQueueName();
+   }
+
+   /**
+    * @return the consumer information that defines the properties of federation queue consumers
+    */
+   public FederationConsumerInfo getConsumerInfo() {
+      return consumerInfo;
+   }
+
+   /**
+    * @return <code>true</code> if a consumer is currently set on this entry.
+    */
+   public boolean hasConsumer() {
+      return consumer != null;
    }
 
    /**
@@ -54,6 +78,30 @@ public class FederationQueueEntry {
     */
    public FederationConsumerInternal getConsumer() {
       return consumer;
+   }
+
+   /**
+    * Sets the consumer assigned to this entry to the given instance.
+    *
+    * @param consumer
+    *    The federation consumer that is currently active for this entry.
+    *
+    * @return this federation queue consumer entry.
+    */
+   public FederationQueueEntry setConsumer(FederationConsumerInternal consumer) {
+      Objects.requireNonNull(consumer, "Cannot assign a null consumer to this entry, call clear to unset");
+      this.consumer = consumer;
+      return this;
+   }
+
+   /**
+    * Clears the currently assigned consumer from this entry.
+    *
+    * @return this federation queue consumer entry.
+    */
+   public FederationQueueEntry clearConsumer() {
+      this.consumer = null;
+      return this;
    }
 
    /**

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/federation/internal/FederationQueuePolicyManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/federation/internal/FederationQueuePolicyManager.java
@@ -28,13 +28,16 @@ import java.util.function.Predicate;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.core.filter.Filter;
 import org.apache.activemq.artemis.core.filter.impl.FilterImpl;
+import org.apache.activemq.artemis.core.postoffice.Binding;
 import org.apache.activemq.artemis.core.postoffice.QueueBinding;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.server.ServerConsumer;
 import org.apache.activemq.artemis.core.server.ServerSession;
 import org.apache.activemq.artemis.core.server.federation.Federation;
+import org.apache.activemq.artemis.core.server.plugin.ActiveMQServerBindingPlugin;
 import org.apache.activemq.artemis.core.server.plugin.ActiveMQServerConsumerPlugin;
+import org.apache.activemq.artemis.core.transaction.Transaction;
 import org.apache.activemq.artemis.protocol.amqp.federation.FederationConsumer;
 import org.apache.activemq.artemis.protocol.amqp.federation.FederationConsumerInfo;
 import org.apache.activemq.artemis.protocol.amqp.federation.FederationReceiveFromQueuePolicy;
@@ -46,14 +49,14 @@ import org.slf4j.LoggerFactory;
  * monitoring broker queues for demand and creating a consumer for on the remote side
  * to federate messages back to this peer.
  */
-public abstract class FederationQueuePolicyManager implements ActiveMQServerConsumerPlugin {
+public abstract class FederationQueuePolicyManager implements ActiveMQServerConsumerPlugin, ActiveMQServerBindingPlugin {
 
    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    protected final ActiveMQServer server;
    protected final Predicate<ServerConsumer> federationConsumerMatcher;
    protected final FederationReceiveFromQueuePolicy policy;
-   protected final Map<String, FederationQueueEntry> remoteConsumers = new HashMap<>();
+   protected final Map<String, FederationQueueEntry> demandTracking = new HashMap<>();
    protected final FederationInternal federation;
 
    private volatile boolean started;
@@ -93,8 +96,12 @@ public abstract class FederationQueuePolicyManager implements ActiveMQServerCons
          // broker plugin instances.
          server.unRegisterBrokerPlugin(this);
          started = false;
-         remoteConsumers.forEach((k, v) -> v.getConsumer().close()); // Cleanup and recreate if ever reconnected.
-         remoteConsumers.clear();
+         demandTracking.forEach((k, v) -> {
+            if (v.hasConsumer()) {
+               v.getConsumer().close();
+            }
+         });
+         demandTracking.clear();
       }
    }
 
@@ -109,7 +116,7 @@ public abstract class FederationQueuePolicyManager implements ActiveMQServerCons
    public synchronized void afterCloseConsumer(ServerConsumer consumer, boolean failed) {
       if (started) {
          final String queueName = consumer.getQueue().getName().toString();
-         final FederationQueueEntry entry = remoteConsumers.get(queueName);
+         final FederationQueueEntry entry = demandTracking.get(queueName);
 
          if (entry == null) {
             return;
@@ -119,7 +126,7 @@ public abstract class FederationQueuePolicyManager implements ActiveMQServerCons
 
          logger.trace("Reducing demand on federated queue {}, remaining demand? {}", queueName, entry.hasDemand());
 
-         if (!entry.hasDemand()) {
+         if (!entry.hasDemand() && entry.hasConsumer()) {
             final FederationConsumerInternal federationConsuner = entry.getConsumer();
 
             try {
@@ -127,8 +134,20 @@ public abstract class FederationQueuePolicyManager implements ActiveMQServerCons
                federationConsuner.close();
                signalAfterCloseFederationConsumer(federationConsuner);
             } finally {
-               remoteConsumers.remove(queueName);
+               demandTracking.remove(queueName);
             }
+         }
+      }
+   }
+
+   @Override
+   public synchronized void afterRemoveBinding(Binding binding, Transaction tx, boolean deleteData) throws ActiveMQException {
+      if (binding instanceof QueueBinding) {
+         final QueueBinding queueBinding = (QueueBinding) binding;
+         final FederationQueueEntry entry = demandTracking.remove(queueBinding.getQueue().getName().toString());
+
+         if (entry != null && entry.hasConsumer()) {
+            entry.getConsumer().close();
          }
       }
    }
@@ -150,7 +169,9 @@ public abstract class FederationQueuePolicyManager implements ActiveMQServerCons
    }
 
    protected final void reactIfConsumerMatchesPolicy(ServerConsumer consumer) {
-      if (testIfQueueMatchesPolicy(consumer.getQueueAddress().toString(), consumer.getQueueName().toString())) {
+      final String queueName = consumer.getQueue().getName().toString();
+
+      if (testIfQueueMatchesPolicy(consumer.getQueueAddress().toString(), queueName)) {
          // We should ignore federation consumers from remote peers but configuration does allow
          // these to be federated again for some very specific use cases so we check before then
          // moving onto any server plugin checks kick in.
@@ -158,49 +179,59 @@ public abstract class FederationQueuePolicyManager implements ActiveMQServerCons
             return;
          }
 
-         if (isPluginBlockingFederationConsumerCreate(consumer.getQueue())) {
-            return;
-         }
-
          logger.trace("Federation Policy matched on consumer for binding: {}", consumer.getBinding());
 
-         final FederationConsumerInfo consumerInfo = createConsumerInfo(consumer);
+         final FederationQueueEntry entry;
 
-         // Check for existing consumer add demand from a additional local consumer
-         // to ensure the remote consumer remains active until all local demand is
-         // withdrawn.
-         if (remoteConsumers.containsKey(consumerInfo.getQueueName())) {
-            logger.trace("Federation Queue Policy manager found existing demand for queue: {}, adding demand", consumerInfo.getQueueName());
-            remoteConsumers.get(consumerInfo.getQueueName()).addDemand(consumer);
+         // Check for existing consumer add demand from a additional local consumer to ensure
+         // the remote consumer remains active until all local demand is withdrawn.
+         if (demandTracking.containsKey(queueName)) {
+            logger.trace("Federation Queue Policy manager found existing demand for queue: {}, adding demand", queueName);
+            entry = demandTracking.get(queueName);
          } else {
-            logger.trace("Federation Queue Policy manager creating remote consumer for queue: {}", consumerInfo.getQueueName());
-
-            signalBeforeCreateFederationConsumer(consumerInfo);
-
-            final FederationConsumerInternal queueConsumer = createFederationConsumer(consumerInfo);
-            final FederationQueueEntry entry = createServerConsumerEntry(queueConsumer).addDemand(consumer);
-
-            // Handle remote close with remove of consumer which means that future demand will
-            // attempt to create a new consumer for that demand. Ensure that thread safety is
-            // accounted for here as the notification can be asynchronous.
-            queueConsumer.setRemoteClosedHandler((closedConsumer) -> {
-               synchronized (this) {
-                  try {
-                     remoteConsumers.remove(closedConsumer.getConsumerInfo().getQueueName());
-                  } finally {
-                     closedConsumer.close();
-                  }
-               }
-            });
-
-            // Called under lock so state should stay in sync
-            remoteConsumers.put(consumerInfo.getQueueName(), entry);
-
-            // Now that we are tracking it we can start it
-            queueConsumer.start();
-
-            signalAfterCreateFederationConsumer(queueConsumer);
+            demandTracking.put(queueName, entry = createConsumerEntry(createConsumerInfo(consumer)));
          }
+
+         // Demand passed all binding plugin blocking checks so we track it, plugin can still
+         // stop federation of the queue based on some external criteria but once it does
+         // (if ever) allow it we will have tracked all allowed demand.
+         entry.addDemand(consumer);
+
+         tryCreateFederationConsumerForQueue(entry, consumer.getQueue());
+      }
+   }
+
+   private void tryCreateFederationConsumerForQueue(FederationQueueEntry queueEntry, Queue queue) {
+      if (queueEntry.hasDemand() && !queueEntry.hasConsumer() && !isPluginBlockingFederationConsumerCreate(queue)) {
+         logger.trace("Federation Queue Policy manager creating remote consumer for queue: {}", queueEntry.getQueueName());
+
+         signalBeforeCreateFederationConsumer(queueEntry.getConsumerInfo());
+
+         final FederationConsumerInternal queueConsumer = createFederationConsumer(queueEntry.getConsumerInfo());
+
+         // Handle remote close with remove of consumer which means that future demand will
+         // attempt to create a new consumer for that demand. Ensure that thread safety is
+         // accounted for here as the notification can be asynchronous.
+         queueConsumer.setRemoteClosedHandler((closedConsumer) -> {
+            synchronized (this) {
+               try {
+                  final FederationQueueEntry tracked = demandTracking.get(closedConsumer.getConsumerInfo().getQueueName());
+
+                  if (tracked != null) {
+                     tracked.clearConsumer();
+                  }
+               } finally {
+                  closedConsumer.close();
+               }
+            }
+         });
+
+         queueEntry.setConsumer(queueConsumer);
+
+         // Now that we are tracking it we can start it
+         queueConsumer.start();
+
+         signalAfterCreateFederationConsumer(queueConsumer);
       }
    }
 
@@ -220,17 +251,15 @@ public abstract class FederationQueuePolicyManager implements ActiveMQServerCons
       // We ignore the remote address as locally the policy can be a wild card match and we can
       // try to federate based on the Queue only, if the remote rejects the federation consumer
       // binding again the request will once more be recorded and we will get another event if
-      // the queue were recreated such that a match could be made.
-      if (started && testIfQueueMatchesPolicy(queueName)) {
+      // the queue were recreated such that a match could be made. We retain all the current
+      // demand and don't need to re-check the server state before trying to create the
+      // remote queue consumer.
+      if (started && testIfQueueMatchesPolicy(queueName) && demandTracking.containsKey(queueName)) {
+         final Queue queue = server.locateQueue(queueName);
 
-         // Find a matching Queue with the given name and then check for demand based
-         // on the attached consumers and the current policy constraints.
-
-         server.getPostOffice()
-               .getAllBindings()
-               .filter(b -> b instanceof QueueBinding && ((QueueBinding) b).getQueue().getName().toString().equals(queueName))
-               .map(b -> (QueueBinding) b)
-               .forEach(b -> checkQueueForMatch(b.getQueue()));
+         if (queue != null) {
+            tryCreateFederationConsumerForQueue(demandTracking.get(queueName), queue);
+         }
       }
    }
 
@@ -286,13 +315,13 @@ public abstract class FederationQueuePolicyManager implements ActiveMQServerCons
     * instance. A subclass can override this method to return a more customized entry type with additional
     * state data.
     *
-    * @param consumer
-    *    The {@link FederationConsumerInternal} instance that will be housed in this entry.
+    * @param consumerInfo
+    *    The consumer information that defines characteristics of the federation queue consumer
     *
-    * @return a new {@link FederationQueueEntry} that holds the given federation consumer.
+    * @return a new {@link FederationQueueEntry} that holds the given queue name.
     */
-   protected FederationQueueEntry createServerConsumerEntry(FederationConsumerInternal consumer) {
-      return new FederationQueueEntry(consumer);
+   protected FederationQueueEntry createConsumerEntry(FederationConsumerInfo consumerInfo) {
+      return new FederationQueueEntry(consumerInfo);
    }
 
    /**


### PR DESCRIPTION
…blocked

Under some scenarios federation demand tracking is losing track of total demand for a federated resource leading to teardown of federated links before all local demand has been removed from the resource. This occurs most often if the attempts to establish a federation link are refused because the resource hasn't yet been created and an eventual attach succeeds, but can also occur in combination with a plugin blocking or not blocking federation link creation in some cases.