### PR TITLE
ARTEMIS-5381 Use a stable FQQN for federation address receivers

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederation.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederation.java
@@ -165,6 +165,11 @@ public abstract class AMQPFederation implements Federation {
    public abstract AMQPFederationConfiguration getConfiguration();
 
    /**
+    * {@return the federation capabilities that is in effect following negotiation}
+    */
+   public abstract AMQPFederationCapabilities getCapabilities();
+
+   /**
     * Initialize this federation instance if not already initialized.
     *
     * @throws ActiveMQException if an error occurs during the initialization process.

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationAddressPolicyManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationAddressPolicyManager.java
@@ -436,7 +436,10 @@ public final class AMQPFederationAddressPolicyManager extends AMQPFederationLoca
    }
 
    private String generateQueueName(AddressInfo address) {
-      return "federation." + federation.getName() + ".address." + address.getName() + ".node." + server.getNodeID();
+      return "federation." + federation.getName() +
+             ".policy." + getPolicyName() +
+             ".address." + address.getName() +
+             ".node." + server.getNodeID();
    }
 
    private static boolean isAddressInDivertForwards(final SimpleString targetAddress, final SimpleString forwardAddress) {

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationCapabilities.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationCapabilities.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.federation;
+
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_V1;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_VERSION;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.engine.Link;
+
+/**
+ * Capabilities class that provides a reconciliation between what the remote offered as compared to what
+ * this federation instance desired in order to determine what features can and cannot be used.
+ */
+public final class AMQPFederationCapabilities {
+
+   private boolean initialized;
+   private int localVersion = FEDERATION_V1;
+   private int remoteVersion = FEDERATION_V1;
+   private boolean fqqnAddressSubscriptions;
+
+   /**
+    * Initialize the federation versions all federation capabilities using the state of the opened control
+    * link to match on locally set desired capabilities sent to the remote and remotely offered capabilities.
+    * <p>
+    * We cannot use any feature that was not indicated as locally desired when offered by the remote.
+    *
+    * @param controlLink The federation control link on the source or target side of the connection.
+    *
+    * @return this federation capabilities instance fully initialized.
+    */
+   public AMQPFederationCapabilities initialize(Link controlLink) {
+      if (!initialized) {
+         initialized = true;
+
+         final Map<Symbol, Object> localProperties = controlLink.getProperties() != null ? controlLink.getProperties() : Collections.emptyMap();
+         final Map<Symbol, Object> remoteProperties = controlLink.getRemoteProperties() != null ? controlLink.getRemoteProperties() : Collections.emptyMap();
+
+         final Object local = localProperties.getOrDefault(FEDERATION_VERSION, FEDERATION_V1);
+         final Object remote = remoteProperties.getOrDefault(FEDERATION_VERSION, FEDERATION_V1);
+
+         if (!(local instanceof Integer localVersionNo)) {
+            throw new IllegalArgumentException("Invalid value set on federation local version number: " + local);
+         } else {
+            this.localVersion = localVersionNo.intValue();
+         }
+
+         if (!(remote instanceof Integer remoteVersionNo)) {
+            throw new IllegalArgumentException("Invalid value sent in federation remote version number: " + local);
+         } else {
+            this.remoteVersion = remoteVersionNo.intValue();
+         }
+
+         // Remote must be using V2 otherwise it cannot handle FQQN subscriptions and we need to fall back.
+         if (remoteVersion >= 2) {
+            fqqnAddressSubscriptions = true;
+         }
+      }
+
+      return this;
+   }
+
+   /**
+    * {@return the federation version in use on the local side of the connection.}
+    */
+   public int getLocalVersion() {
+      return localVersion;
+   }
+
+   /**
+    * {@return the federation version in use on the remote side of the connection.}
+    */
+   public int getRemoteVersion() {
+      return remoteVersion;
+   }
+
+   /**
+    * {@return <code>true</code> if federation address receivers can use FQQN source addresses or only legacy style.}
+    */
+   public boolean isUseFQQNAddressSubscriptions() {
+      checkIsInitialized();
+
+      return fqqnAddressSubscriptions;
+   }
+
+   private void checkIsInitialized() {
+      if (!initialized) {
+         throw new IllegalStateException("Cannot check capabilities until this instance is initialized");
+      }
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationConstants.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationConstants.java
@@ -29,6 +29,32 @@ import org.apache.qpid.proton.amqp.Symbol;
 public final class AMQPFederationConstants {
 
    /**
+    * Property added on the AMQP federation control link that carries a version associated with the
+    * side of the link the attach frame that carries it came from. A control link will provide two
+    * versions to the AMQP federation instance, the local side and the remote side once the link has
+    * fully opened.
+    */
+   public static final Symbol FEDERATION_VERSION = Symbol.getSymbol("federation_version");
+
+   /**
+    * Default AMQP federation version used when the version is not set on the control link as that
+    * would indicate all versions prior to the addition of versions being added on the control link.
+    */
+   public static final int FEDERATION_V1 = 1;
+
+   /**
+    * Version 2 marker for AMQP federation control links. Version 2.0 bump primarily adjusts the address federation
+    * link names to avoid potential link stealing when demand is quickly added and removed and as a result the AMQP
+    * source address value uses an FQQN that provides a stable address and queue binding name for the remote federation
+    * subscription which is recoverable on reconnects or on broker restart.
+    * <p>
+    * Also in this version AMQP federation queue consumers that are included in federation demand tracking are forwarded
+    * to the remote with their original priority values to avoid a case of infinite decreasing priority loops that can
+    * occur in some configurations.
+    */
+   public static final int FEDERATION_V2 = 2;
+
+   /**
     * Address used by a remote broker instance to validate that an incoming federation connection has access rights to
     * perform federation operations. The user that connects to the AMQP federation endpoint and attempts to create the
     * control link must have write access to this address and any address prefixed by this value.

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationQueueConsumer.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationQueueConsumer.java
@@ -89,6 +89,7 @@ public final class AMQPFederationQueueConsumer extends AMQPFederationConsumer {
 
    private String generateLinkName() {
       return "federation-" + federation.getName() +
+             "-policy-" + policy.getPolicyName() +
              "-queue-receiver-" + consumerInfo.getFqqn() +
              "-" + federation.getServer().getNodeID() + ":" +
              LINK_SEQUENCE_ID.getAndIncrement();

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationTarget.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationTarget.java
@@ -43,8 +43,9 @@ public class AMQPFederationTarget extends AMQPFederation {
    private final AMQPRemoteBrokerConnection brokerConnection;
    private final AMQPConnectionContext connection;
    private final AMQPFederationConfiguration configuration;
+   private final AMQPFederationCapabilities capabilities;
 
-   public AMQPFederationTarget(AMQPRemoteBrokerConnection brokerConnection, String name, AMQPFederationConfiguration configuration, AMQPSessionContext session) {
+   public AMQPFederationTarget(AMQPRemoteBrokerConnection brokerConnection, String name, AMQPFederationConfiguration configuration, AMQPFederationCapabilities capabilities, AMQPSessionContext session) {
       super(name, brokerConnection.getServer());
 
       Objects.requireNonNull(session, "Provided session instance cannot be null");
@@ -54,12 +55,18 @@ public class AMQPFederationTarget extends AMQPFederation {
       this.connection = session.getAMQPConnectionContext();
       this.connection.addLinkRemoteCloseListener(getName(), this::handleLinkRemoteClose);
       this.configuration = configuration;
+      this.capabilities = capabilities;
       this.connected = true;
    }
 
    @Override
    public AMQPConnectionContext getConnectionContext() {
       return connection;
+   }
+
+   @Override
+   public AMQPFederationCapabilities getCapabilities() {
+      return capabilities;
    }
 
    @Override

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPSessionContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPSessionContext.java
@@ -33,6 +33,7 @@ import org.apache.activemq.artemis.api.core.ActiveMQSecurityException;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.protocol.amqp.connect.AMQPRemoteBrokerConnection;
 import org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederation;
+import org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationCapabilities;
 import org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationCommandProcessor;
 import org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConfiguration;
 import org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationEventDispatcher;
@@ -451,7 +452,8 @@ public class AMQPSessionContext extends ProtonInitializable {
             final AMQPRemoteBrokerConnection brokerConnection =
                AMQPRemoteBrokerConnection.getOrCreateRemoteBrokerConnection(server, connection, protonConnection);
             final AMQPFederationConfiguration configuration = new AMQPFederationConfiguration(connection, federationConfigurationMap);
-            final AMQPFederationTarget federation = new AMQPFederationTarget(brokerConnection, remoteFederationName, configuration, this);
+            final AMQPFederationCapabilities capabilities = new AMQPFederationCapabilities();
+            final AMQPFederationTarget federation = new AMQPFederationTarget(brokerConnection, remoteFederationName, configuration, capabilities, this);
 
             federation.initialize();
 


### PR DESCRIPTION
When subscribing a federation address consumer a stable subscription queue name must be used to ensure that reconnections recover past subscriptions and consume messages sent while the receiver was offline. This also supports connections to previous versions where this was not done to ensure full backwards and forwards compatibility on federation configurations.