### PR TITLE
ARTEMIS-4645 Update broker connection tests to use unique broker names

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationAddressPolicyTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationAddressPolicyTest.java
@@ -173,11 +173,11 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          receiveFromAddress.setAutoDeleteMessageCount(-1L);
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -193,7 +193,7 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
 
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("address-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -268,11 +268,11 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          receiveFromAddress.setAutoDeleteMessageCount(-1L);
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -288,7 +288,7 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("address-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -343,11 +343,11 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          receiveFromAddress.addProperty(RECEIVER_CREDITS_LOW, "5");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -363,7 +363,7 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("address-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -417,11 +417,11 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          receiveFromAddress.setAutoDeleteMessageCount(-1L);
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -439,7 +439,7 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("address-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -532,11 +532,11 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          receiveFromAddress.setAutoDeleteMessageCount(-1L);
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -552,7 +552,7 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("address-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -611,11 +611,11 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          receiveFromAddress.setAutoDeleteMessageCount(-1L);
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -631,7 +631,7 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("address-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -697,11 +697,11 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          receiveFromAddress.setAutoDeleteMessageCount(-1L);
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -717,7 +717,7 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("address-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -771,11 +771,11 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          receiveFromAddress.addToIncludes("test");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -786,7 +786,7 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("address-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -813,7 +813,7 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("address-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -862,11 +862,11 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          receiveFromAddress.setEnableDivertBindings(true);
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -888,7 +888,7 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("address-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -944,11 +944,11 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          receiveFromAddress.setEnableDivertBindings(true);
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -970,7 +970,7 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("address-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -1034,11 +1034,11 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          receiveFromAddress.setEnableDivertBindings(true);
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -1060,7 +1060,7 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("address-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -1118,11 +1118,11 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          receiveFromAddress.setEnableDivertBindings(true);
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("myFederations");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -1149,7 +1149,7 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
-                            .withName(allOf(containsString("myFederations"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("source"),
                                             containsString("address-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -1207,11 +1207,11 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          receiveFromAddress.setEnableDivertBindings(true);
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("myFederations");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -1238,7 +1238,7 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
-                            .withName(allOf(containsString("myFederations"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("source"),
                                             containsString("address-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -1298,11 +1298,11 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          receiveFromAddress.setEnableDivertBindings(true);
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -1324,7 +1324,7 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("source"),
                                             containsString("address-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -1380,11 +1380,11 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          receiveFromAddress.setEnableDivertBindings(true);
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -1407,7 +1407,7 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("address-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -1468,11 +1468,11 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          receiveFromAddress.addToIncludes("test");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -1483,7 +1483,7 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("address-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -2108,11 +2108,11 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          receiveFromAddress.addToIncludes("test");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -2123,7 +2123,7 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("address-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -2186,12 +2186,12 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          receiveFromAddress.setAutoDeleteMessageCount(-1L);
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
             new AMQPBrokerConnectConfiguration(
-               "test-address-federation", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort() + "?amqpCredits=0");
+               getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort() + "?amqpCredits=0");
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -2395,11 +2395,11 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          receiveFromAddress.addToIncludes("test");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.setAutostart(false);
          amqpConnection.addElement(element);
@@ -2444,7 +2444,7 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          peer.expectFlow().withLinkCredit(10);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("address-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -2501,11 +2501,11 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          receiveFromAddress.setEnableDivertBindings(true);
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.setAutostart(false);
          amqpConnection.addElement(element);
@@ -2560,7 +2560,7 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          peer.expectFlow().withLinkCredit(10);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("address-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -2609,11 +2609,11 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          receiveFromAddress.setEnableDivertBindings(true);
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.setAutostart(false);
          amqpConnection.addElement(element);
@@ -2673,7 +2673,7 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          peer.expectFlow().withLinkCredit(10);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("address-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -2740,11 +2740,11 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          receiveFromAddress.setEnableDivertBindings(true);
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(5);
          amqpConnection.addElement(element);
 
@@ -2795,7 +2795,7 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
             peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
             peer.expectAttach().ofReceiver()
                                .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
-                               .withName(allOf(containsString("sample-federation"),
+                               .withName(allOf(containsString(getTestName()),
                                                containsString("test"),
                                                containsString("address-receiver"),
                                                containsString(server.getNodeID().toString())))
@@ -2880,12 +2880,12 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          remoteReceiveFromAddress.setMaxHops(5);
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(localReceiveFromAddress);
          element.addRemoteAddressPolicy(remoteReceiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -2950,11 +2950,11 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          remoteReceiveFromAddress.setMaxHops(5);
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addRemoteAddressPolicy(remoteReceiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -3070,11 +3070,11 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          receiveFromAddress.setAutoDeleteMessageCount(-1L);
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -3091,7 +3091,7 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          // Reject the initial attempt
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("address-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -3112,7 +3112,7 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("address-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -3159,11 +3159,11 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          receiveFromAddress.addToIncludes("test");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -3306,11 +3306,11 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          receiveFromAddress.addToIncludes("test");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -3407,11 +3407,11 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          receiveFromAddress.addToIncludes("test");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationBrokerPliuginTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationBrokerPliuginTest.java
@@ -109,11 +109,11 @@ public class AMQPFederationBrokerPliuginTest extends AmqpClientTestSupport {
       localAddressPolicy.setAutoDeleteMessageCount(-1L);
 
       final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-      element.setName("test");
+      element.setName(getTestName());
       element.addLocalAddressPolicy(localAddressPolicy);
 
       final AMQPBrokerConnectConfiguration amqpConnection =
-         new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://localhost:" + SERVER_PORT_REMOTE);
+         new AMQPBrokerConnectConfiguration(getTestName(), "tcp://localhost:" + SERVER_PORT_REMOTE);
       amqpConnection.setReconnectAttempts(10);// Limit reconnects
       amqpConnection.addElement(element);
 
@@ -192,11 +192,11 @@ public class AMQPFederationBrokerPliuginTest extends AmqpClientTestSupport {
       localQueuePolicy.addToIncludes("test", "test");
 
       final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-      element.setName("test");
+      element.setName(getTestName());
       element.addLocalQueuePolicy(localQueuePolicy);
 
       final AMQPBrokerConnectConfiguration amqpConnection =
-         new AMQPBrokerConnectConfiguration("test-queue-federation", "tcp://localhost:" + SERVER_PORT_REMOTE);
+         new AMQPBrokerConnectConfiguration(getTestName(), "tcp://localhost:" + SERVER_PORT_REMOTE);
       amqpConnection.setReconnectAttempts(10);// Limit reconnects
       amqpConnection.addElement(element);
 
@@ -274,17 +274,17 @@ public class AMQPFederationBrokerPliuginTest extends AmqpClientTestSupport {
 
       final AMQPFederationAddressPolicyElement localAddressPolicy = new AMQPFederationAddressPolicyElement();
       localAddressPolicy.setName("test-policy");
-      localAddressPolicy.addToIncludes("test");
+      localAddressPolicy.addToIncludes(getTestName());
       localAddressPolicy.setAutoDelete(false);
       localAddressPolicy.setAutoDeleteDelay(-1L);
       localAddressPolicy.setAutoDeleteMessageCount(-1L);
 
       final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-      element.setName("test");
+      element.setName(getTestName());
       element.addLocalAddressPolicy(localAddressPolicy);
 
       final AMQPBrokerConnectConfiguration amqpConnection =
-         new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://localhost:" + SERVER_PORT_REMOTE);
+         new AMQPBrokerConnectConfiguration(getTestName(), "tcp://localhost:" + SERVER_PORT_REMOTE);
       amqpConnection.setReconnectAttempts(10);// Limit reconnects
       amqpConnection.addElement(element);
 
@@ -348,11 +348,11 @@ public class AMQPFederationBrokerPliuginTest extends AmqpClientTestSupport {
       localQueuePolicy.addToIncludes("test", "test");
 
       final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-      element.setName("test");
+      element.setName(getTestName());
       element.addLocalQueuePolicy(localQueuePolicy);
 
       final AMQPBrokerConnectConfiguration amqpConnection =
-         new AMQPBrokerConnectConfiguration("test-queue-federation", "tcp://localhost:" + SERVER_PORT_REMOTE);
+         new AMQPBrokerConnectConfiguration(getTestName(), "tcp://localhost:" + SERVER_PORT_REMOTE);
       amqpConnection.setReconnectAttempts(10);// Limit reconnects
       amqpConnection.addElement(element);
 
@@ -423,11 +423,11 @@ public class AMQPFederationBrokerPliuginTest extends AmqpClientTestSupport {
       localAddressPolicy.setEnableDivertBindings(true);
 
       final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-      element.setName("test");
+      element.setName(getTestName());
       element.addLocalAddressPolicy(localAddressPolicy);
 
       final AMQPBrokerConnectConfiguration amqpConnection =
-         new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://localhost:" + SERVER_PORT_REMOTE);
+         new AMQPBrokerConnectConfiguration(getTestName(), "tcp://localhost:" + SERVER_PORT_REMOTE);
       amqpConnection.setReconnectAttempts(10);// Limit reconnects
       amqpConnection.addElement(element);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationConfigurationReloadTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationConfigurationReloadTest.java
@@ -116,11 +116,11 @@ public class AMQPFederationConfigurationReloadTest extends AmqpClientTestSupport
          receiveFromAddress.setAutoDeleteMessageCount(-1L);
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -136,7 +136,7 @@ public class AMQPFederationConfigurationReloadTest extends AmqpClientTestSupport
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("address-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -163,7 +163,7 @@ public class AMQPFederationConfigurationReloadTest extends AmqpClientTestSupport
             updatedReceiveFromAddress.setAutoDeleteMessageCount(-1L);
 
             final AMQPFederatedBrokerConnectionElement updatedElement = new AMQPFederatedBrokerConnectionElement();
-            updatedElement.setName("sample-federation");
+            updatedElement.setName(getTestName());
             updatedElement.addLocalAddressPolicy(updatedReceiveFromAddress);
 
             amqpConnection.getConnectionElements().clear();
@@ -215,11 +215,11 @@ public class AMQPFederationConfigurationReloadTest extends AmqpClientTestSupport
          receiveFromAddress.setAutoDeleteMessageCount(-1L);
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName() + ":1");
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName() + ":1", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -235,7 +235,7 @@ public class AMQPFederationConfigurationReloadTest extends AmqpClientTestSupport
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName() + ":1"),
                                             containsString("test"),
                                             containsString("address-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -281,11 +281,11 @@ public class AMQPFederationConfigurationReloadTest extends AmqpClientTestSupport
                updatedReceiveFromAddress.setAutoDeleteMessageCount(-1L);
 
                final AMQPFederatedBrokerConnectionElement updatedElement = new AMQPFederatedBrokerConnectionElement();
-               updatedElement.setName("sample-federation-2");
+               updatedElement.setName(getTestName() + ":2");
                updatedElement.addLocalAddressPolicy(updatedReceiveFromAddress);
 
                final AMQPBrokerConnectConfiguration updatedAmqpConnection =
-                  new AMQPBrokerConnectConfiguration("test-address-federation-2", "tcp://" + remoteURI2.getHost() + ":" + remoteURI2.getPort());
+                  new AMQPBrokerConnectConfiguration(getTestName() + ":2", "tcp://" + remoteURI2.getHost() + ":" + remoteURI2.getPort());
                updatedAmqpConnection.setReconnectAttempts(0);// No reconnects
                updatedAmqpConnection.addElement(updatedElement);
 
@@ -296,7 +296,7 @@ public class AMQPFederationConfigurationReloadTest extends AmqpClientTestSupport
                peer2.waitForScriptToComplete(5, TimeUnit.SECONDS);
                peer2.expectAttach().ofReceiver()
                                    .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
-                                   .withName(allOf(containsString("sample-federation"),
+                                   .withName(allOf(containsString(getTestName() + ":2"),
                                                    containsString("test"),
                                                    containsString("address-receiver"),
                                                    containsString(server.getNodeID().toString())))
@@ -343,11 +343,11 @@ public class AMQPFederationConfigurationReloadTest extends AmqpClientTestSupport
          receiveFromAddress.setAutoDeleteMessageCount(-1L);
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -363,7 +363,7 @@ public class AMQPFederationConfigurationReloadTest extends AmqpClientTestSupport
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("address-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -432,11 +432,11 @@ public class AMQPFederationConfigurationReloadTest extends AmqpClientTestSupport
          receiveFromAddress.setAutoDeleteMessageCount(-1L);
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalAddressPolicy(receiveFromAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("test-federation", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -452,7 +452,7 @@ public class AMQPFederationConfigurationReloadTest extends AmqpClientTestSupport
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("address-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -487,7 +487,7 @@ public class AMQPFederationConfigurationReloadTest extends AmqpClientTestSupport
             peer.expectFlow().withLinkCredit(10);
             peer.expectAttach().ofReceiver()
                                .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                               .withName(allOf(containsString("sample-federation"),
+                               .withName(allOf(containsString(getTestName()),
                                                containsString("queue::queue"),
                                                containsString("queue-receiver"),
                                                containsString(server.getNodeID().toString())))
@@ -512,11 +512,11 @@ public class AMQPFederationConfigurationReloadTest extends AmqpClientTestSupport
             updatedReceiveFromQueue.addToIncludes("*", "queue");
 
             final AMQPFederatedBrokerConnectionElement updatedElement = new AMQPFederatedBrokerConnectionElement();
-            updatedElement.setName("sample-federation");
+            updatedElement.setName(getTestName());
             updatedElement.addLocalQueuePolicy(updatedReceiveFromQueue);
 
             final AMQPBrokerConnectConfiguration updatedAmqpConnection =
-               new AMQPBrokerConnectConfiguration("test-federation", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+               new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
             updatedAmqpConnection.setReconnectAttempts(0);// No reconnects
             updatedAmqpConnection.addElement(updatedElement);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationConnectTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationConnectTest.java
@@ -102,7 +102,7 @@ public class AMQPFederationConnectTest extends AmqpClientTestSupport {
 
          // No user or pass given, it will have to select ANONYMOUS even though PLAIN also offered
          AMQPBrokerConnectConfiguration amqpConnection =
-               new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+               new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          server.getConfiguration().addAMQPConnection(amqpConnection);
          server.start();
@@ -123,7 +123,7 @@ public class AMQPFederationConnectTest extends AmqpClientTestSupport {
          logger.info("Connect test started, peer listening on: {}", remoteURI);
 
          AMQPBrokerConnectConfiguration amqpConnection =
-               new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+               new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          server.getConfiguration().addAMQPConnection(amqpConnection);
          amqpConnection.setUser("user");
@@ -170,7 +170,7 @@ public class AMQPFederationConnectTest extends AmqpClientTestSupport {
          logger.info("Connect test started, peer listening on: {}", remoteURI);
 
          final AMQPBrokerConnectConfiguration amqpConnection = new AMQPBrokerConnectConfiguration(
-            "testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort() +
+            getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort() +
             "?amqpCredits=" + AMQP_CREDITS + "&amqpLowCredits=" + AMQP_CREDITS_LOW +
             "&amqpMinLargeMessageSize=" + AMQP_MIN_LARGE_MESSAGE_SIZE);
          amqpConnection.setReconnectAttempts(0);// No reconnects
@@ -201,9 +201,9 @@ public class AMQPFederationConnectTest extends AmqpClientTestSupport {
          logger.info("Connect test started, peer listening on: {}", remoteURI);
 
          AMQPBrokerConnectConfiguration amqpConnection =
-               new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+               new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
-         amqpConnection.addElement(new AMQPFederatedBrokerConnectionElement("test"));
+         amqpConnection.addElement(new AMQPFederatedBrokerConnectionElement(getTestName()));
          server.getConfiguration().addAMQPConnection(amqpConnection);
          server.start();
 
@@ -242,10 +242,10 @@ public class AMQPFederationConnectTest extends AmqpClientTestSupport {
          logger.info("Connect test started, peer listening on: {}", remoteURI);
 
          AMQPBrokerConnectConfiguration amqpConnection =
-               new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+               new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(1);// One reconnects
          amqpConnection.setRetryInterval(200);
-         amqpConnection.addElement(new AMQPFederatedBrokerConnectionElement("test"));
+         amqpConnection.addElement(new AMQPFederatedBrokerConnectionElement(getTestName()));
          server.getConfiguration().addAMQPConnection(amqpConnection);
          server.start();
 
@@ -313,11 +313,11 @@ public class AMQPFederationConnectTest extends AmqpClientTestSupport {
          sendToQueue.addToExcludes("g", "h");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("test");
+         element.setName(getTestName());
          element.addRemoteQueuePolicy(sendToQueue);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -388,11 +388,11 @@ public class AMQPFederationConnectTest extends AmqpClientTestSupport {
          sendToQueue.addToExcludes("g", "h");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("test");
+         element.setName(getTestName());
          element.addRemoteQueuePolicy(sendToQueue);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -460,11 +460,11 @@ public class AMQPFederationConnectTest extends AmqpClientTestSupport {
          sendToAddress.addToExcludes("exclude");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("test");
+         element.setName(getTestName());
          element.addRemoteAddressPolicy(sendToAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("test-send-policy", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -533,11 +533,11 @@ public class AMQPFederationConnectTest extends AmqpClientTestSupport {
          sendToAddress.addToExcludes("exclude");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("test");
+         element.setName(getTestName());
          element.addRemoteAddressPolicy(sendToAddress);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("test-send-policy", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -554,7 +554,7 @@ public class AMQPFederationConnectTest extends AmqpClientTestSupport {
       server.start();
 
       try (ProtonTestClient peer = new ProtonTestClient()) {
-         scriptFederationConnectToRemote(peer, "test");
+         scriptFederationConnectToRemote(peer, getTestName());
          peer.connect("localhost", AMQP_PORT);
 
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
@@ -575,7 +575,7 @@ public class AMQPFederationConnectTest extends AmqpClientTestSupport {
       server.start();
 
       try (ProtonTestClient peer = new ProtonTestClient()) {
-         scriptFederationConnectToRemote(peer, "test", false, null, null, true, false);
+         scriptFederationConnectToRemote(peer, getTestName(), false, null, null, true, false);
          peer.connect("localhost", AMQP_PORT);
 
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
@@ -596,7 +596,7 @@ public class AMQPFederationConnectTest extends AmqpClientTestSupport {
       server.start();
 
       try (ProtonTestClient peer = new ProtonTestClient()) {
-         scriptFederationConnectToRemote(peer, "test", false, null, null, false, true);
+         scriptFederationConnectToRemote(peer, getTestName(), false, null, null, false, true);
          peer.connect("localhost", AMQP_PORT);
 
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
@@ -617,7 +617,7 @@ public class AMQPFederationConnectTest extends AmqpClientTestSupport {
       server.start();
 
       try (ProtonTestClient peer = new ProtonTestClient()) {
-         scriptFederationConnectToRemote(peer, "test", false, null, null, true, true);
+         scriptFederationConnectToRemote(peer, getTestName(), false, null, null, true, true);
          peer.connect("localhost", AMQP_PORT);
 
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
@@ -639,7 +639,7 @@ public class AMQPFederationConnectTest extends AmqpClientTestSupport {
       server.start();
 
       try (ProtonTestClient peer = new ProtonTestClient()) {
-         scriptFederationConnectToRemote(peer, "test", fullUser, fullPass);
+         scriptFederationConnectToRemote(peer, getTestName(), fullUser, fullPass);
          peer.connect("localhost", AMQP_PORT);
 
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
@@ -661,7 +661,7 @@ public class AMQPFederationConnectTest extends AmqpClientTestSupport {
       server.start();
 
       try (ProtonTestClient peer = new ProtonTestClient()) {
-         scriptFederationConnectToRemoteNotAuthorizedForControlAddress(peer, "test", guestUser, guestPass);
+         scriptFederationConnectToRemoteNotAuthorizedForControlAddress(peer, getTestName(), guestUser, guestPass);
          peer.connect("localhost", AMQP_PORT);
 
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationQueuePolicyTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationQueuePolicyTest.java
@@ -174,11 +174,11 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          receiveFromQueue.addToIncludes("test", "test");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalQueuePolicy(receiveFromQueue);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -191,7 +191,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test::test"),
                                             containsString("queue-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -243,11 +243,11 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          receiveFromQueue.addToIncludes("test", "test");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalQueuePolicy(receiveFromQueue);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -261,7 +261,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("queue-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -311,11 +311,11 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          receiveFromQueue.addProperty(RECEIVER_CREDITS_LOW, "3");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalQueuePolicy(receiveFromQueue);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -328,7 +328,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("queue-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -376,11 +376,11 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          receiveFromQueue.addToIncludes("test", "test");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalQueuePolicy(receiveFromQueue);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -393,7 +393,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test::test"),
                                             containsString("queue-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -440,11 +440,11 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          receiveFromQueue.addToIncludes("test", "test");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalQueuePolicy(receiveFromQueue);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -457,7 +457,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test::test"),
                                             containsString("queue-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -484,7 +484,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test::test"),
                                             containsString("queue-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -528,11 +528,11 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          receiveFromQueue.addToIncludes("test", "test");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalQueuePolicy(receiveFromQueue);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -545,7 +545,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("queue-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -594,11 +594,11 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          receiveFromQueue.addToIncludes("addr2", "test.2");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalQueuePolicy(receiveFromQueue);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -614,7 +614,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("addr1::test.1"),
                                             containsString("queue-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -630,7 +630,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
             peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
             peer.expectAttach().ofReceiver()
                                .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                               .withName(allOf(containsString("sample-federation"),
+                               .withName(allOf(containsString(getTestName()),
                                                containsString("addr2::test.2"),
                                                containsString("queue-receiver"),
                                                containsString(server.getNodeID().toString())))
@@ -674,11 +674,11 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          receiveFromQueue.addToIncludes("", "test.#");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalQueuePolicy(receiveFromQueue);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -691,7 +691,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("queue-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -738,11 +738,11 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          receiveFromQueue.addToIncludes("", "test.#");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalQueuePolicy(receiveFromQueue);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -755,7 +755,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("queue-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -805,11 +805,11 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          receiveFromQueue.addToIncludes("", "test.#");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalQueuePolicy(receiveFromQueue);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -822,7 +822,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("queue-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -848,7 +848,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
             peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
             peer.expectAttach().ofReceiver()
                                .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                               .withName(allOf(containsString("sample-federation"),
+                               .withName(allOf(containsString(getTestName()),
                                                containsString("test::test.queue"),
                                                containsString("queue-receiver"),
                                                containsString(server.getNodeID().toString())))
@@ -898,11 +898,11 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          receiveFromQueue.addToIncludes("", "test.#");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalQueuePolicy(receiveFromQueue);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -915,7 +915,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test::test.queue"),
                                             containsString("queue-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -939,7 +939,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
             peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
             peer.expectAttach().ofReceiver()
                                .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                               .withName(allOf(containsString("sample-federation"),
+                               .withName(allOf(containsString(getTestName()),
                                                containsString("test::test.queue"),
                                                containsString("queue-receiver"),
                                                containsString(server.getNodeID().toString())))
@@ -980,11 +980,11 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          receiveFromQueue.addToIncludes("", "test.#");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalQueuePolicy(receiveFromQueue);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(1); // One reconnect to meet test expectations and use a
          amqpConnection.setRetryInterval(100);   // Short reconnect interval.
          amqpConnection.addElement(element);
@@ -998,7 +998,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test::test.queue"),
                                             containsString("queue-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -1033,7 +1033,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
             peer.expectFlow().withLinkCredit(10);
             peer.expectAttach().ofReceiver()
                                .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                               .withName(allOf(containsString("sample-federation"),
+                               .withName(allOf(containsString(getTestName()),
                                                containsString("test::test.queue"),
                                                containsString("queue-receiver"),
                                                containsString(server.getNodeID().toString())))
@@ -1075,11 +1075,11 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          receiveFromQueue.addToIncludes("", "test.#");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalQueuePolicy(receiveFromQueue);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -1092,7 +1092,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test::test.queue"),
                                             containsString("queue-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -1167,11 +1167,11 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          receiveFromQueue.addToIncludes("test", "test");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalQueuePolicy(receiveFromQueue);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -1184,7 +1184,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test::test"),
                                             containsString("queue-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -1234,11 +1234,11 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          receiveFromQueue.addToIncludes("addr", "test.3");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalQueuePolicy(receiveFromQueue);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -1257,7 +1257,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("addr::test.1"),
                                             containsString("queue-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -1273,7 +1273,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
             peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
             peer.expectAttach().ofReceiver()
                                .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                               .withName(allOf(containsString("sample-federation"),
+                               .withName(allOf(containsString(getTestName()),
                                                containsString("addr::test.2"),
                                                containsString("queue-receiver"),
                                                containsString(server.getNodeID().toString())))
@@ -1285,7 +1285,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
             peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
             peer.expectAttach().ofReceiver()
                                .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                               .withName(allOf(containsString("sample-federation"),
+                               .withName(allOf(containsString(getTestName()),
                                                containsString("addr::test.3"),
                                                containsString("queue-receiver"),
                                                containsString(server.getNodeID().toString())))
@@ -2037,11 +2037,11 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          receiveFromQueue.setIncludeFederated(false); // No federation for federation subscriptions
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalQueuePolicy(receiveFromQueue);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -2093,7 +2093,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          // Would fail if any frames arrived that are not scripted to.
          target.waitForScriptToComplete(5, TimeUnit.SECONDS);
          target.expectAttach().ofReceiver().withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                                           .withName(allOf(containsString("sample-federation"),
+                                           .withName(allOf(containsString(getTestName()),
                                                            containsString("test::test"),
                                                            containsString("queue-receiver"),
                                                            containsString(server.getNodeID().toString())))
@@ -2146,11 +2146,11 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          receiveFromQueue.setIncludeFederated(true); // do federate for federation subscriptions
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalQueuePolicy(receiveFromQueue);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -2165,7 +2165,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          // but because this is a federation of a federation the priority should drop by an additional
          // increment as we apply the adjustment on each step
          target.expectAttach().ofReceiver().withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                                           .withName(allOf(containsString("sample-federation"),
+                                           .withName(allOf(containsString(getTestName()),
                                                            containsString("test::test"),
                                                            containsString("queue-receiver"),
                                                            containsString(server.getNodeID().toString())))
@@ -2251,11 +2251,11 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          receiveFromQueue.addToIncludes("test", "test");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalQueuePolicy(receiveFromQueue);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -2268,7 +2268,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("queue-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -2327,12 +2327,12 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          receiveFromQueue.addToIncludes("test", "test");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalQueuePolicy(receiveFromQueue);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
             new AMQPBrokerConnectConfiguration(
-               "testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort() + "?amqpCredits=0");
+               getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort() + "?amqpCredits=0");
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -2345,7 +2345,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("queue-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -2390,12 +2390,12 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          receiveFromQueue.addToIncludes("test", "test");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalQueuePolicy(receiveFromQueue);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
             new AMQPBrokerConnectConfiguration(
-               "testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort() + "?amqpCredits=0");
+               getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort() + "?amqpCredits=0");
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -2405,7 +2405,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("queue-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -2466,12 +2466,12 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          receiveFromQueue.addToIncludes("test", "test");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalQueuePolicy(receiveFromQueue);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
             new AMQPBrokerConnectConfiguration(
-               "testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort() + "?amqpCredits=0");
+               getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort() + "?amqpCredits=0");
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -2481,7 +2481,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test"),
                                             containsString("queue-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -2726,11 +2726,11 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          receiveFromQueue.addToIncludes("test", "test");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalQueuePolicy(receiveFromQueue);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.setAutostart(false);
          amqpConnection.addElement(element);
@@ -2781,7 +2781,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          peer.expectFlow().withLinkCredit(10);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test::test"),
                                             containsString("queue-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -2867,7 +2867,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          remoteReceiveFromQueue.addToIncludes("*", "test");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalQueuePolicy(localReceiveFromQueue);
          element.addRemoteQueuePolicy(remoteReceiveFromQueue);
 
@@ -2933,7 +2933,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          remoteReceiveFromQueue.addToIncludes("*", "test");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addRemoteQueuePolicy(remoteReceiveFromQueue);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
@@ -3047,7 +3047,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          receiveFromQueue.addToIncludes("*", "test");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalQueuePolicy(receiveFromQueue);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
@@ -3063,7 +3063,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          // Reject the initial attempt
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test::test"),
                                             containsString("queue-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -3086,7 +3086,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()
                             .withDesiredCapability(FEDERATION_QUEUE_RECEIVER.toString())
-                            .withName(allOf(containsString("sample-federation"),
+                            .withName(allOf(containsString(getTestName()),
                                             containsString("test::test"),
                                             containsString("queue-receiver"),
                                             containsString(server.getNodeID().toString())))
@@ -3133,7 +3133,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          receiveFromQueue.addToIncludes("*", "test");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalQueuePolicy(receiveFromQueue);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
@@ -3286,11 +3286,11 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          receiveFromQueue.addToIncludes("test", "test");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalQueuePolicy(receiveFromQueue);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
@@ -3390,11 +3390,11 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          receiveFromQueue.addToIncludes("test", "test");
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-         element.setName("sample-federation");
+         element.setName(getTestName());
          element.addLocalQueuePolicy(receiveFromQueue);
 
          final AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationServerToServerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationServerToServerTest.java
@@ -129,11 +129,11 @@ public class AMQPFederationServerToServerTest extends AmqpClientTestSupport {
       localAddressPolicy.setAutoDeleteMessageCount(-1L);
 
       final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-      element.setName("test");
+      element.setName(getTestName());
       element.addLocalAddressPolicy(localAddressPolicy);
 
       final AMQPBrokerConnectConfiguration amqpConnection =
-         new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://localhost:" + SERVER_PORT_REMOTE);
+         new AMQPBrokerConnectConfiguration(getTestName(), "tcp://localhost:" + SERVER_PORT_REMOTE);
       amqpConnection.setReconnectAttempts(10);// Limit reconnects
       amqpConnection.addElement(element);
 
@@ -199,11 +199,11 @@ public class AMQPFederationServerToServerTest extends AmqpClientTestSupport {
       localAddressPolicy.setEnableDivertBindings(true);
 
       final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-      element.setName("test");
+      element.setName(getTestName());
       element.addLocalAddressPolicy(localAddressPolicy);
 
       final AMQPBrokerConnectConfiguration amqpConnection =
-         new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://localhost:" + SERVER_PORT_REMOTE);
+         new AMQPBrokerConnectConfiguration(getTestName(), "tcp://localhost:" + SERVER_PORT_REMOTE);
       amqpConnection.setReconnectAttempts(10);// Limit reconnects
       amqpConnection.addElement(element);
 
@@ -274,11 +274,11 @@ public class AMQPFederationServerToServerTest extends AmqpClientTestSupport {
       localQueuePolicy.addToIncludes("#", "test");
 
       final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-      element.setName("test");
+      element.setName(getTestName());
       element.addLocalQueuePolicy(localQueuePolicy);
 
       final AMQPBrokerConnectConfiguration amqpConnection =
-         new AMQPBrokerConnectConfiguration("test-queue-federation", "tcp://localhost:" + SERVER_PORT_REMOTE);
+         new AMQPBrokerConnectConfiguration(getTestName(), "tcp://localhost:" + SERVER_PORT_REMOTE);
       amqpConnection.setReconnectAttempts(10);// Limit reconnects
       amqpConnection.addElement(element);
 
@@ -345,11 +345,11 @@ public class AMQPFederationServerToServerTest extends AmqpClientTestSupport {
       remoteAddressPolicy.setAutoDeleteMessageCount(-1L);
 
       final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-      element.setName("test");
+      element.setName(getTestName());
       element.addRemoteAddressPolicy(remoteAddressPolicy);
 
       final AMQPBrokerConnectConfiguration amqpConnection =
-         new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://localhost:" + SERVER_PORT_REMOTE);
+         new AMQPBrokerConnectConfiguration(getTestName(), "tcp://localhost:" + SERVER_PORT_REMOTE);
       amqpConnection.setReconnectAttempts(10);// Limit reconnects
       amqpConnection.addElement(element);
 
@@ -411,11 +411,11 @@ public class AMQPFederationServerToServerTest extends AmqpClientTestSupport {
       remoteQueuePolicy.addToIncludes("#", "test");
 
       final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-      element.setName("test");
+      element.setName(getTestName());
       element.addRemoteQueuePolicy(remoteQueuePolicy);
 
       final AMQPBrokerConnectConfiguration amqpConnection =
-         new AMQPBrokerConnectConfiguration("test-queue-federation", "tcp://localhost:" + SERVER_PORT_REMOTE);
+         new AMQPBrokerConnectConfiguration(getTestName(), "tcp://localhost:" + SERVER_PORT_REMOTE);
       amqpConnection.setReconnectAttempts(10);// Limit reconnects
       amqpConnection.addElement(element);
 
@@ -483,11 +483,11 @@ public class AMQPFederationServerToServerTest extends AmqpClientTestSupport {
       remoteAddressPolicy.setEnableDivertBindings(true);
 
       final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-      element.setName("test");
+      element.setName(getTestName());
       element.addRemoteAddressPolicy(remoteAddressPolicy);
 
       final AMQPBrokerConnectConfiguration amqpConnection =
-         new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://localhost:" + SERVER_PORT_REMOTE);
+         new AMQPBrokerConnectConfiguration(getTestName(), "tcp://localhost:" + SERVER_PORT_REMOTE);
       amqpConnection.setReconnectAttempts(10);// Limit reconnects
       amqpConnection.addElement(element);
 
@@ -571,11 +571,11 @@ public class AMQPFederationServerToServerTest extends AmqpClientTestSupport {
       localAddressPolicy.addProperty(AmqpSupport.TUNNEL_CORE_MESSAGES, Boolean.toString(enableCoreTunneling));
 
       final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-      element.setName("test");
+      element.setName(getTestName());
       element.addLocalAddressPolicy(localAddressPolicy);
 
       final AMQPBrokerConnectConfiguration amqpConnection =
-         new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://localhost:" + SERVER_PORT_REMOTE);
+         new AMQPBrokerConnectConfiguration(getTestName(), "tcp://localhost:" + SERVER_PORT_REMOTE);
       amqpConnection.setReconnectAttempts(10);// Limit reconnects
       amqpConnection.addElement(element);
 
@@ -662,11 +662,11 @@ public class AMQPFederationServerToServerTest extends AmqpClientTestSupport {
       localQueuePolicy.addProperty(AmqpSupport.TUNNEL_CORE_MESSAGES, Boolean.toString(enableCoreTunneling));
 
       final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-      element.setName("test");
+      element.setName(getTestName());
       element.addLocalQueuePolicy(localQueuePolicy);
 
       final AMQPBrokerConnectConfiguration amqpConnection =
-         new AMQPBrokerConnectConfiguration("test-queue-federation", "tcp://localhost:" + SERVER_PORT_REMOTE);
+         new AMQPBrokerConnectConfiguration(getTestName(), "tcp://localhost:" + SERVER_PORT_REMOTE);
       amqpConnection.setReconnectAttempts(10);// Limit reconnects
       amqpConnection.addElement(element);
 
@@ -761,23 +761,23 @@ public class AMQPFederationServerToServerTest extends AmqpClientTestSupport {
       localAddressPolicy.addProperty(AmqpSupport.TUNNEL_CORE_MESSAGES, Boolean.toString(enableCoreTunneling));
 
       final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-      element.setName("hops-test");
+      element.setName(getTestName());
       element.addLocalAddressPolicy(localAddressPolicy);
 
       final AMQPBrokerConnectConfiguration amqpConnection1 =
-         new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://localhost:" + SERVER_PORT_REMOTE);
+         new AMQPBrokerConnectConfiguration(getTestName(), "tcp://localhost:" + SERVER_PORT_REMOTE);
       amqpConnection1.setReconnectAttempts(10);// Limit reconnects
       amqpConnection1.setRetryInterval(100);
       amqpConnection1.addElement(element);
 
       final AMQPBrokerConnectConfiguration amqpConnection2 =
-         new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://localhost:" + SERVER2_PORT_REMOTE);
+         new AMQPBrokerConnectConfiguration(getTestName(), "tcp://localhost:" + SERVER2_PORT_REMOTE);
       amqpConnection2.setReconnectAttempts(10);// Limit reconnects
       amqpConnection1.setRetryInterval(100);
       amqpConnection2.addElement(element);
 
       final AMQPBrokerConnectConfiguration amqpConnection3 =
-         new AMQPBrokerConnectConfiguration("test-address-federation", "tcp://localhost:" + SERVER_PORT);
+         new AMQPBrokerConnectConfiguration(getTestName(), "tcp://localhost:" + SERVER_PORT);
       amqpConnection3.setReconnectAttempts(10);// Limit reconnects
       amqpConnection1.setRetryInterval(100);
       amqpConnection3.addElement(element);
@@ -941,11 +941,11 @@ public class AMQPFederationServerToServerTest extends AmqpClientTestSupport {
       localQueuePolicy.addProperty(AmqpSupport.TUNNEL_CORE_MESSAGES, Boolean.toString(enableCoreTunneling));
 
       final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
-      element.setName("test");
+      element.setName(getTestName());
       element.addLocalQueuePolicy(localQueuePolicy);
 
       final AMQPBrokerConnectConfiguration amqpConnection =
-         new AMQPBrokerConnectConfiguration("test-queue-federation", "tcp://localhost:" + SERVER_PORT_REMOTE);
+         new AMQPBrokerConnectConfiguration(getTestName(), "tcp://localhost:" + SERVER_PORT_REMOTE);
       amqpConnection.setReconnectAttempts(10);// Limit reconnects
       amqpConnection.addElement(element);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPMirrorConnectionTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPMirrorConnectionTest.java
@@ -96,7 +96,7 @@ public class AMQPMirrorConnectionTest extends AmqpClientTestSupport {
 
          // No user or pass given, it will have to select ANONYMOUS even though PLAIN also offered
          AMQPBrokerConnectConfiguration amqpConnection =
-               new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+               new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(new AMQPMirrorBrokerConnectionElement());
          server.getConfiguration().addAMQPConnection(amqpConnection);
@@ -129,7 +129,7 @@ public class AMQPMirrorConnectionTest extends AmqpClientTestSupport {
          logger.info("Connect test started, peer listening on: {}", remoteURI);
 
          AMQPBrokerConnectConfiguration amqpConnection =
-               new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+               new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.setUser("user");
          amqpConnection.setPassword("pass");
@@ -160,7 +160,7 @@ public class AMQPMirrorConnectionTest extends AmqpClientTestSupport {
 
          // No user or pass given, it will have to select ANONYMOUS even though PLAIN also offered
          AMQPBrokerConnectConfiguration amqpConnection =
-               new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+               new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(new AMQPMirrorBrokerConnectionElement());
          server.getConfiguration().addAMQPConnection(amqpConnection);
@@ -196,7 +196,7 @@ public class AMQPMirrorConnectionTest extends AmqpClientTestSupport {
          logger.info("Connect test started, peer listening on: {}", remoteURI);
 
          AMQPBrokerConnectConfiguration amqpConnection =
-               new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+               new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.setUser("user");
          amqpConnection.setPassword("pass");
@@ -239,7 +239,7 @@ public class AMQPMirrorConnectionTest extends AmqpClientTestSupport {
          logger.info("Connect test started, peer listening on: {}", remoteURI);
 
          AMQPBrokerConnectConfiguration amqpConnection =
-               new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+               new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.setUser("user");
          amqpConnection.setPassword("pass");
@@ -305,7 +305,7 @@ public class AMQPMirrorConnectionTest extends AmqpClientTestSupport {
          mirrorElement.addProperty(TUNNEL_CORE_MESSAGES, Boolean.toString(tunneling));
 
          AMQPBrokerConnectConfiguration amqpConnection =
-               new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+               new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.setUser("user");
          amqpConnection.setPassword("pass");
@@ -369,7 +369,7 @@ public class AMQPMirrorConnectionTest extends AmqpClientTestSupport {
          mirrorElement.setQueueCreation(true);
 
          AMQPBrokerConnectConfiguration amqpConnection =
-               new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+               new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.setUser("user");
          amqpConnection.setPassword("pass");
@@ -432,7 +432,7 @@ public class AMQPMirrorConnectionTest extends AmqpClientTestSupport {
          mirrorElement.setQueueCreation(true);
 
          AMQPBrokerConnectConfiguration amqpConnection =
-               new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+               new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.setUser("user");
          amqpConnection.setPassword("pass");
@@ -495,7 +495,7 @@ public class AMQPMirrorConnectionTest extends AmqpClientTestSupport {
          mirrorElement.setQueueCreation(true);
 
          AMQPBrokerConnectConfiguration amqpConnection =
-               new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+               new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.setUser("user");
          amqpConnection.setPassword("pass");
@@ -558,7 +558,7 @@ public class AMQPMirrorConnectionTest extends AmqpClientTestSupport {
          mirror.setName("test");
 
          AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.setUser("user");
          amqpConnection.setPassword("pass");
@@ -584,7 +584,7 @@ public class AMQPMirrorConnectionTest extends AmqpClientTestSupport {
             mirrorUpdated.setName("test");
 
             AMQPBrokerConnectConfiguration amqpConnectionUpdated =
-               new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+               new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
             amqpConnectionUpdated.setReconnectAttempts(0);// No reconnects
             amqpConnectionUpdated.setUser("user1");
             amqpConnectionUpdated.setPassword("pass1");
@@ -646,7 +646,7 @@ public class AMQPMirrorConnectionTest extends AmqpClientTestSupport {
          mirror.setName("test");
 
          AMQPBrokerConnectConfiguration amqpConnection =
-            new AMQPBrokerConnectConfiguration("testSimpleConnect", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.setUser("user");
          amqpConnection.setPassword("pass");


### PR DESCRIPTION
Use the test name to create unique names for broker connections in the tests and the associated test logs