### PR TITLE
ARTEMIS-5096 exclude unnecessary jars from console war

### DIFF
--- a/artemis-distribution/src/main/assembly/dep.xml
+++ b/artemis-distribution/src/main/assembly/dep.xml
@@ -72,9 +72,18 @@
          <includes>
             <include>org.apache.activemq:artemis-console:war</include>
          </includes>
-         <outputDirectory>web</outputDirectory>
-         <unpack>false</unpack>
-         <outputFileNameMapping>console.war</outputFileNameMapping>
+         <outputDirectory>web/console.war</outputDirectory>
+         <unpack>true</unpack>
+         <!-- Exclude these jar files from console since they are already provided in the broker distribution.
+              If any of these jars is dropped from the broker distribution they should be added back to the console. -->
+         <unpackOptions>
+            <excludes>
+               <exclude>**/guava*.jar</exclude>
+               <exclude>**/commons-io*.jar</exclude>
+               <exclude>**/commons-logging*.jar</exclude>
+               <exclude>**/failureaccess*.jar</exclude>
+            </excludes>
+         </unpackOptions>
          <useProjectArtifact>false</useProjectArtifact>
          <directoryMode>0755</directoryMode>
          <fileMode>0644</fileMode>

--- a/docs/user-manual/versions.adoc
+++ b/docs/user-manual/versions.adoc
@@ -20,6 +20,12 @@ https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315920&versio
 
 * The `two-way` algorithm of the default codec is deprecated, use a custom codec instead.
 
+=== Upgrading from 2.37.0
+
+* Due to https://issues.apache.org/jira/browse/ARTEMIS-5096[ARTEMIS-5096] the web console's archive (i.e. `console.war`) will now be uncompressed.
+This change was necessary in order to remove certain jar files from the archive which were already being distributed in the broker's main `lib` directory.
+Eliminating these duplicate jars will decrease the size of the broker distribution and it also means the console will, in some cases, use updated dependencies and prevent security tools from flagging older jars.
+
 == 2.37.0
 
 https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315920&version=12354977[Full release notes]


### PR DESCRIPTION
This particular change will be moot when we integrate the new console, but we should do something similar at that point.