### PR TITLE
ARTEMIS-5351 harmonize AddressControl and AddressView

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/AddressControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/AddressControl.java
@@ -30,22 +30,28 @@ public interface AddressControl {
    String LIMIT_PERCENT_DESCRIPTION = "the % of memory limit (global or local) that is in use by this address";
 
    /**
-    * {@return the managed address}
+    * {@return the internal ID of this address}
     */
-   @Attribute(desc = "managed address")
+   @Attribute(desc = "the internal ID of this address")
+   long getId();
+
+   /**
+    * {@return the name of this address}
+    */
+   @Attribute(desc = "the name of this address")
    String getAddress();
 
    /**
-    * {@return whether multicast routing is enabled for this address}
+    * {@return the routing types enabled on this address}
     */
-   @Attribute(desc = "Get the routing types enabled on this address")
+   @Attribute(desc = "the routing types enabled on this address")
    String[] getRoutingTypes();
 
    /**
     * {@return the routing types enabled on this address as JSON}
     */
-   @Attribute(desc = "Get the routing types enabled on this address as JSON")
-   String getRoutingTypesAsJSON() throws Exception;
+   @Attribute(desc = "the routing types enabled on this address as JSON")
+   String getRoutingTypesAsJSON();
 
    /**
     * {@return the roles (name and permissions) associated with this address}
@@ -58,7 +64,7 @@ public interface AddressControl {
     * <p>
     * Java objects can be recreated from JSON serialization using {@link RoleInfo#from(String)}}.
     */
-   @Attribute(desc = "roles  (name and permissions) associated with this address using JSON serialization")
+   @Attribute(desc = "roles (name and permissions) associated with this address using JSON serialization")
    String getRolesAsJSON() throws Exception;
 
    /**
@@ -67,7 +73,6 @@ public interface AddressControl {
     */
    @Attribute(desc = ADDRESS_SIZE_DESCRIPTION)
    long getAddressSize();
-
 
    /**
     * {@return the maximum number of bytes that can be read into memory from paged files}
@@ -162,6 +167,15 @@ public interface AddressControl {
    @Attribute(desc = "names of all bindings (both queues and diverts) bound to this address")
    String[] getBindingNames() throws Exception;
 
+   /**
+    * {@return number of local queues bound to this address}
+    */
+   @Attribute(desc = "number of local queues bound to this address")
+   long getQueueCount();
+
+   /**
+    * {@return number of messages currently in all queues bound to this address (includes scheduled, paged, and in-delivery messages)}
+    */
    @Attribute(desc = "number of messages currently in all queues bound to this address (includes scheduled, paged, and in-delivery messages)")
    long getMessageCount();
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -2607,17 +2607,13 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
       checkStarted();
       clearIO();
       try {
-         final Set<SimpleString> addresses = server.getPostOffice().getAddresses();
-         List<AddressInfo> addressInfo = new ArrayList<>();
-         for (SimpleString address : addresses) {
-            AddressInfo info = server.getPostOffice().getAddressInfo(address);
-            //ignore if no longer available
-            if (info != null) {
-               addressInfo.add(info);
-            }
+         List<AddressControl> addresses = new ArrayList<>();
+         Object[] qs = server.getManagementService().getResources(AddressControl.class);
+         for (int i = 0; i < qs.length; i++) {
+            addresses.add((AddressControl) qs[i]);
          }
          AddressView view = new AddressView(server);
-         view.setCollection(addressInfo);
+         view.setCollection(addresses);
          view.setOptions(options);
          return view.getResultsAsJson(page, pageSize);
       } finally {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/AddressControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/AddressControlImpl.java
@@ -93,6 +93,11 @@ public class AddressControlImpl extends AbstractControl implements AddressContro
    // AddressControlMBean implementation ----------------------------
 
    @Override
+   public long getId() {
+      return addressInfo.getId();
+   }
+
+   @Override
    public String getAddress() {
       return addressInfo.getName().toString();
    }
@@ -112,7 +117,7 @@ public class AddressControlImpl extends AbstractControl implements AddressContro
    }
 
    @Override
-   public String getRoutingTypesAsJSON() throws Exception {
+   public String getRoutingTypesAsJSON() {
       if (AuditLogger.isBaseLoggingEnabled()) {
          AuditLogger.getRoutingTypesAsJSON(this.addressInfo);
       }
@@ -506,6 +511,19 @@ public class AddressControlImpl extends AbstractControl implements AddressContro
             AuditLogger.getMessageCount(this.addressInfo);
          }
          return getMessageCount(DurabilityType.ALL);
+      } catch (Exception e) {
+         throw new RuntimeException(e.getMessage(), e);
+      }
+   }
+
+   @Override
+   public long getQueueCount() {
+      // prevent parallel tasks running
+      try (AutoCloseable lock = server.managementLock()) {
+         if (AuditLogger.isBaseLoggingEnabled()) {
+            AuditLogger.getQueueCount(this.addressInfo);
+         }
+         return getQueueNames(SearchType.LOCAL).length;
       } catch (Exception e) {
          throw new RuntimeException(e.getMessage(), e);
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/ActiveMQAbstractView.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/ActiveMQAbstractView.java
@@ -34,6 +34,9 @@ import org.apache.activemq.artemis.utils.JsonLoader;
 
 public abstract class ActiveMQAbstractView<T> {
 
+   // use this for values which couldn't be retrieved (e.g. an exception was thrown)
+   protected static final String N_A = "n/a";
+
    private static final String FILTER_FIELD = "field";
 
    private static final String FILTER_OPERATION = "operation";

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/AddressField.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/AddressField.java
@@ -23,9 +23,25 @@ public enum AddressField {
    ID("id"),
    NAME("name"),
    ROUTING_TYPES("routingTypes"),
-   PRODUCER_ID("producerId"),
    QUEUE_COUNT("queueCount"),
-   INTERNAL("internal");
+   INTERNAL("internal"),
+   TEMPORARY("temporary"),
+   AUTO_CREATED("autoCreated"),
+   PAUSED("paused"),
+   CURRENT_DUPLICATE_ID_CACHE_SIZE("currentDuplicateIdCacheSize"),
+   RETROACTIVE_RESOURCE("retroactiveResource"),
+   UNROUTED_MESSAGE_COUNT("unroutedMessageCount"),
+   ROUTED_MESSAGE_COUNT("routedMessageCount"),
+   MESSAGE_COUNT("MessageCount"),
+   NUMBER_OF_BYTES_PER_PAGE("numberOfBytesPerPage"),
+   ADDRESS_LIMIT_PERCENT("addressLimitPercent"),
+   PAGING("paging"),
+   NUMBER_OF_PAGES("numberOfPages"),
+   ADDRESS_SIZE("addressSize"),
+   MAX_PAGE_READ_BYTES("maxPageReadBytes"),
+   MAX_PAGE_READ_MESSAGES("maxPageReadMessages"),
+   PREFETCH_PAGE_BYTES("prefetchPageBytes"),
+   PREFETCH_PAGE_MESSAGES("prefetchPageMessages");
 
    private static final Map<String, AddressField> lookup = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/AddressView.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/AddressView.java
@@ -16,13 +16,13 @@
  */
 package org.apache.activemq.artemis.core.management.impl.view;
 
+import org.apache.activemq.artemis.api.core.management.AddressControl;
 import org.apache.activemq.artemis.json.JsonObjectBuilder;
 import org.apache.activemq.artemis.core.management.impl.view.predicate.AddressFilterPredicate;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
-import org.apache.activemq.artemis.core.server.impl.AddressInfo;
 import org.apache.activemq.artemis.utils.JsonLoader;
 
-public class AddressView extends ActiveMQAbstractView<AddressInfo> {
+public class AddressView extends ActiveMQAbstractView<AddressControl> {
 
    private static final String defaultSortField = AddressField.ID.getName();
 
@@ -36,56 +36,94 @@ public class AddressView extends ActiveMQAbstractView<AddressInfo> {
 
    @Override
    public Class getClassT() {
-      return AddressInfo.class;
+      return AddressControl.class;
    }
 
    @Override
-   public JsonObjectBuilder toJson(AddressInfo address) {
+   public JsonObjectBuilder toJson(AddressControl address) {
       if (address == null) {
          return null;
       }
 
       JsonObjectBuilder obj = JsonLoader.createObjectBuilder()
          .add(AddressField.ID.getName(), toString(address.getId()))
-         .add(AddressField.NAME.getName(), toString(address.getName()))
+         .add(AddressField.NAME.getName(), toString(address.getAddress()))
+         .add(AddressField.ROUTING_TYPES.getName(), toString(address.getRoutingTypesAsJSON()))
+         .add(AddressField.QUEUE_COUNT.getName(), toString(address.getQueueCount()))
          .add(AddressField.INTERNAL.getName(), toString(address.isInternal()))
-         .add(AddressField.ROUTING_TYPES.getName(), toString(address.getRoutingTypes()));
+         .add(AddressField.TEMPORARY.getName(), toString(address.isTemporary()))
+         .add(AddressField.AUTO_CREATED.getName(), toString(address.isAutoCreated()))
+         .add(AddressField.PAUSED.getName(), toString(address.isPaused()))
+         .add(AddressField.CURRENT_DUPLICATE_ID_CACHE_SIZE.getName(), toString(address.getCurrentDuplicateIdCacheSize()))
+         .add(AddressField.RETROACTIVE_RESOURCE.getName(), toString(address.isRetroactiveResource()))
+         .add(AddressField.UNROUTED_MESSAGE_COUNT.getName(), toString(address.getUnRoutedMessageCount()))
+         .add(AddressField.ROUTED_MESSAGE_COUNT.getName(), toString(address.getRoutedMessageCount()))
+         .add(AddressField.MESSAGE_COUNT.getName(), toString(address.getMessageCount()))
+         .add(AddressField.ADDRESS_LIMIT_PERCENT.getName(), toString(address.getAddressLimitPercent()))
+         .add(AddressField.NUMBER_OF_PAGES.getName(), toString(address.getNumberOfPages()))
+         .add(AddressField.ADDRESS_SIZE.getName(), toString(address.getAddressSize()))
+         .add(AddressField.MAX_PAGE_READ_BYTES.getName(), toString(address.getMaxPageReadBytes()))
+         .add(AddressField.MAX_PAGE_READ_MESSAGES.getName(), toString(address.getMaxPageReadMessages()))
+         .add(AddressField.PREFETCH_PAGE_BYTES.getName(), toString(address.getPrefetchPageBytes()))
+         .add(AddressField.PREFETCH_PAGE_MESSAGES.getName(), toString(address.getPrefetchPageBytes()));
 
       try {
-         obj.add(AddressField.QUEUE_COUNT.getName(), toString(server.bindingQuery(address.getName()).getQueueNames().size()));
-         return obj;
+         obj.add(AddressField.NUMBER_OF_BYTES_PER_PAGE.getName(), toString(address.getNumberOfBytesPerPage()));
       } catch (Exception e) {
-         obj.add(AddressField.QUEUE_COUNT.getName(), 0);
+         obj.add(AddressField.NUMBER_OF_BYTES_PER_PAGE.getName(), N_A);
+      }
+
+      try {
+         obj.add(AddressField.PAGING.getName(), toString(address.isPaging()));
+      } catch (Exception e) {
+         obj.add(AddressField.PAGING.getName(), N_A);
       }
       return obj;
    }
 
    @Override
-   public Object getField(AddressInfo address, String fieldName) {
+   public Object getField(AddressControl address, String fieldName) {
       if (address == null) {
          return null;
       }
 
-      AddressField field = AddressField.valueOfName(fieldName);
-
-      switch (field) {
-         case ID:
-            return address.getId();
-         case NAME:
-            return address.getName();
-         case INTERNAL:
-            return address.isInternal();
-         case ROUTING_TYPES:
-            return address.getRoutingTypes();
-         case QUEUE_COUNT:
+      return switch (AddressField.valueOfName(fieldName)) {
+         case ID -> address.getId();
+         case NAME -> address.getAddress();
+         case ROUTING_TYPES -> address.getRoutingTypes();
+         case QUEUE_COUNT -> address.getQueueCount();
+         case INTERNAL -> address.isInternal();
+         case TEMPORARY -> address.isTemporary();
+         case AUTO_CREATED -> address.isAutoCreated();
+         case PAUSED -> address.isPaused();
+         case CURRENT_DUPLICATE_ID_CACHE_SIZE -> address.getCurrentDuplicateIdCacheSize();
+         case RETROACTIVE_RESOURCE -> address.isRetroactiveResource();
+         case UNROUTED_MESSAGE_COUNT -> address.getUnRoutedMessageCount();
+         case ROUTED_MESSAGE_COUNT -> address.getRoutedMessageCount();
+         case MESSAGE_COUNT -> address.getMessageCount();
+         case NUMBER_OF_BYTES_PER_PAGE -> {
             try {
-               return server.bindingQuery(address.getName()).getQueueNames().size();
+               yield address.getNumberOfBytesPerPage();
             } catch (Exception e) {
-               return 0;
+               yield N_A;
             }
-         default:
-            throw new IllegalArgumentException("Unsupported field, " + fieldName);
-      }
+         }
+         case ADDRESS_LIMIT_PERCENT -> address.getAddressLimitPercent();
+         case PAGING -> {
+            try {
+               yield address.isPaging();
+            } catch (Exception e) {
+               yield N_A;
+            }
+         }
+         case NUMBER_OF_PAGES -> address.getNumberOfPages();
+         case ADDRESS_SIZE -> address.getAddressSize();
+         case MAX_PAGE_READ_BYTES -> address.getMaxPageReadBytes();
+         case MAX_PAGE_READ_MESSAGES -> address.getMaxPageReadMessages();
+         case PREFETCH_PAGE_BYTES -> address.getPrefetchPageBytes();
+         case PREFETCH_PAGE_MESSAGES -> address.getPrefetchPageBytes();
+         default -> throw new IllegalArgumentException("Unsupported field, " + fieldName);
+      };
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/predicate/AddressFilterPredicate.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/predicate/AddressFilterPredicate.java
@@ -16,11 +16,13 @@
  */
 package org.apache.activemq.artemis.core.management.impl.view.predicate;
 
+import java.util.Arrays;
+
+import org.apache.activemq.artemis.api.core.management.AddressControl;
 import org.apache.activemq.artemis.core.management.impl.view.AddressField;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
-import org.apache.activemq.artemis.core.server.impl.AddressInfo;
 
-public class AddressFilterPredicate extends ActiveMQFilterPredicate<AddressInfo> {
+public class AddressFilterPredicate extends ActiveMQFilterPredicate<AddressControl> {
 
    private AddressField f;
 
@@ -32,27 +34,37 @@ public class AddressFilterPredicate extends ActiveMQFilterPredicate<AddressInfo>
    }
 
    @Override
-   public boolean test(AddressInfo address) {
+   public boolean test(AddressControl address) {
       if (f == null)
          return true;
       try {
-         switch (f) {
-            case ID:
-               return matches(address.getId());
-            case NAME:
-               return matches(address.getName());
-            case ROUTING_TYPES:
-               return matchAny(address.getRoutingTypes());
-            case PRODUCER_ID:
-               return matches("TODO");
-            case QUEUE_COUNT:
-               return matches(server.bindingQuery(address.getName()).getQueueNames().size());
-         }
+         return switch (f) {
+            case ID -> matches(address.getId());
+            case NAME -> matches(address.getAddress());
+            case ROUTING_TYPES -> matchAny(Arrays.asList(address.getRoutingTypes()));
+            case QUEUE_COUNT -> matches(address.getQueueCount());
+            case INTERNAL -> matches(address.isInternal());
+            case TEMPORARY -> matches(address.isTemporary());
+            case AUTO_CREATED -> matches(address.isAutoCreated());
+            case PAUSED -> matches(address.isPaused());
+            case CURRENT_DUPLICATE_ID_CACHE_SIZE -> matches(address.getCurrentDuplicateIdCacheSize());
+            case RETROACTIVE_RESOURCE -> matches(address.isRetroactiveResource());
+            case UNROUTED_MESSAGE_COUNT -> matches(address.getUnRoutedMessageCount());
+            case ROUTED_MESSAGE_COUNT -> matches(address.getRoutedMessageCount());
+            case MESSAGE_COUNT -> matches(address.getMessageCount());
+            case NUMBER_OF_BYTES_PER_PAGE -> matches(address.getNumberOfBytesPerPage());
+            case ADDRESS_LIMIT_PERCENT -> matches(address.getAddressLimitPercent());
+            case PAGING -> matches(address.isPaging());
+            case NUMBER_OF_PAGES -> matches(address.getNumberOfPages());
+            case ADDRESS_SIZE -> matches(address.getAddressSize());
+            case MAX_PAGE_READ_BYTES -> matches(address.getMaxPageReadBytes());
+            case MAX_PAGE_READ_MESSAGES -> matches(address.getMaxPageReadMessages());
+            case PREFETCH_PAGE_BYTES -> matches(address.getPrefetchPageBytes());
+            case PREFETCH_PAGE_MESSAGES -> matches(address.getPrefetchPageBytes());
+         };
       } catch (Exception e) {
          return false;
       }
-
-      return true;
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/predicate/QueueFilterPredicate.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/predicate/QueueFilterPredicate.java
@@ -36,71 +36,46 @@ public class QueueFilterPredicate extends ActiveMQFilterPredicate<QueueControl> 
 
    @Override
    public boolean test(QueueControl queue) {
-      // Using switch over enum vs string comparison is better for perf.
+      if (f == null)
+         return true;
       try {
-         if (f == null)
-            return true;
-         switch (f) {
-            case ID:
-               return matches(queue.getID());
-            case NAME:
-               return matches(queue.getName());
-            case CONSUMER_ID:
+         return switch (f) {
+            case ID -> matches(queue.getID());
+            case NAME -> matches(queue.getName());
+            case CONSUMER_ID -> {
                Queue q = server.locateQueue(SimpleString.of(queue.getName()));
                for (Consumer consumer : q.getConsumers()) {
                   if (matches(consumer.sequentialID()))
-                     return true;
+                     yield true;
                }
-               return false;
-            case MAX_CONSUMERS:
-               return matches(queue.getMaxConsumers());
-            case ADDRESS:
-               return matches(queue.getAddress());
-            case FILTER:
-               return matches(queue.getFilter());
-            case MESSAGE_COUNT:
-               return matches(queue.getMessageCount());
-            case CONSUMER_COUNT:
-               return matches(queue.getConsumerCount());
-            case DELIVERING_COUNT:
-               return matches(queue.getDeliveringCount());
-            case MESSAGES_ADDED:
-               return matches(queue.getMessagesAdded());
-            case MESSAGES_ACKED:
-               return matches(queue.getMessagesAcknowledged());
-            case MESSAGES_EXPIRED:
-               return matches(queue.getMessagesExpired());
-            case ROUTING_TYPE:
-               return matches(queue.getRoutingType());
-            case AUTO_CREATED:
-               return matches(server.locateQueue(SimpleString.of(queue.getName())).isAutoCreated());
-            case DURABLE:
-               return matches(queue.isDurable());
-            case PAUSED:
-               return matches(queue.isPaused());
-            case TEMPORARY:
-               return matches(queue.isTemporary());
-            case PURGE_ON_NO_CONSUMERS:
-               return matches(queue.isPurgeOnNoConsumers());
-            case MESSAGES_KILLED:
-               return matches(queue.getMessagesKilled());
-            case EXCLUSIVE:
-               return matches(queue.isExclusive());
-            case LAST_VALUE:
-               return matches(queue.isLastValue());
-            case SCHEDULED_COUNT:
-               return matches(queue.getScheduledCount());
-            case USER:
-               return matches(queue.getUser());
-            case INTERNAL_QUEUE:
-               return matches(queue.isInternalQueue());
-            default:
-               return true;
-         }
+               yield false;
+            }
+            case MAX_CONSUMERS -> matches(queue.getMaxConsumers());
+            case ADDRESS -> matches(queue.getAddress());
+            case FILTER -> matches(queue.getFilter());
+            case MESSAGE_COUNT -> matches(queue.getMessageCount());
+            case CONSUMER_COUNT -> matches(queue.getConsumerCount());
+            case DELIVERING_COUNT -> matches(queue.getDeliveringCount());
+            case MESSAGES_ADDED -> matches(queue.getMessagesAdded());
+            case MESSAGES_ACKED -> matches(queue.getMessagesAcknowledged());
+            case MESSAGES_EXPIRED -> matches(queue.getMessagesExpired());
+            case ROUTING_TYPE -> matches(queue.getRoutingType());
+            case AUTO_CREATED -> matches(server.locateQueue(SimpleString.of(queue.getName())).isAutoCreated());
+            case DURABLE -> matches(queue.isDurable());
+            case PAUSED -> matches(queue.isPaused());
+            case TEMPORARY -> matches(queue.isTemporary());
+            case PURGE_ON_NO_CONSUMERS -> matches(queue.isPurgeOnNoConsumers());
+            case MESSAGES_KILLED -> matches(queue.getMessagesKilled());
+            case EXCLUSIVE -> matches(queue.isExclusive());
+            case LAST_VALUE -> matches(queue.isLastValue());
+            case SCHEDULED_COUNT -> matches(queue.getScheduledCount());
+            case USER -> matches(queue.getUser());
+            case INTERNAL_QUEUE -> matches(queue.isInternalQueue());
+            default -> true;
+         };
       } catch (Exception e) {
          return true;
       }
-
    }
 
    @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/ActiveMQServerControlTest.java
@@ -4175,6 +4175,7 @@ public class ActiveMQServerControlTest extends ManagementTestBase {
       addressesAsJsonString = serverControl.listAddresses(filterString, 1, 50);
       addressesAsJsonObject = JsonUtil.readJsonObject(addressesAsJsonString);
       array = (JsonArray) addressesAsJsonObject.get("data");
+      System.out.println(array);
 
       assertEquals(1, array.size(), "number of addresses returned from query");
       //check all field names

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/AddressControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/AddressControlUsingCoreTest.java
@@ -52,6 +52,11 @@ public class AddressControlUsingCoreTest extends AddressControlTest {
          }
 
          @Override
+         public long getId() {
+            return ((Number)proxy.retrieveAttributeValue("id")).longValue();
+         }
+
+         @Override
          public String getAddress() {
             return (String) proxy.retrieveAttributeValue("address");
          }
@@ -62,7 +67,7 @@ public class AddressControlUsingCoreTest extends AddressControlTest {
          }
 
          @Override
-         public String getRoutingTypesAsJSON() throws Exception {
+         public String getRoutingTypesAsJSON() {
             return (String) proxy.retrieveAttributeValue("routingTypesAsJSON");
          }
 
@@ -134,6 +139,11 @@ public class AddressControlUsingCoreTest extends AddressControlTest {
          @Override
          public String[] getBindingNames() throws Exception {
             return (String[]) proxy.retrieveAttributeValue("bindingNames", String.class);
+         }
+
+         @Override
+         public long getQueueCount() {
+            return (long) proxy.retrieveAttributeValue("queueCount");
          }
 
          @Override


### PR DESCRIPTION
There are a number of attributes available via AddressControl that are not available on AddressView. These two classes should be harmonized so that, e.g. the web console's "Addresses" tab can have the same details as the JMX MBean view and vice versa.