### PR TITLE
ARTEMIS-5103 Remove hardcoded secure random algorithm from default codec

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/DefaultSensitiveStringCodec.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/DefaultSensitiveStringCodec.java
@@ -225,7 +225,6 @@ public class DefaultSensitiveStringCodec implements SensitiveDataCodec<String> {
    private static class PBKDF2Algorithm extends CodecAlgorithm {
       private static final String SEPARATOR = ":";
       private String sceretKeyAlgorithm = "PBKDF2WithHmacSHA1";
-      private String randomScheme = "SHA1PRNG";
       private int keyLength = 64 * 8;
       private int saltLength = 32;
       private int iterations = 1024;
@@ -236,7 +235,7 @@ public class DefaultSensitiveStringCodec implements SensitiveDataCodec<String> {
          super(params);
          skf = SecretKeyFactory.getInstance(sceretKeyAlgorithm);
          if (sr == null) {
-            sr = SecureRandom.getInstance(randomScheme);
+            sr = new SecureRandom();
          }
       }
 


### PR DESCRIPTION
The one-way algorithm of the default codec use the hardcoded secure random algorithm SHA1PRNG that could not be available. Removing the hardcoded value would allow to use the default secure random algorithm.