### PR TITLE
ARTEMIS-4306 add authn/z cache metrics

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/logs/AuditLogger.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/logs/AuditLogger.java
@@ -2716,4 +2716,32 @@ public interface AuditLogger {
 
    @LogMessage(id = 601777, value = "User {} is getting broker plugin class names on target resource: {}", level = LogMessage.Level.INFO)
    void getBrokerPluginClassNames(String user, Object source);
+
+   static void getAuthenticationSuccessCount(Object source) {
+      BASE_LOGGER.getAuthenticationSuccessCount(getCaller(), source);
+   }
+
+   @LogMessage(id = 601778, value = "User {} is getting authentication success count on target resource: {}", level = LogMessage.Level.INFO)
+   void getAuthenticationSuccessCount(String user, Object source);
+
+   static void getAuthenticationFailureCount(Object source) {
+      BASE_LOGGER.getAuthenticationFailureCount(getCaller(), source);
+   }
+
+   @LogMessage(id = 601779, value = "User {} is getting authentication failure count on target resource: {}", level = LogMessage.Level.INFO)
+   void getAuthenticationFailureCount(String user, Object source);
+
+   static void getAuthorizationSuccessCount(Object source) {
+      BASE_LOGGER.getAuthorizationSuccessCount(getCaller(), source);
+   }
+
+   @LogMessage(id = 601780, value = "User {} is getting authorization success count on target resource: {}", level = LogMessage.Level.INFO)
+   void getAuthorizationSuccessCount(String user, Object source);
+
+   static void getAuthorizationFailureCount(Object source) {
+      BASE_LOGGER.getAuthorizationFailureCount(getCaller(), source);
+   }
+
+   @LogMessage(id = 601781, value = "User {} is getting authorization failure count on target resource: {}", level = LogMessage.Level.INFO)
+   void getAuthorizationFailureCount(String user, Object source);
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
@@ -679,6 +679,9 @@ public final class ActiveMQDefaultConfiguration {
    // Whether or not to report logging metrics
    private static final boolean DEFAULT_LOGGING_METRICS = false;
 
+   // Whether or not to report security cache metrics
+   private static final boolean DEFAULT_SECURITY_CACHE_METRICS = false;
+
    // How often (in ms) to scan for expired MQTT sessions
    private static long DEFAULT_MQTT_SESSION_SCAN_INTERVAL = 500;
 
@@ -1890,6 +1893,13 @@ public final class ActiveMQDefaultConfiguration {
     */
    public static Boolean getDefaultLoggingMetrics() {
       return DEFAULT_LOGGING_METRICS;
+   }
+
+   /**
+    * Whether or not to report security cache metrics
+    */
+   public static Boolean getDefaultSecurityCacheMetrics() {
+      return DEFAULT_SECURITY_CACHE_METRICS;
    }
 
    /**

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
@@ -33,6 +33,10 @@ public interface ActiveMQServerControl {
    String DISK_STORE_USAGE_DESCRIPTION = "Fraction of total disk store used";
    String REPLICA_SYNC_DESCRIPTION = "If the initial replication synchronization process is complete";
    String IS_ACTIVE_DESCRIPTION = "If the server is active";
+   String AUTHENTICATION_SUCCESS_COUNT = "Number of successful authentication attempts";
+   String AUTHENTICATION_FAILURE_COUNT = "Number of failed authentication attempts";
+   String AUTHORIZATION_SUCCESS_COUNT = "Number of successful authorization attempts";
+   String AUTHORIZATION_FAILURE_COUNT = "Number of failed authorization attempts";
 
    /**
     * Returns this server's name.
@@ -2072,5 +2076,17 @@ public interface ActiveMQServerControl {
 
    @Operation(desc = "Clear the authorization cache", impact = MBeanOperationInfo.ACTION)
    void clearAuthorizationCache() throws Exception;
+
+   @Attribute(desc = AUTHENTICATION_SUCCESS_COUNT)
+   long getAuthenticationSuccessCount();
+
+   @Attribute(desc = AUTHENTICATION_FAILURE_COUNT)
+   long getAuthenticationFailureCount();
+
+   @Attribute(desc = AUTHORIZATION_SUCCESS_COUNT)
+   long getAuthorizationSuccessCount();
+
+   @Attribute(desc = AUTHORIZATION_FAILURE_COUNT)
+   long getAuthorizationFailureCount();
 }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/MetricsConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/MetricsConfiguration.java
@@ -31,6 +31,7 @@ public class MetricsConfiguration implements Serializable {
    private boolean processor = ActiveMQDefaultConfiguration.getDefaultProcessorMetrics();
    private boolean uptime = ActiveMQDefaultConfiguration.getDefaultUptimeMetrics();
    private boolean logging = ActiveMQDefaultConfiguration.getDefaultLoggingMetrics();
+   private boolean securityCaches = ActiveMQDefaultConfiguration.getDefaultSecurityCacheMetrics();
    private ActiveMQMetricsPlugin plugin;
 
    public boolean isJvmMemory() {
@@ -111,6 +112,15 @@ public class MetricsConfiguration implements Serializable {
 
    public MetricsConfiguration setPlugin(ActiveMQMetricsPlugin plugin) {
       this.plugin = plugin;
+      return this;
+   }
+
+   public boolean isSecurityCaches() {
+      return securityCaches;
+   }
+
+   public MetricsConfiguration setSecurityCaches(boolean securityCaches) {
+      this.securityCaches = securityCaches;
       return this;
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -1040,6 +1040,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
                metricsConfiguration.setUptime(XMLUtil.parseBoolean(child));
             } else if (child.getNodeName().equals("logging")) {
                metricsConfiguration.setLogging(XMLUtil.parseBoolean(child));
+            } else if (child.getNodeName().equals("security-caches")) {
+               metricsConfiguration.setSecurityCaches(XMLUtil.parseBoolean(child));
             } else if (child.getNodeName().equals("plugin")) {
                metricsConfiguration.setPlugin(parseMetricsPlugin(child, config));
             }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -4691,6 +4691,38 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
       ((SecurityStoreImpl)server.getSecurityStore()).invalidateAuthorizationCache();
    }
 
+   @Override
+   public long getAuthenticationSuccessCount() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getAuthenticationSuccessCount(this.server);
+      }
+      return server.getSecurityStore().getAuthenticationSuccessCount();
+   }
+
+   @Override
+   public long getAuthenticationFailureCount() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getAuthenticationFailureCount(this.server);
+      }
+      return server.getSecurityStore().getAuthenticationFailureCount();
+   }
+
+   @Override
+   public long getAuthorizationSuccessCount() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getAuthorizationSuccessCount(this.server);
+      }
+      return server.getSecurityStore().getAuthorizationSuccessCount();
+   }
+
+   @Override
+   public long getAuthorizationFailureCount() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getAuthorizationFailureCount(this.server);
+      }
+      return server.getSecurityStore().getAuthorizationFailureCount();
+   }
+
    public ActiveMQServer getServer() {
       return server;
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/security/SecurityStore.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/security/SecurityStore.java
@@ -37,4 +37,12 @@ public interface SecurityStore {
    void stop();
 
    Subject getSessionSubject(SecurityAuth session);
+
+   long getAuthenticationSuccessCount();
+
+   long getAuthenticationFailureCount();
+
+   long getAuthorizationSuccessCount();
+
+   long getAuthorizationFailureCount();
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -3313,7 +3313,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
        * are not required to be included in the OSGi bundle and the Micrometer jars apparently don't support OSGi.
        */
       if (configuration.getMetricsConfiguration() != null && configuration.getMetricsConfiguration().getPlugin() != null) {
-         metricsManager = new MetricsManager(configuration.getName(), configuration.getMetricsConfiguration(), addressSettingsRepository);
+         metricsManager = new MetricsManager(configuration.getName(), configuration.getMetricsConfiguration(), addressSettingsRepository, securityStore);
       }
 
       postOffice = new PostOfficeImpl(this, storageManager, pagingManager, queueFactory, managementService, configuration.getMessageExpiryScanPeriod(), configuration.getAddressQueueScanPeriod(), configuration.getWildcardConfiguration(), configuration.getIDCacheSize(), configuration.isPersistIDCache(), addressSettingsRepository);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/impl/ManagementServiceImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/impl/ManagementServiceImpl.java
@@ -25,7 +25,9 @@ import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +36,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.regex.Pattern;
 
+import io.micrometer.core.instrument.Tag;
 import org.apache.activemq.artemis.api.core.BroadcastEndpointFactory;
 import org.apache.activemq.artemis.api.core.BroadcastGroupConfiguration;
 import org.apache.activemq.artemis.api.core.ChannelBroadcastEndpointFactory;
@@ -236,13 +239,17 @@ public class ManagementServiceImpl implements ManagementService {
       MetricsManager metricsManager = messagingServer.getMetricsManager();
       if (metricsManager != null) {
          metricsManager.registerBrokerGauge(builder -> {
-            builder.build(BrokerMetricNames.CONNECTION_COUNT, messagingServer, metrics -> (double) messagingServer.getConnectionCount(), ActiveMQServerControl.CONNECTION_COUNT_DESCRIPTION);
-            builder.build(BrokerMetricNames.TOTAL_CONNECTION_COUNT, messagingServer, metrics -> (double) messagingServer.getTotalConnectionCount(), ActiveMQServerControl.TOTAL_CONNECTION_COUNT_DESCRIPTION);
-            builder.build(BrokerMetricNames.ADDRESS_MEMORY_USAGE, messagingServer, metrics -> (double) messagingServerControl.getAddressMemoryUsage(), ActiveMQServerControl.ADDRESS_MEMORY_USAGE_DESCRIPTION);
-            builder.build(BrokerMetricNames.ADDRESS_MEMORY_USAGE_PERCENTAGE, messagingServer, metrics -> (double) messagingServerControl.getAddressMemoryUsagePercentage(), ActiveMQServerControl.ADDRESS_MEMORY_USAGE_PERCENTAGE_DESCRIPTION);
-            builder.build(BrokerMetricNames.DISK_STORE_USAGE, messagingServer, metrics -> messagingServer.getDiskStoreUsage(), ActiveMQServerControl.DISK_STORE_USAGE_DESCRIPTION);
-            builder.build(BrokerMetricNames.REPLICA_SYNC, messagingServer, metrics -> messagingServer.isReplicaSync() ? 1D : 0D, ActiveMQServerControl.REPLICA_SYNC_DESCRIPTION);
-            builder.build(BrokerMetricNames.ACTIVE, messagingServer, metrics -> messagingServer.isActive() ? 1D : 0D, ActiveMQServerControl.IS_ACTIVE_DESCRIPTION);
+            builder.build(BrokerMetricNames.CONNECTION_COUNT, messagingServer, metrics -> (double) messagingServer.getConnectionCount(), ActiveMQServerControl.CONNECTION_COUNT_DESCRIPTION, Collections.emptyList());
+            builder.build(BrokerMetricNames.TOTAL_CONNECTION_COUNT, messagingServer, metrics -> (double) messagingServer.getTotalConnectionCount(), ActiveMQServerControl.TOTAL_CONNECTION_COUNT_DESCRIPTION, Collections.emptyList());
+            builder.build(BrokerMetricNames.ADDRESS_MEMORY_USAGE, messagingServer, metrics -> (double) messagingServerControl.getAddressMemoryUsage(), ActiveMQServerControl.ADDRESS_MEMORY_USAGE_DESCRIPTION, Collections.emptyList());
+            builder.build(BrokerMetricNames.ADDRESS_MEMORY_USAGE_PERCENTAGE, messagingServer, metrics -> (double) messagingServerControl.getAddressMemoryUsagePercentage(), ActiveMQServerControl.ADDRESS_MEMORY_USAGE_PERCENTAGE_DESCRIPTION, Collections.emptyList());
+            builder.build(BrokerMetricNames.DISK_STORE_USAGE, messagingServer, metrics -> messagingServer.getDiskStoreUsage(), ActiveMQServerControl.DISK_STORE_USAGE_DESCRIPTION, Collections.emptyList());
+            builder.build(BrokerMetricNames.REPLICA_SYNC, messagingServer, metrics -> messagingServer.isReplicaSync() ? 1D : 0D, ActiveMQServerControl.REPLICA_SYNC_DESCRIPTION, Collections.emptyList());
+            builder.build(BrokerMetricNames.ACTIVE, messagingServer, metrics -> messagingServer.isActive() ? 1D : 0D, ActiveMQServerControl.IS_ACTIVE_DESCRIPTION, Collections.emptyList());
+            builder.build(BrokerMetricNames.AUTHENTICATION_COUNT, securityStore, metrics -> (double) securityStore.getAuthenticationSuccessCount(), ActiveMQServerControl.AUTHENTICATION_SUCCESS_COUNT, Arrays.asList(Tag.of("result", "success")));
+            builder.build(BrokerMetricNames.AUTHENTICATION_COUNT, securityStore, metrics -> (double) securityStore.getAuthenticationFailureCount(), ActiveMQServerControl.AUTHENTICATION_FAILURE_COUNT, Arrays.asList(Tag.of("result", "failure")));
+            builder.build(BrokerMetricNames.AUTHORIZATION_COUNT, securityStore, metrics -> (double) securityStore.getAuthorizationSuccessCount(), ActiveMQServerControl.AUTHORIZATION_SUCCESS_COUNT, Arrays.asList(Tag.of("result", "success")));
+            builder.build(BrokerMetricNames.AUTHORIZATION_COUNT, securityStore, metrics -> (double) securityStore.getAuthorizationFailureCount(), ActiveMQServerControl.AUTHORIZATION_FAILURE_COUNT, Arrays.asList(Tag.of("result", "failure")));
          });
       }
    }
@@ -277,10 +284,10 @@ public class ManagementServiceImpl implements ManagementService {
          MetricsManager metricsManager = messagingServer.getMetricsManager();
          if (metricsManager != null) {
             metricsManager.registerAddressGauge(addressInfo.getName().toString(), builder -> {
-               builder.build(AddressMetricNames.ROUTED_MESSAGE_COUNT, addressInfo, metrics -> (double) addressInfo.getRoutedMessageCount(), AddressControl.ROUTED_MESSAGE_COUNT_DESCRIPTION);
-               builder.build(AddressMetricNames.UNROUTED_MESSAGE_COUNT, addressInfo, metrics -> (double) addressInfo.getUnRoutedMessageCount(), AddressControl.UNROUTED_MESSAGE_COUNT_DESCRIPTION);
-               builder.build(AddressMetricNames.ADDRESS_SIZE, addressInfo, metrics -> (double) addressControl.getAddressSize(), AddressControl.ADDRESS_SIZE_DESCRIPTION);
-               builder.build(AddressMetricNames.PAGES_COUNT, addressInfo, metrics -> (double) addressControl.getNumberOfPages(), AddressControl.NUMBER_OF_PAGES_DESCRIPTION);
+               builder.build(AddressMetricNames.ROUTED_MESSAGE_COUNT, addressInfo, metrics -> (double) addressInfo.getRoutedMessageCount(), AddressControl.ROUTED_MESSAGE_COUNT_DESCRIPTION, Collections.emptyList());
+               builder.build(AddressMetricNames.UNROUTED_MESSAGE_COUNT, addressInfo, metrics -> (double) addressInfo.getUnRoutedMessageCount(), AddressControl.UNROUTED_MESSAGE_COUNT_DESCRIPTION, Collections.emptyList());
+               builder.build(AddressMetricNames.ADDRESS_SIZE, addressInfo, metrics -> (double) addressControl.getAddressSize(), AddressControl.ADDRESS_SIZE_DESCRIPTION, Collections.emptyList());
+               builder.build(AddressMetricNames.PAGES_COUNT, addressInfo, metrics -> (double) addressControl.getNumberOfPages(), AddressControl.NUMBER_OF_PAGES_DESCRIPTION, Collections.emptyList());
             });
          }
       }
@@ -336,26 +343,26 @@ public class ManagementServiceImpl implements ManagementService {
          MetricsManager metricsManager = messagingServer.getMetricsManager();
          if (metricsManager != null) {
             metricsManager.registerQueueGauge(queue.getAddress().toString(), queue.getName().toString(), (builder) -> {
-               builder.build(QueueMetricNames.MESSAGE_COUNT, queue, metrics -> (double) queue.getMessageCount(), QueueControl.MESSAGE_COUNT_DESCRIPTION);
-               builder.build(QueueMetricNames.DURABLE_MESSAGE_COUNT, queue, metrics -> (double) queue.getDurableMessageCount(), QueueControl.DURABLE_MESSAGE_COUNT_DESCRIPTION);
-               builder.build(QueueMetricNames.PERSISTENT_SIZE, queue, metrics -> (double) queue.getPersistentSize(), QueueControl.PERSISTENT_SIZE_DESCRIPTION);
-               builder.build(QueueMetricNames.DURABLE_PERSISTENT_SIZE, queue, metrics -> (double) queue.getDurablePersistentSize(), QueueControl.DURABLE_PERSISTENT_SIZE_DESCRIPTION);
+               builder.build(QueueMetricNames.MESSAGE_COUNT, queue, metrics -> (double) queue.getMessageCount(), QueueControl.MESSAGE_COUNT_DESCRIPTION, Collections.emptyList());
+               builder.build(QueueMetricNames.DURABLE_MESSAGE_COUNT, queue, metrics -> (double) queue.getDurableMessageCount(), QueueControl.DURABLE_MESSAGE_COUNT_DESCRIPTION, Collections.emptyList());
+               builder.build(QueueMetricNames.PERSISTENT_SIZE, queue, metrics -> (double) queue.getPersistentSize(), QueueControl.PERSISTENT_SIZE_DESCRIPTION, Collections.emptyList());
+               builder.build(QueueMetricNames.DURABLE_PERSISTENT_SIZE, queue, metrics -> (double) queue.getDurablePersistentSize(), QueueControl.DURABLE_PERSISTENT_SIZE_DESCRIPTION, Collections.emptyList());
 
-               builder.build(QueueMetricNames.DELIVERING_MESSAGE_COUNT, queue, metrics -> (double) queue.getDeliveringCount(), QueueControl.DELIVERING_MESSAGE_COUNT_DESCRIPTION);
-               builder.build(QueueMetricNames.DELIVERING_DURABLE_MESSAGE_COUNT, queue, metrics -> (double) queue.getDurableDeliveringCount(), QueueControl.DURABLE_DELIVERING_MESSAGE_COUNT_DESCRIPTION);
-               builder.build(QueueMetricNames.DELIVERING_PERSISTENT_SIZE, queue, metrics -> (double) queue.getDeliveringSize(), QueueControl.DELIVERING_SIZE_DESCRIPTION);
-               builder.build(QueueMetricNames.DELIVERING_DURABLE_PERSISTENT_SIZE, queue, metrics -> (double) queue.getDurableDeliveringSize(), QueueControl.DURABLE_DELIVERING_SIZE_DESCRIPTION);
+               builder.build(QueueMetricNames.DELIVERING_MESSAGE_COUNT, queue, metrics -> (double) queue.getDeliveringCount(), QueueControl.DELIVERING_MESSAGE_COUNT_DESCRIPTION, Collections.emptyList());
+               builder.build(QueueMetricNames.DELIVERING_DURABLE_MESSAGE_COUNT, queue, metrics -> (double) queue.getDurableDeliveringCount(), QueueControl.DURABLE_DELIVERING_MESSAGE_COUNT_DESCRIPTION, Collections.emptyList());
+               builder.build(QueueMetricNames.DELIVERING_PERSISTENT_SIZE, queue, metrics -> (double) queue.getDeliveringSize(), QueueControl.DELIVERING_SIZE_DESCRIPTION, Collections.emptyList());
+               builder.build(QueueMetricNames.DELIVERING_DURABLE_PERSISTENT_SIZE, queue, metrics -> (double) queue.getDurableDeliveringSize(), QueueControl.DURABLE_DELIVERING_SIZE_DESCRIPTION, Collections.emptyList());
 
-               builder.build(QueueMetricNames.SCHEDULED_MESSAGE_COUNT, queue, metrics -> (double) queue.getScheduledCount(), QueueControl.SCHEDULED_MESSAGE_COUNT_DESCRIPTION);
-               builder.build(QueueMetricNames.SCHEDULED_DURABLE_MESSAGE_COUNT, queue, metrics -> (double) queue.getDurableScheduledCount(), QueueControl.DURABLE_SCHEDULED_MESSAGE_COUNT_DESCRIPTION);
-               builder.build(QueueMetricNames.SCHEDULED_PERSISTENT_SIZE, queue, metrics -> (double) queue.getScheduledSize(), QueueControl.SCHEDULED_SIZE_DESCRIPTION);
-               builder.build(QueueMetricNames.SCHEDULED_DURABLE_PERSISTENT_SIZE, queue, metrics -> (double) queue.getDurableScheduledSize(), QueueControl.DURABLE_SCHEDULED_SIZE_DESCRIPTION);
+               builder.build(QueueMetricNames.SCHEDULED_MESSAGE_COUNT, queue, metrics -> (double) queue.getScheduledCount(), QueueControl.SCHEDULED_MESSAGE_COUNT_DESCRIPTION, Collections.emptyList());
+               builder.build(QueueMetricNames.SCHEDULED_DURABLE_MESSAGE_COUNT, queue, metrics -> (double) queue.getDurableScheduledCount(), QueueControl.DURABLE_SCHEDULED_MESSAGE_COUNT_DESCRIPTION, Collections.emptyList());
+               builder.build(QueueMetricNames.SCHEDULED_PERSISTENT_SIZE, queue, metrics -> (double) queue.getScheduledSize(), QueueControl.SCHEDULED_SIZE_DESCRIPTION, Collections.emptyList());
+               builder.build(QueueMetricNames.SCHEDULED_DURABLE_PERSISTENT_SIZE, queue, metrics -> (double) queue.getDurableScheduledSize(), QueueControl.DURABLE_SCHEDULED_SIZE_DESCRIPTION, Collections.emptyList());
 
-               builder.build(QueueMetricNames.MESSAGES_ACKNOWLEDGED, queue, metrics -> (double) queue.getMessagesAcknowledged(), QueueControl.MESSAGES_ACKNOWLEDGED_DESCRIPTION);
-               builder.build(QueueMetricNames.MESSAGES_ADDED, queue, metrics -> (double) queue.getMessagesAdded(), QueueControl.MESSAGES_ADDED_DESCRIPTION);
-               builder.build(QueueMetricNames.MESSAGES_KILLED, queue, metrics -> (double) queue.getMessagesKilled(), QueueControl.MESSAGES_KILLED_DESCRIPTION);
-               builder.build(QueueMetricNames.MESSAGES_EXPIRED, queue, metrics -> (double) queue.getMessagesExpired(), QueueControl.MESSAGES_EXPIRED_DESCRIPTION);
-               builder.build(QueueMetricNames.CONSUMER_COUNT, queue, metrics -> (double) queue.getConsumerCount(), QueueControl.CONSUMER_COUNT_DESCRIPTION);
+               builder.build(QueueMetricNames.MESSAGES_ACKNOWLEDGED, queue, metrics -> (double) queue.getMessagesAcknowledged(), QueueControl.MESSAGES_ACKNOWLEDGED_DESCRIPTION, Collections.emptyList());
+               builder.build(QueueMetricNames.MESSAGES_ADDED, queue, metrics -> (double) queue.getMessagesAdded(), QueueControl.MESSAGES_ADDED_DESCRIPTION, Collections.emptyList());
+               builder.build(QueueMetricNames.MESSAGES_KILLED, queue, metrics -> (double) queue.getMessagesKilled(), QueueControl.MESSAGES_KILLED_DESCRIPTION, Collections.emptyList());
+               builder.build(QueueMetricNames.MESSAGES_EXPIRED, queue, metrics -> (double) queue.getMessagesExpired(), QueueControl.MESSAGES_EXPIRED_DESCRIPTION, Collections.emptyList());
+               builder.build(QueueMetricNames.CONSUMER_COUNT, queue, metrics -> (double) queue.getConsumerCount(), QueueControl.CONSUMER_COUNT_DESCRIPTION, Collections.emptyList());
             });
          }
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/metrics/BrokerMetricNames.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/metrics/BrokerMetricNames.java
@@ -25,4 +25,6 @@ public class BrokerMetricNames {
    public static final String DISK_STORE_USAGE = "disk.store.usage";
    public static final String REPLICA_SYNC = "replica.sync";
    public static final String ACTIVE = "active";
+   public static final String AUTHENTICATION_COUNT = "authentication.count";
+   public static final String AUTHORIZATION_COUNT = "authorization.count";
 }

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -4913,6 +4913,14 @@
                </xsd:annotation>
             </xsd:element>
 
+            <xsd:element name="security-caches" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     whether to report metrics for the authentication and authorization caches
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
             <xsd:element name="plugin" maxOccurs="1" minOccurs="0">
                <xsd:complexType>
                   <xsd:annotation>

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/DefaultsFileConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/DefaultsFileConfigurationTest.java
@@ -157,5 +157,7 @@ public class DefaultsFileConfigurationTest extends AbstractConfigurationTestBase
       Assert.assertEquals(ActiveMQDefaultConfiguration.getDefaultUptimeMetrics(), conf.getMetricsConfiguration().isUptime());
 
       Assert.assertEquals(ActiveMQDefaultConfiguration.getDefaultLoggingMetrics(), conf.getMetricsConfiguration().isLogging());
+
+      Assert.assertEquals(ActiveMQDefaultConfiguration.getDefaultSecurityCacheMetrics(), conf.getMetricsConfiguration().isSecurityCaches());
    }
 }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
@@ -643,6 +643,7 @@ public class FileConfigurationTest extends AbstractConfigurationTestBase {
       assertTrue(metricsConfiguration.isProcessor());
       assertTrue(metricsConfiguration.isUptime());
       assertTrue(metricsConfiguration.isLogging());
+      assertTrue(metricsConfiguration.isSecurityCaches());
    }
 
    private void verifyAddresses() {

--- a/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
@@ -385,6 +385,7 @@
          <processor>true</processor>
          <uptime>true</uptime>
          <logging>true</logging>
+         <security-caches>true</security-caches>
          <plugin class-name="org.apache.activemq.artemis.core.server.metrics.plugins.SimpleMetricsPlugin">
             <property key="foo" value="x"/>
             <property key="bar" value="y"/>

--- a/artemis-server/src/test/resources/ConfigurationTest-xinclude-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-xinclude-config.xml
@@ -272,6 +272,7 @@
          <processor>true</processor>
          <uptime>true</uptime>
          <logging>true</logging>
+         <security-caches>true</security-caches>
          <plugin class-name="org.apache.activemq.artemis.core.server.metrics.plugins.SimpleMetricsPlugin">
             <property key="foo" value="x"/>
             <property key="bar" value="y"/>

--- a/artemis-server/src/test/resources/ConfigurationTest-xinclude-schema-config-metrics.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-xinclude-schema-config-metrics.xml
@@ -23,6 +23,7 @@
    <processor>true</processor>
    <uptime>true</uptime>
    <logging>true</logging>
+   <security-caches>true</security-caches>
    <plugin class-name="org.apache.activemq.artemis.core.server.metrics.plugins.SimpleMetricsPlugin">
       <property key="foo" value="x"/>
       <property key="bar" value="y"/>

--- a/artemis-server/src/test/resources/metrics.xml
+++ b/artemis-server/src/test/resources/metrics.xml
@@ -28,6 +28,7 @@
          <processor>true</processor>
          <uptime>true</uptime>
          <logging>true</logging>
+         <security-caches>true</security-caches>
          <plugin class-name="org.apache.activemq.artemis.core.config.impl.FileConfigurationTest$FakeMetricPlugin">
             <property key="key1" value="value1"/>
             <property key="key2" value="value2"/>

--- a/docs/user-manual/metrics.adoc
+++ b/docs/user-manual/metrics.adoc
@@ -45,40 +45,55 @@ It takes no key/value properties for configuration.
 The following metrics are exported, categorized by component.
 A description for each metric is exported along with the metric itself therefore the description will not be repeated here.
 
+*Every* metric is "tagged" with the `broker` tag (configured via `<name>` in `broker.xml`).
+A _tag_ is a piece of metadata that gives context to the metric.
+These tags are the foundation of what is sometimes referred to as "dimensional metrics."
+Metrics _may_ have additional tags, but at the very least they will all have the `broker` tag.
+
+Lastly, all metrics specifically for ActiveMQ Artemis are prefixed with `artemis.`.
+
 === Broker
 
-* connection.count
-* total.connection.count
-* address.memory.usage
-* address.memory.usage.percentage
-* disk.store.usage
+* `connection.count`
+* `total.connection.count`
+* `address.memory.usage`
+* `address.memory.usage.percentage`
+* `disk.store.usage`
+* `replica.sync`
+* `active`
+* `authentication.count` tagged by `result` - either `success` or `failure`
+* `authorization.count` tagged by `result` - either `success` or `failure`
 
 === Address
 
-* routed.message.count
-* unrouted.message.count
-* address.size
-* number.of.pages
+These metrics are tagged with the `address` tag which reflects the name of the corresponding address.
+
+* `routed.message.count`
+* `unrouted.message.count`
+* `address.size`
+* `number.of.pages`
 
 === Queue
 
-* message.count
-* durable.message.count
-* persistent.size
-* durable.persistent.size
-* delivering.message.count
-* delivering.durable.message.count
-* delivering.persistent.size
-* delivering.durable.persistent.size
-* scheduled.message.count
-* scheduled.durable.message.count
-* scheduled.persistent.size
-* scheduled.durable.persistent.size
-* messages.acknowledged
-* messages.added
-* messages.killed
-* messages.expired
-* consumer.count
+These metrics are tagged with the `address` & `queue` tags which reflects the name of the corresponding address & queue respectively.
+
+* `message.count`
+* `durable.message.count`
+* `persistent.size`
+* `durable.persistent.size`
+* `delivering.message.count`
+* `delivering.durable.message.count`
+* `delivering.persistent.size`
+* `delivering.durable.persistent.size`
+* `scheduled.message.count`
+* `scheduled.durable.message.count`
+* `scheduled.persistent.size`
+* `scheduled.durable.persistent.size`
+* `messages.acknowledged`
+* `messages.added`
+* `messages.killed`
+* `messages.expired`
+* `consumer.count`
 
 It may appear that some higher level broker metrics are missing (e.g. total message count).
 However, these metrics can be deduced by aggregating the lower level metrics (e.g. aggregate the message.count metrics from all queues to get the total).
@@ -86,6 +101,7 @@ However, these metrics can be deduced by aggregating the lower level metrics (e.
 === Optional metrics
 
 There are a handful of other useful metrics that are related to the JVM, the underlying operating system, etc.
+These metrics are provided specifically by Micrometer and therefore do not have the `artmemis.` prefix.
 
 JVM memory metrics::
 Gauges buffer and memory pool utilization.
@@ -128,6 +144,16 @@ Disabled by default.
 This works _exclusively_ with Log4j2 (i.e the default logging implementation shipped with the broker).
 If you're embedding the broker and using a different logging implementation (e.g. Log4j 1.x, JUL, Logback, etc.) and you enable these metrics then the broker will fail to start with a `java.lang.NoClassDefFoundError` as it attempts to locate Log4j2 classes that don't exist on the classpath.
 ====
+Security caches::
+The following authentication & authorization cache metrics are exported. They are all tagged by `cache` (either `authentication` or `authorization`). Additional tags are noted.
+* `cache.size`
+* `cache.puts`
+* `cache.gets` tagged by `result` - either `hit` or `miss`
+* `cache.evictions`
+* `cache.eviction.weight`
+
++
+Disabled by default.
 
 == Configuration
 
@@ -148,6 +174,7 @@ Here's a configuration with all optional metrics:
    <processor>true</processor> <!-- defaults to false -->
    <uptime>true</uptime> <!-- defaults to false -->
    <logging>true</logging> <!-- defaults to false -->
+   <security-caches>true</security-caches> <!-- defaults to false -->
    <plugin class-name="org.apache.activemq.artemis.core.server.metrics.plugins.LoggingMetricsPlugin"/>
 </metrics>
 ----

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
@@ -1800,6 +1800,26 @@ public class ActiveMQServerControlUsingCoreTest extends ActiveMQServerControlTes
          public void clearAuthorizationCache() throws Exception {
             proxy.invokeOperation("clearAuthorizationCache");
          }
+
+         @Override
+         public long getAuthenticationSuccessCount() {
+            return (long) proxy.retrieveAttributeValue("authenticationSuccessCount");
+         }
+
+         @Override
+         public long getAuthenticationFailureCount() {
+            return (long) proxy.retrieveAttributeValue("authenticationFailureCount");
+         }
+
+         @Override
+         public long getAuthorizationSuccessCount() {
+            return (long) proxy.retrieveAttributeValue("authorizationSuccessCount");
+         }
+
+         @Override
+         public long getAuthorizationFailureCount() {
+            return (long) proxy.retrieveAttributeValue("authorizationFailureCount");
+         }
       };
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/plugin/CacheMetricsTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/plugin/CacheMetricsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <br>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <br>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.tests.integration.plugin;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import org.apache.activemq.artemis.core.config.MetricsConfiguration;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.metrics.plugins.SimpleMetricsPlugin;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CacheMetricsTest extends ActiveMQTestBase {
+
+   @Override
+   @Before
+   public void setUp() throws Exception {
+      super.setUp();
+   }
+
+   @Test
+   public void testCacheMetricsEnabled() throws Exception {
+      testCacheMetrics(true);
+   }
+
+   @Test
+   public void testCacheMetricsDisabled() throws Exception {
+      testCacheMetrics(false);
+   }
+
+   private void testCacheMetrics(boolean enabled) throws Exception {
+      ActiveMQServer server = createServer(false, createDefaultInVMConfig().setSecurityEnabled(true)
+         .setMetricsConfiguration(new MetricsConfiguration()
+                                     .setPlugin(new SimpleMetricsPlugin().init(null))
+                                     .setSecurityCaches(enabled)));
+      server.start();
+      List<Meter.Id> metersToMatch = new ArrayList<>();
+      for (String cacheTagValue : Arrays.asList("authentication", "authorization")) {
+         Tags defaultTags = Tags.of(Tag.of("broker", "localhost"), Tag.of("cache", cacheTagValue));
+         metersToMatch.add(new Meter.Id("cache.size", defaultTags, null, null, null));
+         metersToMatch.add(new Meter.Id("cache.puts", defaultTags, null, null, null));
+         metersToMatch.add(new Meter.Id("cache.gets", defaultTags.and(Tag.of("result", "miss")), null, null, null));
+         metersToMatch.add(new Meter.Id("cache.gets", defaultTags.and(Tag.of("result", "hit")), null, null, null));
+         metersToMatch.add(new Meter.Id("cache.evictions", defaultTags, null, null, null));
+         metersToMatch.add(new Meter.Id("cache.eviction.weight", defaultTags, null, null, null));
+      }
+      assertEquals(enabled, MetricsPluginTest.getMetrics(server).keySet().containsAll(metersToMatch));
+   }
+}


### PR DESCRIPTION
This commit includes the following changes:

 - Management operations to get sucess & failure counts for authn and authz along with the corresponding audit logging.
 - Export the aforementioned authn & authz metrics.
 - Export metrics for the underlying authn & authz caches including the ability to enable/disable them.
 - Update metrics tests to validate tags in addition to keys and values.
 - Update documentation to explain new functionality and clarify existing metric tags.