### PR TITLE
ARTEMIS-5131 Add A Copy message button to console

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/logs/AuditLogger.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/logs/AuditLogger.java
@@ -2801,4 +2801,11 @@ public interface AuditLogger {
    @LogMessage(id = 601789, value = "User {} is getting the number of messages received on target resource: {}", level = LogMessage.Level.INFO)
    void getMessagesReceived(String user, Object source);
 
+
+   static void copyMessage(Object source, Object... args) {
+      BASE_LOGGER.copyMessage(getCaller(), source, parametersList(args));
+   }
+
+   @LogMessage(id = 601790, value = "User {} is copying a message to another queue on target resource: {} {}", level = LogMessage.Level.INFO)
+   void copyMessage(String user, Object source, String args);
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/QueueControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/QueueControl.java
@@ -536,6 +536,10 @@ public interface QueueControl {
                     @Parameter(name = "rejectDuplicates", desc = "Reject messages identified as duplicate by the duplicate message") boolean rejectDuplicates,
                     @Parameter(name = "messageCount", desc = "Number of messages to move.") int messageCount) throws Exception;
 
+   @Operation(desc = "Send a copy of the message with given messageID to another queue)", impact = MBeanOperationInfo.ACTION)
+   boolean copyMessage(@Parameter(name = "messageID", desc = "A message ID") long messageID,
+                       @Parameter(name = "targetQueue", desc = "The name of the queue to copy the messages to") String  targetQueue) throws Exception;
+
    /**
     * Sends the message corresponding to the specified message ID to this queue's dead letter address.
     *

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/Queue.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/Queue.java
@@ -380,6 +380,9 @@ public interface Queue extends Bindable,CriticalComponent {
                       int messageCount,
                       Binding binding) throws Exception;
 
+
+   boolean copyReference(long messageID, SimpleString queue, Binding binding) throws Exception;
+
    int retryMessages(Filter filter) throws Exception;
 
    default int retryMessages(Filter filter, Integer expectedHits) throws Exception {

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/RoutingContextTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/RoutingContextTest.java
@@ -729,6 +729,11 @@ public class RoutingContextTest {
       }
 
       @Override
+      public boolean copyReference(long messageID, SimpleString address, Binding binding) throws Exception {
+         return false;
+      }
+
+      @Override
       public int retryMessages(Filter filter) throws Exception {
          return 0;
       }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/ScheduledDeliveryHandlerTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/ScheduledDeliveryHandlerTest.java
@@ -1487,6 +1487,11 @@ public class ScheduledDeliveryHandlerTest {
       }
 
       @Override
+      public boolean copyReference(long messageID, SimpleString address, Binding binding) throws Exception {
+         return false;
+      }
+
+      @Override
       public void addRedistributor(long delay) {
 
       }

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/fakes/FakeQueue.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/fakes/FakeQueue.java
@@ -949,6 +949,11 @@ public class FakeQueue extends CriticalComponentImpl implements Queue {
    }
 
    @Override
+   public boolean copyReference(long messageID, SimpleString address, Binding binding) throws Exception {
+      return false;
+   }
+
+   @Override
    public void forceDelivery() {
       // no-op
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlUsingCoreTest.java
@@ -507,6 +507,11 @@ public class QueueControlUsingCoreTest extends QueueControlTest {
          }
 
          @Override
+         public boolean copyMessage(long messageID, String targetQueue) throws Exception {
+            return (Boolean) proxy.invokeOperation("copyMessage", messageID, targetQueue);
+         }
+
+         @Override
          public int moveMessages(final String filter,
                                  final String otherQueueName,
                                  final boolean rejectDuplicates) throws Exception {


### PR DESCRIPTION
This exposes a copyMessage method that simply copies a message to a different queue so the new console can add a copy button