### PR TITLE
ARTEMIS-5139 improve locking on TypedProperties

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessage.java
@@ -790,7 +790,8 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
          Long.BYTES +                                    // expiration
          Long.BYTES +                                    // timestamp
          Byte.BYTES;                                     // priority
-      synchronized (properties) {
+      properties.getReadLock().lock();
+      try {
          final int propertiesEncodeSize = properties.getEncodeSize();
          final int totalEncodedSize = headersSize + propertiesEncodeSize;
          ensureExactWritable(buffer, totalEncodedSize);
@@ -810,6 +811,8 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
          assert buffer.writerIndex() == initialWriterIndex + headersSize : "Bad Headers encode size estimation";
          final int realPropertiesEncodeSize = properties.encode(buffer);
          assert realPropertiesEncodeSize == propertiesEncodeSize : "TypedProperties has a wrong encode size estimation or is being modified concurrently";
+      } finally {
+         properties.getReadLock().unlock();
       }
    }
 


### PR DESCRIPTION
Back in 8e40b2d4f4f242271d3dfcda4f9b96d3f94cee1b thread safety was added to TypedProperties by synchronizing all relevant methods. This was simple and effective but suffers from performance issues in read-heavy use-cases.

This commit improves the performance by using a read/write locking mechanism so reads can execute concurrently.

No new tests were added since the original commit added tests to verify thread safety.