### PR TITLE
ARTEMIS-5133: Remove private field systemProperties is not written anywhere

### DIFF
--- a/artemis-maven-plugin/src/main/java/org/apache/activemq/artemis/maven/ArtemisClientPlugin.java
+++ b/artemis-maven-plugin/src/main/java/org/apache/activemq/artemis/maven/ArtemisClientPlugin.java
@@ -47,11 +47,6 @@ public class ArtemisClientPlugin extends ArtemisAbstractPlugin {
    @Parameter(defaultValue = "${noClient}")
    boolean ignore;
 
-   /**
-    * @parameter
-    */
-   private Properties systemProperties;
-
    @Override
    protected boolean isIgnore() {
       return ignore;
@@ -71,10 +66,6 @@ public class ArtemisClientPlugin extends ArtemisAbstractPlugin {
    @Override
    protected void doExecute() throws MojoExecutionException, MojoFailureException {
       try {
-         if (systemProperties != null && !systemProperties.isEmpty()) {
-            System.getProperties().putAll(systemProperties);
-         }
-
          Class aClass;
          if (classPath != null) {
             ClassLoader loader = defineClassLoader(classPath);


### PR DESCRIPTION
Private field systemProperties is not written anywhere in the class, so it will always be empty at the time of checking in the doExecute method and system properties will not be set. If this variable is not used, consider removing it from the class. [link](https://github.com/apache/activemq-artemis/blob/0afab64f6426a00e0b0faef416133aac10496e42/artemis-maven-plugin/src/main/java/org/apache/activemq/artemis/maven/ArtemisClientPlugin.java#L74)