### PR TITLE
ARTEMIS-5013 do not override Netty leak detection

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnector.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnector.java
@@ -172,8 +172,10 @@ public class NettyConnector extends AbstractConnector {
    public static final Map<String, Object> DEFAULT_CONFIG;
 
    static {
-      // Disable resource leak detection for performance reasons by default
-      ResourceLeakDetector.setLevel(Level.DISABLED);
+      // Disable default Netty leak detection if the Netty leak detection level system properties are not in use
+      if (System.getProperty("io.netty.leakDetectionLevel") == null && System.getProperty("io.netty.leakDetection.level") == null) {
+         ResourceLeakDetector.setLevel(Level.DISABLED);
+      }
 
       // Set default Configuration
       Map<String, Object> config = new HashMap<>();


### PR DESCRIPTION
… on command line

same behaviour as server library

https://github.com/apache/activemq-artemis/commit/127ce3a84a99f4fcf95320de064e98d91e776e4c