### PR TITLE
ARTEMIS-4817 Check policy credits before checking parent credits

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationAddressPolicyManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationAddressPolicyManager.java
@@ -107,7 +107,7 @@ public class AMQPFederationAddressPolicyManager extends FederationAddressPolicyM
 
       // Address consumers can't pull as we have no real metric to indicate when / how much
       // we should pull so instead we refuse to match if credit set to zero.
-      if (federation.getConfiguration().getReceiverCredits() <= 0) {
+      if (configuration.getReceiverCredits() <= 0) {
          logger.debug("Federation address policy rejecting match on {} because credit is set to zero:", addressInfo.getName());
          return false;
       } else {


### PR DESCRIPTION
When checking if address federation can be done the manager needs to look at the policy level settings before looking at federation or connector level settings for amqp credits.