### PR TITLE
NO-JIRA: fix docs locator.createClientSessionFactory should be locator.createSessionFactory

### DIFF
--- a/docs/user-manual/configuring-transports.adoc
+++ b/docs/user-manual/configuring-transports.adoc
@@ -71,7 +71,7 @@ Here's an example of creating a `ClientSessionFactory` which will connect direct
 ----
 ServerLocator locator = ActiveMQClient.createServerLocator("tcp://localhost:61617");
 
-ClientSessionFactory sessionFactory = locator.createClientSessionFactory();
+ClientSessionFactory sessionFactory = locator.createSessionFactory();
 
 ClientSession session = sessionFactory.createSession(...);
 ----

--- a/docs/user-manual/connection-ttl.adoc
+++ b/docs/user-manual/connection-ttl.adoc
@@ -19,7 +19,7 @@ ClientSession session = null;
 try {
    locator = ActiveMQClient.createServerLocatorWithoutHA(..);
 
-   sf = locator.createClientSessionFactory();
+   sf = locator.createSessionFactory();
 
    session = sf.createSession(...);
 

--- a/docs/user-manual/core.adoc
+++ b/docs/user-manual/core.adoc
@@ -121,7 +121,7 @@ ServerLocator locator = ActiveMQClient.createServerLocator("vm://0");
 
 // In this simple example, we just use one session for both producing and receiving
 
-ClientSessionFactory factory =  locator.createClientSessionFactory();
+ClientSessionFactory factory =  locator.createSessionFactory();
 ClientSession session = factory.createSession();
 
 // A producer is associated with an address ...


### PR DESCRIPTION
[`ServerLocator`](https://github.com/apache/activemq-artemis/blob/ae5d98337f00d5a123d95994b8437cdca1d319c4/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/client/ServerLocator.java#L41) interface doesn't have `createClientSessionFactory` method -> should be `createSessionFactory`