### PR TITLE
ARTEMIS-4788 Fix a rare race on broker shutdown in AMQP federation

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationConsumerConfiguration.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationConsumerConfiguration.java
@@ -28,6 +28,7 @@ import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPF
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport;
 import org.apache.qpid.proton.engine.Receiver;
@@ -41,11 +42,13 @@ import org.apache.qpid.proton.engine.Receiver;
 public final class AMQPFederationConsumerConfiguration {
 
    private final Map<String, Object> properties;
-   private final AMQPFederation federation;
+   private final AMQPFederationConfiguration configuration;
 
    @SuppressWarnings("unchecked")
-   public AMQPFederationConsumerConfiguration(AMQPFederation federation, Map<String, ?> properties) {
-      this.federation = federation;
+   public AMQPFederationConsumerConfiguration(AMQPFederationConfiguration configuration, Map<String, ?> properties) {
+      Objects.requireNonNull(configuration, "Federation configuration cannot be null");
+
+      this.configuration = configuration;
 
       if (properties == null || properties.isEmpty()) {
          this.properties = Collections.EMPTY_MAP;
@@ -61,7 +64,7 @@ public final class AMQPFederationConsumerConfiguration {
       } else if (property instanceof String) {
          return Integer.parseInt((String) property);
       } else {
-         return federation.getConfiguration().getReceiverCredits();
+         return configuration.getReceiverCredits();
       }
    }
 
@@ -72,7 +75,7 @@ public final class AMQPFederationConsumerConfiguration {
       } else if (property instanceof String) {
          return Integer.parseInt((String) property);
       } else {
-         return federation.getConfiguration().getReceiverCreditsLow();
+         return configuration.getReceiverCreditsLow();
       }
    }
 
@@ -86,7 +89,7 @@ public final class AMQPFederationConsumerConfiguration {
       } else if (property instanceof String) {
          return Integer.parseInt((String) property);
       } else {
-         return federation.getConfiguration().getPullReceiverBatchSize();
+         return configuration.getPullReceiverBatchSize();
       }
    }
 
@@ -97,7 +100,7 @@ public final class AMQPFederationConsumerConfiguration {
       } else if (property instanceof String) {
          return Integer.parseInt((String) property);
       } else {
-         return federation.getConfiguration().getLargeMessageThreshold();
+         return configuration.getLargeMessageThreshold();
       }
    }
 
@@ -108,7 +111,7 @@ public final class AMQPFederationConsumerConfiguration {
       } else if (property instanceof String) {
          return Integer.parseInt((String) property);
       } else {
-         return federation.getConfiguration().getLinkAttachTimeout();
+         return configuration.getLinkAttachTimeout();
       }
    }
 
@@ -119,7 +122,7 @@ public final class AMQPFederationConsumerConfiguration {
       } else if (property instanceof String) {
          return Boolean.parseBoolean((String) property);
       } else {
-         return federation.getConfiguration().isCoreMessageTunnelingEnabled();
+         return configuration.isCoreMessageTunnelingEnabled();
       }
    }
 
@@ -130,7 +133,7 @@ public final class AMQPFederationConsumerConfiguration {
       } else if (property instanceof String) {
          return Boolean.parseBoolean((String) property);
       } else {
-         return federation.getConfiguration().isIgnoreSubscriptionFilters();
+         return configuration.isIgnoreSubscriptionFilters();
       }
    }
 
@@ -141,7 +144,7 @@ public final class AMQPFederationConsumerConfiguration {
       } else if (property instanceof String) {
          return Boolean.parseBoolean((String) property);
       } else {
-         return federation.getConfiguration().isIgnoreSubscriptionPriorities();
+         return configuration.isIgnoreSubscriptionPriorities();
       }
    }
 }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/federation/internal/FederationAddressPolicyManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/federation/internal/FederationAddressPolicyManager.java
@@ -87,6 +87,7 @@ public abstract class FederationAddressPolicyManager implements ActiveMQServerBi
    public synchronized void start() {
       if (!started) {
          started = true;
+         handlePolicyManagerStarted(policy);
          server.registerBrokerPlugin(this);
          scanAllBindings(); // Create remote consumers for existing addresses with demand.
       }
@@ -476,6 +477,16 @@ public abstract class FederationAddressPolicyManager implements ActiveMQServerBi
    protected boolean testIfAddressMatchesPolicy(String address, RoutingType type) {
       return policy.test(address, type);
    }
+
+   /**
+    * Called on start of the manager before any other actions are taken to allow the subclass time
+    * to configure itself and prepare any needed state prior to starting management of federated
+    * resources.
+    *
+    * @param policy
+    *    The policy configuration for this policy manager.
+    */
+   protected abstract void handlePolicyManagerStarted(FederationReceiveFromAddressPolicy policy);
 
    /**
     * Create a new {@link FederationConsumerInfo} based on the given {@link AddressInfo}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/federation/internal/FederationQueuePolicyManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/federation/internal/FederationQueuePolicyManager.java
@@ -80,6 +80,7 @@ public abstract class FederationQueuePolicyManager implements ActiveMQServerCons
    public synchronized void start() {
       if (!started) {
          started = true;
+         handlePolicyManagerStarted(policy);
          server.registerBrokerPlugin(this);
          scanAllQueueBindings(); // Create consumers for existing queue with demand.
       }
@@ -302,6 +303,16 @@ public abstract class FederationQueuePolicyManager implements ActiveMQServerCons
    protected boolean testIfQueueMatchesPolicy(String queueName) {
       return policy.testQueue(queueName);
    }
+
+   /**
+    * Called on start of the manager before any other actions are taken to allow the subclass time
+    * to configure itself and prepare any needed state prior to starting management of federated
+    * resources.
+    *
+    * @param policy
+    *    The policy configuration for this policy manager.
+    */
+   protected abstract void handlePolicyManagerStarted(FederationReceiveFromQueuePolicy policy);
 
    /**
     * Create a new {@link FederationConsumerInfo} based on the given {@link ServerConsumer}


### PR DESCRIPTION
Race on consumer create and broker shutdown could lead to a deadlocak trying to access configuration from the policy manager while the federation instance is trying to shutdown the policy manager.