### PR TITLE
add common tags to meters instead of changing the provided registry

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/metrics/NettyPooledAllocatorMetrics.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/metrics/NettyPooledAllocatorMetrics.java
@@ -21,6 +21,7 @@ import java.util.function.Function;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.netty.buffer.PoolChunkListMetric;
 import io.netty.buffer.PoolChunkMetric;
@@ -33,53 +34,64 @@ public final class NettyPooledAllocatorMetrics implements MeterBinder {
 
    private static final String BYTES_UNIT = "bytes";
    private final PooledByteBufAllocatorMetric metric;
+   private final Tags tags;
 
-   public NettyPooledAllocatorMetrics(final PooledByteBufAllocatorMetric pooledAllocatorMetric) {
+   public NettyPooledAllocatorMetrics(final PooledByteBufAllocatorMetric pooledAllocatorMetric, final Tags tags) {
       this.metric = pooledAllocatorMetric;
+      this.tags = tags;
    }
 
    @Override
    public void bindTo(final MeterRegistry registry) {
 
       Gauge.builder("netty.pooled.used.memory", this.metric, metric -> metric.usedDirectMemory())
+         .tags(tags)
          .tags("type", "direct")
          .description("The used memory")
          .baseUnit(BYTES_UNIT).register(registry);
 
       Gauge.builder("netty.pooled.used.memory", this.metric, metric -> metric.usedHeapMemory())
+         .tags(tags)
          .tags("type", "heap")
          .description("The used memory")
          .baseUnit(BYTES_UNIT).register(registry);
 
       Gauge.builder("netty.pooled.arenas.num", this.metric, metric -> metric.numDirectArenas())
+         .tags(tags)
          .tags("type", "direct")
          .description("The number of arenas")
          .register(registry);
 
       Gauge.builder("netty.pooled.arenas.num", this.metric, metric -> metric.numHeapArenas())
+         .tags(tags)
          .tags("type", "heap").description("The number or arenas")
          .register(registry);
 
       Gauge.builder("netty.pooled.cachesize", this.metric, metric -> metric.tinyCacheSize())
+         .tags(tags)
          .tags("type", "tiny")
          .description("The cachesize used by this netty allocator")
          .register(registry);
 
       Gauge.builder("netty.pooled.cachesize", this.metric, metric -> metric.smallCacheSize())
+         .tags(tags)
          .tags("type", "small")
          .description("The cachesize used by this netty allocator")
          .register(registry);
 
       Gauge.builder("netty.pooled.cachesize", this.metric, metric -> metric.normalCacheSize())
+         .tags(tags)
          .tags("type", "normal")
          .description("The cachesize used by this netty allocator")
          .register(registry);
 
       Gauge.builder("netty.pooled.threadlocalcache.num", this.metric, metric -> metric.numThreadLocalCaches())
+         .tags(tags)
          .description("The number of thread local caches used by this netty allocator")
          .register(registry);
 
       Gauge.builder("netty.pooled.chunk.size", this.metric, metric -> metric.chunkSize())
+         .tags(tags)
          .description("The arena chunk size of this netty allocator")
          .baseUnit(BYTES_UNIT)
          .register(registry);
@@ -107,120 +119,140 @@ public final class NettyPooledAllocatorMetrics implements MeterBinder {
        */
       final String poolArenaIndexString = Integer.toString(poolArenaIndex);
       Gauge.builder("netty.pooled.arena.threadcaches.num", poolArenaMetric, metric -> metric.numThreadCaches())
+         .tags(tags)
          .tags("pool_arena_type", poolArenaType, "pool_arena_index", poolArenaIndexString)
          .description("The number of thread caches backed by this arena")
          .register(registry);
 
       FunctionCounter.builder("netty.pooled.arena.allocations.num", poolArenaMetric,
          metric -> metric.numAllocations())
+         .tags(tags)
          .tags("pool_arena_type", poolArenaType, "pool_arena_index", poolArenaIndexString, "size", "all")
          .description("The number of allocations done via the arena. This includes all sizes")
          .register(registry);
 
       FunctionCounter.builder("netty.pooled.arena.allocations.num", poolArenaMetric,
          metric -> metric.numTinyAllocations())
+         .tags(tags)
          .tags("pool_arena_type", poolArenaType, "pool_arena_index", poolArenaIndexString, "size", "tiny")
          .description("The number of tiny allocations done via the arena")
          .register(registry);
 
       FunctionCounter.builder("netty.pooled.arena.allocations.num", poolArenaMetric,
          metric -> metric.numSmallAllocations())
+         .tags(tags)
          .tags("pool_arena_type", poolArenaType, "pool_arena_index", poolArenaIndexString, "size", "small")
          .description("The number of small allocations done via the arena")
          .register(registry);
 
       FunctionCounter.builder("netty.pooled.arena.allocations.num", poolArenaMetric,
          metric -> metric.numNormalAllocations())
+         .tags(tags)
          .tags("pool_arena_type", poolArenaType, "pool_arena_index", poolArenaIndexString, "size", "normal")
          .description("The number of normal allocations done via the arena")
          .register(registry);
 
       FunctionCounter.builder("netty.pooled.arena.allocations.num", poolArenaMetric,
          metric -> metric.numHugeAllocations())
+         .tags(tags)
          .tags("pool_arena_type", poolArenaType, "pool_arena_index", poolArenaIndexString, "size", "huge")
          .description("The number of huge allocations done via the arena")
          .register(registry);
 
       FunctionCounter.builder("netty.pooled.arena.deallocations.num", poolArenaMetric,
          metric -> metric.numDeallocations())
+         .tags(tags)
          .tags("pool_arena_type", poolArenaType, "pool_arena_index", poolArenaIndexString, "size", "all")
          .description("The number of deallocations done via the arena. This includes all sizes")
          .register(registry);
 
       FunctionCounter.builder("netty.pooled.arena.deallocations.num", poolArenaMetric,
          metric -> metric.numTinyDeallocations())
+         .tags(tags)
          .tags("pool_arena_type", poolArenaType, "pool_arena_index", poolArenaIndexString, "size", "tiny")
          .description("The number of tiny deallocations done via the arena")
          .register(registry);
 
       FunctionCounter.builder("netty.pooled.arena.deallocations.num", poolArenaMetric,
          metric -> metric.numSmallDeallocations())
+         .tags(tags)
          .tags("pool_arena_type", poolArenaType, "pool_arena_index", poolArenaIndexString, "size", "small")
          .description("The number of small deallocations done via the arena")
          .register(registry);
 
       FunctionCounter.builder("netty.pooled.arena.deallocations.num", poolArenaMetric,
          metric -> metric.numNormalDeallocations())
+         .tags(tags)
          .tags("pool_arena_type", poolArenaType, "pool_arena_index", poolArenaIndexString, "size", "normal")
          .description("The number of normal deallocations done via the arena")
          .register(registry);
 
       FunctionCounter.builder("netty.pooled.arena.deallocations.num", poolArenaMetric,
          metric -> metric.numHugeDeallocations())
+         .tags(tags)
          .tags("pool_arena_type", poolArenaType, "pool_arena_index", poolArenaIndexString, "size", "huge")
          .description("The number of huge deallocations done via the arena")
          .register(registry);
 
       Gauge.builder("netty.pooled.arena.active.allocations.num", poolArenaMetric,
          metric -> metric.numActiveAllocations())
+         .tags(tags)
          .tags("pool_arena_type", poolArenaType, "pool_arena_index", poolArenaIndexString, "size", "all")
          .description("The number of currently active allocations")
          .register(registry);
 
       Gauge.builder("netty.pooled.arena.active.allocations.num", poolArenaMetric,
          metric -> metric.numActiveTinyAllocations())
+         .tags(tags)
          .tags("pool_arena_type", poolArenaType, "pool_arena_index", poolArenaIndexString, "size", "tiny")
          .description("The number of currently active tiny allocations")
          .register(registry);
 
       Gauge.builder("netty.pooled.arena.active.allocations.num", poolArenaMetric,
          metric -> metric.numActiveSmallAllocations())
+         .tags(tags)
          .tags("pool_arena_type", poolArenaType, "pool_arena_index", poolArenaIndexString, "size", "small")
          .description("The number of currently active small allocations")
          .register(registry);
 
       Gauge.builder("netty.pooled.arena.active.allocations.num", poolArenaMetric,
          metric -> metric.numActiveNormalAllocations())
+         .tags(tags)
          .tags("pool_arena_type", poolArenaType, "pool_arena_index", poolArenaIndexString, "size", "normal")
          .description("The number of currently active normal allocations")
          .register(registry);
 
       Gauge.builder("netty.pooled.arena.active.allocations.num", poolArenaMetric,
          metric -> metric.numActiveHugeAllocations())
+         .tags(tags)
          .tags("pool_arena_type", poolArenaType, "pool_arena_index", poolArenaIndexString, "size", "huge")
          .description("The number of currently active huge allocations")
          .register(registry);
 
       Gauge.builder("netty.pooled.arena.active.allocated.num", poolArenaMetric,
          metric -> metric.numActiveBytes())
+         .tags(tags)
          .tags("pool_arena_type", poolArenaType, "pool_arena_index", poolArenaIndexString)
          .description("The number of active bytes that are currently allocated by the arena")
          .baseUnit(BYTES_UNIT).register(registry);
 
       Gauge.builder("netty.pooled.arena.chunk.num", poolArenaMetric,
          metric -> metric.numChunkLists())
+         .tags(tags)
          .tags("pool_arena_type", poolArenaType, "pool_arena_index", poolArenaIndexString)
          .description("The number of chunk lists for the arena")
          .register(registry);
 
       Gauge.builder("netty.pooled.arena.subpages.num", poolArenaMetric,
          metric -> metric.numTinySubpages())
+         .tags(tags)
          .tags("pool_arena_type", poolArenaType, "pool_arena_index", poolArenaIndexString, "size", "tiny")
          .description("The number of tiny sub-pages for the arena")
          .register(registry);
 
       Gauge.builder("netty.pooled.arena.subpages.num", poolArenaMetric,
          metric -> metric.numSmallSubpages())
+         .tags(tags)
          .tags("pool_arena_type", poolArenaType, "pool_arena_index", poolArenaIndexString, "size", "small")
          .description("The number of small sub-pages for the arena")
          .register(registry);
@@ -255,6 +287,7 @@ public final class NettyPooledAllocatorMetrics implements MeterBinder {
          }
          return total;
       })
+         .tags(tags)
          .tags("pool_arena_type", poolArenaType, "pool_arena_index", poolArenaIndex, "size", size)
          .description("The total count of subpages")
          .register(registry);
@@ -266,6 +299,7 @@ public final class NettyPooledAllocatorMetrics implements MeterBinder {
          }
          return total;
       })
+         .tags(tags)
          .tags("pool_arena_type", poolArenaType, "pool_arena_index", poolArenaIndex, "size", size)
          .description("The total size (in bytes) of the elements that will be allocated")
          .baseUnit(BYTES_UNIT)
@@ -278,6 +312,7 @@ public final class NettyPooledAllocatorMetrics implements MeterBinder {
          }
          return total;
       })
+         .tags(tags)
          .tags("pool_arena_type", poolArenaType, "pool_arena_index", poolArenaIndex, "size", size)
          .description("The total number of maximal elements that can be allocated out of the sub-page.")
          .register(registry);
@@ -289,6 +324,7 @@ public final class NettyPooledAllocatorMetrics implements MeterBinder {
          }
          return total;
       })
+         .tags(tags)
          .tags("pool_arena_type", poolArenaType, "pool_arena_index", poolArenaIndex, "size", size)
          .description("The total number of available elements to be allocated")
          .register(registry);
@@ -299,6 +335,7 @@ public final class NettyPooledAllocatorMetrics implements MeterBinder {
          }
          return total;
       })
+         .tags(tags)
          .tags("pool_arena_type", poolArenaType, "pool_arena_index", poolArenaIndex, "size", size)
          .description("The total size (in bytes) of the pages")
          .baseUnit(BYTES_UNIT)
@@ -338,6 +375,7 @@ public final class NettyPooledAllocatorMetrics implements MeterBinder {
          }
          return total;
       })
+         .tags(tags)
          .tags("pool_arena_type", poolArenaType, "pool_arena_index", poolArenaIndex, "pool_chunk_list_type", poolChunkListType)
          .description("The total capacity in bytes of the chunks in the list")
          .baseUnit(BYTES_UNIT)
@@ -349,6 +387,7 @@ public final class NettyPooledAllocatorMetrics implements MeterBinder {
          }
          return total;
       })
+         .tags(tags)
          .tags("pool_arena_type", poolArenaType, "pool_arena_index", poolArenaIndex, "pool_chunk_list_type", poolChunkListType)
          .description("The total free bytes of the chunks in the list")
          .baseUnit(BYTES_UNIT)
@@ -361,6 +400,7 @@ public final class NettyPooledAllocatorMetrics implements MeterBinder {
          }
          return total;
       })
+         .tags(tags)
          .tags("pool_arena_type", poolArenaType, "pool_arena_index", poolArenaIndex, "pool_chunk_list_type", poolChunkListType)
          .description("The number of chunks in the list")
          .register(registry);


### PR DESCRIPTION
After #4487 an embedded broker is overriding the tagging configuration of all metrics exposed by the embedding application.

Only meters created by the broker should add broker tags