### PR TITLE
ARTEMIS-5360 Use newer syntax in Dockerfiles

### DIFF
--- a/artemis-docker/Dockerfile-alpine-21
+++ b/artemis-docker/Dockerfile-alpine-21
@@ -28,10 +28,10 @@ RUN /bin/sh -c "apk update && apk upgrade --no-cache && apk add --no-cache bash 
 
 WORKDIR /opt
 
-ENV ARTEMIS_USER artemis
-ENV ARTEMIS_PASSWORD artemis
-ENV ANONYMOUS_LOGIN false
-ENV EXTRA_ARGS --http-host 0.0.0.0 --relax-jolokia
+ENV ARTEMIS_USER=artemis
+ENV ARTEMIS_PASSWORD=artemis
+ENV ANONYMOUS_LOGIN=false
+ENV EXTRA_ARGS="--http-host 0.0.0.0 --relax-jolokia"
 
 USER artemis
 
@@ -53,7 +53,7 @@ EXPOSE \
 
 USER root
 
-RUN mkdir /var/lib/artemis-instance && chown -R artemis.artemis /var/lib/artemis-instance
+RUN mkdir /var/lib/artemis-instance && chown -R artemis:artemis /var/lib/artemis-instance
 
 COPY ./docker/docker-run.sh /
 

--- a/artemis-docker/Dockerfile-alpine-21-jre
+++ b/artemis-docker/Dockerfile-alpine-21-jre
@@ -28,10 +28,10 @@ RUN /bin/sh -c "apk update && apk upgrade --no-cache && apk add --no-cache bash 
 
 WORKDIR /opt
 
-ENV ARTEMIS_USER artemis
-ENV ARTEMIS_PASSWORD artemis
-ENV ANONYMOUS_LOGIN false
-ENV EXTRA_ARGS --http-host 0.0.0.0 --relax-jolokia
+ENV ARTEMIS_USER=artemis
+ENV ARTEMIS_PASSWORD=artemis
+ENV ANONYMOUS_LOGIN=false
+ENV EXTRA_ARGS="--http-host 0.0.0.0 --relax-jolokia"
 
 USER artemis
 
@@ -53,7 +53,7 @@ EXPOSE \
 
 USER root
 
-RUN mkdir /var/lib/artemis-instance && chown -R artemis.artemis /var/lib/artemis-instance
+RUN mkdir /var/lib/artemis-instance && chown -R artemis:artemis /var/lib/artemis-instance
 
 COPY ./docker/docker-run.sh /
 

--- a/artemis-docker/Dockerfile-ubuntu-21
+++ b/artemis-docker/Dockerfile-ubuntu-21
@@ -21,10 +21,10 @@ FROM eclipse-temurin:21-jdk
 LABEL maintainer="Apache ActiveMQ Team"
 WORKDIR /opt
 
-ENV ARTEMIS_USER artemis
-ENV ARTEMIS_PASSWORD artemis
-ENV ANONYMOUS_LOGIN false
-ENV EXTRA_ARGS --http-host 0.0.0.0 --relax-jolokia
+ENV ARTEMIS_USER=artemis
+ENV ARTEMIS_PASSWORD=artemis
+ENV ANONYMOUS_LOGIN=false
+ENV EXTRA_ARGS="--http-host 0.0.0.0 --relax-jolokia"
 
 # add user and group for artemis
 RUN groupadd -g 1001 -r artemis && useradd -r -u 1001 -g artemis artemis
@@ -55,7 +55,7 @@ EXPOSE \
 
 USER root
 
-RUN mkdir /var/lib/artemis-instance && chown -R artemis.artemis /var/lib/artemis-instance
+RUN mkdir /var/lib/artemis-instance && chown -R artemis:artemis /var/lib/artemis-instance
 
 COPY ./docker/docker-run.sh /
 

--- a/artemis-docker/Dockerfile-ubuntu-21-jre
+++ b/artemis-docker/Dockerfile-ubuntu-21-jre
@@ -21,10 +21,10 @@ FROM eclipse-temurin:21-jre
 LABEL maintainer="Apache ActiveMQ Team"
 WORKDIR /opt
 
-ENV ARTEMIS_USER artemis
-ENV ARTEMIS_PASSWORD artemis
-ENV ANONYMOUS_LOGIN false
-ENV EXTRA_ARGS --http-host 0.0.0.0 --relax-jolokia
+ENV ARTEMIS_USER=artemis
+ENV ARTEMIS_PASSWORD=artemis
+ENV ANONYMOUS_LOGIN=false
+ENV EXTRA_ARGS="--http-host 0.0.0.0 --relax-jolokia"
 
 # add user and group for artemis
 RUN groupadd -g 1001 -r artemis && useradd -r -u 1001 -g artemis artemis
@@ -55,7 +55,7 @@ EXPOSE \
 
 USER root
 
-RUN mkdir /var/lib/artemis-instance && chown -R artemis.artemis /var/lib/artemis-instance
+RUN mkdir /var/lib/artemis-instance && chown -R artemis:artemis /var/lib/artemis-instance
 
 COPY ./docker/docker-run.sh /
 


### PR DESCRIPTION
`ENV VAR value` produces warnings in newer Docker Engine versions and according to Docker manual should not be used.

While at it, I also updated chown syntax to follow POSIX 1003.1-2001 standard.