### PR TITLE
ARTEMIS-4814 Speeding up WildcardAddressManagerUnitTest::testConcurre…

### DIFF
--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/WildcardAddressManagerUnitTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/WildcardAddressManagerUnitTest.java
@@ -408,6 +408,7 @@ public class WildcardAddressManagerUnitTest extends ActiveMQTestBase {
 
 
       CountDownLatch latch = new CountDownLatch(threads);
+      CountDownLatch latch2 = new CountDownLatch(1);
 
       AtomicInteger errors = new AtomicInteger(0);
       AtomicBoolean running = new AtomicBoolean(true);
@@ -418,10 +419,13 @@ public class WildcardAddressManagerUnitTest extends ActiveMQTestBase {
             while (running.get()) {
                // just to make things worse
                simpleAddressManager.getDirectBindings(addressSimpleString);
+               Thread.sleep(1);
             }
          } catch (Exception e) {
             logger.warn(e.getMessage(), e);
             errors.incrementAndGet();
+         } finally {
+            latch2.countDown();
          }
       });
 
@@ -450,6 +454,8 @@ public class WildcardAddressManagerUnitTest extends ActiveMQTestBase {
       Assertions.assertTrue(latch.await(1, TimeUnit.MINUTES));
 
       running.set(false);
+
+      Assertions.assertTrue(latch2.await(1, TimeUnit.MINUTES));
 
       Assertions.assertEquals(0, errors.get());
 


### PR DESCRIPTION
…ntCalls2

This test is spinning a concurrent call on getDirectBindings Since I added a synchronization point to get the Bindings the test could be taking up to 5 seconds, being a variance between 500ms and 5 seconds.

Adding Thread.sleep(1) on this loop solved  the issue as it is now letting other threads to do work since I'm starting more executors than cores I have on my box.