### PR TITLE
ARTEMIS-2777 Add core federation and broker connections to the management console

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/logs/AuditLogger.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/logs/AuditLogger.java
@@ -2744,4 +2744,61 @@ public interface AuditLogger {
 
    @LogMessage(id = 601781, value = "User {} is getting authorization failure count on target resource: {}", level = LogMessage.Level.INFO)
    void getAuthorizationFailureCount(String user, Object source);
+
+   static void startFederation(Object source) {
+      BASE_LOGGER.startFederation(getCaller(), source);
+   }
+
+   @LogMessage(id = 601782, value = "User {} is starting a federation on target resource: {}", level = LogMessage.Level.INFO)
+   void startFederation(String user, Object source);
+
+   static void stopFederation(Object source) {
+      BASE_LOGGER.stopFederation(getCaller(), source);
+   }
+
+   @LogMessage(id = 601783, value = "User {} is stopping a federation on target resource: {}", level = LogMessage.Level.INFO)
+   void stopFederation(String user, Object source);
+
+   static void isSharedConnection(Object source) {
+      BASE_LOGGER.isSharedConnection(getCaller(), source);
+   }
+
+   @LogMessage(id = 601784, value = "User {} is querying isSharedConnection on target resource: {}", level = LogMessage.Level.INFO)
+   void isSharedConnection(String user, Object source);
+
+   static void isPull(Object source) {
+      BASE_LOGGER.isPull(getCaller(), source);
+   }
+
+   @LogMessage(id = 601785, value = "User {} is querying isPull on target resource: {}", level = LogMessage.Level.INFO)
+   void isPull(String user, Object source);
+
+   static void getPriority(Object source) {
+      BASE_LOGGER.getPriority(getCaller(), source);
+   }
+
+   @LogMessage(id = 601786, value = "User {} is getting priority on target resource: {}", level = LogMessage.Level.INFO)
+   void getPriority(String user, Object source);
+
+   static void isOpen(Object source) {
+      BASE_LOGGER.isOpen(getCaller(), source);
+   }
+
+   @LogMessage(id = 601787, value = "User {} is querying isOpen on target resource: {}", level = LogMessage.Level.INFO)
+   void isOpen(String user, Object source);
+
+   static void getUri(Object source) {
+      BASE_LOGGER.getUri(getCaller(), source);
+   }
+
+   @LogMessage(id = 601788, value = "User {} is getting uri on target resource: {}", level = LogMessage.Level.INFO)
+   void getUri(String user, Object source);
+
+   static void getProtocol(Object source) {
+      BASE_LOGGER.getProtocol(getCaller(), source);
+   }
+
+   @LogMessage(id = 601789, value = "User {} is getting protocol on target resource: {}", level = LogMessage.Level.INFO)
+   void getProtocol(String user, Object source);
+
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/BrokerConnectionControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/BrokerConnectionControl.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.api.core.management;
+
+/**
+ * A BrokerConnectionControl is used to manage a BrokerConnections.
+ */
+public interface BrokerConnectionControl extends ActiveMQComponentControl {
+
+   /**
+    * Returns {@code true} if this connection is open, {@code false} else.
+    */
+   @Attribute(desc = "whether this connection is open")
+   boolean isOpen();
+
+   /**
+    * Returns the name of this broker connection
+    */
+   @Attribute(desc = "name of this broker connection")
+   String getName();
+
+   /**
+    * Returns the connection uri for this broker connection.
+    */
+   @Attribute(desc = "connection uri for this broker connection")
+   String getUri();
+
+   /**
+    * Returns the user this broker connection is using.
+    */
+   @Attribute(desc = "the user this broker connection is using")
+   String getUser();
+
+   /**
+    * Returns the protocol this broker connection is using.
+    */
+   @Attribute(desc = "protocol this broker connection is using")
+   String getProtocol();
+
+   /**
+    * Returns the retry interval used by this broker connection.
+    */
+   @Attribute(desc = "retry interval used by this broker connection")
+   long getRetryInterval();
+
+   /**
+    * Returns the number of reconnection attempts used by this broker connection.
+    */
+   @Attribute(desc = "number of reconnection attempts used by this broker connection")
+   int getReconnectAttempts();
+
+}

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/FederationControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/FederationControl.java
@@ -14,30 +14,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.core.server;
+package org.apache.activemq.artemis.api.core.management;
 
-import org.apache.activemq.artemis.core.config.brokerConnectivity.BrokerConnectConfiguration;
-
-public interface BrokerConnection extends ActiveMQComponent {
+/**
+ * A federationControl is used to manage a federation.
+ */
+public interface FederationControl extends ActiveMQComponentControl {
 
    /**
-    * @return the unique name of the broker connection
+    * Returns the name of this federation
     */
+   @Attribute(desc = "name of this federation")
    String getName();
 
    /**
-    * @return the protocol that underlies the broker connection implementation.
+    * Returns the name of the user the federation is associated with.
     */
-   String getProtocol();
-
-   /**
-    * @return the configuration that was used to create this broker connection.
-    */
-   BrokerConnectConfiguration getConfiguration();
-
-   /**
-    * @return if the connection is currently open.
-    */
-   boolean isOpen();
+   @Attribute(desc = "name of the user the federation is associated with")
+   String getUser();
 
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/FederationRemoteConsumerControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/FederationRemoteConsumerControl.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.api.core.management;
+
+/**
+ * A BridgeControl is used to manage a federation stream.
+ */
+public interface FederationRemoteConsumerControl {
+
+   /**
+    * Returns the name of the queue that is being federated too
+    */
+   @Attribute(desc = "name of the queue that is being federated too")
+   String getQueueName();
+
+   /**
+    * Returns the address this remote consumer will forward messages from.
+    */
+   @Attribute(desc = "address this remote consumer will forward messages from")
+   String getAddress();
+
+   /**
+    * Returns the priority of this remote consumer will consumer messages.
+    */
+   @Attribute(desc = "address this remote consumer will consumer messages")
+   int getPriority();
+
+   /**
+    * Returns the routing type associated with this address.
+    */
+   @Attribute(desc = "routing type for this address")
+   String getRoutingType();
+
+   /**
+    * Returns the filter string associated with this remote consumer.
+    */
+   @Attribute(desc = "filter string associated with this remote consumer")
+   String getFilterString();
+
+   /**
+    * Returns the queue filter string associated with this remote consumer.
+    */
+   @Attribute(desc = "queue filter string associated with this remote consumer")
+   String getQueueFilterString();
+
+   /**
+    * Returns the fully qualified queue name associated with this remote consumer.
+    */
+//   @Attribute(desc = "fully qualified queue name associated with this remote consumer")
+//   String getFqqn();
+
+   /**
+    * Returns the number of messages that have been federated for this address.
+    */
+   @Attribute(desc = "number of messages that have been federated for this address")
+   long getFederatedMessageCount();
+}

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/FederationStreamControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/FederationStreamControl.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.api.core.management;
+
+/**
+ * A BridgeControl is used to manage a federation stream.
+ */
+public interface FederationStreamControl {
+
+   /**
+    * Returns the name of this federation stream
+    */
+   @Attribute(desc = "name of this federation stream")
+   String getName();
+
+   /**
+    * Returns any list of static connectors used by this federation stream
+    */
+   @Attribute(desc = "list of static connectors used by this federation stream")
+   String[] getStaticConnectors() throws Exception;
+
+   /**
+    * Returns the name of the discovery group used by this federation stream.
+    */
+   @Attribute(desc = "name of the discovery group used by this federation stream")
+   String getDiscoveryGroupName();
+
+   /**
+    * Returns the retry interval used by this federation stream.
+    */
+   @Attribute(desc = "retry interval used by this federation stream")
+   long getRetryInterval();
+
+   /**
+    * Returns the retry interval multiplier used by this federation stream.
+    */
+   @Attribute(desc = "retry interval multiplier used by this federation stream")
+   double getRetryIntervalMultiplier();
+
+   /**
+    * Returns the max retry interval used by this federation stream.
+    */
+   @Attribute(desc = "max retry interval used by this federation stream")
+   long getMaxRetryInterval();
+
+   /**
+    * Returns the number of reconnection attempts used by this federation stream.
+    */
+   @Attribute(desc = "number of reconnection attempts used by this federation stream")
+   int getReconnectAttempts();
+
+   /**
+    * Returns {@code true} if steam allows a shared connection, {@code false} else.
+    */
+   @Attribute(desc = "whether this stream will allow the connection to be shared")
+   boolean isSharedConnection();
+
+   /**
+    * Returns {@code true} if  this connection is configured to pull, {@code false} else.
+    */
+   @Attribute(desc = "whether this connection is configured to pull")
+   boolean isPull();
+
+   /**
+    * Returns {@code true} the connection is configured for HA, {@code false} else.
+    */
+   @Attribute(desc = "whether this connection is configured for HA")
+   boolean isHA();
+
+   /**
+    * Returns the name of the user the federation is associated with
+    */
+   @Attribute(desc = "name of the user the federation is associated with")
+   String getUser();
+
+}

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ObjectNameBuilder.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ObjectNameBuilder.java
@@ -127,12 +127,30 @@ public final class ObjectNameBuilder {
    }
 
    /**
+    * Returns the ObjectName used by BrokerConnectionControl.
+    *
+    * @see BrokerConnectionControl
+    */
+   public ObjectName getBrokerConnectionObjectName(String name) throws Exception {
+      return createObjectName("broker-connection", name);
+   }
+
+   /**
     * Returns the ObjectName used by BridgeControl.
     *
     * @see BridgeControl
     */
    public ObjectName getBridgeObjectName(final String name) throws Exception {
       return createObjectName("bridge", name);
+   }
+
+   /**
+    * Returns the ObjectName used by FederationControl.
+    *
+    * @see FederationControl
+    */
+   public ObjectName getFederationObjectName(String name) throws Exception {
+      return createObjectName("federation", name);
    }
 
    /**
@@ -169,4 +187,28 @@ public final class ObjectNameBuilder {
    public ObjectName getSecurityObjectName() throws Exception {
       return ObjectName.getInstance("hawtio:type=security,area=jmx,name=ArtemisJMXSecurity");
    }
+
+   /**
+    * Returns the ObjectName used by FederationStreamControl.
+    *
+    * @see FederationStreamControl
+    */
+   public ObjectName getFederationStreamObjectName(SimpleString federationName,
+                                                   SimpleString streamName) throws Exception {
+      return ObjectName.getInstance(String.format("%s,component=federations,name=%s,streamName=%s", getActiveMQServerName(), ObjectName.quote(federationName.toString()), ObjectName.quote(streamName.toString().toLowerCase())));
+   }
+
+   /**
+    * Returns the ObjectName used by FederationRemoteConsumerControl.
+    *
+    * @see FederationRemoteConsumerControl
+    */
+   public ObjectName getFederationRemoteConsumerObjectName(final SimpleString federationName,
+                                                           final SimpleString streamName,
+                                                           final SimpleString address,
+                                                           final SimpleString queueName,
+                                                           RoutingType routingType) throws Exception {
+      return ObjectName.getInstance(String.format("%s,component=federations,name=%s,streamName=%s,address=%s,subcomponent=queues,routing-type=%s,queue=%s", getActiveMQServerName(), ObjectName.quote(federationName.toString()), ObjectName.quote(streamName.toString()), ObjectName.quote(address.toString()), ObjectName.quote(routingType.toString().toLowerCase()), ObjectName.quote(queueName.toString())));
+   }
+
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ResourceNames.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ResourceNames.java
@@ -34,7 +34,15 @@ public final class ResourceNames {
 
    public static final String ADDRESS = "address.";
 
+   public static final String BROKER_CONNECTION = "brokerconnection.";
+
    public static final String BRIDGE = "bridge.";
+
+   public static final String FEDERATION = "federation.";
+
+   public static final String FEDERATION_STREAM = "federationstream.";
+
+   public static final String FEDERATION_REMOTE_CONSUMER = "federationremoteconsumer.";
 
    public static final String ACCEPTOR = "acceptor.";
 

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/AMQPBrokerConnection.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/AMQPBrokerConnection.java
@@ -195,6 +195,15 @@ public class AMQPBrokerConnection implements ClientConnectionLifeCycleListener, 
    }
 
    @Override
+   public boolean isOpen() {
+      if (connection != null) {
+         return connection.isOpen();
+      } else {
+         return false;
+      }
+   }
+
+   @Override
    public boolean isStarted() {
       return started;
    }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/AMQPBrokerConnectionManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/AMQPBrokerConnectionManager.java
@@ -89,7 +89,7 @@ public class AMQPBrokerConnectionManager implements ActiveMQComponent, ClientCon
       AMQPBrokerConnection amqpBrokerConnection = new AMQPBrokerConnection(this, configuration, protonProtocolManagerFactory, server);
       amqpBrokerConnections.put(configuration.getName(), amqpBrokerConnection);
       server.registerBrokerConnection(amqpBrokerConnection);
-
+      server.getManagementService().registerBrokerConnection(amqpBrokerConnection);
       if (start) {
          amqpBrokerConnection.start();
       }
@@ -142,6 +142,7 @@ public class AMQPBrokerConnectionManager implements ActiveMQComponent, ClientCon
                   connection.stop();
                } finally {
                   server.unregisterBrokerConnection(connection);
+                  server.getManagementService().unregisterBrokerConnection(connection.getName());
                }
             }
 
@@ -183,6 +184,7 @@ public class AMQPBrokerConnectionManager implements ActiveMQComponent, ClientCon
                connection.stop();
             } finally {
                server.unregisterBrokerConnection(connection);
+               server.getManagementService().unregisterBrokerConnection(connection.getName());
             }
          }
       }
@@ -211,6 +213,7 @@ public class AMQPBrokerConnectionManager implements ActiveMQComponent, ClientCon
                   connection.stop();
                } finally {
                   server.unregisterBrokerConnection(connection);
+                  server.getManagementService().unregisterBrokerConnection(connection.getName());
                }
             }
          } finally {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -4018,6 +4018,8 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
             obj.add("name", brokerConnection.getName());
             obj.add("protocol", brokerConnection.getProtocol());
             obj.add("started", brokerConnection.isStarted());
+            obj.add("uri", brokerConnection.getConfiguration().getUri());
+            obj.add("open", brokerConnection.isOpen());
             connections.add(obj.build());
          }
          return connections.build().toString();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/BrokerConnectionControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/BrokerConnectionControlImpl.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.management.impl;
+
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanOperationInfo;
+import javax.management.NotCompliantMBeanException;
+
+import org.apache.activemq.artemis.api.core.management.BrokerConnectionControl;
+import org.apache.activemq.artemis.core.persistence.StorageManager;
+import org.apache.activemq.artemis.core.server.BrokerConnection;
+import org.apache.activemq.artemis.logs.AuditLogger;
+
+public class BrokerConnectionControlImpl extends AbstractControl implements BrokerConnectionControl {
+
+   private final BrokerConnection brokerConnection;
+
+   public BrokerConnectionControlImpl(BrokerConnection brokerConnection,
+                                      StorageManager storageManager) throws NotCompliantMBeanException {
+      super(BrokerConnectionControl.class, storageManager);
+      this.brokerConnection = brokerConnection;
+   }
+
+   @Override
+   public boolean isStarted() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.isStarted(this.brokerConnection);
+      }
+      clearIO();
+      try {
+         return brokerConnection.isStarted();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public boolean isOpen() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.isOpen(this.brokerConnection);
+      }
+      clearIO();
+      try {
+         return brokerConnection.isOpen();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public void start() throws Exception {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.startBrokerConnection(this.brokerConnection.getName());
+      }
+      clearIO();
+      try {
+         brokerConnection.start();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public void stop() throws Exception {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.startBrokerConnection(this.brokerConnection.getName());
+      }
+      clearIO();
+      try {
+         brokerConnection.stop();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public String getName() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getName(this.brokerConnection);
+      }
+      clearIO();
+      try {
+         return brokerConnection.getName();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public String getUri() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getUri(this.brokerConnection);
+      }
+      clearIO();
+      try {
+         return brokerConnection.getConfiguration().getUri();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public String getUser() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getUser(this.brokerConnection);
+      }
+      clearIO();
+      try {
+         return brokerConnection.getConfiguration().getUser();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public String getProtocol() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getProtocol(this.brokerConnection);
+      }
+      clearIO();
+      try {
+         return brokerConnection.getProtocol();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public long getRetryInterval() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getRetryInterval(this.brokerConnection);
+      }
+      clearIO();
+      try {
+         return brokerConnection.getConfiguration().getRetryInterval();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public int getReconnectAttempts() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getReconnectAttempts(this.brokerConnection);
+      }
+      clearIO();
+      try {
+         return brokerConnection.getConfiguration().getReconnectAttempts();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   protected MBeanOperationInfo[] fillMBeanOperationInfo() {
+      return MBeanInfoHelper.getMBeanOperationsInfo(BrokerConnectionControl.class);
+   }
+
+   @Override
+   protected MBeanAttributeInfo[] fillMBeanAttributeInfo() {
+      return MBeanInfoHelper.getMBeanAttributesInfo(BrokerConnectionControl.class);
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/FederationControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/FederationControlImpl.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.management.impl;
+
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanOperationInfo;
+
+import org.apache.activemq.artemis.api.core.management.FederationControl;
+import org.apache.activemq.artemis.core.persistence.StorageManager;
+import org.apache.activemq.artemis.core.server.federation.Federation;
+import org.apache.activemq.artemis.logs.AuditLogger;
+
+public class FederationControlImpl extends AbstractControl implements FederationControl {
+
+   private final Federation federation;
+
+   public FederationControlImpl(final Federation federation, final StorageManager storageManager) throws Exception {
+      super(FederationControl.class, storageManager);
+      this.federation = federation;
+   }
+
+   @Override
+   public String getUser() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getUser(this.federation);
+      }
+      clearIO();
+      try {
+         return federation.getConfig().getCredentials().getUser();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public String getName() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getName(this.federation);
+      }
+      clearIO();
+      try {
+         return federation.getName().toString();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public boolean isStarted() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.isStarted(this.federation);
+      }
+      clearIO();
+      try {
+         return federation.isStarted();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public void start() throws Exception {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.startFederation(this.federation);
+      }
+      clearIO();
+      try {
+         federation.start();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public void stop() throws Exception {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.stopFederation(this.federation);
+      }
+      clearIO();
+      try {
+         federation.stop();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   protected MBeanOperationInfo[] fillMBeanOperationInfo() {
+      return MBeanInfoHelper.getMBeanOperationsInfo(FederationControl.class);
+   }
+
+   @Override
+   protected MBeanAttributeInfo[] fillMBeanAttributeInfo() {
+      return MBeanInfoHelper.getMBeanAttributesInfo(FederationControl.class);
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/FederationRemoteConsumerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/FederationRemoteConsumerControlImpl.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.management.impl;
+
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanOperationInfo;
+
+import org.apache.activemq.artemis.api.core.management.FederationRemoteConsumerControl;
+import org.apache.activemq.artemis.core.persistence.StorageManager;
+import org.apache.activemq.artemis.core.server.federation.FederatedConsumerKey;
+import org.apache.activemq.artemis.core.server.federation.FederatedQueueConsumer;
+import org.apache.activemq.artemis.logs.AuditLogger;
+
+public class FederationRemoteConsumerControlImpl extends AbstractControl implements FederationRemoteConsumerControl {
+
+   private final FederatedConsumerKey federatedConsumerKey;
+   private final FederatedQueueConsumer federatedConsumer;
+
+   public FederationRemoteConsumerControlImpl(final FederatedQueueConsumer federatedConsumer,
+                                              final StorageManager storageManager) throws Exception {
+      super(FederationRemoteConsumerControl.class, storageManager);
+      this.federatedConsumerKey = federatedConsumer.getKey();
+      this.federatedConsumer = federatedConsumer;
+   }
+
+   @Override
+   public String getAddress() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getAddress(federatedConsumer);
+      }
+      clearIO();
+      try {
+         return federatedConsumerKey.getAddress().toString();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public int getPriority() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getPriority(federatedConsumer);
+      }
+      clearIO();
+      try {
+         return federatedConsumerKey.getPriority();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public String getRoutingType() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getRoutingType(federatedConsumer);
+      }
+      clearIO();
+      try {
+         return federatedConsumerKey.getRoutingType().toString();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public String getFilterString() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getFilterString(federatedConsumer);
+      }
+      clearIO();
+      try {
+         return federatedConsumerKey.getFilterString().toString();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public String getQueueName() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getQueueName(federatedConsumer);
+      }
+      clearIO();
+      try {
+         return federatedConsumerKey.getQueueName().toString();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public String getQueueFilterString() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getFilterString(federatedConsumer);
+      }
+      clearIO();
+      try {
+         return federatedConsumerKey.getQueueFilterString().toString();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   /*
+   @Override
+   public String getFqqn() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getFqqn(federatedConsumer);
+      }
+      clearIO();
+      try {
+         return federatedConsumerKey.getFqqn().toString();
+      } finally {
+         blockOnIO();
+      }
+   }
+*/
+
+   @Override
+   protected MBeanOperationInfo[] fillMBeanOperationInfo() {
+      return MBeanInfoHelper.getMBeanOperationsInfo(FederationRemoteConsumerControl.class);
+   }
+
+   @Override
+   protected MBeanAttributeInfo[] fillMBeanAttributeInfo() {
+      return MBeanInfoHelper.getMBeanAttributesInfo(FederationRemoteConsumerControl.class);
+   }
+
+   @Override
+   public long getFederatedMessageCount() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getMessageCount(federatedConsumer);
+      }
+      clearIO();
+      try {
+         return federatedConsumer.federatedMessageCount();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/FederationStreamControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/FederationStreamControlImpl.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.management.impl;
+
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanOperationInfo;
+
+import org.apache.activemq.artemis.api.core.management.FederationStreamControl;
+import org.apache.activemq.artemis.core.persistence.StorageManager;
+import org.apache.activemq.artemis.core.server.federation.FederationStream;
+import org.apache.activemq.artemis.logs.AuditLogger;
+
+public class FederationStreamControlImpl extends AbstractControl implements FederationStreamControl {
+
+   private final FederationStream federationStream;
+
+   public FederationStreamControlImpl(final FederationStream federationStream,
+                                      final StorageManager storageManager) throws Exception {
+      super(FederationStreamControl.class, storageManager);
+      this.federationStream = federationStream;
+   }
+
+   @Override
+   public String getUser() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getUser(this.federationStream);
+      }
+      clearIO();
+      try {
+         return federationStream.getConfig().getConnectionConfiguration().getUsername();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public String getName() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getName(this.federationStream);
+      }
+      clearIO();
+      try {
+         return federationStream.getName().toString();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public String[] getStaticConnectors() throws Exception {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getStaticConnectors(this.federationStream);
+      }
+      clearIO();
+      try {
+         return federationStream.getConnection().getConfig().getStaticConnectors().toArray(new String[0]);
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public String getDiscoveryGroupName() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getDiscoveryGroupName(this.federationStream);
+      }
+      clearIO();
+      try {
+         return federationStream.getConnection().getConfig().getDiscoveryGroupName();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public long getRetryInterval() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getRetryInterval(this.federationStream);
+      }
+      clearIO();
+      try {
+         return federationStream.getConnection().getConfig().getRetryInterval();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public double getRetryIntervalMultiplier() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getRetryIntervalMultiplier(this.federationStream);
+      }
+      clearIO();
+      try {
+         return federationStream.getConnection().getConfig().getRetryIntervalMultiplier();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public long getMaxRetryInterval() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getMaxRetryInterval(this.federationStream);
+      }
+      clearIO();
+      try {
+         return federationStream.getConnection().getConfig().getMaxRetryInterval();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public int getReconnectAttempts() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getReconnectAttempts(this.federationStream);
+      }
+      clearIO();
+      try {
+         return federationStream.getConnection().getConfig().getReconnectAttempts();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public boolean isSharedConnection() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.isSharedConnection(this.federationStream);
+      }
+      clearIO();
+      try {
+         return federationStream.getConnection().isSharedConnection();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public boolean isPull() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.isPull(this.federationStream);
+      }
+      clearIO();
+      try {
+         return federationStream.getConnection().isPull();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public boolean isHA() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.isHA(this.federationStream);
+      }
+      clearIO();
+      try {
+         return federationStream.getConnection().getConfig().isHA();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   protected MBeanOperationInfo[] fillMBeanOperationInfo() {
+      return MBeanInfoHelper.getMBeanOperationsInfo(FederationStreamControl.class);
+   }
+
+   @Override
+   protected MBeanAttributeInfo[] fillMBeanAttributeInfo() {
+      return MBeanInfoHelper.getMBeanAttributesInfo(FederationStreamControl.class);
+   }
+
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/CoreProtocolManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/CoreProtocolManager.java
@@ -477,19 +477,31 @@ public class CoreProtocolManager implements ProtocolManager<Interceptor, ActiveM
             //Register close and failure listeners, if the initial downstream connection goes down then we
             //want to terminate the upstream connection
             rc.addCloseListener(() -> {
-               server.getFederationManager().undeploy(config.getName());
+               try {
+                  server.getFederationManager().undeploy(config.getName());
+               } catch (Throwable ignored) {
+                  logger.debug(ignored.getMessage(), ignored);
+               }
             });
 
             rc.addFailureListener(new FailureListener() {
                @Override
                public void connectionFailed(ActiveMQException exception, boolean failedOver) {
-                  server.getFederationManager().undeploy(config.getName());
+                  try {
+                     server.getFederationManager().undeploy(config.getName());
+                  } catch (Throwable ignored) {
+                     logger.debug(ignored.getMessage(), ignored);
+                  }
                }
 
                @Override
                public void connectionFailed(ActiveMQException exception, boolean failedOver,
                                             String scaleDownTargetNodeID) {
-                  server.getFederationManager().undeploy(config.getName());
+                  try {
+                     server.getFederationManager().undeploy(config.getName());
+                  } catch (Throwable ignored) {
+                     logger.debug(ignored.getMessage(), ignored);
+                  }
                }
             });
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/federation/FederatedQueueConsumer.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/federation/FederatedQueueConsumer.java
@@ -52,4 +52,6 @@ public interface FederatedQueueConsumer extends MessageHandler {
    void start();
 
    void close();
+
+   long federatedMessageCount();
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/ManagementService.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/ManagementService.java
@@ -41,9 +41,13 @@ import org.apache.activemq.artemis.core.security.SecurityAuth;
 import org.apache.activemq.artemis.core.security.SecurityStore;
 import org.apache.activemq.artemis.core.server.ActiveMQComponent;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.BrokerConnection;
 import org.apache.activemq.artemis.core.server.Divert;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.server.QueueFactory;
+import org.apache.activemq.artemis.core.server.federation.FederatedQueueConsumer;
+import org.apache.activemq.artemis.core.server.federation.Federation;
+import org.apache.activemq.artemis.core.server.federation.FederationStream;
 import org.apache.activemq.artemis.core.server.routing.ConnectionRouter;
 import org.apache.activemq.artemis.core.server.cluster.Bridge;
 import org.apache.activemq.artemis.core.server.cluster.BroadcastGroup;
@@ -124,6 +128,22 @@ public interface ManagementService extends NotificationService, ActiveMQComponen
 
    void unregisterBridge(String name) throws Exception;
 
+   void registerFederation(Federation federation) throws Exception;
+
+   void unregisterFederation(String name) throws Exception;
+
+   void registerFederationStream(FederationStream federationStream) throws Exception;
+
+   void unregisterFederationStream(SimpleString federationName, SimpleString streamName) throws Exception;
+
+   void registerFederationRemoteConsumer(FederatedQueueConsumer federatedQueueConsumer) throws Exception;
+
+   void unregisterFederationRemoteConsumer(SimpleString name,
+                                           SimpleString streamName,
+                                           SimpleString address,
+                                           SimpleString queueName,
+                                           RoutingType routingType) throws Exception;
+
    void registerCluster(ClusterConnection cluster, ClusterConnectionConfiguration configuration) throws Exception;
 
    void unregisterCluster(String name) throws Exception;
@@ -145,4 +165,8 @@ public interface ManagementService extends NotificationService, ActiveMQComponen
    Object getAttribute(String resourceName, String attribute, SecurityAuth auth);
 
    Object invokeOperation(String resourceName, String operation, Object[] params, SecurityAuth auth) throws Exception;
+
+   void registerBrokerConnection(BrokerConnection brokerConnection) throws Exception;
+
+   void unregisterBrokerConnection(String name) throws Exception;
 }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/group/impl/ClusteredResetMockTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/group/impl/ClusteredResetMockTest.java
@@ -45,9 +45,13 @@ import org.apache.activemq.artemis.core.security.Role;
 import org.apache.activemq.artemis.core.security.SecurityAuth;
 import org.apache.activemq.artemis.core.security.SecurityStore;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.BrokerConnection;
 import org.apache.activemq.artemis.core.server.Divert;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.server.QueueFactory;
+import org.apache.activemq.artemis.core.server.federation.FederatedQueueConsumer;
+import org.apache.activemq.artemis.core.server.federation.Federation;
+import org.apache.activemq.artemis.core.server.federation.FederationStream;
 import org.apache.activemq.artemis.core.server.management.GuardInvocationHandler;
 import org.apache.activemq.artemis.core.server.routing.ConnectionRouter;
 import org.apache.activemq.artemis.core.server.cluster.Bridge;
@@ -317,6 +321,40 @@ public class ClusteredResetMockTest extends ServerTestBase {
       }
 
       @Override
+      public void registerFederation(Federation federation) {
+
+      }
+
+      @Override
+      public void unregisterFederation(String name) {
+
+      }
+
+      @Override
+      public void registerFederationStream(FederationStream federationStream) {
+
+      }
+
+      @Override
+      public void unregisterFederationStream(SimpleString federationName, SimpleString streamName) {
+
+      }
+
+      @Override
+      public void registerFederationRemoteConsumer(FederatedQueueConsumer federatedQueueConsumer) {
+
+      }
+
+      @Override
+      public void unregisterFederationRemoteConsumer(SimpleString name,
+                                                     SimpleString streamame,
+                                                     SimpleString address,
+                                                     SimpleString queueName,
+                                                     RoutingType routingType) {
+
+      }
+
+      @Override
       public void registerCluster(ClusterConnection cluster,
                                   ClusterConnectionConfiguration configuration) throws Exception {
 
@@ -370,6 +408,16 @@ public class ClusteredResetMockTest extends ServerTestBase {
       @Override
       public Object invokeOperation(String resourceName, String operation, Object[] params, SecurityAuth auth) throws Exception {
          return null;
+      }
+
+      @Override
+      public void registerBrokerConnection(BrokerConnection brokerConnection) {
+
+      }
+
+      @Override
+      public void unregisterBrokerConnection(String name) {
+
       }
 
       @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
@@ -6149,6 +6149,12 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
          public BrokerConnectConfiguration getConfiguration() {
             return null;
          }
+
+         @Override
+         public boolean isOpen() {
+            return false;
+         }
+
       }
       Fake fake = new Fake("fake" + UUIDGenerator.getInstance().generateStringUUID());
       server.registerBrokerConnection(fake);


### PR DESCRIPTION
This is a bit out of the blue but basically it has been bugging me how outgoing connections aren't able to be managed in Artemis for anything but Bridges. So I looked into adding something similar primarily for federation but also for the AMQP broker-connections. Simply displaying the configuration didn't seem useful so similar to Bridges i tried to pull up some attribute related to the actual state, for AMQP broker-connections, i exposed if the connection was actually open. For core federations I added visibility into the upstream consumers that are generate from the policy and a message count for messages they have transferred back.

<img width="745" alt="Screenshot 2024-10-04 at 10 36 23 AM" src="https://github.com/user-attachments/assets/c6d954b3-a8e2-42d1-b3c3-c2c0fff9183c">

<img width="813" alt="Screenshot 2024-10-04 at 10 26 41 AM" src="https://github.com/user-attachments/assets/3fe7d780-1064-4955-a2c0-4ff642a08c7b">

<img width="814" alt="Screenshot 2024-10-04 at 10 24 59 AM" src="https://github.com/user-attachments/assets/8e1f650a-112d-43b5-858d-f25391256b08">

