### PR TITLE
ARTEMIS-5168 Improve remoting to brokers from Artemis shell

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/Artemis.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/Artemis.java
@@ -275,7 +275,7 @@ public class Artemis implements Runnable {
       commandLine.addSubcommand(new QueueGroup(commandLine));
       commandLine.addSubcommand(new AddressGroup(commandLine));
 
-      if (shellEnabled) {
+      if (Shell.inShell()) {
          commandLine.addSubcommand(new Connect());
          commandLine.addSubcommand(new Disconnect());
       }

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Connect.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Connect.java
@@ -17,6 +17,7 @@
 
 package org.apache.activemq.artemis.cli.commands;
 
+import org.apache.activemq.artemis.cli.Shell;
 import org.apache.activemq.artemis.cli.commands.messages.ConnectionAbstract;
 import picocli.CommandLine;
 
@@ -30,6 +31,11 @@ public class Connect extends ConnectionAbstract {
          CONNECTION_INFORMATION.remove();
          createConnectionFactory();
          context.out.println("Connection Successful!");
+
+         if (Shell.inShell()) {
+            Shell.setConnected(true);
+         }
+
       } catch (Exception e) {
          context.out.println("Connection Failure!");
          e.printStackTrace();

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Disconnect.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Disconnect.java
@@ -17,6 +17,7 @@
 
 package org.apache.activemq.artemis.cli.commands;
 
+import org.apache.activemq.artemis.cli.Shell;
 import org.apache.activemq.artemis.cli.commands.messages.ConnectionAbstract;
 import picocli.CommandLine;
 
@@ -28,6 +29,12 @@ public class Disconnect extends ConnectionAbstract {
       super.execute(context);
       CONNECTION_INFORMATION.remove();
       context.out.println("Connection information cleared!");
+
+      if (Shell.inShell()) {
+         Shell.setDefaultPrompt();
+         Shell.setConnected(false);
+      }
+
       return null;
    }
 }

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/ConnectionConfigurationAbtract.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/ConnectionConfigurationAbtract.java
@@ -137,6 +137,13 @@ public class ConnectionConfigurationAbtract extends InputAbstract {
          this.brokerURL = brokerURL;
          this.user = user;
          this.password = password;
+
+         if (user != null) {
+            Shell.setPrompt(user + "@" + brokerURL);
+         } else {
+            Shell.setPrompt(brokerURL);
+         }
+
       }
    }
 


### PR DESCRIPTION
This PR adds back connect + disconnect to shell
Changes prompt to reflect if connected to a broker (and which one)
It also captures "Ctrl + D" to return to shell if issued when connected to a broker (instead of exiting). If not connected it exits as usual.