### PR TITLE
ARTEMIS-4710 Keep pem-keystore dependencies as is; make it really optional

### DIFF
--- a/artemis-core-client/pom.xml
+++ b/artemis-core-client/pom.xml
@@ -124,15 +124,6 @@
          <groupId>de.dentrassi.crypto</groupId>
          <artifactId>pem-keystore</artifactId>
       </dependency>
-      <!-- bcprov-jdk18on replaces bcprov-jdk15on excluded pem-keystore -->
-      <dependency>
-         <groupId>org.bouncycastle</groupId>
-         <artifactId>bcprov-jdk18on</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>org.bouncycastle</groupId>
-         <artifactId>bcpkix-jdk18on</artifactId>
-      </dependency>
 
       <!-- The johnzon-core and json-api contents are repackaged in -commons,
            However maven can still need them during tests, which run against

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/ssl/SSLSupport.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/ssl/SSLSupport.java
@@ -47,7 +47,6 @@ import java.security.cert.X509CertSelector;
 import java.security.cert.X509Certificate;
 import java.util.Collection;
 
-import de.dentrassi.crypto.pem.PemKeyStoreProvider;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
@@ -356,7 +355,8 @@ public class SSLSupport {
    public static void checkPemProviderLoaded(String keystoreType) {
       if (keystoreType != null && keystoreType.startsWith("PEM")) {
          if (Security.getProvider("PEM") == null) {
-            Security.insertProviderAt(new PemKeyStoreProvider(), Integer.parseInt(System.getProperty("artemis.pemProvider.insertAt", "0")));
+            Security.insertProviderAt(new de.dentrassi.crypto.pem.PemKeyStoreProvider(),
+               Integer.parseInt(System.getProperty("artemis.pemProvider.insertAt", "0")));
          }
       }
    }

--- a/artemis-pom/pom.xml
+++ b/artemis-pom/pom.xml
@@ -162,17 +162,6 @@
             <artifactId>pem-keystore</artifactId>
             <version>${pem-keystore.version}</version>
             <!-- Eclipse Public License - v 1.0 -->
-            <exclusions>
-               <!-- exclude bcprov-jdk15on to avoid conflicts with bcprov-jdk18on -->
-               <exclusion>
-                  <groupId>org.bouncycastle</groupId>
-                  <artifactId>bcprov-jdk15on</artifactId>
-               </exclusion>
-               <exclusion>
-                  <groupId>org.bouncycastle</groupId>
-                  <artifactId>bcpkix-jdk15on</artifactId>
-               </exclusion>
-            </exclusions>
          </dependency>
          <dependency>
             <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
The latest version already uses bcprov-jdk18on