### PR TITLE
ARTEMIS-5381 Use a stable FQQN for federation address receivers

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederation.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederation.java
@@ -165,6 +165,11 @@ public abstract class AMQPFederation implements Federation {
    public abstract AMQPFederationConfiguration getConfiguration();
 
    /**
+    * {@return the federation capabilities that is in effect following negotiation}
+    */
+   public abstract AMQPFederationCapabilities getCapabilities();
+
+   /**
     * Initialize this federation instance if not already initialized.
     *
     * @throws ActiveMQException if an error occurs during the initialization process.

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationAddressPolicyManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationAddressPolicyManager.java
@@ -436,7 +436,10 @@ public final class AMQPFederationAddressPolicyManager extends AMQPFederationLoca
    }
 
    private String generateQueueName(AddressInfo address) {
-      return "federation." + federation.getName() + ".address." + address.getName() + ".node." + server.getNodeID();
+      return "federation." + federation.getName() +
+             ".policy." + getPolicyName() +
+             ".address." + address.getName() +
+             ".node." + server.getNodeID();
    }
 
    private static boolean isAddressInDivertForwards(final SimpleString targetAddress, final SimpleString forwardAddress) {

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationCapabilities.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationCapabilities.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.federation;
+
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FQQN_ADDRESS_SUBSCRIPTIONS;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.engine.Link;
+
+/**
+ * Capabilities class that provides a reconciliation between what the remote offered as compared to what
+ * this federation instance desired in order to determine what features can and cannot be used.
+ */
+public final class AMQPFederationCapabilities {
+
+   private boolean initialized;
+   private boolean fqqnAddressSubscriptions;
+
+   /**
+    * Initialize all federation capabilities using the state of the opened control link to match
+    * on locally set desired capabilities sent to the remote and remotely offered capabilities.
+    * <p>
+    * We cannot use any feature that was not indicated as locally desired when offered by the remote.
+    *
+    * @param controlLink The federation control link on the source or target side of the connection.
+    *
+    * @return this federation capabilities instance fully initialized.
+    */
+   public AMQPFederationCapabilities initialize(Link controlLink) {
+      if (!initialized) {
+         initialized = true;
+
+         final Collection<Symbol> desiredList = controlLink.getDesiredCapabilities() == null ? Collections.emptyList() : Arrays.asList(controlLink.getDesiredCapabilities());
+         final Collection<Symbol> offeredList = controlLink.getRemoteOfferedCapabilities() == null ? Collections.emptyList() : Arrays.asList(controlLink.getRemoteOfferedCapabilities());
+
+         processCapabilities(desiredList, offeredList);
+      }
+
+      return this;
+   }
+
+   /**
+    * {@return <code>true</code> if federation address receivers can use FQQN source addresses or only legacy style.}
+    */
+   public boolean isUseFQQNAddressSubscriptions() {
+      checkIsInitialized();
+
+      return fqqnAddressSubscriptions;
+   }
+
+   private void processCapabilities(Collection<Symbol> desired, Collection<Symbol> offered) {
+      fqqnAddressSubscriptions = desired.contains(FQQN_ADDRESS_SUBSCRIPTIONS) && offered.contains(FQQN_ADDRESS_SUBSCRIPTIONS);
+   }
+
+   private void checkIsInitialized() {
+      if (!initialized) {
+         throw new IllegalStateException("Cannot check capabilities until this instance is initialized");
+      }
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationConstants.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationConstants.java
@@ -75,6 +75,14 @@ public final class AMQPFederationConstants {
    public static final Symbol FEDERATION_EVENT_LINK = Symbol.getSymbol("AMQ_FEDERATION_EVENT_LINK");
 
    /**
+    * Capability added to federation control links that indicates to the remote if federation address consumers
+    * will use FQQN syntax in the source address for a federation address receiver. If the remote does not offer
+    * the capability then the older variant use address and subscription name from the link name variant must be
+    * used when creating address receivers based on local demand.
+    */
+   public static final Symbol FQQN_ADDRESS_SUBSCRIPTIONS = Symbol.getSymbol("FQQN_ADDRESS_SUBSCRIPTIONS");
+
+   /**
     * Property name used to embed a nested map of properties meant to be applied if the federation resources created on
     * the remote end of the control link if configured to do so. These properties essentially carry local configuration
     * to the remote side that would otherwise use broker defaults and not match behaviors of resources created on the

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationQueueConsumer.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationQueueConsumer.java
@@ -89,6 +89,7 @@ public final class AMQPFederationQueueConsumer extends AMQPFederationConsumer {
 
    private String generateLinkName() {
       return "federation-" + federation.getName() +
+             "-policy-" + policy.getPolicyName() +
              "-queue-receiver-" + consumerInfo.getFqqn() +
              "-" + federation.getServer().getNodeID() + ":" +
              LINK_SEQUENCE_ID.getAndIncrement();

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationTarget.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationTarget.java
@@ -43,8 +43,9 @@ public class AMQPFederationTarget extends AMQPFederation {
    private final AMQPRemoteBrokerConnection brokerConnection;
    private final AMQPConnectionContext connection;
    private final AMQPFederationConfiguration configuration;
+   private final AMQPFederationCapabilities capabilities;
 
-   public AMQPFederationTarget(AMQPRemoteBrokerConnection brokerConnection, String name, AMQPFederationConfiguration configuration, AMQPSessionContext session) {
+   public AMQPFederationTarget(AMQPRemoteBrokerConnection brokerConnection, String name, AMQPFederationConfiguration configuration, AMQPFederationCapabilities capabilities, AMQPSessionContext session) {
       super(name, brokerConnection.getServer());
 
       Objects.requireNonNull(session, "Provided session instance cannot be null");
@@ -54,12 +55,18 @@ public class AMQPFederationTarget extends AMQPFederation {
       this.connection = session.getAMQPConnectionContext();
       this.connection.addLinkRemoteCloseListener(getName(), this::handleLinkRemoteClose);
       this.configuration = configuration;
+      this.capabilities = capabilities;
       this.connected = true;
    }
 
    @Override
    public AMQPConnectionContext getConnectionContext() {
       return connection;
+   }
+
+   @Override
+   public AMQPFederationCapabilities getCapabilities() {
+      return capabilities;
    }
 
    @Override

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPSessionContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPSessionContext.java
@@ -33,6 +33,7 @@ import org.apache.activemq.artemis.api.core.ActiveMQSecurityException;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.protocol.amqp.connect.AMQPRemoteBrokerConnection;
 import org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederation;
+import org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationCapabilities;
 import org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationCommandProcessor;
 import org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConfiguration;
 import org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationEventDispatcher;
@@ -451,7 +452,8 @@ public class AMQPSessionContext extends ProtonInitializable {
             final AMQPRemoteBrokerConnection brokerConnection =
                AMQPRemoteBrokerConnection.getOrCreateRemoteBrokerConnection(server, connection, protonConnection);
             final AMQPFederationConfiguration configuration = new AMQPFederationConfiguration(connection, federationConfigurationMap);
-            final AMQPFederationTarget federation = new AMQPFederationTarget(brokerConnection, remoteFederationName, configuration, this);
+            final AMQPFederationCapabilities capabilities = new AMQPFederationCapabilities();
+            final AMQPFederationTarget federation = new AMQPFederationTarget(brokerConnection, remoteFederationName, configuration, capabilities, this);
 
             federation.initialize();
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationAddressPolicyTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationAddressPolicyTest.java
@@ -32,6 +32,7 @@ import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPF
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_CONTROL_LINK;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_EVENT_LINK;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_POLICY_NAME;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FQQN_ADDRESS_SUBSCRIPTIONS;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.LARGE_MESSAGE_THRESHOLD;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.OPERATION_TYPE;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.POLICY_NAME;
@@ -58,6 +59,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.startsWith;
 
 import java.lang.invoke.MethodHandles;
 import java.net.URI;
@@ -251,6 +253,343 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
          logger.info("Removing Queues from federated address to eliminate demand");
          server.destroyQueue(SimpleString.of("test"));
          Wait.assertFalse(() -> server.queueQuery(SimpleString.of("test")).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectClose();
+         peer.remoteClose().now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testFederationCreatesAddressReceiverWithFQQNWhenLocalQueueIsStaticlyDefined() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.expectAttach().ofSender()
+                            .withDesiredCapability(FEDERATION_CONTROL_LINK.toString())
+                            .withDesiredCapability(FQQN_ADDRESS_SUBSCRIPTIONS.toString())
+                            .respond()
+                            .withOfferedCapabilities(FEDERATION_CONTROL_LINK.toString(), FQQN_ADDRESS_SUBSCRIPTIONS.toString());
+         peer.expectAttach().ofReceiver()
+                            .withSenderSettleModeSettled()
+                            .withSource().withDynamic(true)
+                            .and()
+                            .withDesiredCapability(FEDERATION_EVENT_LINK.toString())
+                            .respondInKind()
+                            .withTarget().withAddress("test-dynamic-events");
+         peer.expectFlow().withLinkCredit(10);
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPFederationAddressPolicyElement receiveFromAddress = new AMQPFederationAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.setAutoDelete(false);
+         receiveFromAddress.setAutoDeleteDelay(-1L);
+         receiveFromAddress.setAutoDeleteMessageCount(-1L);
+
+         final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addLocalAddressPolicy(receiveFromAddress);
+         element.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         final Map<String, Object> expectedSourceProperties = new HashMap<>();
+         expectedSourceProperties.put(ADDRESS_AUTO_DELETE, false);
+         expectedSourceProperties.put(ADDRESS_AUTO_DELETE_DELAY, -1L);
+         expectedSourceProperties.put(ADDRESS_AUTO_DELETE_MSG_COUNT, -1L);
+
+         final AtomicReference<String> capturedSourceAddress1 = new AtomicReference<>();
+         final AtomicReference<String> capturedSourceAddress2 = new AtomicReference<>();
+
+         peer.expectAttach().ofReceiver()
+                            .withCapture((attach) -> capturedSourceAddress1.set(attach.getSource().getAddress()))
+                            .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-policy"),
+                                            containsString("address-receiver"),
+                                            containsString(server.getNodeID().toString())))
+                            .withProperty(FEDERATED_ADDRESS_SOURCE_PROPERTIES.toString(), expectedSourceProperties)
+                            .withProperty(FEDERATION_POLICY_NAME.toString(), "address-policy")
+                            .withSource().withAddress(startsWith(getTestName() + "::federation." + getTestName())).and()
+                            .respond()
+                            .withOfferedCapabilities(FEDERATION_ADDRESS_RECEIVER.toString());
+         peer.expectFlow().withLinkCredit(1000);
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.MULTICAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         // Should be no frames generated as we already federated the address and the statically added
+         // queue should retain demand when this consumer leaves.
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+
+            session.createConsumer(session.createTopic(getTestName()));
+            session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                          .respond()
+                          .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+         peer.expectDetach().respond();
+
+         // This should trigger the federation consumer to be shutdown as the statically defined queue
+         // should be the only remaining demand on the address.
+         logger.info("Removing Queues from federated address to eliminate demand");
+         server.destroyQueue(SimpleString.of(getTestName()));
+         Wait.assertFalse(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withCapture((attach) -> capturedSourceAddress2.set(attach.getSource().getAddress()))
+                            .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-policy"),
+                                            containsString("address-receiver"),
+                                            containsString(server.getNodeID().toString())))
+                            .withProperty(FEDERATED_ADDRESS_SOURCE_PROPERTIES.toString(), expectedSourceProperties)
+                            .withProperty(FEDERATION_POLICY_NAME.toString(), "address-policy")
+                            .withSource().withAddress(startsWith(getTestName() + "::federation." + getTestName())).and()
+                            .respond()
+                            .withOfferedCapabilities(FEDERATION_ADDRESS_RECEIVER.toString());
+         peer.expectFlow().withLinkCredit(1000);
+
+         // Create new demand and ensure the attach carries a stable FQQN
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+
+            session.createConsumer(session.createTopic(getTestName()));
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach().respond();
+
+            connection.start();
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectClose();
+         peer.remoteClose().now();
+
+         // Each connect to the remote should use a stable source address
+         assertNotNull(capturedSourceAddress1.get());
+         assertNotNull(capturedSourceAddress2.get());
+         assertEquals(capturedSourceAddress1.get(), capturedSourceAddress2.get());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testFederationUsesStableFQQNForAddressConsumersAcrossConnections() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.expectAttach().ofSender()
+                            .withDesiredCapability(FEDERATION_CONTROL_LINK.toString())
+                            .withDesiredCapability(FQQN_ADDRESS_SUBSCRIPTIONS.toString())
+                            .respond()
+                            .withOfferedCapabilities(FEDERATION_CONTROL_LINK.toString(), FQQN_ADDRESS_SUBSCRIPTIONS.toString());
+         peer.expectAttach().ofReceiver()
+                            .withSenderSettleModeSettled()
+                            .withSource().withDynamic(true)
+                            .and()
+                            .withDesiredCapability(FEDERATION_EVENT_LINK.toString())
+                            .respondInKind()
+                            .withTarget().withAddress("test-dynamic-events");
+         peer.expectFlow().withLinkCredit(10);
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPFederationAddressPolicyElement receiveFromAddress = new AMQPFederationAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.setAutoDelete(false);
+         receiveFromAddress.setAutoDeleteDelay(-1L);
+         receiveFromAddress.setAutoDeleteMessageCount(-1L);
+
+         final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addLocalAddressPolicy(receiveFromAddress);
+         element.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(10);
+         amqpConnection.setRetryInterval(10);
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         final AtomicReference<String> capturedSourceAddress1 = new AtomicReference<>();
+         final AtomicReference<String> capturedSourceAddress2 = new AtomicReference<>();
+
+         peer.expectAttach().ofReceiver()
+                            .withCapture((attach) -> capturedSourceAddress1.set(attach.getSource().getAddress()))
+                            .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-policy"),
+                                            containsString("address-receiver"),
+                                            containsString(server.getNodeID().toString())))
+                            .withProperty(FEDERATION_POLICY_NAME.toString(), "address-policy")
+                            .withSource().withAddress(startsWith(getTestName() + "::federation." + getTestName())).and()
+                            .respond()
+                            .withOfferedCapabilities(FEDERATION_ADDRESS_RECEIVER.toString());
+         peer.expectFlow().withLinkCredit(1000);
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.MULTICAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectClose().optional();
+         peer.expectConnectionToDrop();
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.expectAttach().ofSender()
+                            .withDesiredCapability(FEDERATION_CONTROL_LINK.toString())
+                            .withDesiredCapability(FQQN_ADDRESS_SUBSCRIPTIONS.toString())
+                            .respond()
+                            .withOfferedCapabilities(FEDERATION_CONTROL_LINK.toString(), FQQN_ADDRESS_SUBSCRIPTIONS.toString());
+         peer.expectAttach().ofReceiver()
+                            .withSenderSettleModeSettled()
+                            .withSource().withDynamic(true)
+                            .and()
+                            .withDesiredCapability(FEDERATION_EVENT_LINK.toString())
+                            .respondInKind()
+                            .withTarget().withAddress("test-dynamic-events");
+         peer.expectFlow().withLinkCredit(10);
+         peer.expectAttach().ofReceiver()
+                            .withCapture((attach) -> capturedSourceAddress2.set(attach.getSource().getAddress()))
+                            .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-policy"),
+                                            containsString("address-receiver"),
+                                            containsString(server.getNodeID().toString())))
+                            .withProperty(FEDERATION_POLICY_NAME.toString(), "address-policy")
+                            .withSource().withAddress(startsWith(getTestName() + "::federation." + getTestName())).and()
+                            .respond()
+                            .withOfferedCapabilities(FEDERATION_ADDRESS_RECEIVER.toString());
+         peer.expectFlow().withLinkCredit(1000);
+         peer.remoteClose().now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         // Each connect to the remote should use a stable source address
+         assertNotNull(capturedSourceAddress1.get());
+         assertNotNull(capturedSourceAddress2.get());
+         assertEquals(capturedSourceAddress1.get(), capturedSourceAddress2.get());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testFederationCreatesAddressReceiverWithoutFQQNWhenLocalQueueIsStaticlyDefinedAndFQQNNotOffered() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.expectAttach().ofSender()
+                            .withDesiredCapabilities(FEDERATION_CONTROL_LINK.toString(), FQQN_ADDRESS_SUBSCRIPTIONS.toString())
+                            .respond()
+                            .withOfferedCapabilities(FEDERATION_CONTROL_LINK.toString()); // No FQQN for address subscriptions
+         peer.expectAttach().ofReceiver()
+                            .withSenderSettleModeSettled()
+                            .withSource().withDynamic(true)
+                            .and()
+                            .withDesiredCapability(FEDERATION_EVENT_LINK.toString())
+                            .respondInKind()
+                            .withTarget().withAddress("test-dynamic-events");
+         peer.expectFlow().withLinkCredit(10);
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPFederationAddressPolicyElement receiveFromAddress = new AMQPFederationAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.setAutoDelete(false);
+         receiveFromAddress.setAutoDeleteDelay(-1L);
+         receiveFromAddress.setAutoDeleteMessageCount(-1L);
+
+         final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addLocalAddressPolicy(receiveFromAddress);
+         element.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         final Map<String, Object> expectedSourceProperties = new HashMap<>();
+         expectedSourceProperties.put(ADDRESS_AUTO_DELETE, false);
+         expectedSourceProperties.put(ADDRESS_AUTO_DELETE_DELAY, -1L);
+         expectedSourceProperties.put(ADDRESS_AUTO_DELETE_MSG_COUNT, -1L);
+
+         peer.expectAttach().ofReceiver()
+                            .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-policy"),
+                                            containsString("address-receiver"),
+                                            containsString(server.getNodeID().toString())))
+                            .withProperty(FEDERATED_ADDRESS_SOURCE_PROPERTIES.toString(), expectedSourceProperties)
+                            .withProperty(FEDERATION_POLICY_NAME.toString(), "address-policy")
+                            .withSource().withAddress(getTestName()).and() // Legacy address only
+                            .respond()
+                            .withOfferedCapabilities(FEDERATION_ADDRESS_RECEIVER.toString());
+         peer.expectFlow().withLinkCredit(1000);
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.MULTICAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
 
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectClose();
@@ -1788,6 +2127,78 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
             final MessageConsumer consumer = session.createConsumer(session.createTopic("address1"));
 
             connection.start();
+
+            final Message message = consumer.receive(5_000);
+            assertNotNull(message);
+            assertInstanceOf(TextMessage.class, message);
+            assertEquals("test-message", ((TextMessage) message).getText());
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(999).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach(); // demand will be gone and receiver link should close.
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectClose();
+         peer.remoteClose().now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+
+         server.stop();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testRemoteFederatesAddressWhenDemandIsAppliedUsingFQQNWhenSupported() throws Exception {
+      server.start();
+
+      final List<String> includes = new ArrayList<>();
+      includes.add("address1");
+
+      final Map<String, Object> properties = new HashMap<>();
+      properties.put(ADDRESS_RECEIVER_IDLE_TIMEOUT, 5);
+
+      final FederationReceiveFromAddressPolicy policy =
+         new FederationReceiveFromAddressPolicy("test-address-policy",
+                                                true, 30_000L, 1000L, 1, true,
+                                                includes, null, properties, null,
+                                                DEFAULT_WILDCARD_CONFIGURATION);
+
+      try (ProtonTestClient peer = new ProtonTestClient()) {
+         scriptFederationConnectToRemote(peer, "test", true);
+         peer.connect("localhost", AMQP_PORT);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDisposition().withSettled(true).withState().accepted();
+
+         sendAddresPolicyToRemote(peer, policy);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withDesiredCapability(FEDERATION_ADDRESS_RECEIVER.toString())
+                            .withSource().withAddress(startsWith("address1::federation.")) // FQQN prefix
+                            .and()
+                            .respondInKind(); // Server detected demand
+         peer.expectFlow().withLinkCredit(1000);
+         peer.remoteTransfer().withBody().withString("test-message")
+                              .also()
+                              .withDeliveryId(1)
+                              .queue();
+         peer.expectDisposition().withSettled(true).withState().accepted();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageConsumer consumer = session.createConsumer(session.createTopic("address1"));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
 
             final Message message = consumer.receive(5_000);
             assertNotNull(message);
@@ -4975,15 +5386,19 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
       scriptFederationConnectToRemote(peer, federationName, AmqpSupport.AMQP_CREDITS_DEFAULT, AmqpSupport.AMQP_LOW_CREDITS_DEFAULT);
    }
 
+   private static void scriptFederationConnectToRemote(ProtonTestClient peer, String federationName, boolean fqqnSubscriptions) {
+      scriptFederationConnectToRemote(peer, federationName, AmqpSupport.AMQP_CREDITS_DEFAULT, AmqpSupport.AMQP_LOW_CREDITS_DEFAULT, false, false, fqqnSubscriptions);
+   }
+
    private static void scriptFederationConnectToRemote(ProtonTestClient peer, String federationName, int amqpCredits, int amqpLowCredits) {
-      scriptFederationConnectToRemote(peer, federationName, amqpCredits, amqpLowCredits, false, false);
+      scriptFederationConnectToRemote(peer, federationName, amqpCredits, amqpLowCredits, false, false, false);
    }
 
    private static void scriptFederationConnectToRemote(ProtonTestClient peer, String federationName, boolean eventsSender, boolean eventsReceiver) {
-      scriptFederationConnectToRemote(peer, federationName, AmqpSupport.AMQP_CREDITS_DEFAULT, AmqpSupport.AMQP_LOW_CREDITS_DEFAULT, eventsSender, eventsReceiver);
+      scriptFederationConnectToRemote(peer, federationName, AmqpSupport.AMQP_CREDITS_DEFAULT, AmqpSupport.AMQP_LOW_CREDITS_DEFAULT, eventsSender, eventsReceiver, false);
    }
 
-   private static void scriptFederationConnectToRemote(ProtonTestClient peer, String federationName, int amqpCredits, int amqpLowCredits, boolean eventsSender, boolean eventsReceiver) {
+   private static void scriptFederationConnectToRemote(ProtonTestClient peer, String federationName, int amqpCredits, int amqpLowCredits, boolean eventsSender, boolean eventsReceiver, boolean fqqnAddressSubs) {
       final String federationControlLinkName = "Federation:control:" + UUID.randomUUID().toString();
 
       final Map<String, Object> federationConfiguration = new HashMap<>();
@@ -4998,21 +5413,40 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
       peer.expectOpen();
       peer.remoteBegin().queue();
       peer.expectBegin();
-      peer.remoteAttach().ofSender()
-                         .withInitialDeliveryCount(0)
-                         .withName(federationControlLinkName)
-                         .withPropertiesMap(senderProperties)
-                         .withDesiredCapabilities(FEDERATION_CONTROL_LINK.toString())
-                         .withSenderSettleModeUnsettled()
-                         .withReceivervSettlesFirst()
-                         .withSource().also()
-                         .withTarget().withDynamic(true)
-                                      .withDurabilityOfNone()
-                                      .withExpiryPolicyOnLinkDetach()
-                                      .withLifetimePolicyOfDeleteOnClose()
-                                      .withCapabilities("temporary-topic")
-                                      .also()
-                         .queue();
+      if (fqqnAddressSubs) {
+         peer.remoteAttach().ofSender()
+                            .withInitialDeliveryCount(0)
+                            .withName(federationControlLinkName)
+                            .withPropertiesMap(senderProperties)
+                            .withDesiredCapabilities(FEDERATION_CONTROL_LINK.toString(), FQQN_ADDRESS_SUBSCRIPTIONS.toString())
+                            .withOfferedCapabilities(FQQN_ADDRESS_SUBSCRIPTIONS.toString())
+                            .withSenderSettleModeUnsettled()
+                            .withReceivervSettlesFirst()
+                            .withSource().also()
+                            .withTarget().withDynamic(true)
+                                         .withDurabilityOfNone()
+                                         .withExpiryPolicyOnLinkDetach()
+                                         .withLifetimePolicyOfDeleteOnClose()
+                                         .withCapabilities("temporary-topic")
+                                         .also()
+                            .queue();
+      } else {
+         peer.remoteAttach().ofSender()
+                            .withInitialDeliveryCount(0)
+                            .withName(federationControlLinkName)
+                            .withPropertiesMap(senderProperties)
+                            .withDesiredCapabilities(FEDERATION_CONTROL_LINK.toString())
+                            .withSenderSettleModeUnsettled()
+                            .withReceivervSettlesFirst()
+                            .withSource().also()
+                            .withTarget().withDynamic(true)
+                                         .withDurabilityOfNone()
+                                         .withExpiryPolicyOnLinkDetach()
+                                         .withLifetimePolicyOfDeleteOnClose()
+                                         .withCapabilities("temporary-topic")
+                                         .also()
+                            .queue();
+      }
       peer.expectAttach().ofReceiver()
                          .withTarget()
                             .withAddress(notNullValue())


### PR DESCRIPTION
When subscribing a federation address consumer a stable subscription queue name must be used to ensure that reconnections recover past subscriptions and consume messages sent while the receiver was offline. This must support connections to previous versions where this was not done to ensure full backwards and forwards compatibility on federation configurations.