### PR TITLE
ARTEMIS-5004 Clean up federation address consumer bindings proactively

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationBaseSenderController.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationBaseSenderController.java
@@ -79,14 +79,20 @@ public abstract class AMQPFederationBaseSenderController implements SenderContro
    }
 
    @Override
-   public void close() throws Exception {
+   public final void close() throws Exception {
       if (federation != null) {
          federation.removeLinkClosedInterceptor(controllerId);
       }
+
+      handleLinkRemotelyClosed();
+   }
+
+   protected void handleLinkRemotelyClosed() {
+      // Default does nothing.
    }
 
    @Override
-   public void close(ErrorCondition error) {
+   public final void close(ErrorCondition error) {
       if (error != null && AmqpError.RESOURCE_DELETED.equals(error.getCondition())) {
          if (resourceDeletedAction != null) {
             resourceDeletedAction.accept(error);
@@ -96,6 +102,12 @@ public abstract class AMQPFederationBaseSenderController implements SenderContro
       if (federation != null) {
          federation.removeLinkClosedInterceptor(controllerId);
       }
+
+      handleLinkLocallyClosed(error);
+   }
+
+   protected void handleLinkLocallyClosed(ErrorCondition error) {
+      // Default does nothing.
    }
 
    @Override


### PR DESCRIPTION
When an address consumer explicitly closes or is closed we should remove the address binding for that consumer right away instead of waiting for possible configured auto delete as the demand is gone and we don't need to binding to stick around any longer.