### PR TITLE
ARTEMIS-4785 ARTEMIS-4702 Add profile and log4j2 files for non-run CLI commands

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
@@ -71,12 +71,15 @@ public class Create extends InstallAbstract {
    public static final String ARTEMIS_SERVICE_XML = "artemis-service.xml";
    public static final String BIN_ARTEMIS_SERVICE_XML = "bin/" + ARTEMIS_SERVICE_XML;
    public static final String ETC_ARTEMIS_PROFILE_CMD = "artemis.profile.cmd";
+   public static final String ETC_ARTEMIS_UTILITY_PROFILE_CMD = "artemis-utility.profile.cmd";
    public static final String ARTEMIS = "artemis";
    public static final String BIN_ARTEMIS = "bin/" + ARTEMIS;
    public static final String ARTEMIS_SERVICE = "artemis-service";
    public static final String BIN_ARTEMIS_SERVICE = "bin/" + ARTEMIS_SERVICE;
    public static final String ETC_ARTEMIS_PROFILE = "artemis.profile";
+   public static final String ETC_ARTEMIS_UTILITY_PROFILE = "artemis-utility.profile";
    public static final String ETC_LOG4J2_PROPERTIES = "log4j2.properties";
+   public static final String ETC_LOG4J2_UTILITY_PROPERTIES = "log4j2-utility.properties";
    public static final String ETC_BOOTSTRAP_XML = "bootstrap.xml";
    public static final String ETC_MANAGEMENT_XML = "management.xml";
    public static final String ETC_BROKER_XML = "broker.xml";
@@ -152,8 +155,6 @@ public class Create extends InstallAbstract {
    @Option(names = "--force", description = "Overwrite configuration at destination directory.")
    private boolean force;
 
-   @Option(names = "--data", description = "Directory where ActiveMQ data are stored. Paths can be absolute or relative to artemis.instance directory. Default: data.")
-   private String data = "data";
 
    @Option(names = "--clustered", description = "Enable clustering.")
    private boolean clustered = false;
@@ -713,12 +714,13 @@ public class Create extends InstallAbstract {
       new File(directory, "tmp").mkdirs();
       new File(directory, "lib").mkdirs();
       File dataFolder = createDirectory(data, directory);
-      File logFolder = createDirectory("log", directory);
-      File oomeDumpFile = new File(logFolder, "oom_dump.hprof");
+      File logFolder = createDirectory(LOG_DIRNAME, directory);
+      File oomeDumpFile = new File(logFolder, OOM_DUMP_FILENAME);
 
       String processedJavaOptions = getJavaOptions();
+      String processedJavaUtilityOptions = getJavaUtilityOptions();
 
-      addScriptFilters(filters, getHome(), getInstance(), etcFolder, dataFolder, oomeDumpFile, javaMemory, processedJavaOptions, role);
+      addScriptFilters(filters, getHome(), getInstance(), etcFolder, dataFolder, oomeDumpFile, javaMemory, processedJavaOptions, processedJavaUtilityOptions, role);
 
       boolean allowAnonymous = isAllowAnonymous();
 
@@ -758,6 +760,7 @@ public class Create extends InstallAbstract {
          write(BIN_ARTEMIS_SERVICE_EXE_CONFIG, force);
          write(BIN_ARTEMIS_SERVICE_XML, filters, false);
          writeEtc(ETC_ARTEMIS_PROFILE_CMD, etcFolder, filters, false);
+         writeEtc(ETC_ARTEMIS_UTILITY_PROFILE_CMD, etcFolder, filters, false);
       }
 
       if (IS_NIX) {
@@ -766,9 +769,11 @@ public class Create extends InstallAbstract {
          write(BIN_ARTEMIS_SERVICE, filters, true);
          makeExec(BIN_ARTEMIS_SERVICE);
          writeEtc(ETC_ARTEMIS_PROFILE, etcFolder, filters, true);
+         writeEtc(ETC_ARTEMIS_UTILITY_PROFILE, etcFolder, filters, true);
       }
 
       writeEtc(ETC_LOG4J2_PROPERTIES, etcFolder, null, false);
+      writeEtc(ETC_LOG4J2_UTILITY_PROPERTIES, etcFolder, null, false);
 
       if (noWeb) {
          filters.put("${bootstrap-web-settings}", "");
@@ -883,6 +888,7 @@ public class Create extends InstallAbstract {
                           File oomeDumpFile,
                           String javaMemory,
                           String javaOptions,
+                          String javaUtilityOptions,
                           String role) throws IOException {
       filters.put("${artemis.home}", path(home));
       // I am using a different replacing pattern here, for cases where want an actual ${artemis.instance} in the output
@@ -900,6 +906,7 @@ public class Create extends InstallAbstract {
       filters.put("${artemis.instance.data}", path(dataFolder));
       filters.put("${java-memory}", javaMemory);
       filters.put("${java-opts}", javaOptions);
+      filters.put("${java-utility-opts}", javaUtilityOptions);
       filters.put("${role}", role);
    }
 

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/InstallAbstract.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/InstallAbstract.java
@@ -37,11 +37,17 @@ import picocli.CommandLine.Parameters;
 
 public class InstallAbstract extends InputAbstract {
 
+   protected static final String LOG_DIRNAME = "log";
+   protected static final String OOM_DUMP_FILENAME = "oom_dump.hprof";
+
    @Parameters(description = "The instance directory to hold the broker's configuration and data. Path must be writable.")
    protected File directory;
 
    @Option(names = "--etc", description = "Directory where ActiveMQ configuration is located. Paths can be absolute or relative to artemis.instance directory. Default: etc.")
    protected String etc = "etc";
+
+   @Option(names = "--data", description = "Directory where ActiveMQ data are stored. Paths can be absolute or relative to artemis.instance directory. Default: data.")
+   protected String data = "data";
 
    @Option(names = "--home", description = "Directory where ActiveMQ Artemis is installed.")
    protected File home;
@@ -58,6 +64,9 @@ public class InstallAbstract extends InputAbstract {
    @Option(names = "--java-options", description = "Extra Java options to be passed to the profile.")
    protected List<String> javaOptions;
 
+   @Option(names = "--java-utility-options", description = "Extra Java options to be passed to the utility profile.")
+   protected List<String> javaUtilityOptions;
+
    @Option(names = "--java-memory", description = "Define the -Xmx memory parameter for the broker. Default: 2G.")
    protected String javaMemory = "2G";
 
@@ -70,6 +79,14 @@ public class InstallAbstract extends InputAbstract {
       StringBuilder builder = new StringBuilder();
       if (javaOptions != null) {
          javaOptions.forEach(s -> builder.append(s).append(" "));
+      }
+      return builder.toString();
+   }
+
+   protected String getJavaUtilityOptions() {
+      StringBuilder builder = new StringBuilder();
+      if (javaUtilityOptions != null) {
+         javaUtilityOptions.forEach(s -> builder.append(s).append(" "));
       }
       return builder.toString();
    }

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis
@@ -48,7 +48,16 @@ HAWTIO_ROLE="NO_HAWTIO_ROLE"
 
 # Load Profile Data
 ARTEMIS_INSTANCE_ETC='${artemis.instance.etc}'
-. "$ARTEMIS_INSTANCE_ETC/artemis.profile"
+
+if [ -z "$ARTEMIS_PROFILE" ] ; then
+  if [ "$1" = "run" ]; then
+    ARTEMIS_PROFILE='artemis.profile'
+  else
+    ARTEMIS_PROFILE="artemis-utility.profile"
+  fi
+fi
+
+. "$ARTEMIS_INSTANCE_ETC/${ARTEMIS_PROFILE}"
 
 
 CLASSPATH="$ARTEMIS_HOME/lib/artemis-boot.jar"
@@ -101,6 +110,7 @@ if [ -f "$ARTEMIS_OOME_DUMP" ] ; then
 fi
 
 exec "$JAVACMD" \
+    $LOGGING_ARGS \
     $JAVA_ARGS \
     -Dhawtio.role="$HAWTIO_ROLE" \
     -Djava.security.auth.login.config="$ARTEMIS_INSTANCE_ETC/login.config" \

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis.cmd
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis.cmd
@@ -46,7 +46,13 @@ echo.
 
 rem "Load Profile Config"
 set ARTEMIS_INSTANCE_ETC="${artemis.instance.etc}"
-call %ARTEMIS_INSTANCE_ETC%\artemis.profile.cmd %*
+
+if not "%ARTEMIS_PROFILE%"=="" goto LOAD_ARTEMIS_PROFILE
+set ARTEMIS_PROFILE=artemis-utility.profile.cmd
+if "%1"=="run" set ARTEMIS_PROFILE=artemis.profile.cmd
+
+:LOAD_ARTEMIS_PROFILE
+call %ARTEMIS_INSTANCE_ETC%\%ARTEMIS_PROFILE% %*
 
 if not exist %ARTEMIS_OOME_DUMP% goto NO_ARTEMIS_OOME_DUMP
 rem "Backup the last OOME heap dump"
@@ -55,7 +61,8 @@ move /Y %ARTEMIS_OOME_DUMP% %ARTEMIS_OOME_DUMP%.bkp
 :NO_ARTEMIS_OOME_DUMP
 
 rem "Create full JVM Args"
-set JVM_ARGS=%JAVA_ARGS%
+set JVM_ARGS=%LOGGING_ARGS%
+set JVM_ARGS=%JVM_ARGS% %JAVA_ARGS%
 if not "%ARTEMIS_CLUSTER_PROPS%"=="" set JVM_ARGS=%JVM_ARGS% %ARTEMIS_CLUSTER_PROPS%
 set JVM_ARGS=%JVM_ARGS% -classpath %ARTEMIS_HOME%\lib\artemis-boot.jar
 set JVM_ARGS=%JVM_ARGS% -Dartemis.home=%ARTEMIS_HOME%

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis-utility.profile
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis-utility.profile
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ARTEMIS_HOME='${artemis.home}'
+ARTEMIS_INSTANCE='@artemis.instance@'
+ARTEMIS_DATA_DIR='${artemis.instance.data}'
+ARTEMIS_ETC_DIR='${artemis.instance.etc}'
+ARTEMIS_OOME_DUMP='${artemis.instance.oome.dump}'
+
+# The logging config will need an URI
+# this will be encoded in case you use spaces or special characters
+# on your directory structure
+ARTEMIS_INSTANCE_URI='${artemis.instance.uri}'
+ARTEMIS_INSTANCE_ETC_URI='${artemis.instance.etc.uri}'
+
+if [ -z "$LOGGING_ARGS" ]; then
+    LOGGING_ARGS="-Dlog4j2.configurationFile=${ARTEMIS_INSTANCE_ETC_URI}log4j2-utility.properties"
+fi
+
+if [ -z "$JAVA_ARGS" ]; then
+    JAVA_ARGS="-Dlog4j2.disableJmx=true --add-opens java.base/jdk.internal.misc=ALL-UNNAMED ${java-utility-opts}"
+fi
+
+# Uncomment to enable remote debugging
+# DEBUG_ARGS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis-utility.profile.cmd
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis-utility.profile.cmd
@@ -1,0 +1,37 @@
+@echo off
+rem Licensed to the Apache Software Foundation (ASF) under one
+rem or more contributor license agreements.  See the NOTICE file
+rem distributed with this work for additional information
+rem regarding copyright ownership.  The ASF licenses this file
+rem to you under the Apache License, Version 2.0 (the
+rem "License"); you may not use this file except in compliance
+rem with the License.  You may obtain a copy of the License at
+rem
+rem   http://www.apache.org/licenses/LICENSE-2.0
+rem
+rem Unless required by applicable law or agreed to in writing,
+rem software distributed under the License is distributed on an
+rem "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+rem KIND, either express or implied.  See the License for the
+rem specific language governing permissions and limitations
+rem under the License.
+
+set ARTEMIS_HOME="${artemis.home}"
+set ARTEMIS_INSTANCE="@artemis.instance@"
+set ARTEMIS_DATA_DIR="${artemis.instance.data}"
+set ARTEMIS_ETC_DIR="${artemis.instance.etc}"
+set ARTEMIS_OOME_DUMP="${artemis.instance.oome.dump}"
+
+
+rem The logging config will need an URI
+rem this will be encoded in case you use spaces or special characters
+rem on your directory structure
+set ARTEMIS_INSTANCE_URI="${artemis.instance.uri.windows}"
+set ARTEMIS_INSTANCE_ETC_URI="${artemis.instance.etc.uri.windows}"
+
+IF "%LOGGING_ARGS%"=="" (set LOGGING_ARGS=-Dlog4j2.configurationFile=%ARTEMIS_INSTANCE_ETC_URI%log4j2-utility.properties)
+
+IF "%JAVA_ARGS%"=="" (set JAVA_ARGS=-Dlog4j2.disableJmx=true --add-opens java.base/jdk.internal.misc=ALL-UNNAMED ${java-utility-opts})
+
+rem Uncomment to enable remote debugging
+rem set DEBUG_ARGS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/log4j2-utility.properties
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/log4j2-utility.properties
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Log4J 2 configuration
+
+# Monitor config file every X seconds for updates
+monitorInterval = 5
+
+rootLogger.level = ERROR
+rootLogger.appenderRef.console.ref = console
+
+# Console appender
+appender.console.type=Console
+appender.console.name=console
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d %-5level [%logger] %msg%n

--- a/artemis-cli/src/test/java/org/apache/activemq/cli/test/StreamClassPathTest.java
+++ b/artemis-cli/src/test/java/org/apache/activemq/cli/test/StreamClassPathTest.java
@@ -37,9 +37,11 @@ public class StreamClassPathTest {
       testStream(Create.class, Create.BIN_ARTEMIS_SERVICE_EXE_CONFIG);
       testStream(Create.class, Create.BIN_ARTEMIS_SERVICE_XML);
       testStream(Create.class, "etc/" + Create.ETC_ARTEMIS_PROFILE_CMD);
+      testStream(Create.class, "etc/" + Create.ETC_ARTEMIS_UTILITY_PROFILE_CMD);
       testStream(Create.class, Create.BIN_ARTEMIS);
       testStream(Create.class, Create.BIN_ARTEMIS_SERVICE);
       testStream(Create.class, "etc/" + Create.ETC_ARTEMIS_PROFILE);
+      testStream(Create.class, "etc/" + Create.ETC_ARTEMIS_UTILITY_PROFILE);
       testStream(Create.class, "etc/" + Create.ETC_LOG4J2_PROPERTIES);
       testStream(Create.class, "etc/" + Create.ETC_BOOTSTRAP_XML);
       testStream(Create.class, "etc/" + Create.ETC_MANAGEMENT_XML);

--- a/docs/migration-guide/_configuration.adoc
+++ b/docs/migration-guide/_configuration.adoc
@@ -24,11 +24,13 @@ The main configuration file is `etc/broker.xml`.
 Similarly to ActiveMQ's `conf/activemq.xml`, this is where you configure most of the aspects of the broker, like connector ports, destination names, security policies, etc.
 We will go through this file in details in the following articles.
 
-The `etc/artemis.profile` file is similar to the `bin/env` file in ActiveMQ.
-Here you can configure environment variables for the broker, mostly regular JVM args related to SSL context, debugging, etc.
+The `etc/artemis.profile` and `etc/artemis-utility.profile` files are similar to the `bin/env` file in ActiveMQ.
+In the `etc/artemis.profile` you can configure environment variables for the broker started by executing the `run` command, mostly regular JVM args related to SSL context, debugging, etc.
+In the `etc/artemis-utility.profile` file you can configure environment variables for all CLI commands other than run, mostly regular JVM args related to SSL context, debugging, etc.
 
 There's not much difference in logging configuration between two brokers, so anyone familiar with Java logging systems in general will find herself at home here.
-The `etc/log4j-config.properties` file is where it's all configured.
+The `etc/log4j2.properties` file is where it's all configured for the broker.
+The `etc/log4j2-utility.properties` file is where it's all configured for all CLI commands other than run.
 
 Finally, we have JAAS configuration files (`login.config`, `artemis-users.properties` and `artemis-roles.properties`), which cover same roles as in ActiveMQ and we will go into more details on these in the article that covers security.
 

--- a/docs/user-manual/logging.adoc
+++ b/docs/user-manual/logging.adoc
@@ -3,7 +3,7 @@
 :idseparator: -
 
 Apache ActiveMQ Artemis uses the https://www.slf4j.org/[SLF4J] logging facade for logging, with the broker assembly providing https://logging.apache.org/log4j/2.x/manual/[Log4J 2] as the logging implementation.
-This is configurable via the `log4j2.properties` file found in the broker instance `etc` directory, which is configured by default to log to both the console and to a file.
+When the broker is started by executing the `run` command, this is configurable via the `log4j2.properties` file found in the broker instance `etc` directory, which is configured by default to log to both the console and to a file. For the other CLI commands, this is configurable via the `log4j2-utility.properties` file found in the broker instance `etc` directory, which is configured by default to log only errors to the console (in addition to the usual command output).
 
 There are a handful of general loggers available:
 
@@ -65,7 +65,7 @@ monitorInterval = 5
 
 == Logging in a client application
 
-Firstly, if you want to enable logging on the client side you need to include a logging implementation in your application which supports the the SLF4J facade.
+Firstly, if you want to enable logging on the client side you need to include a logging implementation in your application which supports the SLF4J facade.
 Taking Log4J2 as an example logging implementation, since it used by the broker, when using Maven your client and logging dependencies might be e.g.:
 
 [,xml,subs="normal"]

--- a/docs/user-manual/perf-tools.adoc
+++ b/docs/user-manual/perf-tools.adoc
@@ -25,7 +25,7 @@ As they progress, some internal architectural details of the tool and the config
 [NOTE]
 ====
 The tools can run both from within the broker's instance folder or from the home folder.
-In the former case it will use the same JVM parameter configured on the instance (on `artemis.profile`), while in the latter case the user should set `JAVA_ARGS` environment variable to override default heap and GC parameters (e.g. `-XX:+UseParallelGC -Xms512M -Xmx1024M`)
+In both cases, the user should set `JAVA_ARGS` environment variable to override default heap and GC parameters (e.g. `-XX:+UseParallelGC -Xms512M -Xmx1024M`)
 ====
 
 == Case 1: Single producer Single consumer over a queue

--- a/docs/user-manual/upgrading.adoc
+++ b/docs/user-manual/upgrading.adoc
@@ -20,7 +20,7 @@ It also simplifies updating to newer versions of Artemis.
 Upgrading may require some specific steps noted in the xref:versions.adoc#versions[versions], but the general process is as follows:
 
 . Navigate to the `etc` folder of the broker instance that's being upgraded
-. Open `artemis.profile` (`artemis.profile.cmd` on Windows).
+. Open `artemis.profile` and `artemis-utility.profile` (`artemis.profile.cmd` and `artemis-utility.profile.cmd` on Windows).
 It contains a property which is relevant for the upgrade:
 +
 ----
@@ -55,8 +55,8 @@ cd $NEW_ARTEMIS_DOWNLOAD/bin/
 ./artemis upgrade PATH_TO_UPGRADING_INSTANCE
 ----
 
-The broker instance `bin/artemis` script and `etc/artemis.profile`(`artemis.cmd` and `artemis.cmd.profile` on Windows) will be updated to the new versions, setting its ARTEMIS_HOME to refer to the new broker version home path.
-The tool will also create the new `<instance>/etc/log4j2.properties` configuration file if needed (e.g if you are migrating from a version prior to 2.27.0), and remove the old `<instance>/etc/logging.properties` file if present.
+The broker instance script `bin/artemis` plus profiles `etc/artemis.profile` and `etc/artemis-utility.profile` (`artemis.cmd`, `artemis.cmd.profile`, and `artemis-utility.cmd.profile` on Windows) will be updated to the new versions, setting its ARTEMIS_HOME to refer to the new broker version home path.
+The tool will also create the new `<instance>/etc/log4j2.properties` and `<instance>/etc/log4j2-default.properties` configuration files if needed (e.g if you are migrating from a version prior to 2.27.0), and remove the old `<instance>/etc/logging.properties` file if present.
 
 The `broker.xml` file and data are retained as-is.
 
@@ -66,5 +66,5 @@ Most existing customisations to the old configuration files and scripts will be 
 As such you should compare the old configuration files with the refreshed ones and then port any missing customisations you may have made as necessary.
 The upgrade command itself will copy the older files it changes to an `old-config-bkp.` folder within the instance dir.
 
-Similarly, if you had customised the old `logging.properties` file you may need to prepare analogous changes for the new `log4j2.properties` file.
+Similarly, if you had customised the old `logging.properties` file you may need to prepare analogous changes for the new `log4j2.properties` and `log4j2-utility.properties` files.
 ====

--- a/docs/user-manual/versions.adoc
+++ b/docs/user-manual/versions.adoc
@@ -12,6 +12,21 @@ NOTE: If the upgrade spans multiple versions then the steps from *each* version 
 
 NOTE: Follow the general upgrade procedure outlined in the xref:upgrading.adoc#upgrading-the-broker[Upgrading the Broker]  chapter in addition to any version-specific upgrade instructions outlined here.
 
+== 2.37.0
+
+https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315920&version=12354977[Full release notes]
+
+=== Highlights
+
+* The environment variables of the CLI commands other than run is configurable via the `artemis-utility.profile` file.
+* The logging configuration of the CLI commands other than run is configurable via the `log4j2-utility.properties` file.
+* The run command has been removed from the artemis shell, use the `artemis` script (`artemis.cmd` on Windows) to execute it.
+
+=== Upgrading from 2.36.0
+
+The CLI commands other than run will now need to define the environment variables via the `artemis-utility.profile` file and the logging configuration via the `log4j2-utility.properties` file.
+See xref:logging.adoc#logging[logging] for more information.
+
 == 2.36.0
 
 https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315920&version=12354818[Full release notes]

--- a/tests/smoke-tests/pom.xml
+++ b/tests/smoke-tests/pom.xml
@@ -278,6 +278,8 @@
                      </resources>
                   </configuration>
                </execution>
+               <!-- This creates a copy of various config files (filtered, as above in resources config) to
+                    be used in CompareUpgradeTest to verify CLI upgrade behaviour for backups made -->
                <execution>
                   <id>copy-reference-for-upgrade-backup-checks</id>
                   <phase>process-test-resources</phase>
@@ -360,8 +362,11 @@
                      <goal>create</goal>
                   </goals>
                   <configuration>
+                     <!-- A test, CompareUpgradeTest#testCompareWindowsFreshInstance, removes the "Expected"
+                          suffixes included here, during comparison to the instance upgraded above -->
                      <allowAnonymous>true</allowAnonymous>
                      <instance>${basedir}/target/classes/servers/windowsUpgradeExpected</instance>
+                     <dataFolder>data-customExpected</dataFolder>
                      <noWeb>false</noWeb>
                      <role>amq</role>
                      <user>y</user>
@@ -382,8 +387,11 @@
                      <goal>create</goal>
                   </goals>
                   <configuration>
+                     <!-- A test, CompareUpgradeTest#testCompareLinuxFreshInstance, removes the "Expected"
+                          suffixes included here, during comparison to the instance upgraded above -->
                      <allowAnonymous>true</allowAnonymous>
                      <instance>${basedir}/target/classes/servers/linuxUpgradeExpected</instance>
+                     <dataFolder>data-customExpected</dataFolder>
                      <noWeb>false</noWeb>
                      <role>amq</role>
                      <user>y</user>

--- a/tests/smoke-tests/src/main/filtered-resources/servers/linuxUpgradeETC/artemis.profile
+++ b/tests/smoke-tests/src/main/filtered-resources/servers/linuxUpgradeETC/artemis.profile
@@ -17,7 +17,7 @@
 
 ARTEMIS_HOME='must-change'
 ARTEMIS_INSTANCE='${project.basedir}/target/classes/servers/linuxUpgrade'
-ARTEMIS_DATA_DIR='${project.basedir}/target/classes/servers/linuxUpgrade/data'
+ARTEMIS_DATA_DIR='${project.basedir}/target/classes/servers/linuxUpgrade/data-custom'
 ARTEMIS_ETC_DIR='${project.basedir}/target/classes/servers/linuxUpgradeETC'
 ARTEMIS_OOME_DUMP='${project.basedir}/target/classes/servers/linuxUpgrade/log/oom_dump.hprof'
 

--- a/tests/smoke-tests/src/main/filtered-resources/servers/windowsUpgrade/bin/artemis-service.xml
+++ b/tests/smoke-tests/src/main/filtered-resources/servers/windowsUpgrade/bin/artemis-service.xml
@@ -27,7 +27,7 @@
    <env name="ARTEMIS_INSTANCE_ETC" value="${project.basedir}/target/classes/servers/windowsUpgradeETC"/>
    <env name="ARTEMIS_INSTANCE_URI" value="file:${project.basedir}/target/classes/servers/windowsUpgrade/"/>
    <env name="ARTEMIS_INSTANCE_ETC_URI" value="file:${project.basedir}/target/classes/servers/windowsUpgradeETC/"/>
-   <env name="ARTEMIS_DATA_DIR" value="${project.basedir}/target/classes/servers/windowsUpgrade/data"/>
+   <env name="ARTEMIS_DATA_DIR" value="${project.basedir}/target/classes/servers/windowsUpgrade/data-custom"/>
 
    <logpath>${project.basedir}/target/classes/servers/windowsUpgrade\log</logpath>
    <logmode>roll</logmode>

--- a/tests/smoke-tests/src/main/filtered-resources/servers/windowsUpgradeETC/artemis.profile.cmd
+++ b/tests/smoke-tests/src/main/filtered-resources/servers/windowsUpgradeETC/artemis.profile.cmd
@@ -18,7 +18,7 @@ rem under the License.
 
 set ARTEMIS_HOME="must-change"
 set ARTEMIS_INSTANCE="${project.basedir}/target/classes/servers/windowsUpgrade"
-set ARTEMIS_DATA_DIR="${project.basedir}/target/classes/servers/windowsUpgrade/data"
+set ARTEMIS_DATA_DIR="${project.basedir}/target/classes/servers/windowsUpgrade/data-custom"
 set ARTEMIS_ETC_DIR="${project.basedir}/target/classes/servers/windowsUpgradeETC"
 set ARTEMIS_OOME_DUMP="${project.basedir}/target/classes/servers/windowsUpgrade/log/oom_dump.hprof"
 


### PR DESCRIPTION
The run command uses the artemis.profile and log4j2.properties files while all other CLI commands use the artemis-utility.profile and log4j2-default.properties files.