### PR TITLE
ARTEMIS-4971 Warning on Unacked messages through mirror AckManager

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
@@ -715,6 +715,7 @@ public final class ActiveMQDefaultConfiguration {
 
    private static final int DEFAULT_MIRROR_ACK_MANAGER_RETRY_DELAY = Integer.parseInt(System.getProperty(FORMER_ACK_RETRY_CLASS_NAME + ".RETRY_DELAY", "100"));;
 
+   private static final boolean DEFAULT_MIRROR_ACK_MANAGER_WARN_UNACKED = false;
    private static final boolean DEFAULT_MIRROR_PAGE_TRANSACTION = false;
 
    /**
@@ -1959,6 +1960,10 @@ public final class ActiveMQDefaultConfiguration {
 
    public static int getMirrorAckManagerPageAttempts() {
       return DEFAULT_MIRROR_ACK_MANAGER_PAGE_ATTEMPTS;
+   }
+
+   public static boolean getMirrorAckManagerWarnUnacked() {
+      return DEFAULT_MIRROR_ACK_MANAGER_WARN_UNACKED;
    }
 
    public static int getMirrorAckManagerRetryDelay() {

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/mirror/AckManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/mirror/AckManager.java
@@ -57,6 +57,7 @@ import org.apache.activemq.artemis.core.server.impl.AddressInfo;
 import org.apache.activemq.artemis.core.server.mirror.MirrorController;
 import org.apache.activemq.artemis.core.transaction.Transaction;
 import org.apache.activemq.artemis.core.transaction.impl.TransactionImpl;
+import org.apache.activemq.artemis.protocol.amqp.logger.ActiveMQAMQPProtocolLogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,6 +79,7 @@ public class AckManager implements ActiveMQComponent {
    ActiveMQScheduledComponent scheduledComponent;
 
    public AckManager(ActiveMQServer server) {
+      assert server != null && server.getConfiguration() != null;
       this.server = server;
       this.configuration = server.getConfiguration();
       this.ioCriticalErrorListener = server.getIoCriticalErrorListener();
@@ -260,7 +262,7 @@ public class AckManager implements ActiveMQComponent {
                   page.usageDown();
                }
             }
-            validateExpiredSet(acksToRetry);
+            validateExpiredSet(address, acksToRetry);
          } else {
             logger.trace("Page Scan not required for address {}", address);
          }
@@ -283,16 +285,19 @@ public class AckManager implements ActiveMQComponent {
 
    }
 
-   private void validateExpiredSet(LongObjectHashMap<JournalHashMap<AckRetry, AckRetry, Queue>> queuesToRetry) {
-      queuesToRetry.forEach(this::validateExpireSet);
+   private void validateExpiredSet(SimpleString address, LongObjectHashMap<JournalHashMap<AckRetry, AckRetry, Queue>> queuesToRetry) {
+      queuesToRetry.forEach((q, r) -> this.validateExpireSet(address, q, r));
    }
 
-   private void validateExpireSet(long queueID, JournalHashMap<AckRetry, AckRetry, Queue> retries) {
+   private void validateExpireSet(SimpleString address, long queueID, JournalHashMap<AckRetry, AckRetry, Queue> retries) {
       for (AckRetry retry : retries.valuesCopy()) {
          if (retry.getQueueAttempts() >= configuration.getMirrorAckManagerQueueAttempts()) {
             if (retry.attemptedPage() >= configuration.getMirrorAckManagerPageAttempts()) {
+               if (configuration.isMirrorAckManagerWarnUnacked()) {
+                  ActiveMQAMQPProtocolLogger.LOGGER.ackRetryFailed(retry, address, queueID);
+               }
                if (logger.isDebugEnabled()) {
-                  logger.debug("Retried {} {} times, giving up on the entry now. Configuration Page Attempts={}", retry, retry.getPageAttempts(), configuration.getMirrorAckManagerPageAttempts());
+                  logger.debug("Retried {} {} times, giving up on the entry now. Configured Page Attempts={}", retry, retry.getPageAttempts(), configuration.getMirrorAckManagerPageAttempts());
                }
                retries.remove(retry);
             } else {
@@ -300,6 +305,8 @@ public class AckManager implements ActiveMQComponent {
                   logger.debug("Retry {} attempted {} times on paging, Configuration Page Attempts={}", retry, retry.getPageAttempts(), configuration.getMirrorAckManagerPageAttempts());
                }
             }
+         } else {
+            logger.debug("Retry {} queue attempted {} times on paging, QueueAttempts {} Configuration Page Attempts={}", retry, retry.getQueueAttempts(), retry.getPageAttempts(), configuration.getMirrorAckManagerPageAttempts());
          }
       }
    }
@@ -418,9 +425,14 @@ public class AckManager implements ActiveMQComponent {
       if (reference == null) {
          if (logger.isDebugEnabled()) {
             logger.debug("ACK Manager could not find reference nodeID={} (while localID={}), messageID={} on queue {}, server={}. Adding retry with minQueue={}, maxPage={}, delay={}", nodeID, referenceIDSupplier.getDefaultNodeID(), messageID, targetQueue.getName(), server, configuration.getMirrorAckManagerQueueAttempts(), configuration.getMirrorAckManagerPageAttempts(), configuration.getMirrorAckManagerRetryDelay());
-            printQueueDebug(targetQueue);
          }
+
          if (allowRetry) {
+            if (configuration != null && configuration.isMirrorAckManagerWarnUnacked() && targetQueue.getConsumerCount() > 0) {
+               ActiveMQAMQPProtocolLogger.LOGGER.unackWithConsumer(targetQueue.getConsumerCount(), targetQueue.getName(), nodeID, messageID);
+            } else {
+               logger.debug("There are {} consumers on queue {}, what made Ack for message with nodeID={}, messageID={} enter a retry list", targetQueue.getConsumerCount(), targetQueue.getName(), nodeID, messageID);
+            }
             addRetry(nodeID, targetQueue, messageID, reason);
          }
          return false;
@@ -434,10 +446,6 @@ public class AckManager implements ActiveMQComponent {
          doACK(targetQueue, reference, reason);
          return true;
       }
-   }
-
-   private void printQueueDebug(Queue targetQueue) {
-      logger.debug("... queue {}/{} had {} consumers, {} messages, {} scheduled messages, {} delivering messages, paging={}", targetQueue.getID(), targetQueue.getName(), targetQueue.getConsumerCount(), targetQueue.getMessageCount(), targetQueue.getScheduledCount(), targetQueue.getDeliveringCount(), targetQueue.getPagingStore().isPaging());
    }
 
    private void doACK(Queue targetQueue, MessageReference reference, AckReason reason) {

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/logger/ActiveMQAMQPProtocolLogger.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/logger/ActiveMQAMQPProtocolLogger.java
@@ -67,4 +67,10 @@ public interface ActiveMQAMQPProtocolLogger {
 
    @LogMessage(id = 111010, value = "Duplicate AckManager node detected. Queue={}, ServerID={}, recordID={}", level = LogMessage.Level.WARN)
    void duplicateNodeStoreID(String queue, String serverId, long recordID, Exception trace);
+
+   @LogMessage(id = 111011, value = "There are {} consumers on queue {}, what made the Ack for message with nodeID={}, messageID={} enter a retry list", level = LogMessage.Level.WARN)
+   void unackWithConsumer(int numberOfConsumers, Object queueName, String nodeID, long messageID);
+
+   @LogMessage(id = 111012, value = "Acknowledgement retry failed for {} on address {}, queueID={}", level = LogMessage.Level.WARN)
+   void ackRetryFailed(Object ackRetryInformation, Object address, long queueID);
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
@@ -1535,4 +1535,13 @@ public interface Configuration {
    boolean isMirrorPageTransaction();
 
    Configuration setMirrorPageTransaction(boolean ignorePageTransactions);
+
+   /**
+    * should log.warn when ack retries failed.
+    * @param warnUnacked
+    * @return
+    */
+   Configuration setMirrorAckManagerWarnUnacked(boolean warnUnacked);
+
+   boolean isMirrorAckManagerWarnUnacked();
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
@@ -444,6 +444,8 @@ public class ConfigurationImpl implements Configuration, Serializable {
 
    private int mirrorAckManagerPageAttempts = ActiveMQDefaultConfiguration.getMirrorAckManagerPageAttempts();
 
+   private boolean mirrorAckManagerWarnUnacked = ActiveMQDefaultConfiguration.getMirrorAckManagerWarnUnacked();
+
    private int mirrorAckManagerRetryDelay = ActiveMQDefaultConfiguration.getMirrorAckManagerRetryDelay();
 
    private boolean mirrorPageTransaction = ActiveMQDefaultConfiguration.getMirrorPageTransaction();
@@ -3383,6 +3385,17 @@ public class ConfigurationImpl implements Configuration, Serializable {
    @Override
    public int getMirrorAckManagerQueueAttempts() {
       return mirrorAckManagerQueueAttempts;
+   }
+
+   @Override
+   public boolean isMirrorAckManagerWarnUnacked() {
+      return mirrorAckManagerWarnUnacked;
+   }
+
+   @Override
+   public ConfigurationImpl setMirrorAckManagerWarnUnacked(boolean warnUnacked) {
+      this.mirrorAckManagerWarnUnacked = warnUnacked;
+      return this;
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -386,6 +386,7 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
    private static final String MIRROR_ACK_MANAGER_PAGE_ATTEMPTS = "mirror-ack-manager-page-attempts";
 
    private static final String MIRROR_ACK_MANAGER_RETRY_DELAY = "mirror-ack-manager-retry-delay";
+   private static final String MIRROR_ACK_MANAGER_WARN_UNACKED = "mirror-ack-manager-warn-unacked";
 
    private static final String MIRROR_PAGE_TRANSACTION = "mirror-page-transaction";
 
@@ -867,6 +868,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
       config.setMirrorAckManagerQueueAttempts(getInteger(e, MIRROR_ACK_MANAGER_QUEUE_ATTEMPTS, config.getMirrorAckManagerQueueAttempts(), GT_ZERO));
 
       config.setMirrorAckManagerRetryDelay(getInteger(e, MIRROR_ACK_MANAGER_RETRY_DELAY, config.getMirrorAckManagerRetryDelay(), GT_ZERO));
+
+      config.setMirrorAckManagerWarnUnacked(getBoolean(e, MIRROR_ACK_MANAGER_WARN_UNACKED, config.isMirrorAckManagerWarnUnacked()));
 
       parseAddressSettings(e, config);
 

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -944,6 +944,14 @@
             </xsd:annotation>
          </xsd:element>
 
+         <xsd:element name="mirror-ack-manager-warn-unacked" type="xsd:boolean" maxOccurs="1" minOccurs="0" default="false">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Should the system log.warn when an acknowledgment retry fails (unacked).
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
          <xsd:element name="mirror-page-transaction" type="xsd:boolean" maxOccurs="1" minOccurs="0" default="false">
             <xsd:annotation>
                <xsd:documentation>

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
@@ -582,6 +582,7 @@ public class FileConfigurationTest extends AbstractConfigurationTestBase {
       assertEquals(Integer.valueOf(128), conf.getAddressSettings().get("a2").getInitialQueueBufferSize());
 
       assertEquals(111, conf.getMirrorAckManagerQueueAttempts());
+      assertTrue(conf.isMirrorAckManagerWarnUnacked());
       assertEquals(222, conf.getMirrorAckManagerPageAttempts());
       assertEquals(333, conf.getMirrorAckManagerRetryDelay());
       assertTrue(conf.isMirrorPageTransaction());

--- a/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
@@ -558,6 +558,7 @@
       <mirror-ack-manager-queue-attempts>111</mirror-ack-manager-queue-attempts>
       <mirror-ack-manager-page-attempts>222</mirror-ack-manager-page-attempts>
       <mirror-ack-manager-retry-delay>333</mirror-ack-manager-retry-delay>
+      <mirror-ack-manager-warn-unacked>true</mirror-ack-manager-warn-unacked>
       <mirror-page-transaction>true</mirror-page-transaction>
 
       <security-settings>

--- a/artemis-server/src/test/resources/ConfigurationTest-xinclude-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-xinclude-config.xml
@@ -74,6 +74,7 @@
       <mirror-ack-manager-queue-attempts>111</mirror-ack-manager-queue-attempts>
       <mirror-ack-manager-page-attempts>222</mirror-ack-manager-page-attempts>
       <mirror-ack-manager-retry-delay>333</mirror-ack-manager-retry-delay>
+      <mirror-ack-manager-warn-unacked>true</mirror-ack-manager-warn-unacked>
       <mirror-page-transaction>true</mirror-page-transaction>
 
       <remoting-incoming-interceptors>

--- a/artemis-server/src/test/resources/ConfigurationTest-xinclude-schema-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-xinclude-schema-config.xml
@@ -74,6 +74,7 @@
       <mirror-ack-manager-queue-attempts>111</mirror-ack-manager-queue-attempts>
       <mirror-ack-manager-page-attempts>222</mirror-ack-manager-page-attempts>
       <mirror-ack-manager-retry-delay>333</mirror-ack-manager-retry-delay>
+      <mirror-ack-manager-warn-unacked>true</mirror-ack-manager-warn-unacked>
       <mirror-page-transaction>true</mirror-page-transaction>
 
 


### PR DESCRIPTION
I am adding an option to configuration to log warns when messages are unbacked. By default the system will still no log.warn.