### PR TITLE
ARTEMIS-5263 Remove unused Docker directive

### DIFF
--- a/artemis-docker/Dockerfile-alpine-21
+++ b/artemis-docker/Dockerfile-alpine-21
@@ -26,8 +26,6 @@ RUN addgroup --gid 1001 --system artemis && adduser --uid 1001 --ingroup artemis
 # alpine doesn't come with bash
 RUN /bin/sh -c "apk update && apk upgrade --no-cache && apk add --no-cache bash libaio"
 
-# Make sure pipes are considered to determine success, see: https://github.com/hadolint/hadolint/wiki/DL4006
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 WORKDIR /opt
 
 ENV ARTEMIS_USER artemis
@@ -44,13 +42,13 @@ EXPOSE \
     8161 \
 # Port for CORE,MQTT,AMQP,HORNETQ,STOMP,OPENWIRE
     61616 \
-# Port for HORNETQ,STOMP
+# Port for legacy HORNETQ,STOMP clients
     5445 \
 # Port for AMQP
     5672 \
 # Port for MQTT
     1883 \
-#Port for STOMP
+# Port for STOMP
     61613
 
 USER root

--- a/artemis-docker/Dockerfile-alpine-21-jre
+++ b/artemis-docker/Dockerfile-alpine-21-jre
@@ -26,8 +26,6 @@ RUN addgroup --gid 1001 --system artemis && adduser --uid 1001 --ingroup artemis
 # alpine doesn't come with bash
 RUN /bin/sh -c "apk update && apk upgrade --no-cache && apk add --no-cache bash libaio"
 
-# Make sure pipes are considered to determine success, see: https://github.com/hadolint/hadolint/wiki/DL4006
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 WORKDIR /opt
 
 ENV ARTEMIS_USER artemis
@@ -44,13 +42,13 @@ EXPOSE \
     8161 \
 # Port for CORE,MQTT,AMQP,HORNETQ,STOMP,OPENWIRE
     61616 \
-# Port for HORNETQ,STOMP
+# Port for legacy HORNETQ,STOMP clients
     5445 \
 # Port for AMQP
     5672 \
 # Port for MQTT
     1883 \
-#Port for STOMP
+# Port for STOMP
     61613
 
 USER root

--- a/artemis-docker/Dockerfile-ubuntu-21
+++ b/artemis-docker/Dockerfile-ubuntu-21
@@ -19,8 +19,6 @@
 
 FROM eclipse-temurin:21-jdk
 LABEL maintainer="Apache ActiveMQ Team"
-# Make sure pipes are considered to determine success, see: https://github.com/hadolint/hadolint/wiki/DL4006
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 WORKDIR /opt
 
 ENV ARTEMIS_USER artemis
@@ -34,9 +32,8 @@ RUN groupadd -g 1001 -r artemis && useradd -r -u 1001 -g artemis artemis
 # install AIO
 RUN apt-get -qq -o=Dpkg::Use-Pty=0 update && \
     apt-get -qq -o=Dpkg::Use-Pty=0 install -y libaio1t64 && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/libaio.so.1
+    rm -rf /var/lib/apt/lists/* && \
+    ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/libaio.so.1
 
 USER artemis
 
@@ -47,13 +44,13 @@ EXPOSE \
     8161 \
 # Port for CORE,MQTT,AMQP,HORNETQ,STOMP,OPENWIRE
     61616 \
-# Port for HORNETQ,STOMP
+# Port for legacy HORNETQ,STOMP clients
     5445 \
 # Port for AMQP
     5672 \
 # Port for MQTT
     1883 \
-#Port for STOMP
+# Port for STOMP
     61613
 
 USER root

--- a/artemis-docker/Dockerfile-ubuntu-21-jre
+++ b/artemis-docker/Dockerfile-ubuntu-21-jre
@@ -19,8 +19,6 @@
 
 FROM eclipse-temurin:21-jre
 LABEL maintainer="Apache ActiveMQ Team"
-# Make sure pipes are considered to determine success, see: https://github.com/hadolint/hadolint/wiki/DL4006
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 WORKDIR /opt
 
 ENV ARTEMIS_USER artemis
@@ -34,9 +32,8 @@ RUN groupadd -g 1001 -r artemis && useradd -r -u 1001 -g artemis artemis
 # install AIO
 RUN apt-get -qq -o=Dpkg::Use-Pty=0 update && \
     apt-get -qq -o=Dpkg::Use-Pty=0 install -y libaio1t64 && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/libaio.so.1
+    rm -rf /var/lib/apt/lists/* && \
+    ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/libaio.so.1
 
 USER artemis
 
@@ -47,13 +44,13 @@ EXPOSE \
     8161 \
 # Port for CORE,MQTT,AMQP,HORNETQ,STOMP,OPENWIRE
     61616 \
-# Port for HORNETQ,STOMP
+# Port for legacy HORNETQ,STOMP clients
     5445 \
 # Port for AMQP
     5672 \
 # Port for MQTT
     1883 \
-#Port for STOMP
+# Port for STOMP
     61613
 
 USER root


### PR DESCRIPTION
JMX Exporter is long gone and pipes are not used in the scripts anymore. Plus, some other minor adjustments.

P.S. Next bash could probably also be removed from Alpine images to keep them small as the whole point of Alpine images are small size. I didn't do tests at the moment, but quickly looking at docker-run.sh and prepare-docker.sh didn't find anything requiring bash.