### PR TITLE
NO-JIRA  Remove first empty line from cherry-pick-report.sh

### DIFF
--- a/scripts/cherry-pick-report.sh
+++ b/scripts/cherry-pick-report.sh
@@ -1,4 +1,3 @@
-
 #!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
A shebang only has an effect when it appears as the first line in a script.