### PR TITLE
ARTEMIS-5381 Use FQQN to remove federation address subscription if set

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationAddressSenderController.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationAddressSenderController.java
@@ -223,8 +223,17 @@ public final class AMQPFederationAddressSenderController extends AMQPFederationS
       try {
          final Sender sender = senderContext.getSender();
          final Source source = (Source) sender.getRemoteSource();
-         final SimpleString queueName = SimpleString.of(sender.getName());
+         final SimpleString sourceAddress = SimpleString.of(source.getAddress());
          final RoutingType routingType = getRoutingType(source);
+
+         final SimpleString queueName;
+
+         // Either we have negotiated subscriptions using FQQN or we default to older behavior based on link names
+         if (CompositeAddress.isFullyQualified(sourceAddress)) {
+            queueName = CompositeAddress.extractQueueName(sourceAddress);
+         } else {
+            queueName = SimpleString.of(sender.getName());
+         }
 
          final QueueQueryResult queueQuery = sessionSPI.queueQuery(queueName, routingType, false);
          if (queueQuery.isExists()) {


### PR DESCRIPTION
If the remote used an FQQN to define the address and stable subscription for the address consumer recover the subscription from the FQQN when the remote closes the consumer due to demand having been removed on the remote for that address.