### PR TITLE
ARTEMIS-4972 Use Lock in start() for Binding Variables

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/group/impl/LocalGroupingHandler.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/group/impl/LocalGroupingHandler.java
@@ -322,9 +322,15 @@ public final class LocalGroupingHandler extends GroupHandlingAbstract {
       if (started)
          return;
 
-      if (expectedBindings == null) {
-         // just in case the component is restarted
-         expectedBindings = new LinkedList<>();
+      lock.lock();
+
+      try {
+         if (expectedBindings == null) {
+            // just in case the component is restarted
+            expectedBindings = new LinkedList<>();
+         }
+      } finally {
+         lock.unlock();
       }
 
       if (reaperPeriod > 0 && groupTimeout > 0) {


### PR DESCRIPTION
The start() method should use a lock to access the expectedBindings variable to ensure thread safety, since other methods use the lock and interact with expectedBindings at the same time.

Using the lock in the start() method ensures that access to the expectedBindings variable is safe in a multi-threaded environment, preventing potential thread contention issues.

[ARTEMIS-4972](https://issues.apache.org/jira/browse/ARTEMIS-4972)