### PR TITLE
NO-JIRA Improving AuditLoggerTest::testAuditHotLog* tests

### DIFF
--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/artemis/utils/RealServerTestBase.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/artemis/utils/RealServerTestBase.java
@@ -187,7 +187,7 @@ public class RealServerTestBase extends ActiveMQTestBase {
       recreateDirectory(homeInstance + "/log");
    }
 
-   protected void checkLogRecord(File logFile, boolean exist, String... values) throws Exception {
+   protected boolean findLogRecord(File logFile, String... values) throws Exception {
       Assert.assertTrue(logFile.exists());
       boolean hasRecord = false;
       try (BufferedReader reader = new BufferedReader(new FileReader(logFile))) {
@@ -203,17 +203,13 @@ public class RealServerTestBase extends ActiveMQTestBase {
                }
                if (hasAll) {
                   hasRecord = true;
-                  System.out.println("audit has it: " + line);
+                  logger.debug("audit found: {}", line);
                   break;
                }
             }
             line = reader.readLine();
          }
-         if (exist) {
-            Assert.assertTrue(hasRecord);
-         } else {
-            Assert.assertFalse(hasRecord);
-         }
+         return hasRecord;
       }
    }
 

--- a/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/logging/AuditLoggerAMQPMutualSSLTest.java
+++ b/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/logging/AuditLoggerAMQPMutualSSLTest.java
@@ -26,6 +26,7 @@ import javax.jms.Session;
 import javax.jms.TextMessage;
 
 import org.apache.qpid.jms.JmsConnectionFactory;
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -73,11 +74,11 @@ public class AuditLoggerAMQPMutualSSLTest extends AuditLoggerTestBase {
          assertNotNull(m);
       }
 
-      checkAuditLogRecord(true, "AMQ601715: User myUser(producers)@", "successfully authenticated");
-      checkAuditLogRecord(true, "AMQ601267: User myUser(producers)@", "is creating a core session");
-      checkAuditLogRecord(true, "AMQ601500: User myUser(producers)@", "sent a message AMQPStandardMessage");
-      checkAuditLogRecord(true, "AMQ601265: User myUser(producers)@", "is creating a core consumer");
-      checkAuditLogRecord(true, "AMQ601501: User myUser(producers)@", "is consuming a message from exampleQueue");
-      checkAuditLogRecord(true, "AMQ601502: User myUser(producers)@", "acknowledged message from exampleQueue: AMQPStandardMessage");
+      Assert.assertTrue(findLogRecord(getAuditLog(), "AMQ601715: User myUser(producers)@", "successfully authenticated"));
+      Assert.assertTrue(findLogRecord(getAuditLog(), "AMQ601267: User myUser(producers)@", "is creating a core session"));
+      Assert.assertTrue(findLogRecord(getAuditLog(), "AMQ601500: User myUser(producers)@", "sent a message AMQPStandardMessage"));
+      Assert.assertTrue(findLogRecord(getAuditLog(), "AMQ601265: User myUser(producers)@", "is creating a core consumer"));
+      Assert.assertTrue(findLogRecord(getAuditLog(), "AMQ601501: User myUser(producers)@", "is consuming a message from exampleQueue"));
+      Assert.assertTrue(findLogRecord(getAuditLog(), "AMQ601502: User myUser(producers)@", "acknowledged message from exampleQueue: AMQPStandardMessage"));
    }
 }

--- a/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/logging/AuditLoggerResourceTest.java
+++ b/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/logging/AuditLoggerResourceTest.java
@@ -42,6 +42,7 @@ import org.apache.activemq.artemis.tests.util.CFUtil;
 import org.apache.activemq.artemis.utils.RandomUtil;
 import org.fusesource.mqtt.client.BlockingConnection;
 import org.fusesource.mqtt.client.MQTT;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class AuditLoggerResourceTest extends AuditLoggerTestBase {
@@ -62,27 +63,27 @@ public class AuditLoggerResourceTest extends AuditLoggerTestBase {
          ActiveMQServerControl serverControl = MBeanServerInvocationHandler.newProxyInstance(mBeanServerConnection, objectNameBuilder.getActiveMQServerObjectName(), ActiveMQServerControl.class, false);
 
          serverControl.createAddress("auditAddress", "ANYCAST,MULTICAST");
-         checkAuditLogRecord(true, "successfully created address:");
+         Assert.assertTrue(findLogRecord(getAuditLog(), "successfully created address:"));
          serverControl.updateAddress("auditAddress", "ANYCAST");
-         checkAuditLogRecord(true, "successfully updated address:");
+         Assert.assertTrue(findLogRecord(getAuditLog(),"successfully updated address:"));
          serverControl.deleteAddress("auditAddress");
-         checkAuditLogRecord(true, "successfully deleted address:");
+         Assert.assertTrue(findLogRecord(getAuditLog(),"successfully deleted address:"));
          serverControl.createQueue("auditAddress", "auditQueue", "ANYCAST");
-         checkAuditLogRecord(true, "successfully created queue:");
+         Assert.assertTrue(findLogRecord(getAuditLog(),"successfully created queue:"));
          serverControl.updateQueue("auditQueue", "ANYCAST", -1, false);
          final QueueControl queueControl = MBeanServerInvocationHandler.newProxyInstance(mBeanServerConnection,
                objectNameBuilder.getQueueObjectName(new SimpleString( "auditAddress"), new SimpleString("auditQueue"), RoutingType.ANYCAST),
                QueueControl.class,
                false);
-         checkAuditLogRecord(true, "successfully updated queue:");
+         Assert.assertTrue(findLogRecord(getAuditLog(),"successfully updated queue:"));
          queueControl.removeAllMessages();
-         checkAuditLogRecord(true, "has removed 0 messages");
+         Assert.assertTrue(findLogRecord(getAuditLog(),"has removed 0 messages"));
          queueControl.sendMessage(new HashMap<>(), 0, "foo", true, "admin", "admin");
-         checkAuditLogRecord(true, "sent message to");
+         Assert.assertTrue(findLogRecord(getAuditLog(),"sent message to"));
          CompositeData[] browse = queueControl.browse();
-         checkAuditLogRecord(true, "browsed " + browse.length + " messages");
+         Assert.assertTrue(findLogRecord(getAuditLog(),"browsed " + browse.length + " messages"));
          serverControl.destroyQueue("auditQueue");
-         checkAuditLogRecord(true, "successfully deleted queue:");
+         Assert.assertTrue(findLogRecord(getAuditLog(),"successfully deleted queue:"));
 
          ServerLocator locator = createNettyNonHALocator();
          ClientSessionFactory sessionFactory = locator.createSessionFactory();
@@ -120,10 +121,10 @@ public class AuditLoggerResourceTest extends AuditLoggerTestBase {
       ConnectionFactory factory = CFUtil.createConnectionFactory(protocol, url);
       Connection connection = factory.createConnection();
       Session s = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
-      checkAuditLogRecord(true, "AMQ601767: " + protocol + " connection");
+      Assert.assertTrue(findLogRecord(getAuditLog(),"AMQ601767: " + protocol + " connection"));
       s.close();
       connection.close();
-      checkAuditLogRecord(true, "AMQ601768: " + protocol + " connection");
+      Assert.assertTrue(findLogRecord(getAuditLog(),"AMQ601768: " + protocol + " connection"));
    }
 
    @Test
@@ -138,8 +139,8 @@ public class AuditLoggerResourceTest extends AuditLoggerTestBase {
       final BlockingConnection connection = mqtt.blockingConnection();
       connection.connect();
       connection.disconnect();
-      checkAuditLogRecord(true, "AMQ601767: MQTT connection");
-      checkAuditLogRecord(true, "AMQ601768: MQTT connection");
+      Assert.assertTrue(findLogRecord(getAuditLog(),"AMQ601767: MQTT connection"));
+      Assert.assertTrue(findLogRecord(getAuditLog(),"AMQ601768: MQTT connection"));
    }
 
    @Test
@@ -147,7 +148,7 @@ public class AuditLoggerResourceTest extends AuditLoggerTestBase {
       StompClientConnection connection = StompClientConnectionFactory.createClientConnection(new URI("tcp://localhost:61613"));
       connection.connect();
       connection.disconnect();
-      checkAuditLogRecord(true, "AMQ601767: STOMP connection");
-      checkAuditLogRecord(true, "AMQ601768: STOMP connection");
+      Assert.assertTrue(findLogRecord(getAuditLog(),"AMQ601767: STOMP connection"));
+      Assert.assertTrue(findLogRecord(getAuditLog(),"AMQ601768: STOMP connection"));
    }
 }

--- a/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/logging/AuditLoggerTest.java
+++ b/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/logging/AuditLoggerTest.java
@@ -89,7 +89,7 @@ public class AuditLoggerTest extends AuditLoggerTestBase {
       Wait.waitFor(() -> addressControl.getMessageCount() == 1);
       Assert.assertEquals(1, addressControl.getMessageCount());
 
-      checkAuditLogRecord(true, "sending a message", uniqueStr);
+      Assert.assertTrue(findLogRecord(getAuditLog(),"sending a message", uniqueStr));
 
       //failure log
       address = RandomUtil.randomSimpleString();
@@ -112,9 +112,9 @@ public class AuditLoggerTest extends AuditLoggerTestBase {
          //ignore
       }
 
-      checkAuditLogRecord(true, "AMQ601264: User guest", "gets security check failure, reason = AMQ229213: User: guest does not have permission='DELETE_NON_DURABLE_QUEUE'");
+      Assert.assertTrue(findLogRecord(getAuditLog(),"AMQ601264: User guest", "gets security check failure, reason = AMQ229213: User: guest does not have permission='DELETE_NON_DURABLE_QUEUE'"));
       //hot patch not in log
-      checkAuditLogRecord(true, "is sending a message");
+      Assert.assertTrue(findLogRecord(getAuditLog(),"is sending a message"));
    }
 
    @Test
@@ -177,10 +177,10 @@ public class AuditLoggerTest extends AuditLoggerTestBase {
          Wait.waitFor(() -> addressControl.getMessageCount() == 2);
          Assert.assertEquals(2, addressControl.getMessageCount());
 
-         checkAuditLogRecord(false, "messageID=0");
-         checkAuditLogRecord(true, "sent a message");
-         checkAuditLogRecord(true, uniqueStr);
-         checkAuditLogRecord(true, "Hello2");
+         Assert.assertFalse(findLogRecord(getAuditLog(), "messageID=0"));
+         Assert.assertTrue(findLogRecord(getAuditLog(), "sent a message"));
+         Assert.assertTrue(findLogRecord(getAuditLog(), uniqueStr));
+         Assert.assertTrue(findLogRecord(getAuditLog(), "Hello2"));
 
          connection.start();
          MessageConsumer consumer = session.createConsumer(session.createQueue(address.toString()));
@@ -191,7 +191,7 @@ public class AuditLoggerTest extends AuditLoggerTestBase {
       } finally {
          connection.close();
       }
-      checkAuditLogRecord(true, "is consuming a message from");
-      checkAuditLogRecord(true, "acknowledged message from");
+      Wait.assertTrue(() -> findLogRecord(getAuditLog(), "is consuming a message from"), 5000);
+      Wait.assertTrue(() -> findLogRecord(getAuditLog(), "acknowledged message from"), 5000);
    }
 }

--- a/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/logging/AuditLoggerTestBase.java
+++ b/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/logging/AuditLoggerTestBase.java
@@ -64,8 +64,4 @@ public abstract class AuditLoggerTestBase extends SmokeTestBase {
 
    abstract String getServerName();
 
-   //check the audit log has a line that contains all the values
-   protected void checkAuditLogRecord(boolean exist, String... values) throws Exception {
-      checkLogRecord(getAuditLog(), exist, values);
-   }
 }

--- a/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/nettynative/NettyNativeTest.java
+++ b/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/nettynative/NettyNativeTest.java
@@ -88,8 +88,8 @@ public class NettyNativeTest extends SmokeTestBase {
       }
 
       File artemisLog = new File("target/" + SERVER_NAME + "/log/artemis.log");
-      checkLogRecord(artemisLog, true, "Acceptor using native");
-      checkLogRecord(artemisLog, false, "Acceptor using nio");
+      Assert.assertTrue(findLogRecord(artemisLog,  "Acceptor using native"));
+      Assert.assertFalse(findLogRecord(artemisLog, "Acceptor using nio"));
    }
 
 }

--- a/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/clusterNotificationsContinuity/ClusterNotificationsContinuityTest.java
+++ b/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/clusterNotificationsContinuity/ClusterNotificationsContinuityTest.java
@@ -40,6 +40,7 @@ import org.apache.activemq.artemis.utils.SpawnedVMSupport;
 import org.apache.activemq.artemis.utils.Wait;
 import org.apache.activemq.artemis.utils.cli.helper.HelperCreate;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -186,7 +187,7 @@ public class ClusterNotificationsContinuityTest extends SoakTestBase {
          String serverName = SERVER_NAME_BASE + i;
 
          File artemisLog = new File("target/" + serverName + "/log/artemis.log");
-         checkLogRecord(artemisLog, false, "AMQ224037");
+         Assert.assertFalse(findLogRecord(artemisLog, "AMQ224037"));
       }
 
    }


### PR DESCRIPTION
These tests are using an asynchronous feature. the check on Log has to use the Wait.assertEquals

I had to make a few changes to the methods to allow the use of Wait