### PR TITLE
ARTEMIS-4722 Exclude netty-tcnative-boringssl-static artifacts

### DIFF
--- a/artemis-lockmanager/artemis-lockmanager-ri/pom.xml
+++ b/artemis-lockmanager/artemis-lockmanager-ri/pom.xml
@@ -69,6 +69,7 @@
       <dependency>
          <groupId>org.apache.zookeeper</groupId>
          <artifactId>zookeeper</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.zookeeper</groupId>

--- a/artemis-pom/pom.xml
+++ b/artemis-pom/pom.xml
@@ -729,6 +729,10 @@
                   <artifactId>netty-transport-native-epoll</artifactId>
                </exclusion>
                <exclusion>
+                  <groupId>io.netty</groupId>
+                  <artifactId>netty-tcnative-boringssl-static</artifactId>
+               </exclusion>
+               <exclusion>
                   <groupId>org.apache.yetus</groupId>
                   <artifactId>audience-annotations</artifactId>
                </exclusion>


### PR DESCRIPTION
The lib folder includes netty-tcnative-boringssl-static artifacts non-aligned with the netty-tcnative-version in pom.xml. Those artifacts are included because of zookeeper-server.