### PR TITLE
ARTEMIS-4787 anycast q is not auto-created if multicast q already exists on address

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -61,7 +61,6 @@ import org.apache.activemq.artemis.core.persistence.StorageManager;
 import org.apache.activemq.artemis.core.persistence.impl.journal.LargeServerMessageImpl;
 import org.apache.activemq.artemis.core.postoffice.Binding;
 import org.apache.activemq.artemis.core.postoffice.BindingType;
-import org.apache.activemq.artemis.core.postoffice.Bindings;
 import org.apache.activemq.artemis.core.postoffice.PostOffice;
 import org.apache.activemq.artemis.core.postoffice.QueueBinding;
 import org.apache.activemq.artemis.core.postoffice.RoutingStatus;
@@ -1848,11 +1847,7 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
          Queue q = server.locateQueue(unPrefixedQueue);
          if (q == null) {
             // The queue doesn't exist.
-            Bindings bindings = server.getPostOffice().lookupBindingsForAddress(unPrefixedAddress);
-            if (bindings != null && bindings.hasLocalBinding() && !queueConfig.isFqqn()) {
-               // The address has another queue with a different name, which is fine. Just ignore it.
-               result = AutoCreateResult.EXISTED;
-            } else if (addressSettings.isAutoCreateQueues() || queueConfig.isTemporary()) {
+            if (addressSettings.isAutoCreateQueues() || queueConfig.isTemporary()) {
                // Try to create the queue.
                try {
                   createQueue(QueueConfiguration.of(queueConfig).setAutoCreated(true));

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/multiprotocol/JMSAutoCreateQueueAndTopicWithSameName.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/multiprotocol/JMSAutoCreateQueueAndTopicWithSameName.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.jms.multiprotocol;
+
+import javax.jms.Connection;
+import javax.jms.Session;
+
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.postoffice.Binding;
+import org.apache.activemq.artemis.core.postoffice.Bindings;
+import org.apache.activemq.artemis.core.postoffice.impl.LocalQueueBinding;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class JMSAutoCreateQueueAndTopicWithSameName extends MultiprotocolJMSClientTestSupport {
+
+   @Test
+   public void testAutoCreateTopicThenQueueCore() throws Exception {
+      testAutoCreateTopicThenQueue(createCoreConnection());
+   }
+
+   @Test
+   public void testAutoCreateTopicThenQueueOpenWire() throws Exception {
+      testAutoCreateTopicThenQueue(createOpenWireConnection());
+   }
+
+   @Disabled // disable for now since AMQP doesn't support this at all
+   @Test
+   public void testAutoCreateTopicThenQueueAMQP() throws Exception {
+      testAutoCreateTopicThenQueue(createConnection());
+   }
+
+   private void testAutoCreateTopicThenQueue(Connection c) throws Exception {
+      Session s = c.createSession();
+      s.createConsumer(s.createTopic(getName()));
+      s.createConsumer(s.createQueue(getName()));
+      verifyBindings(SimpleString.of(getName()));
+      c.close();
+   }
+
+   @Test
+   public void testAutoCreateQueueThenTopicCore() throws Exception {
+      testAutoCreateQueueThenTopic(createCoreConnection());
+   }
+
+   @Test
+   public void testAutoCreateQueueThenTopicOpenWire() throws Exception {
+      testAutoCreateQueueThenTopic(createOpenWireConnection());
+   }
+
+   @Disabled // disable for now since AMQP doesn't support this at all
+   @Test
+   public void testAutoCreateQueueThenTopicAMQP() throws Exception {
+      testAutoCreateQueueThenTopic(createConnection());
+   }
+
+   private void testAutoCreateQueueThenTopic(Connection c) throws Exception {
+      Session s = c.createSession();
+      s.createConsumer(s.createQueue(getName()));
+      s.createConsumer(s.createTopic(getName()));
+      verifyBindings(SimpleString.of(getName()));
+      c.close();
+   }
+
+   private void verifyBindings(SimpleString address) throws Exception {
+      Bindings bindings = server.getPostOffice().getBindingsForAddress(address);
+      assertEquals(2, bindings.size());
+      int multicastCount = 0;
+      int anycastCount = 0;
+      for (Binding binding : bindings.getBindings()) {
+         assertTrue(binding instanceof LocalQueueBinding);
+         if (((LocalQueueBinding) binding).getQueue().getRoutingType() == RoutingType.ANYCAST) {
+            anycastCount++;
+            assertEquals(address, ((LocalQueueBinding) binding).getQueue().getName());
+         } else {
+            multicastCount++;
+         }
+      }
+      assertEquals(1, multicastCount);
+      assertEquals(1, anycastCount);
+   }
+}


### PR DESCRIPTION
There's an edge-case in the auto-creation logic for anycast queues that checks to see if any queue already exists on the address and if so then nothing further is created. It's not clear to me what use-case this is for, and it precludes the use-case detailed on ARTEMIS-4787 where a migrating user has overlapping names for JMS queues and topics.
    
This commit removes this edge-case and adds a test to verify auto-creation works properly with both OpenWire and Core. The test includes methods for AMQP, but they are disabled since the AMQP protocol handler doesn't handle this use-case at all. This PR is specifically for OpenWire.