### PR TITLE
ARTEMIS-4789 Page.destroy race with cleanup

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingManagerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/PagingManagerImpl.java
@@ -405,15 +405,16 @@ public final class PagingManagerImpl implements PagingManager {
 
    @Override
    public void deletePageStore(final SimpleString storeName) throws Exception {
+      PagingStore store;
       syncLock.readLock().lock();
       try {
-         PagingStore store = stores.remove(CompositeAddress.extractAddressName(storeName));
-         if (store != null) {
-            store.stop();
-            store.destroy();
-         }
+         store = stores.remove(CompositeAddress.extractAddressName(storeName));
       } finally {
          syncLock.readLock().unlock();
+      }
+
+      if (store != null) {
+         store.destroy();
       }
    }
 


### PR DESCRIPTION
this is fixing PagingTest::testPagingStoreDestroyed(db=derby) (or any other DB).

This could eventually also fail on journal.

The cleanup could act on a destroyed folder, and issue an IOException stopping the server with this race.

You would need the server active cleaning messages while the queue is being removed.