### PR TITLE
NO-JIRA: have dependabot ignore jgroups until JGRP-2794 is resolved

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,6 +65,11 @@ updates:
         versions: '>= 3'
       - dependency-name: 'jakarta.resource:jakarta.resource-api'
         versions: '>= 2'        
+
+      # Ignore until JGRP-2794 is resolved
+      - dependency-name: 'org.jgroups:jgroups'
+        versions: '>= 5'
+
     open-pull-requests-limit: 10
     commit-message:
       # This prefix is added to remind committers to create a Jira for this dependency upgrade and update the branch with the actual Jira ID


### PR DESCRIPTION
I have seen some compatibility issues with rolling upgrades between the past few broker releases because of JGRP-2794.