### PR TITLE
ARTEMIS-5100 support journal-max-io on 'create' CLI command

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
@@ -298,6 +298,9 @@ public class Create extends InstallAbstract {
    @Option(names = "--security-manager", description = "Which security manager to use - jaas or basic. Default: jaas.")
    private String securityManager = "jaas";
 
+   @Option(names = "--journal-max-io", description = "The journal-max-io value to use when also using the ASYNCIO journal-type. When using NIO or MAPPED this value is always '1'. Default: 4096")
+   private int journalMaxIo = ActiveMQDefaultConfiguration.getDefaultJournalMaxIoAio();
+
    @Option(names = "--jdbc-bindings-table-name", description = "Name of the jdbc bindings table.")
    private String jdbcBindings = ActiveMQDefaultConfiguration.getDefaultBindingsTableName();
 
@@ -500,6 +503,30 @@ public class Create extends InstallAbstract {
 
    public void setRole(String role) {
       this.role = role;
+   }
+
+   public int getJournalMaxIo() {
+      return journalMaxIo;
+   }
+
+   public void setJournalMaxIo(int journalMaxIo) {
+      this.journalMaxIo = journalMaxIo;
+   }
+
+   public boolean isAio() {
+      return aio;
+   }
+
+   public void setAio(boolean aio) {
+      this.aio = aio;
+   }
+
+   public boolean isNio() {
+      return nio;
+   }
+
+   public void setNio(boolean nio) {
+      this.nio = nio;
    }
 
    private boolean isBackup() {
@@ -862,7 +889,7 @@ public class Create extends InstallAbstract {
       context.out.println(String.format("   \"%s\" run", path(new File(directory, "bin/artemis"))));
 
       File service = new File(directory, BIN_ARTEMIS_SERVICE);
-      context.out.println("");
+      context.out.println();
 
       if (IS_NIX) {
          context.out.println("Or you can run the broker in the background using:");
@@ -1049,7 +1076,7 @@ public class Create extends InstallAbstract {
                Map<String, String> syncFilter = new HashMap<>();
                syncFilter.put("${nanoseconds}", "0");
                syncFilter.put("${writesPerMillisecond}", "0");
-               syncFilter.put("${maxaio}", journalType == JournalType.ASYNCIO ? "" + ActiveMQDefaultConfiguration.getDefaultJournalMaxIoAio() : "1");
+               syncFilter.put("${maxaio}", "1");
 
                getActionContext().out.println("...Since you disabled sync and are using MAPPED journal, we are diabling buffer times");
 
@@ -1066,7 +1093,7 @@ public class Create extends InstallAbstract {
                Map<String, String> syncFilter = new HashMap<>();
                syncFilter.put("${nanoseconds}", Long.toString(nanoseconds));
                syncFilter.put("${writesPerMillisecond}", writesPerMillisecondStr);
-               syncFilter.put("${maxaio}", journalType == JournalType.ASYNCIO ? "" + ActiveMQDefaultConfiguration.getDefaultJournalMaxIoAio() : "1");
+               syncFilter.put("${maxaio}", journalType == JournalType.ASYNCIO ? "" + journalMaxIo : "1");
 
                getActionContext().out.println("done! Your system can make " + writesPerMillisecondStr +
                                                  " writes per millisecond, your journal-buffer-timeout will be " + nanoseconds);

--- a/artemis-cli/src/test/java/org/apache/activemq/artemis/cli/commands/CreateTestIndividualSettings.java
+++ b/artemis-cli/src/test/java/org/apache/activemq/artemis/cli/commands/CreateTestIndividualSettings.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.cli.commands;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+
+import org.apache.activemq.artemis.tests.extensions.TargetTempDirFactory;
+import org.apache.activemq.artemis.utils.RandomUtil;
+import org.apache.activemq.cli.test.TestActionContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CreateTestIndividualSettings {
+
+   @TempDir(factory = TargetTempDirFactory.class)
+   public File temporaryFolder;
+
+   public TestActionContext context;
+   public File testInstance;
+
+   @BeforeEach
+   public void setUp() {
+      context = new TestActionContext();
+      testInstance = new File(temporaryFolder, "test-instance");
+   }
+
+   @Test
+   public void testJournalMaxIo() throws Exception {
+      int journalMaxIo = RandomUtil.randomInt();
+
+      Create c = new Create();
+      c.setAio(true);
+      c.setJournalMaxIo(journalMaxIo);
+      c.setInstance(testInstance);
+      c.execute(context);
+
+      assertTrue(fileContains(new File(testInstance, "etc/" + Create.ETC_BROKER_XML), "<journal-max-io>" + journalMaxIo + "</journal-max-io>"));
+   }
+
+   @Test
+   public void testJournalMaxIoNegative() throws Exception {
+      int journalMaxIo = RandomUtil.randomInt();
+
+      Create c = new Create();
+      c.setNio(true);
+      c.setJournalMaxIo(journalMaxIo);
+      c.setInstance(testInstance);
+      c.execute(context);
+
+      assertFalse(fileContains(new File(testInstance, "etc/" + Create.ETC_BROKER_XML), "<journal-max-io>" + journalMaxIo + "</journal-max-io>"));
+      assertTrue(fileContains(new File(testInstance, "etc/" + Create.ETC_BROKER_XML), "<journal-max-io>1</journal-max-io>"));
+   }
+
+   private boolean fileContains(File file, String search) {
+      try (BufferedReader br = new BufferedReader(new FileReader(file))) {
+         String line;
+         while ((line = br.readLine()) != null) {
+            if (line.contains(search)) {
+               return true;
+            }
+         }
+      } catch (IOException e) {
+      }
+      return false;
+   }
+}


### PR DESCRIPTION
I struggled to decide the name of the input, ultimately settling on `--aio-journal-max-io` to clarify that it only applies to `journal-max-io` when using aio.