### PR TITLE
ARTEMIS-4726 fix original commit

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/PagedReferenceImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/PagedReferenceImpl.java
@@ -275,6 +275,11 @@ public class PagedReferenceImpl extends AbstractProtocolReference implements Pag
       getQueue().acknowledge(tx, this, reason, consumer, true);
    }
 
+   @Override
+   public void acknowledge(Transaction tx, AckReason reason, ServerConsumer consumer, boolean delivering) throws Exception {
+      getQueue().acknowledge(tx, this, reason, consumer, delivering);
+   }
+
    /* (non-Javadoc)
        * @see java.lang.Object#toString()
        */

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/MessageReference.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/MessageReference.java
@@ -114,6 +114,8 @@ public interface MessageReference {
 
    void acknowledge(Transaction tx, AckReason reason, ServerConsumer consumer) throws Exception;
 
+   void acknowledge(Transaction tx, AckReason reason, ServerConsumer consumer, boolean delivering) throws Exception;
+
    void emptyConsumerID();
 
    void setConsumerId(long consumerID);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/GroupFirstMessageReference.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/GroupFirstMessageReference.java
@@ -169,6 +169,11 @@ public class GroupFirstMessageReference implements MessageReference {
    }
 
    @Override
+   public void acknowledge(Transaction tx, AckReason reason, ServerConsumer consumer, boolean delivering) throws Exception {
+      messageReference.acknowledge(tx, reason, consumer, delivering);
+   }
+
+   @Override
    public void emptyConsumerID() {
       messageReference.emptyConsumerID();
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/MessageReferenceImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/MessageReferenceImpl.java
@@ -266,10 +266,15 @@ public class MessageReferenceImpl extends AbstractProtocolReference implements M
 
    @Override
    public void acknowledge(Transaction tx, AckReason reason, ServerConsumer consumer) throws Exception {
+      acknowledge(tx, reason, consumer, true);
+   }
+
+   @Override
+   public void acknowledge(Transaction tx, AckReason reason, ServerConsumer consumer, boolean delivering) throws Exception {
       if (tx == null) {
          getQueue().acknowledge(this, reason, consumer);
       } else {
-         getQueue().acknowledge(tx, this, reason, consumer, true);
+         getQueue().acknowledge(tx, this, reason, consumer, delivering);
       }
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ScheduledDeliveryHandlerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ScheduledDeliveryHandlerImpl.java
@@ -175,9 +175,10 @@ public class ScheduledDeliveryHandlerImpl implements ScheduledDeliveryHandler {
          while (iter.hasNext()) {
             MessageReference ref = iter.next().getRef();
             if (ref.getMessage().getMessageID() == id) {
-               ref.acknowledge(tx);
+               ref.acknowledge(tx, AckReason.NORMAL, null, false);
                iter.remove();
                notifyScheduledReferencesUpdated();
+               metrics.decrementMetrics(ref);
                return ref;
             }
          }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/scheduling/ScheduledMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/scheduling/ScheduledMessageTest.java
@@ -557,8 +557,10 @@ public class ScheduledMessageTest extends ActiveMQTestBase {
 
       QueueControl queueControl = (QueueControl) server.getManagementService().getResource(ResourceNames.QUEUE + atestq);
       assertEquals(1, queueControl.getMessageCount());
+      assertEquals(1, queueControl.getScheduledCount());
       assertTrue(queueControl.removeMessage((long) queueControl.listScheduledMessages()[0].get("messageID")));
       assertEquals(0, queueControl.getMessageCount());
+      assertEquals(0, queueControl.getScheduledCount());
    }
 
    @Test


### PR DESCRIPTION
The original commit (1ee3e884b707a659d924188048c2960a3b22df35) for this issue wasn't completely correct. This commit fixes those issues so that both the messageCount and scheduledMessageCount are accurate now when a scheduled message is removed by its ID.