### PR TITLE
NO-JIRA Fix a few cases of federation test fails on unexpected frames

### DIFF
--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationAddressPolicyTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationAddressPolicyTest.java
@@ -3234,7 +3234,7 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          peer.remoteDetach().withClosed(true)
                             .withErrorCondition(AmqpError.NOT_FOUND.toString(), "Address not found")
                             .queue();
-         peer.expectFlow();
+         peer.expectFlow().optional();
          peer.expectDetach();
 
          // Triggers the initial attach based on demand.

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationConnectTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationConnectTest.java
@@ -209,6 +209,7 @@ public class AMQPFederationConnectTest extends AmqpClientTestSupport {
          peer.expectOpen().respond();
          peer.expectBegin().respond();
          peer.expectAttach().ofSender().withDesiredCapability(FEDERATION_CONTROL_LINK.toString()).respond();
+         peer.expectClose().optional(); // Can sometimes be sent
          peer.expectConnectionToDrop();
          peer.start();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationQueuePolicyTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationQueuePolicyTest.java
@@ -3476,7 +3476,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          peer.remoteDetach().withClosed(true)
                             .withErrorCondition(AmqpError.NOT_FOUND.toString(), "Queue not found")
                             .queue();
-         peer.expectFlow();
+         peer.expectFlow().optional();
          peer.expectDetach();
 
          final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);


### PR DESCRIPTION
Add a couple optional flags for performatives that might arrive based on the timing of connection close or remote detach etc.