### PR TITLE
ARTEMIS-5259 don't expose port 9404 in Docker

### DIFF
--- a/artemis-docker/Dockerfile-alpine-21
+++ b/artemis-docker/Dockerfile-alpine-21
@@ -39,10 +39,9 @@ USER artemis
 
 ADD . /opt/activemq-artemis
 
-# Web Server
-EXPOSE 8161 \
-# JMX Exporter
-    9404 \
+EXPOSE \
+# Port for HTTP
+    8161 \
 # Port for CORE,MQTT,AMQP,HORNETQ,STOMP,OPENWIRE
     61616 \
 # Port for HORNETQ,STOMP

--- a/artemis-docker/Dockerfile-alpine-21-jre
+++ b/artemis-docker/Dockerfile-alpine-21-jre
@@ -39,10 +39,9 @@ USER artemis
 
 ADD . /opt/activemq-artemis
 
-# Web Server
-EXPOSE 8161 \
-# JMX Exporter
-    9404 \
+EXPOSE \
+# Port for HTTP
+    8161 \
 # Port for CORE,MQTT,AMQP,HORNETQ,STOMP,OPENWIRE
     61616 \
 # Port for HORNETQ,STOMP

--- a/artemis-docker/Dockerfile-ubuntu-21
+++ b/artemis-docker/Dockerfile-ubuntu-21
@@ -42,10 +42,9 @@ USER artemis
 
 ADD . /opt/activemq-artemis
 
-# Web Server
-EXPOSE 8161 \
-# JMX Exporter
-    9404 \
+EXPOSE \
+# Port for HTTP
+    8161 \
 # Port for CORE,MQTT,AMQP,HORNETQ,STOMP,OPENWIRE
     61616 \
 # Port for HORNETQ,STOMP

--- a/artemis-docker/Dockerfile-ubuntu-21-jre
+++ b/artemis-docker/Dockerfile-ubuntu-21-jre
@@ -42,10 +42,9 @@ USER artemis
 
 ADD . /opt/activemq-artemis
 
-# Web Server
-EXPOSE 8161 \
-# JMX Exporter
-    9404 \
+EXPOSE \
+# Port for HTTP
+    8161 \
 # Port for CORE,MQTT,AMQP,HORNETQ,STOMP,OPENWIRE
     61616 \
 # Port for HORNETQ,STOMP


### PR DESCRIPTION
Port 9404 is exposed in all the Docker files. This port is for the Prometheus JMX Exporter which we have never used. We recommend folks use the Prometheus metrics plugin instead which is available on the normal HTTP port (i.e. 8161).