### PR TITLE
ARTEMIS-4658 Prevent reflections when using dual address federation

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/ProtonProtocolManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/ProtonProtocolManager.java
@@ -238,7 +238,7 @@ public class ProtonProtocolManager extends AbstractProtocolManager<AMQPMessage, 
          ttl = 0;
       }
 
-      String id = server.getConfiguration().getName();
+      String id = server.getNodeID().toString();
       boolean useCoreSubscriptionNaming = server.getConfiguration().isAmqpUseCoreSubscriptionNaming();
       AMQPConnectionContext amqpConnection = new AMQPConnectionContext(this, connectionCallback, id, (int) ttl, getMaxFrameSize(), AMQPConstants.Connection.DEFAULT_CHANNEL_MAX, useCoreSubscriptionNaming, server.getScheduledPool(), true, saslFactory, null, outgoing);
 

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationPolicySupport.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationPolicySupport.java
@@ -105,17 +105,17 @@ public final class AMQPFederationPolicySupport {
     * to indicate no max hops for federated messages on an address.
     *
     * @param maxHops
-    *    The max allowed number of hops before a message should stop cross federation links.
+    *    The max allowed number of hops before a message should stop crossing federation links.
     *
-    * @return the address filter string or null if not needed.
+    * @return the address filter string that should be applied (or null).
     */
    public static String generateAddressFilter(int maxHops) {
       if (maxHops <= 0) {
          return null;
       }
 
-      return "(\"m." + MESSAGE_HOPS_ANNOTATION.toString() +
-             "\" IS NULL OR \"m." + MESSAGE_HOPS_ANNOTATION.toString() +
+      return "(\"m." + MESSAGE_HOPS_ANNOTATION +
+             "\" IS NULL OR \"m." + MESSAGE_HOPS_ANNOTATION +
              "\"<" + maxHops + ")" +
              " AND " +
              "(" + MESSAGE_HOPS_PROPERTY + " IS NULL OR " +

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpInboundConnectionTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpInboundConnectionTest.java
@@ -75,6 +75,8 @@ public class AmqpInboundConnectionTest extends AmqpClientTestSupport {
 
    @Test(timeout = 60000)
    public void testBrokerContainerId() throws Exception {
+      final String containerId = server.getNodeID().toString();
+
       AmqpClient client = createAmqpClient();
       assertNotNull(client);
 
@@ -82,7 +84,7 @@ public class AmqpInboundConnectionTest extends AmqpClientTestSupport {
 
          @Override
          public void inspectOpenedResource(Connection connection) {
-            if (!BROKER_NAME.equals(connection.getRemoteContainer())) {
+            if (!containerId.equals(connection.getRemoteContainer())) {
                markAsInvalid("Broker did not send the expected container ID");
             }
          }


### PR DESCRIPTION
When federation is configured in two directions between nodes for an address the message can reflect from one node to another if max hops is not set or not set correctly and in some federation topologies the max hops value can't solve the issue and still result in a working configuration. This reflection should be prevented at the federation consumer level for address consumers.