### PR TITLE
ARTEMIS-4765 DuplicateIDCache on Mirror Target is using 20K elements instead of amqpCredits

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/StorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/StorageManager.java
@@ -377,6 +377,8 @@ public interface StorageManager extends IDGenerator, ActiveMQComponent {
 
    List<AbstractPersistedAddressSetting> recoverAddressSettings() throws Exception;
 
+   AbstractPersistedAddressSetting recoverAddressSettings(SimpleString address);
+
    void storeSecuritySetting(PersistedSecuritySetting persistedRoles) throws Exception;
 
    void deleteSecuritySetting(SimpleString addressMatch) throws Exception;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AbstractJournalStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AbstractJournalStorageManager.java
@@ -752,6 +752,11 @@ public abstract class AbstractJournalStorageManager extends CriticalComponentImp
    }
 
    @Override
+   public AbstractPersistedAddressSetting recoverAddressSettings(SimpleString address) {
+      return mapPersistedAddressSettings.get(address);
+   }
+
+   @Override
    public List<PersistedSecuritySetting> recoverSecuritySettings() throws Exception {
       return new ArrayList<>(mapPersistedSecuritySettings.values());
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/nullpm/NullStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/nullpm/NullStorageManager.java
@@ -80,6 +80,11 @@ public class NullStorageManager implements StorageManager {
 
    private final IOCriticalErrorListener ioCriticalErrorListener;
 
+   @Override
+   public AbstractPersistedAddressSetting recoverAddressSettings(SimpleString address) {
+      return null;
+   }
+
    public NullStorageManager(IOCriticalErrorListener ioCriticalErrorListener) {
       this.ioCriticalErrorListener = ioCriticalErrorListener;
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/DuplicateIDCache.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/DuplicateIDCache.java
@@ -31,6 +31,8 @@ public interface DuplicateIDCache {
 
    void addToCache(byte[] duplicateID, Transaction tx) throws Exception;
 
+   int getSize();
+
    /**
     * it will add the data to the cache.
     * If TX == null it won't use a transaction.

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/InMemoryDuplicateIDCache.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/InMemoryDuplicateIDCache.java
@@ -277,4 +277,9 @@ final class InMemoryDuplicateIDCache implements DuplicateIDCache {
          return null;
       }
    }
+
+   @Override
+   public int getSize() {
+      return cacheSize;
+   }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/NoOpDuplicateIDCache.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/NoOpDuplicateIDCache.java
@@ -74,4 +74,9 @@ public final class NoOpDuplicateIDCache implements DuplicateIDCache {
    public List<Pair<byte[], Long>> getMap() {
       return Collections.emptyList();
    }
+
+   @Override
+   public int getSize() {
+      return 0;
+   }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PersistentDuplicateIDCache.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PersistentDuplicateIDCache.java
@@ -396,4 +396,9 @@ final class PersistentDuplicateIDCache implements DuplicateIDCache {
       }
    }
 
+   @Override
+   public int getSize() {
+      return cacheSize;
+   }
+
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1614,4 +1614,7 @@ public interface ActiveMQServerLogger {
 
    @LogMessage(id = 224137, value = "Skipping SSL auto reload for sources of store {} because of {}", level = LogMessage.Level.WARN)
    void skipSSLAutoReloadForSourcesOfStore(String storePath, String reason);
+
+   @LogMessage(id = 224138, value = "Error Registering DuplicateCacheSize on namespace {}", level = LogMessage.Level.WARN)
+   void errorRegisteringDuplicateCacheSize(String address, Exception reason);
 }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/transaction/impl/TransactionImplTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/transaction/impl/TransactionImplTest.java
@@ -333,6 +333,11 @@ public class TransactionImplTest extends ServerTestBase {
       }
 
       @Override
+      public AbstractPersistedAddressSetting recoverAddressSettings(SimpleString address) {
+         return null;
+      }
+
+      @Override
       public void asyncCommit(long txID) throws Exception {
 
       }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SendAckFailTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SendAckFailTest.java
@@ -304,6 +304,11 @@ public class SendAckFailTest extends SpawnedTestBase {
       }
 
       @Override
+      public AbstractPersistedAddressSetting recoverAddressSettings(SimpleString address) {
+         return null;
+      }
+
+      @Override
       public void stop() throws Exception {
          manager.stop();
       }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/ResizeDuplicateCacheTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/ResizeDuplicateCacheTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.persistence;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl;
+import org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds;
+import org.apache.activemq.artemis.core.postoffice.DuplicateIDCache;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.apache.activemq.artemis.utils.RandomUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ResizeDuplicateCacheTest extends ActiveMQTestBase {
+
+   @Test
+   public void testReloadCache() throws Exception {
+      internalReloadCache(false, null);
+   }
+
+   @Test
+   public void testReloadCacheAdditionalSettings() throws Exception {
+      // this variance will add a settings on the same namespace for something else
+      // this will validate that the setting should be merged
+      internalReloadCache(true, null);
+   }
+
+   @Test
+   public void testReloadCacheAdditionalSettingsValueSet() throws Exception {
+      // this variance will add a settings on the same namespace for something else
+      // this will validate that the setting should be merged
+      internalReloadCache(true, 50_000);
+   }
+
+   public void internalReloadCache(boolean additionalSettings, Integer preExistingCacheValue) throws Exception {
+      int duplicateSize = 30;
+      SimpleString randomString = RandomUtil.randomSimpleString();
+
+      ActiveMQServer server = createServer(true, false);
+      server.start();
+
+      ActiveMQServerControl serverControl = server.getActiveMQServerControl();
+
+      if (additionalSettings) {
+         AddressSettings settings = new AddressSettings().setDefaultRingSize(3333);
+         if (preExistingCacheValue != null) {
+            settings.setIDCacheSize(preExistingCacheValue);
+         }
+         serverControl.addAddressSettings(randomString.toString(), settings.toJSON());
+         String json = serverControl.getAddressSettingsAsJSON(randomString.toString());
+         AddressSettings settingsFromJson = AddressSettings.fromJSON(json);
+         Assert.assertEquals(preExistingCacheValue, settingsFromJson.getIDCacheSize());
+         Assert.assertEquals(3333, settingsFromJson.getDefaultRingSize());
+      }
+
+      DuplicateIDCache duplicateIDCache = server.getPostOffice().getDuplicateIDCache(randomString, duplicateSize);
+
+      for (int i = 0; i < duplicateSize * 2; i++) {
+         duplicateIDCache.addToCache(("a" + i).getBytes(StandardCharsets.UTF_8));
+      }
+
+      server.stop();
+      server = createServer(true, false);
+      server.start();
+      serverControl = server.getActiveMQServerControl();
+
+      duplicateIDCache = server.getPostOffice().getDuplicateIDCache(randomString, duplicateSize);
+
+      Assert.assertEquals(duplicateSize, duplicateIDCache.getSize());
+
+      server.getStorageManager().getMessageJournal().scheduleCompactAndBlock(10_000);
+      HashMap<Integer, AtomicInteger> records = countJournal(server.getConfiguration());
+
+      AtomicInteger duplicateRecordsCount = records.get((int) JournalRecordIds.DUPLICATE_ID);
+      Assert.assertNotNull(duplicateRecordsCount);
+      Assert.assertEquals(duplicateSize, duplicateRecordsCount.get());
+
+      if (additionalSettings) {
+         String json = serverControl.getAddressSettingsAsJSON(randomString.toString());
+
+         // checking if the previous value was merged as expected
+         AddressSettings settingsFromJson = AddressSettings.fromJSON(json);
+         Assert.assertEquals(Integer.valueOf(duplicateSize), settingsFromJson.getIDCacheSize());
+         Assert.assertEquals(3333, settingsFromJson.getDefaultRingSize());
+      }
+
+      server.stop();
+   }
+}


### PR DESCRIPTION
in this commit I'm storing a binding record with the address-settings for the correct size this is also validating eventual merges of the AddressSettings in the same namespace.