### PR TITLE
ARTEMIS-4785 Add log4j2-default.properties for non-run CLI commands

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
@@ -77,6 +77,7 @@ public class Create extends InstallAbstract {
    public static final String BIN_ARTEMIS_SERVICE = "bin/" + ARTEMIS_SERVICE;
    public static final String ETC_ARTEMIS_PROFILE = "artemis.profile";
    public static final String ETC_LOG4J2_PROPERTIES = "log4j2.properties";
+   public static final String ETC_LOG4J2_DEFAULT_PROPERTIES = "log4j2-default.properties";
    public static final String ETC_BOOTSTRAP_XML = "bootstrap.xml";
    public static final String ETC_MANAGEMENT_XML = "management.xml";
    public static final String ETC_BROKER_XML = "broker.xml";
@@ -769,6 +770,7 @@ public class Create extends InstallAbstract {
       }
 
       writeEtc(ETC_LOG4J2_PROPERTIES, etcFolder, null, false);
+      writeEtc(ETC_LOG4J2_DEFAULT_PROPERTIES, etcFolder, null, false);
 
       if (noWeb) {
          filters.put("${bootstrap-web-settings}", "");

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Upgrade.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Upgrade.java
@@ -348,6 +348,15 @@ public class Upgrade extends InstallAbstract {
             }
          }
       }
+
+      File newDefaultLogging = new File(etcFolder, Create.ETC_LOG4J2_DEFAULT_PROPERTIES);
+      if (!newDefaultLogging.exists()) {
+         context.out.println("Creating " + newDefaultLogging);
+         try (InputStream inputStream = openStream("etc/" + Create.ETC_LOG4J2_DEFAULT_PROPERTIES);
+              OutputStream outputStream = new FileOutputStream(newDefaultLogging)) {
+            copy(inputStream, outputStream);
+         }
+      }
    }
 
    protected File findBackup(ActionContext context) throws IOException {

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile
@@ -60,4 +60,6 @@ if [ "$1" = "run" ]; then :
 
     # Uncomment for async profiler
     # DEBUG_ARGS="-XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints"
+else
+    JAVA_ARGS="$JAVA_ARGS -Dlog4j2.configurationFile=${ARTEMIS_INSTANCE_ETC_URI}log4j2-default.properties "
 fi

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile.cmd
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile.cmd
@@ -48,3 +48,4 @@ rem set JAVA_ARGS=%JAVA_ARGS% -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=%
 rem Only enable debug options for the 'run' command
 rem Uncomment to enable remote debugging
 rem if "%1"=="run" set DEBUG_ARGS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005
+if not "%1"=="run" set JAVA_ARGS=%JAVA_ARGS% -Dlog4j2.configurationFile=%ARTEMIS_ETC_DIR%\log4j2-default.properties

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/log4j2-default.properties
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/log4j2-default.properties
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Log4J 2 configuration
+
+# Monitor config file every X seconds for updates
+monitorInterval = 5
+
+rootLogger.level = ERROR
+rootLogger.appenderRef.console.ref = console
+
+# Console appender
+appender.console.type=Console
+appender.console.name=console
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d %-5level [%logger] %msg%n

--- a/docs/user-manual/logging.adoc
+++ b/docs/user-manual/logging.adoc
@@ -3,7 +3,7 @@
 :idseparator: -
 
 Apache ActiveMQ Artemis uses the https://www.slf4j.org/[SLF4J] logging facade for logging, with the broker assembly providing https://logging.apache.org/log4j/2.x/manual/[Log4J 2] as the logging implementation.
-This is configurable via the `log4j2.properties` file found in the broker instance `etc` directory, which is configured by default to log to both the console and to a file.
+When the broker is started by executing the `run` command, this is configurable via the `log4j2.properties` file found in the broker instance `etc` directory, which is configured by default to log to both the console and to a file. For the other CLI commands, this is configurable via the `log4j2-default.properties` file found in the broker instance `etc` directory, which is configured by default to log only errors to the console.
 
 There are a handful of general loggers available:
 
@@ -65,7 +65,7 @@ monitorInterval = 5
 
 == Logging in a client application
 
-Firstly, if you want to enable logging on the client side you need to include a logging implementation in your application which supports the the SLF4J facade.
+Firstly, if you want to enable logging on the client side you need to include a logging implementation in your application which supports the SLF4J facade.
 Taking Log4J2 as an example logging implementation, since it used by the broker, when using Maven your client and logging dependencies might be e.g.:
 
 [,xml,subs="normal"]

--- a/docs/user-manual/upgrading.adoc
+++ b/docs/user-manual/upgrading.adoc
@@ -56,7 +56,7 @@ cd $NEW_ARTEMIS_DOWNLOAD/bin/
 ----
 
 The broker instance `bin/artemis` script and `etc/artemis.profile`(`artemis.cmd` and `artemis.cmd.profile` on Windows) will be updated to the new versions, setting its ARTEMIS_HOME to refer to the new broker version home path.
-The tool will also create the new `<instance>/etc/log4j2.properties` configuration file if needed (e.g if you are migrating from a version prior to 2.27.0), and remove the old `<instance>/etc/logging.properties` file if present.
+The tool will also create the new `<instance>/etc/log4j2.properties` and `<instance>/etc/log4j2-default.properties` configuration files if needed (e.g if you are migrating from a version prior to 2.27.0), and remove the old `<instance>/etc/logging.properties` file if present.
 
 The `broker.xml` file and data are retained as-is.
 
@@ -66,5 +66,5 @@ Most existing customisations to the old configuration files and scripts will be 
 As such you should compare the old configuration files with the refreshed ones and then port any missing customisations you may have made as necessary.
 The upgrade command itself will copy the older files it changes to an `old-config-bkp.` folder within the instance dir.
 
-Similarly, if you had customised the old `logging.properties` file you may need to prepare analogous changes for the new `log4j2.properties` file.
+Similarly, if you had customised the old `logging.properties` or `log4j2-default.properties` files you may need to prepare analogous changes for the new `log4j2.properties` and `log4j2-default.properties` files.
 ====

--- a/docs/user-manual/versions.adoc
+++ b/docs/user-manual/versions.adoc
@@ -12,6 +12,19 @@ NOTE: If the upgrade spans multiple versions then the steps from *each* version 
 
 NOTE: Follow the general upgrade procedure outlined in the xref:upgrading.adoc#upgrading-the-broker[Upgrading the Broker]  chapter in addition to any version-specific upgrade instructions outlined here.
 
+== 2.37.0
+
+https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315920&version=12354977[Full release notes]
+
+=== Highlights
+
+* The logging configuration of the CLI commands other than run is configurable via the `log4j2-default.properties` file.
+
+=== Upgrading from 2.36.0
+
+The CLI commands other than run will now need to define the logging configuration via the `log4j2-default.properties` file.
+See xref:logging.adoc#logging[logging] for more information.
+
 == 2.36.0
 
 https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315920&version=12354818[Full release notes]


### PR DESCRIPTION
The run command uses log4j2.properties and all other commands use log4j2-default.properties.