### PR TITLE
ARTEMIS-4305 Zero persistence does not work in kubernetes

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
@@ -1910,6 +1910,9 @@ public interface ActiveMQServerControl {
    @Operation(desc = "List the Network Topology", impact = MBeanOperationInfo.INFO)
    String listNetworkTopology() throws Exception;
 
+   @Operation(desc = "Number of peers in the topology of a given cluster connection", impact = MBeanOperationInfo.INFO)
+   int countTopologyPeers(@Parameter(name = "clusterConnectionName", desc = "Name of the cluster connection") String clusterConnectionName) throws Exception;
+
    @Operation(desc = "Get the selected address", impact = MBeanOperationInfo.INFO)
    String getAddressInfo(@Parameter(name = "address", desc = "The address") String address) throws ActiveMQAddressDoesNotExistException;
 

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionFactoryImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionFactoryImpl.java
@@ -69,6 +69,7 @@ import org.apache.activemq.artemis.utils.ClassloadingUtil;
 import org.apache.activemq.artemis.utils.ConfirmationWindowWarning;
 import org.apache.activemq.artemis.utils.ExecutorFactory;
 import org.apache.activemq.artemis.utils.PasswordMaskingUtil;
+import org.apache.activemq.artemis.utils.UUID;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
 import org.apache.activemq.artemis.utils.actors.OrderedExecutorFactory;
 import org.apache.activemq.artemis.utils.collections.ConcurrentHashSet;
@@ -273,6 +274,11 @@ public class ClientSessionFactoryImpl implements ClientSessionFactoryInternal, C
       }
 
       this.connectorConfigs = connectorConfigs;
+   }
+
+   @Override
+   public UUID getNodeUUID() {
+      return serverLocator.getNodeUUID();
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionFactoryImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionFactoryImpl.java
@@ -122,7 +122,7 @@ public class ClientSessionFactoryImpl implements ClientSessionFactoryInternal, C
 
    private final Executor flowControlExecutor;
 
-   private RemotingConnection connection;
+   private volatile RemotingConnection connection;
 
    private final long retryInterval;
 
@@ -1450,7 +1450,7 @@ public class ClientSessionFactoryImpl implements ClientSessionFactoryInternal, C
          final RemotingConnection connectionInUse = connection;
 
          if (connectionInUse != null && clientFailureCheckPeriod != -1 && connectionTTL != -1 && now >= lastCheck + connectionTTL) {
-            if (!connectionInUse.checkDataReceived()) {
+            if (!connectionInUse.checkDataReceived() || !connectionInUse.isHealthy()) {
 
                // We use a different thread to send the fail
                // but the exception has to be created here to preserve the stack trace

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionFactoryImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionFactoryImpl.java
@@ -322,7 +322,7 @@ public class ClientSessionFactoryImpl implements ClientSessionFactoryInternal, C
       // to create a connector just to validate if the parameters are ok.
       // so this will create the instance to be used on the isEquivalent check
       if (localConnector == null) {
-         localConnector = connectorFactory.createConnector(currentConnectorConfig.getCombinedParams(), new DelegatingBufferHandler(), this, closeExecutor, threadPool, scheduledThreadPool, clientProtocolManager);
+         localConnector = connectorFactory.createConnector(currentConnectorConfig, new DelegatingBufferHandler(), this, closeExecutor, threadPool, scheduledThreadPool, clientProtocolManager);
       }
 
       if (localConnector.isEquivalent(primary.getParams()) && backUp != null && !localConnector.isEquivalent(backUp.getParams())
@@ -1230,7 +1230,7 @@ public class ClientSessionFactoryImpl implements ClientSessionFactoryInternal, C
    }
 
    protected Connector createConnector(ConnectorFactory connectorFactory, TransportConfiguration configuration) {
-      Connector connector = connectorFactory.createConnector(configuration.getCombinedParams(), new DelegatingBufferHandler(), this, closeExecutor, threadPool, scheduledThreadPool, clientProtocolManager);
+      Connector connector = connectorFactory.createConnector(configuration, new DelegatingBufferHandler(), this, closeExecutor, threadPool, scheduledThreadPool, clientProtocolManager);
       if (connector instanceof NettyConnector) {
          NettyConnector nettyConnector = (NettyConnector) connector;
          if (nettyConnector.getConnectTimeoutMillis() < 0) {

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionFactoryInternal.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionFactoryInternal.java
@@ -24,8 +24,10 @@ import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.SessionFailureListener;
 import org.apache.activemq.artemis.utils.ConfirmationWindowWarning;
+import org.apache.activemq.artemis.utils.UUID;
 
 public interface ClientSessionFactoryInternal extends ClientSessionFactory {
+   UUID getNodeUUID();
 
    void causeExit();
 

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorImpl.java
@@ -69,6 +69,7 @@ import org.apache.activemq.artemis.utils.ActiveMQThreadFactory;
 import org.apache.activemq.artemis.utils.ActiveMQThreadPoolExecutor;
 import org.apache.activemq.artemis.utils.ClassloadingUtil;
 import org.apache.activemq.artemis.utils.ThreadDumpUtil;
+import org.apache.activemq.artemis.utils.UUID;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
 import org.apache.activemq.artemis.utils.actors.Actor;
 import org.apache.activemq.artemis.utils.actors.OrderedExecutor;
@@ -166,6 +167,8 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
    private String groupID;
 
    private String nodeID;
+
+   private UUID nodeUUID;
 
    private TransportConfiguration clusterTransportConfiguration;
 
@@ -1347,6 +1350,17 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
    @Override
    public String getNodeID() {
       return nodeID;
+   }
+
+   @Override
+   public ServerLocatorInternal setNodeUUID(UUID nodeUUID) {
+      this.nodeUUID = nodeUUID;
+      return this;
+   }
+
+   @Override
+   public UUID getNodeUUID() {
+      return nodeUUID;
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorInternal.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorInternal.java
@@ -24,6 +24,7 @@ import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.spi.core.remoting.ClientProtocolManager;
+import org.apache.activemq.artemis.utils.UUID;
 
 public interface ServerLocatorInternal extends ServerLocator {
 
@@ -45,6 +46,10 @@ public interface ServerLocatorInternal extends ServerLocator {
    ServerLocatorInternal setNodeID(String nodeID);
 
    String getNodeID();
+
+   ServerLocatorInternal setNodeUUID(UUID nodeUUID);
+
+   UUID getNodeUUID();
 
    void cleanup();
 

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/cluster/DiscoveryGroup.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/cluster/DiscoveryGroup.java
@@ -321,7 +321,7 @@ public final class DiscoveryGroup implements ActiveMQComponent {
                for (int i = 0; i < size; i++) {
                   TransportConfiguration connector = new TransportConfiguration();
 
-                  connector.decode(buffer);
+                  connector.decode(originatingNodeID, buffer);
 
                   entriesRead[i] = new DiscoveryEntry(originatingNodeID, connector, System.currentTimeMillis());
                }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ActiveMQClientProtocolManager.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ActiveMQClientProtocolManager.java
@@ -228,7 +228,7 @@ public class ActiveMQClientProtocolManager implements ClientProtocolManager {
    public void ping(long connectionTTL) {
       Channel channel = connection.getChannel(ChannelImpl.CHANNEL_ID.PING.id, -1);
 
-      Ping ping = new Ping(connectionTTL);
+      Ping ping = new Ping(factoryInternal.getNodeUUID(), connectionTTL);
 
       channel.send(ping);
 

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ClusterTopologyChangeMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ClusterTopologyChangeMessage.java
@@ -111,7 +111,7 @@ public class ClusterTopologyChangeMessage extends PacketImpl {
          TransportConfiguration a;
          if (hasPrimary) {
             a = new TransportConfiguration();
-            a.decode(buffer);
+            a.decode(nodeID, buffer);
          } else {
             a = null;
          }
@@ -119,7 +119,7 @@ public class ClusterTopologyChangeMessage extends PacketImpl {
          TransportConfiguration b;
          if (hasBackup) {
             b = new TransportConfiguration();
-            b.decode(buffer);
+            b.decode(nodeID, buffer);
          } else {
             b = null;
          }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ClusterTopologyChangeMessage_V2.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ClusterTopologyChangeMessage_V2.java
@@ -110,7 +110,7 @@ public class ClusterTopologyChangeMessage_V2 extends ClusterTopologyChangeMessag
          TransportConfiguration a;
          if (hasPrimary) {
             a = new TransportConfiguration();
-            a.decode(buffer);
+            a.decode(nodeID, buffer);
          } else {
             a = null;
          }
@@ -118,7 +118,7 @@ public class ClusterTopologyChangeMessage_V2 extends ClusterTopologyChangeMessag
          TransportConfiguration b;
          if (hasBackup) {
             b = new TransportConfiguration();
-            b.decode(buffer);
+            b.decode(nodeID, buffer);
          } else {
             b = null;
          }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/DisconnectMessage_V3.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/DisconnectMessage_V3.java
@@ -79,7 +79,7 @@ public class DisconnectMessage_V3 extends DisconnectMessage {
       boolean hasTargetConnector = buffer.readBoolean();
       if (hasTargetConnector) {
          targetConnector = new TransportConfiguration();
-         targetConnector.decode(buffer);
+         targetConnector.decode(targetNodeID.toString(), buffer);
       } else {
          targetConnector = null;
       }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnection.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnection.java
@@ -20,6 +20,7 @@ import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 
@@ -59,6 +60,7 @@ public class NettyConnection implements Connection {
    protected final Channel channel;
    private final BaseConnectionLifeCycleListener<?> listener;
    private final boolean directDeliver;
+   private final TransportConfiguration transportConfiguration;
    private final Map<String, Object> configuration;
    /**
     * if {@link #isWritable(ReadyListener)} returns false, we add a callback
@@ -74,14 +76,15 @@ public class NettyConnection implements Connection {
 
    private boolean ready = true;
 
-   public NettyConnection(final Map<String, Object> configuration,
+   public NettyConnection(final TransportConfiguration transportConfiguration,
                           final Channel channel,
                           final BaseConnectionLifeCycleListener<?> listener,
                           boolean batchingEnabled,
                           boolean directDeliver) {
       checkNotNull(channel);
 
-      this.configuration = configuration;
+      this.transportConfiguration = transportConfiguration;
+      this.configuration = transportConfiguration.getCombinedParams();
 
       this.channel = channel;
 
@@ -427,11 +430,7 @@ public class NettyConnection implements Connection {
 
    @Override
    public final TransportConfiguration getConnectorConfig() {
-      if (configuration != null) {
-         return new TransportConfiguration(NettyConnectorFactory.class.getName(), this.configuration);
-      } else {
-         return null;
-      }
+      return transportConfiguration;
    }
 
    @Override
@@ -446,7 +445,7 @@ public class NettyConnection implements Connection {
          if (cfg == null) {
             continue;
          }
-         if (NettyConnectorFactory.class.getName().equals(cfg.getFactoryClassName())) {
+         if (Objects.equals(transportConfiguration.getFactoryClassName(), cfg.getFactoryClassName())) {
             int port1 = ConfigurationHelper.getIntProperty(TransportConstants.PORT_PROP_NAME, TransportConstants.DEFAULT_PORT, configuration);
             int port2 = ConfigurationHelper.getIntProperty(TransportConstants.PORT_PROP_NAME, TransportConstants.DEFAULT_PORT, cfg.getParams());
             if (port1 == port2) {

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnector.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnector.java
@@ -107,6 +107,7 @@ import io.netty.util.concurrent.GlobalEventExecutor;
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.Pair;
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.client.ActiveMQClientLogger;
 import org.apache.activemq.artemis.core.client.ActiveMQClientMessageBundle;
 import org.apache.activemq.artemis.core.protocol.core.impl.ActiveMQClientProtocolManager;
@@ -313,7 +314,7 @@ public class NettyConnector extends AbstractConnector {
 
    private final Map<String, String> httpHeaders;
 
-   public NettyConnector(final Map<String, Object> configuration,
+   public NettyConnector(final TransportConfiguration configuration,
                          final BufferHandler handler,
                          final BaseConnectionLifeCycleListener<?> listener,
                          final Executor closeExecutor,
@@ -322,7 +323,7 @@ public class NettyConnector extends AbstractConnector {
       this(configuration, handler, listener, closeExecutor, threadPool, scheduledThreadPool, new ActiveMQClientProtocolManager());
    }
 
-   public NettyConnector(final Map<String, Object> configuration,
+   public NettyConnector(final TransportConfiguration configuration,
                          final BufferHandler handler,
                          final BaseConnectionLifeCycleListener<?> listener,
                          final Executor closeExecutor,
@@ -332,7 +333,7 @@ public class NettyConnector extends AbstractConnector {
       this(configuration, handler, listener, closeExecutor, threadPool, scheduledThreadPool, protocolManager, false);
    }
 
-   public NettyConnector(final Map<String, Object> configuration,
+   public NettyConnector(final TransportConfiguration transportConfiguration,
                          final BufferHandler handler,
                          final BaseConnectionLifeCycleListener<?> listener,
                          final Executor closeExecutor,
@@ -340,7 +341,7 @@ public class NettyConnector extends AbstractConnector {
                          final ScheduledExecutorService scheduledThreadPool,
                          final ClientProtocolManager protocolManager,
                          final boolean serverConnection) {
-      super(configuration);
+      super(transportConfiguration);
 
       this.serverConnection = serverConnection;
 
@@ -995,7 +996,7 @@ public class NettyConnector extends AbstractConnector {
 
          // No acceptor on a client connection
          Listener connectionListener = new Listener();
-         NettyConnection conn = new NettyConnection(configuration, ch, connectionListener, !httpEnabled && batchDelay > 0, false);
+         NettyConnection conn = new NettyConnection(transportConfiguration, ch, connectionListener, !httpEnabled && batchDelay > 0, false);
          connectionListener.connectionCreated(null, conn, protocolManager);
          return conn;
       } else {

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnectorFactory.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnectorFactory.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.spi.core.remoting.BufferHandler;
 import org.apache.activemq.artemis.spi.core.remoting.ClientConnectionLifeCycleListener;
 import org.apache.activemq.artemis.spi.core.remoting.ClientProtocolManager;
@@ -40,7 +41,7 @@ public class NettyConnectorFactory implements ConnectorFactory {
    }
 
    @Override
-   public Connector createConnector(final Map<String, Object> configuration,
+   public Connector createConnector(final TransportConfiguration configuration,
                                     final BufferHandler handler,
                                     final ClientConnectionLifeCycleListener listener,
                                     final Executor closeExecutor,

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/protocol/RemotingConnection.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/protocol/RemotingConnection.java
@@ -200,6 +200,16 @@ public interface RemotingConnection extends BufferHandler {
    boolean checkDataReceived();
 
    /**
+    * Implementation specific flag to indicate momentary connection state. The process using this
+    * connection may choose to close it if it becomes unhealthy.
+    *
+    * @return true if it is currently healthy, false otherwise
+    */
+   default boolean isHealthy() {
+      return true;
+   }
+
+   /**
     * flush all outstanding data from the connection.
     */
    void flush();

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/AbstractConnector.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/AbstractConnector.java
@@ -18,14 +18,17 @@ package org.apache.activemq.artemis.spi.core.remoting;
 
 import java.util.Map;
 
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
+
 /**
  * Abstract connector
  */
 public abstract class AbstractConnector implements Connector {
-
+   protected final TransportConfiguration transportConfiguration;
    protected final Map<String, Object> configuration;
 
-   protected AbstractConnector(Map<String, Object> configuration) {
-      this.configuration = configuration;
+   protected AbstractConnector(TransportConfiguration configuration) {
+      this.transportConfiguration = configuration;
+      this.configuration = configuration.getCombinedParams();
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/ConnectorFactory.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/ConnectorFactory.java
@@ -16,10 +16,10 @@
  */
 package org.apache.activemq.artemis.spi.core.remoting;
 
-import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.TransportConfigurationHelper;
 
 /**
@@ -40,7 +40,7 @@ public interface ConnectorFactory extends TransportConfigurationHelper {
     * @param scheduledThreadPool the scheduled thread pool
     * @return a new connector
     */
-   Connector createConnector(Map<String, Object> configuration,
+   Connector createConnector(TransportConfiguration configuration,
                              BufferHandler handler,
                              ClientConnectionLifeCycleListener listener,
                              Executor closeExecutor,

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/AMQPBrokerConnection.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/AMQPBrokerConnection.java
@@ -357,7 +357,7 @@ public class AMQPBrokerConnection implements ClientConnectionLifeCycleListener, 
          ProtonProtocolManager protonProtocolManager =
             (ProtonProtocolManager)protonProtocolManagerFactory.createProtocolManager(server, configuration.getExtraParams(), null, null);
          NettyConnector connector = (NettyConnector)CONNECTOR_FACTORY.createConnector(
-            configuration.getParams(), null, this, server.getExecutorFactory().getExecutor(), server.getThreadPool(), server.getScheduledPool(), new ClientProtocolManagerWithAMQP(protonProtocolManager));
+            configuration, null, this, server.getExecutorFactory().getExecutor(), server.getThreadPool(), server.getScheduledPool(), new ClientProtocolManagerWithAMQP(protonProtocolManager));
          connector.start();
 
          logger.debug("Connecting {}", configuration);

--- a/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPConnectionContextTest.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPConnectionContextTest.java
@@ -22,8 +22,10 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.EventLoop;
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnection;
+import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.protocol.amqp.broker.AMQPConnectionCallback;
 import org.apache.activemq.artemis.protocol.amqp.broker.ProtonProtocolManager;
@@ -33,7 +35,7 @@ import org.apache.qpid.proton.engine.Connection;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 public class AMQPConnectionContextTest {
@@ -55,7 +57,8 @@ public class AMQPConnectionContextTest {
       Mockito.when(transportChannel.config()).thenReturn(Mockito.mock(ChannelConfig.class));
       Mockito.when(transportChannel.eventLoop()).thenReturn(eventLoop);
       Mockito.when(eventLoop.inEventLoop()).thenReturn(true);
-      NettyConnection transportConnection = new NettyConnection(new HashMap<>(), transportChannel, null, false, false);
+      NettyConnection transportConnection = new NettyConnection(new TransportConfiguration(
+              NettyConnectorFactory.class.getName(), Map.of(), "test"), transportChannel, null, false, false);
 
       Connection connection = Mockito.mock(Connection.class);
       AMQPConnectionCallback protonSPI = Mockito.mock(AMQPConnectionCallback.class);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -4162,6 +4162,25 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
       }
    }
 
+   @Override
+   public int countTopologyPeers(String clusterConnectionName) {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.listNetworkTopology(this.server);
+      }
+      checkStarted();
+
+      clearIO();
+      try {
+         ClusterConnection clusterConnection =
+                 server.getClusterManager().getClusterConnection(clusterConnectionName);
+         if (clusterConnection == null) {
+            throw new IllegalArgumentException(clusterConnectionName);
+         }
+         return clusterConnection.getTopology().getMembers().size();
+      } finally {
+         blockOnIO();
+      }
+   }
 
    @Override
    public String listNetworkTopology() throws Exception {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/CoreProtocolManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/CoreProtocolManager.java
@@ -291,7 +291,7 @@ public class CoreProtocolManager implements ProtocolManager<Interceptor, ActiveM
             }
 
             // Just send a ping back
-            channel0.send(packet);
+            channel0.send(new Ping(server.getNodeManager().getUUID(), ping.getConnectionTTL()));
          } else if (packet.getType() == PacketImpl.SUBSCRIBE_TOPOLOGY
             || packet.getType() == PacketImpl.SUBSCRIBE_TOPOLOGY_V2) {
             SubscribeClusterTopologyUpdatesMessage msg = (SubscribeClusterTopologyUpdatesMessage) packet;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/NodeAnnounceMessage.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/NodeAnnounceMessage.java
@@ -131,11 +131,11 @@ public class NodeAnnounceMessage extends PacketImpl {
       this.currentEventID = buffer.readLong();
       if (buffer.readBoolean()) {
          connector = new TransportConfiguration();
-         connector.decode(buffer);
+         connector.decode(nodeID, buffer);
       }
       if (buffer.readBoolean()) {
          backupConnector = new TransportConfiguration();
-         backupConnector.decode(buffer);
+         backupConnector.decode(nodeID, buffer);
       }
       scaleDownGroupName = buffer.readNullableString();
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/AbstractAcceptor.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/AbstractAcceptor.java
@@ -21,14 +21,20 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.activemq.artemis.api.core.BaseInterceptor;
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.spi.core.protocol.ProtocolManager;
 import org.apache.activemq.artemis.spi.core.remoting.Acceptor;
 
 public abstract class AbstractAcceptor implements Acceptor {
 
    protected final Map<String, ProtocolManager> protocolMap;
+   protected final Map<String, Object> configuration;
+   protected final TransportConfiguration transportConfiguration;
 
-   public AbstractAcceptor(Map<String, ProtocolManager> protocolMap) {
+   public AbstractAcceptor(TransportConfiguration transportConfiguration, Map<String,
+           ProtocolManager> protocolMap) {
+      this.transportConfiguration = transportConfiguration;
+      this.configuration = transportConfiguration.getCombinedParams();
       this.protocolMap = protocolMap;
    }
 
@@ -41,6 +47,11 @@ public abstract class AbstractAcceptor implements Acceptor {
       for (ProtocolManager manager : protocolMap.values()) {
          manager.updateInterceptors(incomingInterceptors, outgoingInterceptors);
       }
+   }
+
+   @Override
+   public Map<String, Object> getConfiguration() {
+      return Collections.unmodifiableMap(configuration);
    }
 
    public Map<String, ProtocolManager> getProtocolMap() {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMAcceptor.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMAcceptor.java
@@ -23,6 +23,7 @@ import java.util.concurrent.Executor;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.management.CoreNotificationType;
 import org.apache.activemq.artemis.core.remoting.impl.AbstractAcceptor;
@@ -63,8 +64,6 @@ public final class InVMAcceptor extends AbstractAcceptor {
 
    private NotificationService notificationService;
 
-   private final Map<String, Object> configuration;
-
    private ActiveMQPrincipal defaultActiveMQPrincipal;
 
    private final long connectionsAllowed;
@@ -77,18 +76,16 @@ public final class InVMAcceptor extends AbstractAcceptor {
 
    public InVMAcceptor(final String name,
                        final ClusterConnection clusterConnection,
-                       final Map<String, Object> configuration,
+                       final TransportConfiguration transportConfiguration,
                        final BufferHandler handler,
                        final ServerConnectionLifeCycleListener listener,
                        final Map<String, ProtocolManager> protocolMap,
                        final Executor threadPool) {
-      super(protocolMap);
+      super(transportConfiguration, protocolMap);
 
       this.name = name;
 
       this.clusterConnection = clusterConnection;
-
-      this.configuration = configuration;
 
       this.handler = handler;
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMAcceptorFactory.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMAcceptorFactory.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.server.cluster.ClusterConnection;
 import org.apache.activemq.artemis.spi.core.protocol.ProtocolManager;
 import org.apache.activemq.artemis.spi.core.remoting.Acceptor;
@@ -32,7 +33,7 @@ public class InVMAcceptorFactory implements AcceptorFactory {
    @Override
    public Acceptor createAcceptor(final String name,
                                   final ClusterConnection clusterConnection,
-                                  final Map<String, Object> configuration,
+                                  final TransportConfiguration configuration,
                                   final BufferHandler handler,
                                   final ServerConnectionLifeCycleListener listener,
                                   final Executor threadPool,

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMConnector.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMConnector.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.core.server.ActiveMQComponent;
 import org.apache.activemq.artemis.core.server.ActiveMQMessageBundle;
@@ -133,13 +134,13 @@ public class InVMConnector extends AbstractConnector {
       return threadPoolExecutor;
    }
 
-   public InVMConnector(final Map<String, Object> configuration,
+   public InVMConnector(final TransportConfiguration transportConfiguration,
                         final BufferHandler handler,
                         final ClientConnectionLifeCycleListener listener,
                         final Executor closeExecutor,
                         final Executor threadPool,
                         ClientProtocolManager protocolManager) {
-      super(configuration);
+      super(transportConfiguration);
       this.listener = listener;
 
       id = ConfigurationHelper.getIntProperty(TransportConstants.SERVER_ID_PROP_NAME, 0, configuration);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMConnectorFactory.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMConnectorFactory.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.spi.core.remoting.BufferHandler;
 import org.apache.activemq.artemis.spi.core.remoting.ClientConnectionLifeCycleListener;
 import org.apache.activemq.artemis.spi.core.remoting.ClientProtocolManager;
@@ -29,7 +30,7 @@ import org.apache.activemq.artemis.spi.core.remoting.ConnectorFactory;
 public class InVMConnectorFactory implements ConnectorFactory {
 
    @Override
-   public Connector createConnector(final Map<String, Object> configuration,
+   public Connector createConnector(final TransportConfiguration configuration,
                                     final BufferHandler handler,
                                     final ClientConnectionLifeCycleListener listener,
                                     final Executor closeExecutor,

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptor.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptor.java
@@ -209,8 +209,6 @@ public class NettyAcceptor extends AbstractAcceptor {
 
    private final ConcurrentMap<Object, NettyServerConnection> connections = new ConcurrentHashMap<>();
 
-   private final Map<String, Object> configuration;
-
    private final ScheduledExecutorService scheduledThreadPool;
 
    private NotificationService notificationService;
@@ -249,21 +247,19 @@ public class NettyAcceptor extends AbstractAcceptor {
 
    public NettyAcceptor(final String name,
                         final ClusterConnection clusterConnection,
-                        final Map<String, Object> configuration,
+                        final TransportConfiguration transportConfiguration,
                         final BufferHandler handler,
                         final ServerConnectionLifeCycleListener listener,
                         final ScheduledExecutorService scheduledThreadPool,
                         final Executor failureExecutor,
                         final Map<String, ProtocolManager> protocolMap) {
-      super(protocolMap);
+      super(transportConfiguration, protocolMap);
 
       this.failureExecutor = failureExecutor;
 
       this.name = name;
 
       this.clusterConnection = clusterConnection;
-
-      this.configuration = configuration;
 
       this.handler = handler;
 
@@ -913,7 +909,7 @@ public class NettyAcceptor extends AbstractAcceptor {
             super.channelActive(ctx);
             Listener connectionListener = new Listener();
 
-            NettyServerConnection nc = new NettyServerConnection(configuration, ctx.channel(), connectionListener, !httpEnabled && batchDelay > 0, directDeliver, router);
+            NettyServerConnection nc = new NettyServerConnection(transportConfiguration, ctx.channel(), connectionListener, !httpEnabled && batchDelay > 0, directDeliver, router);
 
             connectionListener.connectionCreated(NettyAcceptor.this, nc, protocolHandler.getProtocol(protocol));
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptorFactory.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptorFactory.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.server.cluster.ClusterConnection;
 import org.apache.activemq.artemis.spi.core.protocol.ProtocolManager;
 import org.apache.activemq.artemis.spi.core.remoting.Acceptor;
@@ -33,7 +34,7 @@ public class NettyAcceptorFactory implements AcceptorFactory {
    @Override
    public Acceptor createAcceptor(final String name,
                                   final ClusterConnection connection,
-                                  final Map<String, Object> configuration,
+                                  final TransportConfiguration configuration,
                                   final BufferHandler handler,
                                   final ServerConnectionLifeCycleListener listener,
                                   final Executor threadPool,

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyServerConnection.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyServerConnection.java
@@ -16,9 +16,9 @@
  */
 package org.apache.activemq.artemis.core.remoting.impl.netty;
 
-import java.util.Map;
-
 import io.netty.channel.Channel;
+
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.spi.core.remoting.ServerConnectionLifeCycleListener;
 
 public class NettyServerConnection extends NettyConnection {
@@ -27,7 +27,7 @@ public class NettyServerConnection extends NettyConnection {
 
    private final String router;
 
-   public NettyServerConnection(Map<String, Object> configuration,
+   public NettyServerConnection(TransportConfiguration configuration,
                                 Channel channel,
                                 ServerConnectionLifeCycleListener listener,
                                 boolean batchingEnabled,

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/server/impl/RemotingServiceImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/server/impl/RemotingServiceImpl.java
@@ -264,7 +264,7 @@ public class RemotingServiceImpl implements RemotingService, ServerConnectionLif
             selectedProtocols.put(entry.getKey(), entry.getValue().createProtocolManager(server, info.getCombinedParams(), incomingInterceptors, outgoingInterceptors));
          }
 
-         acceptor = factory.createAcceptor(info.getName(), clusterConnection, info.getParams(), new DelegatingBufferHandler(), this, threadPool, scheduledThreadPool, selectedProtocols);
+         acceptor = factory.createAcceptor(info.getName(), clusterConnection, info, new DelegatingBufferHandler(), this, threadPool, scheduledThreadPool, selectedProtocols);
 
          if (defaultInvmSecurityPrincipal != null && acceptor.isUnsecurable()) {
             acceptor.setDefaultActiveMQPrincipal(defaultInvmSecurityPrincipal);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ClusterController.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ClusterController.java
@@ -52,6 +52,7 @@ import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
 import org.apache.activemq.artemis.core.server.cluster.quorum.QuorumManager;
 import org.apache.activemq.artemis.core.server.impl.Activation;
 import org.apache.activemq.artemis.spi.core.remoting.Acceptor;
+import org.apache.activemq.artemis.utils.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.lang.invoke.MethodHandles;
@@ -225,6 +226,7 @@ public class ClusterController implements ActiveMQComponent {
                              ServerLocatorInternal serverLocator,
                              ClusterConnectionConfiguration config,
                              TransportConfiguration connector) {
+      serverLocator.setNodeUUID(getNodeUUID());
       serverLocator.setConnectionTTL(config.getConnectionTTL());
       serverLocator.setClientFailureCheckPeriod(config.getClientFailureCheckPeriod());
       //if the cluster isn't available we want to hang around until it is
@@ -369,6 +371,10 @@ public class ClusterController implements ActiveMQComponent {
 
    public SimpleString getNodeID() {
       return server.getNodeID();
+   }
+
+   public UUID getNodeUUID() {
+      return server.getNodeManager().getUUID();
    }
 
    public String getIdentity() {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/impl/ClusterConnectionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/impl/ClusterConnectionImpl.java
@@ -75,6 +75,7 @@ import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
 import org.apache.activemq.artemis.utils.CompositeAddress;
 import org.apache.activemq.artemis.utils.ExecutorFactory;
 import org.apache.activemq.artemis.utils.FutureLatch;
+import org.apache.activemq.artemis.utils.UUID;
 import org.apache.activemq.artemis.utils.collections.TypedProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -687,6 +688,7 @@ public final class ClusterConnectionImpl implements ClusterConnection, AfterConn
          }
 
          serverLocator.setNodeID(nodeManager.getNodeId().toString());
+         serverLocator.setNodeUUID(nodeManager.getUUID());
          serverLocator.setIdentity("(main-ClusterConnection::" + server.toString() + ")");
          serverLocator.setReconnectAttempts(0);
          serverLocator.setClusterConnection(true);
@@ -858,6 +860,7 @@ public final class ClusterConnectionImpl implements ClusterConnection, AfterConn
                                 final Queue queue,
                                 final boolean start) throws Exception {
       String nodeId;
+      UUID nodeUUID;
 
       synchronized (this) {
          if (!started) {
@@ -869,6 +872,7 @@ public final class ClusterConnectionImpl implements ClusterConnection, AfterConn
          }
 
          nodeId = serverLocator.getNodeID();
+         nodeUUID = serverLocator.getNodeUUID();
       }
 
       final ServerLocatorInternal targetLocator = new ServerLocatorImpl(topology, true, connector);
@@ -898,6 +902,7 @@ public final class ClusterConnectionImpl implements ClusterConnection, AfterConn
       serverLocator.setProtocolManagerFactory(ActiveMQServerSideProtocolManagerFactory.getInstance(serverLocator, server.getStorageManager()));
 
       targetLocator.setNodeID(nodeId);
+      targetLocator.setNodeUUID(nodeUUID);
 
       targetLocator.setClusterTransportConfiguration(serverLocator.getClusterTransportConfiguration());
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/remoting/AcceptorFactory.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/remoting/AcceptorFactory.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.server.cluster.ClusterConnection;
 import org.apache.activemq.artemis.spi.core.protocol.ProtocolManager;
 
@@ -44,7 +45,7 @@ public interface AcceptorFactory {
     */
    Acceptor createAcceptor(String name,
                            ClusterConnection clusterConnection,
-                           Map<String, Object> configuration,
+                           TransportConfiguration configuration,
                            BufferHandler handler,
                            ServerConnectionLifeCycleListener listener,
                            Executor threadPool,

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/uri/AcceptorParserTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/uri/AcceptorParserTest.java
@@ -54,7 +54,7 @@ public class AcceptorParserTest {
       assertEquals(33, ConfigurationHelper.getIntProperty(TransportConstants.QUIET_PERIOD, -1, configs.get(0).getParams()));
       assertEquals(55, ConfigurationHelper.getIntProperty(TransportConstants.SHUTDOWN_TIMEOUT, -1, configs.get(0).getParams()));
 
-      NettyAcceptor nettyAcceptor = new NettyAcceptor("name", null, configs.get(0).getParams(), null, null, null, null, new HashMap<>());
+      NettyAcceptor nettyAcceptor = new NettyAcceptor("name", null, configs.get(0), null, null, null, null, new HashMap<>());
 
       assertEquals(33, nettyAcceptor.getQuietPeriod());
       assertEquals(55, nettyAcceptor.getShutdownTimeout());

--- a/artemis-unit-test-support/src/main/java/org/apache/activemq/artemis/tests/extensions/ThreadLeakCheckDelegate.java
+++ b/artemis-unit-test-support/src/main/java/org/apache/activemq/artemis/tests/extensions/ThreadLeakCheckDelegate.java
@@ -269,6 +269,8 @@ public class ThreadLeakCheckDelegate {
          return true;
       } else if (threadName.contains("ForkJoinPool.commonPool")) {
          return true;
+      } else if (threadName.contains("CompletableFutureDelayScheduler")) {
+         return true;
       } else if (threadName.contains("GC Daemon")) {
          return true;
       } else if (threadName.contains("junit-jupiter-timeout-watcher")) {

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/artemis/utils/RealServerTestBase.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/artemis/utils/RealServerTestBase.java
@@ -80,9 +80,13 @@ public class RealServerTestBase extends ActiveMQTestBase {
    }
 
    public void killServer(Process process) {
+      killServer(process, false);
+   }
+
+   public void killServer(Process process, boolean forcibly) {
       processes.remove(process);
       try {
-         ServerUtil.killServer(process);
+         ServerUtil.killServer(process, forcibly);
       } catch (Throwable e) {
          e.printStackTrace();
       }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpOutboundConnectionTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpOutboundConnectionTest.java
@@ -31,8 +31,10 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.ActiveMQRemoteDisconnectException;
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.remoting.FailureListener;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnector;
+import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory;
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.protocol.amqp.broker.ProtonProtocolManagerFactory;
@@ -108,7 +110,8 @@ public class AmqpOutboundConnectionTest extends AmqpClientTestSupport {
 
       ProtonClientConnectionManager lifeCycleListener = new ProtonClientConnectionManager(new AMQPClientConnectionFactory(server, "myid", Collections.singletonMap(Symbol.getSymbol("myprop"), "propvalue"), 5000), Optional.of(eventHandler), clientSASLFactory);
       ProtonClientProtocolManager protocolManager = new ProtonClientProtocolManager(new ProtonProtocolManagerFactory(), server);
-      NettyConnector connector = new NettyConnector(config, lifeCycleListener, lifeCycleListener, server.getExecutorFactory().getExecutor(), server.getExecutorFactory().getExecutor(), server.getScheduledPool(), protocolManager);
+      TransportConfiguration configuration = new TransportConfiguration(NettyConnectorFactory.class.getName(), config, "test");
+      NettyConnector connector = new NettyConnector(configuration, lifeCycleListener, lifeCycleListener, server.getExecutorFactory().getExecutor(), server.getExecutorFactory().getExecutor(), server.getScheduledPool(), protocolManager);
       connector.start();
 
       Object connectionId = connector.createConnection().getID();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSSaslExternalTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSSaslExternalTest.java
@@ -40,6 +40,7 @@ import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptorFactory;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnector;
+import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory;
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.core.security.Role;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
@@ -222,7 +223,8 @@ public class JMSSaslExternalTest extends ActiveMQTestBase {
 
       ProtonClientConnectionManager lifeCycleListener = new ProtonClientConnectionManager(new AMQPClientConnectionFactory(server, "myid", Collections.singletonMap(Symbol.getSymbol("myprop"), "propvalue"), 5000), Optional.of(eventHandler), clientSASLFactory);
       ProtonClientProtocolManager protocolManager = new ProtonClientProtocolManager(new ProtonProtocolManagerFactory(), server);
-      NettyConnector connector = new NettyConnector(config, lifeCycleListener, lifeCycleListener, server.getExecutorFactory().getExecutor(), server.getExecutorFactory().getExecutor(), server.getScheduledPool(), protocolManager);
+      TransportConfiguration configuration = new TransportConfiguration(NettyConnectorFactory.class.getName(), config, "test");
+      NettyConnector connector = new NettyConnector(configuration, lifeCycleListener, lifeCycleListener, server.getExecutorFactory().getExecutor(), server.getExecutorFactory().getExecutor(), server.getScheduledPool(), protocolManager);
       connector.start();
       connector.createConnection();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSSaslGssapiTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSSaslGssapiTest.java
@@ -52,7 +52,9 @@ import javax.jms.Queue;
 import javax.jms.Session;
 import javax.jms.TextMessage;
 
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnector;
+import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory;
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.core.security.Role;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
@@ -302,7 +304,8 @@ public class JMSSaslGssapiTest extends JMSClientTestSupport {
 
       ProtonClientConnectionManager lifeCycleListener = new ProtonClientConnectionManager(new AMQPClientConnectionFactory(server, "myid", Collections.singletonMap(Symbol.getSymbol("myprop"), "propvalue"), 5000), Optional.of(eventHandler), clientSASLFactory);
       ProtonClientProtocolManager protocolManager = new ProtonClientProtocolManager(new ProtonProtocolManagerFactory(), server);
-      NettyConnector connector = new NettyConnector(config, lifeCycleListener, lifeCycleListener, server.getExecutorFactory().getExecutor(), server.getExecutorFactory().getExecutor(), server.getScheduledPool(), protocolManager);
+      TransportConfiguration configuration = new TransportConfiguration(NettyConnectorFactory.class.getName(), config, "test");
+      NettyConnector connector = new NettyConnector(configuration, lifeCycleListener, lifeCycleListener, server.getExecutorFactory().getExecutor(), server.getExecutorFactory().getExecutor(), server.getScheduledPool(), protocolManager);
       connector.start();
       connector.createConnection();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/ZeroPersistenceSymmetricalClusterTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/distribution/ZeroPersistenceSymmetricalClusterTest.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.tests.integration.cluster.distribution;
+
+import java.io.File;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.management.MBeanServerConnection;
+import javax.management.MBeanServerInvocationHandler;
+import javax.management.remote.JMXConnector;
+
+import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
+import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl;
+import org.apache.activemq.artemis.api.core.management.ObjectNameBuilder;
+import org.apache.activemq.artemis.utils.RealServerTestBase;
+import org.apache.activemq.artemis.utils.cli.helper.HelperCreate;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Verifies ARTEMIS-4305. Servers 2 and 3 are deliberately configured on the same port.
+ */
+// to run locally on OSX see https://issues.apache.org/jira/browse/ARTEMIS-2341
+public class ZeroPersistenceSymmetricalClusterTest extends RealServerTestBase {
+   private static final Logger log = LoggerFactory.getLogger(ZeroPersistenceSymmetricalClusterTest.class);
+
+   public static final String SERVER_NAME_0 = "0";
+   public static final String SERVER_NAME_1 = "1";
+   public static final String SERVER_NAME_2 = "2";
+   public static final String SERVER_NAME_3 = "3";
+
+   private static final int TOTAL_TOPOLOGY_AWAIT_SECONDS = 90;
+
+   private ScheduledExecutorService s;
+
+   @BeforeEach
+   @Override
+   public void setUp() throws Exception {
+      super.setUp();
+      cleanupData(SERVER_NAME_0);
+      cleanupData(SERVER_NAME_1);
+      cleanupData(SERVER_NAME_2);
+      cleanupData(SERVER_NAME_3);
+      s = Executors.newSingleThreadScheduledExecutor();
+   }
+
+   @AfterEach
+   @Override
+   public void after() throws Exception {
+      super.after();
+      s.shutdownNow();
+      cleanupData(SERVER_NAME_0);
+      cleanupData(SERVER_NAME_1);
+      cleanupData(SERVER_NAME_2);
+      cleanupData(SERVER_NAME_3);
+   }
+
+   @Test
+   public void test() throws Throwable {
+      createServer(SERVER_NAME_0);
+      createServer(SERVER_NAME_1);
+      createServer(SERVER_NAME_2);
+      Process s0 = startServer(SERVER_NAME_0, 0, 5000);
+      Process s1 = startServer(SERVER_NAME_1, 1, 5000);
+      Process s2 = startServer(SERVER_NAME_2, 2, 5000);
+      await(
+         expectTopology(SERVER_NAME_0, 0, 3),
+         expectTopology(SERVER_NAME_1, 1, 3),
+         expectTopology(SERVER_NAME_2, 2, 3)
+      );
+      killServer(s2, true);
+      await(
+         expectTopology(SERVER_NAME_0, 0, 2),
+         expectTopology(SERVER_NAME_1, 1, 2)
+      );
+      createServer(SERVER_NAME_3);
+      startServer(SERVER_NAME_3, 3, 5000);
+      killServer(s0, true);
+      killServer(s1, true);
+      cleanupData(SERVER_NAME_0);
+      cleanupData(SERVER_NAME_1);
+      await(expectTopology(SERVER_NAME_3, 3, 1));
+      createServer(SERVER_NAME_0);
+      createServer(SERVER_NAME_1);
+      startServer(SERVER_NAME_0, 0, 5000);
+      startServer(SERVER_NAME_1, 1, 5000);
+      await(
+         expectTopology(SERVER_NAME_0, 0, 3),
+         expectTopology(SERVER_NAME_1, 1, 3),
+         expectTopology(SERVER_NAME_3, 3, 3)
+      );
+   }
+
+   private void createServer(String name) throws Exception {
+      File serverLocation = getFileServerLocation(name);
+      deleteDirectory(serverLocation);
+
+      HelperCreate cliCreateServer = new HelperCreate()
+         .setAllowAnonymous(true)
+         .setNoWeb(true)
+         .setArtemisInstance(serverLocation)
+         .setConfiguration("./src/test/resources/servers/symmetric-discovery" + name)
+         .setJavaOptions("-Djava.rmi.server.hostname=localhost -Djava.net.preferIPv4Stack=true");
+      cliCreateServer.createServer();
+   }
+
+   private void await(CompletableFuture<?>... tasks) throws Throwable {
+      Throwable result = CompletableFuture
+         .allOf(tasks)
+         .orTimeout(TOTAL_TOPOLOGY_AWAIT_SECONDS, TimeUnit.SECONDS)
+         .handle((v, t) -> t).join();
+      if (result instanceof CompletionException && result.getCause() instanceof TimeoutException) {
+         fail("The nodes did not get the expected topology on time");
+      }
+      if (result != null) {
+         throw result;
+      }
+   }
+
+   // wait to get the expected count, and then wait 5 more seconds and check again
+   private CompletableFuture<?> expectTopology(String name, int node, int expectedCount) throws Exception {
+      JMXConnector jmxConnector = getJmxConnector("localhost", 10090 + node);
+      MBeanServerConnection mBeanServerConnection = jmxConnector.getMBeanServerConnection();
+      ObjectNameBuilder objectNameBuilder = ObjectNameBuilder.create(
+         ActiveMQDefaultConfiguration.getDefaultJmxDomain(),
+         name,
+         true);
+
+      ActiveMQServerControl control = MBeanServerInvocationHandler.newProxyInstance(
+         mBeanServerConnection,
+         objectNameBuilder.getActiveMQServerObjectName(),
+         ActiveMQServerControl.class,
+         false);
+      CompletableFuture<?> monitor = new CompletableFuture<>().orTimeout(TOTAL_TOPOLOGY_AWAIT_SECONDS, TimeUnit.SECONDS);
+      ScheduledFuture<?> notifier = s.scheduleAtFixedRate(() -> {
+         try {
+            int count = getNodeCount(name, control);
+            log.debug("Node count at {}: {}", name, count);
+            if (count == expectedCount) {
+               s.schedule(() -> {
+                  try {
+                     int countAfter = getNodeCount(name, control);
+                     if (countAfter == expectedCount) {
+                        monitor.complete(null);
+                     }
+                  } catch (Exception e) {
+                     monitor.completeExceptionally(e);
+                  }
+               }, 5, TimeUnit.SECONDS);
+               throw new CancellationException();
+            }
+         } catch (CancellationException e) {
+            throw e;
+         } catch (Exception e) {
+            monitor.completeExceptionally(e);
+         }
+      }, 500, 500, TimeUnit.MILLISECONDS);
+      return monitor.whenComplete((v, t) -> {
+         notifier.cancel(true);
+         try {
+            if (log.isDebugEnabled()) {
+               log.debug("Final topology for {}:{}{}", name, System.lineSeparator(), control.listNetworkTopology());
+            }
+            jmxConnector.close();
+         } catch (Exception e) {
+            log.debug("Could not close the jmx connector");
+         }
+      });
+   }
+
+   private int getNodeCount(String serverName, ActiveMQServerControl control) {
+      try {
+         return control.countTopologyPeers("cluster0");
+      } catch (Exception e) {
+         log.debug("Could not get the node count of " + serverName, e);
+         throw new RuntimeException(e);
+      }
+   }
+}

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
@@ -1450,6 +1450,11 @@ public class ActiveMQServerControlUsingCoreTest extends ActiveMQServerControlTes
          }
 
          @Override
+         public int countTopologyPeers(String clusterConnectionName) throws Exception {
+            return (int) proxy.invokeOperation("countTopologyPeers", clusterConnectionName);
+         }
+
+         @Override
          public String getAddressInfo(String address) throws ActiveMQAddressDoesNotExistException {
             return null;
          }

--- a/tests/integration-tests/src/test/resources/servers/symmetric-discovery0/broker.xml
+++ b/tests/integration-tests/src/test/resources/servers/symmetric-discovery0/broker.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<configuration xmlns="urn:activemq" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="urn:activemq /schema/artemis-server.xsd">
+    <core xmlns="urn:activemq:core">
+        <name>0</name>
+        <persistence-enabled>false</persistence-enabled>
+        <bindings-directory>./data/bindings</bindings-directory>
+        <journal-directory>./data/journal</journal-directory>
+        <large-messages-directory>./data/largemessages</large-messages-directory>
+        <paging-directory>./data/paging</paging-directory>
+        <security-enabled>false</security-enabled>
+        <journal-compact-min-files>0</journal-compact-min-files>
+        <journal-compact-percentage>0</journal-compact-percentage>
+        <journal-datasync>false</journal-datasync>
+        <jmx-management-enabled>true</jmx-management-enabled>
+        <global-max-messages>67108864</global-max-messages>
+        <journal-sync-non-transactional>false</journal-sync-non-transactional>
+        <journal-min-files>2</journal-min-files>
+        <journal-file-size>10485760</journal-file-size>
+        <max-disk-usage>100</max-disk-usage>
+        <ha-policy>
+            <primary-only/>
+        </ha-policy>
+
+        <connectors>
+            <connector name="netty-connector">tcp://localhost:61616</connector>
+        </connectors>
+
+        <!-- Acceptors -->
+        <acceptors>
+            <acceptor name="netty-acceptor">tcp://localhost:61616</acceptor>
+        </acceptors>
+
+        <broadcast-groups>
+            <broadcast-group name="bg1">
+                <local-bind-address>127.0.0.1</local-bind-address>
+                <group-address>230.1.2.3</group-address>
+                <group-port>6001</group-port>
+                <broadcast-period>500</broadcast-period>
+                <connector-ref>netty-connector</connector-ref>
+            </broadcast-group>
+        </broadcast-groups>
+        <discovery-groups>
+            <discovery-group name="dg1">
+                <local-bind-address>127.0.0.1</local-bind-address>
+                <group-address>230.1.2.3</group-address>
+                <group-port>6001</group-port>
+                <refresh-timeout>10000</refresh-timeout>
+                <initial-wait-timeout>1000</initial-wait-timeout>
+            </discovery-group>
+        </discovery-groups>
+        <cluster-connections>
+            <cluster-connection name="cluster0">
+                <connector-ref>netty-connector</connector-ref>
+                <connection-ttl>60000</connection-ttl>
+                <notification-attempts>120</notification-attempts>
+                <notification-interval>1000</notification-interval>
+                <check-period>30000</check-period>
+                <retry-interval>2000</retry-interval>
+                <max-retry-interval>20000</max-retry-interval>
+                <retry-interval-multiplier>2</retry-interval-multiplier>
+                <reconnect-attempts>-1</reconnect-attempts>
+                <initial-connect-attempts>-1</initial-connect-attempts>
+                <use-duplicate-detection>true</use-duplicate-detection>
+                <message-load-balancing>STRICT</message-load-balancing>
+                <max-hops>1</max-hops>
+                <producer-window-size>-1</producer-window-size>
+                <discovery-group-ref discovery-group-name="dg1"/>
+            </cluster-connection>
+        </cluster-connections>
+    </core>
+</configuration>

--- a/tests/integration-tests/src/test/resources/servers/symmetric-discovery0/management.xml
+++ b/tests/integration-tests/src/test/resources/servers/symmetric-discovery0/management.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License. You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<management-context xmlns="http://activemq.apache.org/schema">
+   <connector connector-port="10090" connector-host="localhost"/>
+</management-context>

--- a/tests/integration-tests/src/test/resources/servers/symmetric-discovery1/broker.xml
+++ b/tests/integration-tests/src/test/resources/servers/symmetric-discovery1/broker.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<configuration xmlns="urn:activemq" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="urn:activemq /schema/artemis-server.xsd">
+    <core xmlns="urn:activemq:core">
+        <name>1</name>
+        <persistence-enabled>false</persistence-enabled>
+        <bindings-directory>./data/bindings</bindings-directory>
+        <journal-directory>./data/journal</journal-directory>
+        <large-messages-directory>./data/largemessages</large-messages-directory>
+        <paging-directory>./data/paging</paging-directory>
+        <security-enabled>false</security-enabled>
+        <journal-compact-min-files>0</journal-compact-min-files>
+        <journal-compact-percentage>0</journal-compact-percentage>
+        <journal-datasync>false</journal-datasync>
+        <jmx-management-enabled>true</jmx-management-enabled>
+        <global-max-messages>67108864</global-max-messages>
+        <journal-sync-non-transactional>false</journal-sync-non-transactional>
+        <journal-min-files>2</journal-min-files>
+        <journal-file-size>10485760</journal-file-size>
+        <max-disk-usage>100</max-disk-usage>
+        <ha-policy>
+            <primary-only/>
+        </ha-policy>
+
+        <connectors>
+            <connector name="netty-connector">tcp://localhost:61617</connector>
+        </connectors>
+
+        <!-- Acceptors -->
+        <acceptors>
+            <acceptor name="netty-acceptor">tcp://localhost:61617</acceptor>
+        </acceptors>
+
+        <broadcast-groups>
+            <broadcast-group name="bg1">
+                <local-bind-address>127.0.0.1</local-bind-address>
+                <group-address>230.1.2.3</group-address>
+                <group-port>6001</group-port>
+                <broadcast-period>500</broadcast-period>
+                <connector-ref>netty-connector</connector-ref>
+            </broadcast-group>
+        </broadcast-groups>
+        <discovery-groups>
+            <discovery-group name="dg1">
+                <local-bind-address>127.0.0.1</local-bind-address>
+                <group-address>230.1.2.3</group-address>
+                <group-port>6001</group-port>
+                <refresh-timeout>10000</refresh-timeout>
+                <initial-wait-timeout>1000</initial-wait-timeout>
+            </discovery-group>
+        </discovery-groups>
+        <cluster-connections>
+            <cluster-connection name="cluster0">
+                <connector-ref>netty-connector</connector-ref>
+                <connection-ttl>60000</connection-ttl>
+                <notification-attempts>120</notification-attempts>
+                <notification-interval>1000</notification-interval>
+                <check-period>30000</check-period>
+                <retry-interval>2000</retry-interval>
+                <max-retry-interval>20000</max-retry-interval>
+                <retry-interval-multiplier>2</retry-interval-multiplier>
+                <reconnect-attempts>-1</reconnect-attempts>
+                <initial-connect-attempts>-1</initial-connect-attempts>
+                <use-duplicate-detection>true</use-duplicate-detection>
+                <message-load-balancing>STRICT</message-load-balancing>
+                <max-hops>1</max-hops>
+                <producer-window-size>-1</producer-window-size>
+                <discovery-group-ref discovery-group-name="dg1"/>
+            </cluster-connection>
+        </cluster-connections>
+    </core>
+</configuration>

--- a/tests/integration-tests/src/test/resources/servers/symmetric-discovery1/management.xml
+++ b/tests/integration-tests/src/test/resources/servers/symmetric-discovery1/management.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License. You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<management-context xmlns="http://activemq.apache.org/schema">
+   <connector connector-port="10091" connector-host="localhost"/>
+</management-context>

--- a/tests/integration-tests/src/test/resources/servers/symmetric-discovery2/broker.xml
+++ b/tests/integration-tests/src/test/resources/servers/symmetric-discovery2/broker.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<configuration xmlns="urn:activemq" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="urn:activemq /schema/artemis-server.xsd">
+    <core xmlns="urn:activemq:core">
+        <name>2</name>
+        <persistence-enabled>false</persistence-enabled>
+        <bindings-directory>./data/bindings</bindings-directory>
+        <journal-directory>./data/journal</journal-directory>
+        <large-messages-directory>./data/largemessages</large-messages-directory>
+        <paging-directory>./data/paging</paging-directory>
+        <security-enabled>false</security-enabled>
+        <journal-compact-min-files>0</journal-compact-min-files>
+        <journal-compact-percentage>0</journal-compact-percentage>
+        <journal-datasync>false</journal-datasync>
+        <jmx-management-enabled>true</jmx-management-enabled>
+        <global-max-messages>67108864</global-max-messages>
+        <journal-sync-non-transactional>false</journal-sync-non-transactional>
+        <journal-min-files>2</journal-min-files>
+        <journal-file-size>10485760</journal-file-size>
+        <max-disk-usage>100</max-disk-usage>
+        <ha-policy>
+            <primary-only/>
+        </ha-policy>
+
+        <connectors>
+            <connector name="netty-connector">tcp://localhost:61618</connector>
+        </connectors>
+
+        <!-- Acceptors -->
+        <acceptors>
+            <acceptor name="netty-acceptor">tcp://localhost:61618</acceptor>
+        </acceptors>
+
+        <broadcast-groups>
+            <broadcast-group name="bg1">
+                <local-bind-address>127.0.0.1</local-bind-address>
+                <group-address>230.1.2.3</group-address>
+                <group-port>6001</group-port>
+                <broadcast-period>500</broadcast-period>
+                <connector-ref>netty-connector</connector-ref>
+            </broadcast-group>
+        </broadcast-groups>
+        <discovery-groups>
+            <discovery-group name="dg1">
+                <local-bind-address>127.0.0.1</local-bind-address>
+                <group-address>230.1.2.3</group-address>
+                <group-port>6001</group-port>
+                <refresh-timeout>10000</refresh-timeout>
+                <initial-wait-timeout>1000</initial-wait-timeout>
+            </discovery-group>
+        </discovery-groups>
+        <cluster-connections>
+            <cluster-connection name="cluster0">
+                <connector-ref>netty-connector</connector-ref>
+                <connection-ttl>60000</connection-ttl>
+                <notification-attempts>120</notification-attempts>
+                <notification-interval>1000</notification-interval>
+                <check-period>30000</check-period>
+                <retry-interval>2000</retry-interval>
+                <max-retry-interval>20000</max-retry-interval>
+                <retry-interval-multiplier>2</retry-interval-multiplier>
+                <reconnect-attempts>-1</reconnect-attempts>
+                <initial-connect-attempts>-1</initial-connect-attempts>
+                <use-duplicate-detection>true</use-duplicate-detection>
+                <message-load-balancing>STRICT</message-load-balancing>
+                <max-hops>1</max-hops>
+                <producer-window-size>-1</producer-window-size>
+                <discovery-group-ref discovery-group-name="dg1"/>
+            </cluster-connection>
+        </cluster-connections>
+    </core>
+</configuration>

--- a/tests/integration-tests/src/test/resources/servers/symmetric-discovery2/management.xml
+++ b/tests/integration-tests/src/test/resources/servers/symmetric-discovery2/management.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License. You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<management-context xmlns="http://activemq.apache.org/schema">
+   <connector connector-port="10092" connector-host="localhost"/>
+</management-context>

--- a/tests/integration-tests/src/test/resources/servers/symmetric-discovery3/broker.xml
+++ b/tests/integration-tests/src/test/resources/servers/symmetric-discovery3/broker.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<configuration xmlns="urn:activemq" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="urn:activemq /schema/artemis-server.xsd">
+    <core xmlns="urn:activemq:core">
+        <name>3</name>
+        <persistence-enabled>false</persistence-enabled>
+        <bindings-directory>./data/bindings</bindings-directory>
+        <journal-directory>./data/journal</journal-directory>
+        <large-messages-directory>./data/largemessages</large-messages-directory>
+        <paging-directory>./data/paging</paging-directory>
+        <security-enabled>false</security-enabled>
+        <journal-compact-min-files>0</journal-compact-min-files>
+        <journal-compact-percentage>0</journal-compact-percentage>
+        <journal-datasync>false</journal-datasync>
+        <jmx-management-enabled>true</jmx-management-enabled>
+        <global-max-messages>67108864</global-max-messages>
+        <journal-sync-non-transactional>false</journal-sync-non-transactional>
+        <journal-min-files>2</journal-min-files>
+        <journal-file-size>10485760</journal-file-size>
+        <max-disk-usage>100</max-disk-usage>
+        <ha-policy>
+            <primary-only/>
+        </ha-policy>
+
+        <connectors>
+            <connector name="netty-connector">tcp://localhost:61618</connector>
+        </connectors>
+
+        <!-- Acceptors -->
+        <acceptors>
+            <acceptor name="netty-acceptor">tcp://localhost:61618</acceptor>
+        </acceptors>
+
+        <broadcast-groups>
+            <broadcast-group name="bg1">
+                <local-bind-address>127.0.0.1</local-bind-address>
+                <group-address>230.1.2.3</group-address>
+                <group-port>6001</group-port>
+                <broadcast-period>500</broadcast-period>
+                <connector-ref>netty-connector</connector-ref>
+            </broadcast-group>
+        </broadcast-groups>
+        <discovery-groups>
+            <discovery-group name="dg1">
+                <local-bind-address>127.0.0.1</local-bind-address>
+                <group-address>230.1.2.3</group-address>
+                <group-port>6001</group-port>
+                <refresh-timeout>10000</refresh-timeout>
+                <initial-wait-timeout>1000</initial-wait-timeout>
+            </discovery-group>
+        </discovery-groups>
+        <cluster-connections>
+            <cluster-connection name="cluster0">
+                <connector-ref>netty-connector</connector-ref>
+                <connection-ttl>60000</connection-ttl>
+                <notification-attempts>120</notification-attempts>
+                <notification-interval>1000</notification-interval>
+                <check-period>30000</check-period>
+                <retry-interval>2000</retry-interval>
+                <max-retry-interval>20000</max-retry-interval>
+                <retry-interval-multiplier>2</retry-interval-multiplier>
+                <reconnect-attempts>-1</reconnect-attempts>
+                <initial-connect-attempts>-1</initial-connect-attempts>
+                <use-duplicate-detection>true</use-duplicate-detection>
+                <message-load-balancing>STRICT</message-load-balancing>
+                <max-hops>1</max-hops>
+                <producer-window-size>-1</producer-window-size>
+                <discovery-group-ref discovery-group-name="dg1"/>
+            </cluster-connection>
+        </cluster-connections>
+    </core>
+</configuration>

--- a/tests/integration-tests/src/test/resources/servers/symmetric-discovery3/management.xml
+++ b/tests/integration-tests/src/test/resources/servers/symmetric-discovery3/management.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License. You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<management-context xmlns="http://activemq.apache.org/schema">
+   <connector connector-port="10093" connector-host="localhost"/>
+</management-context>

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/netty/NettyAcceptorFactoryTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/netty/NettyAcceptorFactoryTest.java
@@ -17,11 +17,11 @@
 package org.apache.activemq.artemis.tests.unit.core.remoting.impl.netty;
 
 import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.Executors;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptor;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptorFactory;
 import org.apache.activemq.artemis.core.server.ActiveMQComponent;
@@ -42,7 +42,7 @@ public class NettyAcceptorFactoryTest extends ActiveMQTestBase {
    public void testCreateAcceptor() throws Exception {
       NettyAcceptorFactory factory = new NettyAcceptorFactory();
 
-      Map<String, Object> params = new HashMap<>();
+      TransportConfiguration params = new TransportConfiguration();
       BufferHandler handler = (connectionID, buffer) -> {
       };
 

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/netty/NettyAcceptorTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/netty/NettyAcceptorTest.java
@@ -24,7 +24,9 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptor;
+import org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptorFactory;
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.core.server.ActiveMQComponent;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
@@ -73,7 +75,7 @@ public class NettyAcceptorTest extends ActiveMQTestBase {
       BufferHandler handler = (connectionID, buffer) -> {
       };
 
-      Map<String, Object> params = new HashMap<>();
+      TransportConfiguration params = new TransportConfiguration();
       ServerConnectionLifeCycleListener listener = new ServerConnectionLifeCycleListener() {
 
          @Override
@@ -147,9 +149,9 @@ public class NettyAcceptorTest extends ActiveMQTestBase {
    public void testInvalidSSLConfig() {
       Map<String, Object> params = new HashMap<>();
       params.put(TransportConstants.SSL_ENABLED_PROP_NAME, "true");
-
+      TransportConfiguration configuration = new TransportConfiguration(NettyAcceptorFactory.class.getName(), params, "test");
       try {
-         new NettyAcceptor("netty", null, params, null, null, null, null, Map.of());
+         new NettyAcceptor("netty", null, configuration, null, null, null, null, Map.of());
          fail("This should have failed with an IllegalArgumentException");
       } catch (IllegalArgumentException e) {
          // expected
@@ -161,7 +163,8 @@ public class NettyAcceptorTest extends ActiveMQTestBase {
       Map<String, Object> params = new HashMap<>();
       params.put(TransportConstants.SSL_ENABLED_PROP_NAME, "true");
       params.put(TransportConstants.KEYSTORE_PROVIDER_PROP_NAME, RandomUtil.randomString());
-      new NettyAcceptor("netty", null, params, null, null, null, null, Map.of());
+      TransportConfiguration configuration = new TransportConfiguration(NettyAcceptorFactory.class.getName(), params, "test");
+      new NettyAcceptor("netty", null, configuration, null, null, null, null, Map.of());
    }
 
    @Test
@@ -169,6 +172,7 @@ public class NettyAcceptorTest extends ActiveMQTestBase {
       Map<String, Object> params = new HashMap<>();
       params.put(TransportConstants.SSL_ENABLED_PROP_NAME, "true");
       params.put(TransportConstants.SSL_CONTEXT_PROP_NAME, RandomUtil.randomString());
-      new NettyAcceptor("netty", null, params, null, null, null, null, Map.of());
+      TransportConfiguration configuration = new TransportConfiguration(NettyAcceptorFactory.class.getName(), params, "test");
+      new NettyAcceptor("netty", null, configuration, null, null, null, null, Map.of());
    }
 }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/netty/NettyConnectionTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/netty/NettyConnectionTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.ByteBuffer;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -45,7 +44,7 @@ import org.junit.jupiter.api.Test;
 
 public class NettyConnectionTest extends ActiveMQTestBase {
 
-   private static final Map<String, Object> emptyMap = Collections.emptyMap();
+   private static final TransportConfiguration emptyMap = new TransportConfiguration();
 
    @Test
    public void testGetID() throws Exception {
@@ -130,7 +129,7 @@ public class NettyConnectionTest extends ActiveMQTestBase {
       TransportConfiguration tf6 = new TransportConfiguration("some.other.FactoryClass", config6, "tf6");
 
       Channel channel = createChannel();
-      NettyConnection conn = new NettyConnection(config, channel, new MyListener(), false, false);
+      NettyConnection conn = new NettyConnection(tf1, channel, new MyListener(), false, false);
 
       assertTrue(conn.isSameTarget(tf1));
       assertTrue(conn.isSameTarget(tf2));

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/netty/NettyConnectorTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/netty/NettyConnectorTest.java
@@ -28,6 +28,7 @@ import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
 import org.apache.activemq.artemis.core.remoting.impl.netty.ActiveMQChannelHandler;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnector;
+import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory;
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.core.server.ActiveMQComponent;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
@@ -109,7 +110,7 @@ public class NettyConnectorTest extends ActiveMQTestBase {
    public void testStartStop() throws Exception {
       BufferHandler handler = (connectionID, buffer) -> {
       };
-      Map<String, Object> params = new HashMap<>();
+      TransportConfiguration params = new TransportConfiguration();
 
       NettyConnector connector = new NettyConnector(params, handler, listener, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
 
@@ -123,7 +124,7 @@ public class NettyConnectorTest extends ActiveMQTestBase {
    public void testNullParams() throws Exception {
       BufferHandler handler = (connectionID, buffer) -> {
       };
-      Map<String, Object> params = new HashMap<>();
+      TransportConfiguration params = new TransportConfiguration();
 
       try {
          new NettyConnector(params, null, listener, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
@@ -158,8 +159,8 @@ public class NettyConnectorTest extends ActiveMQTestBase {
 
       Map<String, Object> params = new HashMap<>();
       params.put(TransportConstants.SSL_ENABLED_PROP_NAME, true);
-
-      NettyConnector connector = new NettyConnector(params, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
+      TransportConfiguration configuration = new TransportConfiguration(NettyConnectorFactory.class.getName(), params, "test");
+      NettyConnector connector = new NettyConnector(configuration, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
 
       connector.start();
       assertTrue(connector.isStarted());
@@ -188,8 +189,9 @@ public class NettyConnectorTest extends ActiveMQTestBase {
 
       Map<String, Object> params = new HashMap<>();
       params.put(TransportConstants.SSL_ENABLED_PROP_NAME, true);
+      TransportConfiguration configuration = new TransportConfiguration(NettyConnectorFactory.class.getName(), params, "test");
 
-      NettyConnector connector = new NettyConnector(params, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
+      NettyConnector connector = new NettyConnector(configuration, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
 
       connector.start();
       assertTrue(connector.isStarted());
@@ -218,8 +220,9 @@ public class NettyConnectorTest extends ActiveMQTestBase {
 
       Map<String, Object> params = new HashMap<>();
       params.put(TransportConstants.SSL_ENABLED_PROP_NAME, true);
+      TransportConfiguration configuration = new TransportConfiguration(NettyConnectorFactory.class.getName(), params, "test");
 
-      NettyConnector connector = new NettyConnector(params, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
+      NettyConnector connector = new NettyConnector(configuration, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
 
       connector.start();
       assertTrue(connector.isStarted());
@@ -246,8 +249,9 @@ public class NettyConnectorTest extends ActiveMQTestBase {
       params.put(TransportConstants.KEYSTORE_PASSWORD_PROP_NAME, "securepass");
       params.put(TransportConstants.TRUSTSTORE_PATH_PROP_NAME,"server-ca-truststore.jks");
       params.put(TransportConstants.TRUSTSTORE_PASSWORD_PROP_NAME, "securepass");
+      TransportConfiguration configuration = new TransportConfiguration(NettyConnectorFactory.class.getName(), params, "test");
 
-      NettyConnector connector = new NettyConnector(params, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
+      NettyConnector connector = new NettyConnector(configuration, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
 
       connector.start();
       assertTrue(connector.isStarted());
@@ -276,8 +280,9 @@ public class NettyConnectorTest extends ActiveMQTestBase {
       params.put(TransportConstants.KEYSTORE_PASSWORD_PROP_NAME, "bad password");
       params.put(TransportConstants.TRUSTSTORE_PATH_PROP_NAME, "bad path");
       params.put(TransportConstants.TRUSTSTORE_PASSWORD_PROP_NAME, "bad password");
+      TransportConfiguration configuration = new TransportConfiguration(NettyConnectorFactory.class.getName(), params, "test");
 
-      NettyConnector connector = new NettyConnector(params, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
+      NettyConnector connector = new NettyConnector(configuration, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
 
       connector.start();
       assertTrue(connector.isStarted());
@@ -308,8 +313,9 @@ public class NettyConnectorTest extends ActiveMQTestBase {
       params.put(TransportConstants.KEYSTORE_PASSWORD_PROP_NAME, "securepass");
       params.put(TransportConstants.TRUSTSTORE_PATH_PROP_NAME,"server-ca-truststore.jks");
       params.put(TransportConstants.TRUSTSTORE_PASSWORD_PROP_NAME, "securepass");
+      TransportConfiguration configuration = new TransportConfiguration(NettyConnectorFactory.class.getName(), params, "test");
 
-      NettyConnector connector = new NettyConnector(params, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
+      NettyConnector connector = new NettyConnector(configuration, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
 
       connector.start();
       assertTrue(connector.isStarted());
@@ -338,8 +344,9 @@ public class NettyConnectorTest extends ActiveMQTestBase {
 
       // forcing SSL parameters will "undo" the values set by the system properties; all properties will be set to default values
       params.put(TransportConstants.FORCE_SSL_PARAMETERS, true);
+      TransportConfiguration configuration = new TransportConfiguration(NettyConnectorFactory.class.getName(), params, "test");
 
-      NettyConnector connector = new NettyConnector(params, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
+      NettyConnector connector = new NettyConnector(configuration, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
 
       connector.start();
       assertTrue(connector.isStarted());
@@ -361,8 +368,9 @@ public class NettyConnectorTest extends ActiveMQTestBase {
       };
       Map<String, Object> params = new HashMap<>();
       params.put(TransportConstants.SSL_ENABLED_PROP_NAME, true);
+      TransportConfiguration configuration = new TransportConfiguration(NettyConnectorFactory.class.getName(), params, "test");
 
-      NettyConnector connector = new NettyConnector(params, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
+      NettyConnector connector = new NettyConnector(configuration, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
 
       System.setProperty(NettyConnector.ACTIVEMQ_KEYSTORE_PATH_PROP_NAME, "client-keystore.jks");
       System.setProperty(NettyConnector.ACTIVEMQ_KEYSTORE_PASSWORD_PROP_NAME, "securepass");
@@ -383,8 +391,9 @@ public class NettyConnectorTest extends ActiveMQTestBase {
       };
       Map<String, Object> params = new HashMap<>();
       params.put(TransportConstants.SSL_ENABLED_PROP_NAME, true);
+      TransportConfiguration configuration = new TransportConfiguration(NettyConnectorFactory.class.getName(), params, "test");
 
-      NettyConnector connector = new NettyConnector(params, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
+      NettyConnector connector = new NettyConnector(configuration, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
 
       DefaultSensitiveStringCodec codec = new DefaultSensitiveStringCodec();
 
@@ -407,8 +416,9 @@ public class NettyConnectorTest extends ActiveMQTestBase {
       };
       Map<String, Object> params = new HashMap<>();
       params.put(TransportConstants.SSL_ENABLED_PROP_NAME, true);
+      TransportConfiguration configuration = new TransportConfiguration(NettyConnectorFactory.class.getName(), params, "test");
 
-      NettyConnector connector = new NettyConnector(params, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
+      NettyConnector connector = new NettyConnector(configuration, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
 
       DefaultSensitiveStringCodec codec = new DefaultSensitiveStringCodec();
 
@@ -452,8 +462,9 @@ public class NettyConnectorTest extends ActiveMQTestBase {
       };
       Map<String, Object> params = new HashMap<>();
       params.put(TransportConstants.SSL_ENABLED_PROP_NAME, true);
+      TransportConfiguration configuration = new TransportConfiguration(NettyConnectorFactory.class.getName(), params, "test");
 
-      NettyConnector connector = new NettyConnector(params, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
+      NettyConnector connector = new NettyConnector(configuration, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
 
       NettyConnectorTestPasswordCodec codec = new NettyConnectorTestPasswordCodec();
 
@@ -477,8 +488,9 @@ public class NettyConnectorTest extends ActiveMQTestBase {
       };
       Map<String, Object> params = new HashMap<>();
       params.put(TransportConstants.SSL_ENABLED_PROP_NAME, true);
+      TransportConfiguration configuration = new TransportConfiguration(NettyConnectorFactory.class.getName(), params, "test");
 
-      NettyConnector connector = new NettyConnector(params, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
+      NettyConnector connector = new NettyConnector(configuration, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
 
       System.setProperty(NettyConnector.ACTIVEMQ_SSL_PASSWORD_CODEC_CLASS_PROP_NAME, NettyConnectorTestPasswordCodec.class.getName());
       System.setProperty(NettyConnector.ACTIVEMQ_KEYSTORE_PATH_PROP_NAME, "client-keystore.jks");
@@ -500,8 +512,9 @@ public class NettyConnectorTest extends ActiveMQTestBase {
       };
       Map<String, Object> params = new HashMap<>();
       params.put(TransportConstants.SSL_ENABLED_PROP_NAME, true);
+      TransportConfiguration configuration = new TransportConfiguration(NettyConnectorFactory.class.getName(), params, "test");
 
-      NettyConnector connector = new NettyConnector(params, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
+      NettyConnector connector = new NettyConnector(configuration, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
 
       DefaultSensitiveStringCodec codec = new DefaultSensitiveStringCodec();
 
@@ -524,8 +537,9 @@ public class NettyConnectorTest extends ActiveMQTestBase {
       };
       Map<String, Object> params = new HashMap<>();
       params.put(TransportConstants.SSL_ENABLED_PROP_NAME, true);
+      TransportConfiguration configuration = new TransportConfiguration(NettyConnector.class.getName(), params);
 
-      NettyConnector connector = new NettyConnector(params, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
+      NettyConnector connector = new NettyConnector(configuration, handler, listener, executorService, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
 
       System.setProperty(NettyConnector.ACTIVEMQ_KEYSTORE_PATH_PROP_NAME, "client-keystore.jks");
       System.setProperty(NettyConnector.ACTIVEMQ_KEYSTORE_PASSWORD_PROP_NAME, "securepass");
@@ -552,8 +566,9 @@ public class NettyConnectorTest extends ActiveMQTestBase {
       Map<String, Object> params = new HashMap<>();
       params.put(TransportConstants.SSL_ENABLED_PROP_NAME, true);
       params.put(TransportConstants.ENABLED_CIPHER_SUITES_PROP_NAME, "myBadCipherSuite");
+      TransportConfiguration configuration = new TransportConfiguration(NettyConnectorFactory.class.getName(), params, "test");
 
-      NettyConnector connector = new NettyConnector(params, handler, listener, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
+      NettyConnector connector = new NettyConnector(configuration, handler, listener, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
 
       connector.start();
       assertTrue(connector.isStarted());
@@ -569,8 +584,9 @@ public class NettyConnectorTest extends ActiveMQTestBase {
       Map<String, Object> params = new HashMap<>();
       params.put(TransportConstants.SSL_ENABLED_PROP_NAME, true);
       params.put(TransportConstants.ENABLED_PROTOCOLS_PROP_NAME, "myBadProtocol");
+      TransportConfiguration configuration = new TransportConfiguration(NettyConnectorFactory.class.getName(), params, "test");
 
-      NettyConnector connector = new NettyConnector(params, handler, listener, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
+      NettyConnector connector = new NettyConnector(configuration, handler, listener, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())));
 
       connector.start();
       assertTrue(connector.isStarted());
@@ -583,7 +599,7 @@ public class NettyConnectorTest extends ActiveMQTestBase {
    public void testChannelHandlerRemovedWhileCreatingConnection() throws Exception {
       BufferHandler handler = (connectionID, buffer) -> {
       };
-      Map<String, Object> params = new HashMap<>();
+      TransportConfiguration params = new TransportConfiguration();
       final ExecutorService closeExecutor = Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName()));
       final ExecutorService threadPool = Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName()));
       final ScheduledExecutorService scheduledThreadPool = Executors.newScheduledThreadPool(5, ActiveMQThreadFactory.defaultThreadFactory(getClass().getName()));

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/netty/SocksProxyTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/netty/SocksProxyTest.java
@@ -45,7 +45,9 @@ import io.netty.handler.proxy.Socks5ProxyHandler;
 import io.netty.resolver.AddressResolverGroup;
 import io.netty.resolver.NoopAddressResolverGroup;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnector;
+import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory;
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.core.server.ActiveMQComponent;
 import org.apache.activemq.artemis.spi.core.remoting.BufferHandler;
@@ -105,6 +107,7 @@ public class SocksProxyTest extends ActiveMQTestBase {
       params.put(TransportConstants.HOST_PROP_NAME, address.getHostAddress());
       params.put(TransportConstants.PROXY_ENABLED_PROP_NAME, true);
       params.put(TransportConstants.PROXY_HOST_PROP_NAME, "localhost");
+      TransportConfiguration configuration = new TransportConfiguration(NettyConnectorFactory.class.getName(), params, "test");
 
       ClientConnectionLifeCycleListener listener = new ClientConnectionLifeCycleListener() {
          @Override
@@ -126,7 +129,7 @@ public class SocksProxyTest extends ActiveMQTestBase {
          }
       };
 
-      NettyConnector connector = new NettyConnector(params, handler, listener, closeExecutor, threadPool, scheduledThreadPool);
+      NettyConnector connector = new NettyConnector(configuration, handler, listener, closeExecutor, threadPool, scheduledThreadPool);
 
       connector.start();
       assertTrue(connector.isStarted());
@@ -168,6 +171,7 @@ public class SocksProxyTest extends ActiveMQTestBase {
       params.put(TransportConstants.HOST_PROP_NAME, "localhost");
       params.put(TransportConstants.PROXY_ENABLED_PROP_NAME, true);
       params.put(TransportConstants.PROXY_HOST_PROP_NAME, "localhost");
+      TransportConfiguration configuration = new TransportConfiguration(NettyConnectorFactory.class.getName(), params, "test");
 
       ClientConnectionLifeCycleListener listener = new ClientConnectionLifeCycleListener() {
          @Override
@@ -189,7 +193,7 @@ public class SocksProxyTest extends ActiveMQTestBase {
          }
       };
 
-      NettyConnector connector = new NettyConnector(params, handler, listener, closeExecutor, threadPool, scheduledThreadPool);
+      NettyConnector connector = new NettyConnector(configuration, handler, listener, closeExecutor, threadPool, scheduledThreadPool);
 
       connector.start();
       assertTrue(connector.isStarted());
@@ -212,6 +216,7 @@ public class SocksProxyTest extends ActiveMQTestBase {
       params.put(TransportConstants.PROXY_HOST_PROP_NAME, "localhost");
       params.put(TransportConstants.PROXY_PORT_PROP_NAME, SOCKS_PORT);
       params.put(TransportConstants.PROXY_REMOTE_DNS_PROP_NAME, true);
+      TransportConfiguration configuration = new TransportConfiguration(NettyConnectorFactory.class.getName(), params, "test");
 
       ClientConnectionLifeCycleListener listener = new ClientConnectionLifeCycleListener() {
          @Override
@@ -233,7 +238,7 @@ public class SocksProxyTest extends ActiveMQTestBase {
          }
       };
 
-      NettyConnector connector = new NettyConnector(params, handler, listener, closeExecutor, threadPool, scheduledThreadPool);
+      NettyConnector connector = new NettyConnector(configuration, handler, listener, closeExecutor, threadPool, scheduledThreadPool);
 
       connector.start();
       assertTrue(connector.isStarted());

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/server/impl/fake/FakeAcceptorFactory.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/server/impl/fake/FakeAcceptorFactory.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.apache.activemq.artemis.api.core.BaseInterceptor;
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.security.ActiveMQPrincipal;
 import org.apache.activemq.artemis.core.server.cluster.ClusterConnection;
 import org.apache.activemq.artemis.core.server.management.NotificationService;
@@ -38,7 +39,7 @@ public class FakeAcceptorFactory implements AcceptorFactory {
    @Override
    public Acceptor createAcceptor(String name,
                                   ClusterConnection clusterConnection,
-                                  Map<String, Object> configuration,
+                                  TransportConfiguration configuration,
                                   BufferHandler handler,
                                   ServerConnectionLifeCycleListener listener,
                                   Executor threadPool,


### PR DESCRIPTION
In a cluster deployed in kubernetes, when a node is destroyed it terminates the process and shuts down the network before the process has a chance to close connections. Then a new node might be brought up, reusing the old node’s ip. If this happens before the connection ttl, from artemis’ point of view, it looks like as if the connection came back. Yet it is actually not the same, the peer has a new node id, etc. This messes things up with the cluster, the old message flow record is invalid.

This also solves another similar issue - if a node goes down and a new one comes in with a new nodeUUID and the same IP before the cluster connections in the others timeout, it would cause them to get stuck and list both the old and the new nodes in their topologies.

The changes are grouped in tightly related incremental commits to make it easier to understand what is changed:

1. `Ping` packets include `nodeUUID`
2. Acceptors and connectors carry `TransportConfiguration`
3. `RemotingConnectionImpl#doBufferReceived` tracks for ping nodeUUID mismatch with the target to flag it as `unhealthy`;  `ClientSessionFactoryImpl` destroys unhealthy connections(in addition to not receiving any data on time)