### PR TITLE
ARTEMIS-5042 don't throw Exception when clearing cluster-connection bindings

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1621,4 +1621,7 @@ public interface ActiveMQServerLogger {
 
    @LogMessage(id = 224139, value = "Failed to stop bridge: {}", level = LogMessage.Level.ERROR)
    void errorStoppingBridge(String bridgeName, Exception e);
+
+   @LogMessage(id = 224140, value = "Clearing bindings on cluster-connection {} failed to remove binding {}: {}", level = LogMessage.Level.WARN)
+   void clusterConnectionFailedToRemoveBindingOnClear(String clusterConnection, String binding, String exceptionMessage);
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/impl/ClusterConnectionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/impl/ClusterConnectionImpl.java
@@ -1245,10 +1245,14 @@ public final class ClusterConnectionImpl implements ClusterConnection, AfterConn
          server.getGroupingHandler().sendProposalResponse(response, hops + 1);
       }
 
-      private synchronized void clearBindings() throws Exception {
+      private synchronized void clearBindings() {
          logger.debug("{} clearing bindings", ClusterConnectionImpl.this);
          for (RemoteQueueBinding binding : new HashSet<>(bindings.values())) {
-            removeBinding(binding.getClusterName());
+            try {
+               removeBinding(binding.getClusterName());
+            } catch (Exception e) {
+               ActiveMQServerLogger.LOGGER.clusterConnectionFailedToRemoveBindingOnClear(getName().toString(), binding.getClusterName().toString(), e.getMessage());
+            }
          }
       }
 


### PR DESCRIPTION


Throwing an exception when clearing the bindings when a cluster-connection is closed short-circuits the clearing (and closing) process. This commit fixes that by simply logging the failure to clear and continues on.

No new tests are added with this commit. It relies on existing tests.