### PR TITLE
ARTEMIS-4777 Add additional configuration for broker connection

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPReceiverBrokerConnectionElement.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPReceiverBrokerConnectionElement.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.core.config.amqpBrokerConnectivity;
+
+/**
+ * Broker connection AMQP receiver connection element configuration.
+ */
+public class AMQPReceiverBrokerConnectionElement extends AMQPBrokerConnectionElement {
+
+   private static final long serialVersionUID = 4037077229638061905L;
+
+   private String sourceAddress;
+   private String sourceCapabilities;
+
+   public AMQPReceiverBrokerConnectionElement() {
+      this.setType(AMQPBrokerConnectionAddressType.RECEIVER);
+   }
+
+   public AMQPReceiverBrokerConnectionElement(String name) {
+      this.setType(AMQPBrokerConnectionAddressType.RECEIVER);
+      this.setName(name);
+   }
+
+   public String getSourceAddress() {
+      return sourceAddress;
+   }
+
+   public void setSourceAddress(String sourceAddress) {
+      this.sourceAddress = sourceAddress;
+   }
+
+   public String getSourceCapabilities() {
+      return sourceCapabilities;
+   }
+
+   public void setSourceCapabilities(String sourceCapabilities) {
+      this.sourceCapabilities = sourceCapabilities;
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPSenderBrokerConnectionElement.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPSenderBrokerConnectionElement.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.core.config.amqpBrokerConnectivity;
+
+/**
+ * Broker connection AMQP sender connection element configuration.
+ */
+public class AMQPSenderBrokerConnectionElement extends AMQPBrokerConnectionElement {
+
+   private static final long serialVersionUID = 1059627894111477952L;
+
+   private String targetAddress;
+   private String targetCapabilities;
+
+   public AMQPSenderBrokerConnectionElement() {
+      this.setType(AMQPBrokerConnectionAddressType.SENDER);
+   }
+
+   public AMQPSenderBrokerConnectionElement(String name) {
+      this.setType(AMQPBrokerConnectionAddressType.SENDER);
+      this.setName(name);
+   }
+
+   public String getTargetAddress() {
+      return targetAddress;
+   }
+
+   public void setTargetAddress(String targetAddress) {
+      this.targetAddress = targetAddress;
+   }
+
+   public String getTargetCapabilities() {
+      return targetCapabilities;
+   }
+
+   public void setTargetCapabilities(String targetCapabilities) {
+      this.targetCapabilities = targetCapabilities;
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -63,6 +63,8 @@ import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPFedera
 import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPFederationAddressPolicyElement;
 import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPFederationQueuePolicyElement;
 import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPMirrorBrokerConnectionElement;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPReceiverBrokerConnectionElement;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPSenderBrokerConnectionElement;
 import org.apache.activemq.artemis.core.config.federation.FederationAddressPolicyConfiguration;
 import org.apache.activemq.artemis.core.config.federation.FederationDownstreamConfiguration;
 import org.apache.activemq.artemis.core.config.federation.FederationPolicySet;
@@ -2238,6 +2240,34 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
                connectionElement = amqpFederationConnectionElement;
                connectionElement.setType(AMQPBrokerConnectionAddressType.FEDERATION);
+            } else if (nodeType == AMQPBrokerConnectionAddressType.SENDER) {
+               final String match = getAttributeValue(e2, "address-match");
+               final String queue = getAttributeValue(e2, "queue-name");
+               final String targetAddress = getAttributeValue(e2, "target-address");
+               final String targetCapabilities = getAttributeValue(e2, "target-capabilities");
+
+               final AMQPSenderBrokerConnectionElement amqpSenderConnectionElement = new AMQPSenderBrokerConnectionElement(name);
+
+               amqpSenderConnectionElement.setMatchAddress(SimpleString.toSimpleString(match)).setType(nodeType);
+               amqpSenderConnectionElement.setQueueName(SimpleString.toSimpleString(queue));
+               amqpSenderConnectionElement.setTargetAddress(targetAddress);
+               amqpSenderConnectionElement.setTargetCapabilities(targetCapabilities);
+
+               connectionElement = amqpSenderConnectionElement;
+            } else if (nodeType == AMQPBrokerConnectionAddressType.RECEIVER) {
+               final String match = getAttributeValue(e2, "address-match");
+               final String queue = getAttributeValue(e2, "queue-name");
+               final String sourceAddress = getAttributeValue(e2, "source-address");
+               final String sourceCapabilities = getAttributeValue(e2, "source-capabilities");
+
+               final AMQPReceiverBrokerConnectionElement amqpReceiverConnectionElement = new AMQPReceiverBrokerConnectionElement(name);
+
+               amqpReceiverConnectionElement.setMatchAddress(SimpleString.toSimpleString(match)).setType(nodeType);
+               amqpReceiverConnectionElement.setQueueName(SimpleString.toSimpleString(queue));
+               amqpReceiverConnectionElement.setSourceAddress(sourceAddress);
+               amqpReceiverConnectionElement.setSourceCapabilities(sourceCapabilities);
+
+               connectionElement = amqpReceiverConnectionElement;
             } else {
                String match = getAttributeValue(e2, "address-match");
                String queue = getAttributeValue(e2, "queue-name");

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -2151,8 +2151,8 @@
    <xsd:complexType name="amqp-connectionUriType">
       <xsd:sequence>
          <xsd:choice maxOccurs="unbounded">
-            <xsd:element name="sender" type="amqp-address-match-type"/>
-            <xsd:element name="receiver" type="amqp-address-match-type"/>
+            <xsd:element name="sender" type="amqp-broker-connect-sender-type"/>
+            <xsd:element name="receiver" type="amqp-broker-connect-receiver-type"/>
             <xsd:element name="peer" type="amqp-address-match-type"/>
             <xsd:element name="mirror" type="amqp-mirror-type"/>
             <xsd:element name="federation" type="amqp-federation-type"/>
@@ -2226,6 +2226,50 @@
             </xsd:documentation>
          </xsd:annotation>
       </xsd:attribute>
+   </xsd:complexType>
+
+   <xsd:complexType name="amqp-broker-connect-sender-type">
+      <xsd:complexContent>
+         <xsd:extension base="amqp-address-match-type">
+            <xsd:attribute name="target-address" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     This address to assign to the AMQP sender link Target.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="target-capabilities" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     This comma separated list of capabilities assigned to the AMQP Sender
+                     link Target capabilities.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+
+   <xsd:complexType name="amqp-broker-connect-receiver-type">
+      <xsd:complexContent>
+         <xsd:extension base="amqp-address-match-type">
+            <xsd:attribute name="source-address" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     This address to assign to the AMQP receiver link Source.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="source-capabilities" type="xsd:string" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     This comma separated list of capabilities assigned to the AMQP Receiver
+                     link Source capabilities.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:complexContent>
    </xsd:complexType>
 
    <xsd:complexType name="amqp-mirror-type">

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBrokerConnectionReceiverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBrokerConnectionReceiverTest.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.tests.integration.amqp.connect;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.MessageConsumer;
+import javax.jms.Session;
+import javax.jms.Topic;
+
+import org.apache.activemq.artemis.api.core.QueueConfiguration;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBrokerConnectConfiguration;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBrokerConnectionAddressType;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBrokerConnectionElement;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPReceiverBrokerConnectionElement;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.tests.integration.amqp.AmqpClientTestSupport;
+import org.apache.activemq.artemis.tests.util.CFUtil;
+import org.apache.qpid.protonj2.test.driver.ProtonTestServer;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test the Receiver functionality on AMQP broker connections
+ */
+public class AMQPBrokerConnectionReceiverTest extends AmqpClientTestSupport {
+
+   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   @Override
+   protected String getConfiguredProtocols() {
+      return "AMQP,CORE";
+   }
+
+   @Override
+   protected ActiveMQServer createServer() throws Exception {
+      // Creates the broker used to make the outgoing connection. The port passed is for
+      // that brokers acceptor. The test server connected to by the broker binds to a random port.
+      return createServer(AMQP_PORT, false);
+   }
+
+   @Test(timeout = 20000)
+   public void testBrokerConnectionCreatesReceiverOnRemoteUsingBaseConnectionType() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.expectAttach().ofReceiver().respondInKind();
+         peer.expectFlow();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         LOG.info("Test started, peer listening on: {}", remoteURI);
+
+         // This can still be done in code or via broker properties
+         final AMQPBrokerConnectionElement element = new AMQPBrokerConnectionElement();
+         element.setType(AMQPBrokerConnectionAddressType.RECEIVER);
+         element.setName(getTestName());
+         element.setMatchAddress("test");
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);
+         amqpConnection.addElement(element);
+         amqpConnection.setAutostart(true);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(new QueueConfiguration("test").setRoutingType(RoutingType.ANYCAST)
+                                                          .setAddress("test")
+                                                          .setAutoCreated(false));
+
+         peer.waitForScriptToComplete();
+         peer.expectClose();
+         peer.remoteClose().now();
+         peer.waitForScriptToComplete();
+         peer.close();
+      }
+   }
+
+   @Test(timeout = 20000)
+   public void testBrokerConnectionCreatesReceiverOnRemoteWhenQueueConfigured() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.expectAttach().ofReceiver().respondInKind();
+         peer.expectFlow();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         LOG.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPReceiverBrokerConnectionElement element = new AMQPReceiverBrokerConnectionElement();
+         element.setName(getTestName());
+         element.setQueueName("test");
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);
+         amqpConnection.addElement(element);
+         amqpConnection.setAutostart(true);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(new QueueConfiguration("test").setRoutingType(RoutingType.ANYCAST)
+                                                          .setAddress("test")
+                                                          .setAutoCreated(false));
+
+         peer.waitForScriptToComplete();
+         peer.expectClose();
+         peer.remoteClose().now();
+         peer.waitForScriptToComplete();
+         peer.close();
+      }
+   }
+
+   @Test(timeout = 20000)
+   public void testCreatesReceiverOnRemoteAfterClientConnects() throws Exception {
+      doTestCreatesReceiverOnRemote("test", null, "test", null);
+   }
+
+   @Test(timeout = 20000)
+   public void testCreatesReceiverWithConfiguredSourceAddressOnRemote() throws Exception {
+      doTestCreatesReceiverOnRemote("test", "topic://test", "topic://test", null);
+   }
+
+   @Test(timeout = 20000)
+   public void testCreatesReceiverWithConfiguredSourceElementsOnRemote() throws Exception {
+      doTestCreatesReceiverOnRemote("test", "topic://test", "topic://test", "topic");
+   }
+
+   @Test(timeout = 20000)
+   public void testCreatesReceiverMultipleTargetCapabilitiesOnRemote() throws Exception {
+      doTestCreatesReceiverOnRemote("test", "topic://test", "topic://test", "queue,test,capabilitiy");
+   }
+
+   private void doTestCreatesReceiverOnRemote(String address, String sourceAddress, String expectedSourceAddress, String sourceCapabilities) throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         LOG.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPReceiverBrokerConnectionElement element = new AMQPReceiverBrokerConnectionElement();
+         element.setName(getTestName());
+         element.setMatchAddress(address);
+         if (sourceAddress != null) {
+            element.setSourceAddress("topic://test");
+         }
+         if (sourceCapabilities != null) {
+            element.setSourceCapabilities(sourceCapabilities);
+         }
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);
+         amqpConnection.addElement(element);
+         amqpConnection.setAutostart(true);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         final String[] capabilities = sourceCapabilities == null ? null : sourceCapabilities.split(",");
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver().withSource()
+                                         .withAddress(expectedSourceAddress)
+                                         .withCapabilities(capabilities)
+                                         .and()
+                                         .respondInKind();
+         peer.expectFlow();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final Topic topic = session.createTopic("test");
+            final MessageConsumer consumer = session.createConsumer(topic);
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            consumer.close();
+         }
+
+         peer.expectClose();
+         peer.remoteClose().now();
+         peer.waitForScriptToComplete();
+
+         peer.close();
+      }
+   }
+}

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBrokerConnectionSenderTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBrokerConnectionSenderTest.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.tests.integration.amqp.connect;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.MessageConsumer;
+import javax.jms.Session;
+import javax.jms.Topic;
+
+import org.apache.activemq.artemis.api.core.QueueConfiguration;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBrokerConnectConfiguration;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBrokerConnectionAddressType;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBrokerConnectionElement;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPSenderBrokerConnectionElement;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.tests.integration.amqp.AmqpClientTestSupport;
+import org.apache.activemq.artemis.tests.util.CFUtil;
+import org.apache.qpid.protonj2.test.driver.ProtonTestServer;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test the Sender functionality on AMQP broker connections
+ */
+public class AMQPBrokerConnectionSenderTest extends AmqpClientTestSupport {
+
+   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   @Override
+   protected String getConfiguredProtocols() {
+      return "AMQP,CORE";
+   }
+
+   @Override
+   protected ActiveMQServer createServer() throws Exception {
+      // Creates the broker used to make the outgoing connection. The port passed is for
+      // that brokers acceptor. The test server connected to by the broker binds to a random port.
+      return createServer(AMQP_PORT, false);
+   }
+
+   @Test(timeout = 20000)
+   public void testBrokerConnectionCreatesSenderOnRemoteUsingBaseConnectionType() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.expectAttach().ofSender().respondInKind();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         LOG.info("Test started, peer listening on: {}", remoteURI);
+
+         // This can still be done in code or via broker properties
+         final AMQPBrokerConnectionElement element = new AMQPBrokerConnectionElement();
+         element.setType(AMQPBrokerConnectionAddressType.SENDER);
+         element.setName(getTestName());
+         element.setMatchAddress("test");
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);
+         amqpConnection.addElement(element);
+         amqpConnection.setAutostart(true);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(new QueueConfiguration("test").setRoutingType(RoutingType.ANYCAST)
+                                                          .setAddress("test")
+                                                          .setAutoCreated(false));
+
+         peer.waitForScriptToComplete();
+         peer.expectClose();
+         peer.remoteClose().now();
+         peer.waitForScriptToComplete();
+         peer.close();
+      }
+   }
+
+   @Test(timeout = 20000)
+   public void testBrokerConnectionCreatesSenderOnRemoteWhenQueueIsConfigured() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.expectAttach().ofSender().withTarget().withAddress("test").and().respondInKind();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         LOG.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPSenderBrokerConnectionElement element = new AMQPSenderBrokerConnectionElement();
+         element.setName(getTestName());
+         element.setQueueName("test");
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);
+         amqpConnection.addElement(element);
+         amqpConnection.setAutostart(true);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(new QueueConfiguration("test").setRoutingType(RoutingType.MULTICAST)
+                                                          .setAddress("test")
+                                                          .setAutoCreated(false));
+
+         peer.waitForScriptToComplete();
+         peer.expectClose();
+         peer.remoteClose().now();
+         peer.waitForScriptToComplete();
+         peer.close();
+      }
+   }
+
+   @Test(timeout = 20000)
+   public void testCreatesSenderOnRemoteAfterClientConnects() throws Exception {
+      doTestCreatesSenderOnRemote("test", null, "test", null);
+   }
+
+   @Test(timeout = 20000)
+   public void testCreatesSenderWithConfiguredTargetAddressOnRemote() throws Exception {
+      doTestCreatesSenderOnRemote("test", "topic://test", "topic://test", null);
+   }
+
+   @Test(timeout = 20000)
+   public void testCreatesSenderWithConfiguredTargetElementsOnRemote() throws Exception {
+      doTestCreatesSenderOnRemote("test", "topic://test", "topic://test", "topic");
+   }
+
+   @Test(timeout = 20000)
+   public void testCreatesSenderMultipleTargetCapabilitiesOnRemote() throws Exception {
+      doTestCreatesSenderOnRemote("test", "topic://test", "topic://test", "topic,temp,test");
+   }
+
+   private void doTestCreatesSenderOnRemote(String address, String targetAddress, String expectedTargetAddress, String targetCapabilities) throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         LOG.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPSenderBrokerConnectionElement element = new AMQPSenderBrokerConnectionElement();
+         element.setName(getTestName());
+         element.setMatchAddress(address);
+         if (targetAddress != null) {
+            element.setTargetAddress("topic://test");
+         }
+         if (targetCapabilities != null) {
+            element.setTargetCapabilities(targetCapabilities);
+         }
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);
+         amqpConnection.addElement(element);
+         amqpConnection.setAutostart(true);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         final String[] capabilities = targetCapabilities == null ? null : targetCapabilities.split(",");
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender().withTarget()
+                                       .withAddress(expectedTargetAddress)
+                                       .withCapabilities(capabilities)
+                                       .and()
+                                       .respondInKind();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final Topic topic = session.createTopic("test");
+            final MessageConsumer consumer = session.createConsumer(topic);
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            consumer.close();
+         }
+
+         peer.expectClose();
+         peer.remoteClose().now();
+         peer.waitForScriptToComplete();
+
+         peer.close();
+      }
+   }
+}


### PR DESCRIPTION
Add additional configuration for the broker connection senders and receivers that allows for setting the source or target address value and optional source and target capabilities to allow providing address mapping on some remote peers.