### PR TITLE
ARTEMIS-4834 support consuming messages forever with CLI

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/Consumer.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/Consumer.java
@@ -41,7 +41,7 @@ public class Consumer extends DestAbstract {
    @Option(names = "--break-on-null", description = "Stop consuming when a null message is received.")
    boolean breakOnNull = false;
 
-   @Option(names = "--receive-timeout", description = "Timeout for receiving messages (in milliseconds).")
+   @Option(names = "--receive-timeout", description = "Timeout for receiving messages (in milliseconds). Specify -1 to wait forever.")
    int receiveTimeout = 3000;
 
    @Option(names = "--filter", description = "The message filter.")

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/ConsumerThread.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/ConsumerThread.java
@@ -167,7 +167,7 @@ public class ConsumerThread extends Thread {
       running = true;
       MessageConsumer consumer = null;
       String threadName = Thread.currentThread().getName();
-      context.out.println(threadName + " wait until " + messageCount + " messages are consumed");
+      context.out.println(threadName + " wait " + (receiveTimeOut == -1 ? "forever" : receiveTimeOut + "ms") + " until " + messageCount + " messages are consumed");
       try {
          if (durable && destination instanceof Topic) {
             if (filter != null) {
@@ -185,7 +185,12 @@ public class ConsumerThread extends Thread {
          long tStart = System.currentTimeMillis();
          int count = 0;
          while (running && received < messageCount) {
-            Message msg = consumer.receive(receiveTimeOut);
+            Message msg;
+            if (receiveTimeOut == -1) {
+               msg = consumer.receive();
+            } else {
+               msg = consumer.receive(receiveTimeOut);
+            }
             if (msg != null) {
                if (verbose) {
                   context.out.println(threadName + " Received " + (msg instanceof TextMessage ? ((TextMessage) msg).getText() : msg.getJMSMessageID()));

--- a/artemis-cli/src/test/java/org/apache/activemq/cli/test/CliConsumerTest.java
+++ b/artemis-cli/src/test/java/org/apache/activemq/cli/test/CliConsumerTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.cli.test;
+
+import javax.jms.Connection;
+
+import org.apache.activemq.artemis.api.core.Pair;
+import org.apache.activemq.artemis.cli.commands.messages.Consumer;
+import org.apache.activemq.artemis.cli.commands.messages.Producer;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.management.ManagementContext;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.apache.activemq.artemis.utils.Wait;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CliConsumerTest extends CliTestBase {
+   private ActiveMQServer server;
+   private Connection connection;
+   private ActiveMQConnectionFactory cf;
+   private static final int TEST_MESSAGE_COUNT = 10;
+
+   @BeforeEach
+   @Override
+   public void setup() throws Exception {
+      setupAuth();
+      super.setup();
+      server = ((Pair<ManagementContext, ActiveMQServer>)startServer()).getB();
+      cf = getConnectionFactory(61616);
+      connection = cf.createConnection("admin", "admin");
+   }
+
+   @AfterEach
+   @Override
+   public void tearDown() throws Exception {
+      closeConnection(cf, connection);
+      super.tearDown();
+   }
+
+   private void produceMessages(String address, String message, long msgCount) throws Exception {
+      produceMessages(address, message, msgCount, null);
+   }
+
+   private void produceMessages(String address, String message, long msgCount, String properties) throws Exception {
+      new Producer()
+         .setMessage(message)
+         .setProperties(properties)
+         .setMessageCount(msgCount)
+         .setDestination(address)
+         .setUser("admin")
+         .setPassword("admin")
+         .execute(new TestActionContext());
+   }
+
+   private void produceMessages(String address, long msgCount) throws Exception {
+      produceMessages(address, null, msgCount);
+   }
+
+   @Test
+   public void testConsumeMessageTimeoutZero() throws Exception {
+      sendAndConsume(TEST_MESSAGE_COUNT, 0);
+   }
+
+   @Test
+   public void testConsumeMessageTimeoutOneSecond() throws Exception {
+      sendAndConsume(TEST_MESSAGE_COUNT, 1000);
+   }
+
+   @Test
+   public void testConsumeMessageTimeoutNegativeOne() throws Exception {
+      sendAndConsume(TEST_MESSAGE_COUNT, -1);
+   }
+
+   private void sendAndConsume(long messageCount, int timeout) throws Exception {
+      String address = "test";
+
+      produceMessages(address, messageCount);
+
+      Wait.assertEquals(messageCount, () -> server.locateQueue(address).getMessageCount(), 2000, 50);
+
+      TestActionContext context = new TestActionContext();
+
+      new Consumer()
+         .setReceiveTimeout(timeout)
+         .setMessageCount(messageCount)
+         .setDestination(address)
+         .setUser("admin")
+         .setPassword("admin")
+         .execute(context);
+
+      if (timeout == -1) {
+         assertTrue(context.getStdout().contains("wait forever"));
+      } else {
+         assertTrue(context.getStdout().contains("wait " + timeout + "ms"));
+      }
+
+      Wait.assertEquals(0L, () -> server.locateQueue(address).getMessageCount(), 2000, 50);
+   }
+}


### PR DESCRIPTION
The test here is just a sanity check to ensure an input of `-1` is parsed correctly. There's no real way to functionally test that the consumer will wait forever.

I'm open to ideas about improving the test so please give feedback.