### PR TITLE
ARTEMIS-3163 Experimental support for Netty IO_URING incubator

### DIFF
--- a/artemis-core-client-osgi/pom.xml
+++ b/artemis-core-client-osgi/pom.xml
@@ -70,6 +70,7 @@
                   <Import-Package>
                      org.glassfish.json*;resolution:=optional,
                      de.dentrassi.crypto.pem;resolution:=optional,
+                     io.netty.incubator.*;resolution:=optional,
                      io.netty.buffer;io.netty.*;version="[4.1,5)",
                      *
                   </Import-Package>

--- a/artemis-core-client/pom.xml
+++ b/artemis-core-client/pom.xml
@@ -90,6 +90,15 @@
          <artifactId>netty-transport-classes-kqueue</artifactId>
       </dependency>
       <dependency>
+         <groupId>io.netty.incubator</groupId>
+         <artifactId>netty-incubator-transport-native-io_uring</artifactId>
+         <classifier>${netty-transport-native-io_uring-classifier}</classifier>
+      </dependency>
+      <dependency>
+         <groupId>io.netty.incubator</groupId>
+         <artifactId>netty-incubator-transport-classes-io_uring</artifactId>
+      </dependency>
+      <dependency>
          <groupId>io.netty</groupId>
          <artifactId>netty-codec-http</artifactId>
       </dependency>

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/ActiveMQClientLogger.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/ActiveMQClientLogger.java
@@ -353,4 +353,11 @@ public interface ActiveMQClientLogger {
 
    @LogMessage(id = 214036, value = "Connection closure to {} has been detected: {} [code={}]", level = LogMessage.Level.INFO)
    void connectionClosureDetected(String remoteAddress, String message, ActiveMQExceptionType type);
+
+   @LogMessage(id = 214037, value = "Unable to check IoUring availability ", level = LogMessage.Level.WARN)
+   void unableToCheckIoUringAvailability(Throwable e);
+
+   @LogMessage(id = 214038, value = "IoUring is not available, please add to the classpath or configure useIoUring=false to remove this warning", level = LogMessage.Level.WARN)
+   void unableToCheckIoUringAvailabilitynoClass();
+
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/CheckDependencies.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/CheckDependencies.java
@@ -19,6 +19,7 @@ package org.apache.activemq.artemis.core.remoting.impl.netty;
 
 import io.netty.channel.epoll.Epoll;
 import io.netty.channel.kqueue.KQueue;
+import io.netty.incubator.channel.uring.IOUring;
 import org.apache.activemq.artemis.core.client.ActiveMQClientLogger;
 import org.apache.activemq.artemis.utils.Env;
 import org.slf4j.Logger;
@@ -41,6 +42,18 @@ public class CheckDependencies {
          return false;
       } catch (Throwable e)  {
          ActiveMQClientLogger.LOGGER.unableToCheckEpollAvailability(e);
+         return false;
+      }
+   }
+
+   public static final boolean isIoUringAvailable() {
+      try {
+         return Env.isLinuxOs() && IOUring.isAvailable();
+      } catch (NoClassDefFoundError noClassDefFoundError) {
+         ActiveMQClientLogger.LOGGER.unableToCheckIoUringAvailabilitynoClass();
+         return false;
+      } catch (Throwable e)  {
+         ActiveMQClientLogger.LOGGER.unableToCheckIoUringAvailability(e);
          return false;
       }
    }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/TransportConstants.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/TransportConstants.java
@@ -66,6 +66,8 @@ public class TransportConstants {
 
    public static final String USE_EPOLL_PROP_NAME = "useEpoll";
 
+   public static final String USE_IOURING_PROP_NAME = "useIoUring";
+
    public static final String USE_KQUEUE_PROP_NAME = "useKQueue";
 
    @Deprecated
@@ -212,6 +214,8 @@ public class TransportConstants {
    public static final boolean DEFAULT_USE_EPOLL = true;
 
    public static final boolean DEFAULT_USE_KQUEUE = true;
+
+   public static final boolean DEFAULT_USE_IOURING = false;
 
    public static final boolean DEFAULT_USE_INVM = false;
 
@@ -409,6 +413,7 @@ public class TransportConstants {
       allowableAcceptorKeys.add(TransportConstants.USE_NIO_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.USE_EPOLL_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.USE_KQUEUE_PROP_NAME);
+      allowableAcceptorKeys.add(TransportConstants.USE_IOURING_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.USE_INVM_PROP_NAME);
       //noinspection deprecation
       allowableAcceptorKeys.add(TransportConstants.PROTOCOL_PROP_NAME);
@@ -484,6 +489,7 @@ public class TransportConstants {
       allowableConnectorKeys.add(TransportConstants.USE_NIO_GLOBAL_WORKER_POOL_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.USE_EPOLL_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.USE_KQUEUE_PROP_NAME);
+      allowableConnectorKeys.add(TransportConstants.USE_IOURING_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.USE_GLOBAL_WORKER_POOL_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.HOST_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.PORT_PROP_NAME);

--- a/artemis-jms-client-osgi/pom.xml
+++ b/artemis-jms-client-osgi/pom.xml
@@ -78,6 +78,7 @@
                   <Import-Package>
                      org.glassfish.json*;resolution:=optional,
                      de.dentrassi.crypto.pem;resolution:=optional,
+                     io.netty.incubator.*;resolution:=optional,
                      io.netty.buffer;io.netty.*;version="[4.1,5)",
                      *
                   </Import-Package>

--- a/artemis-pom/pom.xml
+++ b/artemis-pom/pom.xml
@@ -441,6 +441,19 @@
             <!-- License: Apache 2.0 -->
          </dependency>
          <dependency>
+            <groupId>io.netty.incubator</groupId>
+            <artifactId>netty-incubator-transport-classes-io_uring</artifactId>
+            <version>${netty.incubator.io_uring.version}</version>
+            <!-- License: Apache 2.0 -->
+         </dependency>
+         <dependency>
+            <groupId>io.netty.incubator</groupId>
+            <artifactId>netty-incubator-transport-native-io_uring</artifactId>
+            <version>${netty.incubator.io_uring.version}</version>
+            <classifier>${netty-transport-native-io_uring-classifier}</classifier>
+            <!-- License: Apache 2.0 -->
+         </dependency>
+         <dependency>
             <groupId>org.apache.qpid</groupId>
             <artifactId>proton-j</artifactId>
             <version>${proton.version}</version>

--- a/artemis-server-osgi/pom.xml
+++ b/artemis-server-osgi/pom.xml
@@ -128,6 +128,7 @@
                      org.glassfish.json*;resolution:=optional,
                      org.postgresql*;resolution:=optional,
                      de.dentrassi.crypto.pem;resolution:=optional,
+                     io.netty.incubator.*;resolution:=optional,
                      io.netty.buffer;io.netty.*;version="[4.1,5)",
                      java.net.http*;resolution:=optional,
                      com.sun.net.httpserver*;resolution:=optional,

--- a/docs/user-manual/configuring-transports.adoc
+++ b/docs/user-manual/configuring-transports.adoc
@@ -243,14 +243,14 @@ These Native transports add features specific to a particular platform, generate
 
 Both Clients and Server can benefit from this.
 
-Current Supported Platforms.
+Currently supported platforms:
 
 * Linux running 64bit JVM
 * MacOS running 64bit JVM
 
-Apache ActiveMQ Artemis will by default enable the corresponding native transport if a supported platform is detected.
+Apache ActiveMQ Artemis will enable the corresponding native transport by default if a supported platform is detected.
 
-If running on an unsupported platform or any issues loading native libs, Apache ActiveMQ Artemis will fallback onto Java NIO.
+If running on an unsupported platform, or if any issues occur while loading the native libs, Apache ActiveMQ Artemis will fallback onto Java NIO.
 
 ==== Linux Native Transport
 
@@ -262,6 +262,23 @@ useEpoll::
 enables the use of epoll if a supported linux platform is running a 64bit JVM is detected.
 Setting this to `false` will force the use of Java NIO instead of epoll.
 Default is `true`
+
+
+Additionally, Apache ActiveMQ Artemis offers `experimental` support for using IO_URING, @see https://en.wikipedia.org/wiki/Io_uring.
+
+The following properties are specific to this native transport:
+
+useIoUring::
+enables the use of IO_URING if a supported linux platform running a 64bit JVM is detected.
+Setting this to `false` will attempt the use of `epoll`, then finally falling back to using Java NIO.
+Default is `false`
+
+[WARNING]
+====
+[#io_uring-warning]
+IO_URING support is `experimental` at this point. Using it _could_ introduce unwanted side effects or unpredicted behavior.
+It's currently not recommended for production or any otherwise critical use.
+====
 
 ==== MacOS Native Transport
 

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,7 @@
       <mockito.version>5.14.1</mockito.version>
       <jctools.version>4.0.5</jctools.version>
       <netty.version>4.1.114.Final</netty.version>
+      <netty.incubator.io_uring.version>0.0.25.Final</netty.incubator.io_uring.version>
       <hdrhistogram.version>2.2.2</hdrhistogram.version>
       <curator.version>5.7.0</curator.version>
       <zookeeper.version>3.9.2</zookeeper.version>
@@ -261,6 +262,7 @@
 
       <netty-transport-native-epoll-classifier>linux-x86_64</netty-transport-native-epoll-classifier>
       <netty-transport-native-kqueue-classifier>osx-x86_64</netty-transport-native-kqueue-classifier>
+      <netty-transport-native-io_uring-classifier>linux-x86_64</netty-transport-native-io_uring-classifier>
 
       <fast-tests>false</fast-tests>
 


### PR DESCRIPTION
I got interested by #3479 and decided to test those changes out against a "fresh" build of the broker. I found it quite impressive and decided to implement what was discussed on @franz1981 original pr in hopes it would interest someone else. I take no credit for this PR, as it contains almost exclusively the original changes and what was discussed in #3479.
 
One thing I did actually change was to default the amount of "remotingThreads" to 1 instead of "3 * CPUCount" (for IO_URING) based on suggestions in the original PR as well as here: [netty-incubator-transport-io_uring/issues/106#issuecomment-876173958]( https://github.com/netty/netty-incubator-transport-io_uring/issues/106#issuecomment-876173958)

According to my own testing this is what the default value should be, with only a few "extremes"  benefiting from a few more.

I have seen some impressive results from using IO_URING as the transport that I should be able to share after a few more rounds of testing.