### PR TITLE
ARTEMIS-5337 consumer + auto-create receives from existing wildcard queue

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
@@ -70,6 +70,7 @@ import org.apache.activemq.artemis.core.server.ServerSession;
 import org.apache.activemq.artemis.core.server.SlowConsumerDetectionListener;
 import org.apache.activemq.artemis.core.server.TempQueueObserver;
 import org.apache.activemq.artemis.core.server.impl.RefsOperation;
+import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.core.transaction.ResourceManager;
 import org.apache.activemq.artemis.core.transaction.Transaction;
 import org.apache.activemq.artemis.core.transaction.TransactionOperationAbstract;
@@ -743,7 +744,6 @@ public class OpenWireConnection extends AbstractRemotingConnection implements Se
 
    @Override
    public void fail(ActiveMQException me, String message) {
-
       final ThresholdActor<Command> localVisibleActor = openWireActor;
       if (localVisibleActor != null) {
          localVisibleActor.requestShutdown();
@@ -1022,7 +1022,10 @@ public class OpenWireConnection extends AbstractRemotingConnection implements Se
    }
 
    public void addKnownDestination(final SimpleString address) {
-      knownDestinations.add(address);
+      AddressSettings addressSettings = server.getAddressSettingsRepository().getMatch(address.toString());
+      if (!addressSettings.isAutoDeleteAddresses() && !addressSettings.isAutoDeleteQueues()) {
+         knownDestinations.add(address);
+      }
    }
 
    public boolean containsKnownDestination(final SimpleString address) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/WildcardConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/WildcardConfiguration.java
@@ -178,6 +178,26 @@ public class WildcardConfiguration implements Serializable {
       }
    }
 
+   /**
+    * Detect whether the input {@code CharSequence} contains any unescaped "single word" or "any words" characters.
+    *
+    * {@code CharSequence} is used here to support both {@code String} and {@code SimpleString} objects.
+    */
+   public boolean isWild(CharSequence input) {
+      if (input == null || input.isEmpty()) {
+         return false;
+      } else if (input.charAt(0) == getSingleWord() || input.charAt(0) == getAnyWords()) {
+         return true;
+      } else {
+         for (int i = 1; i < input.length(); i++) {
+            if ((input.charAt(i) == getSingleWord() || input.charAt(i) == getAnyWords()) && input.charAt(i - 1) != ESCAPE) {
+               return true;
+            }
+         }
+      }
+      return false;
+   }
+
    private String escape(final String input, WildcardConfiguration from) {
       String result = input.replace(escapeString, escapeString + escapeString);
       if (delimiter != from.getDelimiter()) {
@@ -200,7 +220,12 @@ public class WildcardConfiguration implements Serializable {
          .replace(ESCAPE + getAnyWordsString(), getAnyWordsString());
    }
 
-   private boolean isEscaped(final String input) {
+   /**
+    * {@return whether the input contains any escaped characters}
+    *
+    * @param input the {@code CharSequence} to inspect
+    */
+   private boolean isEscaped(final CharSequence input) {
       for (int i = 0; i < input.length() - 1; i++) {
          if (input.charAt(i) == ESCAPE && (input.charAt(i + 1) == getDelimiter() || input.charAt(i + 1) == getSingleWord() || input.charAt(i + 1) == getAnyWords())) {
             return true;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/SimpleAddressManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/SimpleAddressManager.java
@@ -198,7 +198,7 @@ public class SimpleAddressManager implements AddressManager {
          Bindings bindings = mappings.get(realAddress);
          if (bindings != null) {
             for (Binding theBinding : bindings.getBindings()) {
-               if (theBinding instanceof LocalQueueBinding) {
+               if (theBinding instanceof LocalQueueBinding && !wildcardConfiguration.isWild(theBinding.getUniqueName())) {
                   binding = theBinding;
                   break;
                }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -61,7 +61,6 @@ import org.apache.activemq.artemis.core.persistence.StorageManager;
 import org.apache.activemq.artemis.core.persistence.impl.journal.LargeServerMessageImpl;
 import org.apache.activemq.artemis.core.postoffice.Binding;
 import org.apache.activemq.artemis.core.postoffice.BindingType;
-import org.apache.activemq.artemis.core.postoffice.Bindings;
 import org.apache.activemq.artemis.core.postoffice.PostOffice;
 import org.apache.activemq.artemis.core.postoffice.QueueBinding;
 import org.apache.activemq.artemis.core.postoffice.RoutingStatus;
@@ -1833,9 +1832,8 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
          Queue q = server.locateQueue(unPrefixedQueue);
          if (q == null) {
             // The queue doesn't exist.
-            Bindings bindings = server.getPostOffice().lookupBindingsForAddress(unPrefixedAddress);
-            if (bindings != null && bindings.hasLocalBinding() && !queueConfig.isFqqn()) {
-               // The address has another queue with a different name, which is fine. Just ignore it.
+            if (!queueConfig.isFqqn() && server.getPostOffice().getMatchingQueue(unPrefixedAddress, queueConfig.getRoutingType()) != null) {
+               // The address has a local, non-wildcard queue with a different name, which is fine. Just ignore it.
                result = AutoCreateResult.EXISTED;
             } else if (addressSettings.isAutoCreateQueues() || queueConfig.isTemporary()) {
                // Try to create the queue.

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/HierarchicalObjectRepository.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/HierarchicalObjectRepository.java
@@ -196,7 +196,7 @@ public class HierarchicalObjectRepository<T> implements HierarchicalRepository<T
       lock.writeLock().lock();
       try {
          // an exact match (i.e. one without wildcards) won't impact any other matches so no need to clear the cache
-         if (usesWildcards(modifiedMatch)) {
+         if (wildcardConfiguration.isWild(modifiedMatch)) {
             clearCache();
          } else if (modifiedMatch != null && cache.containsKey(modifiedMatch)) {
             cache.remove(modifiedMatch);
@@ -209,7 +209,7 @@ public class HierarchicalObjectRepository<T> implements HierarchicalRepository<T
          Match<T> match1 = new Match<>(modifiedMatch, value, wildcardConfiguration, literal);
          if (literal) {
             literalMatches.put(modifiedMatch, match1);
-         } else if (usesWildcards(modifiedMatch)) {
+         } else if (wildcardConfiguration.isWild(modifiedMatch)) {
             wildcardMatches.put(modifiedMatch, match1);
          } else {
             exactMatches.put(modifiedMatch, match1);
@@ -222,10 +222,6 @@ public class HierarchicalObjectRepository<T> implements HierarchicalRepository<T
       if (notifyListeners) {
          onChange();
       }
-   }
-
-   private boolean usesWildcards(String modifiedMatch) {
-      return modifiedMatch == null ? false : (modifiedMatch.contains(wildcardConfiguration.getAnyWordsString()) || modifiedMatch.contains(wildcardConfiguration.getSingleWordString()));
    }
 
    @Override
@@ -306,7 +302,7 @@ public class HierarchicalObjectRepository<T> implements HierarchicalRepository<T
              * Clear the cache before removing the match, but only if the match used wildcards. This will force any
              * thread at {@link #getMatch(String)} to get the lock to recompute.
              */
-            if (usesWildcards(modMatch)) {
+            if (wildcardConfiguration.isWild(modMatch)) {
                clearCache();
                wildcardMatches.remove(modMatch);
             } else {

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/WildcardConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/WildcardConfigurationTest.java
@@ -16,12 +16,14 @@
  */
 package org.apache.activemq.artemis.core.config;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
-
 import org.apache.activemq.artemis.utils.RandomUtil;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class WildcardConfigurationTest {
 
@@ -123,5 +125,29 @@ public class WildcardConfigurationTest {
       assertNotEquals(a, b);
       assertNotEquals(b, a);
       assertNotEquals(a.hashCode(), b.hashCode());
+   }
+
+   @Test
+   public void testIsWild() {
+      assertFalse(DEFAULT_WILDCARD.isWild(null));
+      assertFalse(DEFAULT_WILDCARD.isWild(""));
+
+      assertFalse(DEFAULT_WILDCARD.isWild("a"));
+      assertFalse(DEFAULT_WILDCARD.isWild("a.b"));
+      assertFalse(DEFAULT_WILDCARD.isWild("a\\.\\#"));
+      assertFalse(DEFAULT_WILDCARD.isWild("a\\.\\*"));
+      assertFalse(DEFAULT_WILDCARD.isWild("\\*"));
+      assertFalse(DEFAULT_WILDCARD.isWild("\\#"));
+
+      assertTrue(DEFAULT_WILDCARD.isWild("*"));
+      assertTrue(DEFAULT_WILDCARD.isWild("#"));
+      assertTrue(DEFAULT_WILDCARD.isWild("a.*"));
+      assertTrue(DEFAULT_WILDCARD.isWild("*.b"));
+      assertTrue(DEFAULT_WILDCARD.isWild("a.*.c"));
+      assertTrue(DEFAULT_WILDCARD.isWild("a.#"));
+      assertTrue(DEFAULT_WILDCARD.isWild("a.b.#"));
+      assertTrue(DEFAULT_WILDCARD.isWild("a.*.#"));
+      assertTrue(DEFAULT_WILDCARD.isWild("a.*.\\#"));
+      assertTrue(DEFAULT_WILDCARD.isWild("a.\\*.#"));
    }
 }


### PR DESCRIPTION
Most protocols don't natively understand the address/queue model used by Artemis. When those protocols want anycast semantics the standard behavior is to create an address and a queue with the same name. However, sometimes a queue already exists on the address with that particular name in which case the broker will attach the consumer to that queue.

This is acceptable most of the time, but it is problematic when that queue uses a wild-card. In this case the consumer will potentially receive messages sent to other addresses (i.e. whatever the wild-card covers).

This commit fixes that by detecting the wild-card queue and ignoring it. Instead the broker will create a new queue specifically for the incoming consumer.