### PR TITLE
ARTEMIS-4923 reduce synchronization in ManagementServiceImpl

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1070,8 +1070,8 @@ public interface ActiveMQServerLogger {
    @LogMessage(id = 222255, value = "Unable to calculate file store usage", level = LogMessage.Level.WARN)
    void unableToCalculateFileStoreUsage(Exception e);
 
-   @LogMessage(id = 222256, value = "Failed to unregister acceptors", level = LogMessage.Level.WARN)
-   void failedToUnregisterAcceptors(Exception e);
+   @LogMessage(id = 222256, value = "Failed to unregister acceptor: {}", level = LogMessage.Level.WARN)
+   void failedToUnregisterAcceptor(String acceptor, Exception e);
 
    @LogMessage(id = 222257, value = "Failed to decrement message reference count", level = LogMessage.Level.WARN)
    void failedToDecrementMessageReferenceCount(Exception e);

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/management/impl/ManagementServiceImplTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/management/impl/ManagementServiceImplTest.java
@@ -111,7 +111,7 @@ public class ManagementServiceImplTest {
       Mockito.when(queue.getRoutingType()).thenReturn(RoutingType.ANYCAST);
 
       StorageManager storageManager = Mockito.mock(StorageManager.class);
-      managementService.registerQueue(queue, new AddressInfo(queueName), storageManager);
+      managementService.registerQueue(queue, queueName, storageManager);
       managementService.getAttribute(ResourceNames.QUEUE + queueName, "ringSize", auth);
 
       expected = SimpleString.of("mm.queue." + queueName + ".getRingSize");
@@ -174,7 +174,7 @@ public class ManagementServiceImplTest {
       Mockito.when(queue.getRoutingType()).thenReturn(RoutingType.ANYCAST);
 
       StorageManager storageManager = Mockito.mock(StorageManager.class);
-      managementService.registerQueue(queue, new AddressInfo(queueName), storageManager);
+      managementService.registerQueue(queue, queueName, storageManager);
       managementService.invokeOperation(ResourceNames.QUEUE + queueName, "getRingSize", new Object[]{}, auth);
 
       expected = SimpleString.of("$mm.queue." + queueName + ".getRingSize");


### PR DESCRIPTION
The `ManagementService` is used by the broker to register and unregister components for management as well as send notifications. When the broker is busy dealing with new sessions and auto-creating queues, addresses, etc. there is a lot of contention.

To reduce synchronization and improve the service overall this commit does the following:

 - Remove `synchronized` from most methods. In most cases it's completely unnecessary because the methods are already using a thread-safe data-structure (e.g. `ConcurrentHashMap`) or more specific synchronization is already in place (e.g. on `mbeanServer`).
 - Adds new & clarifies existing logging.
 - Synchronizes `start` & `stop` methods and adds gates via `started`.
 - Simplifies the `sendNotification` method by synchronizing once rather than twice and performing legitimacy checks sooner.
 - Removing an unnecessary overload of the `registereQueue` method.

To be clear, there are no tests included with this commit as there should be no semantic changes. Existing tests should be sufficient to identify any regressions.