### PR TITLE
ARTEMIS-4952 Use getObjectPropertyForFilter when applying filters

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/QueueControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/QueueControlImpl.java
@@ -1161,7 +1161,7 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
          if (groupByProperty == null) {
             result.compute(null, (k, v) -> v == null ? 1 : ++v);
          } else {
-            Object value = message.getObjectProperty(groupByProperty);
+            Object value = message.getObjectPropertyForFilter(groupByProperty);
             String valueStr = value == null ? null : value.toString();
             result.compute(valueStr, (k, v) -> v == null ? 1 : ++v);
          }


### PR DESCRIPTION
When counting messages with provided filters and grouping use the API getObjectPropertyForFilter which translates values from AMQP message annotations that are otherwise missed by the filters.