### PR TITLE
ARTEMIS-5279 Add remote federation views to management services

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ObjectNameBuilder.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ObjectNameBuilder.java
@@ -141,12 +141,44 @@ public final class ObjectNameBuilder {
     * for use in an ObjectName.getIstnace call but is intended for use by broker connection components to create
     * names specific to a broker connection feature that registers its own object for management.
     *
+    * @param name
+    *    The broker connection name
+    *
     * @return the base object name string that is used for broker connection Object names.
     *
     * @see BrokerConnectionControl
     */
    public String getBrokerConnectionBaseObjectNameString(String name) throws Exception {
       return getActiveMQServerName() + ",component=broker-connections,name=" + ObjectName.quote(name);
+   }
+
+   /**
+    * Returns the ObjectName used by remote broker connection management objects for incoming connections.
+    *
+    * @see RemoteBrokerConnectionControl
+    */
+   public ObjectName getRemoteBrokerConnectionObjectName(String nodeId, String name) throws Exception {
+      return ObjectName.getInstance(getRemoteBrokerConnectionBaseObjectNameString(nodeId, name));
+   }
+
+   /**
+    * Returns the base ObjectName string used by for incoming broker connections and possibly broker connection
+    * services that are registered by broker connection specific features. This value is pre-quoted and ready
+    * for use in an ObjectName.getIstnace call but is intended for use by broker connection components to create
+    * names specific to a broker connection feature that registers its own object for management.
+    *
+    * @param nodeId
+    *    The node ID of the remote broker that initiated the broker connection.
+    * @param name
+    *    The broker connection name configured on the initiating broker.
+    *
+    * @return the base object name string that is used for broker connection Object names.
+    */
+   public String getRemoteBrokerConnectionBaseObjectNameString(String nodeId, String name) throws Exception {
+      return getActiveMQServerName() +
+             ",component=remote-broker-connections" +
+             ",nodeId=" + ObjectName.quote(nodeId) +
+             ",name=" + ObjectName.quote(name);
    }
 
    /**

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/RemoteBrokerConnectionControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/RemoteBrokerConnectionControl.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.api.core.management;
+
+/**
+ * An API for a RemoteBrokerConnectionControl object that is used to view information about
+ * active remote broker connections.
+ */
+public interface RemoteBrokerConnectionControl {
+
+   /**
+    * Returns the name of the remote broker connection
+    */
+   @Attribute(desc = "name of the remote broker connection")
+   String getName();
+
+   /**
+    * Returns the Node ID of the remote broker connection
+    */
+   @Attribute(desc = "Node ID of the remote broker connection")
+   String getNodeId();
+
+   /**
+    * Returns the wire protocol this broker connection is using.
+    */
+   @Attribute(desc = "the wire protocol this broker connection is using")
+   String getProtocol();
+
+}

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ResourceNames.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ResourceNames.java
@@ -36,6 +36,8 @@ public final class ResourceNames {
 
    public static final String BROKER_CONNECTION = "brokerconnection.";
 
+   public static final String REMOTE_BROKER_CONNECTION = "remotebrokerconnection.";
+
    public static final String BRIDGE = "bridge.";
 
    public static final String ACCEPTOR = "acceptor.";

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/ProtonProtocolManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/ProtonProtocolManager.java
@@ -51,6 +51,7 @@ import org.apache.activemq.artemis.spi.core.remoting.Connection;
 
 import io.netty.channel.ChannelPipeline;
 import org.apache.activemq.artemis.utils.DestinationUtil;
+import org.apache.qpid.proton.amqp.Symbol;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.lang.invoke.MethodHandles;
@@ -220,20 +221,24 @@ public class ProtonProtocolManager extends AbstractProtocolManager<AMQPMessage, 
 
    @Override
    public ConnectionEntry createConnectionEntry(Acceptor acceptorUsed, Connection remotingConnection) {
-      return internalConnectionEntry(remotingConnection, false, null);
+      return internalConnectionEntry(remotingConnection, false, null, null);
    }
 
    /** This method is not part of the ProtocolManager interface because it only makes sense on AMQP.
     *  More specifically on AMQP Bridges */
    public ConnectionEntry createOutgoingConnectionEntry(Connection remotingConnection) {
-      return internalConnectionEntry(remotingConnection, true, null);
+      return internalConnectionEntry(remotingConnection, true, null, null);
    }
 
    public ConnectionEntry createOutgoingConnectionEntry(Connection remotingConnection, ClientSASLFactory saslFactory) {
-      return internalConnectionEntry(remotingConnection, true, saslFactory);
+      return internalConnectionEntry(remotingConnection, true, saslFactory, null);
    }
 
-   private ConnectionEntry internalConnectionEntry(Connection remotingConnection, boolean outgoing, ClientSASLFactory saslFactory) {
+   public ConnectionEntry createOutgoingConnectionEntry(Connection remotingConnection, ClientSASLFactory saslFactory, Map<Symbol, Object> connectionProperties) {
+      return internalConnectionEntry(remotingConnection, true, saslFactory, connectionProperties);
+   }
+
+   private ConnectionEntry internalConnectionEntry(Connection remotingConnection, boolean outgoing, ClientSASLFactory saslFactory, Map<Symbol, Object> connectionProperties) {
       AMQPConnectionCallback connectionCallback = new AMQPConnectionCallback(this, remotingConnection, server.getExecutorFactory().getExecutor(), server);
       long ttl = ActiveMQClient.DEFAULT_CONNECTION_TTL;
 
@@ -251,7 +256,7 @@ public class ProtonProtocolManager extends AbstractProtocolManager<AMQPMessage, 
 
       String id = server.getNodeID().toString();
       boolean useCoreSubscriptionNaming = server.getConfiguration().isAmqpUseCoreSubscriptionNaming();
-      AMQPConnectionContext amqpConnection = new AMQPConnectionContext(this, connectionCallback, id, (int) ttl, getMaxFrameSize(), AMQPConstants.Connection.DEFAULT_CHANNEL_MAX, useCoreSubscriptionNaming, server.getScheduledPool(), true, saslFactory, null, outgoing);
+      AMQPConnectionContext amqpConnection = new AMQPConnectionContext(this, connectionCallback, id, (int) ttl, getMaxFrameSize(), AMQPConstants.Connection.DEFAULT_CHANNEL_MAX, useCoreSubscriptionNaming, server.getScheduledPool(), true, saslFactory, connectionProperties, outgoing);
 
       Executor executor = server.getExecutorFactory().getExecutor();
 

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/AMQPBrokerConnection.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/AMQPBrokerConnection.java
@@ -113,6 +113,9 @@ import org.apache.qpid.proton.engine.Session;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.activemq.artemis.protocol.amqp.connect.AMQPBrokerConnectionConstants.BROKER_CONNECTION_INFO;
+import static org.apache.activemq.artemis.protocol.amqp.connect.AMQPBrokerConnectionConstants.CONNECTION_NAME;
+import static org.apache.activemq.artemis.protocol.amqp.connect.AMQPBrokerConnectionConstants.NODE_ID;
 import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.AMQP_LINK_INITIALIZER_KEY;
 import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.verifyCapabilities;
 import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.verifyOfferedCapabilities;
@@ -460,8 +463,17 @@ public class AMQPBrokerConnection implements ClientConnectionLifeCycleListener, 
 
          ClientSASLFactory saslFactory = new SaslFactory(connection, brokerConnectConfiguration);
 
+         final Map<String, Object> brokerConnectionInfo = new HashMap<>();
+
+         brokerConnectionInfo.put(CONNECTION_NAME, getName());
+         brokerConnectionInfo.put(NODE_ID, server.getNodeID().toString());
+
+         final Map<Symbol, Object> brokerConnectionProperties = new HashMap<>();
+
+         brokerConnectionProperties.put(BROKER_CONNECTION_INFO, brokerConnectionInfo);
+
          NettyConnectorCloseHandler connectorCloseHandler = new NettyConnectorCloseHandler(connector, connectExecutor);
-         ConnectionEntry entry = protonProtocolManager.createOutgoingConnectionEntry(connection, saslFactory);
+         ConnectionEntry entry = protonProtocolManager.createOutgoingConnectionEntry(connection, saslFactory, brokerConnectionProperties);
          server.getRemotingService().addConnectionEntry(connection, entry);
          protonRemotingConnection = (ActiveMQProtonRemotingConnection) entry.connection;
          protonRemotingConnection.getAmqpConnection().addLinkRemoteCloseListener(getName(), this::linkClosed);

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/AMQPBrokerConnectionConstants.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/AMQPBrokerConnectionConstants.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect;
+
+import org.apache.qpid.proton.amqp.Symbol;
+
+/**
+ * A collection of constants used for AMQP broker connections.
+ */
+public abstract class AMQPBrokerConnectionConstants {
+
+   /**
+    * Property name used to embed a nested map of properties meant to be conveyed to the remote
+    * peer describing attributes assigned to the AMQP broker connection
+    */
+   public static final Symbol BROKER_CONNECTION_INFO = Symbol.getSymbol("broker-connection-info");
+
+   /**
+    * Map entry key used to carry the AMQP broker connection name to the remote peer in the
+    * information map sent in the AMQP connection properties.
+    */
+   public static final String CONNECTION_NAME = "connectionName";
+
+   /**
+    * Map entry key used to carry the Node ID of the server where the AMQP broker connection
+    * originates from to the remote peer in the information map sent in the AMQP connection properties.
+    */
+   public static final String NODE_ID = "nodeId";
+
+   private AMQPBrokerConnectionConstants() {
+      // Hidden
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/AMQPRemoteBrokerConnection.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/AMQPRemoteBrokerConnection.java
@@ -1,0 +1,286 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect;
+
+import static org.apache.activemq.artemis.protocol.amqp.connect.AMQPBrokerConnectionConstants.BROKER_CONNECTION_INFO;
+import static org.apache.activemq.artemis.protocol.amqp.connect.AMQPBrokerConnectionConstants.CONNECTION_NAME;
+import static org.apache.activemq.artemis.protocol.amqp.connect.AMQPBrokerConnectionConstants.NODE_ID;
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.ActiveMQIllegalStateException;
+import org.apache.activemq.artemis.core.remoting.FailureListener;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.RemoteBrokerConnection;
+import org.apache.activemq.artemis.protocol.amqp.broker.ActiveMQProtonRemotingConnection;
+import org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationTarget;
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPConnectionContext;
+import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.engine.Connection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A Utility class that represents the remote end of an incoming AMQP broker
+ * connection used to provide a common root for services that are active on
+ * a given incoming broker connection.
+ */
+public class AMQPRemoteBrokerConnection implements RemoteBrokerConnection {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   public static final String REMOTE_BROKER_CONNECTION_RECORD = "REMOTE_BROKER_CONNECTION_RECORD";
+
+   private enum State {
+      UNINITIALIZED,
+      STARTED,
+      SHUTDOWN
+   }
+
+   private List<AMQPFederationTarget> federations = new ArrayList<>();
+   private final ActiveMQServer server;
+   private final AMQPConnectionContext connection;
+   private final String remoteNodeId;
+   private final String remoteConnectionName;
+
+   private State state = State.UNINITIALIZED;
+
+   public AMQPRemoteBrokerConnection(ActiveMQServer server, AMQPConnectionContext connection, String remoteNodeId, String remoteConnectionName) {
+      this.server = server;
+      this.connection = connection;
+      this.remoteNodeId = remoteNodeId;
+      this.remoteConnectionName = remoteConnectionName;
+   }
+
+   /**
+    * @return the server instance that owns this remote broker connection
+    */
+   public ActiveMQServer getServer() {
+      return server;
+   }
+
+   /**
+    * @return the connection context for this incoming broker connection.
+    */
+   public AMQPConnectionContext getConnection() {
+      return connection;
+   }
+
+   /**
+    * @return the remote node ID if it was provided or null if not supplied on connect.
+    */
+   @Override
+   public String getNodeId() {
+      return remoteNodeId;
+   }
+
+   /**
+    * @return the remote broker connection name if it was provided or null if not supplied on connect.
+    */
+   @Override
+   public String getName() {
+      return remoteConnectionName;
+   }
+
+   @Override
+   public String getProtocol() {
+      return "AMQP";
+   }
+
+   /**
+    * Returns <code>true</code> if the remote broker connection was established with enough information to uniquely
+    * identify the connection source for purposes of adding the remote connection into the server management services.
+    *
+    * @return <code>true</code> if the remote broker connection was created with sufficient information to add to management.
+    */
+   public boolean isManagable() {
+      return remoteConnectionName != null &&
+             !remoteConnectionName.isBlank() &&
+             remoteNodeId != null &&
+             !remoteNodeId.isBlank();
+   }
+
+   /**
+    * @return has this remote broker connection been initialized.
+    */
+   public boolean isInitialized() {
+      return state.ordinal() > State.UNINITIALIZED.ordinal();
+   }
+
+   /**
+    * @return has this remote broker connection been started.
+    */
+   public boolean isStarted() {
+      return state == State.STARTED;
+   }
+
+   /**
+    * @return has this remote broker connection been shutdown.
+    */
+   public boolean isShutdown() {
+      return state == State.SHUTDOWN;
+   }
+
+   /**
+    * Initialize the remote broker connection object which moves it to the started state where
+    * it will remain until shutdown.
+    *
+    * @throws ActiveMQException if an error occurs on initialization.
+    */
+   @Override
+   public synchronized void initialize() throws ActiveMQException {
+      failIfShutdown();
+
+      if (state == State.UNINITIALIZED) {
+         state = State.STARTED;
+
+         if (isManagable()) {
+            try {
+               server.getManagementService().registerRemoteBrokerConnection(this);
+            } catch (Exception e) {
+               logger.warn("Ignoring error while attempting to register remote broker connection with management services");
+            }
+         }
+      }
+   }
+
+   /**
+    * Shutdown the remote broker connection object which removes any management objects and
+    * informs any registered services of the shutdown.
+    */
+   @Override
+   public synchronized void shutdown() {
+      if (state.ordinal() < State.SHUTDOWN.ordinal()) {
+         state = State.SHUTDOWN;
+
+         if (isManagable()) {
+            try {
+               server.getManagementService().unregisterRemoteBrokerConnection(getNodeId(), getName());
+            } catch (Exception e) {
+               logger.warn("Ignoring error while attempting to unregister remote broker connection with management services");
+            }
+         }
+
+         federations.forEach((federation) -> {
+            try {
+               federation.shutdown();
+            } catch (ActiveMQException e) {
+               logger.warn("Exception suppressed on remote broker federation shutdown: ", e);
+            }
+         });
+      }
+   }
+
+   /**
+    * Add a new federation target to this remote broker connection instance which will
+    * be started if this federation instance has already been started.
+    *
+    * @param federation
+    *
+    * @return this remote broker connection instance.
+    *
+    * @throws ActiveMQException if an error occurs while adding the federation to this connection.
+    */
+   public synchronized AMQPRemoteBrokerConnection addFederationTarget(AMQPFederationTarget federation) throws ActiveMQException {
+      failIfShutdown();
+
+      if (isStarted()) {
+         federation.start();
+      }
+
+      this.federations.add(federation);
+
+      return this;
+   }
+
+   /**
+    * Utility methods for checking the current connection for an existing remote broker connection instance
+    * and returning it, or creating a new instance if none yet exists and initializing it.
+    *
+    * @param server
+    *    The server instance that has accepted the remote broker connection.
+    * @param connection
+    *    The connection context object that is assigned to the active connection.
+    * @param protonConnection
+    *    The proton connection instance where the connection attachments are stored.
+    *
+    * @return a remote broker connection instance that has been initialized that is scoped to the active connection.
+    *
+    * @throws ActiveMQException if an error occurs while attempting to get a remote broker connection instance.
+    */
+   @SuppressWarnings("unchecked")
+   public static AMQPRemoteBrokerConnection getOrCreateRemoteBrokerConnection(ActiveMQServer server, AMQPConnectionContext connection, Connection protonConnection) throws ActiveMQException {
+      final org.apache.qpid.proton.engine.Record attachments = protonConnection.attachments();
+
+      // There is only one instance per remote broker connection, either this is the first time a service
+      // requested it in which case we build it, or we already built it so we can get it from the attachments.
+      AMQPRemoteBrokerConnection brokerConnection = attachments.get(REMOTE_BROKER_CONNECTION_RECORD, AMQPRemoteBrokerConnection.class);
+
+      if (brokerConnection == null) {
+         final Map<Symbol, Object> connectionProperties = protonConnection.getRemoteProperties() != null ?
+            protonConnection.getRemoteProperties() : Collections.EMPTY_MAP;
+         final Map<String, Object> brokerConnectionInfo = (Map<String, Object>) connectionProperties.getOrDefault(BROKER_CONNECTION_INFO, Collections.EMPTY_MAP);
+
+         final ActiveMQProtonRemotingConnection remoteingConnection = connection.getConnectionCallback().getProtonConnectionDelegate();
+         final String remoteNodeId = (String) brokerConnectionInfo.get(NODE_ID);
+         final String remoteConnectionName = (String) brokerConnectionInfo.get(CONNECTION_NAME);
+
+         final AMQPRemoteBrokerConnection newBrokerConnection =
+            brokerConnection = new AMQPRemoteBrokerConnection(server, connection, remoteNodeId, remoteConnectionName);
+
+         brokerConnection.initialize();
+
+         // When the connection drops the remote broker connection needs to cleanup all its resources to ensure
+         // things like management objects are properly removed and cleaned up.
+         remoteingConnection.addCloseListener(() -> handleConnectionShutdown(newBrokerConnection));
+         remoteingConnection.addFailureListener(new FailureListener() {
+
+            @Override
+            public void connectionFailed(ActiveMQException exception, boolean failedOver, String scaleDownTargetNodeID) {
+               handleConnectionShutdown(newBrokerConnection);
+            }
+
+            @Override
+            public void connectionFailed(ActiveMQException exception, boolean failedOver) {
+               handleConnectionShutdown(newBrokerConnection);
+            }
+         });
+
+         attachments.set(REMOTE_BROKER_CONNECTION_RECORD, AMQPRemoteBrokerConnection.class, brokerConnection);
+      }
+
+      return brokerConnection;
+   }
+
+   private static void handleConnectionShutdown(AMQPRemoteBrokerConnection connection) {
+      try {
+         connection.shutdown();
+      } catch (Exception e) {
+         logger.warn("Exception suppressed on remote broker connection shutdown: ", e);
+      }
+   }
+
+   private void failIfShutdown() throws ActiveMQIllegalStateException {
+      if (state == State.SHUTDOWN) {
+         throw new ActiveMQIllegalStateException("The remote broker connection instance has been shutdown");
+      }
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederation.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederation.java
@@ -53,7 +53,7 @@ public abstract class AMQPFederation implements Federation {
    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
    private enum State {
-      UNITIALIZED,
+      UNINITIALIZED,
       STOPPED,
       STARTED,
       SHUTDOWN
@@ -82,7 +82,6 @@ public abstract class AMQPFederation implements Federation {
    protected final WildcardConfiguration wildcardConfiguration;
    protected final ScheduledExecutorService scheduler;
 
-   protected final String brokerConnectionName;
    protected final String name;
    protected final ActiveMQServer server;
    protected final AMQPFederationMetrics metrics = new AMQPFederationMetrics();
@@ -94,14 +93,13 @@ public abstract class AMQPFederation implements Federation {
    protected volatile AMQPConnectionContext connection;
    protected volatile AMQPSessionContext session;
 
-   protected volatile State state = State.UNITIALIZED;
+   protected volatile State state = State.UNINITIALIZED;
    protected volatile boolean connected;
 
-   public AMQPFederation(String brokerConnectionName, String name, ActiveMQServer server) {
+   public AMQPFederation(String name, ActiveMQServer server) {
       Objects.requireNonNull(name, "Federation name cannot be null");
       Objects.requireNonNull(server, "Provided server instance cannot be null");
 
-      this.brokerConnectionName = brokerConnectionName;
       this.name = name;
       this.server = server;
       this.scheduler = server.getScheduledPool();
@@ -176,7 +174,7 @@ public abstract class AMQPFederation implements Federation {
    public final synchronized void initialize() throws ActiveMQException {
       failIfShutdown();
 
-      if (state == State.UNITIALIZED) {
+      if (state == State.UNINITIALIZED) {
          state = State.STOPPED;
          handleFederationInitialized();
 
@@ -719,6 +717,6 @@ public abstract class AMQPFederation implements Federation {
 
    abstract void registerFederationProducerManagement(AMQPFederationSenderController sender) throws Exception;
 
-   abstract void unregisterFederationProdcerManagement(AMQPFederationSenderController sender) throws Exception;
+   abstract void unregisterFederationProducerManagement(AMQPFederationSenderController sender) throws Exception;
 
 }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationConfiguration.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationConfiguration.java
@@ -85,7 +85,6 @@ public final class AMQPFederationConfiguration {
    private final Map<String, Object> properties;
    private final AMQPConnectionContext connection;
 
-   @SuppressWarnings("unchecked")
    public AMQPFederationConfiguration(AMQPConnectionContext connection, Map<String, Object> properties) {
       Objects.requireNonNull(connection, "Connection provided cannot be null");
 

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationConstants.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationConstants.java
@@ -302,6 +302,14 @@ public final class AMQPFederationConstants {
    public static final String RECEIVER_QUIESCE_TIMEOUT = "receiverQuiesceTimeout";
 
    /**
+    * Property name used to carry the name of the federation that triggered creation of the remote
+    * connection. This value is intended to be added to AMQP control link properties to provide the
+    * remote peer with the name of the federation that triggered the creation of the control link
+    * and allow for lookup of metrics or other data associated with a remote federation targets.
+    */
+   public static final Symbol FEDERATION_NAME = Symbol.valueOf("federationName");
+
+   /**
     * Property name used to carry the name of the federation policy that triggered creation of the
     * remote resource. This value is intended to be added to AMQP link properties to provide the
     * remote peer with the name of the federation policy that triggered the creation of the link

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationManagementSupport.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationManagementSupport.java
@@ -29,29 +29,60 @@ import org.apache.activemq.artemis.utils.CompositeAddress;
  */
 public abstract class AMQPFederationManagementSupport {
 
+   // Resource names specific to federation resources that exist on the local end of a broker connection.
+
    /**
     * Template used to denote federation source instances in the server management registry.
     */
-   public static final String FEDERATION_SOURCE_RESOURCE_TEMPLATE = "brokerconnection.local.federation.%s";
+   public static final String FEDERATION_SOURCE_RESOURCE_TEMPLATE = "brokerconnection.%s.federation.%s";
 
    /**
-    * Template used to denote local federation policy managers in the server management registry.
+    * Template used to denote federation policy managers created on the source in the server management registry.
     */
-   public static final String FEDERATION_POLICY_RESOURCE_TEMPLATE = "brokerconnection.local.federation.%s.policy.%s";
+   public static final String FEDERATION_SOURCE_POLICY_RESOURCE_TEMPLATE = FEDERATION_SOURCE_RESOURCE_TEMPLATE + ".policy.%s";
 
    /**
-    * Template used to denote local federation consumers in the server management registry. Since policy names
-    * are unique on the local broker AMQP federation configuration these names should not collide as each policy
-    * will create only one consumer for a given address or queue.
+    * Template used to denote federation consumers on the source in the server management registry. Since policy
+    * names are unique on the local broker AMQP federation configuration these names should not collide as each
+    * policy will create only one consumer for a given address or queue.
     */
-   public static final String FEDERATION_CONSUMER_RESOURCE_TEMPLATE = "brokerconnection.local.federation.%s.policy.%s.consumer.%s";
+   public static final String FEDERATION_SOURCE_CONSUMER_RESOURCE_TEMPLATE = FEDERATION_SOURCE_POLICY_RESOURCE_TEMPLATE + ".consumer.%s";
 
    /**
-    * Template used to denote local federation producers in the server management registry. Since policy names
-    * are unique on the local broker AMQP federation configuration these names should not collide as each policy
-    * will create only one producer for a given address or queue.
+    * Template used to denote federation producers on the source in the server management registry. Since policy
+    * names are unique on the local broker AMQP federation configuration these names should not collide as each
+    * policy will create only one producer for a given address or queue.
     */
-   public static final String FEDERATION_PRODUCER_RESOURCE_TEMPLATE = "brokerconnection.local.federation.%s.policy.%s.producer.%s";
+   public static final String FEDERATION_SOURCE_PRODUCER_RESOURCE_TEMPLATE = FEDERATION_SOURCE_POLICY_RESOURCE_TEMPLATE + ".producer.%s";
+
+   // Resource names specific to federation resources that exist on the remote end of a broker connection.
+
+   /**
+    * Template used to denote federation source instances in the server management registry.
+    */
+   public static final String FEDERATION_TARGET_RESOURCE_TEMPLATE = "node.%s.brokerconnection.%s.federation.%s";
+
+   /**
+    * Template used to denote federation policy managers created on the source in the server management registry.
+    */
+   public static final String FEDERATION_TARGET_POLICY_RESOURCE_TEMPLATE = FEDERATION_TARGET_RESOURCE_TEMPLATE + ".policy.%s";
+
+   /**
+    * Template used to denote federation consumers on the source in the server management registry. Since policy
+    * names are unique on the local broker AMQP federation configuration these names should not collide as each
+    * policy will create only one consumer for a given address or queue.
+    */
+   public static final String FEDERATION_TARGET_CONSUMER_RESOURCE_TEMPLATE = FEDERATION_TARGET_POLICY_RESOURCE_TEMPLATE + ".consumer.%s";
+
+   /**
+    * Template used to denote federation producers on the source in the server management registry. Since policy
+    * names are unique on the local broker AMQP federation configuration these names should not collide as each
+    * policy will create only one producer for a given address or queue.
+    */
+   public static final String FEDERATION_TARGET_PRODUCER_RESOURCE_TEMPLATE = FEDERATION_TARGET_POLICY_RESOURCE_TEMPLATE + ".producer.%s";
+
+   // MBean naming that will be registered under an name that links to the location of the bean
+   // either source or target end of the broker connection.
 
    /**
     * The template used to create the object name suffix that is appending to the broker connection
@@ -99,7 +130,7 @@ public abstract class AMQPFederationManagementSupport {
     *
     * @throws Exception if an error occurs while registering the federation with the management services.
     */
-   public static void registerFederationManagement(AMQPFederationSource federation) throws Exception {
+   public static void registerFederationSource(AMQPFederationSource federation) throws Exception {
       final String federationName = federation.getName();
       final String brokerConnectionName = federation.getBrokerConnection().getName();
       final ActiveMQServer server = federation.getServer();
@@ -107,7 +138,7 @@ public abstract class AMQPFederationManagementSupport {
       final AMQPFederationSourceControlType control = new AMQPFederationSourceControlType(server, federation);
 
       management.registerInJMX(getFederationSourceObjectName(management, brokerConnectionName, federationName), control);
-      management.registerInRegistry(getFederationSourceResourceName(federationName), control);
+      management.registerInRegistry(getFederationSourceResourceName(brokerConnectionName, federationName), control);
    }
 
    /**
@@ -118,33 +149,77 @@ public abstract class AMQPFederationManagementSupport {
     *
     * @throws Exception if an error occurs while unregistering the federation with the management services.
     */
-   public static void unregisterFederationManagement(AMQPFederationSource federation) throws Exception {
+   public static void unregisterFederationSource(AMQPFederationSource federation) throws Exception {
       final String federationName = federation.getName();
       final String brokerConnectionName = federation.getBrokerConnection().getName();
       final ActiveMQServer server = federation.getServer();
       final ManagementService management = server.getManagementService();
 
       management.unregisterFromJMX(getFederationSourceObjectName(management, brokerConnectionName, federationName));
-      management.unregisterFromRegistry(getFederationSourceResourceName(federationName));
+      management.unregisterFromRegistry(getFederationSourceResourceName(brokerConnectionName, federationName));
    }
 
-   public static String getFederationSourceResourceName(String federationName) {
-      return String.format(FEDERATION_SOURCE_RESOURCE_TEMPLATE, federationName);
+   public static String getFederationSourceResourceName(String brokerConnectionName, String federationName) {
+      return String.format(FEDERATION_SOURCE_RESOURCE_TEMPLATE, brokerConnectionName, federationName);
    }
 
    public static ObjectName getFederationSourceObjectName(ManagementService management, String brokerConnection, String federationName) throws Exception {
-      final String brokerConnectionName = management.getObjectNameBuilder().getBrokerConnectionBaseObjectNameString(brokerConnection);
-
       return ObjectName.getInstance(
          String.format("%s," + FEDERATION_NAME_TEMPLATE,
-            brokerConnectionName,
+            management.getObjectNameBuilder().getBrokerConnectionBaseObjectNameString(brokerConnection),
+            ObjectName.quote(federationName)));
+   }
+
+   /**
+    * Register the given {@link AMQPFederationTarget} instance with the broker management services.
+    *
+    * @param federation
+    *    The federation target instance being registered with management.
+    *
+    * @throws Exception if an error occurs while registering the federation with the management services.
+    */
+   public static void registerFederationTarget(String remoteNodeId, String brokerConnectionName, AMQPFederationTarget federation) throws Exception {
+      final String federationName = federation.getName();
+      final ActiveMQServer server = federation.getServer();
+      final ManagementService management = server.getManagementService();
+      final AMQPFederationTargetControlType control = new AMQPFederationTargetControlType(server, federation);
+
+      management.registerInJMX(getFederationTargetObjectName(management, remoteNodeId, brokerConnectionName, federationName), control);
+      management.registerInRegistry(getFederationTargetResourceName(remoteNodeId, brokerConnectionName, federationName), control);
+   }
+
+   /**
+    * Unregister the given {@link AMQPFederationTarget} instance with the broker management services.
+    *
+    * @param federation
+    *    The federation target instance being unregistered from management.
+    *
+    * @throws Exception if an error occurs while unregistering the federation with the management services.
+    */
+   public static void unregisterFederationTarget(String remoteNodeId, String brokerConnectionName, AMQPFederationTarget federation) throws Exception {
+      final String federationName = federation.getName();
+      final ActiveMQServer server = federation.getServer();
+      final ManagementService management = server.getManagementService();
+
+      management.unregisterFromJMX(getFederationTargetObjectName(management, remoteNodeId, brokerConnectionName, federationName));
+      management.unregisterFromRegistry(getFederationTargetResourceName(remoteNodeId, brokerConnectionName, federationName));
+   }
+
+   public static String getFederationTargetResourceName(String remoteNodeId, String brokerConnectionName, String federationName) {
+      return String.format(FEDERATION_TARGET_RESOURCE_TEMPLATE, remoteNodeId, brokerConnectionName, federationName);
+   }
+
+   public static ObjectName getFederationTargetObjectName(ManagementService management, String remoteNodeId, String brokerConnection, String federationName) throws Exception {
+      return ObjectName.getInstance(
+         String.format("%s," + FEDERATION_NAME_TEMPLATE,
+            management.getObjectNameBuilder().getRemoteBrokerConnectionBaseObjectNameString(remoteNodeId, brokerConnection),
             ObjectName.quote(federationName)));
    }
 
    // APIs for federation address and queue policy management
 
    /**
-    * Register a local federation policy manager with the server management services.
+    * Register a local federation policy manager with the server management services for a federation source.
     *
     * @param brokerConnectionName
     *    The name of the broker connection that owns the manager being registered.
@@ -153,7 +228,7 @@ public abstract class AMQPFederationManagementSupport {
     *
     * @throws Exception if an error occurs while registering the manager with the management services.
     */
-   public static void registerLocalPolicyManagement(String brokerConnectionName, AMQPFederationLocalPolicyManager manager) throws Exception {
+   public static void registerLocalPolicyOnSource(String brokerConnectionName, AMQPFederationLocalPolicyManager manager) throws Exception {
       final AMQPFederation federation = manager.getFederation();
       final ActiveMQServer server = federation.getServer();
       final ManagementService management = server.getManagementService();
@@ -161,12 +236,12 @@ public abstract class AMQPFederationManagementSupport {
       final String federationName = federation.getName();
       final String policyName = manager.getPolicyName();
 
-      management.registerInJMX(getFederationPolicyObjectName(management, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName), control);
-      management.registerInRegistry(getFederationPolicyResourceName(federationName, policyName), control);
+      management.registerInJMX(getFederationSourcePolicyObjectName(management, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName), control);
+      management.registerInRegistry(getFederationSourcePolicyResourceName(brokerConnectionName, federationName, policyName), control);
    }
 
    /**
-    * Unregister a local federation policy manager with the server management services.
+    * Unregister a local federation policy manager with the server management services for a federation source.
     *
     * @param brokerConnectionName
     *    The name of the broker connection that owns the manager being unregistered.
@@ -175,19 +250,19 @@ public abstract class AMQPFederationManagementSupport {
     *
     * @throws Exception if an error occurs while unregistering the manager with the management services.
     */
-   public static void unregisterLocalPolicyManagement(String brokerConnectionName, AMQPFederationLocalPolicyManager manager) throws Exception {
+   public static void unregisterLocalPolicyOnSource(String brokerConnectionName, AMQPFederationLocalPolicyManager manager) throws Exception {
       final AMQPFederation federation = manager.getFederation();
       final ActiveMQServer server = federation.getServer();
       final ManagementService management = server.getManagementService();
       final String federationName = federation.getName();
       final String policyName = manager.getPolicyName();
 
-      management.unregisterFromJMX(getFederationPolicyObjectName(management, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName));
-      management.unregisterFromRegistry(getFederationPolicyResourceName(federationName, policyName));
+      management.unregisterFromJMX(getFederationSourcePolicyObjectName(management, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName));
+      management.unregisterFromRegistry(getFederationSourcePolicyResourceName(brokerConnectionName, federationName, policyName));
    }
 
    /**
-    * Register a remote federation policy manager with the server management services.
+    * Register a remote federation policy manager with the server management services for a federation source.
     *
     * @param brokerConnectionName
     *    The name of the broker connection that owns the manager being registered.
@@ -196,7 +271,7 @@ public abstract class AMQPFederationManagementSupport {
     *
     * @throws Exception if an error occurs while registering the manager with the management services.
     */
-   public static void registerRemotePolicyManagement(String brokerConnectionName, AMQPFederationRemotePolicyManager manager) throws Exception {
+   public static void registerRemotePolicyOnSource(String brokerConnectionName, AMQPFederationRemotePolicyManager manager) throws Exception {
       final AMQPFederation federation = manager.getFederation();
       final ActiveMQServer server = federation.getServer();
       final ManagementService management = server.getManagementService();
@@ -204,12 +279,12 @@ public abstract class AMQPFederationManagementSupport {
       final String federationName = federation.getName();
       final String policyName = manager.getPolicyName();
 
-      management.registerInJMX(getFederationPolicyObjectName(management, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName), control);
-      management.registerInRegistry(getFederationPolicyResourceName(federationName, policyName), control);
+      management.registerInJMX(getFederationSourcePolicyObjectName(management, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName), control);
+      management.registerInRegistry(getFederationSourcePolicyResourceName(brokerConnectionName, federationName, policyName), control);
    }
 
    /**
-    * Unregister a remote federation policy manager with the server management services.
+    * Unregister a remote federation policy manager with the server management services for a federation source.
     *
     * @param brokerConnectionName
     *    The name of the broker connection that owns the manager being unregistered.
@@ -218,27 +293,132 @@ public abstract class AMQPFederationManagementSupport {
     *
     * @throws Exception if an error occurs while unregistering the manager with the management services.
     */
-   public static void unregisterRemotePolicyManagement(String brokerConnectionName, AMQPFederationRemotePolicyManager manager) throws Exception {
+   public static void unregisterRemotePolicyOnSource(String brokerConnectionName, AMQPFederationRemotePolicyManager manager) throws Exception {
       final AMQPFederation federation = manager.getFederation();
       final ActiveMQServer server = federation.getServer();
       final ManagementService management = server.getManagementService();
       final String federationName = federation.getName();
       final String policyName = manager.getPolicyName();
 
-      management.unregisterFromJMX(getFederationPolicyObjectName(management, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName));
-      management.unregisterFromRegistry(getFederationPolicyResourceName(federationName, policyName));
+      management.unregisterFromJMX(getFederationSourcePolicyObjectName(management, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName));
+      management.unregisterFromRegistry(getFederationSourcePolicyResourceName(brokerConnectionName, federationName, policyName));
    }
 
-   public static String getFederationPolicyResourceName(String federationName, String policyName) {
-      return String.format(FEDERATION_POLICY_RESOURCE_TEMPLATE, federationName, policyName);
+   public static String getFederationSourcePolicyResourceName(String brokerConnectionName, String federationName, String policyName) {
+      return String.format(FEDERATION_SOURCE_POLICY_RESOURCE_TEMPLATE, brokerConnectionName, federationName, policyName);
    }
 
-   public static ObjectName getFederationPolicyObjectName(ManagementService management, String brokerConnection, String federationName, String policyType, String policyName) throws Exception {
-      final String brokerConnectionName = management.getObjectNameBuilder().getBrokerConnectionBaseObjectNameString(brokerConnection);
-
+   public static ObjectName getFederationSourcePolicyObjectName(ManagementService management, String brokerConnection, String federationName, String policyType, String policyName) throws Exception {
       return ObjectName.getInstance(
          String.format("%s," + FEDERATION_POLICY_NAME_TEMPLATE,
-            brokerConnectionName,
+            management.getObjectNameBuilder().getBrokerConnectionBaseObjectNameString(brokerConnection),
+            ObjectName.quote(federationName),
+            ObjectName.quote(policyType),
+            ObjectName.quote(policyName)));
+   }
+
+   /**
+    * Register a local federation policy manager with the server management services for a federation target.
+    *
+    * @param remoteNodeId
+    *    The remote broker node ID that is the source of the federation operations.
+    * @param brokerConnectionName
+    *    The name of the remote broker connection that owns the manager being registered.
+    * @param manager
+    *    The AMQP federation policy manager instance that is being managed.
+    *
+    * @throws Exception if an error occurs while registering the manager with the management services.
+    */
+   public static void registerLocalPolicyOnTarget(String remoteNodeId, String brokerConnectionName, AMQPFederationLocalPolicyManager manager) throws Exception {
+      final AMQPFederation federation = manager.getFederation();
+      final ActiveMQServer server = federation.getServer();
+      final ManagementService management = server.getManagementService();
+      final AMQPFederationLocalPolicyControlType control = new AMQPFederationLocalPolicyControlType(manager);
+      final String federationName = federation.getName();
+      final String policyName = manager.getPolicyName();
+
+      management.registerInJMX(getFederationTargetPolicyObjectName(management, remoteNodeId, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName), control);
+      management.registerInRegistry(getFederationTargetPolicyResourceName(remoteNodeId, brokerConnectionName, federationName, policyName), control);
+   }
+
+   /**
+    * Unregister a local federation policy manager with the server management services for a federation target.
+    *
+    * @param remoteNodeId
+    *    The remote broker node ID that is the source of the federation operations.
+    * @param brokerConnectionName
+    *    The name of the remote broker connection that owns the manager being unregistered.
+    * @param manager
+    *    The AMQP federation policy manager instance that is being managed.
+    *
+    * @throws Exception if an error occurs while unregistering the manager with the management services.
+    */
+   public static void unregisterLocalPolicyOnTarget(String remoteNodeId, String brokerConnectionName, AMQPFederationLocalPolicyManager manager) throws Exception {
+      final AMQPFederation federation = manager.getFederation();
+      final ActiveMQServer server = federation.getServer();
+      final ManagementService management = server.getManagementService();
+      final String federationName = federation.getName();
+      final String policyName = manager.getPolicyName();
+
+      management.unregisterFromJMX(getFederationTargetPolicyObjectName(management, remoteNodeId, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName));
+      management.unregisterFromRegistry(getFederationTargetPolicyResourceName(remoteNodeId, brokerConnectionName, federationName, policyName));
+   }
+
+   /**
+    * Register a remote federation policy manager with the server management services for a federation target.
+    *
+    * @param remoteNodeId
+    *    The remote broker node ID that is the source of the federation operations.
+    * @param brokerConnectionName
+    *    The name of the remote broker connection that owns the manager being registered.
+    * @param manager
+    *    The AMQP federation policy manager instance that is being managed.
+    *
+    * @throws Exception if an error occurs while registering the manager with the management services.
+    */
+   public static void registerRemotePolicyOnTarget(String remoteNodeId, String brokerConnectionName, AMQPFederationRemotePolicyManager manager) throws Exception {
+      final AMQPFederation federation = manager.getFederation();
+      final ActiveMQServer server = federation.getServer();
+      final ManagementService management = server.getManagementService();
+      final AMQPFederationRemotePolicyControl control = new AMQPFederationRemotePolicyControlType(server, manager);
+      final String federationName = federation.getName();
+      final String policyName = manager.getPolicyName();
+
+      management.registerInJMX(getFederationTargetPolicyObjectName(management, remoteNodeId, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName), control);
+      management.registerInRegistry(getFederationTargetPolicyResourceName(remoteNodeId, brokerConnectionName, federationName, policyName), control);
+   }
+
+   /**
+    * Unregister a remote federation policy manager with the server management services for a federation target.
+    *
+    * @param remoteNodeId
+    *    The remote broker node ID that is the source of the federation operations.
+    * @param brokerConnectionName
+    *    The name of the remote broker connection that owns the manager being unregistered.
+    * @param manager
+    *    The AMQP federation policy manager instance that is being managed.
+    *
+    * @throws Exception if an error occurs while unregistering the manager with the management services.
+    */
+   public static void unregisterRemotePolicyOnTarget(String remoteNodeId, String brokerConnectionName, AMQPFederationRemotePolicyManager manager) throws Exception {
+      final AMQPFederation federation = manager.getFederation();
+      final ActiveMQServer server = federation.getServer();
+      final ManagementService management = server.getManagementService();
+      final String federationName = federation.getName();
+      final String policyName = manager.getPolicyName();
+
+      management.unregisterFromJMX(getFederationTargetPolicyObjectName(management, remoteNodeId, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName));
+      management.unregisterFromRegistry(getFederationTargetPolicyResourceName(remoteNodeId, brokerConnectionName, federationName, policyName));
+   }
+
+   public static String getFederationTargetPolicyResourceName(String remoteNodeId, String brokerConnectionName, String federationName, String policyName) {
+      return String.format(FEDERATION_TARGET_POLICY_RESOURCE_TEMPLATE, remoteNodeId, brokerConnectionName, federationName, policyName);
+   }
+
+   public static ObjectName getFederationTargetPolicyObjectName(ManagementService management, String remoteNodeId, String brokerConnection, String federationName, String policyType, String policyName) throws Exception {
+      return ObjectName.getInstance(
+         String.format("%s," + FEDERATION_POLICY_NAME_TEMPLATE,
+            management.getObjectNameBuilder().getRemoteBrokerConnectionBaseObjectNameString(remoteNodeId, brokerConnection),
             ObjectName.quote(federationName),
             ObjectName.quote(policyType),
             ObjectName.quote(policyName)));
@@ -247,7 +427,7 @@ public abstract class AMQPFederationManagementSupport {
    // APIs for federation consumer and producer management
 
    /**
-    * Registers the federation consumer with the server management services.
+    * Registers the federation consumer with the server management services on the source.
     *
     * @param brokerConnectionName
     *    The name of the broker connection that owns the consumer being registered.
@@ -256,7 +436,7 @@ public abstract class AMQPFederationManagementSupport {
     *
     * @throws Exception if an error occurs while registering the consumer with the management services.
     */
-   public static void registerFederationConsumerManagement(String brokerConnectionName, AMQPFederationConsumer consumer) throws Exception {
+   public static void registerFederationSourceConsumer(String brokerConnectionName, AMQPFederationConsumer consumer) throws Exception {
       final AMQPFederationPolicyManager manager = consumer.getPolicyManager();
       final AMQPFederation federation = manager.getFederation();
       final ActiveMQServer server = federation.getServer();
@@ -266,16 +446,16 @@ public abstract class AMQPFederationManagementSupport {
       final String policyName = manager.getPolicyName();
 
       if (consumer.getRole() == FederationConsumerInfo.Role.ADDRESS_CONSUMER) {
-         management.registerInJMX(getFederationAddressConsumerObjectName(management, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName, consumer.getConsumerInfo().getAddress()), control);
-         management.registerInRegistry(getFederationAddressConsumerResourceName(federationName, policyName, consumer.getConsumerInfo().getAddress()), control);
+         management.registerInJMX(getFederationSourceAddressConsumerObjectName(management, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName, consumer.getConsumerInfo().getAddress()), control);
+         management.registerInRegistry(getFederationSourceAddressConsumerResourceName(brokerConnectionName, federationName, policyName, consumer.getConsumerInfo().getAddress()), control);
       } else {
-         management.registerInJMX(getFederationQueueConsumerObjectName(management, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName, consumer.getConsumerInfo().getFqqn()), control);
-         management.registerInRegistry(getFederationQueueConsumerResourceName(federationName, policyName, consumer.getConsumerInfo().getFqqn()), control);
+         management.registerInJMX(getFederationSourceQueueConsumerObjectName(management, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName, consumer.getConsumerInfo().getFqqn()), control);
+         management.registerInRegistry(getFederationSourceQueueConsumerResourceName(brokerConnectionName, federationName, policyName, consumer.getConsumerInfo().getFqqn()), control);
       }
    }
 
    /**
-    * Unregisters the federation consumer with the server management services.
+    * Unregisters the federation consumer with the server management services on the source.
     *
     * @param brokerConnectionName
     *    The name of the broker connection that owns the consumer being registered.
@@ -284,7 +464,7 @@ public abstract class AMQPFederationManagementSupport {
     *
     * @throws Exception if an error occurs while registering the consumer with the management services.
     */
-   public static void unregisterFederationConsumerManagement(String brokerConnectionName, AMQPFederationConsumer consumer) throws Exception {
+   public static void unregisterFederationSourceConsumer(String brokerConnectionName, AMQPFederationConsumer consumer) throws Exception {
       final AMQPFederationPolicyManager manager = consumer.getPolicyManager();
       final AMQPFederation federation = manager.getFederation();
       final ActiveMQServer server = federation.getServer();
@@ -293,16 +473,16 @@ public abstract class AMQPFederationManagementSupport {
       final String policyName = manager.getPolicyName();
 
       if (consumer.getRole() == FederationConsumerInfo.Role.ADDRESS_CONSUMER) {
-         management.unregisterFromJMX(getFederationAddressConsumerObjectName(management, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName, consumer.getConsumerInfo().getAddress()));
-         management.unregisterFromRegistry(getFederationAddressConsumerResourceName(federationName, policyName, consumer.getConsumerInfo().getAddress()));
+         management.unregisterFromJMX(getFederationSourceAddressConsumerObjectName(management, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName, consumer.getConsumerInfo().getAddress()));
+         management.unregisterFromRegistry(getFederationSourceAddressConsumerResourceName(brokerConnectionName, federationName, policyName, consumer.getConsumerInfo().getAddress()));
       } else {
-         management.unregisterFromJMX(getFederationQueueConsumerObjectName(management, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName, consumer.getConsumerInfo().getFqqn()));
-         management.unregisterFromRegistry(getFederationQueueConsumerResourceName(federationName, policyName, consumer.getConsumerInfo().getFqqn()));
+         management.unregisterFromJMX(getFederationSourceQueueConsumerObjectName(management, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName, consumer.getConsumerInfo().getFqqn()));
+         management.unregisterFromRegistry(getFederationSourceQueueConsumerResourceName(brokerConnectionName, federationName, policyName, consumer.getConsumerInfo().getFqqn()));
       }
    }
 
    /**
-    * Registers the federation producer with the server management services.
+    * Registers the federation producer with the server management services on the source.
     *
     * @param brokerConnectionName
     *    The name of the broker connection that owns the producer being registered.
@@ -311,7 +491,7 @@ public abstract class AMQPFederationManagementSupport {
     *
     * @throws Exception if an error occurs while registering the producer with the management services.
     */
-   public static void registerFederationProducerManagement(String brokerConnectionName, AMQPFederationSenderController sender) throws Exception {
+   public static void registerFederationSourceProducer(String brokerConnectionName, AMQPFederationSenderController sender) throws Exception {
       final AMQPFederationPolicyManager manager = sender.getPolicyManager();
       final AMQPFederation federation = manager.getFederation();
       final ActiveMQServer server = federation.getServer();
@@ -323,18 +503,18 @@ public abstract class AMQPFederationManagementSupport {
       if (sender.getRole() == Role.ADDRESS_PRODUCER) {
          final String address = control.getAddress();
 
-         management.registerInJMX(getFederationAddressProducerObjectName(management, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName, address), control);
-         management.registerInRegistry(getFederationAddressProducerResourceName(federationName, policyName, address), control);
+         management.registerInJMX(getFederationSourceAddressProducerObjectName(management, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName, address), control);
+         management.registerInRegistry(getFederationSourceAddressProducerResourceName(brokerConnectionName, federationName, policyName, address), control);
       } else {
          final String fqqn = control.getFqqn();
 
-         management.registerInJMX(getFederationQueueProducerObjectName(management, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName, fqqn), control);
-         management.registerInRegistry(getFederationQueueProducerResourceName(federationName, policyName, fqqn), control);
+         management.registerInJMX(getFederationSourceQueueProducerObjectName(management, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName, fqqn), control);
+         management.registerInRegistry(getFederationSourceQueueProducerResourceName(brokerConnectionName, federationName, policyName, fqqn), control);
       }
    }
 
    /**
-    * Unregisters the federation producer with the server management services.
+    * Unregisters the federation producer with the server management services on the source.
     *
     * @param brokerConnectionName
     *    The name of the broker connection that owns the producer being registered.
@@ -343,7 +523,7 @@ public abstract class AMQPFederationManagementSupport {
     *
     * @throws Exception if an error occurs while registering the producer with the management services.
     */
-   public static void unregisterFederationProducerManagement(String brokerConnectionName, AMQPFederationSenderController sender) throws Exception {
+   public static void unregisterFederationSourceProducer(String brokerConnectionName, AMQPFederationSenderController sender) throws Exception {
       final AMQPFederationPolicyManager manager = sender.getPolicyManager();
       final AMQPFederation federation = manager.getFederation();
       final ActiveMQServer server = federation.getServer();
@@ -354,74 +534,240 @@ public abstract class AMQPFederationManagementSupport {
       if (sender.getRole() == Role.ADDRESS_PRODUCER) {
          final String address = sender.getServerConsumer().getQueueAddress().toString();
 
-         management.unregisterFromJMX(getFederationAddressProducerObjectName(management, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName, address));
-         management.unregisterFromRegistry(getFederationAddressProducerResourceName(federationName, policyName, address));
+         management.unregisterFromJMX(getFederationSourceAddressProducerObjectName(management, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName, address));
+         management.unregisterFromRegistry(getFederationSourceAddressProducerResourceName(brokerConnectionName, federationName, policyName, address));
       } else {
          final String fqqn = CompositeAddress.toFullyQualified(sender.getServerConsumer().getQueueAddress().toString(), sender.getServerConsumer().getQueueName().toString());
 
-         management.unregisterFromJMX(getFederationQueueProducerObjectName(management, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName, fqqn));
-         management.unregisterFromRegistry(getFederationQueueProducerResourceName(federationName, policyName, fqqn));
+         management.unregisterFromJMX(getFederationSourceQueueProducerObjectName(management, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName, fqqn));
+         management.unregisterFromRegistry(getFederationSourceQueueProducerResourceName(brokerConnectionName, federationName, policyName, fqqn));
       }
    }
 
-   public static String getFederationAddressConsumerResourceName(String federationName, String policyName, String address) {
-      return String.format(FEDERATION_CONSUMER_RESOURCE_TEMPLATE, federationName, policyName, address);
+   public static String getFederationSourceAddressConsumerResourceName(String brokerConnectionName, String federationName, String policyName, String address) {
+      return String.format(FEDERATION_SOURCE_CONSUMER_RESOURCE_TEMPLATE, brokerConnectionName, federationName, policyName, address);
    }
 
-   public static String getFederationQueueConsumerResourceName(String federationName, String policyName, String fqqn) {
-      return String.format(FEDERATION_CONSUMER_RESOURCE_TEMPLATE, federationName, policyName, fqqn);
+   public static String getFederationSourceQueueConsumerResourceName(String brokerConnectionName, String federationName, String policyName, String fqqn) {
+      return String.format(FEDERATION_SOURCE_CONSUMER_RESOURCE_TEMPLATE, brokerConnectionName, federationName, policyName, fqqn);
    }
 
-   public static String getFederationAddressProducerResourceName(String federationName, String policyName, String address) {
-      return String.format(FEDERATION_PRODUCER_RESOURCE_TEMPLATE, federationName, policyName, address);
+   public static String getFederationSourceAddressProducerResourceName(String brokerConnectionName, String federationName, String policyName, String address) {
+      return String.format(FEDERATION_SOURCE_PRODUCER_RESOURCE_TEMPLATE, brokerConnectionName, federationName, policyName, address);
    }
 
-   public static String getFederationQueueProducerResourceName(String federationName, String policyName, String fqqn) {
-      return String.format(FEDERATION_PRODUCER_RESOURCE_TEMPLATE, federationName, policyName, fqqn);
+   public static String getFederationSourceQueueProducerResourceName(String brokerConnectionName, String federationName, String policyName, String fqqn) {
+      return String.format(FEDERATION_SOURCE_PRODUCER_RESOURCE_TEMPLATE, brokerConnectionName, federationName, policyName, fqqn);
    }
 
-   public static ObjectName getFederationAddressConsumerObjectName(ManagementService management, String brokerConnection, String federationName, String policyType, String policyName, String address) throws Exception {
-      final String brokerConnectionName = management.getObjectNameBuilder().getBrokerConnectionBaseObjectNameString(brokerConnection);
-
+   public static ObjectName getFederationSourceAddressConsumerObjectName(ManagementService management, String brokerConnection, String federationName, String policyType, String policyName, String address) throws Exception {
       return ObjectName.getInstance(
          String.format("%s," + FEDERATION_ADDRESS_CONSUMER_NAME_TEMPLATE,
-            brokerConnectionName,
+            management.getObjectNameBuilder().getBrokerConnectionBaseObjectNameString(brokerConnection),
             ObjectName.quote(federationName),
             ObjectName.quote(policyType),
             ObjectName.quote(policyName),
             ObjectName.quote(address)));
    }
 
-   public static ObjectName getFederationAddressProducerObjectName(ManagementService management, String brokerConnection, String federationName, String policyType, String policyName, String address) throws Exception {
-      final String brokerConnectionName = management.getObjectNameBuilder().getBrokerConnectionBaseObjectNameString(brokerConnection);
-
+   public static ObjectName getFederationSourceAddressProducerObjectName(ManagementService management, String brokerConnection, String federationName, String policyType, String policyName, String address) throws Exception {
       return ObjectName.getInstance(
          String.format("%s," + FEDERATION_ADDRESS_PRODUCER_NAME_TEMPLATE,
-            brokerConnectionName,
+            management.getObjectNameBuilder().getBrokerConnectionBaseObjectNameString(brokerConnection),
             ObjectName.quote(federationName),
             ObjectName.quote(policyType),
             ObjectName.quote(policyName),
             ObjectName.quote(address)));
    }
 
-   public static ObjectName getFederationQueueConsumerObjectName(ManagementService management, String brokerConnection, String federationName, String policyType, String policyName, String fqqn) throws Exception {
-      final String brokerConnectionName = management.getObjectNameBuilder().getBrokerConnectionBaseObjectNameString(brokerConnection);
-
+   public static ObjectName getFederationSourceQueueConsumerObjectName(ManagementService management, String brokerConnection, String federationName, String policyType, String policyName, String fqqn) throws Exception {
       return ObjectName.getInstance(
          String.format("%s," + FEDERATION_QUEUE_CONSUMER_NAME_TEMPLATE,
-            brokerConnectionName,
+            management.getObjectNameBuilder().getBrokerConnectionBaseObjectNameString(brokerConnection),
             ObjectName.quote(federationName),
             ObjectName.quote(policyType),
             ObjectName.quote(policyName),
             ObjectName.quote(fqqn)));
    }
 
-   public static ObjectName getFederationQueueProducerObjectName(ManagementService management, String brokerConnection, String federationName, String policyType, String policyName, String fqqn) throws Exception {
-      final String brokerConnectionName = management.getObjectNameBuilder().getBrokerConnectionBaseObjectNameString(brokerConnection);
-
+   public static ObjectName getFederationSourceQueueProducerObjectName(ManagementService management, String brokerConnection, String federationName, String policyType, String policyName, String fqqn) throws Exception {
       return ObjectName.getInstance(
          String.format("%s," + FEDERATION_QUEUE_PRODUCER_NAME_TEMPLATE,
-            brokerConnectionName,
+            management.getObjectNameBuilder().getBrokerConnectionBaseObjectNameString(brokerConnection),
+            ObjectName.quote(federationName),
+            ObjectName.quote(policyType),
+            ObjectName.quote(policyName),
+            ObjectName.quote(fqqn)));
+   }
+
+   /**
+    * Registers the federation consumer with the server management services on the target.
+    *
+    * @param brokerConnectionName
+    *    The name of the remote broker connection that owns the consumer being registered.
+    * @param consumer
+    *    The AMQP federation consumer instance that is being managed.
+    *
+    * @throws Exception if an error occurs while registering the consumer with the management services.
+    */
+   public static void registerFederationTargetConsumer(String remoteNodeId, String brokerConnectionName, AMQPFederationConsumer consumer) throws Exception {
+      final AMQPFederationPolicyManager manager = consumer.getPolicyManager();
+      final AMQPFederation federation = manager.getFederation();
+      final ActiveMQServer server = federation.getServer();
+      final ManagementService management = server.getManagementService();
+      final AMQPFederationConsumerControlType control = new AMQPFederationConsumerControlType(consumer);
+      final String federationName = federation.getName();
+      final String policyName = manager.getPolicyName();
+
+      if (consumer.getRole() == FederationConsumerInfo.Role.ADDRESS_CONSUMER) {
+         management.registerInJMX(getFederationTargetAddressConsumerObjectName(management, remoteNodeId, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName, consumer.getConsumerInfo().getAddress()), control);
+         management.registerInRegistry(getFederationTargetAddressConsumerResourceName(remoteNodeId, brokerConnectionName, federationName, policyName, consumer.getConsumerInfo().getAddress()), control);
+      } else {
+         management.registerInJMX(getFederationTargetQueueConsumerObjectName(management, remoteNodeId, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName, consumer.getConsumerInfo().getFqqn()), control);
+         management.registerInRegistry(getFederationTargetQueueConsumerResourceName(remoteNodeId, brokerConnectionName, federationName, policyName, consumer.getConsumerInfo().getFqqn()), control);
+      }
+   }
+
+   /**
+    * Unregisters the federation consumer with the server management services on the target.
+    *
+    * @param brokerConnectionName
+    *    The name of the remote broker connection that owns the consumer being registered.
+    * @param consumer
+    *    The AMQP federation consumer instance that is being managed.
+    *
+    * @throws Exception if an error occurs while registering the consumer with the management services.
+    */
+   public static void unregisterFederationTargetConsumer(String remoteNodeId, String brokerConnectionName, AMQPFederationConsumer consumer) throws Exception {
+      final AMQPFederationPolicyManager manager = consumer.getPolicyManager();
+      final AMQPFederation federation = manager.getFederation();
+      final ActiveMQServer server = federation.getServer();
+      final ManagementService management = server.getManagementService();
+      final String federationName = federation.getName();
+      final String policyName = manager.getPolicyName();
+
+      if (consumer.getRole() == FederationConsumerInfo.Role.ADDRESS_CONSUMER) {
+         management.unregisterFromJMX(getFederationTargetAddressConsumerObjectName(management, remoteNodeId, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName, consumer.getConsumerInfo().getAddress()));
+         management.unregisterFromRegistry(getFederationTargetAddressConsumerResourceName(remoteNodeId, brokerConnectionName, federationName, policyName, consumer.getConsumerInfo().getAddress()));
+      } else {
+         management.unregisterFromJMX(getFederationTargetQueueConsumerObjectName(management, remoteNodeId, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName, consumer.getConsumerInfo().getFqqn()));
+         management.unregisterFromRegistry(getFederationTargetQueueConsumerResourceName(remoteNodeId, brokerConnectionName, federationName, policyName, consumer.getConsumerInfo().getFqqn()));
+      }
+   }
+
+   /**
+    * Registers the federation producer with the server management services on the target.
+    *
+    * @param brokerConnectionName
+    *    The name of the remote broker connection that owns the producer being registered.
+    * @param sender
+    *    The AMQP federation sender controller that manages the federation producer.
+    *
+    * @throws Exception if an error occurs while registering the producer with the management services.
+    */
+   public static void registerFederationTargetProducer(String remoteNodeId, String brokerConnectionName, AMQPFederationSenderController sender) throws Exception {
+      final AMQPFederationPolicyManager manager = sender.getPolicyManager();
+      final AMQPFederation federation = manager.getFederation();
+      final ActiveMQServer server = federation.getServer();
+      final ManagementService management = server.getManagementService();
+      final AMQPFederationProducerControlType control = new AMQPFederationProducerControlType(sender);
+      final String federationName = federation.getName();
+      final String policyName = manager.getPolicyName();
+
+      if (sender.getRole() == Role.ADDRESS_PRODUCER) {
+         final String address = control.getAddress();
+
+         management.registerInJMX(getFederationTargetAddressProducerObjectName(management, remoteNodeId, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName, address), control);
+         management.registerInRegistry(getFederationTargetAddressProducerResourceName(remoteNodeId, brokerConnectionName, federationName, policyName, address), control);
+      } else {
+         final String fqqn = control.getFqqn();
+
+         management.registerInJMX(getFederationTargetQueueProducerObjectName(management, remoteNodeId, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName, fqqn), control);
+         management.registerInRegistry(getFederationTargetQueueProducerResourceName(remoteNodeId, brokerConnectionName, federationName, policyName, fqqn), control);
+      }
+   }
+
+   /**
+    * Unregisters the federation producer with the server management services on the target.
+    *
+    * @param brokerConnectionName
+    *    The name of the remote broker connection that owns the producer being registered.
+    * @param sender
+    *    The AMQP federation sender controller that manages the federation producer.
+    *
+    * @throws Exception if an error occurs while registering the producer with the management services.
+    */
+   public static void unregisterFederationTargetProducer(String remoteNodeId, String brokerConnectionName, AMQPFederationSenderController sender) throws Exception {
+      final AMQPFederationPolicyManager manager = sender.getPolicyManager();
+      final AMQPFederation federation = manager.getFederation();
+      final ActiveMQServer server = federation.getServer();
+      final ManagementService management = server.getManagementService();
+      final String federationName = federation.getName();
+      final String policyName = manager.getPolicyName();
+
+      if (sender.getRole() == Role.ADDRESS_PRODUCER) {
+         final String address = sender.getServerConsumer().getQueueAddress().toString();
+
+         management.unregisterFromJMX(getFederationTargetAddressProducerObjectName(management, remoteNodeId, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName, address));
+         management.unregisterFromRegistry(getFederationTargetAddressProducerResourceName(remoteNodeId, brokerConnectionName, federationName, policyName, address));
+      } else {
+         final String fqqn = CompositeAddress.toFullyQualified(sender.getServerConsumer().getQueueAddress().toString(), sender.getServerConsumer().getQueueName().toString());
+
+         management.unregisterFromJMX(getFederationTargetQueueProducerObjectName(management, remoteNodeId, brokerConnectionName, federationName, manager.getPolicyType().toString(), policyName, fqqn));
+         management.unregisterFromRegistry(getFederationTargetQueueProducerResourceName(remoteNodeId, brokerConnectionName, federationName, policyName, fqqn));
+      }
+   }
+
+   public static String getFederationTargetAddressConsumerResourceName(String remoteNodeId, String brokerConnectionName, String federationName, String policyName, String address) {
+      return String.format(FEDERATION_SOURCE_CONSUMER_RESOURCE_TEMPLATE, brokerConnectionName, federationName, policyName, address);
+   }
+
+   public static String getFederationTargetQueueConsumerResourceName(String remoteNodeId, String brokerConnectionName, String federationName, String policyName, String fqqn) {
+      return String.format(FEDERATION_SOURCE_CONSUMER_RESOURCE_TEMPLATE, brokerConnectionName, federationName, policyName, fqqn);
+   }
+
+   public static String getFederationTargetAddressProducerResourceName(String remoteNodeId, String brokerConnectionName, String federationName, String policyName, String address) {
+      return String.format(FEDERATION_SOURCE_PRODUCER_RESOURCE_TEMPLATE, brokerConnectionName, federationName, policyName, address);
+   }
+
+   public static String getFederationTargetQueueProducerResourceName(String remoteNodeId, String brokerConnectionName, String federationName, String policyName, String fqqn) {
+      return String.format(FEDERATION_SOURCE_PRODUCER_RESOURCE_TEMPLATE, brokerConnectionName, federationName, policyName, fqqn);
+   }
+
+   public static ObjectName getFederationTargetAddressConsumerObjectName(ManagementService management, String remoteNodeId, String brokerConnection, String federationName, String policyType, String policyName, String address) throws Exception {
+      return ObjectName.getInstance(
+         String.format("%s," + FEDERATION_ADDRESS_CONSUMER_NAME_TEMPLATE,
+            management.getObjectNameBuilder().getRemoteBrokerConnectionBaseObjectNameString(remoteNodeId, brokerConnection),
+            ObjectName.quote(federationName),
+            ObjectName.quote(policyType),
+            ObjectName.quote(policyName),
+            ObjectName.quote(address)));
+   }
+
+   public static ObjectName getFederationTargetAddressProducerObjectName(ManagementService management, String remoteNodeId, String brokerConnection, String federationName, String policyType, String policyName, String address) throws Exception {
+      return ObjectName.getInstance(
+         String.format("%s," + FEDERATION_ADDRESS_PRODUCER_NAME_TEMPLATE,
+            management.getObjectNameBuilder().getRemoteBrokerConnectionBaseObjectNameString(remoteNodeId, brokerConnection),
+            ObjectName.quote(federationName),
+            ObjectName.quote(policyType),
+            ObjectName.quote(policyName),
+            ObjectName.quote(address)));
+   }
+
+   public static ObjectName getFederationTargetQueueConsumerObjectName(ManagementService management, String remoteNodeId, String brokerConnection, String federationName, String policyType, String policyName, String fqqn) throws Exception {
+      return ObjectName.getInstance(
+         String.format("%s," + FEDERATION_QUEUE_CONSUMER_NAME_TEMPLATE,
+            management.getObjectNameBuilder().getRemoteBrokerConnectionBaseObjectNameString(remoteNodeId, brokerConnection),
+            ObjectName.quote(federationName),
+            ObjectName.quote(policyType),
+            ObjectName.quote(policyName),
+            ObjectName.quote(fqqn)));
+   }
+
+   public static ObjectName getFederationTargetQueueProducerObjectName(ManagementService management, String remoteNodeId, String brokerConnection, String federationName, String policyType, String policyName, String fqqn) throws Exception {
+      return ObjectName.getInstance(
+         String.format("%s," + FEDERATION_QUEUE_PRODUCER_NAME_TEMPLATE,
+            management.getObjectNameBuilder().getRemoteBrokerConnectionBaseObjectNameString(remoteNodeId, brokerConnection),
             ObjectName.quote(federationName),
             ObjectName.quote(policyType),
             ObjectName.quote(policyName),

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationPolicySupport.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationPolicySupport.java
@@ -472,7 +472,6 @@ public final class AMQPFederationPolicySupport {
     *
     * @return a new address match and handling policy for use in the broker connection.
     */
-   @SuppressWarnings("unchecked")
    public static FederationReceiveFromAddressPolicy create(AMQPFederationAddressPolicyElement element, WildcardConfiguration wildcards) {
       final Set<String> includes;
       final Set<String> excludes;
@@ -525,7 +524,6 @@ public final class AMQPFederationPolicySupport {
     *
     * @return a new queue match and handling policy for use in the broker connection.
     */
-   @SuppressWarnings("unchecked")
    public static FederationReceiveFromQueuePolicy create(AMQPFederationQueuePolicyElement element, WildcardConfiguration wildcards) {
       final Set<Map.Entry<String, String>> includes;
       final Set<Map.Entry<String, String>> excludes;

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationSenderController.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationSenderController.java
@@ -249,7 +249,7 @@ public abstract class AMQPFederationSenderController implements SenderController
 
    private void unregisterSenderManagement() {
       try {
-         federation.unregisterFederationProdcerManagement(this);
+         federation.unregisterFederationProducerManagement(this);
       } catch (Exception e) {
          logger.trace("Ignored exception while removing sender from management: ", e);
       }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationSource.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationSource.java
@@ -19,6 +19,7 @@ package org.apache.activemq.artemis.protocol.amqp.connect.federation;
 
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_CONTROL_LINK;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_EVENT_LINK;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_NAME;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_CONFIGURATION;
 import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.AMQP_LINK_INITIALIZER_KEY;
 
@@ -102,9 +103,8 @@ public class AMQPFederationSource extends AMQPFederation {
     * @param connection
     *    The broker connection over which this federation will occur.
     */
-   @SuppressWarnings("unchecked")
    public AMQPFederationSource(String name, Map<String, Object> properties, AMQPBrokerConnection connection) {
-      super(connection.getName(), name, connection.getServer());
+      super(name, connection.getServer());
 
       if (properties == null || properties.isEmpty()) {
          this.properties = Collections.emptyMap();
@@ -298,52 +298,52 @@ public class AMQPFederationSource extends AMQPFederation {
 
    @Override
    void registerFederationManagement() throws Exception {
-      AMQPFederationManagementSupport.registerFederationManagement(this);
+      AMQPFederationManagementSupport.registerFederationSource(this);
    }
 
    @Override
    void unregisterFederationManagement() throws Exception {
-      AMQPFederationManagementSupport.unregisterFederationManagement(this);
+      AMQPFederationManagementSupport.unregisterFederationSource(this);
    }
 
    @Override
    void registerLocalPolicyManagement(AMQPFederationLocalPolicyManager manager) throws Exception {
-      AMQPFederationManagementSupport.registerLocalPolicyManagement(brokerConnectionName, manager);
+      AMQPFederationManagementSupport.registerLocalPolicyOnSource(brokerConnection.getName(), manager);
    }
 
    @Override
    void unregisterLocalPolicyManagement(AMQPFederationLocalPolicyManager manager) throws Exception {
-      AMQPFederationManagementSupport.unregisterLocalPolicyManagement(brokerConnectionName, manager);
+      AMQPFederationManagementSupport.unregisterLocalPolicyOnSource(brokerConnection.getName(), manager);
    }
 
    @Override
    void registerRemotePolicyManagement(AMQPFederationRemotePolicyManager manager) throws Exception {
-      AMQPFederationManagementSupport.registerRemotePolicyManagement(brokerConnectionName, manager);
+      AMQPFederationManagementSupport.registerRemotePolicyOnSource(brokerConnection.getName(), manager);
    }
 
    @Override
    void unregisterRemotePolicyManagement(AMQPFederationRemotePolicyManager manager) throws Exception {
-      AMQPFederationManagementSupport.unregisterRemotePolicyManagement(brokerConnectionName, manager);
+      AMQPFederationManagementSupport.unregisterRemotePolicyOnSource(brokerConnection.getName(), manager);
    }
 
    @Override
    void registerFederationConsumerManagement(AMQPFederationConsumer consumer) throws Exception {
-      AMQPFederationManagementSupport.registerFederationConsumerManagement(brokerConnectionName, consumer);
+      AMQPFederationManagementSupport.registerFederationSourceConsumer(brokerConnection.getName(), consumer);
    }
 
    @Override
    void unregisterFederationConsumerManagement(AMQPFederationConsumer consumer) throws Exception {
-      AMQPFederationManagementSupport.unregisterFederationConsumerManagement(brokerConnectionName, consumer);
+      AMQPFederationManagementSupport.unregisterFederationSourceConsumer(brokerConnection.getName(), consumer);
    }
 
    @Override
    void registerFederationProducerManagement(AMQPFederationSenderController sender) throws Exception {
-      AMQPFederationManagementSupport.registerFederationProducerManagement(brokerConnectionName, sender);
+      AMQPFederationManagementSupport.registerFederationSourceProducer(brokerConnection.getName(), sender);
    }
 
    @Override
-   void unregisterFederationProdcerManagement(AMQPFederationSenderController sender) throws Exception {
-      AMQPFederationManagementSupport.unregisterFederationProducerManagement(brokerConnectionName, sender);
+   void unregisterFederationProducerManagement(AMQPFederationSenderController sender) throws Exception {
+      AMQPFederationManagementSupport.unregisterFederationSourceProducer(brokerConnection.getName(), sender);
    }
 
    private void asyncCreateTargetEventsSender(AMQPFederationCommandDispatcher commandLink) {
@@ -609,6 +609,7 @@ public class AMQPFederationSource extends AMQPFederation {
             // for use when creating remote federation resources.
             final Map<Symbol, Object> senderProperties = new HashMap<>();
             senderProperties.put(FEDERATION_CONFIGURATION, configuration.toConfigurationMap());
+            senderProperties.put(FEDERATION_NAME, getName());
 
             sender.setSenderSettleMode(SenderSettleMode.UNSETTLED);
             sender.setReceiverSettleMode(ReceiverSettleMode.FIRST);

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationTarget.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationTarget.java
@@ -20,7 +20,7 @@ package org.apache.activemq.artemis.protocol.amqp.connect.federation;
 import java.util.Objects;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.protocol.amqp.connect.AMQPRemoteBrokerConnection;
 import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPException;
 import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPInternalErrorException;
 import org.apache.activemq.artemis.protocol.amqp.federation.FederationConstants;
@@ -42,14 +42,16 @@ import org.apache.qpid.proton.engine.Link;
  */
 public class AMQPFederationTarget extends AMQPFederation {
 
+   private final AMQPRemoteBrokerConnection brokerConnection;
    private final AMQPConnectionContext connection;
    private final AMQPFederationConfiguration configuration;
 
-   public AMQPFederationTarget(String name, AMQPFederationConfiguration configuration, AMQPSessionContext session, ActiveMQServer server) {
-      super(null, name, server);
+   public AMQPFederationTarget(AMQPRemoteBrokerConnection brokerConnection, String name, AMQPFederationConfiguration configuration, AMQPSessionContext session) {
+      super(name, brokerConnection.getServer());
 
       Objects.requireNonNull(session, "Provided session instance cannot be null");
 
+      this.brokerConnection = brokerConnection;
       this.session = session;
       this.connection = session.getAMQPConnectionContext();
       this.connection.addLinkRemoteCloseListener(getName(), this::handleLinkRemoteClose);
@@ -137,51 +139,71 @@ public class AMQPFederationTarget extends AMQPFederation {
 
    @Override
    void registerFederationManagement() throws Exception {
-      // Not yet implemented for the target side of the federation connection
+      if (brokerConnection.isManagable()) {
+         AMQPFederationManagementSupport.registerFederationTarget(brokerConnection.getNodeId(), brokerConnection.getName(), this);
+      }
    }
 
    @Override
    void unregisterFederationManagement() throws Exception {
-      // Not yet implemented for the target side of the federation connection
+      if (brokerConnection.isManagable()) {
+         AMQPFederationManagementSupport.unregisterFederationTarget(brokerConnection.getNodeId(), brokerConnection.getName(), this);
+      }
    }
 
    @Override
    void registerLocalPolicyManagement(AMQPFederationLocalPolicyManager manager) throws Exception {
-      // Not yet implemented for the target side of the federation connection
+      if (brokerConnection.isManagable()) {
+         AMQPFederationManagementSupport.registerLocalPolicyOnTarget(brokerConnection.getNodeId(), brokerConnection.getName(), manager);
+      }
    }
 
    @Override
    void unregisterLocalPolicyManagement(AMQPFederationLocalPolicyManager manager) throws Exception {
-      // Not yet implemented for the target side of the federation connection
+      if (brokerConnection.isManagable()) {
+         AMQPFederationManagementSupport.unregisterLocalPolicyOnTarget(brokerConnection.getNodeId(), brokerConnection.getName(), manager);
+      }
    }
 
    @Override
    void registerRemotePolicyManagement(AMQPFederationRemotePolicyManager manager) throws Exception {
-      // Not yet implemented for the target side of the federation connection
+      if (brokerConnection.isManagable()) {
+         AMQPFederationManagementSupport.registerRemotePolicyOnTarget(brokerConnection.getNodeId(), brokerConnection.getName(), manager);
+      }
    }
 
    @Override
    void unregisterRemotePolicyManagement(AMQPFederationRemotePolicyManager manager) throws Exception {
-      // Not yet implemented for the target side of the federation connection
+      if (brokerConnection.isManagable()) {
+         AMQPFederationManagementSupport.unregisterRemotePolicyOnTarget(brokerConnection.getNodeId(), brokerConnection.getName(), manager);
+      }
    }
 
    @Override
    void registerFederationConsumerManagement(AMQPFederationConsumer consumer) throws Exception {
-      // Not yet implemented for the target side of the federation connection
+      if (brokerConnection.isManagable()) {
+         AMQPFederationManagementSupport.registerFederationTargetConsumer(brokerConnection.getNodeId(), brokerConnection.getName(), consumer);
+      }
    }
 
    @Override
    void unregisterFederationConsumerManagement(AMQPFederationConsumer consumer) throws Exception {
-      // Not yet implemented for the target side of the federation connection
+      if (brokerConnection.isManagable()) {
+         AMQPFederationManagementSupport.unregisterFederationTargetConsumer(brokerConnection.getNodeId(), brokerConnection.getName(), consumer);
+      }
    }
 
    @Override
    void registerFederationProducerManagement(AMQPFederationSenderController sender) throws Exception {
-      // Not yet implemented for the target side of the federation connection
+      if (brokerConnection.isManagable()) {
+         AMQPFederationManagementSupport.registerFederationTargetProducer(brokerConnection.getNodeId(), brokerConnection.getName(), sender);
+      }
    }
 
    @Override
-   void unregisterFederationProdcerManagement(AMQPFederationSenderController sender) throws Exception {
-      // Not yet implemented for the target side of the federation connection
+   void unregisterFederationProducerManagement(AMQPFederationSenderController sender) throws Exception {
+      if (brokerConnection.isManagable()) {
+         AMQPFederationManagementSupport.unregisterFederationTargetProducer(brokerConnection.getNodeId(), brokerConnection.getName(), sender);
+      }
    }
 }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationTargetControlType.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationTargetControlType.java
@@ -26,15 +26,15 @@ import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.logs.AuditLogger;
 
 /**
- * Management service control instance for an AMQPFederationSource instance that federates messages
- * from the remote broker on the opposing side of this broker connection. The federation source has
- * a lifetime that matches that of its parent broker connection.
+ * Management service control instance for an AMQPFederationTarget instance that is the target of an
+ * AMQP broker connection with federation configured. The target can behave much the same as a federation
+ * source but its scoped to the connection and all operations cease as soon as the connection is closed.
  */
-public final class AMQPFederationSourceControlType extends AbstractControl implements AMQPFederationControl {
+public final class AMQPFederationTargetControlType extends AbstractControl implements AMQPFederationControl {
 
-   private final AMQPFederationSource federation;
+   private final AMQPFederationTarget federation;
 
-   public AMQPFederationSourceControlType(ActiveMQServer server, AMQPFederationSource federation) throws NotCompliantMBeanException {
+   public AMQPFederationTargetControlType(ActiveMQServer server, AMQPFederationTarget federation) throws NotCompliantMBeanException {
       super(AMQPFederationControl.class, server.getStorageManager());
 
       this.federation = federation;

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/federation/FederationReceiveFromAddressPolicy.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/federation/FederationReceiveFromAddressPolicy.java
@@ -55,7 +55,6 @@ public class FederationReceiveFromAddressPolicy implements FederationReceiveFrom
    private final Map<String, Object> properties;
    private final TransformerConfiguration transformerConfig;
 
-   @SuppressWarnings("unchecked")
    public FederationReceiveFromAddressPolicy(String name, boolean autoDelete, long autoDeleteDelay,
                                              long autoDeleteMessageCount, int maxHops, boolean enableDivertBindings,
                                              Collection<String> includeAddresses, Collection<String> excludeAddresses,

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/federation/FederationReceiveFromQueuePolicy.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/federation/FederationReceiveFromQueuePolicy.java
@@ -49,7 +49,6 @@ public class FederationReceiveFromQueuePolicy implements FederationReceiveFromRe
    private final Map<String, Object> properties;
    private final TransformerConfiguration transformerConfig;
 
-   @SuppressWarnings("unchecked")
    public FederationReceiveFromQueuePolicy(String name, boolean includeFederated, int priorotyAdjustment,
                                            Collection<Map.Entry<String, String>> includeQueues,
                                            Collection<Map.Entry<String, String>> excludeQueues,

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/RemoteBrokerConnectionControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/RemoteBrokerConnectionControlImpl.java
@@ -14,66 +14,62 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.protocol.amqp.connect.federation;
+package org.apache.activemq.artemis.core.management.impl;
 
 import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanOperationInfo;
 import javax.management.NotCompliantMBeanException;
 
-import org.apache.activemq.artemis.core.management.impl.AbstractControl;
-import org.apache.activemq.artemis.core.management.impl.MBeanInfoHelper;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.api.core.management.RemoteBrokerConnectionControl;
+import org.apache.activemq.artemis.core.persistence.StorageManager;
+import org.apache.activemq.artemis.core.server.RemoteBrokerConnection;
 import org.apache.activemq.artemis.logs.AuditLogger;
 
-/**
- * Management service control instance for an AMQPFederationSource instance that federates messages
- * from the remote broker on the opposing side of this broker connection. The federation source has
- * a lifetime that matches that of its parent broker connection.
- */
-public final class AMQPFederationSourceControlType extends AbstractControl implements AMQPFederationControl {
+public class RemoteBrokerConnectionControlImpl extends AbstractControl implements RemoteBrokerConnectionControl {
 
-   private final AMQPFederationSource federation;
+   private final RemoteBrokerConnection connection;
 
-   public AMQPFederationSourceControlType(ActiveMQServer server, AMQPFederationSource federation) throws NotCompliantMBeanException {
-      super(AMQPFederationControl.class, server.getStorageManager());
+   public RemoteBrokerConnectionControlImpl(RemoteBrokerConnection connection,
+                                            StorageManager storageManager) throws NotCompliantMBeanException {
+      super(RemoteBrokerConnectionControl.class, storageManager);
 
-      this.federation = federation;
+      this.connection = connection;
    }
 
    @Override
    public String getName() {
       if (AuditLogger.isBaseLoggingEnabled()) {
-         AuditLogger.getName(federation);
+         AuditLogger.getName(connection);
       }
       clearIO();
       try {
-         return federation.getName();
+         return connection.getName();
       } finally {
          blockOnIO();
       }
    }
 
    @Override
-   public long getMessagesReceived() {
+   public String getNodeId() {
       if (AuditLogger.isBaseLoggingEnabled()) {
-         AuditLogger.getMessagesReceived(federation);
+         AuditLogger.getNodeID(connection);
       }
       clearIO();
       try {
-         return federation.getMetrics().getMessagesReceived();
+         return connection.getNodeId();
       } finally {
          blockOnIO();
       }
    }
 
    @Override
-   public long getMessagesSent() {
+   public String getProtocol() {
       if (AuditLogger.isBaseLoggingEnabled()) {
-         AuditLogger.getMessagesSent(federation);
+         AuditLogger.getProtocol(connection);
       }
       clearIO();
       try {
-         return federation.getMetrics().getMessagesSent();
+         return connection.getProtocol();
       } finally {
          blockOnIO();
       }
@@ -81,11 +77,11 @@ public final class AMQPFederationSourceControlType extends AbstractControl imple
 
    @Override
    protected MBeanOperationInfo[] fillMBeanOperationInfo() {
-      return MBeanInfoHelper.getMBeanOperationsInfo(AMQPFederationControl.class);
+      return MBeanInfoHelper.getMBeanOperationsInfo(RemoteBrokerConnectionControl.class);
    }
 
    @Override
    protected MBeanAttributeInfo[] fillMBeanAttributeInfo() {
-      return MBeanInfoHelper.getMBeanAttributesInfo(AMQPFederationControl.class);
+      return MBeanInfoHelper.getMBeanAttributesInfo(RemoteBrokerConnectionControl.class);
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/BrokerConnection.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/BrokerConnection.java
@@ -18,6 +18,10 @@ package org.apache.activemq.artemis.core.server;
 
 import org.apache.activemq.artemis.core.config.brokerConnectivity.BrokerConnectConfiguration;
 
+/**
+ * A broker connection defines a server connection created to provide services
+ * between this server and another instance.
+ */
 public interface BrokerConnection extends ActiveMQComponent {
 
    default void initialize() throws Exception {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/RemoteBrokerConnection.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/RemoteBrokerConnection.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.server;
+
+/**
+ * A remote broker connection defines a view of the remote end of an active
+ * {@link BrokerConnection}.
+ */
+public interface RemoteBrokerConnection {
+
+   /**
+    * Handles initialization when the remote connection is setup.
+    *
+    * @throws Exception if an error occurs during initialization.
+    */
+   void initialize() throws Exception;
+
+   /**
+    * Handles cleanup when the remote connection is closed or becomes disconnect.
+    *
+    * @throws Exception if an error occurs during shutdown.
+    */
+   void shutdown() throws Exception;
+
+   /**
+    * Returns the name of the broker connection as defined on the remote server. This value
+    * is unique on the remote server but is only unique on the local end when combined with
+    * the unique node Id from which the broker connection was initiated.
+    *
+    * @return the unique name of the remote broker connection.
+    */
+   String getName();
+
+   /**
+    * @return the node Id of the remote broker that created the incoming connection.
+    */
+   String getNodeId();
+
+   /**
+    * @return the protocol that underlies the broker connection implementation.
+    */
+   String getProtocol();
+
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/ManagementService.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/ManagementService.java
@@ -45,6 +45,7 @@ import org.apache.activemq.artemis.core.server.BrokerConnection;
 import org.apache.activemq.artemis.core.server.Divert;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.server.QueueFactory;
+import org.apache.activemq.artemis.core.server.RemoteBrokerConnection;
 import org.apache.activemq.artemis.core.server.routing.ConnectionRouter;
 import org.apache.activemq.artemis.core.server.cluster.Bridge;
 import org.apache.activemq.artemis.core.server.cluster.BroadcastGroup;
@@ -136,6 +137,10 @@ public interface ManagementService extends NotificationService, ActiveMQComponen
    void registerBrokerConnection(BrokerConnection brokerConnection) throws Exception;
 
    void unregisterBrokerConnection(String name) throws Exception;
+
+   void registerRemoteBrokerConnection(RemoteBrokerConnection brokerConnection) throws Exception;
+
+   void unregisterRemoteBrokerConnection(String nodeId, String name) throws Exception;
 
    Object getResource(String resourceName);
 

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/group/impl/ClusteredResetMockTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/group/impl/ClusteredResetMockTest.java
@@ -49,6 +49,7 @@ import org.apache.activemq.artemis.core.server.BrokerConnection;
 import org.apache.activemq.artemis.core.server.Divert;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.server.QueueFactory;
+import org.apache.activemq.artemis.core.server.RemoteBrokerConnection;
 import org.apache.activemq.artemis.core.server.management.GuardInvocationHandler;
 import org.apache.activemq.artemis.core.server.routing.ConnectionRouter;
 import org.apache.activemq.artemis.core.server.cluster.Bridge;
@@ -416,6 +417,16 @@ public class ClusteredResetMockTest extends ServerTestBase {
 
       @Override
       public void removeNotificationListener(NotificationListener listener) {
+
+      }
+
+      @Override
+      public void registerRemoteBrokerConnection(RemoteBrokerConnection brokerConnection) throws Exception {
+
+      }
+
+      @Override
+      public void unregisterRemoteBrokerConnection(String nodeId, String name) throws Exception {
 
       }
    }


### PR DESCRIPTION
Provide remote broker connections management beans that mirror the management objects added on the local broker when AMQP federation is configured and the connection is active.