### PR TITLE
ARTEMIS-5001 Partially reverting commit d41f01a5aa3722002fc8199eda34198753cc23f2

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
@@ -717,8 +717,6 @@ public final class ActiveMQDefaultConfiguration {
 
    private static final boolean DEFAULT_MIRROR_PAGE_TRANSACTION = false;
 
-   private static final boolean DEFAULT_MIRROR_REPLICA_SYNC = true;
-
    /**
     * If true then the ActiveMQ Artemis Server will make use of any Protocol Managers that are in available on the classpath. If false then only the core protocol will be available, unless in Embedded mode where users can inject their own Protocol Managers.
     */
@@ -1965,10 +1963,6 @@ public final class ActiveMQDefaultConfiguration {
 
    public static int getMirrorAckManagerRetryDelay() {
       return DEFAULT_MIRROR_ACK_MANAGER_RETRY_DELAY;
-   }
-
-   public static boolean getMirrorReplicaSync() {
-      return DEFAULT_MIRROR_REPLICA_SYNC;
    }
 
    public static boolean getMirrorPageTransaction() {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
@@ -1535,10 +1535,4 @@ public interface Configuration {
    boolean isMirrorPageTransaction();
 
    Configuration setMirrorPageTransaction(boolean ignorePageTransactions);
-
-   /** It is possible to relax data synchronization requirements on a target mirror configured to use journal replication.
-    *  If this is set to false Mirror Operations will not wait a response from replication before completing any operations */
-   boolean isMirrorReplicaSync();
-
-   Configuration setMirrorReplicaSync(boolean replicaSync);
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
@@ -448,8 +448,6 @@ public class ConfigurationImpl implements Configuration, Serializable {
 
    private boolean mirrorPageTransaction = ActiveMQDefaultConfiguration.getMirrorPageTransaction();
 
-   private boolean mirrorReplicaSync = ActiveMQDefaultConfiguration.getMirrorReplicaSync();
-
 
    /**
     * Parent folder for all data folders.
@@ -3415,18 +3413,6 @@ public class ConfigurationImpl implements Configuration, Serializable {
    public ConfigurationImpl setMirrorAckManagerRetryDelay(int delay) {
       logger.debug("Setting mirrorAckManagerRetryDelay = {}", delay);
       this.mirrorAckManagerRetryDelay = delay;
-      return this;
-   }
-
-   @Override
-   public boolean isMirrorReplicaSync() {
-      return mirrorReplicaSync;
-   }
-
-   @Override
-   public ConfigurationImpl setMirrorReplicaSync(boolean replicaSync) {
-      logger.debug("setMirrorReplicaSync {}", replicaSync);
-      this.mirrorReplicaSync = replicaSync;
       return this;
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -389,8 +389,6 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
    private static final String MIRROR_PAGE_TRANSACTION = "mirror-page-transaction";
 
-   private static final String MIRROR_REPLICA_SYNC = "mirror-replica-sync";
-
    private static final String INITIAL_QUEUE_BUFFER_SIZE = "initial-queue-buffer-size";
 
    private boolean validateAIO = false;
@@ -863,8 +861,6 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       config.setManagementRbacPrefix(getString(e, "management-rbac-prefix", config.getManagementRbacPrefix(), NO_CHECK));
 
       config.setMirrorPageTransaction(getBoolean(e, MIRROR_PAGE_TRANSACTION, config.isMirrorPageTransaction()));
-
-      config.setMirrorReplicaSync(getBoolean(e, MIRROR_REPLICA_SYNC, config.isMirrorReplicaSync()));
 
       config.setMirrorAckManagerPageAttempts(getInteger(e, MIRROR_ACK_MANAGER_PAGE_ATTEMPTS, config.getMirrorAckManagerPageAttempts(), GT_ZERO));
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/OperationContextImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/OperationContextImpl.java
@@ -47,19 +47,6 @@ import org.apache.commons.collections.buffer.CircularFifoBuffer;
  */
 public class OperationContextImpl implements OperationContext {
 
-
-   private boolean syncReplication = true;
-
-   @Override
-   public void setSyncReplication(boolean syncReplication) {
-      this.syncReplication = syncReplication;
-   }
-
-   @Override
-   public boolean isSyncReplication() {
-      return syncReplication;
-   }
-
    private static final ThreadLocal<OperationContext> threadLocalContext = new ThreadLocal<>();
 
    public static void clearContext() {
@@ -107,29 +94,6 @@ public class OperationContextImpl implements OperationContext {
    static final AtomicLongFieldUpdater<OperationContextImpl> PAGE_LINEUP_UPDATER = AtomicLongFieldUpdater
       .newUpdater(OperationContextImpl.class, "pageLineUpField");
 
-   public long getReplicationLineUpField() {
-      return replicationLineUpField;
-   }
-
-   public long getReplicated() {
-      return replicated;
-   }
-
-   public long getStoreLineUpField() {
-      return storeLineUpField;
-   }
-
-   public long getStored() {
-      return stored;
-   }
-
-   public long getPagedLinedUpField() {
-      return pageLineUpField;
-   }
-
-   public long getPaged() {
-      return paged;
-   }
 
    volatile int executorsPendingField = 0;
    volatile long storeLineUpField = 0;
@@ -320,7 +284,7 @@ public class OperationContextImpl implements OperationContext {
       // no need to use an iterator here, we can save that cost
       for (int i = 0; i < size; i++) {
          final TaskHolder holder = tasks.peek();
-         if (stored < holder.storeLined || syncReplication && replicated < holder.replicationLined || paged < holder.pageLined) {
+         if (stored < holder.storeLined || replicated < holder.replicationLined || paged < holder.pageLined) {
             // End of list here. No other task will be completed after this
             return;
          }
@@ -336,7 +300,7 @@ public class OperationContextImpl implements OperationContext {
          checkStoreTasks();
       }
 
-      if (stored >= minimalStore && (!syncReplication || replicated >= minimalReplicated) && paged >= minimalPage) {
+      if (stored >= minimalStore && replicated >= minimalReplicated && paged >= minimalPage) {
          checkCompleteContext();
       }
    }

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -957,16 +957,6 @@
             </xsd:annotation>
          </xsd:element>
 
-         <xsd:element name="mirror-replica-sync" type="xsd:boolean" maxOccurs="1" minOccurs="0" default="true">
-            <xsd:annotation>
-               <xsd:documentation>
-                  If journal replication is used on a target mirror, it is possible to ignore replica waits for any mirror operation.
-
-                  This is exposed as mirrorReplicaSync on broker properties.
-               </xsd:documentation>
-            </xsd:annotation>
-         </xsd:element>
-
          <xsd:element name="suppress-session-notifications" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
             <xsd:annotation>
                <xsd:documentation>

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/DefaultsFileConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/DefaultsFileConfigurationTest.java
@@ -161,7 +161,5 @@ public class DefaultsFileConfigurationTest extends AbstractConfigurationTestBase
       assertEquals(ActiveMQDefaultConfiguration.getDefaultLoggingMetrics(), conf.getMetricsConfiguration().isLogging());
 
       assertEquals(ActiveMQDefaultConfiguration.getDefaultSecurityCacheMetrics(), conf.getMetricsConfiguration().isSecurityCaches());
-
-      assertEquals(ActiveMQDefaultConfiguration.getMirrorReplicaSync(), conf.isMirrorReplicaSync());
    }
 }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
@@ -582,7 +582,6 @@ public class FileConfigurationTest extends AbstractConfigurationTestBase {
       assertEquals(222, conf.getMirrorAckManagerPageAttempts());
       assertEquals(333, conf.getMirrorAckManagerRetryDelay());
       assertTrue(conf.isMirrorPageTransaction());
-      assertFalse(conf.isMirrorReplicaSync());
 
       assertTrue(conf.getResourceLimitSettings().containsKey("myUser"));
       assertEquals(104, conf.getResourceLimitSettings().get("myUser").getMaxConnections());

--- a/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
@@ -557,7 +557,6 @@
       <mirror-ack-manager-page-attempts>222</mirror-ack-manager-page-attempts>
       <mirror-ack-manager-retry-delay>333</mirror-ack-manager-retry-delay>
       <mirror-page-transaction>true</mirror-page-transaction>
-      <mirror-replica-sync>false</mirror-replica-sync>
 
       <security-settings>
          <security-setting match="a1">

--- a/artemis-server/src/test/resources/ConfigurationTest-xinclude-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-xinclude-config.xml
@@ -75,7 +75,6 @@
       <mirror-ack-manager-page-attempts>222</mirror-ack-manager-page-attempts>
       <mirror-ack-manager-retry-delay>333</mirror-ack-manager-retry-delay>
       <mirror-page-transaction>true</mirror-page-transaction>
-      <mirror-replica-sync>false</mirror-replica-sync>
 
       <remoting-incoming-interceptors>
          <class-name>org.apache.activemq.artemis.tests.unit.core.config.impl.TestInterceptor1</class-name>

--- a/artemis-server/src/test/resources/ConfigurationTest-xinclude-schema-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-xinclude-schema-config.xml
@@ -75,7 +75,6 @@
       <mirror-ack-manager-page-attempts>222</mirror-ack-manager-page-attempts>
       <mirror-ack-manager-retry-delay>333</mirror-ack-manager-retry-delay>
       <mirror-page-transaction>true</mirror-page-transaction>
-      <mirror-replica-sync>false</mirror-replica-sync>
 
 
       <xi:include href="${xincludePath}/ConfigurationTest-xinclude-schema-config-remoting-incoming-interceptors.xml"/>

--- a/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/brokerConnection/mirror/ReplicatedBothNodesMirrorTest.java
+++ b/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/brokerConnection/mirror/ReplicatedBothNodesMirrorTest.java
@@ -191,7 +191,6 @@ public class ReplicatedBothNodesMirrorTest extends SoakTestBase {
       brokerProperties.put("addressSettings.#.prefetchPageMessages", "500");
       // if we don't use pageTransactions we may eventually get a few duplicates
       brokerProperties.put("mirrorPageTransaction", "true");
-      brokerProperties.put("mirrorReplicaSync", "false");
       File brokerPropertiesFile = new File(serverLocation, "broker.properties");
       saveProperties(brokerProperties, brokerPropertiesFile);
 
@@ -255,7 +254,6 @@ public class ReplicatedBothNodesMirrorTest extends SoakTestBase {
       brokerProperties.put("addressSettings.#.prefetchPageMessages", "500");
       // if we don't use pageTransactions we may eventually get a few duplicates
       brokerProperties.put("mirrorPageTransaction", "true");
-      brokerProperties.put("mirrorReplicaSync", "false");
       File brokerPropertiesFile = new File(serverLocation, "broker.properties");
       saveProperties(brokerProperties, brokerPropertiesFile);
 


### PR DESCRIPTION
I found a better solution. Mirroring should send the messages ignoring replication, however the ACKs towards its source should use the replication callback. This will allow the send to happen faster, and in case of a failure the source server would re-send the message as it wasn't yet acked.