### PR TITLE
ARTEMIS-4814 Make direct binding lookup time constant

### DIFF
--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/WildcardAddressManagerUnitTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/WildcardAddressManagerUnitTest.java
@@ -196,6 +196,7 @@ public class WildcardAddressManagerUnitTest extends ActiveMQTestBase {
 
       assertEquals(0, ad.getAddresses().size());
       assertEquals(0, ad.getBindings().count());
+      assertEquals(0, ad.getDirectBindings(SimpleString.of("Topic1.>")).size());
    }
 
    @Test
@@ -367,6 +368,8 @@ public class WildcardAddressManagerUnitTest extends ActiveMQTestBase {
 
                // publish again, read only
                ad.getBindingsForRoutingAddress(pubAddr);
+
+               ad.getDirectBindings(pubAddr);
 
             } catch (Exception e) {
                e.printStackTrace();


### PR DESCRIPTION
Currently, with 500K+ queues, the cleanup step of `TempQueueCleanerUpper` requires invoking `SimpleAddressManager#getDirectBindings`, which is O(k) in the number of queues `k`.

From method profiling, this can consume up to 95% of our CPU time when needing to clean up many of these.

Add a new map to keep track of the direct bindings, and add a test assertion that fails if we don't properly remove it.