### PR TITLE
ARTEMIS-4832: direct test output to file, make results more visible

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,14 @@ jobs:
           rm -rf ~/.m2/repository/org/apache/activemq/examples
           if [ -d ~/.m2/repository/org/apache/activemq ]; then find ~/.m2/repository/org/apache/activemq -name "*-SNAPSHOT" -type d -prune -exec rm -r '{}' \; ; fi
 
+      - name: Archive Test Logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports-jdk-${{ matrix.java }}
+          path: activemq-artemis/**/target/surefire-reports/*
+          retention-days: 10
+
   checks:
     name: Checks (${{ matrix.java }})
     runs-on: ubuntu-22.04

--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
       <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
       <maven.test.failure.ignore>false</maven.test.failure.ignore>
-      <maven.test.redirectTestOutputToFile>false</maven.test.redirectTestOutputToFile>
+      <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
 
       <!--
 


### PR DESCRIPTION
Direct test output to file, make results more visible.

Archives test logs upon GHA CI job failure to allow inspection.