### PR TITLE
 ARTEMIS-5038 Mirrored ACKs are broken if using multiple priorities on producers

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/FileUtil.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/FileUtil.java
@@ -16,8 +16,11 @@
  */
 package org.apache.activemq.artemis.utils;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.lang.invoke.MethodHandles;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -27,6 +30,10 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.activemq.artemis.logs.ActiveMQUtilLogger;
 import org.slf4j.Logger;
@@ -124,6 +131,23 @@ public class FileUtil {
       } else {
          return false;
       }
+   }
+
+   public static String readFile(InputStream inputStream) throws Exception {
+      BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
+      String fileOutput = bufferedReader.lines().collect(Collectors.joining(System.lineSeparator()));
+      return fileOutput;
+   }
+
+   public static boolean find(File file, Predicate<String> search) throws Exception {
+      AtomicBoolean found = new AtomicBoolean(false);
+      try (Stream<String> lines = Files.lines(file.toPath())) {
+         lines.filter(search::test).findFirst().ifPresent(line -> {
+            logger.info("pattern found at {}", line);
+            found.set(true);
+         });
+      }
+      return found.get();
    }
 
 }

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/collections/EmptyList.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/collections/EmptyList.java
@@ -62,6 +62,11 @@ public class EmptyList<E> implements LinkedList<E> {
       }
 
       @Override
+      public E removeLastElement() {
+         return null;
+      }
+
+      @Override
       public void close() {
       }
 

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/collections/LinkedListImpl.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/collections/LinkedListImpl.java
@@ -599,14 +599,21 @@ public class LinkedListImpl<E> implements LinkedList<E> {
 
       @Override
       public void remove() {
+         removeLastElement();
+      }
+
+      @Override
+      public E removeLastElement() {
          synchronized (LinkedListImpl.this) {
             if (last == null) {
                throw new NoSuchElementException();
             }
 
             if (current == null) {
-               return;
+               return null;
             }
+
+            E returningElement = current.val();
 
             Node<E> prev = current.prev;
 
@@ -615,6 +622,8 @@ public class LinkedListImpl<E> implements LinkedList<E> {
 
                last = null;
             }
+
+            return returningElement;
          }
       }
 

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/collections/NodeStore.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/collections/NodeStore.java
@@ -30,6 +30,14 @@ public interface NodeStore<E> {
 
    void removeNode(E element, LinkedListImpl.Node<E> node);
 
+   default NodeStore<E> setName(String name) {
+      return this;
+   }
+
+   default String getName() {
+      return null;
+   }
+
    /** this is meant to be a quick help to Garbage Collection.
     *  Whenever the IDSupplier list is being cleared, you should first call the clear method and
     *  empty every list before you let the instance go. */

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/collections/PriorityLinkedList.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/collections/PriorityLinkedList.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.utils.collections;
 
+import java.util.function.Supplier;
+
 /**
  * A type of linked list which maintains items according to a priority
  * and allows adding and removing of elements at both ends, and peeking.<br>
@@ -40,7 +42,7 @@ public interface PriorityLinkedList<E> {
     * @see LinkedList#setNodeStore(NodeStore)
     * @param supplier
     */
-   void setNodeStore(NodeStore<E> supplier);
+   void setNodeStore(Supplier<NodeStore<E>> supplier);
 
    E removeWithID(String listID, long id);
 

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/logger/ActiveMQAMQPProtocolLogger.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/logger/ActiveMQAMQPProtocolLogger.java
@@ -64,4 +64,7 @@ public interface ActiveMQAMQPProtocolLogger {
 
    @LogMessage(id = 111009, value = "The AckManager was interrupt. timeout = {} milliseconds", level = LogMessage.Level.WARN)
    void interruptedAckManager(Exception e);
+
+   @LogMessage(id = 111010, value = "Duplicate AckManager node detected. Queue={}, ServerID={}, recordID={}", level = LogMessage.Level.WARN)
+   void duplicateNodeStoreID(String queue, String serverId, long recordID, Exception trace);
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageSubscriptionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageSubscriptionImpl.java
@@ -1452,6 +1452,11 @@ public final class PageSubscriptionImpl implements PageSubscription {
 
       @Override
       public void remove() {
+         removeLastElement();
+      }
+
+      @Override
+      public PagedReference removeLastElement() {
          PagedReference delivery = currentDelivery;
          if (delivery != null) {
             PageCursorInfo info = PageSubscriptionImpl.this.getPageInfo(delivery.getPagedMessage().getPageNumber());
@@ -1459,6 +1464,7 @@ public final class PageSubscriptionImpl implements PageSubscription {
                info.remove(delivery.getPagedMessage().getMessageNumber());
             }
          }
+         return delivery;
       }
 
       @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/Queue.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/Queue.java
@@ -315,8 +315,6 @@ public interface Queue extends Bindable,CriticalComponent {
 
    MessageReference removeReferenceWithID(long id) throws Exception;
 
-   MessageReference getReference(long id) throws ActiveMQException;
-
    int deleteAllReferences() throws Exception;
 
    int deleteAllReferences(int flushLimit) throws Exception;

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/RoutingContextTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/RoutingContextTest.java
@@ -622,11 +622,6 @@ public class RoutingContextTest {
       }
 
       @Override
-      public MessageReference getReference(long id) throws ActiveMQException {
-         return null;
-      }
-
-      @Override
       public int deleteAllReferences() throws Exception {
          return 0;
       }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/ScheduledDeliveryHandlerTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/ScheduledDeliveryHandlerTest.java
@@ -1388,11 +1388,6 @@ public class ScheduledDeliveryHandlerTest {
       }
 
       @Override
-      public MessageReference getReference(long id) {
-         return null;
-      }
-
-      @Override
       public int deleteAllReferences() throws Exception {
          return 0;
       }

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/fakes/FakeQueue.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/fakes/FakeQueue.java
@@ -710,12 +710,6 @@ public class FakeQueue extends CriticalComponentImpl implements Queue {
    }
 
    @Override
-   public MessageReference getReference(final long id1) {
-      // no-op
-      return null;
-   }
-
-   @Override
    public int getScheduledCount() {
       // no-op
       return 0;

--- a/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/brokerConnection/mirror/AccumulatedInPageSoakTest.java
+++ b/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/brokerConnection/mirror/AccumulatedInPageSoakTest.java
@@ -37,6 +37,7 @@ import org.apache.activemq.artemis.api.core.management.SimpleManagement;
 import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBrokerConnectionAddressType;
 import org.apache.activemq.artemis.tests.soak.SoakTestBase;
 import org.apache.activemq.artemis.tests.util.CFUtil;
+import org.apache.activemq.artemis.tests.util.RandomUtil;
 import org.apache.activemq.artemis.util.ServerUtil;
 import org.apache.activemq.artemis.utils.Wait;
 import org.apache.activemq.artemis.utils.cli.helper.HelperCreate;
@@ -174,6 +175,8 @@ public class AccumulatedInPageSoakTest extends SoakTestBase {
          MessageProducer producer = session.createProducer(queue);
 
          for (int i = 0; i < numberOfMessages; i++) {
+            // This is to reproduce ARTEMIS-5038
+            producer.setPriority(RandomUtil.randomInterval(0, 9));
             producer.send(session.createTextMessage(body));
             if (i > 0 && i % commitInterval == 0) {
                logger.info("Sent {}", i);
@@ -189,6 +192,8 @@ public class AccumulatedInPageSoakTest extends SoakTestBase {
       startDC2();
       Wait.assertEquals(0L, () -> getMessageCount(simpleManagementDC1A, SNF_QUEUE), 240_000, 500);
       Wait.assertEquals(0L, () -> getMessageCount(simpleManagementDC2A, QUEUE_NAME), 60_000, 500);
+      LogAssert.assertServerLogsForMirror(getFileServerLocation(DC2_NODE_A));
+      LogAssert.assertServerLogsForMirror(getFileServerLocation(DC1_NODE_A));
 
    }
 

--- a/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/brokerConnection/mirror/LogAssert.java
+++ b/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/brokerConnection/mirror/LogAssert.java
@@ -14,22 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.utils.collections;
 
-import java.util.Iterator;
+package org.apache.activemq.artemis.tests.soak.brokerConnection.mirror;
 
-/**
- * A LinkedListIterator
- *
- * This iterator allows the last element to be repeated in the next call to hasNext or next
- */
-public interface LinkedListIterator<E> extends Iterator<E>, AutoCloseable {
+import java.io.File;
 
-   void repeat();
+import org.apache.activemq.artemis.utils.FileUtil;
 
-   /** This method is doing exactly what {@link Iterator#remove()} would do, however it will return the removed element being removed. */
-   E removeLastElement();
+public class LogAssert {
 
-   @Override
-   void close();
+   public static void assertServerLogsForMirror(File serverLocation) throws Exception {
+      File log = new File(serverLocation, "log/artemis.log");
+      FileUtil.find(log, l -> l.contains("NullPointerException") || l.contains("AMQ111010"));
+   }
+
 }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/impl/QueueImplTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/server/impl/QueueImplTest.java
@@ -1218,32 +1218,6 @@ public class QueueImplTest extends ActiveMQTestBase {
       assertEquals(getMessagesAdded(queue), 3);
    }
 
-   @Test
-   public void testGetReference() throws Exception {
-      QueueImpl queue = getTemporaryQueue();
-      MessageReference messageReference = generateReference(queue, 1);
-      MessageReference messageReference2 = generateReference(queue, 2);
-      MessageReference messageReference3 = generateReference(queue, 3);
-      queue.addHead(messageReference, false);
-      queue.addHead(messageReference2, false);
-      queue.addHead(messageReference3, false);
-      assertEquals(queue.getReference(2), messageReference2);
-
-   }
-
-   @Test
-   public void testGetNonExistentReference() throws Exception {
-      QueueImpl queue = getTemporaryQueue();
-      MessageReference messageReference = generateReference(queue, 1);
-      MessageReference messageReference2 = generateReference(queue, 2);
-      MessageReference messageReference3 = generateReference(queue, 3);
-      queue.addHead(messageReference, false);
-      queue.addHead(messageReference2, false);
-      queue.addHead(messageReference3, false);
-      assertNull(queue.getReference(5));
-
-   }
-
    /**
     * Test the paused and resumed states with async deliveries.
     *


### PR DESCRIPTION
PriorityLinkedList has multiple sub-lists, before this commit PriorityLinkedList::setNodeStore would set the same node store between all the lists.
When a removeWithID was called for an item on list[0] the remove from list[4] would always succeed first. This operation would work correctly most of the time except
when tail and head is being used. Many NullPointerExceptions would be seen while iterating on the list for remove operations, and the navigation would be completely broken.
    
A test was added to PriorityLinkedListTest to make sure the correct lists were used however I was not able to reproduce the NPE condition in that test.
AccumulatedInPageSoakTest reproduced the exact condition for the NPE when significant load is used.