### PR TITLE
ARTEMIS-5258 Customize browsers to execute console smoke tests

### DIFF
--- a/docs/hacking-guide/_tests.adoc
+++ b/docs/hacking-guide/_tests.adoc
@@ -42,7 +42,8 @@ https://github.com/apache/activemq-artemis/blob/main//tests/integration-tests/sr
 
 The broker has a web console based on https://github.com/hawtio/hawtio[hawtio] and the `smoke-tests` are used to test it.
 For instance, the https://github.com/apache/activemq-artemis/blob/main/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/console/ConsoleTest.java[ConsoleTest] checks the web console using the https://github.com/SeleniumHQ/selenium[selenium framework].
-The tests can be executed using a remote server, local browsers or https://www.testcontainers.org/modules/webdriver_containers[testcontainers].
+The tests can be executed on the Chrome and Firefox browsers by using a remote server, local browsers or https://www.testcontainers.org/modules/webdriver_containers[testcontainers].
+To configure the browsers on which execute the tests set the `webdriver.browsers` property with the comma-separated list of the browsers, i.e. `-Dwebdriver.browsers=chrome,firefox`.
 To use a remote server set the `webdriver.remote.server` property with the URL of the server, ie -Dwebdriver.remote.server=http://localhost:4444/wd/hub To use your local Google Chrome browser download the https://chromedriver.chromium.org/[WebDriver for Chrome] and set the `webdriver.chrome.driver` property with the WebDriver path, ie `-Dwebdriver.chrome.driver=/home/artemis/chromedriver_linux64/chromedriver`.
 To use your local Firefox browser download the https://github.com/mozilla/geckodriver/[WebDriver for Firefox] and set the `webdriver.gecko.driver` property with the WebDriver path, ie `-Dwebdriver.gecko.driver=/home/artemis/geckodriver-linux64/geckodriver`.
 To use https://www.testcontainers.org/modules/webdriver_containers[testcontainers] install docker.

--- a/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/console/ConsoleTest.java
+++ b/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/console/ConsoleTest.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.apache.activemq.artemis.cli.commands.Create;
 import org.apache.activemq.artemis.tests.extensions.parameterized.ParameterizedTestExtension;
@@ -60,20 +61,28 @@ public abstract class ConsoleTest extends SmokeTestBase {
    protected static final String SERVER_ADMIN_USERNAME = "admin";
    protected static final String SERVER_ADMIN_PASSWORD = "admin";
 
+   protected static final String BROWSER_CHROME = "chrome";
+   protected static final String BROWSER_FIREFOX = "firefox";
+
    protected static final int DEFAULT_TIMEOUT = 10000;
 
+   protected String browser;
    protected WebDriver driver;
-   protected MutableCapabilities browserOptions;
    protected String webServerUrl;
    private BrowserWebDriverContainer browserWebDriverContainer;
 
-   @Parameters(name = "browserOptions={0}")
+   @Parameters(name = "browser={0}")
    public static Collection getParameters() {
-      return Arrays.asList(new Object[][]{{new ChromeOptions()}, {new FirefoxOptions()}});
+      String webdriverBrowsers = System.getProperty("webdriver.browsers");
+      if (webdriverBrowsers == null) {
+         webdriverBrowsers = BROWSER_CHROME + "," + BROWSER_FIREFOX;
+      }
+      return Arrays.stream(webdriverBrowsers.split(",")).
+          map(browser -> new Object[]{browser}).collect(Collectors.toList());
    }
 
-   public ConsoleTest(MutableCapabilities browserOptions) {
-      this.browserOptions = browserOptions;
+   public ConsoleTest(String browser) {
+      this.browser = browser;
       this.webServerUrl = String.format("%s://%s:%d", "http", System.getProperty("sts-http-host", "localhost"), 8161);
    }
 
@@ -94,7 +103,10 @@ public abstract class ConsoleTest extends SmokeTestBase {
 
 
       // The ConsoleTest checks the web console using the selenium framework[1].
-      // The tests can be executed using a remote server, local browsers or testcontainers[2].
+      // The tests can be executed on the Chrome and Firefox browser by using
+      // a remote server, local browsers or testcontainers[2].
+      // To configure the browsers on which execute the tests set the `webdriver.browsers` property with
+      // the comma-separated list of the browsers, i.e. `-Dwebdriver.browsers=chrome,firefox`.
       // To use a remote server set the `webdriver.remote.server` property with the URL
       // of the server, ie -Dwebdriver.remote.server=http://localhost:4444/wd/hub
       // To use your local Google Chrome browser download the WebDriver for Chrome[3] and set
@@ -115,19 +127,22 @@ public abstract class ConsoleTest extends SmokeTestBase {
          String webdriverLocation;
          String webdriverArguments;
          String webdriverRemoteServer;
+         MutableCapabilities browserOptions;
          Function<MutableCapabilities, WebDriver> webDriverConstructor;
          BiConsumer<MutableCapabilities, String[]> webdriverArgumentsSetter;
 
-         if (browserOptions instanceof ChromeOptions) {
+         if (BROWSER_CHROME.equals(browser)) {
             webdriverName = "chrome";
-            webDriverConstructor = browserOptions -> new ChromeDriver((ChromeOptions)browserOptions);
-            webdriverArgumentsSetter = (browserOptions, arguments) -> ((ChromeOptions) browserOptions).addArguments(arguments);
-         } else if (browserOptions instanceof FirefoxOptions) {
+            browserOptions = new ChromeOptions();
+            webDriverConstructor = browserOpts -> new ChromeDriver((ChromeOptions)browserOpts);
+            webdriverArgumentsSetter = (browserOpts, arguments) -> ((ChromeOptions) browserOpts).addArguments(arguments);
+         } else if (BROWSER_FIREFOX.equals(browser)) {
             webdriverName = "gecko";
-            webDriverConstructor = browserOptions -> new FirefoxDriver((FirefoxOptions)browserOptions);
-            webdriverArgumentsSetter = (browserOptions, arguments) -> ((FirefoxOptions) browserOptions).addArguments(arguments);
+            browserOptions = new FirefoxOptions();
+            webDriverConstructor = browserOpts -> new FirefoxDriver((FirefoxOptions)browserOpts);
+            webdriverArgumentsSetter = (browserOpts, arguments) -> ((FirefoxOptions) browserOpts).addArguments(arguments);
          } else {
-            throw new IllegalStateException("Unexpected browserOptions: " + browserOptions);
+            throw new IllegalStateException("Unexpected browser: " + browser);
          }
 
          webdriverArguments = System.getProperty("webdriver." + webdriverName + ".driver.args");
@@ -149,7 +164,7 @@ public abstract class ConsoleTest extends SmokeTestBase {
          } else {
             Testcontainers.exposeHostPorts(8161);
             webServerUrl = webServerUrl.replace("localhost", "host.testcontainers.internal");
-            browserWebDriverContainer = new BrowserWebDriverContainer().withCapabilities(this.browserOptions);
+            browserWebDriverContainer = new BrowserWebDriverContainer().withCapabilities(browserOptions);
             browserWebDriverContainer.start();
             driver = browserWebDriverContainer.getWebDriver();
          }

--- a/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/console/LoginTest.java
+++ b/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/console/LoginTest.java
@@ -22,7 +22,6 @@ import org.apache.activemq.artemis.tests.extensions.parameterized.ParameterizedT
 import org.apache.activemq.artemis.tests.smoke.console.pages.LoginPage;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.openqa.selenium.MutableCapabilities;
 
 //Parameters set in super class
 @ExtendWith(ParameterizedTestExtension.class)
@@ -30,8 +29,8 @@ public class LoginTest extends ConsoleTest {
 
    private static final String DEFAULT_CONSOLE_LOGIN_BRAND_IMAGE = "/activemq-branding/plugin/img/activemq.png";
 
-   public LoginTest(MutableCapabilities browserOptions) {
-      super(browserOptions);
+   public LoginTest(String browser) {
+      super(browser);
    }
 
    @TestTemplate

--- a/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/console/QueuesTest.java
+++ b/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/console/QueuesTest.java
@@ -36,7 +36,6 @@ import org.apache.activemq.artemis.tests.smoke.console.pages.StatusPage;
 import org.apache.activemq.artemis.utils.Wait;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.openqa.selenium.MutableCapabilities;
 
 import javax.management.ObjectName;
 
@@ -44,8 +43,8 @@ import javax.management.ObjectName;
 @ExtendWith(ParameterizedTestExtension.class)
 public class QueuesTest extends ConsoleTest {
 
-   public QueuesTest(MutableCapabilities browserOptions) {
-      super(browserOptions);
+   public QueuesTest(String browser) {
+      super(browser);
    }
 
    @TestTemplate

--- a/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/console/RootTest.java
+++ b/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/console/RootTest.java
@@ -21,14 +21,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.apache.activemq.artemis.tests.extensions.parameterized.ParameterizedTestExtension;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.openqa.selenium.MutableCapabilities;
 
 //Parameters set in super class
 @ExtendWith(ParameterizedTestExtension.class)
 public class RootTest extends ConsoleTest {
 
-   public RootTest(MutableCapabilities browserOptions) {
-      super(browserOptions);
+   public RootTest(String browser) {
+      super(browser);
    }
 
    @TestTemplate

--- a/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/console/TabsTest.java
+++ b/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/console/TabsTest.java
@@ -23,15 +23,14 @@ import org.apache.activemq.artemis.tests.smoke.console.pages.LoginPage;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.openqa.selenium.By;
-import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.NoSuchElementException;
 
 //Parameters set in super class
 @ExtendWith(ParameterizedTestExtension.class)
 public class TabsTest extends ConsoleTest {
 
-   public TabsTest(MutableCapabilities browserOptions) {
-      super(browserOptions);
+   public TabsTest(String browser) {
+      super(browser);
    }
 
    @TestTemplate


### PR DESCRIPTION
Support the system property `webdriver.browsers` to customize the list of browsers to execute the console smoke tests.