### PR TITLE
ARTEMIS-5215 Credit handler reset in progress flag when stopped

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationQueueConsumer.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationQueueConsumer.java
@@ -424,14 +424,17 @@ public final class AMQPFederationQueueConsumer extends AMQPFederationConsumer {
       private void performCreditTopUp() {
          connection.requireInHandler();
 
-         if (!isStarted() || receiver.getLocalState() != EndpointState.ACTIVE) {
-            return; // Closed or stopped before this was triggered.
-         }
+         try {
+            if (!isStarted() || receiver.getLocalState() != EndpointState.ACTIVE) {
+               return; // Closed or stopped before this was triggered.
+            }
 
-         receiver.flow(configuration.getPullReceiverBatchSize());
-         connection.instantFlush();
-         lastBacklogCheckDelay = 0;
-         creditTopUpInProgress.set(false);
+            receiver.flow(configuration.getPullReceiverBatchSize());
+            connection.instantFlush();
+            lastBacklogCheckDelay = 0;
+         } finally {
+            creditTopUpInProgress.set(false);
+         }
       }
    }
 }


### PR DESCRIPTION
When a pull mode federation consumer is stopped due to demand being removed and the credit tup-up handler is also awaiting the Queue backlog to clear in order to grant a new batch of credit it might exit that cycle an leave the in-progress flag set to true. Currently this likely won't trigger a stuck consumer but if the code was to be altered to hold open a link for some period of time before fully closing in order to avoid needless attach / detach cycles then it would be possible for the credit replenishment to get stuck because the previous attempt left the in-progress flag set to true.