### PR TITLE
ARTEMIS-5028 use a default filter when none is specified for mngmnt ops

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/ActiveMQAbstractView.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/ActiveMQAbstractView.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -42,6 +43,8 @@ public abstract class ActiveMQAbstractView<T> {
    private static final String SORT_ORDER = "sortOrder";
 
    private static final String SORT_COLUMN = "sortColumn";
+
+   private static final JsonObject DEFAULT_FILTER = JsonUtil.toJsonObject(Map.of(FILTER_FIELD, "", FILTER_OPERATION, "", FILTER_VALUE, ""));
 
    protected Collection<T> collection;
 
@@ -119,7 +122,12 @@ public abstract class ActiveMQAbstractView<T> {
    abstract Object getField(T t, String fieldName);
 
    public void setOptions(String options) {
-      JsonObject json = JsonUtil.readJsonObject(options);
+      JsonObject json;
+      if (options == null || options.isBlank()) {
+         json = DEFAULT_FILTER;
+      } else {
+         json = JsonUtil.readJsonObject(options);
+      }
       if (predicate != null) {
          predicate.setField(json.getString(FILTER_FIELD));
          predicate.setOperation(json.getString(FILTER_OPERATION));

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/management/impl/view/ViewTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/management/impl/view/ViewTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.management.impl.view;
+
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class ViewTest {
+
+   @Test
+   public void testDefaultConnectionViewNullOptions() {
+      ConnectionView connectionView = new ConnectionView(Mockito.mock(ActiveMQServer.class));
+      // sanity check to ensure this doesn't just blow up
+      connectionView.setOptions(null);
+   }
+
+   @Test
+   public void testDefaultConnectionViewEmptyOptions() {
+      ConnectionView connectionView = new ConnectionView(Mockito.mock(ActiveMQServer.class));
+      // sanity check to ensure this doesn't just blow up
+      connectionView.setOptions("");
+   }
+
+   @Test
+   public void testDefaultSessionViewNullOptions() {
+      SessionView sessionView = new SessionView();
+      // sanity check to ensure this doesn't just blow up
+      sessionView.setOptions(null);
+   }
+
+   @Test
+   public void testDefaultSessionViewEmptyOptions() {
+      SessionView sessionView = new SessionView();
+      // sanity check to ensure this doesn't just blow up
+      sessionView.setOptions("");
+   }
+
+   @Test
+   public void testDefaultAddressViewNullOptions() {
+      AddressView addressView = new AddressView(Mockito.mock(ActiveMQServer.class));
+      // sanity check to ensure this doesn't just blow up
+      addressView.setOptions(null);
+   }
+
+   @Test
+   public void testDefaultAddressViewEmptyOptions() {
+      AddressView addressView = new AddressView(Mockito.mock(ActiveMQServer.class));
+      // sanity check to ensure this doesn't just blow up
+      addressView.setOptions("");
+   }
+
+   @Test
+   public void testDefaultQueueViewNullOptions() {
+      QueueView queueView = new QueueView(Mockito.mock(ActiveMQServer.class));
+      // sanity check to ensure this doesn't just blow up
+      queueView.setOptions(null);
+   }
+
+   @Test
+   public void testDefaultQueueViewEmptyOptions() {
+      QueueView queueView = new QueueView(Mockito.mock(ActiveMQServer.class));
+      // sanity check to ensure this doesn't just blow up
+      queueView.setOptions("");
+   }
+
+   @Test
+   public void testDefaultConsumerViewNullOptions() {
+      ConsumerView consumerView = new ConsumerView(Mockito.mock(ActiveMQServer.class));
+      // sanity check to ensure this doesn't just blow up
+      consumerView.setOptions(null);
+   }
+
+   @Test
+   public void testDefaultConsumerViewEmptyOptions() {
+      ConsumerView consumerView = new ConsumerView(Mockito.mock(ActiveMQServer.class));
+      // sanity check to ensure this doesn't just blow up
+      consumerView.setOptions("");
+   }
+
+   @Test
+   public void testDefaultProducerViewNullOptions() {
+      ProducerView producerView = new ProducerView(Mockito.mock(ActiveMQServer.class));
+      // sanity check to ensure this doesn't just blow up
+      producerView.setOptions(null);
+   }
+
+   @Test
+   public void testDefaultProducerViewEmptyOptions() {
+      ProducerView producerView = new ProducerView(Mockito.mock(ActiveMQServer.class));
+      // sanity check to ensure this doesn't just blow up
+      producerView.setOptions("");
+   }
+}


### PR DESCRIPTION
This is a small usability improvement for management whereby invocations of some operations no longer require JSON boilerplate. It impacts the following operations on the ActiveMQServerControl:

 - listConnections
 - listSessions
 - listAddresses
 - listQueues
 - listConsumers
 - listProducers