### PR TITLE
ARTEMIS-4902 Put example XML for core federation in correct order

### DIFF
--- a/docs/user-manual/federation-address.adoc
+++ b/docs/user-manual/federation-address.adoc
@@ -297,15 +297,15 @@ Sample Downstream Address Federation setup:
           <static-connectors>
              <connector-ref>eu-east-1-connector</connector-ref>
           </static-connectors>
-          <upstream-connector-ref>netty-connector</upstream-connector-ref>
           <policy ref="news-address-federation"/>
+          <upstream-connector-ref>netty-connector</upstream-connector-ref>
       </downstream>
       <downstream name="eu-west-1" >
          <static-connectors>
             <connector-ref>eu-west-1-connector</connector-ref>
          </static-connectors>
-         <upstream-connector-ref>netty-connector</upstream-connector-ref>
          <policy ref="news-address-federation"/>
+         <upstream-connector-ref>netty-connector</upstream-connector-ref>
       </downstream>
 
       <address-policy name="news-address-federation" max-hops="1" auto-delete="true" auto-delete-delay="300000" auto-delete-message-count="-1" transformer-ref="news-transformer">

--- a/docs/user-manual/federation-queue.adoc
+++ b/docs/user-manual/federation-queue.adoc
@@ -263,15 +263,15 @@ Sample Downstream Address Federation setup:
           <static-connectors>
              <connector-ref>eu-east-1-connector</connector-ref>
           </static-connectors>
-          <upstream-connector-ref>netty-connector</upstream-connector-ref>
           <policy ref="news-address-federation"/>
+          <upstream-connector-ref>netty-connector</upstream-connector-ref>
       </downstream>
       <downstream name="eu-west-1" >
          <static-connectors>
             <connector-ref>eu-west-1-connector</connector-ref>
          </static-connectors>
-         <upstream-connector-ref>netty-connector</upstream-connector-ref>
          <policy ref="news-address-federation"/>
+         <upstream-connector-ref>netty-connector</upstream-connector-ref>
       </downstream>
 
       <queue-policy name="news-queue-federation" priority-adjustment="-5" include-federated="true" transformer-ref="news-transformer">


### PR DESCRIPTION
The downstream connection setup is not in correct XSD order and fails on start of a broker if cut and pasted into broker configuration.