### PR TITLE
ARTEMIS-5226 Jetty choking on bad URI

### DIFF
--- a/artemis-web/src/main/java/org/apache/activemq/artemis/component/WebServerComponent.java
+++ b/artemis-web/src/main/java/org/apache/activemq/artemis/component/WebServerComponent.java
@@ -201,24 +201,22 @@ public class WebServerComponent implements ExternalComponent, WebServerComponent
       server.setConnectors(connectors);
 
       ResourceHandler homeResourceHandler = new ResourceHandler();
-      homeResourceHandler.setBaseResourceAsString(homeWarDir.toString());
       homeResourceHandler.setDirAllowed(false);
       homeResourceHandler.setWelcomeFiles("index.html");
 
       ContextHandler homeContext = new ContextHandler();
       homeContext.setContextPath("/");
-      homeContext.setBaseResourceAsString(homeWarDir.toString());
+      homeContext.setBaseResourceAsPath(homeWarDir);
       homeContext.setHandler(homeResourceHandler);
       homeContext.setVirtualHosts(Arrays.asList(virtualHosts));
 
       ResourceHandler instanceResourceHandler = new ResourceHandler();
-      instanceResourceHandler.setBaseResourceAsString(instanceWarDir.toString());
       instanceResourceHandler.setDirAllowed(false);
       instanceResourceHandler.setWelcomeFiles("index.html");
 
       ContextHandler instanceContext = new ContextHandler();
       instanceContext.setContextPath("/");
-      instanceContext.setBaseResourceAsString(instanceWarDir.toString());
+      instanceContext.setBaseResourceAsPath(instanceWarDir);
       instanceContext.setHandler(instanceResourceHandler);
       instanceContext.setVirtualHosts(Arrays.asList(virtualHosts));
 


### PR DESCRIPTION
When the broker is started on Windows Jetty logs an exception at DEBUG level regarding a malformed URL which is set via the setBaseResourceAsString method on either
org.eclipse.jetty.server.handler.ResourceHandler or org.eclipse.jetty.server.handler.ContextHandler.

This commit fixes that by using setBaseResourceAsPath instead. It also removes 2 instances of setBaseResourceAsString on the ResourceHandler. These are not necessary because the value set on the ContextHandler will suffice.