### PR TITLE
ARTEMIS-4801 Fix issue with caching address query results

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPSessionCallback.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPSessionCallback.java
@@ -108,8 +108,6 @@ public class AMQPSessionCallback implements SessionCallback {
 
    private final CoreMessageObjectPools coreMessageObjectPools = new CoreMessageObjectPools();
 
-   private final AddressQueryCache<AddressQueryResult> addressQueryCache = new AddressQueryCache<>();
-
    private ProtonTransactionHandler transactionHandler;
 
    private final RunnableList blockedRunnables = new RunnableList();
@@ -409,12 +407,7 @@ public class AMQPSessionCallback implements SessionCallback {
                                           RoutingType routingType,
                                           boolean autoCreate) throws Exception {
 
-      AddressQueryResult addressQueryResult = addressQueryCache.getResult(addressName);
-      if (addressQueryResult != null) {
-         return addressQueryResult;
-      }
-
-      addressQueryResult = serverSession.executeAddressQuery(addressName);
+      AddressQueryResult addressQueryResult = serverSession.executeAddressQuery(addressName);
 
       if (!addressQueryResult.isExists() && addressQueryResult.isAutoCreateAddresses() && autoCreate) {
          try {
@@ -422,10 +415,10 @@ public class AMQPSessionCallback implements SessionCallback {
          } catch (ActiveMQQueueExistsException e) {
             // The queue may have been created by another thread in the mean time.  Catch and do nothing.
          }
+
          addressQueryResult = serverSession.executeAddressQuery(addressName);
       }
 
-      addressQueryCache.setResult(addressName, addressQueryResult);
       return addressQueryResult;
    }
 


### PR DESCRIPTION
When caching address query results the remote session can be blocked forever from creating links on an address if the "does not exist" value is cached since it is never updated again and will always report "does not exist" even if the address is added manually via management later. The cache state can cause other issues for long running sessions as well and should be removed to avoid attach failures for cases where the current broker state could allow the attach to succeed but the cached entry won't allow it.