### PR TITLE
ARTEMIS-5032 Ensure AMQP message priority is honored after restart

### DIFF
--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/AmqpSender.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/AmqpSender.java
@@ -491,7 +491,7 @@ public class AmqpSender extends AmqpAbstractResource<Sender> {
 
    @Override
    public void processFlowUpdates(AmqpConnection connection) throws IOException {
-      logger.trace("Sender {} flow update, credit = {}", getEndpoint().getCredit());
+      logger.trace("Sender {} flow update, credit = {}", senderId, getEndpoint().getCredit());
 
       doCreditInspection();
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpMessagePriorityTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpMessagePriorityTest.java
@@ -19,6 +19,7 @@ package org.apache.activemq.artemis.tests.integration.amqp;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.activemq.artemis.core.server.Queue;
@@ -41,6 +42,13 @@ import java.lang.invoke.MethodHandles;
 public class AmqpMessagePriorityTest extends AmqpClientTestSupport {
 
    protected static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   private static final int MIN_LARGE_MESSAGE_SIZE = 16384;
+
+   @Override
+   protected void configureAMQPAcceptorParameters(Map<String, Object> params) {
+      params.put("amqpMinLargeMessageSize", MIN_LARGE_MESSAGE_SIZE);
+   }
 
    @Test
    @Timeout(60)
@@ -215,37 +223,132 @@ public class AmqpMessagePriorityTest extends AmqpClientTestSupport {
    @Test
    @Timeout(60)
    public void testMessagePriorityOrdering() throws Exception {
-      AmqpClient client = createAmqpClient();
-      AmqpConnection connection = addConnection(client.connect());
-      AmqpSession session = connection.createSession();
+      doTestMessagePriorityOrdering(false);
+   }
 
-      AmqpSender sender = session.createSender(getQueueName());
+   @Test
+   @Timeout(60)
+   public void testMessagePriorityOrderingForLargeMessages() throws Exception {
+      doTestMessagePriorityOrdering(true);
+   }
 
-      for (short i = 0; i <= 9; ++i) {
-         AmqpMessage message = new AmqpMessage();
+   private void doTestMessagePriorityOrdering(boolean largeMessages) throws Exception {
+      final AmqpClient client = createAmqpClient();
+      final AmqpConnection connection = addConnection(client.connect());
+      final AmqpSession session = connection.createSession();
+      final AmqpSender sender = session.createSender(getQueueName());
+
+      final int priorityLevels = 10;
+      final int bodySize = largeMessages ? MIN_LARGE_MESSAGE_SIZE + 10 : 10;
+      final String body = "#".repeat(bodySize);
+
+      for (short i = 0; i < priorityLevels; ++i) {
+         final AmqpMessage message = new AmqpMessage();
+
          message.setMessageId("MessageID:" + i);
          message.setPriority(i);
+         message.setText(body);
+
          sender.send(message);
       }
 
       sender.close();
 
-      Queue queueView = getProxyToQueue(getQueueName());
+      final Queue queueView = getProxyToQueue(getQueueName());
+
       Wait.assertEquals(10L, queueView::getMessageCount, 5000, 10);
 
-      AmqpReceiver receiver = session.createReceiver(getQueueName());
+      final AmqpReceiver receiver = session.createReceiver(getQueueName());
 
       receiver.flow(10);
-      for (int i = 9; i >= 0; --i) {
-         AmqpMessage received = receiver.receive(5, TimeUnit.SECONDS);
+
+      for (int i = priorityLevels - 1; i >= 0; --i) {
+         final AmqpMessage received = receiver.receive(5, TimeUnit.SECONDS);
+
          assertNotNull(received);
          assertEquals((short) i, received.getPriority());
+         assertEquals(body, received.getText());
+
          received.accept();
       }
+
       receiver.close();
 
       Wait.assertEquals(0L, queueView::getMessageCount, 5000, 10);
 
       connection.close();
+   }
+
+   @Test
+   @Timeout(30)
+   public void testMessagePriorityAppliedAfterServerRestart() throws Exception {
+      doTestMessagePriorityAppliedAfterServerRestart(false);
+   }
+
+   @Test
+   @Timeout(30)
+   public void testLargeMessagePriorityAppliedAfterServerRestart() throws Exception {
+      doTestMessagePriorityAppliedAfterServerRestart(true);
+   }
+
+   public void doTestMessagePriorityAppliedAfterServerRestart(boolean largeMessages) throws Exception {
+      final AmqpClient client = createAmqpClient();
+
+      final int priorityLevels = 10;
+      final int bodySize = largeMessages ? MIN_LARGE_MESSAGE_SIZE + 10 : 10;
+      final String body = "#".repeat(bodySize);
+
+      {
+         final AmqpConnection connection = addConnection(client.connect());
+         final AmqpSession session = connection.createSession();
+         final AmqpSender sender = session.createSender(getQueueName());
+         final Queue queueView = getProxyToQueue(getQueueName());
+
+         for (int priority = 0; priority < priorityLevels; ++priority) {
+            AmqpMessage message = new AmqpMessage();
+            message.setDurable(true);
+            message.setMessageId("MessageID:" + priority);
+            message.setPriority((short) priority);
+            message.setText(body);
+
+            sender.send(message);
+         }
+
+         assertEquals(priorityLevels, queueView.getMessageCount());
+
+         sender.close();
+         connection.close();
+      }
+
+      server.stop();
+      server.start();
+
+      {
+         final Queue queueView = getProxyToQueue(getQueueName());
+         final AmqpConnection connection = addConnection(client.connect());
+         final AmqpSession session = connection.createSession();
+         final AmqpReceiver receiver = session.createReceiver(getQueueName());
+
+         Wait.assertEquals((long)priorityLevels, () -> queueView.getMessageCount(), 2_000, 100);
+
+         receiver.flow(priorityLevels);
+
+         for (int priority = priorityLevels - 1; priority >= 0; --priority) {
+            final AmqpMessage message = receiver.receive(5, TimeUnit.SECONDS);
+
+            assertNotNull(message);
+            assertEquals(priority, message.getPriority());
+            assertEquals("MessageID:" + priority, message.getMessageId());
+
+            logger.info("Read message with priority = {}", message.getPriority());
+
+            message.accept();
+         }
+
+         receiver.close();
+         connection.close();
+
+         assertEquals(0, queueView.getMessageCount());
+      }
    }
 }


### PR DESCRIPTION
Ensure that on server restart the original priority value assigned to an AMQP message is used when dispatching durable messages from the store. The AMQP Header section is scanned if present and the priority value is recovered in an efficient manner.