### PR TITLE
ARTEMIS-5338 AckManager flow control

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/logs/AuditLogger.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/logs/AuditLogger.java
@@ -2866,4 +2866,13 @@ public interface AuditLogger {
 
    @LogMessage(id = 601798, value = "User {} is exporting configuration as properties on target resource: {}", level = LogMessage.Level.INFO)
    void exportConfigAsProperties(String user, Object source);
+
+   static void getPendingMirrorAcks(Object source) {
+      BASE_LOGGER.getPendingMirrorAcks(getCaller(), source);
+   }
+
+   @LogMessage(id = 601799, value = "User {} is getting PendingMirrorAcks on target resource: {}", level = LogMessage.Level.INFO)
+   void getPendingMirrorAcks(String user, Object source);
+
+
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ActiveMQServerControl.java
@@ -2091,6 +2091,9 @@ public interface ActiveMQServerControl {
    @Attribute(desc = AUTHORIZATION_FAILURE_COUNT)
    long getAuthorizationFailureCount();
 
+   @Attribute(desc = "Number of pending acknowledgements records on mirroring")
+   int getPendingMirrorAcks();
+
    @Operation(desc = "Export the broker configuration as properties", impact = MBeanOperationInfo.ACTION)
    void exportConfigAsProperties() throws Exception;
 }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/ProtonProtocolManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/ProtonProtocolManager.java
@@ -112,6 +112,8 @@ public class ProtonProtocolManager extends AbstractProtocolManager<AMQPMessage, 
 
    private boolean directDeliver = true;
 
+   private int mirrorMaxPendingAcks = 10_000;
+
    private final AMQPRoutingHandler routingHandler;
 
    /*
@@ -162,6 +164,15 @@ public class ProtonProtocolManager extends AbstractProtocolManager<AMQPMessage, 
 
    public int getAmqpMinLargeMessageSize() {
       return amqpMinLargeMessageSize;
+   }
+
+   public int getMirrorMaxPendingAcks() {
+      return mirrorMaxPendingAcks;
+   }
+
+   public ProtonProtocolManager setMirrorMaxPendingAcks(int maxPendingAcks) {
+      this.mirrorMaxPendingAcks = maxPendingAcks;
+      return this;
    }
 
    public ProtonProtocolManager setAmqpMinLargeMessageSize(int amqpMinLargeMessageSize) {

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/mirror/AckManagerProvider.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/mirror/AckManagerProvider.java
@@ -49,6 +49,9 @@ public class AckManagerProvider {
    }
 
    public static AckManager getManager(ActiveMQServer server) {
+      if (server == null) {
+         throw new NullPointerException("server is null");
+      }
       synchronized (managerHashMap) {
          AckManager ackManager = managerHashMap.get(server);
          if (ackManager != null) {

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonAbstractReceiver.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonAbstractReceiver.java
@@ -175,6 +175,10 @@ public abstract class ProtonAbstractReceiver extends ProtonInitializable impleme
       return state == ReceiverState.STARTED;
    }
 
+   public boolean isBusy() {
+      return false;
+   }
+
    public boolean isStopping() {
       return state == ReceiverState.STOPPING;
    }
@@ -276,7 +280,7 @@ public abstract class ProtonAbstractReceiver extends ProtonInitializable impleme
          if (connection.isHandler()) {
             connection.requireInHandler();
 
-            if (context.isStarted()) {
+            if (context.isStarted() && !context.isBusy()) {
                final int pending = context.pendingSettles;
 
                if (isBellowThreshold(receiver.getCredit(), pending, threshold)) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -4748,6 +4748,14 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
    }
 
    @Override
+   public int getPendingMirrorAcks() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getPendingMirrorAcks(this.server);
+      }
+      return server.getPendingMirrorAcks();
+   }
+
+   @Override
    public void exportConfigAsProperties() throws Exception {
       if (AuditLogger.isBaseLoggingEnabled()) {
          AuditLogger.exportConfigAsProperties(this.server);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServer.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServer.java
@@ -59,6 +59,7 @@ import org.apache.activemq.artemis.core.server.impl.ConnectorsService;
 import org.apache.activemq.artemis.core.server.management.ManagementService;
 import org.apache.activemq.artemis.core.server.metrics.MetricsManager;
 import org.apache.activemq.artemis.core.server.mirror.MirrorController;
+import org.apache.activemq.artemis.core.server.mirror.MirrorRegistry;
 import org.apache.activemq.artemis.core.server.plugin.ActiveMQPluginRunnable;
 import org.apache.activemq.artemis.core.server.plugin.ActiveMQServerAddressPlugin;
 import org.apache.activemq.artemis.core.server.plugin.ActiveMQServerBasePlugin;
@@ -1025,4 +1026,8 @@ public interface ActiveMQServer extends ServiceComponent {
    }
 
    void registerRecordsLoader(Consumer<RecordInfo> recordsLoader);
+
+   MirrorRegistry getMirrorRegistry();
+
+   int getPendingMirrorAcks();
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -170,6 +170,7 @@ import org.apache.activemq.artemis.core.server.management.ManagementService;
 import org.apache.activemq.artemis.core.server.management.impl.ManagementServiceImpl;
 import org.apache.activemq.artemis.core.server.metrics.MetricsManager;
 import org.apache.activemq.artemis.core.server.mirror.MirrorController;
+import org.apache.activemq.artemis.core.server.mirror.MirrorRegistry;
 import org.apache.activemq.artemis.core.server.plugin.ActiveMQPluginRunnable;
 import org.apache.activemq.artemis.core.server.plugin.ActiveMQServerAddressPlugin;
 import org.apache.activemq.artemis.core.server.plugin.ActiveMQServerBasePlugin;
@@ -258,6 +259,8 @@ public class ActiveMQServerImpl implements ActiveMQServer {
    public static final String GENERIC_IGNORED_FILTER = Filter.GENERIC_IGNORED_FILTER;
 
    private HAPolicy haPolicy;
+
+   private MirrorRegistry mirrorRegistry = new MirrorRegistry();
 
    // This will be useful on tests or embedded
    private boolean rebuildCounters = true;
@@ -4820,5 +4823,15 @@ public class ActiveMQServerImpl implements ActiveMQServer {
    @Override
    public IOCriticalErrorListener getIoCriticalErrorListener() {
       return ioCriticalErrorListener;
+   }
+
+   @Override
+   public MirrorRegistry getMirrorRegistry() {
+      return mirrorRegistry;
+   }
+
+   @Override
+   public int getPendingMirrorAcks() {
+      return mirrorRegistry.getMirrorAckSize();
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/mirror/MirrorRegistry.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/mirror/MirrorRegistry.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.core.server.mirror;
+
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
+public class MirrorRegistry {
+
+   private volatile int mirrorAckSize;
+   private static final AtomicIntegerFieldUpdater<MirrorRegistry> sizeUpdater = AtomicIntegerFieldUpdater.newUpdater(MirrorRegistry.class, "mirrorAckSize");
+
+   public int getMirrorAckSize() {
+      return sizeUpdater.get(this);
+   }
+
+   public void incrementMirrorAckSize() {
+      sizeUpdater.incrementAndGet(this);
+   }
+
+   public void decrementMirrorAckSize() {
+      sizeUpdater.decrementAndGet(this);
+   }
+}

--- a/artemis-unit-test-support/src/main/java/org/apache/activemq/artemis/utils/Wait.java
+++ b/artemis-unit-test-support/src/main/java/org/apache/activemq/artemis/utils/Wait.java
@@ -172,6 +172,11 @@ public class Wait {
       assertTrue(failureMessage, condition, duration, SLEEP_MILLIS);
    }
 
+   public static <T> T assertNotNull(Supplier<T> supplier, final long duration, final long sleep) throws Exception {
+      Assertions.assertTrue(waitFor(() -> supplier.get() != null, duration, sleep));
+      return supplier.get();
+   }
+
    public static void assertTrue(Condition condition, final long duration, final long sleep) {
       assertTrue(DEFAULT_FAILURE_MESSAGE, condition, duration, sleep);
    }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
@@ -251,6 +251,18 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
    }
 
    @TestTemplate
+   public void testPendingMirrorAcks() throws Exception {
+      ActiveMQServerControl serverControl = createManagementControl();
+      // faking some data, to make sure we are not just returning a default value
+      for (int i = 0; i < 7; i++) {
+         server.getMirrorRegistry().incrementMirrorAckSize();
+      }
+
+      assertEquals(7, serverControl.getPendingMirrorAcks());
+      assertEquals(7, server.getPendingMirrorAcks());
+   }
+
+   @TestTemplate
    public void testBrokerPluginClassNames() throws Exception {
       ActiveMQServerControl serverControl = createManagementControl();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlUsingCoreTest.java
@@ -1857,6 +1857,12 @@ public class ActiveMQServerControlUsingCoreTest extends ActiveMQServerControlTes
             return (long) proxy.retrieveAttributeValue("authorizationFailureCount");
          }
 
+
+         @Override
+         public int getPendingMirrorAcks() {
+            return ((Number) proxy.retrieveAttributeValue("pendingMirrorAcks")).intValue();
+         }
+
          @Override
          public void exportConfigAsProperties() throws Exception {
             proxy.invokeOperation("exportConfigAsProperties");

--- a/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/brokerConnection/mirror/AccumulatedInPageSoakTest.java
+++ b/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/brokerConnection/mirror/AccumulatedInPageSoakTest.java
@@ -38,6 +38,7 @@ import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBroker
 import org.apache.activemq.artemis.tests.soak.SoakTestBase;
 import org.apache.activemq.artemis.tests.util.CFUtil;
 import org.apache.activemq.artemis.util.ServerUtil;
+import org.apache.activemq.artemis.utils.FileUtil;
 import org.apache.activemq.artemis.utils.RandomUtil;
 import org.apache.activemq.artemis.utils.Wait;
 import org.apache.activemq.artemis.cli.commands.helper.HelperCreate;
@@ -109,6 +110,10 @@ public class AccumulatedInPageSoakTest extends SoakTestBase {
 
       File brokerPropertiesFile = new File(serverLocation, "broker.properties");
       saveProperties(brokerProperties, brokerPropertiesFile);
+
+      File brokerXML = new File(serverLocation, "/etc/broker.xml");
+      // Making sure we flow control mirrorACK on the lower side to make sure things are working
+      assertTrue(FileUtil.findReplace(brokerXML, "</acceptor>", ";mirrorMaxPendingAcks=50</acceptor>"));
    }
 
    @BeforeAll


### PR DESCRIPTION
Say there are too many records in the JournalHashMap. In that case the sender should pace sending more data. The target should limit credits when the configured max pending records is reached.