### PR TITLE
BAD_COPY_PASTE in VersionedStompFrameHandler.java

### DIFF
--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/VersionedStompFrameHandler.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/VersionedStompFrameHandler.java
@@ -273,7 +273,7 @@ public abstract class VersionedStompFrameHandler {
       if (frame.hasHeader(Stomp.Headers.Subscribe.NO_LOCAL)) {
          noLocal = Boolean.parseBoolean(frame.getHeader(Stomp.Headers.Subscribe.NO_LOCAL));
       } else if (frame.hasHeader(Stomp.Headers.Subscribe.ACTIVEMQ_NO_LOCAL)) {
-         noLocal = Boolean.parseBoolean(frame.getHeader(Stomp.Headers.Subscribe.NO_LOCAL));
+         noLocal = Boolean.parseBoolean(frame.getHeader(Stomp.Headers.Subscribe.ACTIVEMQ_NO_LOCAL));
       }
       Integer consumerWindowSize = null;
       if (frame.hasHeader(Headers.Subscribe.CONSUMER_WINDOW_SIZE)) {


### PR DESCRIPTION
In 1st branch (line 274) of the if() statement, the Boolean.parseBoolean() method accepts the value frame.getHeader(Stomp.Headers.Subscribe.NO_LOCAL), which is used in line 273.

In 2nd branch (line 276), the Boolean.parseBoolean() method accepts the value frame.getHeader(Stomp.Headers.Subscribe.NO_LOCAL), although the other value frame.hasHeader(Stomp.Headers.Subscribe.ACTIVEMQ_NO_LOCAL) is used.

Found by Linux Verification Center (portal.linuxtesting.ru) with SVACE.
Author A. Slepykh.