### PR TITLE
ARTEMIS-5150: ActiveMQServerControlImpl.getHAPolicy() gets NPE

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -75,6 +75,7 @@ import org.apache.activemq.artemis.core.config.BridgeConfiguration;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.ConnectorServiceConfiguration;
 import org.apache.activemq.artemis.core.config.DivertConfiguration;
+import org.apache.activemq.artemis.core.config.HAPolicyConfiguration;
 import org.apache.activemq.artemis.core.config.TransformerConfiguration;
 import org.apache.activemq.artemis.core.filter.Filter;
 import org.apache.activemq.artemis.core.management.impl.view.AddressView;
@@ -834,7 +835,8 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
    @Override
    public String getHAPolicy() {
-      return configuration.getHAPolicyConfiguration().getType().getName();
+      HAPolicyConfiguration haConfig = configuration.getHAPolicyConfiguration();
+      return haConfig == null ? null : haConfig.getType().getName();
    }
 
    @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
@@ -240,6 +240,8 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       assertEquals(conf.getJournalCompactPercentage(), serverControl.getJournalCompactPercentage());
       assertEquals(conf.isPersistenceEnabled(), serverControl.isPersistenceEnabled());
       assertEquals(conf.getJournalPoolFiles(), serverControl.getJournalPoolFiles());
+      assertEquals(null, conf.getHAPolicyConfiguration());
+      assertEquals(conf.getHAPolicyConfiguration(), serverControl.getHAPolicy());
       assertTrue(serverControl.isActive());
    }
 


### PR DESCRIPTION
When you start the broker without configuring HAPolicy, if clients call this management api it'll get NPE because it doesn't check if the HAPolicyConfiguration is null.