### PR TITLE
ARTEMIS-5339 Adjust configuration to avoid federation receiver loops

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationConfiguration.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationConfiguration.java
@@ -73,7 +73,7 @@ public final class AMQPFederationConfiguration {
     * consumer subscription is used or if the policy priority offset value is simply applied to the default consumer
     * priority value.
     */
-   public static final boolean DEFAULT_IGNNORE_QUEUE_CONSUMER_PRIORITIES = false;
+   public static final boolean DEFAULT_IGNNORE_QUEUE_CONSUMER_PRIORITIES = true;
 
    /**
     * Default timeout (milliseconds) applied to federation receivers that are being stopped due to removal of local

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationConnectTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationConnectTest.java
@@ -299,6 +299,7 @@ public class AMQPFederationConnectTest extends AmqpClientTestSupport {
          federation.addProperty(RECEIVER_QUIESCE_TIMEOUT, AMQP_RECEIVER_QUIESCE_TIMEOUT);
          federation.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, AMQP_ADDRESS_RECEIVER_IDLE_TIMEOUT);
          federation.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, AMQP_QUEUE_RECEIVER_IDLE_TIMEOUT);
+         federation.addProperty(IGNORE_QUEUE_CONSUMER_PRIORITIES, Boolean.toString(AMQP_INGNORE_CONSUMER_PRIORITIES));
          amqpConnection.addElement(federation);
          server.getConfiguration().addAMQPConnection(amqpConnection);
          server.start();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationQueuePolicyTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationQueuePolicyTest.java
@@ -1492,9 +1492,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          receiveFromQueue.setName("queue-policy");
          receiveFromQueue.setPriorityAdjustment(TEST_BASE_PRIORITY_ADJUSTMENT);
          receiveFromQueue.addToIncludes("test", "test");
-         if (ignoreConsumerPriority) {
-            receiveFromQueue.addProperty(IGNORE_QUEUE_CONSUMER_PRIORITIES, Boolean.valueOf(ignoreConsumerPriority).toString());
-         }
+         receiveFromQueue.addProperty(IGNORE_QUEUE_CONSUMER_PRIORITIES, Boolean.valueOf(ignoreConsumerPriority).toString());
 
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
          element.setName(getTestName());
@@ -2531,6 +2529,7 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          element.setName(getTestName());
          element.addLocalQueuePolicy(receiveFromQueue);
          element.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, 5);
+         element.addProperty(IGNORE_QUEUE_CONSUMER_PRIORITIES, "false");
 
          final AMQPBrokerConnectConfiguration amqpConnection =
             new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());


### PR DESCRIPTION
Adjust the configuration for consumer priority handling to an opt in policy for creating multipe differing priority federation receivers such that if a user configures bi-directional federation and enabled ignore federation receivers they wouldn't end up with an infinite reflection of receivers.