### PR TITLE
ARTEMIS-4820 Read Header TTL as unsigned integer to set expiration

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java
@@ -705,7 +705,7 @@ public abstract class AMQPMessage extends RefCountMessage implements org.apache.
                encodedHeaderSize = data.position() - constructorPos;
                if (header.getTtl() != null) {
                   if (!expirationReload) {
-                     expiration = System.currentTimeMillis() + header.getTtl().intValue();
+                     expiration = System.currentTimeMillis() + header.getTtl().longValue();
                   }
                }
             } else if (DeliveryAnnotations.class.equals(constructor.getTypeClass())) {

--- a/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessageTest.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessageTest.java
@@ -1028,6 +1028,18 @@ public class AMQPMessageTest {
    }
 
    @Test
+   public void testGetExpirationFromMessageWithMaxUIntTTL() {
+      final long ttl = UnsignedInteger.MAX_VALUE.longValue();
+
+      MessageImpl protonMessage = (MessageImpl) Message.Factory.create();
+      protonMessage.setHeader(new Header());
+      protonMessage.setTtl(ttl);
+      AMQPStandardMessage decoded = encodeAndDecodeMessage(protonMessage);
+
+      assertTrue(decoded.getExpiration() > System.currentTimeMillis());
+   }
+
+   @Test
    public void testGetExpirationFromCoreMessageUsingTTL() {
       final long ttl = 100000;
 
@@ -1085,6 +1097,18 @@ public class AMQPMessageTest {
    @Test
    public void testSetExpiration() {
       final Date expirationTime = new Date(System.currentTimeMillis());
+
+      MessageImpl protonMessage = (MessageImpl) Message.Factory.create();
+      AMQPStandardMessage decoded = encodeAndDecodeMessage(protonMessage);
+
+      assertEquals(0, decoded.getExpiration());
+      decoded.setExpiration(expirationTime.getTime());
+      assertEquals(expirationTime.getTime(), decoded.getExpiration());
+   }
+
+   @Test
+   public void testSetExpirationMaxUInt() {
+      final Date expirationTime = new Date(UnsignedInteger.MAX_VALUE.longValue());
 
       MessageImpl protonMessage = (MessageImpl) Message.Factory.create();
       AMQPStandardMessage decoded = encodeAndDecodeMessage(protonMessage);


### PR DESCRIPTION
When setting expiration on the AMQPMessage the AMQP header TTL value should be read as an unsigned integer and as such should use the longValue API of UnsignedInteger to get the right value to set expiration.