### PR TITLE
ARTEMIS-4998 Fix Federation link close wrongly closing the connection

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationAddressSenderController.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationAddressSenderController.java
@@ -17,7 +17,6 @@
 
 package org.apache.activemq.artemis.protocol.amqp.connect.federation;
 
-import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederation.FEDERATION_INSTANCE_RECORD;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.ADDRESS_AUTO_DELETE;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.ADDRESS_AUTO_DELETE_DELAY;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.ADDRESS_AUTO_DELETE_MSG_COUNT;
@@ -79,10 +78,7 @@ public final class AMQPFederationAddressSenderController extends AMQPFederationB
       final Source source = (Source) sender.getRemoteSource();
       final String selector;
       final SimpleString queueName = SimpleString.of(sender.getName());
-      final Connection protonConnection = sender.getSession().getConnection();
-      final org.apache.qpid.proton.engine.Record attachments = protonConnection.attachments();
-
-      AMQPFederation federation = attachments.get(FEDERATION_INSTANCE_RECORD, AMQPFederation.class);
+      final Connection protonConnection = session.getSession().getConnection();
 
       if (federation == null) {
          throw new ActiveMQAMQPIllegalStateException("Cannot create a federation link from non-federation connection");
@@ -195,6 +191,8 @@ public final class AMQPFederationAddressSenderController extends AMQPFederationB
       // removed during the lifetime of the federation receiver, if restored an event will be sent
       // to the remote to prompt it to create a new receiver.
       resourceDeletedAction = (e) -> federation.registerMissingAddress(address.toString());
+
+      registerRemoteLinkClosedInterceptor(sender);
 
       return (Consumer) sessionSPI.createSender(senderContext, queueName, null, false);
    }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationBaseSenderController.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationBaseSenderController.java
@@ -17,6 +17,10 @@
 
 package org.apache.activemq.artemis.protocol.amqp.connect.federation;
 
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederation.FEDERATION_INSTANCE_RECORD;
+
+import java.util.Objects;
+import java.util.UUID;
 import java.util.function.Consumer;
 
 import org.apache.activemq.artemis.api.core.Message;
@@ -34,6 +38,8 @@ import org.apache.activemq.artemis.protocol.amqp.proton.ProtonServerSenderContex
 import org.apache.activemq.artemis.protocol.amqp.proton.SenderController;
 import org.apache.qpid.proton.amqp.transport.AmqpError;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
+import org.apache.qpid.proton.engine.Connection;
+import org.apache.qpid.proton.engine.Sender;
 
 /**
  * A base class abstract {@link SenderController} implementation for use by federation address and
@@ -43,6 +49,8 @@ public abstract class AMQPFederationBaseSenderController implements SenderContro
 
    protected final AMQPSessionContext session;
    protected final AMQPSessionCallback sessionSPI;
+   protected final AMQPFederation federation;
+   protected final String controllerId = UUID.randomUUID().toString();
 
    protected AMQPMessageWriter standardMessageWriter;
    protected AMQPLargeMessageWriter largeMessageWriter;
@@ -54,6 +62,10 @@ public abstract class AMQPFederationBaseSenderController implements SenderContro
    protected Consumer<ErrorCondition> resourceDeletedAction;
 
    public AMQPFederationBaseSenderController(AMQPSessionContext session) throws ActiveMQAMQPException {
+      final Connection protonConnection = session.getSession().getConnection();
+      final org.apache.qpid.proton.engine.Record attachments = protonConnection.attachments();
+
+      this.federation = attachments.get(FEDERATION_INSTANCE_RECORD, AMQPFederation.class);
       this.session = session;
       this.sessionSPI = session.getSessionSPI();
    }
@@ -68,7 +80,9 @@ public abstract class AMQPFederationBaseSenderController implements SenderContro
 
    @Override
    public void close() throws Exception {
-      // Currently there isn't anything needed on close of this controller.
+      if (federation != null) {
+         federation.removeLinkClosedInterceptor(controllerId);
+      }
    }
 
    @Override
@@ -77,6 +91,10 @@ public abstract class AMQPFederationBaseSenderController implements SenderContro
          if (resourceDeletedAction != null) {
             resourceDeletedAction.accept(error);
          }
+      }
+
+      if (federation != null) {
+         federation.removeLinkClosedInterceptor(controllerId);
       }
    }
 
@@ -107,5 +125,19 @@ public abstract class AMQPFederationBaseSenderController implements SenderContro
       }
 
       return selected;
+   }
+
+   protected final void registerRemoteLinkClosedInterceptor(Sender protonSender) {
+      Objects.requireNonNull(federation, "Subclass should have validated federation state before adding an interceptor");
+
+      federation.addLinkClosedInterceptor(controllerId, (link) -> {
+         // Normal close from remote due to demand being removed is handled here but remote close with an error is left
+         // to the parent federation instance to decide on how it should be handled.
+         if (link == protonSender && (link.getRemoteCondition() == null || link.getRemoteCondition().getCondition() == null)) {
+            return true;
+         }
+
+         return false;
+      });
    }
 }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationSource.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationSource.java
@@ -55,7 +55,6 @@ import org.apache.qpid.proton.amqp.messaging.TerminusExpiryPolicy;
 import org.apache.qpid.proton.amqp.transport.ReceiverSettleMode;
 import org.apache.qpid.proton.amqp.transport.SenderSettleMode;
 import org.apache.qpid.proton.engine.Connection;
-import org.apache.qpid.proton.engine.Link;
 import org.apache.qpid.proton.engine.Receiver;
 import org.apache.qpid.proton.engine.Sender;
 import org.apache.qpid.proton.engine.Session;
@@ -277,10 +276,6 @@ public class AMQPFederationSource extends AMQPFederation {
    @Override
    protected void signalError(Exception cause) {
       brokerConnection.runtimeError(cause);
-   }
-
-   protected boolean interceptLinkClosedEvent(Link link) {
-      return false;
    }
 
    private void asyncCreateTargetEventsSender(AMQPFederationCommandDispatcher commandLink) {


### PR DESCRIPTION
The federation sender links can react incorrectly when the source broker closes a receiver because the demand is gone and they can result in the remote broker closing its side of the connection causing the whole federation to need to be rebuilt. Handle the closure events correctly to prevent an unexpected close and rebuild.