### PR TITLE
ARTEMIS-4510 - Add auto-create-destination logic to diverts

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
@@ -698,6 +698,8 @@ public final class ActiveMQDefaultConfiguration {
 
    private static final boolean DEFAULT_MANAGEMENT_MESSAGE_RBAC = false;
 
+   private static final boolean DEFAULT_DIVERT_REUSE_USER_SESSION = false;
+
    /**
     * If true then the ActiveMQ Artemis Server will make use of any Protocol Managers that are in available on the classpath. If false then only the core protocol will be available, unless in Embedded mode where users can inject their own Protocol Managers.
     */
@@ -1918,4 +1920,9 @@ public final class ActiveMQDefaultConfiguration {
    public static boolean getManagementMessagesRbac() {
       return DEFAULT_MANAGEMENT_MESSAGE_RBAC;
    }
+
+   public static boolean isDefaultDivertReuseUserSession() {
+      return DEFAULT_DIVERT_REUSE_USER_SESSION;
+   }
+
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
@@ -1739,6 +1739,18 @@ public interface ActiveMQServerControl {
                      @Parameter(name = "transformerPropertiesAsJSON", desc = "Configuration properties of the divert's transformer in JSON form") String transformerPropertiesAsJSON,
                      @Parameter(name = "routingType", desc = "How should the routing-type on the diverted messages be set?") String routingType) throws Exception;
 
+   @Operation(desc = "Create a Divert", impact = MBeanOperationInfo.ACTION)
+   void createDivert(@Parameter(name = "name", desc = "Name of the divert") String name,
+                     @Parameter(name = "routingName", desc = "Routing name of the divert") String routingName,
+                     @Parameter(name = "address", desc = "Address to divert from") String address,
+                     @Parameter(name = "forwardingAddress", desc = "Address to divert to") String forwardingAddress,
+                     @Parameter(name = "exclusive", desc = "Is the divert exclusive?") boolean exclusive,
+                     @Parameter(name = "filterString", desc = "Filter of the divert") String filterString,
+                     @Parameter(name = "transformerClassName", desc = "Class name of the divert's transformer") String transformerClassName,
+                     @Parameter(name = "transformerProperties", desc = "Configuration properties of the divert's transformer") Map<String, String> transformerProperties,
+                     @Parameter(name = "routingType", desc = "How should the routing-type on the diverted messages be set?") String routingType,
+                     @Parameter(name = "reuseUserSession", desc = "Should the divert route messages using the senders session?") boolean reuseUserSession) throws Exception;
+
    /**
     * update a divert
     */

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/DivertConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/DivertConfiguration.java
@@ -47,6 +47,8 @@ public class DivertConfiguration implements Serializable, EncodingSupport {
 
    private ComponentConfigurationRoutingType routingType = ComponentConfigurationRoutingType.valueOf(ActiveMQDefaultConfiguration.getDefaultDivertRoutingType());
 
+   private boolean reuseUserSession = ActiveMQDefaultConfiguration.isDefaultDivertReuseUserSession();
+
    public DivertConfiguration() {
    }
 
@@ -80,6 +82,10 @@ public class DivertConfiguration implements Serializable, EncodingSupport {
 
    public ComponentConfigurationRoutingType getRoutingType() {
       return routingType;
+   }
+
+   public boolean isReuseUserSession() {
+      return reuseUserSession;
    }
 
    /**
@@ -150,6 +156,14 @@ public class DivertConfiguration implements Serializable, EncodingSupport {
       return this;
    }
 
+   /**
+    * @param reuseUserSession Should the divert route messages using the senders session
+    */
+   public DivertConfiguration setReuseUserSession(final boolean reuseUserSession) {
+      this.reuseUserSession = reuseUserSession;
+      return this;
+   }
+
    @Override
    public int hashCode() {
       final int prime = 31;
@@ -162,6 +176,7 @@ public class DivertConfiguration implements Serializable, EncodingSupport {
       result = prime * result + ((routingName == null) ? 0 : routingName.hashCode());
       result = prime * result + ((transformerConfiguration == null) ? 0 : transformerConfiguration.hashCode());
       result = prime * result + ((routingType == null) ? 0 : routingType.hashCode());
+      result = prime * result + (reuseUserSession ? 1231 : 1237);
       return result;
    }
 
@@ -211,6 +226,9 @@ public class DivertConfiguration implements Serializable, EncodingSupport {
             return false;
       } else if (!routingType.equals(other.routingType))
          return false;
+      if (reuseUserSession != other.reuseUserSession) {
+         return false;
+      }
       return true;
    }
 
@@ -261,7 +279,7 @@ public class DivertConfiguration implements Serializable, EncodingSupport {
 
    @Override
    public String toString() {
-      return "DivertConfiguration{" + "name='" + name + '\'' + ", routingName='" + routingName + '\'' + ", address='" + address + '\'' + ", forwardingAddress='" + forwardingAddress + '\'' + ", exclusive=" + exclusive + ", filterString='" + filterString + '\'' + ", transformerConfiguration=" + transformerConfiguration + '}';
+      return "DivertConfiguration{" + "name='" + name + '\'' + ", routingName='" + routingName + '\'' + ", address='" + address + '\'' + ", forwardingAddress='" + forwardingAddress + '\'' + ", exclusive=" + exclusive + ", filterString='" + filterString + '\'' + ", transformerConfiguration=" + transformerConfiguration + '\'' + ", reuseUserSession=" + reuseUserSession + '}';
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -2829,6 +2829,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
       ComponentConfigurationRoutingType routingType = ComponentConfigurationRoutingType.valueOf(getString(e, "routing-type", ActiveMQDefaultConfiguration.getDefaultDivertRoutingType(), COMPONENT_ROUTING_TYPE));
 
+      boolean reuseUserSession = getBoolean(e, "reuse-user-session", ActiveMQDefaultConfiguration.isDefaultDivertReuseUserSession());
+
       TransformerConfiguration transformerConfiguration = null;
 
       String filterString = null;
@@ -2849,7 +2851,7 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
          transformerConfiguration = getTransformerConfiguration(transformerClassName);
       }
 
-      DivertConfiguration config = new DivertConfiguration().setName(name).setRoutingName(routingName).setAddress(address).setForwardingAddress(forwardingAddress).setExclusive(exclusive).setFilterString(filterString).setTransformerConfiguration(transformerConfiguration).setRoutingType(routingType);
+      DivertConfiguration config = new DivertConfiguration().setName(name).setRoutingName(routingName).setAddress(address).setForwardingAddress(forwardingAddress).setExclusive(exclusive).setFilterString(filterString).setTransformerConfiguration(transformerConfiguration).setRoutingType(routingType).setReuseUserSession(reuseUserSession);
 
       mainConfig.getDivertConfigurations().add(config);
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -3669,6 +3669,20 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
                             final String transformerClassName,
                             final Map<String, String> transformerProperties,
                             final String routingType) throws Exception {
+      createDivert(name, routingName, address, forwardingAddress, exclusive, filterString, transformerClassName, transformerProperties, routingType, ActiveMQDefaultConfiguration.isDefaultDivertReuseUserSession());
+   }
+
+   @Override
+   public void createDivert(final String name,
+                            final String routingName,
+                            final String address,
+                            final String forwardingAddress,
+                            final boolean exclusive,
+                            final String filterString,
+                            final String transformerClassName,
+                            final Map<String, String> transformerProperties,
+                            final String routingType,
+                            final boolean reuseUserSession) throws Exception {
       if (AuditLogger.isBaseLoggingEnabled()) {
          AuditLogger.createDivert(this.server, name, routingName, address, forwardingAddress,
                   exclusive, filterString, transformerClassName, transformerProperties, routingType);
@@ -3678,7 +3692,7 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
       clearIO();
       try {
          TransformerConfiguration transformerConfiguration = transformerClassName == null || transformerClassName.isEmpty() ? null : new TransformerConfiguration(transformerClassName).setProperties(transformerProperties);
-         DivertConfiguration config = new DivertConfiguration().setName(name).setRoutingName(routingName).setAddress(address).setForwardingAddress(forwardingAddress).setExclusive(exclusive).setFilterString(filterString).setTransformerConfiguration(transformerConfiguration).setRoutingType(ComponentConfigurationRoutingType.valueOf(routingType));
+         DivertConfiguration config = new DivertConfiguration().setName(name).setRoutingName(routingName).setAddress(address).setForwardingAddress(forwardingAddress).setExclusive(exclusive).setFilterString(filterString).setTransformerConfiguration(transformerConfiguration).setRoutingType(ComponentConfigurationRoutingType.valueOf(routingType)).setReuseUserSession(reuseUserSession);
          server.deployDivert(config);
       } finally {
          blockOnIO();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -2934,7 +2934,8 @@ public class ActiveMQServerImpl implements ActiveMQServer {
 
       Divert divert = new DivertImpl(sName, sAddress, new SimpleString(config.getForwardingAddress()),
                                      new SimpleString(config.getRoutingName()), config.isExclusive(),
-                                     filter, transformer, postOffice, storageManager, config.getRoutingType());
+                                     filter, transformer, postOffice, storageManager, config.getRoutingType(),
+                                     config.isReuseUserSession());
 
       Binding binding = new DivertBinding(storageManager.generateID(), sAddress, divert);
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/DivertImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/DivertImpl.java
@@ -59,6 +59,8 @@ public class DivertImpl implements Divert {
 
    private volatile ComponentConfigurationRoutingType routingType;
 
+   private final boolean reuseUserSession;
+
    public DivertImpl(final SimpleString uniqueName,
                      final SimpleString address,
                      final SimpleString forwardAddress,
@@ -68,7 +70,8 @@ public class DivertImpl implements Divert {
                      final Transformer transformer,
                      final PostOffice postOffice,
                      final StorageManager storageManager,
-                     final ComponentConfigurationRoutingType routingType) {
+                     final ComponentConfigurationRoutingType routingType,
+                     final boolean reuseUserSession) {
       this.address = address;
 
       this.setForwardAddress(forwardAddress);
@@ -88,6 +91,8 @@ public class DivertImpl implements Divert {
       this.storageManager = storageManager;
 
       this.routingType = routingType;
+
+      this.reuseUserSession = reuseUserSession;
    }
 
    @Override
@@ -140,7 +145,11 @@ public class DivertImpl implements Divert {
             copy = message;
          }
 
-         postOffice.route(copy, new RoutingContextImpl(context.getTransaction()).setReusable(false).setRoutingType(copy.getRoutingType()), false);
+         if (!reuseUserSession) {
+            postOffice.route(copy, new RoutingContextImpl(context.getTransaction()).setReusable(false).setRoutingType(copy.getRoutingType()), false);
+         } else {
+            postOffice.route(copy, new RoutingContextImpl(context.getTransaction()).setReusable(false).setRoutingType(copy.getRoutingType()).setServerSession(context.getServerSession()), false);
+         }
       }
    }
 
@@ -233,6 +242,10 @@ public class DivertImpl implements Divert {
          filter +
          ", transformer=" +
          transformer +
+         ", routingType=" +
+         routingType +
+         ", reuseUserSession=" +
+         reuseUserSession +
          "]";
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/DivertImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/DivertImpl.java
@@ -121,6 +121,10 @@ public class DivertImpl implements Divert {
 
             copy.setExpiration(message.getExpiration());
 
+            //This header could be set if the message is redistributed from a clustered broker.
+            //It needs to be removed as it will interfere with upcoming routing
+            copy.removeExtraBytesProperty(Message.HDR_ROUTE_TO_IDS);
+
             switch (routingType) {
                case ANYCAST:
                   copy.setRoutingType(RoutingType.ANYCAST);

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -2661,6 +2661,14 @@
                </xsd:documentation>
             </xsd:annotation>
          </xsd:element>
+
+         <xsd:element name="reuse-user-session" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Should the divert route messages using the senders session
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
       </xsd:all>
 
       <xsd:attribute name="name" type="xsd:ID" use="required">

--- a/docs/user-manual/configuration-index.adoc
+++ b/docs/user-manual/configuration-index.adoc
@@ -1105,6 +1105,9 @@ Default=false
 | xref:diverts.adoc#diverting-and-splitting-message-flows[routing-type]
 | how to set the routing-type on the diverted message.
 Default=`STRIP`
+
+| xref:diverts.adoc#reusing-the-senders-session[reuse-user-session]
+| should the divert route messages using the senders session
 |===
 
 == address type

--- a/docs/user-manual/diverts.adoc
+++ b/docs/user-manual/diverts.adoc
@@ -120,3 +120,51 @@ Just use a comma separated list in `forwarding-address`, e.g.:
    <exclusive>false</exclusive>
 </divert>
 ----
+
+== Reusing the senders session
+
+By default, after a message is received on the diverts `address`, its consequent routing is done by the divert.
+This means it happens separate to the original sender, freeing it up to proceed with other tasks.
+
+In some cases it's useful to keep the original session coupled with consequent routing.
+
+An example of this would be to enable automatic creation of forwarded destinations if they are missing,
+or being able to roll back message delivery if one of multiple destinations could not accept the message.
+
+This behavior can be configured by setting `reuse-user-session` on the divert, which defaults to `false`.
+
+== Computing destinations at runtime
+
+Using logic in a diverts transformer, it's possible to perform complex routing
+by altering properties on individual messages.
+
+A simple example of this:
+
+[,java]
+----
+@Override
+public Message transform(Message message) {
+   if (message.getBooleanProperty("changeDestination")) {
+      message.setAddress(message.getStringProperty("newDestination"));
+   }
+   return message;
+}
+----
+
+Here, the computed destination will get used instead of the diverts `forwarding-address`.
+
+[NOTE]
+====
+There are two important things to consider when computing messages destination where the resulting destination might
+not exist on the broker beforehand.
+
+1. When the diverting to a destination that is not already present on the broker, auto-creation configuration of the
+destination address applies. This configuration is tested against the sender so `reuse-user-session` needs
+to be set to `true`.
+
+2. To be able to create a new destination, the messages `routing-type` has to be known.
+The default behavior of the divert is to remove this information from a message before handing it over to the `transformer`
+according to the default `routingType = STRIP`.
+To make sure the messages end up where they are supposed to, either set the diverts `routingType` or
+make sure to add this information in the `transformer` with the messages `setRoutingType()` method.
+====

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/divert/DivertTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/divert/DivertTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
+import org.apache.activemq.artemis.api.core.ActiveMQAddressDoesNotExistException;
 import org.apache.activemq.artemis.api.core.ActiveMQIllegalStateException;
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.QueueConfiguration;
@@ -51,6 +52,7 @@ import org.apache.activemq.artemis.core.server.ActiveMQServers;
 import org.apache.activemq.artemis.core.server.ComponentConfigurationRoutingType;
 import org.apache.activemq.artemis.core.server.Divert;
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl;
+import org.apache.activemq.artemis.core.server.impl.QueueManagerImpl;
 import org.apache.activemq.artemis.core.server.impl.ServiceRegistryImpl;
 import org.apache.activemq.artemis.core.server.transformer.Transformer;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
@@ -58,6 +60,7 @@ import org.apache.activemq.artemis.core.settings.impl.DeletionPolicy;
 import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.tests.util.CFUtil;
 import org.apache.activemq.artemis.tests.util.RandomUtil;
+import org.apache.activemq.artemis.tests.util.Wait;
 import org.apache.activemq.command.ActiveMQTopic;
 import org.junit.Assert;
 import org.junit.Test;
@@ -1775,4 +1778,145 @@ public class DivertTest extends ActiveMQTestBase {
       Assert.assertEquals("testAddress" + COUNT, message.getAddress());
       Assert.assertEquals("testAddress" + (COUNT - 1), message.getStringProperty(Message.HDR_ORIGINAL_ADDRESS));
    }
+
+   @Test
+   public void testDivertToNewAddress() throws Exception {
+      final String queueName = "queue";
+      final String dummyQueueName = "dummy";
+      final String noDivertAutoCreateQName = "notAllowed";
+      final String propKey = "newQueue";
+      final String DIVERT = "myDivert";
+      final int numMessages = 10;
+
+      Transformer transformer = message -> message.setAddress(message.getStringProperty(propKey));
+
+      ServiceRegistryImpl serviceRegistry = new ServiceRegistryImpl();
+      serviceRegistry.addDivertTransformer(DIVERT, transformer);
+
+      AddressSettings autoCreateDestinationsAS = new AddressSettings().setAutoCreateAddresses(true).setAutoCreateQueues(true);
+      AddressSettings noAutoCreateDestinationsAS = new AddressSettings().setAutoCreateAddresses(false).setAutoCreateQueues(false);
+
+      ActiveMQServer server = addServer(new ActiveMQServerImpl(createDefaultInVMConfig(), null, null, null, serviceRegistry));
+
+      server.getConfiguration().addAddressSetting("#", autoCreateDestinationsAS);
+      server.getConfiguration().addAddressSetting(noDivertAutoCreateQName, noAutoCreateDestinationsAS);
+
+      server.start();
+
+      server.createQueue(new QueueConfiguration(queueName));
+      server.deployDivert(new DivertConfiguration()
+                             .setName(DIVERT)
+                             .setAddress(queueName)
+                             .setRoutingType(ComponentConfigurationRoutingType.ANYCAST)
+                             .setForwardingAddress(dummyQueueName)
+                             .setExclusive(true)
+                             .setReuseUserSession(true));
+
+      ServerLocator locator = createInVMNonHALocator();
+      ClientSessionFactory sf = createSessionFactory(locator);
+      ClientSession session = sf.createSession(false, true, true);
+      session.start();
+
+      ClientMessage message;
+      ClientProducer producer = session.createProducer(queueName);
+
+      for (int i = 0; i < numMessages; i++) {
+         message = session.createMessage(true);
+         message.putStringProperty(propKey, queueName + "." + i);
+         producer.send(message);
+      }
+
+      for (int i = 0; i < numMessages; i++) {
+         ClientConsumer consumer = session.createConsumer(queueName + "." + i);
+         message = consumer.receive(DivertTest.TIMEOUT);
+         Assert.assertNotNull(message);
+         message.acknowledge();
+         consumer.close();
+      }
+
+      ClientMessage failMessage = session.createMessage(true);
+
+      assertThrows(ActiveMQAddressDoesNotExistException.class, () -> {
+         failMessage.putStringProperty(propKey, noDivertAutoCreateQName);
+         producer.send(failMessage);
+      });
+
+      producer.close();
+
+      Assert.assertNull(server.locateQueue(noDivertAutoCreateQName));
+      Assert.assertNull(server.locateQueue(dummyQueueName));
+
+   }
+
+   @Test
+   public void testHandleAutoDeleteDestination() throws Exception {
+      final String testAddress = "testAddress";
+      final String forwardAddress = "forwardAddress";
+
+      DivertConfiguration divertConf = new DivertConfiguration()
+         .setName("divert")
+         .setRoutingType(ComponentConfigurationRoutingType.ANYCAST)
+         .setExclusive(true)
+         .setAddress(testAddress)
+         .setForwardingAddress(forwardAddress)
+         .setReuseUserSession(true);
+
+      AddressSettings addressSettings = new AddressSettings()
+         .setAutoCreateAddresses(true)
+         .setAutoCreateQueues(true)
+         .setAutoDeleteAddresses(true)
+         .setAutoDeleteQueues(true);
+
+      Configuration config = createDefaultInVMConfig().addDivertConfiguration(divertConf).addAddressSetting("#", addressSettings);
+      ActiveMQServer server = addServer(ActiveMQServers.newActiveMQServer(config, false));
+      server.start();
+
+      ServerLocator locator = createInVMNonHALocator();
+      ClientSessionFactory sf = createSessionFactory(locator);
+      ClientSession session = sf.createSession(false, true, true);
+
+      session.createQueue(new QueueConfiguration(testAddress).setAddress(testAddress).setRoutingType(RoutingType.ANYCAST).setDurable(true));
+      session.createQueue(new QueueConfiguration(forwardAddress).setAddress(forwardAddress).setRoutingType(RoutingType.ANYCAST).setDurable(true));
+      session.start();
+
+      ClientProducer producer = session.createProducer(testAddress);
+      ClientConsumer consumer = session.createConsumer(forwardAddress);
+
+      final int numMessages = 5;
+
+      for (int i = 0; i < numMessages; i++) {
+         ClientMessage message = session.createMessage(true);
+         message.setRoutingType(RoutingType.ANYCAST);
+         producer.send(message);
+      }
+
+      for (int i = 0; i < numMessages; i++) {
+         ClientMessage message = consumer.receive(DivertTest.TIMEOUT);
+         Assert.assertNotNull(message);
+         message.acknowledge();
+      }
+
+      Assert.assertNull(consumer.receiveImmediate());
+      consumer.close();
+
+      //Trigger autoDelete instead of waiting
+      QueueManagerImpl.performAutoDeleteQueue(server, server.locateQueue(forwardAddress));
+      Wait.assertTrue(() -> server.getPostOffice().getAddressInfo(SimpleString.toSimpleString(forwardAddress))
+         .getBindingRemovedTimestamp() != -1, DivertTest.TIMEOUT, 100);
+
+      for (int i = 0; i < numMessages; i++) {
+         ClientMessage message = session.createMessage(true);
+         producer.send(message);
+      }
+
+      consumer = session.createConsumer(forwardAddress);
+      for (int i = 0; i < numMessages; i++) {
+         ClientMessage message = consumer.receive(DivertTest.TIMEOUT);
+         Assert.assertNotNull(message);
+         message.acknowledge();
+      }
+
+      Assert.assertNull(consumer.receiveImmediate());
+   }
+
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
@@ -1493,6 +1493,20 @@ public class ActiveMQServerControlUsingCoreTest extends ActiveMQServerControlTes
                                   boolean exclusive,
                                   String filterString,
                                   String transformerClassName,
+                                  Map<String, String> transformerProperties,
+                                  String routingType,
+                                  boolean reuseUserSession) throws Exception {
+            proxy.invokeOperation("createDivert", name, routingName, address, forwardingAddress, exclusive, filterString, transformerClassName, transformerProperties, routingType, reuseUserSession);
+         }
+
+         @Override
+         public void createDivert(String name,
+                                  String routingName,
+                                  String address,
+                                  String forwardingAddress,
+                                  boolean exclusive,
+                                  String filterString,
+                                  String transformerClassName,
                                   String transformerPropertiesAsJSON,
                                   String routingType) throws Exception {
             proxy.invokeOperation("createDivert", name, routingName, address, forwardingAddress, exclusive, filterString, transformerClassName, transformerPropertiesAsJSON, routingType);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/DivertConfigurationStorageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/DivertConfigurationStorageTest.java
@@ -54,6 +54,7 @@ public class DivertConfigurationStorageTest  extends StorageManagerTestBase {
       mytransformer.getProperties().put("key2", "prop2");
       mytransformer.getProperties().put("key3", "prop3");
       configuration.setTransformerConfiguration(mytransformer);
+      configuration.setReuseUserSession(true);
 
       journal.storeDivertConfiguration(new PersistedDivertConfiguration(configuration));
 
@@ -71,6 +72,7 @@ public class DivertConfigurationStorageTest  extends StorageManagerTestBase {
       Assert.assertEquals(configuration.isExclusive(), persistedDivertConfiguration.getDivertConfiguration().isExclusive());
       Assert.assertEquals(configuration.getForwardingAddress(), persistedDivertConfiguration.getDivertConfiguration().getForwardingAddress());
       Assert.assertEquals(configuration.getRoutingName(), persistedDivertConfiguration.getDivertConfiguration().getRoutingName());
+      Assert.assertEquals(configuration.isReuseUserSession(), persistedDivertConfiguration.getDivertConfiguration().isReuseUserSession());
       Assert.assertNotNull(persistedDivertConfiguration.getDivertConfiguration().getTransformerConfiguration());
       Assert.assertEquals("mytransformer", persistedDivertConfiguration.getDivertConfiguration().getTransformerConfiguration().getClassName());
       Map<String, String> properties = persistedDivertConfiguration.getDivertConfiguration().getTransformerConfiguration().getProperties();


### PR DESCRIPTION
This is the second try of #4681 after a round of feedback on the dev mailing list.
@jbertram @brusdev @clebertsuconic Please let me know if you agree to these changes or if I should change anything else.

An additional thing of note in this PR is added handling for a fringe issue I found while working on this PR pertaining to redistributed messages arriving on the divert. There is an added test for this as well. I can break this part out into a separate PR if preferred.