### PR TITLE
ARTEMIS-5434 Use full exception name in exceptions

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/ActiveMQException.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/ActiveMQException.java
@@ -75,6 +75,6 @@ public class ActiveMQException extends Exception {
 
    @Override
    public String toString() {
-      return this.getClass().getSimpleName() + "[errorType=" + type + " message=" + getMessage() + "]";
+      return this.getClass().getName() + ": [errorType=" + type + " message=" + getMessage() + "]";
    }
 }


### PR DESCRIPTION
I hope that I'm not breaking any backward compatibility here but it would be great to have a full package name in the exception header. Currently Artemis exceptions only include the short name of the exception. On logging systems where exceptions are caught and tracked if they are repeating errors (like for example Google Error Reporting), this groups different Artemis exceptions into single error group.

See https://github.com/apache/logging-log4j2/pull/3586#discussion_r2044006120 for more information and screenshots.