### PR TITLE
ARTEMIS-5234 make style for parentheses consistent

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/SimpleString.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/SimpleString.java
@@ -566,8 +566,8 @@ public final class SimpleString implements CharSequence, Serializable, Comparabl
       final byte highd = (byte) (d >> 8 & 0xFF); // high byte
 
       for (int i = 0; i + 1 < data.length; i += 2) {
-         if ( data[i] == lowc && data[i + 1] == highc ||
-            data[i] == lowd && data[i + 1] == highd ) {
+         if (data[i] == lowc && data[i + 1] == highc ||
+            data[i] == lowd && data[i + 1] == highd) {
             return true;
          }
       }

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/core/buffers/impl/ChannelBufferWrapper.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/core/buffers/impl/ChannelBufferWrapper.java
@@ -392,7 +392,7 @@ public class ChannelBufferWrapper implements ActiveMQBuffer {
 
    @Override
    public ActiveMQBuffer readSlice(final int length) {
-      if ( isPooled ) {
+      if (isPooled) {
          ByteBuf fromBuffer = buffer.readSlice(length);
          ByteBuf newNettyBuffer = Unpooled.buffer(fromBuffer.capacity());
          int read = fromBuffer.readerIndex();
@@ -530,7 +530,7 @@ public class ChannelBufferWrapper implements ActiveMQBuffer {
 
    @Override
    public void release() {
-      if ( this.isPooled ) {
+      if (this.isPooled) {
          buffer.release();
       }
    }

--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/TypedPropertiesConcurrencyTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/TypedPropertiesConcurrencyTest.java
@@ -57,7 +57,7 @@ public class TypedPropertiesConcurrencyTest {
          });
       }
       for (int i = 0; i < 10; i++) {
-         executorService.submit( () -> {
+         executorService.submit(() -> {
             try {
                countDownLatch.await();
                for (int k = 0; k < 1000; k++) {
@@ -107,7 +107,7 @@ public class TypedPropertiesConcurrencyTest {
          });
       }
       for (int i = 0; i < 10; i++) {
-         executorService.submit( () -> {
+         executorService.submit(() -> {
             try {
                countDownLatch.await();
                for (int k = 0; k < 1000; k++) {

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/PacketImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/PacketImpl.java
@@ -399,8 +399,8 @@ public class PacketImpl implements Packet {
       buffer.readerIndex(PACKET_HEADERS_SIZE);
 
       newNettyBuffer.writeBytes(buffer, buffer.readableBytes() - skipBytes);
-      buffer.setIndex( read, writ );
-      newNettyBuffer.setIndex( 0, writ - PACKET_HEADERS_SIZE - skipBytes);
+      buffer.setIndex(read, writ);
+      newNettyBuffer.setIndex(0, writ - PACKET_HEADERS_SIZE - skipBytes);
 
       return newNettyBuffer;
    }

--- a/artemis-dto/src/main/java/org/apache/activemq/artemis/dto/AuthorisationDTO.java
+++ b/artemis-dto/src/main/java/org/apache/activemq/artemis/dto/AuthorisationDTO.java
@@ -26,11 +26,11 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class AuthorisationDTO {
 
-   @XmlElementRef( required = false)
+   @XmlElementRef(required = false)
    @Deprecated(forRemoval = true)
    WhiteListDTO whitelist;
 
-   @XmlElementRef( required = false )
+   @XmlElementRef(required = false)
    AllowListDTO allowList;
 
    @XmlElementRef

--- a/artemis-dto/src/test/java/org/apache/activemq/artemis/dto/test/BindingDTOTest.java
+++ b/artemis-dto/src/test/java/org/apache/activemq/artemis/dto/test/BindingDTOTest.java
@@ -44,10 +44,10 @@ public class BindingDTOTest {
       binding.setExcludedTLSProtocols("TLSv1,TLSv1.1");
       assertArrayEquals(new String[] {"TLSv1", "TLSv1.1"}, binding.getExcludedTLSProtocols());
 
-      binding.setIncludedCipherSuites( "^SSL_.*$");
+      binding.setIncludedCipherSuites("^SSL_.*$");
       assertArrayEquals(new String[] {"^SSL_.*$"}, binding.getIncludedCipherSuites());
 
-      binding.setExcludedCipherSuites( "^.*_(MD5|SHA|SHA1)$,^TLS_RSA_.*$,^.*_NULL_.*$,^.*_anon_.*$");
+      binding.setExcludedCipherSuites("^.*_(MD5|SHA|SHA1)$,^TLS_RSA_.*$,^.*_NULL_.*$,^.*_anon_.*$");
       assertArrayEquals(new String[] {"^.*_(MD5|SHA|SHA1)$", "^TLS_RSA_.*$", "^.*_NULL_.*$", "^.*_anon_.*$"}, binding.getExcludedCipherSuites());
    }
 

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnectionFactory.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnectionFactory.java
@@ -156,7 +156,7 @@ public class ActiveMQConnectionFactory extends JNDIStorable implements Connectio
       if (protocolManagerFactoryStr != null && !protocolManagerFactoryStr.trim().isEmpty() &&
          !protocolManagerFactoryStr.equals("undefined")) {
          AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
-            ClientProtocolManagerFactory protocolManagerFactory = (ClientProtocolManagerFactory) ClassloadingUtil.newInstanceFromClassLoader(ActiveMQConnectionFactory.class, protocolManagerFactoryStr, ClientProtocolManagerFactory.class );
+            ClientProtocolManagerFactory protocolManagerFactory = (ClientProtocolManagerFactory) ClassloadingUtil.newInstanceFromClassLoader(ActiveMQConnectionFactory.class, protocolManagerFactoryStr, ClientProtocolManagerFactory.class);
             serverLocator.setProtocolManagerFactory(protocolManagerFactory);
             return null;
          });

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalImpl.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalImpl.java
@@ -1310,7 +1310,7 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
                                                final byte recordType,
                                                final Persister persister,
                                                final Object record) throws Exception {
-      if ( logger.isTraceEnabled() ) {
+      if (logger.isTraceEnabled()) {
          logger.trace("scheduling appendUpdateRecordTransactional::txID={}, id={}, userRecordType={}, record = {}",
                       txID, id, recordType, record);
       }
@@ -1326,18 +1326,18 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
          try {
             tx.checkErrorCondition();
 
-            JournalInternalRecord updateRecordTX = new JournalAddRecordTX( false, txID, id, recordType, persister, record );
-            JournalFile usedFile = appendRecord( updateRecordTX, false, false, tx, null );
+            JournalInternalRecord updateRecordTX = new JournalAddRecordTX(false, txID, id, recordType, persister, record);
+            JournalFile usedFile = appendRecord(updateRecordTX, false, false, tx, null);
 
             if (logger.isTraceEnabled()) {
                logger.trace("appendUpdateRecordTransactional::txID={}, id={}, userRecordType={}, record = {}, usedFile = {}",
-                            txID, id, recordType, record, usedFile );
+                            txID, id, recordType, record, usedFile);
             }
 
-            tx.addPositive( usedFile, id, updateRecordTX.getEncodeSize(), false);
-         } catch (Throwable e ) {
-            logger.error("Exception during appendUpdateRecordTransactional:", e );
-            setErrorCondition(null, tx, e );
+            tx.addPositive(usedFile, id, updateRecordTX.getEncodeSize(), false);
+         } catch (Throwable e) {
+            logger.error("Exception during appendUpdateRecordTransactional:", e);
+            setErrorCondition(null, tx, e);
          } finally {
             journalLock.readLock().unlock();
          }
@@ -2729,7 +2729,7 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
          try {
             executor.execute(latch::countDown);
             latch.await(10, TimeUnit.SECONDS);
-         } catch (RejectedExecutionException ignored ) {
+         } catch (RejectedExecutionException ignored) {
             // this is fine
          }
       }

--- a/artemis-log-annotation-processor/src/main/java/org/apache/activemq/artemis/logs/annotation/processor/LogAnnotationProcessor.java
+++ b/artemis-log-annotation-processor/src/main/java/org/apache/activemq/artemis/logs/annotation/processor/LogAnnotationProcessor.java
@@ -133,7 +133,7 @@ public class LogAnnotationProcessor extends AbstractProcessor {
                writerOutput.println("   }");
                writerOutput.println();
 
-               writerOutput.println("   public " + simpleClassName + "(Logger logger ) {");
+               writerOutput.println("   public " + simpleClassName + "(Logger logger) {");
                writerOutput.println("      this.logger = logger;");
                writerOutput.println("   }");
                writerOutput.println();
@@ -533,7 +533,7 @@ public class LogAnnotationProcessor extends AbstractProcessor {
          }
 
          Integer nextId = Collections.max(activeIDs) + 1;
-         while (isRetiredID(bundleAnnotation, nextId) ) {
+         while (isRetiredID(bundleAnnotation, nextId)) {
             nextId++;
          }
 

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationAddressPolicyManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationAddressPolicyManager.java
@@ -458,7 +458,7 @@ public final class AMQPFederationAddressPolicyManager extends AMQPFederationPoli
 
                @Override
                public void onComplete(AMQPFederationConsumer context) {
-                  logger.trace("Restarted federation consumer after new demand added." );
+                  logger.trace("Restarted federation consumer after new demand added.");
                }
 
                @Override

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationCommandProcessor.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationCommandProcessor.java
@@ -148,7 +148,7 @@ public class AMQPFederationCommandProcessor extends ProtonAbstractReceiver {
       } catch (Throwable e) {
          logger.warn(e.getMessage(), e);
          federation.signalError(
-            new ActiveMQAMQPInternalErrorException("Error while processing incoming control message: " + e.getMessage() ));
+            new ActiveMQAMQPInternalErrorException("Error while processing incoming control message: " + e.getMessage()));
       }
    }
 

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationEventDispatcher.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationEventDispatcher.java
@@ -209,7 +209,7 @@ public class AMQPFederationEventDispatcher implements SenderController, ActiveMQ
             } catch (Exception e) {
                logger.warn("error on send of address added event: {}", e.getMessage());
                federation.signalError(
-                  new ActiveMQAMQPInternalErrorException("Error while processing address added: " + e.getMessage() ));
+                  new ActiveMQAMQPInternalErrorException("Error while processing address added: " + e.getMessage()));
             }
          }
       });
@@ -232,7 +232,7 @@ public class AMQPFederationEventDispatcher implements SenderController, ActiveMQ
                   // Likely the connection failed if we get here.
                   logger.warn("Error on send of queue added event: {}", e.getMessage());
                   federation.signalError(
-                     new ActiveMQAMQPInternalErrorException("Error while processing queue added: " + e.getMessage() ));
+                     new ActiveMQAMQPInternalErrorException("Error while processing queue added: " + e.getMessage()));
                }
             }
          });

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationEventProcessor.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationEventProcessor.java
@@ -155,7 +155,7 @@ public class AMQPFederationEventProcessor extends ProtonAbstractReceiver {
       } catch (Throwable e) {
          logger.warn(e.getMessage(), e);
          federation.signalError(
-            new ActiveMQAMQPInternalErrorException("Error while processing incoming event message: " + e.getMessage() ));
+            new ActiveMQAMQPInternalErrorException("Error while processing incoming event message: " + e.getMessage()));
       }
    }
 

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationQueuePolicyManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationQueuePolicyManager.java
@@ -290,7 +290,7 @@ public final class AMQPFederationQueuePolicyManager extends AMQPFederationPolicy
 
                @Override
                public void onComplete(AMQPFederationConsumer context) {
-                  logger.trace("Restarted federation consumer after new demand added." );
+                  logger.trace("Restarted federation consumer after new demand added.");
                }
 
                @Override

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/mirror/BasicMirrorController.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/mirror/BasicMirrorController.java
@@ -42,7 +42,7 @@ public class BasicMirrorController<T extends Link> {
    }
 
    public static String getRemoteMirrorID(Link link) {
-      if ( link != null && link.getRemoteProperties() != null && link.getRemoteProperties().containsKey(AMQPMirrorControllerSource.BROKER_ID)) {
+      if (link != null && link.getRemoteProperties() != null && link.getRemoteProperties().containsKey(AMQPMirrorControllerSource.BROKER_ID)) {
          return (String)link.getRemoteProperties().get(AMQPMirrorControllerSource.BROKER_ID);
       } else {
          return null;

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPTunneledCoreLargeMessageReader.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPTunneledCoreLargeMessageReader.java
@@ -177,7 +177,7 @@ public class AMQPTunneledCoreLargeMessageReader implements MessageReader {
                // Advance mark so read bytes can be discarded and we can start from this
                // location next time.
                pendingRecvBuffer.markReaderIndex();
-            } catch (ActiveMQException ex ) {
+            } catch (ActiveMQException ex) {
                throw ex;
             } catch (Exception e) {
                // We expect exceptions from proton when only partial section are received within

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/DefaultSenderController.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/DefaultSenderController.java
@@ -436,7 +436,7 @@ public class DefaultSenderController implements SenderController {
    }
 
    private static Number extractConsumerPriority(Map<String, String> addressParameters) {
-      if (addressParameters != null && !addressParameters.isEmpty() ) {
+      if (addressParameters != null && !addressParameters.isEmpty()) {
          final String priorityString = addressParameters.remove(QueueConfiguration.CONSUMER_PRIORITY);
          if (priorityString != null) {
             return Integer.valueOf(priorityString);

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerReceiverContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerReceiverContext.java
@@ -303,7 +303,7 @@ public class ProtonServerReceiverContext extends ProtonAbstractReceiver {
 
    private static boolean outcomeSupported(final Source source, final Symbol outcome) {
       if (source != null && source.getOutcomes() != null) {
-         return Arrays.asList(( source).getOutcomes()).contains(outcome);
+         return Arrays.asList((source).getOutcomes()).contains(outcome);
       }
       return false;
    }

--- a/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessageTest.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessageTest.java
@@ -346,7 +346,7 @@ public class AMQPMessageTest {
    @Test
    public void testDecodeMultiThreaded() throws Exception {
       MessageImpl protonMessage = (MessageImpl) Message.Factory.create();
-      protonMessage.setHeader( new Header());
+      protonMessage.setHeader(new Header());
       Properties properties = new Properties();
       properties.setTo("someNiceLocal");
       protonMessage.setProperties(properties);

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireProtocolManager.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireProtocolManager.java
@@ -780,7 +780,7 @@ public class OpenWireProtocolManager  extends AbstractProtocolManager<Command, O
                }
                fqqn.append(paths[i]);
             }
-            mappedDestination = new ActiveMQQueue(fqqn.toString() + ( virtualTopicConfig.selectorAware ? "?" + SELECTOR_AWARE_OPTION + "=true" : "" ));
+            mappedDestination = new ActiveMQQueue(fqqn.toString() + (virtualTopicConfig.selectorAware ? "?" + SELECTOR_AWARE_OPTION + "=true" : ""));
             break;
          }
       }

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQActivationSpec.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQActivationSpec.java
@@ -382,7 +382,7 @@ public class ActiveMQActivationSpec extends ConnectionFactoryProperties implemen
 
       try {
          this.acknowledgeMode = ActiveMQActivationValidationUtils.validateAcknowledgeMode(value);
-      } catch ( IllegalArgumentException e ) {
+      } catch (IllegalArgumentException e) {
          ActiveMQRALogger.LOGGER.invalidAcknowledgementMode(value);
          throw e;
       }
@@ -583,7 +583,7 @@ public class ActiveMQActivationSpec extends ConnectionFactoryProperties implemen
    public void setMaxSession(final Integer value) {
       logger.trace("setMaxSession({})", value);
 
-      if ( value < 1 ) {
+      if (value < 1) {
          maxSession = 1;
          ActiveMQRALogger.LOGGER.invalidNumberOfMaxSession(value, maxSession);
       } else

--- a/artemis-selector/src/main/javacc/HyphenatedParser.jj
+++ b/artemis-selector/src/main/javacc/HyphenatedParser.jj
@@ -65,7 +65,7 @@ public class HyphenatedParser {
             return (BooleanExpression) value;
         }
         if (value instanceof PropertyExpression) {
-            return UnaryExpression.createBooleanCast( value );
+            return UnaryExpression.createBooleanCast(value);
         }
         throw new ParseException("Expression will not result in a boolean value: " + value);
     }
@@ -298,13 +298,13 @@ Expression comparisonExpression() :
 		            t = stringLitteral()
 		            {
 			            list = new ArrayList();
-			            list.add( t );
+			            list.add(t);
 		            }
 			        (
 			        	","
 			            t = stringLitteral()
 			            {
-				            list.add( t );
+				            list.add(t);
 			            }
 
 			        )*
@@ -319,13 +319,13 @@ Expression comparisonExpression() :
 		            t = stringLitteral()
 		            {
 			            list = new ArrayList();
-			            list.add( t );
+			            list.add(t);
 		            }
 			        (
 			        	","
 			            t = stringLitteral()
 			            {
-				            list.add( t );
+				            list.add(t);
 			            }
 
 			        )*
@@ -415,17 +415,17 @@ Expression unaryExpr() :
 	    |
 	    <NOT> left=unaryExpr()
 	    {
-		    left = UnaryExpression.createNOT( asBooleanExpression(left) );
+		    left = UnaryExpression.createNOT(asBooleanExpression(left));
 	    }
 	    |
 	    <XPATH> s=stringLitteral()
 	    {
-		    left = UnaryExpression.createXPath( s );
+		    left = UnaryExpression.createXPath(s);
 	    }
 	    |
 	    <XQUERY> s=stringLitteral()
 	    {
-		    left = UnaryExpression.createXQuery( s );
+		    left = UnaryExpression.createXQuery(s);
 	    }
 	    |
 	    left = primaryExpr()
@@ -535,9 +535,9 @@ String stringLitteral() :
     {
     	// Decode the sting value.
     	String image = t.image;
-    	for( int i=1; i < image.length()-1; i++ ) {
+    	for(int i=1; i < image.length()-1; i++) {
     		char c = image.charAt(i);
-    		if( c == '\'' )
+    		if(c == '\'')
     			i++;
    			rc.append(c);
     	}

--- a/artemis-selector/src/main/javacc/StrictParser.jj
+++ b/artemis-selector/src/main/javacc/StrictParser.jj
@@ -65,7 +65,7 @@ public class StrictParser {
             return (BooleanExpression) value;
         }
         if (value instanceof PropertyExpression) {
-            return UnaryExpression.createBooleanCast( value );
+            return UnaryExpression.createBooleanCast(value);
         }
         throw new ParseException("Expression will not result in a boolean value: " + value);
     }
@@ -125,13 +125,13 @@ TOKEN [IGNORE_CASE] :
         | (["0"-"9"])+ <EXPONENT>                     // matches: 5E10
     >
   | < #EXPONENT: "E" (["+","-"])? (["0"-"9"])+ >
-  | < STRING_LITERAL: "'" ( ("''") | ~["'"] )*  "'" >
+  | < STRING_LITERAL: "'" (("''") | ~["'"])*  "'" >
 }
 
 TOKEN [IGNORE_CASE] :
 {
     < ID : ["a"-"z", "_", "$"] (["a"-"z","0"-"9","_", "$"])* >
-    | < QUOTED_ID : "\"" ( ("\"\"") | ~["\""] )*  "\""  >
+    | < QUOTED_ID : "\"" (("\"\"") | ~["\""])*  "\""  >
 }
 
 // ----------------------------------------------------------------------------
@@ -299,13 +299,13 @@ Expression comparisonExpression() :
 		            t = stringLitteral()
 		            {
 			            list = new ArrayList();
-			            list.add( t );
+			            list.add(t);
 		            }
 			        (
 			        	","
 			            t = stringLitteral()
 			            {
-				            list.add( t );
+				            list.add(t);
 			            }
 
 			        )*
@@ -320,13 +320,13 @@ Expression comparisonExpression() :
 		            t = stringLitteral()
 		            {
 			            list = new ArrayList();
-			            list.add( t );
+			            list.add(t);
 		            }
 			        (
 			        	","
 			            t = stringLitteral()
 			            {
-				            list.add( t );
+				            list.add(t);
 			            }
 
 			        )*
@@ -350,7 +350,7 @@ Expression addExpression() :
 {
     left = multExpr()
     (
-	    LOOKAHEAD( ("+"|"-") multExpr())
+	    LOOKAHEAD(("+"|"-") multExpr())
 	    (
 	        "+" right = multExpr()
 	        {
@@ -406,7 +406,7 @@ Expression unaryExpr() :
 }
 {
 	(
-		LOOKAHEAD( "+" unaryExpr() )
+		LOOKAHEAD("+" unaryExpr())
 	    "+" left=unaryExpr()
 	    |
 	    "-" left=unaryExpr()
@@ -416,17 +416,17 @@ Expression unaryExpr() :
 	    |
 	    <NOT> left=unaryExpr()
 	    {
-		    left = UnaryExpression.createNOT( asBooleanExpression(left) );
+		    left = UnaryExpression.createNOT(asBooleanExpression(left));
 	    }
 	    |
 	    <XPATH> s=stringLitteral()
 	    {
-		    left = UnaryExpression.createXPath( s );
+		    left = UnaryExpression.createXPath(s);
 	    }
 	    |
 	    <XQUERY> s=stringLitteral()
 	    {
-		    left = UnaryExpression.createXQuery( s );
+		    left = UnaryExpression.createXQuery(s);
 	    }
 	    |
 	    left = primaryExpr()
@@ -536,9 +536,9 @@ String stringLitteral() :
     {
     	// Decode the sting value.
     	String image = t.image;
-    	for( int i=1; i < image.length()-1; i++ ) {
+    	for(int i=1; i < image.length()-1; i++) {
     		char c = image.charAt(i);
-    		if( c == '\'' )
+    		if(c == '\'')
     			i++;
    			rc.append(c);
     	}
@@ -563,9 +563,9 @@ PropertyExpression variable() :
             // Decode the string value.
             StringBuffer rc = new StringBuffer();
             String image = t.image;
-            for( int i=1; i < image.length()-1; i++ ) {
+            for(int i=1; i < image.length()-1; i++) {
                 char c = image.charAt(i);
-                if( c == '"' )
+                if(c == '"')
                     i++;
                 rc.append(c);
             }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/ha/ReplicationPrimaryPolicyConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/ha/ReplicationPrimaryPolicyConfiguration.java
@@ -105,7 +105,7 @@ public class ReplicationPrimaryPolicyConfiguration implements HAPolicyConfigurat
       } else if (len % 2 != 0) {
          // must be even for conversion to uuid, extend to next even
          this.coordinationId = newCoordinationId + "+";
-      } else if (len > 0 ) {
+      } else if (len > 0) {
          // run with it
          this.coordinationId = newCoordinationId;
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
@@ -3244,7 +3244,7 @@ public class ConfigurationImpl implements Configuration, Serializable {
          int r = idCacheSize / msgNumInFlight;
 
          // This setting is here to accomodate the current default setting.
-         if ( (r >= RANGE_SIZE_MIN) && (r <= RANGE_SZIE_MAX)) {
+         if ((r >= RANGE_SIZE_MIN) && (r <= RANGE_SZIE_MAX)) {
             sizeGood = true;
          }
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -1236,7 +1236,7 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
 
       final RoutingStatus finalStatus;
       try {
-         if ( status == RoutingStatus.NO_BINDINGS) {
+         if (status == RoutingStatus.NO_BINDINGS) {
             finalStatus = maybeSendToDLA(message, context, address, sendToDLA);
          } else {
             finalStatus = status;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/ProtocolHandler.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/ProtocolHandler.java
@@ -132,7 +132,7 @@ public class ProtocolHandler {
          nettySNIHostnameHandler = ctx.pipeline().get(NettySNIHostnameHandler.class);
 
          if (handshakeTimeout > 0) {
-            timeoutFuture = scheduledThreadPool.schedule( () -> {
+            timeoutFuture = scheduledThreadPool.schedule(() -> {
                ActiveMQServerLogger.LOGGER.handshakeTimeout(handshakeTimeout, nettyAcceptor.getName(), ctx.channel().remoteAddress().toString());
                ctx.channel().close();
             }, handshakeTimeout, TimeUnit.SECONDS);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMConnection.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMConnection.java
@@ -175,9 +175,9 @@ public class InVMConnection implements Connection {
    @Override
    public ActiveMQBuffer createTransportBuffer(final int size) {
       if (bufferPoolingEnabled) {
-         return ActiveMQBuffers.pooledBuffer( size );
+         return ActiveMQBuffers.pooledBuffer(size);
       }
-      return ActiveMQBuffers.dynamicBuffer( size );
+      return ActiveMQBuffers.dynamicBuffer(size);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/impl/ClusterConnectionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/impl/ClusterConnectionImpl.java
@@ -932,7 +932,7 @@ public final class ClusterConnectionImpl implements ClusterConnection, AfterConn
          bridge.start();
       }
 
-      if ( !ConfigurationImpl.checkoutDupCacheSize(serverLocator.getConfirmationWindowSize(), server.getConfiguration().getIDCacheSize())) {
+      if (!ConfigurationImpl.checkoutDupCacheSize(serverLocator.getConfirmationWindowSize(), server.getConfiguration().getIDCacheSize())) {
          ActiveMQServerLogger.LOGGER.duplicateCacheSizeWarning(server.getConfiguration().getIDCacheSize(), serverLocator.getConfirmationWindowSize());
       }
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
@@ -224,7 +224,7 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
    private void checkIDSupplier(NodeStoreFactory<MessageReference> nodeStoreFactory) {
       if (this.nodeStoreFactory == null) {
          this.nodeStoreFactory = nodeStoreFactory;
-         messageReferences.setNodeStore( () -> nodeStoreFactory.newNodeStore().setName(String.valueOf(name)));
+         messageReferences.setNodeStore(() -> nodeStoreFactory.newNodeStore().setName(String.valueOf(name)));
       }
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/JMXAccessControlList.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/JMXAccessControlList.java
@@ -109,7 +109,7 @@ public class JMXAccessControlList {
 
    public void addToDefaultAccess(String method, String... roles) {
       if (roles != null) {
-         if ( method.equals(WILDCARD)) {
+         if (method.equals(WILDCARD)) {
             defaultAccess.addCatchAll(roles);
          } else if (method.endsWith(WILDCARD)) {
             String prefix = method.replace(WILDCARD, "");

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/management/ArtemisRbacMBeanServerBuilderTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/management/ArtemisRbacMBeanServerBuilderTest.java
@@ -166,7 +166,7 @@ public class ArtemisRbacMBeanServerBuilderTest extends ServerTestBase {
       handler.brokerDomain = ActiveMQDefaultConfiguration.getDefaultJmxDomain();
       handler.rbacPrefix = SimpleString.of(ActiveMQDefaultConfiguration.getManagementRbacPrefix());
 
-      for (Method m : ObjectNameBuilder.class.getDeclaredMethods() ) {
+      for (Method m : ObjectNameBuilder.class.getDeclaredMethods()) {
          if (Modifier.isPublic(m.getModifiers()) && ObjectName.class == m.getReturnType()) {
             Object[] args = new Object[m.getParameterCount()];
             for (int i = 0; i < args.length; i++) {

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/routing/ConnectionRouterTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/routing/ConnectionRouterTest.java
@@ -47,7 +47,7 @@ public class ConnectionRouterTest {
       Policy policy = null;
       underTest  = new ConnectionRouter("test", KeyType.CLIENT_ID, "^.{3}",
                                       localTarget, "^FOO.*", null, null, policy);
-      assertEquals( localTarget, underTest.getTarget("FOO_EE").getTarget());
+      assertEquals(localTarget, underTest.getTarget("FOO_EE").getTarget());
       assertEquals(TargetResult.REFUSED_USE_ANOTHER_RESULT, underTest.getTarget("BAR_EE"));
    }
 
@@ -62,7 +62,7 @@ public class ConnectionRouterTest {
 
       underTest  = new ConnectionRouter("test", KeyType.CLIENT_ID, "^.{3}",
                                       localTarget, "^FOO.*", null, null, policy);
-      assertEquals( localTarget, underTest.getTarget("TRANSFORM_TO_FOO_EE").getTarget());
+      assertEquals(localTarget, underTest.getTarget("TRANSFORM_TO_FOO_EE").getTarget());
    }
 
 }

--- a/etc/checkstyle.xml
+++ b/etc/checkstyle.xml
@@ -82,6 +82,9 @@ under the License.
       <module name="WhitespaceAfter">
          <property name="tokens" value="COMMA"/>
       </module>
+      <module name="ParenPad">
+         <property name="option" value="nospace"/>
+      </module>
       <!-- Ensure there is no space between the identifier of a method definition, constructor definition, method call, or constructor invocation and the left parenthesis of the parameter list. -->
       <module name="MethodParamPad"/>
       <!-- Ensure proper indentation. -->

--- a/tests/integration-tests-isolated/src/test/java/org/apache/activemq/artemis/tests/integration/isolated/client/ConnectionDroppedTest.java
+++ b/tests/integration-tests-isolated/src/test/java/org/apache/activemq/artemis/tests/integration/isolated/client/ConnectionDroppedTest.java
@@ -414,7 +414,7 @@ public class ConnectionDroppedTest extends ActiveMQTestBase {
                connectionFactory = CFUtil.createConnectionFactory(protocol, "failover:(amqp://localhost:61616)?failover.maxReconnectAttempts=20");
                break;
             case "OPENWIRE":
-               connectionFactory = new org.apache.activemq.ActiveMQConnectionFactory( "failover:(tcp://localhost:61616)?maxReconnectAttempts=20");
+               connectionFactory = new org.apache.activemq.ActiveMQConnectionFactory("failover:(tcp://localhost:61616)?maxReconnectAttempts=20");
                break;
             case "CORE":
                connectionFactory = new org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory("tcp://localhost:61616?ha=true;reconnectAttempts=20;callTimeout=1000");

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpSessionTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpSessionTest.java
@@ -105,7 +105,7 @@ public class AmqpSessionTest extends AmqpClientTestSupport {
 
       assertEquals(1, server.getSessions().size());
       for (ServerSession serverSession : server.getSessions()) {
-         assertNull( ((ServerSessionImpl) serverSession).getCloseables());
+         assertNull(((ServerSessionImpl) serverSession).getCloseables());
       }
 
       connection.close();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationAddressPolicyTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationAddressPolicyTest.java
@@ -4776,7 +4776,7 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
       scriptFederationConnectToRemote(peer, federationName, AmqpSupport.AMQP_CREDITS_DEFAULT, AmqpSupport.AMQP_LOW_CREDITS_DEFAULT, eventsSender, eventsReceiver);
    }
 
-   private static void scriptFederationConnectToRemote(ProtonTestClient peer, String federationName, int amqpCredits, int amqpLowCredits, boolean eventsSender, boolean eventsReceiver ) {
+   private static void scriptFederationConnectToRemote(ProtonTestClient peer, String federationName, int amqpCredits, int amqpLowCredits, boolean eventsSender, boolean eventsReceiver) {
       final String federationControlLinkName = "Federation:control:" + UUID.randomUUID().toString();
 
       final Map<String, Object> federationConfiguration = new HashMap<>();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationQueuePolicyTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationQueuePolicyTest.java
@@ -4610,7 +4610,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
       scriptFederationConnectToRemote(peer, federationName, AmqpSupport.AMQP_CREDITS_DEFAULT, AmqpSupport.AMQP_LOW_CREDITS_DEFAULT, eventsSender, eventsReceiver);
    }
 
-   private void scriptFederationConnectToRemote(ProtonTestClient peer, String federationName, int amqpCredits, int amqpLowCredits, boolean eventsSender, boolean eventsReceiver ) {
+   private void scriptFederationConnectToRemote(ProtonTestClient peer, String federationName, int amqpCredits, int amqpLowCredits, boolean eventsSender, boolean eventsReceiver) {
       final String federationControlLinkName = "Federation:control:" + UUID.randomUUID().toString();
 
       final Map<String, Object> federationConfiguration = new HashMap<>();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/JMSOrderTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/JMSOrderTest.java
@@ -85,7 +85,7 @@ public class JMSOrderTest extends JMSTestBase {
    protected void sendToAmqQueue(int count) throws Exception {
       Connection activemqConnection = protocolCF.createConnection();
       Session amqSession = activemqConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
-      Queue amqTestQueue = amqSession.createQueue( name);
+      Queue amqTestQueue = amqSession.createQueue(name);
       sendMessages(activemqConnection, amqTestQueue, count);
       activemqConnection.close();
    }
@@ -118,7 +118,7 @@ public class JMSOrderTest extends JMSTestBase {
          sendToAmqQueue(totalCount);
 
          Session session = connection.createSession(true, Session.SESSION_TRANSACTED);
-         Queue queue = session.createQueue( name);
+         Queue queue = session.createQueue(name);
          MessageConsumer consumer = session.createConsumer(queue);
 
          for (int i = 1; i <= consumeBeforeRollback; i++) {
@@ -164,7 +164,7 @@ public class JMSOrderTest extends JMSTestBase {
          sendToAmqQueue(totalCount);
 
          Session session = connection.createSession(true, Session.SESSION_TRANSACTED);
-         Queue queue = session.createQueue( name);
+         Queue queue = session.createQueue(name);
          MessageConsumer consumer = session.createConsumer(queue);
 
          for (int i = 1; i <= consumeBeforeRollback; i++) {
@@ -176,7 +176,7 @@ public class JMSOrderTest extends JMSTestBase {
          session.close();
 
          session = connection.createSession(true, Session.SESSION_TRANSACTED);
-         queue = session.createQueue( name);
+         queue = session.createQueue(name);
          consumer = session.createConsumer(queue);
 
          // Consume again.. the previously consumed messages should get delivered
@@ -204,7 +204,7 @@ public class JMSOrderTest extends JMSTestBase {
    protected void sendToAmqQueueOutOfOrder(int totalCount) throws Exception {
       Connection activemqConnection = protocolCF.createConnection();
       Session amqSession = activemqConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
-      Queue amqTestQueue = amqSession.createQueue( name);
+      Queue amqTestQueue = amqSession.createQueue(name);
 
       for (int i = 1; i <= totalCount; i += 2) {
          Session sessionA = activemqConnection.createSession(true, Session.SESSION_TRANSACTED);
@@ -247,7 +247,7 @@ public class JMSOrderTest extends JMSTestBase {
          sendToAmqQueueOutOfOrder(totalCount);
 
          Session session = connection.createSession(true, Session.SESSION_TRANSACTED);
-         Queue queue = session.createQueue( name);
+         Queue queue = session.createQueue(name);
          MessageConsumer consumer = session.createConsumer(queue);
 
          List<Integer> messageNumbers = new ArrayList<>();
@@ -265,7 +265,7 @@ public class JMSOrderTest extends JMSTestBase {
          session.close();
 
          session = connection.createSession(true, Session.SESSION_TRANSACTED);
-         queue = session.createQueue( name);
+         queue = session.createQueue(name);
          consumer = session.createConsumer(queue);
 
          // Consume again.. the previously consumed messages should get delivered

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/clientcrash/ClientCrashTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/clientcrash/ClientCrashTest.java
@@ -115,7 +115,7 @@ public class ClientCrashTest extends ClientTestBase {
       assertNotNull(messageFromClient, "no message received");
       assertEquals(ClientCrashTest.MESSAGE_TEXT_FROM_CLIENT, messageFromClient.getBodyBuffer().readString());
 
-      assertActiveConnections( 1); // One local and one from the other vm
+      assertActiveConnections(1); // One local and one from the other vm
       assertActiveSession(1);
 
       ClientMessage message = session.createMessage(ActiveMQTextMessage.TYPE, false, 0, System.currentTimeMillis(), (byte) 1);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/ClientConnectorFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/ClientConnectorFailoverTest.java
@@ -338,7 +338,7 @@ public class ClientConnectorFailoverTest extends StaticClusterWithBackupFailover
          connectionURL.append(",");
       }
       connectionURL.replace(connectionURL.length() - 1, connectionURL.length(), ")");
-      connectionURL.append( "?ha=true&reconnectAttempts=-1");
+      connectionURL.append("?ha=true&reconnectAttempts=-1");
 
       ConnectionFactory connectionFactory = new ActiveMQConnectionFactory(connectionURL.toString());
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/PagingFailoverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/PagingFailoverTest.java
@@ -187,7 +187,7 @@ public class PagingFailoverTest extends FailoverTestBase {
 
       Queue queue = backupServer.getServer().locateQueue(ADDRESS);
 
-      Wait.assertFalse( () -> {
+      Wait.assertFalse(() -> {
          queue.expireReferences();
          return queue.getPageSubscription().isPaging();
       });

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/ReplicatedMultipleServerFailoverExtraBackupsTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/failover/ReplicatedMultipleServerFailoverExtraBackupsTest.java
@@ -119,11 +119,11 @@ public class ReplicatedMultipleServerFailoverExtraBackupsTest extends Replicated
    protected void sendCrashBackupReceive() throws Exception {
 
       //make sure bindings are ready before sending messages b/c we verify strict load balancing in waitForDistribution
-      this.waitForBindings( backupServers.get(0).getServer(), ADDRESS.toString(), false, 1, 0, 2000);
-      this.waitForBindings( backupServers.get(0).getServer(), ADDRESS.toString(), false, 1, 0, 2000);
+      this.waitForBindings(backupServers.get(0).getServer(), ADDRESS.toString(), false, 1, 0, 2000);
+      this.waitForBindings(backupServers.get(0).getServer(), ADDRESS.toString(), false, 1, 0, 2000);
 
-      this.waitForBindings( backupServers.get(1).getServer(), ADDRESS.toString(), false, 1, 0, 2000);
-      this.waitForBindings( backupServers.get(1).getServer(), ADDRESS.toString(), false, 1, 0, 2000);
+      this.waitForBindings(backupServers.get(1).getServer(), ADDRESS.toString(), false, 1, 0, 2000);
+      this.waitForBindings(backupServers.get(1).getServer(), ADDRESS.toString(), false, 1, 0, 2000);
 
       ServerLocator locator0 = getBackupServerLocator(0);
       ServerLocator locator1 = getBackupServerLocator(1);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/federation/FederatedQueuePullConsumerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/federation/FederatedQueuePullConsumerTest.java
@@ -219,7 +219,7 @@ public class FederatedQueuePullConsumerTest extends FederatedTestBase {
 
          // verify batch end
          final int mumMessages = 150;
-         for (int i = 0; i < mumMessages; i++ ) {
+         for (int i = 0; i < mumMessages; i++) {
             producer.send(session1.createTextMessage("1-" + i));
          }
 
@@ -232,7 +232,7 @@ public class FederatedQueuePullConsumerTest extends FederatedTestBase {
          Wait.assertTrue(() -> getMessageCount(getServer(0), queueName) < 100, 2000, 100);
 
          // verify all available
-         for (int i = 0; i < mumMessages; i++ ) {
+         for (int i = 0; i < mumMessages; i++) {
             assertNotNull(consumer0.receive(4000));
          }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/federation/FederatedTestUtil.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/federation/FederatedTestUtil.java
@@ -31,7 +31,7 @@ public class FederatedTestUtil {
 
    public static FederationConfiguration createAddressFederationConfiguration(String address, int hops) {
       FederationAddressPolicyConfiguration addressPolicyConfiguration = new FederationAddressPolicyConfiguration();
-      addressPolicyConfiguration.setName( "AddressPolicy" + address);
+      addressPolicyConfiguration.setName("AddressPolicy" + address);
       addressPolicyConfiguration.addInclude(new FederationAddressPolicyConfiguration.Matcher().setAddressMatch(address));
       addressPolicyConfiguration.setMaxHops(hops);
 
@@ -156,7 +156,7 @@ public class FederatedTestUtil {
    public static FederationConfiguration createQueueFederationConfiguration(String connector, String queueName, Boolean includeFederated) {
 
       FederationQueuePolicyConfiguration queuePolicyConfiguration = new FederationQueuePolicyConfiguration();
-      queuePolicyConfiguration.setName( "QueuePolicy" + queueName);
+      queuePolicyConfiguration.setName("QueuePolicy" + queueName);
       queuePolicyConfiguration.addInclude(new FederationQueuePolicyConfiguration.Matcher()
                                              .setQueueMatch(queueName).setAddressMatch("#"));
       if (includeFederated != null) {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/MessageProducerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/MessageProducerTest.java
@@ -61,8 +61,8 @@ public class MessageProducerTest extends JMSTestBase {
    public void testHasDefaultDestination() throws Exception {
       Session session = conn.createSession();
       try {
-         Queue queue = createQueue( name);
-         Queue queue2 = createQueue( name + "2");
+         Queue queue = createQueue(name);
+         Queue queue2 = createQueue(name + "2");
          MessageProducer producer = session.createProducer(queue);
          Message m = session.createMessage();
          try {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/jms2client/JmsProducerCompletionListenerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/jms2client/JmsProducerCompletionListenerTest.java
@@ -78,7 +78,7 @@ public class JmsProducerCompletionListenerTest extends JMSTestBase {
       super.setUp();
       context = createContext();
       producer = context.createProducer();
-      queue = createQueue( name + "Queue");
+      queue = createQueue(name + "Queue");
    }
 
    @TestTemplate

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
@@ -5224,7 +5224,7 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
          Session session1 = conn.createSession();
 
          MessageProducer producer1 = session1.createProducer(null);
-         for ( int i = 0; i < 110; i++) {
+         for (int i = 0; i < 110; i++) {
             javax.jms.Queue queue = session1.createQueue(queueName + i);
             producer1.send(queue, session1.createMessage());
          }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/AddressControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/AddressControlTest.java
@@ -793,14 +793,14 @@ public class AddressControlTest extends ManagementTestBase {
       session.commit();
 
       AddressControl addressControl = createManagementControl(address);
-      assertTrue(addressControl.getAddressSize() > numMessages * payLoadSize );
+      assertTrue(addressControl.getAddressSize() > numMessages * payLoadSize);
 
       // restart to reload journal
       server.stop();
       server.start();
 
       addressControl = createManagementControl(address);
-      assertTrue(addressControl.getAddressSize() > numMessages * payLoadSize );
+      assertTrue(addressControl.getAddressSize() > numMessages * payLoadSize);
    }
 
 
@@ -836,7 +836,7 @@ public class AddressControlTest extends ManagementTestBase {
       session.commit();
 
       AddressControl addressControl = createManagementControl(address);
-      assertTrue(addressControl.getAddressSize() > pageLimitNumberOfMessages * payLoadSize );
+      assertTrue(addressControl.getAddressSize() > pageLimitNumberOfMessages * payLoadSize);
 
       final long exactSizeValueBeforeRestart = addressControl.getAddressSize();
       final int exactPercentBeforeRestart = addressControl.getAddressLimitPercent();
@@ -846,7 +846,7 @@ public class AddressControlTest extends ManagementTestBase {
       server.start();
 
       addressControl = createManagementControl(address);
-      assertTrue(addressControl.getAddressSize() > pageLimitNumberOfMessages * payLoadSize );
+      assertTrue(addressControl.getAddressSize() > pageLimitNumberOfMessages * payLoadSize);
       assertEquals(exactSizeValueBeforeRestart, addressControl.getAddressSize());
       assertEquals(exactPercentBeforeRestart, addressControl.getAddressLimitPercent());
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/QueueControlTest.java
@@ -616,7 +616,7 @@ public class QueueControlTest extends ManagementTestBase {
 
       assertTrue(lastDelivered > currentTime);
 
-      assertEquals( 0, jsonObject.getInt(ConsumerField.LAST_ACKNOWLEDGED_TIME.getName()));
+      assertEquals(0, jsonObject.getInt(ConsumerField.LAST_ACKNOWLEDGED_TIME.getName()));
 
       clientMessage.acknowledge();
 
@@ -1157,7 +1157,7 @@ public class QueueControlTest extends ManagementTestBase {
       assertEquals(1, messages.length);
       for (String key : messages[0].keySet()) {
          Object value = messages[0].get(key);
-         System.err.println( key + " " + value);
+         System.err.println(key + " " + value);
          assertTrue(value.toString().length() <= 150);
 
          if (value instanceof byte[]) {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MqttClusterRemoteSubscribeTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MqttClusterRemoteSubscribeTest.java
@@ -224,9 +224,9 @@ public class MqttClusterRemoteSubscribeTest extends ClusterTestBase {
          String message11String = new String(message11.getPayload());
          String message21String = new String(message21.getPayload());
          String message31String = new String(message31.getPayload());
-         assertTrue(payload1.equals(message11String) || payload1.equals(message21String) || payload1.equals(message31String) );
-         assertTrue(payload2.equals(message11String) || payload2.equals(message21String) || payload2.equals(message31String) );
-         assertTrue(payload3.equals(message11String) || payload3.equals(message21String) || payload3.equals(message31String) );
+         assertTrue(payload1.equals(message11String) || payload1.equals(message21String) || payload1.equals(message31String));
+         assertTrue(payload2.equals(message11String) || payload2.equals(message21String) || payload2.equals(message31String));
+         assertTrue(payload3.equals(message11String) || payload3.equals(message21String) || payload3.equals(message31String));
 
       } finally {
          String[] topics = new String[]{ANYCAST_TOPIC};

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/ConfigChangeTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/ConfigChangeTest.java
@@ -98,7 +98,7 @@ public class ConfigChangeTest extends ActiveMQTestBase {
       final String filter1 = "x = 'x'";
       final String filter2 = "x = 'y'";
 
-      Configuration configuration = createDefaultInVMConfig(  );
+      Configuration configuration = createDefaultInVMConfig();
       configuration.addAddressSetting("#", new AddressSettings());
 
       List addressConfigurations = new ArrayList();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/routing/AutoClientIDShardClusterTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/routing/AutoClientIDShardClusterTest.java
@@ -98,7 +98,7 @@ public class AutoClientIDShardClusterTest extends RoutingTestBase {
                try (Connection connection = connectionFactory.createConnection()) {
                   connection.start();
                   try (Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)) {
-                     javax.jms.Topic topic = session.createTopic( name);
+                     javax.jms.Topic topic = session.createTopic(name);
                      try (MessageProducer producer = session.createProducer(topic)) {
                         for (int i = 0; i < 10 && toSend.get() > 0; i++) {
                            Message message = session.createTextMessage();
@@ -141,7 +141,7 @@ public class AutoClientIDShardClusterTest extends RoutingTestBase {
                   connection = connectionFactory.createConnection();
                   connection.start();
                   try (Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)) {
-                     javax.jms.Topic topic = session.createTopic( name);
+                     javax.jms.Topic topic = session.createTopic(name);
                      try (TopicSubscriber durableSubscriber = session.createDurableSubscriber(topic, "Sub-" + id)) {
                         registered.countDown();
                         for (int i = 0; i < 5; i++) {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/ScaleDownTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/ScaleDownTest.java
@@ -812,7 +812,7 @@ public class ScaleDownTest extends ClusterTestBase {
       AddressSettings addressSettings = new AddressSettings().setDeadLetterAddress(dla).setAutoCreateDeadLetterResources(true).setDeadLetterQueuePrefix(dla);
       AddressSettings dlaAddressSettings = new AddressSettings().setDeadLetterAddress(dla).setMaxSizeBytes(200L).setAutoCreateQueues(true);
 
-      servers[0].getAddressSettingsRepository().addMatch( "#", addressSettings);
+      servers[0].getAddressSettingsRepository().addMatch("#", addressSettings);
       servers[0].getAddressSettingsRepository().addMatch(dla.toString(), dlaAddressSettings);
 
       ClientSessionFactory sf = sfs[0];

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/tools/container/LocalTestServer.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/tools/container/LocalTestServer.java
@@ -345,7 +345,7 @@ public class LocalTestServer implements Server, Runnable {
       Object[] subInfos = topic.getQueueNames();
       List<String> subs = new ArrayList<>();
       for (Object o : subInfos) {
-         subs.add( ((String) o).split("\\.")[1]);
+         subs.add(((String) o).split("\\.")[1]);
       }
       return subs;
    }

--- a/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/console/ConsoleMutualSSLTest.java
+++ b/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/console/ConsoleMutualSSLTest.java
@@ -44,7 +44,7 @@ public class ConsoleMutualSSLTest extends SmokeTestBase {
       deleteDirectory(server0Location);
       HelperCreate cliCreateServer = helperCreate();
       cliCreateServer.setRole("amq").setUser("admin").setPassword("admin").setAllowAnonymous(false).setConfiguration("./src/main/resources/servers/console-mutual-ssl").
-         setNoWeb(false).setArtemisInstance(server0Location).setArgs( "--http-host",
+         setNoWeb(false).setArtemisInstance(server0Location).setArgs("--http-host",
                      "localhost",
                      "--http-port",
                      "8443",

--- a/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/jmxfailback/JmxFailbackTest.java
+++ b/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/jmxfailback/JmxFailbackTest.java
@@ -56,14 +56,14 @@ public class JmxFailbackTest extends SmokeTestBase {
       {
          HelperCreate cliCreateServer = helperCreate();
          cliCreateServer.setUser("admin").setPassword("admin").setAllowAnonymous(true).setNoWeb(true).setArtemisInstance(server0Location).
-            setConfiguration("./src/main/resources/servers/jmx-failback1").setArgs( "--java-options", "-Djava.rmi.server.hostname=localhost");
+            setConfiguration("./src/main/resources/servers/jmx-failback1").setArgs("--java-options", "-Djava.rmi.server.hostname=localhost");
          cliCreateServer.createServer();
       }
 
       {
          HelperCreate cliCreateServer = helperCreate();
          cliCreateServer.setUser("admin").setPassword("admin").setAllowAnonymous(true).setNoWeb(true).setArtemisInstance(server1Location).
-            setConfiguration("./src/main/resources/servers/jmx-failback2").setArgs( "--java-options", "-Djava.rmi.server.hostname=localhost");
+            setConfiguration("./src/main/resources/servers/jmx-failback2").setArgs("--java-options", "-Djava.rmi.server.hostname=localhost");
          cliCreateServer.createServer();
       }
    }

--- a/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/logging/AuditLoggerResourceTest.java
+++ b/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/logging/AuditLoggerResourceTest.java
@@ -73,7 +73,7 @@ public class AuditLoggerResourceTest extends AuditLoggerTestBase {
          assertTrue(findLogRecord(getAuditLog(), "successfully created queue:"));
          serverControl.updateQueue("auditQueue", "ANYCAST", -1, false);
          final QueueControl queueControl = MBeanServerInvocationHandler.newProxyInstance(mBeanServerConnection,
-               objectNameBuilder.getQueueObjectName(SimpleString.of( "auditAddress"), SimpleString.of("auditQueue"), RoutingType.ANYCAST),
+               objectNameBuilder.getQueueObjectName(SimpleString.of("auditAddress"), SimpleString.of("auditQueue"), RoutingType.ANYCAST),
                QueueControl.class,
                false);
          assertTrue(findLogRecord(getAuditLog(), "successfully updated queue:"));

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/message/impl/MessageImplTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/message/impl/MessageImplTest.java
@@ -375,7 +375,7 @@ public class MessageImplTest extends ActiveMQTestBase {
                   e.printStackTrace();
                   errors.incrementAndGet();
                } finally {
-                  if ( buf != null ) {
+                  if (buf != null) {
                      buf.release();
                   }
                }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/WildcardAddressManagerPerfTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/WildcardAddressManagerPerfTest.java
@@ -59,7 +59,7 @@ public class WildcardAddressManagerPerfTest {
       final int partitions = 2;
       ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
 
-      for (int i = 0; i < numSubs; i++ ) {
+      for (int i = 0; i < numSubs; i++) {
          final int id = i;
 
          executorService.submit(() -> {
@@ -73,11 +73,11 @@ public class WildcardAddressManagerPerfTest {
                // subscribe as wildcard
                ad.addBinding(new BindingFake(SimpleString.of("Topic1." +  id % partitions +  ".>"), SimpleString.of("" + id), id));
 
-               SimpleString pubAddr = SimpleString.of("Topic1." +  id % partitions + "." + id );
+               SimpleString pubAddr = SimpleString.of("Topic1." +  id % partitions + "." + id);
 
 
                if (id != 0 && id % 1000 == 0) {
-                  System.err.println("0. pub for: " + id );
+                  System.err.println("0. pub for: " + id);
                }
 
                // publish

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/WildcardAddressManagerUnitTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/postoffice/impl/WildcardAddressManagerUnitTest.java
@@ -356,7 +356,7 @@ public class WildcardAddressManagerUnitTest extends ActiveMQTestBase {
       int numThreads = 2;
       ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
 
-      for (int i = 0; i < numSubs; i++ ) {
+      for (int i = 0; i < numSubs; i++) {
          final int id = i;
 
          executorService.submit(() -> {
@@ -368,7 +368,7 @@ public class WildcardAddressManagerUnitTest extends ActiveMQTestBase {
                   ad.addBinding(new BindingFake(SimpleString.of("Topic1.>"), SimpleString.of("" + id)));
                }
 
-               SimpleString pubAddr = SimpleString.of("Topic1." + id );
+               SimpleString pubAddr = SimpleString.of("Topic1." + id);
                // publish to new address, will create
                ad.getBindingsForRoutingAddress(pubAddr);
 


### PR DESCRIPTION
This commit enforces a consistent style for parentheses, namely that there is no padding. Futhermore, it updates all the code that violates this styling so that the code is styled consistently across the entire code-base.