### PR TITLE
ARTEMIS-5202 require Java 17+ (i.e drop support for Java 11)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,13 +20,9 @@ updates:
     schedule:
       interval: "daily"
     ignore:
-      # Ignore all these until we move to JDK >= 17
+      # Ignore all these until we move to JDK >= 21
       - dependency-name: 'org.apache.derby:*'
         versions: '>= 10.16'
-      - dependency-name: 'com.google.errorprone:error_prone_core'
-        versions: '>= 2.32'
-      - dependency-name: 'org.apache.felix:maven-bundle-plugin'
-        versions: '>= 6'
 
       # Ignore all these until we move to Jakarta
       - dependency-name: 'org.springframework:*'
@@ -66,7 +62,7 @@ updates:
       - dependency-name: 'com.sun.xml.bind:*'
         versions: '>= 3'
       - dependency-name: 'jakarta.resource:jakarta.resource-api'
-        versions: '>= 2'        
+        versions: '>= 2'
 
       # Ignore until JGRP-2794 is resolved
       - dependency-name: 'org.jgroups:jgroups'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 11, 17, 21, 22 ]
+        java: [ 17, 21, 22 ]
 
     steps:
       - uses: actions/checkout@v4
@@ -78,7 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 11, 17, 21, 22 ]
+        java: [ 17, 21, 22 ]
 
     steps:
       - uses: actions/checkout@v4
@@ -108,14 +108,14 @@ jobs:
           ref: ${{ env.EXAMPLES_BRANCH }}
           path: activemq-artemis-examples
 
-      - name: Build Main (JDK11 / -Prelease)
-        if: matrix.java == '11'
+      - name: Build Main (JDK17 / -Prelease)
+        if: matrix.java == '17'
         run: |
           cd activemq-artemis
           mvn -s .github/maven-settings.xml -DskipTests -Derrorprone -Pdev -Prelease -Dgpg.skip install
 
-      - name: Build Main (JDK >11)
-        if: matrix.java != '11'
+      - name: Build Main (JDK >17)
+        if: matrix.java != '17'
         run: |
           cd activemq-artemis
           mvn -s .github/maven-settings.xml -DskipTests -Derrorprone -Pdev -Pjmh install
@@ -128,32 +128,32 @@ jobs:
           cd ../activemq-artemis-examples
           ./scripts/update-examples-version.sh ${CURRENT_ARTEMIS_BUILD_VERSION}
 
-      - name: Build Examples (JDK11 / -Prelease)
-        if: matrix.java == '11'
+      - name: Build Examples (JDK17 / -Prelease)
+        if: matrix.java == '17'
         run: |
           cd activemq-artemis-examples
           mvn -s ../activemq-artemis/.github/maven-settings.xml install -Prelease
 
-      - name: Build Examples (JDK >11 / -Pexamples,noRun)
-        if: matrix.java != '11'
+      - name: Build Examples (JDK >17 / -Pexamples,noRun)
+        if: matrix.java != '17'
         run: |
           cd activemq-artemis-examples
           mvn -s ../activemq-artemis/.github/maven-settings.xml install -Pexamples,noRun
 
-      - name: Javadoc Check (JDK11 / -Prelease)
-        if: matrix.java == '11'
+      - name: Javadoc Check (JDK17 / -Prelease)
+        if: matrix.java == '17'
         run: |
           cd activemq-artemis
           mvn -s .github/maven-settings.xml javadoc:javadoc -Prelease -DskipWebsiteDocGeneration=true -DskipWebsiteJavadocGeneration=true
 
-      - name: Javadoc Check (JDK >11)
-        if: matrix.java != '11'
+      - name: Javadoc Check (JDK >17)
+        if: matrix.java != '17'
         run: |
           cd activemq-artemis
           mvn -s .github/maven-settings.xml javadoc:javadoc
 
-      - name: Website Content Check (JDK11 only / -Prelease)
-        if: matrix.java == '11'
+      - name: Website Content Check (JDK17 only / -Prelease)
+        if: matrix.java == '17'
         run: |
           cd activemq-artemis
           mvn -s .github/maven-settings.xml clean install -DskipTests -Prelease -am -pl "artemis-website"

--- a/artemis-cdi-client/pom.xml
+++ b/artemis-cdi-client/pom.xml
@@ -126,6 +126,21 @@
          <scope>test</scope>
       </dependency>
    </dependencies>
+
+   <build>
+      <plugins>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <forkCount>1</forkCount>
+               <reuseForks>false</reuseForks>
+               <argLine>--add-opens java.base/java.lang=ALL-UNNAMED ${activemq-surefire-argline}</argLine>
+            </configuration>
+         </plugin>
+      </plugins>
+   </build>
+
    <profiles>
       <profile>
          <id>Weld</id>
@@ -167,24 +182,6 @@
                <artifactId>jakarta.annotation-api</artifactId>
             </dependency>
          </dependencies>
-      </profile>
-      <profile>
-         <!-- TODO: Changes so these tests can work? -->
-         <id>jdk16on</id>
-         <activation>
-            <jdk>[16,)</jdk>
-         </activation>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-surefire-plugin</artifactId>
-                  <configuration>
-                     <skip>true</skip>
-                  </configuration>
-               </plugin>
-            </plugins>
-         </build>
       </profile>
    </profiles>
 </project>

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/SimpleString.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/SimpleString.java
@@ -195,6 +195,7 @@ public final class SimpleString implements CharSequence, Serializable, Comparabl
       data[1] = high;
    }
 
+   @Override
    public boolean isEmpty() {
       return data.length == 0;
    }

--- a/artemis-features/pom.xml
+++ b/artemis-features/pom.xml
@@ -123,7 +123,7 @@
                         <descriptor>file:${project.build.directory}/classes/features.xml</descriptor>
                      </descriptors>
                      <distribution>org.apache.karaf.features:framework</distribution>
-                     <javase>11</javase>
+                     <javase>${maven.compiler.target}</javase>
                      <framework>
                         <feature>framework</feature>
                      </framework>

--- a/artemis-log-annotation-processor/src/main/java/org/apache/activemq/artemis/logs/annotation/processor/LogAnnotationProcessor.java
+++ b/artemis-log-annotation-processor/src/main/java/org/apache/activemq/artemis/logs/annotation/processor/LogAnnotationProcessor.java
@@ -47,7 +47,7 @@ import org.apache.activemq.artemis.logs.annotation.LogMessage;
 import org.apache.activemq.artemis.logs.annotation.Message;
 
 @SupportedAnnotationTypes({"org.apache.activemq.artemis.logs.annotation.LogBundle"})
-@SupportedSourceVersion(SourceVersion.RELEASE_11)
+@SupportedSourceVersion(SourceVersion.RELEASE_17)
 public class LogAnnotationProcessor extends AbstractProcessor {
    private static final boolean DEBUG;
 

--- a/artemis-website/pom.xml
+++ b/artemis-website/pom.xml
@@ -91,7 +91,6 @@
                         </goals>
                         <configuration>
                            <doctitle>ActiveMQ Artemis ${project.version} API</doctitle>
-                           <source>11</source>
                            <minmemory>128m</minmemory>
                            <maxmemory>512m</maxmemory>
                            <noindex>true</noindex>

--- a/docs/user-manual/versions.adoc
+++ b/docs/user-manual/versions.adoc
@@ -12,6 +12,24 @@ NOTE: If the upgrade spans multiple versions then the steps from *each* version 
 
 NOTE: Follow the general upgrade procedure outlined in the xref:upgrading.adoc#upgrading-the-broker[Upgrading the Broker]  chapter in addition to any version-specific upgrade instructions outlined here.
 
+== 2.39.0
+
+https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315920&version=12355167[Full release notes]
+
+=== Highlights
+
+* *Java 17 is now required.*
+
+=== Upgrading from 2.38.0
+
+* Due to https://issues.apache.org/jira/browse/ARTEMIS-5202[ARTEMIS-5202] *support for Java 11 has been dropped*.
++
+The main reason for this change is that the version of Jetty we were embedding in previous versions (i.e. 10) https://github.com/jetty/jetty.project/issues/10485[will officially reach its end-of-life on January 1, 2025] and will therefore no longer be receiving _any_ fixes - including security fixes.
+Security is critical for us and most of our users so we therefore need to upgrade to Jetty 12 - the only version of Jetty now supported.
+Jetty 12 requires Java 17 so we must also move to Java 17 and drop support for Java 11.
++
+Please note that after upgrading the broker to Java 17 it will be backwards compatible with all previous clients.
+
 == 2.38.0
 
 https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315920&version=12355013[Full release notes]

--- a/pom.xml
+++ b/pom.xml
@@ -78,9 +78,9 @@
    <url>https://activemq.apache.org/components/artemis/</url>
 
    <properties>
-      <maven.compiler.source>11</maven.compiler.source>
-      <maven.compiler.target>11</maven.compiler.target>
-      <maven.compiler.release>11</maven.compiler.release>
+      <maven.compiler.source>17</maven.compiler.source>
+      <maven.compiler.target>17</maven.compiler.target>
+      <maven.compiler.release>17</maven.compiler.release>
 
       <retryTests>false</retryTests>
       <logging.config>log4j2-tests-config.properties</logging.config>
@@ -304,40 +304,8 @@
 
    <profiles>
       <profile>
-         <id>jdk11to15-errorprone</id>
+         <id>errorprone</id>
          <activation>
-            <jdk>[11,16)</jdk>
-            <property>
-               <name>errorprone</name>
-            </property>
-         </activation>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-compiler-plugin</artifactId>
-                  <configuration>
-                     <compilerArgs>
-                        <arg>-Xdiags:verbose</arg>
-                        <arg>-XDcompilePolicy=simple</arg>
-                        <arg>-Xplugin:ErrorProne -Xep:ThreadLocalUsage:ERROR -Xep:MissingOverride:ERROR -Xep:NonAtomicVolatileUpdate:ERROR -Xep:SynchronizeOnNonFinalField:ERROR -Xep:StaticQualifiedUsingExpression:ERROR -Xep:WaitNotInLoop:ERROR -Xep:BanJNDI:OFF -XepExcludedPaths:.*/generated-sources/.*</arg>
-                     </compilerArgs>
-                     <annotationProcessorPaths combine.children="append">
-                        <path>
-                           <groupId>com.google.errorprone</groupId>
-                           <artifactId>error_prone_core</artifactId>
-                           <version>${errorprone.version}</version>
-                        </path>
-                     </annotationProcessorPaths>
-                  </configuration>
-               </plugin>
-            </plugins>
-         </build>
-      </profile>
-      <profile>
-         <id>jdk16on-errorprone</id>
-         <activation>
-            <jdk>[16,)</jdk>
             <property>
                <name>errorprone</name>
             </property>
@@ -454,8 +422,8 @@
                         <configuration>
                            <rules>
                               <requireJavaVersion>
-                                 <version>[11, 12)</version>
-                                 <message>JDK 11 is required when building the release</message>
+                                 <version>[17, 18)</version>
+                                 <message>JDK 17 is required when building the release</message>
                               </requireJavaVersion>
                            </rules>
                         </configuration>
@@ -1046,8 +1014,8 @@
                   <configuration>
                      <rules>
                         <requireJavaVersion>
-                           <version>[11,)</version>
-                           <message>You must use JDK 11+ when building</message>
+                           <version>[17,)</version>
+                           <message>You must use JDK 17+ when building</message>
                         </requireJavaVersion>
                      </rules>
                   </configuration>

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSClientTestSupport.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/JMSClientTestSupport.java
@@ -177,7 +177,7 @@ public abstract class JMSClientTestSupport extends AmqpClientTestSupport {
          String uri = null;
 
          if (isUseSSL()) {
-            uri = "tcp://127.0.0.1:" + port;
+            throw new UnsupportedOperationException("SSL not supported here");
          } else {
             uri = "tcp://127.0.0.1:" + port;
          }
@@ -226,7 +226,7 @@ public abstract class JMSClientTestSupport extends AmqpClientTestSupport {
          String uri = null;
 
          if (isUseSSL()) {
-            uri = "tcp://127.0.0.1:" + port;
+            throw new UnsupportedOperationException("SSL not supported here");
          } else {
             uri = "tcp://127.0.0.1:" + port;
          }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/RedeliveryConsumerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/RedeliveryConsumerTest.java
@@ -211,7 +211,7 @@ public class RedeliveryConsumerTest extends ActiveMQTestBase {
       consumer = session.createConsumer(ADDRESS);
       msg = consumer.receive(1000);
       assertNotNull(msg);
-      assertEquals(strictUpdate ? 2 : 2, msg.getDeliveryCount());
+      assertEquals(2, msg.getDeliveryCount());
       session.close();
    }
 


### PR DESCRIPTION
This commit drops support for Java 11. All code changes were related to output from ErrorProne that prevented the build from completing.