### PR TITLE
ARTEMIS-5358 log when core bridge fails to send a message

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1492,4 +1492,7 @@ public interface ActiveMQServerLogger {
 
    @LogMessage(id = 224142, value = "Unexpected result disconnecting consumer {} while closing session {}: {}", level = LogMessage.Level.WARN)
    void unexpectedResultDisconnectingConsumer(long consumerId, String sessionId, String exceptionMessage);
+
+   @LogMessage(id = 224143, value = "Bridge {} failed to send {}: {} {}", level = LogMessage.Level.WARN)
+   void bridgeFailedToSend(String bridgeName, String message, String exceptionName, String exceptionMessage);
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/impl/BridgeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/impl/BridgeImpl.java
@@ -447,8 +447,8 @@ public class BridgeImpl implements Bridge, SessionFailureListener, SendAcknowled
 
    @Override
    public void sendFailed(Message message, Exception e) {
+      ActiveMQServerLogger.LOGGER.bridgeFailedToSend(configuration.getName(), message.toString(), e.getClass().getSimpleName(), e.getMessage());
       if (e instanceof ActiveMQAddressFullException) {
-         logger.warn(e.getMessage(), e);
          failed(e);
       }
    }


### PR DESCRIPTION
If the core bridge fails to send a message it does not provide any feedback at all. This commit fixes that problem by clearly logging details of the failure when it occurs.