### PR TITLE
ARTEMIS-5364 clean up scripts & profiles

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Create.java
@@ -929,13 +929,10 @@ public class Create extends InstallAbstract {
       // I am using a different replacing pattern here, for cases where want an actual ${artemis.instance} in the output
       // so that's just to make a distinction
       filters.put("@artemis.instance@", path(directory));
-      filters.put("${artemis.instance.uri}", directory.toURI().toString());
-      filters.put("${artemis.instance.uri.windows}", directory.toURI().toString().replaceAll("%", "%%"));
       filters.put("${artemis.instance.name}", directory.getName());
       filters.put("${java.home}", path(System.getProperty("java.home")));
 
       filters.put("${artemis.instance.etc.uri}", etcFolder.toURI().toString());
-      filters.put("${artemis.instance.etc.uri.windows}", etcFolder.toURI().toString().replaceAll("%", "%%"));
       filters.put("${artemis.instance.etc}", path(etcFolder));
       filters.put("${artemis.instance.oome.dump}", path(oomeDumpFile));
       filters.put("${artemis.instance.data}", path(dataFolder));

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Upgrade.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Upgrade.java
@@ -156,8 +156,7 @@ public class Upgrade extends InstallAbstract {
          write(Create.BIN_ARTEMIS_SERVICE_XML, serviceXmlTmp, filters, false, false);
          upgrade(context, serviceXmlTmp, serviceXml, serviceXmlBkp, keepPrefixAlternates,
                  "<env name=\"ARTEMIS_INSTANCE\"", "<env name=\"ARTEMIS_INSTANCE_ETC\"",
-                 "<env name=\"ARTEMIS_INSTANCE_URI\"", "<env name=\"ARTEMIS_INSTANCE_ETC_URI\"",
-                 "<env name=\"ARTEMIS_DATA_DIR\"", "<logpath>", "<startargument>-Xmx", "<stopargument>-Xmx",
+                 "<env name=\"ARTEMIS_DATA_DIR\"", "<logpath>", "<startargument>-Xmx",
                  "<name>", "<id>", "<startargument>-Dhawtio.roles=");
 
          final File artemisProfileCmdTmp = new File(tmp, Create.ETC_ARTEMIS_PROFILE_CMD);
@@ -166,7 +165,7 @@ public class Upgrade extends InstallAbstract {
 
          write("etc/" + Create.ETC_ARTEMIS_PROFILE_CMD, artemisProfileCmdTmp, filters, false, false);
          upgradeJDK(context, JDK_PREFIX_WINDOWS, "", KEEPING_JVM_ARGUMENTS_ALTERNATES, KEEPING_JVM_ARGUMENTS, artemisProfileCmdTmp, artemisProfileCmd, artemisProfileCmdBkp,
-                    Collections.emptyMap(), "set ARTEMIS_INSTANCE=\"", "set ARTEMIS_DATA_DIR=", "set ARTEMIS_ETC_DIR=", "set ARTEMIS_OOME_DUMP=", "set ARTEMIS_INSTANCE_URI=", "set ARTEMIS_INSTANCE_ETC_URI=");
+                    Collections.emptyMap(), "set ARTEMIS_INSTANCE=\"", "set ARTEMIS_DATA_DIR=", "set ARTEMIS_OOME_DUMP=");
 
          File artemisUtilityProfileCmd = new File(etcFolder, Create.ETC_ARTEMIS_UTILITY_PROFILE_CMD);
          File artemisUtilityProfileCmdTmp = new File(tmp, Create.ETC_ARTEMIS_UTILITY_PROFILE_CMD);
@@ -175,7 +174,7 @@ public class Upgrade extends InstallAbstract {
          if (artemisUtilityProfileCmd.exists()) {
             write("etc/" + Create.ETC_ARTEMIS_UTILITY_PROFILE_CMD, artemisUtilityProfileCmdTmp, filters, false, false);
             upgradeJDK(context, JDK_PREFIX_WINDOWS, "", KEEPING_JVM_ARGUMENTS_ALTERNATES, KEEPING_JVM_ARGUMENTS, artemisUtilityProfileCmdTmp, artemisUtilityProfileCmd, artemisUtilityProfileCmdBkp,
-                       Collections.emptyMap(), "set ARTEMIS_INSTANCE=\"", "set ARTEMIS_DATA_DIR=", "set ARTEMIS_ETC_DIR=", "set ARTEMIS_OOME_DUMP=", "set ARTEMIS_INSTANCE_URI=", "set ARTEMIS_INSTANCE_ETC_URI=");
+                       Collections.emptyMap(), "set ARTEMIS_INSTANCE=\"", "set ARTEMIS_DATA_DIR=");
          } else {
             if (data == null || data.equals("data")) {
                dataFolder = getDATA(context, dataFolder, artemisProfileCmd, "set ARTEMIS_DATA_DIR=");
@@ -210,7 +209,7 @@ public class Upgrade extends InstallAbstract {
 
          write("etc/" + Create.ETC_ARTEMIS_PROFILE, artemisProfileTmp, filters, false, false);
          upgradeJDK(context, JDK_PREFIX_LINUX, "\"", KEEPING_JVM_ARGUMENTS_ALTERNATES, KEEPING_JVM_ARGUMENTS, artemisProfileTmp, artemisProfile, artemisProfileBkp,
-               keepPrefixAlternates, "ARTEMIS_INSTANCE=", "ARTEMIS_DATA_DIR=", "ARTEMIS_ETC_DIR=", "ARTEMIS_OOME_DUMP=", "ARTEMIS_INSTANCE_URI=", "ARTEMIS_INSTANCE_ETC_URI=", "HAWTIO_ROLES=");
+               keepPrefixAlternates, "ARTEMIS_INSTANCE=", "ARTEMIS_DATA_DIR=", "ARTEMIS_OOME_DUMP=", "HAWTIO_ROLES=");
 
          File artemisUtilityProfile = new File(etcFolder, Create.ETC_ARTEMIS_UTILITY_PROFILE);
          File artemisUtilityProfileTmp = new File(tmp, Create.ETC_ARTEMIS_UTILITY_PROFILE);
@@ -219,7 +218,7 @@ public class Upgrade extends InstallAbstract {
          if (artemisUtilityProfile.exists()) {
             write("etc/" + Create.ETC_ARTEMIS_UTILITY_PROFILE, artemisUtilityProfileTmp, filters, false, false);
             upgradeJDK(context, JDK_PREFIX_LINUX, "\"", KEEPING_JVM_ARGUMENTS_ALTERNATES, KEEPING_JVM_ARGUMENTS, artemisUtilityProfileTmp, artemisUtilityProfile, artemisUtilityProfileBkp,
-                  keepPrefixAlternates, "ARTEMIS_INSTANCE=", "ARTEMIS_DATA_DIR=", "ARTEMIS_ETC_DIR=", "ARTEMIS_OOME_DUMP=", "ARTEMIS_INSTANCE_URI=", "ARTEMIS_INSTANCE_ETC_URI=", "HAWTIO_ROLES=");
+                  keepPrefixAlternates, "ARTEMIS_INSTANCE=", "ARTEMIS_DATA_DIR=");
          } else {
             if (data == null || data.equals("data")) {
                dataFolder = getDATA(context, dataFolder, artemisProfile, "ARTEMIS_DATA_DIR=");

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis-service.xml
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis-service.xml
@@ -25,17 +25,15 @@
    <env name="ARTEMIS_HOME" value="${artemis.home}"/>
    <env name="ARTEMIS_INSTANCE" value="@artemis.instance@"/>
    <env name="ARTEMIS_INSTANCE_ETC" value="${artemis.instance.etc}"/>
-   <env name="ARTEMIS_INSTANCE_URI" value="${artemis.instance.uri}"/>
-   <env name="ARTEMIS_INSTANCE_ETC_URI" value="${artemis.instance.etc.uri}"/>
    <env name="ARTEMIS_DATA_DIR" value="${artemis.instance.data}"/>
 
    <logpath>@artemis.instance@\log</logpath>
    <logmode>roll</logmode>
 
    <executable>%JAVA_HOME%\bin\java.exe</executable>
-   <startargument>-XX:+UseParallelGC</startargument>
+   <startargument>-XX:+UseG1GC</startargument>
    <startargument>-Xms512M</startargument>
-   <startargument>-Xmx1024M</startargument>
+   <startargument>-Xmx${java-memory}</startargument>
 
    <!-- Cluster Properties: Used to pass startarguments to ActiveMQ Artemis which can be referenced in broker.xml
    <startargument>-Dartemis.remoting.default.port=61617</startargument>
@@ -56,7 +54,7 @@
    <startargument>-Dhawtio.offline="true"</startargument>
    <startargument>-Dhawtio.roles=${role}</startargument>
    <startargument>-Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal</startargument>
-   <startargument>-Djolokia.policyLocation=%ARTEMIS_INSTANCE_ETC_URI%/jolokia-access.xml</startargument>
+   <startargument>-Djolokia.policyLocation=classpath:jolokia-access.xml</startargument>
 
    <!-- Debug args: Uncomment to enable debug
    <startargument>-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005</startargument>
@@ -67,9 +65,6 @@
    <startargument>run</startargument>
 
    <stopexecutable>%JAVA_HOME%\bin\java.exe</stopexecutable>
-   <stopargument>-XX:+UseParallelGC</stopargument>
-   <stopargument>-Xms512M</stopargument>
-   <stopargument>-Xmx1024M</stopargument>
 
    <stopargument>-classpath</stopargument>
    <stopargument>%ARTEMIS_HOME%\lib\artemis-boot.jar</stopargument>

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis.cmd
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/bin/artemis.cmd
@@ -80,6 +80,7 @@ set JVM_ARGS=%JVM_ARGS% -Dartemis.home=%ARTEMIS_HOME%
 set JVM_ARGS=%JVM_ARGS% -Dartemis.instance=%ARTEMIS_INSTANCE%
 set JVM_ARGS=%JVM_ARGS% -Ddata.dir=%ARTEMIS_DATA_DIR%
 set JVM_ARGS=%JVM_ARGS% -Dartemis.instance.etc=%ARTEMIS_INSTANCE_ETC%
+set JVM_ARGS=%JVM_ARGS% -Djava.security.auth.login.config=%ARTEMIS_INSTANCE_ETC%\login.config
 
 if not "%DEBUG_ARGS%"=="" set JVM_ARGS=%JVM_ARGS% %DEBUG_ARGS%
 if not "%$JAVA_ARGS_APPEND%"=="" set JVM_ARGS=%JVM_ARGS% %$JAVA_ARGS_APPEND%

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis-utility.profile
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis-utility.profile
@@ -18,17 +18,9 @@
 ARTEMIS_HOME='${artemis.home}'
 ARTEMIS_INSTANCE='@artemis.instance@'
 ARTEMIS_DATA_DIR='${artemis.instance.data}'
-ARTEMIS_ETC_DIR='${artemis.instance.etc}'
-ARTEMIS_OOME_DUMP='${artemis.instance.oome.dump}'
-
-# The logging config will need an URI
-# this will be encoded in case you use spaces or special characters
-# on your directory structure
-ARTEMIS_INSTANCE_URI='${artemis.instance.uri}'
-ARTEMIS_INSTANCE_ETC_URI='${artemis.instance.etc.uri}'
 
 if [ -z "$LOGGING_ARGS" ]; then
-    LOGGING_ARGS="-Dlog4j2.configurationFile=${ARTEMIS_INSTANCE_ETC_URI}log4j2-utility.properties"
+    LOGGING_ARGS="-Dlog4j2.configurationFile=log4j2-utility.properties"
 fi
 
 if [ -z "$JAVA_ARGS" ]; then

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis-utility.profile.cmd
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis-utility.profile.cmd
@@ -19,17 +19,8 @@ rem under the License.
 set ARTEMIS_HOME="${artemis.home}"
 set ARTEMIS_INSTANCE="@artemis.instance@"
 set ARTEMIS_DATA_DIR="${artemis.instance.data}"
-set ARTEMIS_ETC_DIR="${artemis.instance.etc}"
-set ARTEMIS_OOME_DUMP="${artemis.instance.oome.dump}"
 
-
-rem The logging config will need an URI
-rem this will be encoded in case you use spaces or special characters
-rem on your directory structure
-set ARTEMIS_INSTANCE_URI="${artemis.instance.uri.windows}"
-set ARTEMIS_INSTANCE_ETC_URI="${artemis.instance.etc.uri.windows}"
-
-IF "%LOGGING_ARGS%"=="" (set LOGGING_ARGS=-Dlog4j2.configurationFile=%ARTEMIS_INSTANCE_ETC_URI%log4j2-utility.properties)
+IF "%LOGGING_ARGS%"=="" (set LOGGING_ARGS=-Dlog4j2.configurationFile=log4j2-utility.properties)
 
 IF "%JAVA_ARGS%"=="" (set JAVA_ARGS=-Dlog4j2.disableJmx=true --add-opens java.base/jdk.internal.misc=ALL-UNNAMED ${java-utility-opts})
 

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile
@@ -18,14 +18,7 @@
 ARTEMIS_HOME='${artemis.home}'
 ARTEMIS_INSTANCE='@artemis.instance@'
 ARTEMIS_DATA_DIR='${artemis.instance.data}'
-ARTEMIS_ETC_DIR='${artemis.instance.etc}'
 ARTEMIS_OOME_DUMP='${artemis.instance.oome.dump}'
-
-# The logging config will need an URI
-# this will be encoded in case you use spaces or special characters
-# on your directory structure
-ARTEMIS_INSTANCE_URI='${artemis.instance.uri}'
-ARTEMIS_INSTANCE_ETC_URI='${artemis.instance.etc.uri}'
 
 # Cluster Properties: Used to pass arguments to ActiveMQ Artemis which can be referenced in broker.xml
 #ARTEMIS_CLUSTER_PROPS="-Dactivemq.remoting.default.port=61617 -Dactivemq.remoting.amqp.port=5673 -Dactivemq.remoting.stomp.port=61614 -Dactivemq.remoting.hornetq.port=5446"
@@ -37,7 +30,7 @@ HAWTIO_ROLES='${role}'
 
 # Java Opts
 if [ -z "$JAVA_ARGS" ]; then
-    JAVA_ARGS="-XX:AutoBoxCacheMax=20000 -XX:+PrintClassHistogram -XX:+UseG1GC -XX:+UseStringDeduplication -Xms512M -Xmx${java-memory} -Dhawtio.disableProxy=true -Dhawtio.realm=activemq -Dhawtio.offline=true -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal -Dhawtio.http.strictTransportSecurity=max-age=31536000;includeSubDomains;preload -Djolokia.policyLocation=${ARTEMIS_INSTANCE_ETC_URI}jolokia-access.xml -Dlog4j2.disableJmx=true --add-opens java.base/jdk.internal.misc=ALL-UNNAMED ${java-opts}"
+    JAVA_ARGS="-XX:AutoBoxCacheMax=20000 -XX:+PrintClassHistogram -XX:+UseG1GC -XX:+UseStringDeduplication -Xms512M -Xmx${java-memory} -Dhawtio.disableProxy=true -Dhawtio.realm=activemq -Dhawtio.offline=true -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal -Dhawtio.http.strictTransportSecurity=max-age=31536000;includeSubDomains;preload -Djolokia.policyLocation=classpath:jolokia-access.xml -Dlog4j2.disableJmx=true --add-opens java.base/jdk.internal.misc=ALL-UNNAMED ${java-opts}"
 fi
 
 # Uncomment to enable logging for Safepoint JVM pauses

--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile.cmd
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/artemis.profile.cmd
@@ -19,21 +19,13 @@ rem under the License.
 set ARTEMIS_HOME="${artemis.home}"
 set ARTEMIS_INSTANCE="@artemis.instance@"
 set ARTEMIS_DATA_DIR="${artemis.instance.data}"
-set ARTEMIS_ETC_DIR="${artemis.instance.etc}"
 set ARTEMIS_OOME_DUMP="${artemis.instance.oome.dump}"
-
-
-rem The logging config will need an URI
-rem this will be encoded in case you use spaces or special characters
-rem on your directory structure
-set ARTEMIS_INSTANCE_URI="${artemis.instance.uri.windows}"
-set ARTEMIS_INSTANCE_ETC_URI="${artemis.instance.etc.uri.windows}"
 
 rem Cluster Properties: Used to pass arguments to ActiveMQ Artemis which can be referenced in broker.xml
 rem set ARTEMIS_CLUSTER_PROPS=-Dactivemq.remoting.default.port=61617 -Dactivemq.remoting.amqp.port=5673 -Dactivemq.remoting.stomp.port=61614 -Dactivemq.remoting.hornetq.port=5446
 
 rem Java Opts
-IF "%JAVA_ARGS%"=="" (set JAVA_ARGS=${java-opts} -XX:AutoBoxCacheMax=20000 -XX:+PrintClassHistogram  -XX:+UseG1GC -XX:+UseStringDeduplication -Xms512M -Xmx${java-memory} -Djava.security.auth.login.config=%ARTEMIS_ETC_DIR%\login.config -Dhawtio.disableProxy=true -Dhawtio.offline=true -Dhawtio.realm=activemq -Dhawtio.roles=${role} -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal -Dhawtio.http.strictTransportSecurity=max-age=31536000;includeSubDomains;preload -Djolokia.policyLocation=%ARTEMIS_INSTANCE_ETC_URI%\jolokia-access.xml -Dartemis.instance=%ARTEMIS_INSTANCE%  --add-opens java.base/jdk.internal.misc=ALL-UNNAMED -Dlog4j2.disableJmx=true)
+IF "%JAVA_ARGS%"=="" (set JAVA_ARGS=-XX:AutoBoxCacheMax=20000 -XX:+PrintClassHistogram -XX:+UseG1GC -XX:+UseStringDeduplication -Xms512M -Xmx${java-memory} -Dhawtio.disableProxy=true -Dhawtio.realm=activemq -Dhawtio.offline=true -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal -Dhawtio.http.strictTransportSecurity=max-age=31536000;includeSubDomains;preload -Djolokia.policyLocation=classpath:jolokia-access.xml -Dlog4j2.disableJmx=true --add-opens java.base/jdk.internal.misc=ALL-UNNAMED -Dhawtio.roles=${role} ${java-opts} )
 
 rem Logs Safepoints JVM pauses: Uncomment to enable them
 rem In addition to the traditional GC logs you could enable some JVM flags to know any meaningful and "hidden" pause that could

--- a/artemis-cli/src/test/java/org/apache/activemq/artemis/util/JVMArgumentTest.java
+++ b/artemis-cli/src/test/java/org/apache/activemq/artemis/util/JVMArgumentTest.java
@@ -48,10 +48,10 @@ public class JVMArgumentTest {
       final String arguments;
       if (useNewArgPropName) {
          // Uses new args prop -Dhawtio.roles=
-         arguments = "IF \"%JAVA_ARGS%\"==\"\" (set JAVA_ARGS= -must-go -XX:AutoBoxCacheMax=20000 -XX:+PrintClassHistogram  -XX:+UseG1GC -XX:+UseStringDeduplication -Xms333M -Xmx77G -Djava.security.auth.login.config=%ARTEMIS_ETC_DIR%\\login.config -Dhawtio.disableProxy=true -Dhawtio.offline=true -Dhawtio.realm=activemq -Dhawtio.roles=amq -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal -Dhawtio.http.strictTransportSecurity=max-age=31536000;includeSubDomains;preload -Djolokia.policyLocation=%ARTEMIS_INSTANCE_ETC_URI%\\jolokia-access.xml -Dartemis.instance=%ARTEMIS_INSTANCE%  --add-opens java.base/jdk.internal.misc=ALL-UNNAMED -Dlog4j2.disableJmx=true)";
+         arguments = "IF \"%JAVA_ARGS%\"==\"\" (set JAVA_ARGS= -must-go -XX:AutoBoxCacheMax=20000 -XX:+PrintClassHistogram  -XX:+UseG1GC -XX:+UseStringDeduplication -Xms333M -Xmx77G -Dhawtio.disableProxy=true -Dhawtio.offline=true -Dhawtio.realm=activemq -Dhawtio.roles=amq -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal -Dhawtio.http.strictTransportSecurity=max-age=31536000;includeSubDomains;preload -Djolokia.policyLocation=classpath:jolokia-access.xml --add-opens java.base/jdk.internal.misc=ALL-UNNAMED -Dlog4j2.disableJmx=true)";
       } else {
          // Uses old args prop -Dhawtio.role=
-         arguments = "IF \"%JAVA_ARGS%\"==\"\" (set JAVA_ARGS= -must-go -XX:AutoBoxCacheMax=20000 -XX:+PrintClassHistogram  -XX:+UseG1GC -XX:+UseStringDeduplication -Xms333M -Xmx77G -Djava.security.auth.login.config=%ARTEMIS_ETC_DIR%\\login.config -Dhawtio.disableProxy=true -Dhawtio.offline=true -Dhawtio.realm=activemq -Dhawtio.role=amq -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal -Dhawtio.http.strictTransportSecurity=max-age=31536000;includeSubDomains;preload -Djolokia.policyLocation=%ARTEMIS_INSTANCE_ETC_URI%\\jolokia-access.xml -Dartemis.instance=%ARTEMIS_INSTANCE%  --add-opens java.base/jdk.internal.misc=ALL-UNNAMED -Dlog4j2.disableJmx=true)";
+         arguments = "IF \"%JAVA_ARGS%\"==\"\" (set JAVA_ARGS= -must-go -XX:AutoBoxCacheMax=20000 -XX:+PrintClassHistogram  -XX:+UseG1GC -XX:+UseStringDeduplication -Xms333M -Xmx77G -Dhawtio.disableProxy=true -Dhawtio.offline=true -Dhawtio.realm=activemq -Dhawtio.role=amq -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal -Dhawtio.http.strictTransportSecurity=max-age=31536000;includeSubDomains;preload -Djolokia.policyLocation=classpath:jolokia-access.xml --add-opens java.base/jdk.internal.misc=ALL-UNNAMED -Dlog4j2.disableJmx=true)";
       }
 
       String prefix = "IF \"%JAVA_ARGS%\"==\"\" (set JAVA_ARGS= ";
@@ -66,7 +66,7 @@ public class JVMArgumentTest {
       assertEquals("-Xms333M", usedArgs.get("-Xms"));
       assertEquals("-Dhawtio.roles=amq", usedArgs.get("-Dhawtio.roles="));
 
-      String newLine = "IF \"%JAVA_ARGS%\"==\"\" (set JAVA_ARGS= -XX:AutoBoxCacheMax=20000 -XX:+PrintClassHistogram  -XX:+UseG1GC -XX:+UseStringDeduplication -Xms512M -Xmx1G -Djava.security.auth.login.config=%ARTEMIS_ETC_DIR%\\login.config -Dhawtio.disableProxy=true -Dhawtio.offline=true -Dhawtio.realm=activemq -Dhawtio.roles=replaceThisRole -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal -Djolokia.policyLocation=%ARTEMIS_INSTANCE_ETC_URI%\\jolokia-access.xml -Dartemis.instance=%ARTEMIS_INSTANCE%)";
+      String newLine = "IF \"%JAVA_ARGS%\"==\"\" (set JAVA_ARGS= -XX:AutoBoxCacheMax=20000 -XX:+PrintClassHistogram  -XX:+UseG1GC -XX:+UseStringDeduplication -Xms512M -Xmx1G -Dhawtio.disableProxy=true -Dhawtio.offline=true -Dhawtio.realm=activemq -Dhawtio.roles=replaceThisRole -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal -Djolokia.policyLocation=classpath:jolokia-access.xml)";
 
       String resultLine = JVMArgumentParser.parseNewLine(prefix, "\"", newLine, fixedArguments, usedArgs);
 
@@ -85,7 +85,7 @@ public class JVMArgumentTest {
 
    @Test
    public void testArgumentsLinux() {
-      String arguments = "    JAVA_ARGS=\"-must-go -XX:AutoBoxCacheMax=20000 -XX:+PrintClassHistogram -XX:+UseG1GC -XX:+UseStringDeduplication -Xms333M -Xmx77G -Dhawtio.disableProxy=true -Dhawtio.realm=activemq -Dhawtio.offline=true -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal -Dhawtio.http.strictTransportSecurity=max-age=31536000;includeSubDomains;preload -Djolokia.policyLocation=${ARTEMIS_INSTANCE_ETC_URI}jolokia-access.xml -Dlog4j2.disableJmx=true --add-opens java.base/jdk.internal.misc=ALL-UNNAMED \"";
+      String arguments = "    JAVA_ARGS=\"-must-go -XX:AutoBoxCacheMax=20000 -XX:+PrintClassHistogram -XX:+UseG1GC -XX:+UseStringDeduplication -Xms333M -Xmx77G -Dhawtio.disableProxy=true -Dhawtio.realm=activemq -Dhawtio.offline=true -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal -Dhawtio.http.strictTransportSecurity=max-age=31536000;includeSubDomains;preload -Djolokia.policyLocation=classpath:jolokia-access.xml -Dlog4j2.disableJmx=true --add-opens java.base/jdk.internal.misc=ALL-UNNAMED \"";
 
       String prefix = "JAVA_ARGS=";
 
@@ -97,7 +97,7 @@ public class JVMArgumentTest {
       assertEquals("-Xmx77G", usedArgs.get("-Xmx"));
       assertEquals("-Xms333M", usedArgs.get("-Xms"));
 
-      String newLine = "    JAVA_ARGS=\"-XX:AutoBoxCacheMax=20000 -XX:+PrintClassHistogram -XX:+UseG1GC -XX:+UseStringDeduplication -Xms512M -Xmx1G -Dhawtio.disableProxy=true -Dhawtio.realm=activemq -Dhawtio.offline=true -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal -Dhawtio.http.strictTransportSecurity=max-age=31536000;includeSubDomains;preload -Djolokia.policyLocation=${ARTEMIS_INSTANCE_ETC_URI}jolokia-access.xml -Dlog4j2.disableJmx=true --add-opens java.base/jdk.internal.misc=ALL-UNNAMED \"";
+      String newLine = "    JAVA_ARGS=\"-XX:AutoBoxCacheMax=20000 -XX:+PrintClassHistogram -XX:+UseG1GC -XX:+UseStringDeduplication -Xms512M -Xmx1G -Dhawtio.disableProxy=true -Dhawtio.realm=activemq -Dhawtio.offline=true -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal -Dhawtio.http.strictTransportSecurity=max-age=31536000;includeSubDomains;preload -Djolokia.policyLocation=classpath:jolokia-access.xml -Dlog4j2.disableJmx=true --add-opens java.base/jdk.internal.misc=ALL-UNNAMED \"";
 
       String resultLine = JVMArgumentParser.parseNewLine(prefix, "\"", newLine, fixedArguments, usedArgs);
 

--- a/tests/e2e-tests/src/main/resources/containerService/artemis.profile
+++ b/tests/e2e-tests/src/main/resources/containerService/artemis.profile
@@ -20,19 +20,12 @@
 ARTEMIS_HOME='/opt/activemq-artemis'
 ARTEMIS_INSTANCE='/var/lib/artemis-instance'
 ARTEMIS_DATA_DIR='/var/lib/artemis-instance/data'
-ARTEMIS_ETC_DIR='/var/lib/artemis-instance/etc'
 ARTEMIS_OOME_DUMP='/var/lib/artemis-instance/log/oom_dump.hprof'
-
-# The logging config will need an URI
-# this will be encoded in case you use spaces or special characters
-# on your directory structure
-ARTEMIS_INSTANCE_URI='file:/var/lib/artemis-instance/./'
-ARTEMIS_INSTANCE_ETC_URI='file:/var/lib/artemis-instance/./etc/'
 
 # Hawtio Properties
 HAWTIO_ROLE='amq'
 
 # Java Opts
 if [ -z "$JAVA_ARGS" ]; then
-    JAVA_ARGS="-XX:+PrintClassHistogram -XX:+UseG1GC -XX:+UseStringDeduplication -Xms128M -Xmx512M -Dhawtio.disableProxy=true -Dhawtio.realm=activemq -Dhawtio.offline=true -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal -Djolokia.policyLocation=${ARTEMIS_INSTANCE_ETC_URI}jolokia-access.xml -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=1099 -Dcom.sun.management.jmxremote.rmi.port=1099 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
+    JAVA_ARGS="-XX:+PrintClassHistogram -XX:+UseG1GC -XX:+UseStringDeduplication -Xms128M -Xmx512M -Dhawtio.disableProxy=true -Dhawtio.realm=activemq -Dhawtio.offline=true -Dhawtio.rolePrincipalClasses=org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal -Djolokia.policyLocation=classpath:jolokia-access.xml -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=1099 -Dcom.sun.management.jmxremote.rmi.port=1099 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
 fi

--- a/tests/smoke-tests/src/main/filtered-resources/servers/windowsUpgrade/bin/artemis-service.xml
+++ b/tests/smoke-tests/src/main/filtered-resources/servers/windowsUpgrade/bin/artemis-service.xml
@@ -35,7 +35,7 @@
    <executable>%JAVA_HOME%\bin\java.exe</executable>
    <startargument>-XX:+UseParallelGC</startargument>
    <startargument>-Xms512M</startargument>
-   <startargument>-Xmx1024M</startargument>
+   <startargument>-Xmx1G</startargument>
 
    <!-- Cluster Properties: Used to pass startarguments to ActiveMQ Artemis which can be referenced in broker.xml
    <startargument>-Dartemis.remoting.default.port=61617</startargument>

--- a/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/upgradeTest/CompareUpgradeTest.java
+++ b/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/upgradeTest/CompareUpgradeTest.java
@@ -199,7 +199,6 @@ public class CompareUpgradeTest {
                                                        "<env name=\"ARTEMIS_HOME\" value=", null, // no expected value for this, we will check on the output
                                                        "<env name=\"ARTEMIS_INSTANCE\" value=", "\"" + windows  + "\"/>",
                                                        "<env name=\"ARTEMIS_INSTANCE_ETC\" value=", "\"" + windowsETC + "\"/>",
-                                                       "<env name=\"ARTEMIS_INSTANCE_URI\" value=", "\"file:" + windows + "/\"/>",
                                                        "<env name=\"ARTEMIS_DATA_DIR\" value=", "\"" + windowsData + "\"/>",
                                                        "<startargument>-Dhawtio.roles=", hawtioRoles + "</startargument>"
       );
@@ -212,10 +211,7 @@ public class CompareUpgradeTest {
                                    "set ARTEMIS_HOME=", null, // no expected value for this, we will check on the output
                                    "set ARTEMIS_INSTANCE=", "\"" + windows + "\"",
                                    "set ARTEMIS_DATA_DIR=", "\"" + windowsData + "\"",
-                                   "set ARTEMIS_ETC_DIR=", "\"" + windowsETC + "\"",
-                                   "set ARTEMIS_OOME_DUMP=", "\"" + windows + "/log/oom_dump.hprof\"",
-                                   "set ARTEMIS_INSTANCE_URI=", "\"file:" + windows + "/\"",
-                                   "set ARTEMIS_INSTANCE_ETC_URI=", "\"file:" + windowsETC + "/\"");
+                                   "set ARTEMIS_OOME_DUMP=", "\"" + windows + "/log/oom_dump.hprof\"");
 
       home = brokerProfileResult.get("set ARTEMIS_HOME=");
       assertNotNull(home);
@@ -237,13 +233,9 @@ public class CompareUpgradeTest {
       Map<String, String> utilityProfileResult = checkExpectedValues(utilityProfilePath,
             "set ARTEMIS_HOME=", null, // no expected value for this, we will check on the output
             "set ARTEMIS_INSTANCE=", "\"" + windows + "\"",
-            "set ARTEMIS_DATA_DIR=", "\"" + windowsData + "\"",
-            "set ARTEMIS_ETC_DIR=", "\"" + windowsETC + "\"",
-            "set ARTEMIS_OOME_DUMP=", "\"" + windows + "/log/oom_dump.hprof\"",
-            "set ARTEMIS_INSTANCE_URI=", "\"file:" + windows + "/\"",
-            "set ARTEMIS_INSTANCE_ETC_URI=", "\"file:" + windowsETC + "/\"");
+            "set ARTEMIS_DATA_DIR=", "\"" + windowsData + "\"");
 
-      assertEquals(7, utilityProfileResult.size(), "Unexpected number of results");
+      assertEquals(3, utilityProfileResult.size(), "Unexpected number of results");
 
       utilityProfileResult.forEach((key, value) -> {
          assertEquals(value, brokerProfileResult.get(key), "Unexpected difference between profile values for key: " + key);
@@ -264,10 +256,7 @@ public class CompareUpgradeTest {
                                                        "ARTEMIS_HOME=", null, // no expected value, will check on result
                                                        "ARTEMIS_INSTANCE=", "'" + instanceDir + "'",
                                                        "ARTEMIS_DATA_DIR=", "'" + data + "'",
-                                                       "ARTEMIS_ETC_DIR=", "'" + etc + "'",
-                                                       "ARTEMIS_OOME_DUMP=", "'" + instanceDir + "/log/oom_dump.hprof'",
-                                                       "ARTEMIS_INSTANCE_URI=", "'file:" + instanceDir + "/'",
-                                                       "ARTEMIS_INSTANCE_ETC_URI=", "'file:" + etc + "/'");
+                                                       "ARTEMIS_OOME_DUMP=", "'" + instanceDir + "/log/oom_dump.hprof'");
 
       String home = brokerProfileResult.get("ARTEMIS_HOME=");
       assertNotNull(home);
@@ -286,13 +275,9 @@ public class CompareUpgradeTest {
       Map<String, String> utilityProfileResult = checkExpectedValues(utilityProfilePath,
             "ARTEMIS_HOME=", null, // no expected value, will check on result
             "ARTEMIS_INSTANCE=", "'" + instanceDir + "'",
-            "ARTEMIS_DATA_DIR=", "'" + data + "'",
-            "ARTEMIS_ETC_DIR=", "'" + etc + "'",
-            "ARTEMIS_OOME_DUMP=", "'" + instanceDir + "/log/oom_dump.hprof'",
-            "ARTEMIS_INSTANCE_URI=", "'file:" + instanceDir + "/'",
-            "ARTEMIS_INSTANCE_ETC_URI=", "'file:" + etc + "/'");
+            "ARTEMIS_DATA_DIR=", "'" + data + "'");
 
-      assertEquals(7, utilityProfileResult.size(), "Unexpected number of results");
+      assertEquals(3, utilityProfileResult.size(), "Unexpected number of results");
 
       utilityProfileResult.forEach((key, value) -> {
          assertEquals(value, brokerProfileResult.get(key), "Unexpected difference between profile values for key: " + key);


### PR DESCRIPTION
This commit cleans up the various scripts and profile files via the following changes:

 - Remove ARTEMIS_INSTANCE_URI from all profiles since it is no longer used after we moved to Log4j2
 - Remove ARTEMIS_INSTANCE_ETC_URI from all profiles; it is not necessary because the jolokia-access.xml can be loaded directly from the classpath
 - Remove ARTEMIS_ETC_DIR from all profiles and instead rely on ARTEMIS_INSTANCE_ETC which is already being set in the scripts
 - Remove unnecessary code from Create command
 - Remove ARTEMIS_OOME_DUMP from the utility profiles since it's not used
 - Adjust Upgrade command & related tests
 - Fix Windows service file so it uses the same memory settings as the other configs
 - Update the Windows' profile JAVA_ARGS to match those from Linux