### PR TITLE
Supress the login credentials during pod start-up

### DIFF
--- a/artemis-docker/Dockerfile-alpine-21
+++ b/artemis-docker/Dockerfile-alpine-21
@@ -33,6 +33,7 @@ WORKDIR /opt
 ENV ARTEMIS_USER artemis
 ENV ARTEMIS_PASSWORD artemis
 ENV ANONYMOUS_LOGIN false
+ENV SUPPRESS_CREDENTIALS false
 ENV EXTRA_ARGS --http-host 0.0.0.0 --relax-jolokia
 
 USER artemis

--- a/artemis-docker/Dockerfile-alpine-21-jre
+++ b/artemis-docker/Dockerfile-alpine-21-jre
@@ -33,6 +33,7 @@ WORKDIR /opt
 ENV ARTEMIS_USER artemis
 ENV ARTEMIS_PASSWORD artemis
 ENV ANONYMOUS_LOGIN false
+ENV SUPPRESS_CREDENTIALS false
 ENV EXTRA_ARGS --http-host 0.0.0.0 --relax-jolokia
 
 USER artemis

--- a/artemis-docker/Dockerfile-centos7-17
+++ b/artemis-docker/Dockerfile-centos7-17
@@ -26,6 +26,7 @@ WORKDIR /opt
 ENV ARTEMIS_USER artemis
 ENV ARTEMIS_PASSWORD artemis
 ENV ANONYMOUS_LOGIN false
+ENV SUPPRESS_CREDENTIALS false
 ENV EXTRA_ARGS --http-host 0.0.0.0 --relax-jolokia
 
 USER root

--- a/artemis-docker/Dockerfile-ubuntu-21
+++ b/artemis-docker/Dockerfile-ubuntu-21
@@ -26,6 +26,7 @@ WORKDIR /opt
 ENV ARTEMIS_USER artemis
 ENV ARTEMIS_PASSWORD artemis
 ENV ANONYMOUS_LOGIN false
+ENV SUPPRESS_CREDENTIALS false
 ENV EXTRA_ARGS --http-host 0.0.0.0 --relax-jolokia
 
 # add user and group for artemis

--- a/artemis-docker/Dockerfile-ubuntu-21-jre
+++ b/artemis-docker/Dockerfile-ubuntu-21-jre
@@ -26,6 +26,7 @@ WORKDIR /opt
 ENV ARTEMIS_USER artemis
 ENV ARTEMIS_PASSWORD artemis
 ENV ANONYMOUS_LOGIN false
+ENV SUPPRESS_CREDENTIALS false
 ENV EXTRA_ARGS --http-host 0.0.0.0 --relax-jolokia
 
 # add user and group for artemis

--- a/artemis-docker/docker-run.sh
+++ b/artemis-docker/docker-run.sh
@@ -33,7 +33,11 @@ fi
 
 if ! [ -f ./etc/broker.xml ]; then
     CREATE_ARGUMENTS="--user ${ARTEMIS_USER} --password ${ARTEMIS_PASSWORD} --silent ${LOGIN_OPTION} ${EXTRA_ARGS}"
-    echo CREATE_ARGUMENTS=${CREATE_ARGUMENTS}
+    if [[ ${SUPPRESS_CREDENTIALS,,} == "true" ]]; then
+      echo CREATE_ARGUMENTS="--user XXXXX --password XXXXX --silent ${LOGIN_OPTION} ${EXTRA_ARGS}"
+    else
+      echo CREATE_ARGUMENTS=${CREATE_ARGUMENTS}
+    fi
     /opt/activemq-artemis/bin/artemis create ${CREATE_ARGUMENTS} .
     if [ -d ./etc-override ]; then
         for file in `ls ./etc-override`; do echo copying file to etc folder: $file; cp ./etc-override/$file ./etc || :; done


### PR DESCRIPTION
For troubleshooting the output of our pods are fed to kibana. People analyzing these logs should not have the ability to see these credentials hence the proposal to add a SUPPRESS_CREDENTIALS environment variable to suppress this.