### PR TITLE
ARTEMIS-4816: Docker image echo's admin credentials during startup

### DIFF
--- a/artemis-docker/docker-run.sh
+++ b/artemis-docker/docker-run.sh
@@ -33,7 +33,6 @@ fi
 
 if ! [ -f ./etc/broker.xml ]; then
     CREATE_ARGUMENTS="--user ${ARTEMIS_USER} --password ${ARTEMIS_PASSWORD} --silent ${LOGIN_OPTION} ${EXTRA_ARGS}"
-    echo CREATE_ARGUMENTS=${CREATE_ARGUMENTS}
     /opt/activemq-artemis/bin/artemis create ${CREATE_ARGUMENTS} .
     if [ -d ./etc-override ]; then
         for file in `ls ./etc-override`; do echo copying file to etc folder: $file; cp ./etc-override/$file ./etc || :; done


### PR DESCRIPTION
The artemis-docker/docker-run.sh contains an echo of the startup arguments containing the admin credentials. 

For troubleshooting the output of our pods are fed to kibana. People analyzing these logs should not have the ability to see these credentials hence the proposal to remove this echo.