### PR TITLE
ARTEMIS-5368 Propagate Federation consumer priority unchanged

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationAddressPolicyManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationAddressPolicyManager.java
@@ -93,7 +93,7 @@ public final class AMQPFederationAddressPolicyManager extends AMQPFederationLoca
    @Override
    public synchronized void afterRemoveAddress(SimpleString address, AddressInfo addressInfo) throws ActiveMQException {
       if (isActive()) {
-         final AMQPFederationConsumerManager entry = federationConsumers.remove(address.toString());
+         final AMQPFederationAddressConsumerManager entry = federationConsumers.remove(address.toString());
 
          if (entry != null) {
             logger.trace("Federated address {} was removed, closing federation consumer", address);
@@ -357,7 +357,7 @@ public final class AMQPFederationAddressPolicyManager extends AMQPFederationLoca
       // current demand and don't need to re-check the server state before trying to create the
       // remote address consumer.
       if (isActive() && testIfAddressMatchesPolicy(addressName, RoutingType.MULTICAST)) {
-         final AMQPFederationConsumerManager entry = federationConsumers.get(addressName);
+         final AMQPFederationAddressConsumerManager entry = federationConsumers.get(addressName);
 
          if (entry != null) {
             entry.recover();
@@ -451,7 +451,7 @@ public final class AMQPFederationAddressPolicyManager extends AMQPFederationLoca
       return false;
    }
 
-   private static class AMQPFederationAddressConsumerManager extends AMQPFederationConsumerManager {
+   private static class AMQPFederationAddressConsumerManager extends AMQPFederationConsumerManager<Binding> {
 
       private final AMQPFederationAddressPolicyManager manager;
       private final AddressInfo addressInfo;
@@ -485,6 +485,16 @@ public final class AMQPFederationAddressPolicyManager extends AMQPFederationLoca
       @Override
       protected boolean isPluginBlockingFederationConsumerCreate() {
          return manager.isPluginBlockingFederationConsumerCreate(addressInfo);
+      }
+
+      @Override
+      protected void whenDemandTrackingEntryAdded(Binding entry) {
+         // No current action needed
+      }
+
+      @Override
+      protected void whenDemandTrackingEntryRemoved(Binding entry) {
+         // No current action needed
       }
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ServerConsumer.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ServerConsumer.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.core.server;
 
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 import org.apache.activemq.artemis.core.transaction.Transaction;
@@ -108,4 +109,43 @@ public interface ServerConsumer extends Consumer, ConsumerInfo {
     * @param transaction the tx
     */
    void metricsAcknowledge(MessageReference ref, Transaction transaction);
+
+   /**
+    * Adds the given attachment to the {@link ServerConsumer} which will overwrite any previously
+    * assigned value with the same key.
+    *
+    * @param key
+    *    The key used to identify the attachment.
+    * @param attachment
+    *    The actual value to store for the assigned key.
+    */
+   void addAttachment(String key, Object attachment);
+
+   /**
+    * Remove the any attachment entry from the {@link ServerConsumer} clearing any previously assigned value
+    *
+    * @param key
+    *    The key used to identify the attachment.
+    */
+   void removeAttachment(String key);
+
+   /**
+    * Gets any attachment that has been assigned to this {@link ServerConsumer} using the provided key.
+    * If no value was assigned a null is returned.
+    *
+    * @param key
+    *    The key identifying the target attachment.
+    *
+    * @return the assigned value associated with the given key or null if nothing assigned.
+    */
+   Object getAttachment(String key);
+
+   /**
+    * Provides access to the full {@link Map} of consumer attachments in an unmodifiable {@link Map} instance.
+    * If no attachments are assigned to the consumer an empty {@link Map} instance is returned, never null.
+    *
+    * @return an unmodifiable {@link Map} that carries all consumer attachments.
+    */
+   Map<String, Object> getAttachments();
+
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerConsumerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerConsumerImpl.java
@@ -21,9 +21,11 @@ import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
@@ -162,6 +164,8 @@ public class ServerConsumerImpl implements ServerConsumer, ReadyListener {
    private boolean anycast = false;
 
    private boolean isClosed = false;
+
+   private Map<String, Object> attachments;
 
    @Override
    public boolean isClosed() {
@@ -638,6 +642,8 @@ public class ServerConsumerImpl implements ServerConsumer, ReadyListener {
          callback = null;
 
          session = null;
+
+         attachments = null;
       });
 
    }
@@ -1607,6 +1613,36 @@ public class ServerConsumerImpl implements ServerConsumer, ReadyListener {
 
    public SessionCallback getCallback() {
       return callback;
+   }
+
+   @Override
+   public synchronized void addAttachment(String key, Object attachment) {
+      if (attachments == null) {
+         attachments = new HashMap<>();
+      }
+
+      attachments.put(key, attachment);
+   }
+
+   @Override
+   public synchronized void removeAttachment(String key) {
+      if (attachments != null) {
+         attachments.remove(key);
+      }
+   }
+
+   @Override
+   public synchronized Object getAttachment(String key) {
+      if (attachments != null) {
+         return attachments.get(key);
+      } else {
+         return null;
+      }
+   }
+
+   @Override
+   public synchronized Map<String, Object> getAttachments() {
+      return attachments != null ? Collections.unmodifiableMap(attachments) : Collections.emptyMap();
    }
 
    static class ServerConsumerMetrics extends TransactionOperationAbstract {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationServerToServerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationServerToServerTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.activemq.artemis.tests.integration.amqp.connect;
 
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.IGNORE_QUEUE_CONSUMER_PRIORITIES;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.PULL_RECEIVER_BATCH_SIZE;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.RECEIVER_CREDITS;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -1493,28 +1494,40 @@ public class AMQPFederationServerToServerTest extends AmqpClientTestSupport {
    @RepeatedTest(1)
    @Timeout(20)
    public void testTwoPullConsumerOnPullingFederationConfigurationEachCanTakeOneMessageProduceOnLocal() throws Exception {
-      doTestTwoPullConsumerOnPullingFederationConfigurationEachCanTakeOneMessage(true, false);
+      doTestTwoPullConsumerOnPullingFederationConfigurationEachCanTakeOneMessage(true, false, true);
    }
 
    @RepeatedTest(1)
    @Timeout(20)
    public void testTwoPullConsumerOnPullingFederationConfigurationEachCanTakeOneMessageProduceOnRemote() throws Exception {
-      doTestTwoPullConsumerOnPullingFederationConfigurationEachCanTakeOneMessage(false, false);
+      doTestTwoPullConsumerOnPullingFederationConfigurationEachCanTakeOneMessage(false, false, true);
    }
 
    @RepeatedTest(1)
    @Timeout(20)
    public void testTwoPullConsumerOnPullingFederationConfigurationEachCanTakeOneMessageProduceOnLocalIncludeFederated() throws Exception {
-      doTestTwoPullConsumerOnPullingFederationConfigurationEachCanTakeOneMessage(true, true);
+      doTestTwoPullConsumerOnPullingFederationConfigurationEachCanTakeOneMessage(true, true, true);
    }
 
    @RepeatedTest(1)
    @Timeout(20)
    public void testTwoPullConsumerOnPullingFederationConfigurationEachCanTakeOneMessageProduceOnRemoteIncludeFederated() throws Exception {
-      doTestTwoPullConsumerOnPullingFederationConfigurationEachCanTakeOneMessage(false, true);
+      doTestTwoPullConsumerOnPullingFederationConfigurationEachCanTakeOneMessage(false, true, true);
    }
 
-   public void doTestTwoPullConsumerOnPullingFederationConfigurationEachCanTakeOneMessage(boolean produceLocal, boolean includeFederated) throws Exception {
+   @RepeatedTest(1)
+   @Timeout(20)
+   public void testTwoPullConsumerOnPullingFederationConfigurationEachCanTakeOneMessageProduceOnLocalIncludeFederatedAmdPriority() throws Exception {
+      doTestTwoPullConsumerOnPullingFederationConfigurationEachCanTakeOneMessage(true, true, false);
+   }
+
+   @RepeatedTest(1)
+   @Timeout(20)
+   public void testTwoPullConsumerOnPullingFederationConfigurationEachCanTakeOneMessageProduceOnRemoteIncludeFederatedAndPriority() throws Exception {
+      doTestTwoPullConsumerOnPullingFederationConfigurationEachCanTakeOneMessage(false, true, false);
+   }
+
+   public void doTestTwoPullConsumerOnPullingFederationConfigurationEachCanTakeOneMessage(boolean produceLocal, boolean includeFederated, boolean ignorePriority) throws Exception {
       logger.info("Test started: {}", getTestName());
 
       final AMQPFederationQueuePolicyElement localQueuePolicy = new AMQPFederationQueuePolicyElement();
@@ -1523,6 +1536,7 @@ public class AMQPFederationServerToServerTest extends AmqpClientTestSupport {
       localQueuePolicy.addProperty(RECEIVER_CREDITS, 0);         // Enable Pull mode
       localQueuePolicy.addProperty(PULL_RECEIVER_BATCH_SIZE, 1); // Pull mode batch is one
       localQueuePolicy.setIncludeFederated(includeFederated);
+      localQueuePolicy.addProperty(IGNORE_QUEUE_CONSUMER_PRIORITIES, Boolean.toString(ignorePriority));
 
       final AMQPFederationQueuePolicyElement remoteQueuePolicy = new AMQPFederationQueuePolicyElement();
       remoteQueuePolicy.setName("test-policy-2");
@@ -1530,6 +1544,7 @@ public class AMQPFederationServerToServerTest extends AmqpClientTestSupport {
       remoteQueuePolicy.addProperty(RECEIVER_CREDITS, 0);         // Enable Pull mode
       remoteQueuePolicy.addProperty(PULL_RECEIVER_BATCH_SIZE, 1); // Pull mode batch is one
       remoteQueuePolicy.setIncludeFederated(includeFederated);
+      remoteQueuePolicy.addProperty(IGNORE_QUEUE_CONSUMER_PRIORITIES, Boolean.toString(ignorePriority));
 
       final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
       element.setName(getTestName());

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cli/DummyServerConsumer.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cli/DummyServerConsumer.java
@@ -16,7 +16,9 @@
  */
 package org.apache.activemq.artemis.tests.integration.cli;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 import org.apache.activemq.artemis.api.core.RoutingType;
@@ -327,5 +329,25 @@ public class DummyServerConsumer implements ServerConsumer {
    @Override
    public int getMessagesAcknowledgedAwaitingCommit() {
       return 0;
+   }
+
+   @Override
+   public void addAttachment(String key, Object attachment) {
+
+   }
+
+   @Override
+   public Object getAttachment(String key) {
+      return null;
+   }
+
+   @Override
+   public Map<String, Object> getAttachments() {
+      return Collections.emptyMap();
+   }
+
+   @Override
+   public void removeAttachment(String key) {
+
    }
 }


### PR DESCRIPTION
When passing along a federation queue consumer that matches the includes of a federation queue policy retain the original consumer priority so that if the consumers loop the propagation will stop at the source that started the loop.