### PR TITLE
ARTEMIS-4652 rollback of XAResource impl shouldn't return XA_RETRY

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionImpl.java
@@ -1901,18 +1901,10 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
          workDone = false;
       } catch (XAException xae) {
          throw xae;
-      } catch (ActiveMQException e) {
-         if (e.getType() == ActiveMQExceptionType.UNBLOCKED || e.getType() == ActiveMQExceptionType.CONNECTION_TIMEDOUT || e.getType() == ActiveMQExceptionType.SHUTDOWN_ERROR) {
-            // Unblocked on failover
-            throw new XAException(XAException.XA_RETRY);
-         }
-
-         // This should never occur
-         XAException xaException = new XAException(XAException.XAER_RMFAIL);
-         xaException.initCause(e);
-         throw xaException;
       } catch (Throwable t) {
-         // This could occur if the TM interrupts the thread
+         if (logger.isTraceEnabled()) {
+            logger.trace("Rollback failed:: {}", convert(xid), t);
+         }
          XAException xaException = new XAException(XAException.XAER_RMFAIL);
          xaException.initCause(t);
          throw xaException;


### PR DESCRIPTION
This fix was based on static analysis of the code and inspection of the XA specification. There is no test associated with it due to the difficult nature in reproducing the failure. This code has been essentially the same for a decade and only now have there been any reports of it actually sending back the wrong XA code.