### PR TITLE
ARTEMIS-4664 - autoCreatedResource can get removed while receiving ba…

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -4090,6 +4090,9 @@ public class ActiveMQServerImpl implements ActiveMQServer {
             }
             final QueueBinding queueBinding = (QueueBinding) rawBinding;
             if (ignoreIfExists) {
+               //Reset potentially ongoing auto-delete status of queue
+               queueBinding.getQueue().setSwept(false);
+
                return queueBinding.getQueue();
             } else {
                throw ActiveMQMessageBundle.BUNDLE.queueAlreadyExists(queueConfiguration.getName(), queueBinding.getAddress());


### PR DESCRIPTION
…tch of messages

This is probably not all that likely to ever happen to anyone. I stumbled on this issue while working on something else but I figured it would be better to handle it.

From what I can tell the auto created resource would have to have been empty for one pass of the "AddressQueueReaper" to be marked as "swept", then a large batch of messages would get sent to the resource just as the next pass of  "AddressQueueReaper" begins and finishes before the message batch finishes.