### PR TITLE
ARTEMIS-5312 reduce build-time warnings for JavaDoc

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/QueueConfiguration.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/QueueConfiguration.java
@@ -31,7 +31,7 @@ import org.apache.activemq.artemis.utils.JsonLoader;
 /**
  * This class holds all the properties required to configure a queue. The only strictly required property is
  * {@code name}. Some defaults will be enforced for properties which are not explicitly set:
- * <p><ul>
+ * <ul>
  * <li>{@code address} : the value set for {@code name}
  * <li>{@code transient} : {@code false}
  * <li>{@code temporary} : {@code false}
@@ -39,7 +39,7 @@ import org.apache.activemq.artemis.utils.JsonLoader;
  * <li>{@code autoCreated} : {@code false}
  * <li>{@code internal} : {@code false}
  * <li>{@code configurationManaged} : {@code false}
- * </ul><p>
+ * </ul>
  */
 public class QueueConfiguration implements Serializable {
 
@@ -223,7 +223,7 @@ public class QueueConfiguration implements Serializable {
    /**
     * Set the value of a parameter based on its "key" {@code String}. Valid key names and corresponding {@code static}
     * {@code final} are:
-    * <p><ul>
+    * <ul>
     * <li>id: {@link #ID}
     * <li>name: {@link #NAME}
     * <li>address: {@link #ADDRESS}
@@ -254,7 +254,7 @@ public class QueueConfiguration implements Serializable {
     * <li>internal: {@link #INTERNAL}
     * <li>transient: {@link #TRANSIENT}
     * <li>auto-created: {@link #AUTO_CREATED}
-    * </ul><p>
+    * </ul>
     * The {@code String}-based values will be converted to the proper value types based on the underlying property. For
     * example, if you pass the value "TRUE" for the key "auto-created" the {@code String} "TRUE" will be converted to
     * the {@code Boolean} {@code true}.

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/client/ClientSession.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/client/ClientSession.java
@@ -301,7 +301,7 @@ public interface ClientSession extends XAResource, AutoCloseable {
     * details on configuration specifics.
     * <p>
     * Some static defaults will be enforced for properties which are not set on the {@code QueueConfiguration}:
-    * <p><ul>
+    * <ul>
     * <li>{@code transient} : {@code false}
     * <li>{@code temporary} : {@code false}
     * <li>{@code durable} : {@code true}
@@ -310,9 +310,9 @@ public interface ClientSession extends XAResource, AutoCloseable {
     * <li>{@code configurationManaged} : {@code false}
     * <li>{@code maxConsumers} : {@link org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration#getDefaultMaxQueueConsumers()}
     * <li>{@code purgeOnNoConsumers} : {@link org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration#getDefaultPurgeOnNoConsumers()}
-    * </ul><p>
+    * </ul>
     * Some dynamic defaults will be enforced via address-settings for the corresponding unset properties:
-    * <p><ul>
+    * <ul>
     * <li>{@code exclusive}
     * <li>{@code groupRebalance}
     * <li>{@code groupBuckets}
@@ -328,7 +328,7 @@ public interface ClientSession extends XAResource, AutoCloseable {
     * <li>{@code autoDelete} (only set if queue was auto-created)
     * <li>{@code autoDeleteDelay}
     * <li>{@code autoDeleteMessageCount}
-    * </ul><p>
+    * </ul>
     *
     * @param queueConfiguration the configuration to use when creating the queue
     * @throws ActiveMQException
@@ -339,15 +339,15 @@ public interface ClientSession extends XAResource, AutoCloseable {
     * This method is essentially the same as {@link #createQueue(QueueConfiguration)} with a few key exceptions.
     * <p>
     * If {@code durable} is {@code true} then:
-    * <p><ul>
+    * <ul>
     * <li>{@code transient} will be forced to {@code false}
     * <li>{@code temporary} will be forced to {@code false}
-    * </ul><p>
+    * </ul>
     * If {@code durable} is {@code false} then:
-    * <p><ul>
+    * <ul>
     * <li>{@code transient} will be forced to {@code true}
     * <li>{@code temporary} will be forced to {@code true}
-    * </ul><p>
+    * </ul>
     * In all instances {@code autoCreated} will be forced to {@code false} and {@code autoCreatedAddress} will be forced
     * to {@code true}.
     *

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/client/TopologyMember.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/client/TopologyMember.java
@@ -45,7 +45,6 @@ public interface TopologyMember {
     * <p>
     * This is a server configuration value. An active server will only send its messages to another active server
     * with matching {@code scale-down-group-name}.
-    * <p>
     *
     * @return the {@code scale-down-group-name}
     */

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/config/TransformerConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/config/TransformerConfiguration.java
@@ -60,7 +60,7 @@ public final class TransformerConfiguration implements Serializable {
     * This method returns a {@code TransformerConfiguration} created from the JSON-formatted input {@code String}.
     * The input should contain these entries:
     *
-    * <p><ul>
+    * <ul>
     * <li>class-name - a string value,
     * <li>properties - an object containing string key-value pairs.
     * </ul>

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/BridgeConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/BridgeConfiguration.java
@@ -172,7 +172,7 @@ public final class BridgeConfiguration implements Serializable {
    /**
     * Set the value of a parameter based on its "key" {@code String}. Valid key names and corresponding {@code static}
     * {@code final} are:
-    * <p><ul>
+    * <ul>
     * <li>name: {@link #NAME}
     * <li>queue-name: {@link #QUEUE_NAME}
     * <li>forwarding-address: {@link #FORWARDING_ADDRESS}
@@ -199,7 +199,7 @@ public final class BridgeConfiguration implements Serializable {
     * <li>routing-type: {@link #ROUTING_TYPE}
     * <li>concurrency: {@link #CONCURRENCY}
     * <li>client-id: {@link #CLIENT_ID}
-    * </ul><p>
+    * </ul>
     * The {@code String}-based values will be converted to the proper value types based on the underlying property. For
     * example, if you pass the value "TRUE" for the key "auto-created" the {@code String} "TRUE" will be converted to
     * the {@code Boolean} {@code true}.

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/DivertConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/DivertConfiguration.java
@@ -68,7 +68,7 @@ public class DivertConfiguration implements Serializable, EncodingSupport {
    /**
     * Set the value of a parameter based on its "key" {@code String}. Valid key names and corresponding {@code static}
     * {@code final} are:
-    * <p><ul>
+    * <ul>
     * <li>name: {@link #NAME}
     * <li>routing-name: {@link #ROUTING_NAME}
     * <li>address: {@link #ADDRESS}
@@ -77,7 +77,7 @@ public class DivertConfiguration implements Serializable, EncodingSupport {
     * <li>filter-string: {@link #FILTER_STRING}
     * <li>transformer-configuration: {@link #TRANSFORMER_CONFIGURATION}
     * <li>routing-type: {@link #ROUTING_TYPE}
-    * </ul><p>
+    * </ul>
     * The {@code String}-based values will be converted to the proper value types based on the underlying property. For
     * example, if you pass the value "TRUE" for the key "exclusive" the {@code String} "TRUE" will be converted to
     * the {@code Boolean} {@code true}.

--- a/pom.xml
+++ b/pom.xml
@@ -1051,6 +1051,7 @@
             <artifactId>maven-javadoc-plugin</artifactId>
             <configuration>
                <noindex>true</noindex>
+               <doclint>all,-missing</doclint>
             </configuration>
          </plugin>
          <plugin>


### PR DESCRIPTION
There are number of warnings related to JavaDoc during the build. This commit adjusts a handful of specifica JavaDoc comments to eliminate warnings about empty `<p>` tags. It also modifies the configuration of the Maven JavaDoc plugin to categorically prevent warnings about "missing" JavaDoc comments on public methods, etc.