### PR TITLE
ARTEMIS-4754 Structure the names used for federation internal queues

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPSessionCallback.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPSessionCallback.java
@@ -263,15 +263,32 @@ public class AMQPSessionCallback implements SessionCallback {
    }
 
    public void createTemporaryQueue(SimpleString queueName, RoutingType routingType) throws Exception {
-      createTemporaryQueue(queueName, queueName, routingType, null);
+      createTemporaryQueue(queueName, queueName, routingType, null, null);
+   }
+
+   public void createTemporaryQueue(SimpleString queueName, RoutingType routingType, Integer maxConsumers) throws Exception {
+      createTemporaryQueue(queueName, queueName, routingType, null, maxConsumers);
    }
 
    public void createTemporaryQueue(SimpleString address,
                                     SimpleString queueName,
                                     RoutingType routingType,
                                     SimpleString filter) throws Exception {
+      createTemporaryQueue(address, queueName, routingType, filter, null);
+   }
+
+   public void createTemporaryQueue(SimpleString address,
+                                    SimpleString queueName,
+                                    RoutingType routingType,
+                                    SimpleString filter,
+                                    Integer maxConsumers) throws Exception {
       try {
-         serverSession.createQueue(new QueueConfiguration(queueName).setAddress(address).setRoutingType(routingType).setFilterString(filter).setTemporary(true).setDurable(false));
+         serverSession.createQueue(new QueueConfiguration(queueName).setAddress(address)
+                                                                    .setRoutingType(routingType)
+                                                                    .setFilterString(filter)
+                                                                    .setTemporary(true)
+                                                                    .setDurable(false)
+                                                                    .setMaxConsumers(maxConsumers));
       } catch (ActiveMQSecurityException se) {
          throw ActiveMQAMQPProtocolMessageBundle.BUNDLE.securityErrorCreatingTempDestination(se.getMessage());
       }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederation.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederation.java
@@ -17,6 +17,10 @@
 
 package org.apache.activemq.artemis.protocol.amqp.connect.federation;
 
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_CONTROL_LINK_PREFIX;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_BASE_VALIDATION_ADDRESS;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_EVENTS_LINK_PREFIX;
+
 import java.lang.invoke.MethodHandles;
 import java.util.Map;
 import java.util.Objects;
@@ -168,6 +172,50 @@ public abstract class AMQPFederation implements FederationInternal {
             eventProcessor = null;
          }
       }
+   }
+
+   /**
+    * Performs the prefixing for federation events queues that places the events queues into
+    * the name-space of federation related internal queues.
+    *
+    * @param suffix
+    *    A suffix to append to the federation events link (normally the AMQP link name).
+    *
+    * @return the full internal queue name to use for the given suffix.
+    */
+   String prefixEventsLinkQueueName(String suffix) {
+      final StringBuilder builder = new StringBuilder();
+      final char delimiter = getWildcardConfiguration().getDelimiter();
+
+      builder.append(FEDERATION_BASE_VALIDATION_ADDRESS)
+             .append(delimiter)
+             .append(FEDERATION_EVENTS_LINK_PREFIX)
+             .append(delimiter)
+             .append(suffix);
+
+      return builder.toString();
+   }
+
+   /**
+    * Performs the prefixing for federation control queue name that places the queues
+    * into the name-space of federation related internal queues.
+    *
+    * @param suffix
+    *    A suffix to append to the federation control link (normally the AMQP link name).
+    *
+    * @return the full internal queue name to use for the given suffix.
+    */
+   String prefixControlLinkQueueName(String suffix) {
+      final StringBuilder builder = new StringBuilder();
+      final char delimiter = getWildcardConfiguration().getDelimiter();
+
+      builder.append(FEDERATION_BASE_VALIDATION_ADDRESS)
+             .append(delimiter)
+             .append(FEDERATION_CONTROL_LINK_PREFIX)
+             .append(delimiter)
+             .append(suffix);
+
+      return builder.toString();
    }
 
    /**

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationConstants.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationConstants.java
@@ -30,10 +30,39 @@ public final class AMQPFederationConstants {
 
    /**
     * Address used by a remote broker instance to validate that an incoming federation connection
-    * has access right to perform federation operations. The user that connects to the AMQP federation
-    * endpoint and attempt to create the control link must have write access to this address.
+    * has access rights to perform federation operations. The user that connects to the AMQP federation
+    * endpoint and attempts to create the control link must have write access to this address and any
+    * address prefixed by this value.
+    *
+    * When securing a federation user account the user must have read and write permissions to addresses
+    * under this prefix using the broker defined delimiter, this include the ability to create non-durable
+    * resources.
+    *
+    * <pre>
+    *    $ACTIVEMQ_ARTEMIS_FEDERATION.#;
+    * </pre>
     */
-   public static final String FEDERATION_CONTROL_LINK_VALIDATION_ADDRESS = "$ACTIVEMQ_ARTEMIS_FEDERATION";
+   public static final String FEDERATION_BASE_VALIDATION_ADDRESS = "$ACTIVEMQ_ARTEMIS_FEDERATION";
+
+   /**
+    * The prefix value added when creating a federation control link beyond the initial portion of the
+    * validation address prefix. Links for command and control of federation operations follow the form:
+    *
+    * <pre>
+    *    $ACTIVEMQ_ARTEMIS_FEDERATION.control.&lt;unique-id&gt;
+    * </pre>
+    */
+   public static final String FEDERATION_CONTROL_LINK_PREFIX = "control";
+
+   /**
+    * The prefix value added when creating a federation events links beyond the initial portion of the
+    * validation address prefix. Links for federation events follow the form:
+    *
+    * <pre>
+    *    $ACTIVEMQ_ARTEMIS_FEDERATION.events.&lt;unique-id&gt;
+    * </pre>
+    */
+   public static final String FEDERATION_EVENTS_LINK_PREFIX = "events";
 
    /**
     * A desired capability added to the federation control link that must be offered

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPConnectionContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPConnectionContext.java
@@ -79,7 +79,7 @@ import java.lang.invoke.MethodHandles;
 
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_ADDRESS_RECEIVER;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_CONTROL_LINK;
-import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_CONTROL_LINK_VALIDATION_ADDRESS;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_BASE_VALIDATION_ADDRESS;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_EVENT_LINK;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_QUEUE_RECEIVER;
 import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.AMQP_LINK_INITIALIZER_KEY;
@@ -472,7 +472,7 @@ public class AMQPConnectionContext extends ProtonInitializable implements EventH
    private void handleFederationControlLinkOpened(AMQPSessionContext protonSession, Receiver receiver) throws Exception {
       try {
          try {
-            protonSession.getSessionSPI().check(SimpleString.toSimpleString(FEDERATION_CONTROL_LINK_VALIDATION_ADDRESS), CheckType.SEND, getSecurityAuth());
+            protonSession.getSessionSPI().check(SimpleString.toSimpleString(FEDERATION_BASE_VALIDATION_ADDRESS), CheckType.SEND, getSecurityAuth());
          } catch (ActiveMQSecurityException e) {
             throw new ActiveMQAMQPSecurityException(
                "User does not have permission to attach to the federation control address");

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/Match.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/Match.java
@@ -36,6 +36,10 @@ public class Match<T> {
 
    private static final String DOT_REPLACEMENT = "\\.";
 
+   private static final String DOLLAR = "$";
+
+   private static final String DOLLAR_REPLACEMENT = "\\$";
+
    private final String match;
 
    private final Pattern pattern;
@@ -75,6 +79,7 @@ public class Match<T> {
             actMatch = actMatch.replace(wildcardConfiguration.getDelimiterString() + wildcardConfiguration.getAnyWordsString(), wildcardConfiguration.getAnyWordsString());
          }
          actMatch = actMatch.replace(Match.DOT, Match.DOT_REPLACEMENT);
+         actMatch = actMatch.replace(Match.DOLLAR, Match.DOLLAR_REPLACEMENT);
          actMatch = actMatch.replace(wildcardConfiguration.getSingleWordString(), String.format(WORD_WILDCARD_REPLACEMENT_FORMAT, Pattern.quote(wildcardConfiguration.getDelimiterString())));
 
          if (direct) {

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/settings/impl/MatchTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/settings/impl/MatchTest.java
@@ -78,6 +78,29 @@ public class MatchTest {
       Assert.assertFalse(predicate.test("testing.A"));
       Assert.assertFalse(predicate.test("test"));
       Assert.assertFalse(predicate.test("test.A.B"));
+   }
 
+   @Test
+   public void testDollarMatchingDirectTrue() {
+      final Pattern pattern = Match.createPattern("$test.#", new WildcardConfiguration(), true);
+      final Predicate<String> predicate = pattern.asPredicate();
+
+      Assert.assertTrue(predicate.test("$test.A"));
+      Assert.assertTrue(predicate.test("$test.A.B"));
+
+      Assert.assertFalse(predicate.test("$testing.A"));
+      Assert.assertFalse(predicate.test("$test"));
+   }
+
+   @Test
+   public void testDollarMatchingDirectFalse() {
+      final Pattern pattern = Match.createPattern("$test.#", new WildcardConfiguration(), false);
+      final Predicate<String> predicate = pattern.asPredicate();
+
+      Assert.assertTrue(predicate.test("$test"));
+      Assert.assertTrue(predicate.test("$test.A"));
+      Assert.assertTrue(predicate.test("$test.A.B"));
+
+      Assert.assertFalse(predicate.test("$testing.A"));
    }
 }


### PR DESCRIPTION
When creating internal temporary queues for the federation control links and the events link we should use a structured naming convention to ease in configuring security for the federation user where all internal names fall under a root prefix which can be used to grant read and write access for the federation user. This change allows security on the wildcarded address "$ACTIVEMQ_ARTEMIS_FEDERATION.#". This change also includes some further restrictions added to federation resources and adds support for wildcarding '$' prefixed addresses.