### PR TITLE
ARTEMIS-4649 Use unique STOMP message ID per subscription

### DIFF
--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/ActiveMQStompProtocolMessageBundle.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/ActiveMQStompProtocolMessageBundle.java
@@ -104,7 +104,7 @@ public interface ActiveMQStompProtocolMessageBundle {
    String invalidFrame(String dumpByteArray);
 
    @Message(id = 339025, value = "failed to ack because no message with id: {}")
-   ActiveMQStompException failToAckMissingID(long id);
+   ActiveMQStompException failToAckMissingID(String id);
 
    @Message(id = 339026, value = "subscription id {} does not match {}")
    ActiveMQStompException subscriptionIDMismatch(String subscriptionID, String actualID);

--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompConnection.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompConnection.java
@@ -43,6 +43,7 @@ import org.apache.activemq.artemis.core.protocol.stomp.v12.StompFrameHandlerV12;
 import org.apache.activemq.artemis.core.remoting.FailureListener;
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
+import org.apache.activemq.artemis.core.server.ServerConsumer;
 import org.apache.activemq.artemis.core.server.ServerSession;
 import org.apache.activemq.artemis.core.server.impl.AddressInfo;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
@@ -624,8 +625,9 @@ public final class StompConnection extends AbstractRemotingConnection {
 
    public StompFrame createStompMessage(ICoreMessage message,
                                         StompSubscription subscription,
+                                        ServerConsumer consumer,
                                         int deliveryCount) {
-      return frameHandler.createMessageFrame(message, subscription, deliveryCount);
+      return frameHandler.createMessageFrame(message, subscription, consumer, deliveryCount);
    }
 
    public void addStompEventListener(FrameEventListener listener) {

--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompUtils.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompUtils.java
@@ -104,7 +104,6 @@ public class StompUtils {
    public static void copyStandardHeadersFromMessageToFrame(Message message,
                                                             StompFrame command,
                                                             int deliveryCount) {
-      command.addHeader(Stomp.Headers.Message.MESSAGE_ID, String.valueOf(message.getMessageID()));
       SimpleString prefix = message.getSimpleStringProperty(Message.HDR_PREFIX);
       command.addHeader(Stomp.Headers.Message.DESTINATION,  (prefix == null ? "" : prefix) + message.getAddress());
 

--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/VersionedStompFrameHandler.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/VersionedStompFrameHandler.java
@@ -29,6 +29,7 @@ import org.apache.activemq.artemis.core.protocol.stomp.Stomp.Headers;
 import org.apache.activemq.artemis.core.protocol.stomp.v10.StompFrameHandlerV10;
 import org.apache.activemq.artemis.core.protocol.stomp.v11.StompFrameHandlerV11;
 import org.apache.activemq.artemis.core.protocol.stomp.v12.StompFrameHandlerV12;
+import org.apache.activemq.artemis.core.server.ServerConsumer;
 import org.apache.activemq.artemis.utils.ExecutorFactory;
 
 import static org.apache.activemq.artemis.core.protocol.stomp.ActiveMQStompProtocolMessageBundle.BUNDLE;
@@ -320,7 +321,10 @@ public abstract class VersionedStompFrameHandler {
       return response;
    }
 
-   public StompFrame createMessageFrame(ICoreMessage serverMessage, StompSubscription subscription, int deliveryCount) {
+   public StompFrame createMessageFrame(ICoreMessage serverMessage,
+                                        StompSubscription subscription,
+                                        ServerConsumer consumer,
+                                        int deliveryCount) {
       StompFrame frame = createStompFrame(Stomp.Responses.MESSAGE);
 
       if (subscription.getID() != null) {
@@ -344,7 +348,8 @@ public abstract class VersionedStompFrameHandler {
       }
       frame.setByteBody(data);
 
-      StompUtils.copyStandardHeadersFromMessageToFrame((serverMessage), frame, deliveryCount);
+      frame.addHeader(Stomp.Headers.Message.MESSAGE_ID, new StringBuilder(41).append(consumer.getID()).append(StompSession.MESSAGE_ID_SEPARATOR).append(serverMessage.getMessageID()).toString());
+      StompUtils.copyStandardHeadersFromMessageToFrame(serverMessage, frame, deliveryCount);
 
       return frame;
    }

--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/v12/StompFrameHandlerV12.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/v12/StompFrameHandlerV12.java
@@ -28,6 +28,7 @@ import org.apache.activemq.artemis.core.protocol.stomp.StompSubscription;
 import org.apache.activemq.artemis.core.protocol.stomp.v11.StompFrameHandlerV11;
 import org.apache.activemq.artemis.core.protocol.stomp.v11.StompFrameV11;
 import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
+import org.apache.activemq.artemis.core.server.ServerConsumer;
 import org.apache.activemq.artemis.utils.ExecutorFactory;
 
 import static org.apache.activemq.artemis.core.protocol.stomp.ActiveMQStompProtocolMessageBundle.BUNDLE;
@@ -50,11 +51,12 @@ public class StompFrameHandlerV12 extends StompFrameHandlerV11 {
    @Override
    public StompFrame createMessageFrame(ICoreMessage serverMessage,
                                         StompSubscription subscription,
+                                        ServerConsumer consumer,
                                         int deliveryCount) {
-      StompFrame frame = super.createMessageFrame(serverMessage, subscription, deliveryCount);
+      StompFrame frame = super.createMessageFrame(serverMessage, subscription, consumer, deliveryCount);
 
       if (!subscription.getAck().equals(Stomp.Headers.Subscribe.AckModeValues.AUTO)) {
-         frame.addHeader(Stomp.Headers.Message.ACK, String.valueOf(serverMessage.getMessageID()));
+         frame.addHeader(Stomp.Headers.Message.ACK, frame.getHeader(Stomp.Headers.Message.MESSAGE_ID));
       }
 
       return frame;

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/StompTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/StompTest.java
@@ -2087,4 +2087,31 @@ public class StompTest extends StompTestBase {
 
    }
 
+   @Test
+   public void testSameMessageHasDifferentMessageIdPerConsumer() throws Exception {
+      conn.connect(defUser, defPass);
+
+      subscribeTopic(conn, "sub1", "client", null);
+      subscribeTopic(conn, "sub2", "client", null);
+
+      sendJmsMessage(getName(), topic);
+
+      ClientStompFrame frame1 = conn.receiveFrame();
+      String firstMessageID = frame1.getHeader(Stomp.Headers.Message.MESSAGE_ID);
+      Assert.assertNotNull(firstMessageID);
+
+      ClientStompFrame frame2 = conn.receiveFrame();
+      String secondMessageID = frame2.getHeader(Stomp.Headers.Message.MESSAGE_ID);
+      Assert.assertNotNull(secondMessageID);
+      Assert.assertTrue(firstMessageID + " must not equal " + secondMessageID, !firstMessageID.equals(secondMessageID));
+
+      ack(conn, "sub1", frame1);
+      ack(conn, "sub2", frame2);
+
+      unsubscribe(conn, "sub1");
+      unsubscribe(conn, "sub2");
+
+      conn.disconnect();
+   }
+
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/StompTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/StompTestBase.java
@@ -308,7 +308,7 @@ public abstract class StompTestBase extends ActiveMQTestBase {
       String messageID = messageIdFrame.getHeader(Stomp.Headers.Message.MESSAGE_ID);
 
       ClientStompFrame frame = conn.createFrame(Stomp.Commands.ACK)
-                                      .addHeader(Stomp.Headers.Message.MESSAGE_ID, messageID);
+                                      .addHeader(Stomp.Headers.Ack.MESSAGE_ID, messageID);
 
       if (subscriptionId != null) {
          frame.addHeader(Stomp.Headers.Ack.SUBSCRIPTION, subscriptionId);
@@ -337,7 +337,7 @@ public abstract class StompTestBase extends ActiveMQTestBase {
    public static void nack(StompClientConnection conn, String subscriptionId, String messageId) throws IOException, InterruptedException {
       ClientStompFrame frame = conn.createFrame(Stomp.Commands.NACK)
                                       .addHeader(Stomp.Headers.Ack.SUBSCRIPTION, subscriptionId)
-                                      .addHeader(Stomp.Headers.Message.MESSAGE_ID, messageId);
+                                      .addHeader(Stomp.Headers.Ack.MESSAGE_ID, messageId);
 
       conn.sendFrame(frame);
    }


### PR DESCRIPTION
Use combined consumer and message ID as STOMP message ID.