### PR TITLE
ARTEMIS-5383 performance issues with HierarchicalRepositoryChangeListener

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/NamedHierarchicalRepositoryChangeListener.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/NamedHierarchicalRepositoryChangeListener.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.settings.impl;
+
+import java.util.Objects;
+
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.settings.HierarchicalRepositoryChangeListener;
+
+public abstract class NamedHierarchicalRepositoryChangeListener implements HierarchicalRepositoryChangeListener {
+
+   private SimpleString name;
+
+   public NamedHierarchicalRepositoryChangeListener(SimpleString name) {
+      this.name = Objects.requireNonNull(name);
+   }
+
+   SimpleString getName() {
+      return this.name;
+   }
+
+   @Override
+   public int hashCode() {
+      return name.hashCode();
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o)
+         return true;
+      if (o == null || getClass() != o.getClass())
+         return false;
+
+      NamedHierarchicalRepositoryChangeListener that = (NamedHierarchicalRepositoryChangeListener) o;
+
+      if (!Objects.equals(name, that.name)) {
+         return false;
+      } else {
+         return true;
+      }
+   }
+}


### PR DESCRIPTION
This commit improves performance specifically for removing listeners from o.a.a.a.c.s.i.HierarchicalObjectRepository. It was previously using an ArrayList and the cost to remove an Object is O(n) on average whereas the same operation on a HashSet is O(1) on average assuming good hash values. Furthermore, the list was protected using a ReentrantReadWriteLock. However, by using a ConcurrentHashSet we can eliminate these locks further improving performance.

Switching to a ConcurrentHashSet required a few changes to the listeners themselves to ensure they have good hashCodes, etc.